### PR TITLE
fix(frontend): sortable columns gain a keyboard tab stop in three surfaces

### DIFF
--- a/frontend/src/components/RequestReviewPanel.test.tsx
+++ b/frontend/src/components/RequestReviewPanel.test.tsx
@@ -340,6 +340,48 @@ describe('RequestReviewPanel', () => {
     })
   })
 
+  // #2068 — the desktop header's sortable columns were a bare `<div onClick>`
+  // with no tab stop: no key press could sort them.
+  describe('#2068: sortable column headers are keyboard reachable', () => {
+    it('every sortable header (Requester, Request, Confidence, Status) has a real button', async () => {
+      render(<RequestReviewPanel sessionId={1001} year={2025} />)
+
+      for (const name of ['Requester', 'Request', 'Confidence', 'Status']) {
+        const header = await screen.findByRole('columnheader', { name })
+        expect(within(header).getByRole('button').tagName).toBe('BUTTON')
+      }
+    })
+
+    it('the unsortable Type and Actions columns are not columnheaders', () => {
+      render(<RequestReviewPanel sessionId={1001} year={2025} />)
+
+      expect(screen.queryByRole('columnheader', { name: 'Type' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('columnheader', { name: 'Actions' })).not.toBeInTheDocument()
+    })
+
+    it('Tab reaches the Requester header and Enter sorts it', async () => {
+      render(<RequestReviewPanel sessionId={1001} year={2025} />)
+
+      const requesterButton = await screen.findByRole('button', { name: 'Requester' })
+      requesterButton.focus()
+      await userEvent.keyboard('{Enter}')
+
+      const header = requesterButton.closest('[role="columnheader"]') as HTMLElement
+      expect(['ascending', 'descending']).toContain(header.getAttribute('aria-sort'))
+    })
+
+    it('Space also sorts the Confidence header', async () => {
+      render(<RequestReviewPanel sessionId={1001} year={2025} />)
+
+      const confidenceButton = await screen.findByRole('button', { name: 'Confidence' })
+      confidenceButton.focus()
+      await userEvent.keyboard(' ')
+
+      const header = confidenceButton.closest('[role="columnheader"]') as HTMLElement
+      expect(['ascending', 'descending']).toContain(header.getAttribute('aria-sort'))
+    })
+  })
+
   /**
    * TDD TESTS: Collapsible Filter Bar (UI Optimization Part 1)
    *

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -66,6 +66,7 @@ interface FilterState {
 
 import { sortRequests, DEFAULT_SORT_BY, DEFAULT_SORT_ORDER } from './requestSort'
 import type { SortColumn } from './requestSort'
+import { SortableColumnHeader, type SortDirection } from './ui/SortableColumnHeader'
 
 export default function RequestReviewPanel({
   sessionId,
@@ -750,6 +751,9 @@ export default function RequestReviewPanel({
     }
   }
 
+  const sortDirectionFor = (column: SortColumn): SortDirection | null =>
+    sortBy === column ? (sortOrder === 'desc' ? 'descending' : 'ascending') : null
+
   const handleBulkApprove = () => {
     if (selectedRequests.size === 0) return
     setBulkConfirm({ action: 'approve', count: selectedRequests.size })
@@ -1038,77 +1042,73 @@ export default function RequestReviewPanel({
                   className="rounded"
                 />
               </div>
-              <div
-                className="text-muted-foreground hover:text-foreground cursor-pointer px-4 py-3 text-left text-sm font-medium"
-                onClick={() => handleSort('requester')}
-              >
-                <div className="flex items-center gap-1">
-                  Requester
-                  {sortBy === 'requester' && (
-                    <span className="text-primary">
-                      {sortOrder === 'asc' ? (
-                        <ChevronUp className="h-3 w-3" />
-                      ) : (
-                        <ChevronDown className="h-3 w-3" />
-                      )}
-                    </span>
-                  )}
-                </div>
-              </div>
-              <div
-                className="text-muted-foreground hover:text-foreground cursor-pointer px-4 py-3 text-left text-sm font-medium"
-                onClick={() => handleSort('request')}
-              >
-                <div className="flex items-center gap-1">
-                  Request
-                  {sortBy === 'request' && (
-                    <span className="text-primary">
-                      {sortOrder === 'asc' ? (
-                        <ChevronUp className="h-3 w-3" />
-                      ) : (
-                        <ChevronDown className="h-3 w-3" />
-                      )}
-                    </span>
-                  )}
-                </div>
-              </div>
+              <SortableColumnHeader
+                as="div"
+                label="Requester"
+                direction={sortDirectionFor('requester')}
+                onSort={() => handleSort('requester')}
+                buttonClassName="text-muted-foreground hover:text-foreground px-4 py-3 text-left text-sm font-medium"
+                indicator={
+                  sortBy === 'requester' ? (
+                    sortOrder === 'asc' ? (
+                      <ChevronUp className="text-primary h-3 w-3" />
+                    ) : (
+                      <ChevronDown className="text-primary h-3 w-3" />
+                    )
+                  ) : null
+                }
+              />
+              <SortableColumnHeader
+                as="div"
+                label="Request"
+                direction={sortDirectionFor('request')}
+                onSort={() => handleSort('request')}
+                buttonClassName="text-muted-foreground hover:text-foreground px-4 py-3 text-left text-sm font-medium"
+                indicator={
+                  sortBy === 'request' ? (
+                    sortOrder === 'asc' ? (
+                      <ChevronUp className="text-primary h-3 w-3" />
+                    ) : (
+                      <ChevronDown className="text-primary h-3 w-3" />
+                    )
+                  ) : null
+                }
+              />
               <div className="text-muted-foreground px-4 py-3 text-left text-sm font-medium">
                 Type
               </div>
-              <div
-                className="text-muted-foreground hover:text-foreground cursor-pointer px-4 py-3 text-center text-sm font-medium"
-                onClick={() => handleSort('confidence')}
-              >
-                <div className="flex items-center justify-center gap-1">
-                  Confidence
-                  {sortBy === 'confidence' && (
-                    <span className="text-primary">
-                      {sortOrder === 'asc' ? (
-                        <ChevronUp className="h-3 w-3" />
-                      ) : (
-                        <ChevronDown className="h-3 w-3" />
-                      )}
-                    </span>
-                  )}
-                </div>
-              </div>
-              <div
-                className="text-muted-foreground hover:text-foreground cursor-pointer px-4 py-3 text-center text-sm font-medium"
-                onClick={() => handleSort('status')}
-              >
-                <div className="flex items-center justify-center gap-1">
-                  Status
-                  {sortBy === 'status' && (
-                    <span className="text-primary">
-                      {sortOrder === 'asc' ? (
-                        <ChevronUp className="h-3 w-3" />
-                      ) : (
-                        <ChevronDown className="h-3 w-3" />
-                      )}
-                    </span>
-                  )}
-                </div>
-              </div>
+              <SortableColumnHeader
+                as="div"
+                label="Confidence"
+                direction={sortDirectionFor('confidence')}
+                onSort={() => handleSort('confidence')}
+                buttonClassName="text-muted-foreground hover:text-foreground justify-center px-4 py-3 text-center text-sm font-medium"
+                indicator={
+                  sortBy === 'confidence' ? (
+                    sortOrder === 'asc' ? (
+                      <ChevronUp className="text-primary h-3 w-3" />
+                    ) : (
+                      <ChevronDown className="text-primary h-3 w-3" />
+                    )
+                  ) : null
+                }
+              />
+              <SortableColumnHeader
+                as="div"
+                label="Status"
+                direction={sortDirectionFor('status')}
+                onSort={() => handleSort('status')}
+                buttonClassName="text-muted-foreground hover:text-foreground justify-center px-4 py-3 text-center text-sm font-medium"
+                indicator={
+                  sortBy === 'status' ? (
+                    sortOrder === 'asc' ? (
+                      <ChevronUp className="text-primary h-3 w-3" />
+                    ) : (
+                      <ChevronDown className="text-primary h-3 w-3" />
+                    )
+                  ) : null
+                }
+              />
               <div className="text-muted-foreground px-4 py-3 text-right text-sm font-medium">
                 Actions
               </div>

--- a/frontend/src/components/metrics/DrillDownModal.test.tsx
+++ b/frontend/src/components/metrics/DrillDownModal.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { DrillDownModal } from './DrillDownModal'
@@ -74,6 +75,96 @@ describe('DrillDownModal', () => {
       fireEvent.keyDown(document, { key: 'Tab' })
 
       expect(onClose).not.toHaveBeenCalled()
+    })
+  })
+
+  // #2068 — the 14 sortable columns were a bare `<th onClick>` with no tab
+  // stop at all: no key press could sort them. Sweep every layout so a
+  // partial conversion (some columns still plain <th>) would fail here.
+  describe('#2068: sortable column headers are keyboard reachable', () => {
+    function expectEveryHeaderHasAButton() {
+      const headers = screen.getAllByRole('columnheader')
+      expect(headers.length).toBeGreaterThan(0)
+      headers.forEach((header) => {
+        expect(within(header).getByRole('button').tagName).toBe('BUTTON')
+      })
+    }
+
+    it('every header in the default layout is a real button', () => {
+      renderWithClient(<DrillDownModal {...defaultProps} />)
+      expectEveryHeaderHasAButton()
+    })
+
+    it('every header in the waitlist layout is a real button', () => {
+      const filter: DrilldownFilter = { type: 'waitlist_total', value: '', label: 'Waitlist' }
+      renderWithClient(<DrillDownModal {...defaultProps} filter={filter} />)
+      expectEveryHeaderHasAButton()
+    })
+
+    it('every header in the retention layout is a real button', () => {
+      const filter: DrilldownFilter = {
+        type: 'gender',
+        value: 'F',
+        label: 'Female',
+        retentionContext: { baseYear: 2025, compareYear: 2026 },
+      }
+      renderWithClient(<DrillDownModal {...defaultProps} filter={filter} />)
+      expectEveryHeaderHasAButton()
+    })
+
+    it('every header in the cancellation-special layout is a real button', () => {
+      const filter: DrilldownFilter = {
+        type: 'cancellation_was_enrolled',
+        value: '',
+        label: 'Cancelled',
+      }
+      renderWithClient(<DrillDownModal {...defaultProps} filter={filter} />)
+      expectEveryHeaderHasAButton()
+    })
+
+    it('Tab reaches the Name header and Enter sorts it', async () => {
+      mockAttendees = [
+        {
+          person_id: 1,
+          first_name: 'Zara',
+          last_name: 'Williams',
+          grade: 5,
+          gender: 'F',
+          session_name: 'Session 1',
+          session_cm_id: 1,
+          status: 'enrolled',
+        } as DrilldownAttendee,
+        {
+          person_id: 2,
+          first_name: 'Anna',
+          last_name: 'Chen',
+          grade: 5,
+          gender: 'F',
+          session_name: 'Session 1',
+          session_cm_id: 1,
+          status: 'enrolled',
+        } as DrilldownAttendee,
+      ]
+
+      renderWithClient(<DrillDownModal {...defaultProps} />)
+
+      const nameButton = screen.getByRole('button', { name: 'Name' })
+      nameButton.focus()
+      await userEvent.keyboard('{Enter}')
+
+      const header = nameButton.closest('[role="columnheader"]') as HTMLElement
+      expect(['ascending', 'descending']).toContain(header.getAttribute('aria-sort'))
+    })
+
+    it('Space also sorts a header', async () => {
+      renderWithClient(<DrillDownModal {...defaultProps} />)
+
+      const yearsButton = screen.getByRole('button', { name: 'Years' })
+      yearsButton.focus()
+      await userEvent.keyboard(' ')
+
+      const header = yearsButton.closest('[role="columnheader"]') as HTMLElement
+      expect(['ascending', 'descending']).toContain(header.getAttribute('aria-sort'))
     })
   })
 

--- a/frontend/src/components/metrics/DrillDownModal.tsx
+++ b/frontend/src/components/metrics/DrillDownModal.tsx
@@ -12,6 +12,10 @@ import { useState, useMemo, useEffect } from 'react'
 import { Link } from 'react-router'
 import { X, Download, Search, ArrowUpDown, Loader2 } from 'lucide-react'
 import { SortIcon } from './SortIcon'
+import {
+  SortableColumnHeader,
+  type SortDirection as HeaderSortDirection,
+} from '../ui/SortableColumnHeader'
 import { useDrilldownAttendees } from '../../hooks/useDrilldownAttendees'
 import { shortenSessionName } from '../../utils/sessionDisplay'
 import { buildCsvContent, downloadCsv as triggerCsvDownload } from '../../utils/csvExport'
@@ -222,6 +226,22 @@ export function DrillDownModal({
     }
   }
 
+  const headerDirection = (field: SortField): HeaderSortDirection | null =>
+    sortField === field ? (sortDirection === 'desc' ? 'descending' : 'ascending') : null
+
+  /** Same faint ArrowUpDown-when-inactive treatment for every column — unlike
+   *  the other two sites converted for #2068, this one shows a sort affordance
+   *  even before a column is ever clicked. */
+  const headerIndicator = (field: SortField) => (
+    <SortIcon
+      field={field}
+      activeField={sortField}
+      direction={sortDirection}
+      inactiveIcon={ArrowUpDown}
+      inactiveClassName="h-3 w-3 opacity-50"
+    />
+  )
+
   const downloadCsv = () => {
     const headers = isWaitlistDrilldown
       ? [
@@ -430,236 +450,126 @@ export function DrillDownModal({
           <table className="w-full text-sm">
             <thead className="bg-muted sticky top-0">
               <tr>
-                <th
-                  onClick={() => handleSort('name')}
-                  className="text-muted-foreground hover:text-foreground cursor-pointer px-4 py-3 text-left font-medium"
-                >
-                  <div className="flex items-center gap-1">
-                    Name{' '}
-                    <SortIcon
-                      field="name"
-                      activeField={sortField}
-                      direction={sortDirection}
-                      inactiveIcon={ArrowUpDown}
-                      inactiveClassName="h-3 w-3 opacity-50"
-                    />
-                  </div>
-                </th>
-                <th
-                  onClick={() => handleSort('grade')}
-                  className="text-muted-foreground hover:text-foreground cursor-pointer px-4 py-3 text-center font-medium"
-                >
-                  <div className="flex items-center justify-center gap-1">
-                    Grade{' '}
-                    <SortIcon
-                      field="grade"
-                      activeField={sortField}
-                      direction={sortDirection}
-                      inactiveIcon={ArrowUpDown}
-                      inactiveClassName="h-3 w-3 opacity-50"
-                    />
-                  </div>
-                </th>
-                <th
-                  onClick={() => handleSort('gender')}
-                  className="text-muted-foreground hover:text-foreground cursor-pointer px-4 py-3 text-center font-medium"
-                >
-                  <div className="flex items-center justify-center gap-1">
-                    Gender{' '}
-                    <SortIcon
-                      field="gender"
-                      activeField={sortField}
-                      direction={sortDirection}
-                      inactiveIcon={ArrowUpDown}
-                      inactiveClassName="h-3 w-3 opacity-50"
-                    />
-                  </div>
-                </th>
+                <SortableColumnHeader
+                  label="Name"
+                  direction={headerDirection('name')}
+                  onSort={() => handleSort('name')}
+                  indicator={headerIndicator('name')}
+                  buttonClassName="text-muted-foreground hover:text-foreground px-4 py-3 text-left font-medium"
+                />
+                <SortableColumnHeader
+                  label="Grade"
+                  direction={headerDirection('grade')}
+                  onSort={() => handleSort('grade')}
+                  indicator={headerIndicator('grade')}
+                  buttonClassName="text-muted-foreground hover:text-foreground justify-center px-4 py-3 text-center font-medium"
+                />
+                <SortableColumnHeader
+                  label="Gender"
+                  direction={headerDirection('gender')}
+                  onSort={() => handleSort('gender')}
+                  indicator={headerIndicator('gender')}
+                  buttonClassName="text-muted-foreground hover:text-foreground justify-center px-4 py-3 text-center font-medium"
+                />
                 {!isWaitlistDrilldown && !isRetentionDrilldown && !isCancellationSpecial && (
-                  <th
-                    onClick={() => handleSort('school')}
-                    className="text-muted-foreground hover:text-foreground cursor-pointer px-4 py-3 text-left font-medium"
-                  >
-                    <div className="flex items-center gap-1">
-                      School{' '}
-                      <SortIcon
-                        field="school"
-                        activeField={sortField}
-                        direction={sortDirection}
-                        inactiveIcon={ArrowUpDown}
-                        inactiveClassName="h-3 w-3 opacity-50"
-                      />
-                    </div>
-                  </th>
+                  <SortableColumnHeader
+                    label="School"
+                    direction={headerDirection('school')}
+                    onSort={() => handleSort('school')}
+                    indicator={headerIndicator('school')}
+                    buttonClassName="text-muted-foreground hover:text-foreground px-4 py-3 text-left font-medium"
+                  />
                 )}
-                <th
-                  onClick={() => handleSort('city')}
-                  className="text-muted-foreground hover:text-foreground cursor-pointer px-4 py-3 text-left font-medium"
-                >
-                  <div className="flex items-center gap-1">
-                    City{' '}
-                    <SortIcon
-                      field="city"
-                      activeField={sortField}
-                      direction={sortDirection}
-                      inactiveIcon={ArrowUpDown}
-                      inactiveClassName="h-3 w-3 opacity-50"
-                    />
-                  </div>
-                </th>
-                <th
-                  onClick={() => handleSort('session')}
-                  className="text-muted-foreground hover:text-foreground cursor-pointer px-4 py-3 text-left font-medium"
-                >
-                  <div className="flex items-center gap-1">
-                    {isWaitlistDrilldown
+                <SortableColumnHeader
+                  label="City"
+                  direction={headerDirection('city')}
+                  onSort={() => handleSort('city')}
+                  indicator={headerIndicator('city')}
+                  buttonClassName="text-muted-foreground hover:text-foreground px-4 py-3 text-left font-medium"
+                />
+                <SortableColumnHeader
+                  label={
+                    isWaitlistDrilldown
                       ? 'Waitlisted For'
                       : isRetentionDrilldown
                         ? 'Prior Session'
                         : isCancellationSpecial
                           ? 'Cancelled Session'
-                          : 'Session'}{' '}
-                    <SortIcon
-                      field="session"
-                      activeField={sortField}
-                      direction={sortDirection}
-                      inactiveIcon={ArrowUpDown}
-                      inactiveClassName="h-3 w-3 opacity-50"
-                    />
-                  </div>
-                </th>
+                          : 'Session'
+                  }
+                  direction={headerDirection('session')}
+                  onSort={() => handleSort('session')}
+                  indicator={headerIndicator('session')}
+                  buttonClassName="text-muted-foreground hover:text-foreground px-4 py-3 text-left font-medium"
+                />
                 {isWaitlistDrilldown && (
-                  <th
-                    onClick={() => handleSort('enrolled')}
-                    className="text-muted-foreground hover:text-foreground cursor-pointer px-4 py-3 text-left font-medium"
-                  >
-                    <div className="flex items-center gap-1">
-                      Enrolled In{' '}
-                      <SortIcon
-                        field="enrolled"
-                        activeField={sortField}
-                        direction={sortDirection}
-                        inactiveIcon={ArrowUpDown}
-                        inactiveClassName="h-3 w-3 opacity-50"
-                      />
-                    </div>
-                  </th>
+                  <SortableColumnHeader
+                    label="Enrolled In"
+                    direction={headerDirection('enrolled')}
+                    onSort={() => handleSort('enrolled')}
+                    indicator={headerIndicator('enrolled')}
+                    buttonClassName="text-muted-foreground hover:text-foreground px-4 py-3 text-left font-medium"
+                  />
                 )}
                 {isWaitlistDrilldown && (
-                  <th
-                    onClick={() => handleSort('registration')}
-                    className="text-muted-foreground hover:text-foreground cursor-pointer px-4 py-3 text-left font-medium"
-                  >
-                    <div className="flex items-center gap-1">
-                      Applied{' '}
-                      <SortIcon
-                        field="registration"
-                        activeField={sortField}
-                        direction={sortDirection}
-                        inactiveIcon={ArrowUpDown}
-                        inactiveClassName="h-3 w-3 opacity-50"
-                      />
-                    </div>
-                  </th>
+                  <SortableColumnHeader
+                    label="Applied"
+                    direction={headerDirection('registration')}
+                    onSort={() => handleSort('registration')}
+                    indicator={headerIndicator('registration')}
+                    buttonClassName="text-muted-foreground hover:text-foreground px-4 py-3 text-left font-medium"
+                  />
                 )}
                 {isRetentionDrilldown && (
-                  <th
-                    onClick={() => handleSort('enrolled_current')}
-                    className="text-muted-foreground hover:text-foreground cursor-pointer px-4 py-3 text-left font-medium"
-                  >
-                    <div className="flex items-center gap-1">
-                      Session{' '}
-                      <SortIcon
-                        field="enrolled_current"
-                        activeField={sortField}
-                        direction={sortDirection}
-                        inactiveIcon={ArrowUpDown}
-                        inactiveClassName="h-3 w-3 opacity-50"
-                      />
-                    </div>
-                  </th>
+                  <SortableColumnHeader
+                    label="Session"
+                    direction={headerDirection('enrolled_current')}
+                    onSort={() => handleSort('enrolled_current')}
+                    indicator={headerIndicator('enrolled_current')}
+                    buttonClassName="text-muted-foreground hover:text-foreground px-4 py-3 text-left font-medium"
+                  />
                 )}
                 {isCancellationSpecial && (
                   <>
-                    <th
-                      onClick={() => handleSort('enrolled')}
-                      className="text-muted-foreground hover:text-foreground cursor-pointer px-4 py-3 text-left font-medium"
-                    >
-                      <div className="flex items-center gap-1">
-                        Current Session{' '}
-                        <SortIcon
-                          field="enrolled"
-                          activeField={sortField}
-                          direction={sortDirection}
-                          inactiveIcon={ArrowUpDown}
-                          inactiveClassName="h-3 w-3 opacity-50"
-                        />
-                      </div>
-                    </th>
-                    <th
-                      onClick={() => handleSort('registration')}
-                      className="text-muted-foreground hover:text-foreground cursor-pointer px-4 py-3 text-left font-medium"
-                    >
-                      <div className="flex items-center gap-1">
-                        Registered{' '}
-                        <SortIcon
-                          field="registration"
-                          activeField={sortField}
-                          direction={sortDirection}
-                          inactiveIcon={ArrowUpDown}
-                          inactiveClassName="h-3 w-3 opacity-50"
-                        />
-                      </div>
-                    </th>
-                    <th
-                      onClick={() => handleSort('cancelled')}
-                      className="text-muted-foreground hover:text-foreground cursor-pointer px-4 py-3 text-left font-medium"
-                    >
-                      <div className="flex items-center gap-1">
-                        Cancelled{' '}
-                        <SortIcon
-                          field="cancelled"
-                          activeField={sortField}
-                          direction={sortDirection}
-                          inactiveIcon={ArrowUpDown}
-                          inactiveClassName="h-3 w-3 opacity-50"
-                        />
-                      </div>
-                    </th>
+                    <SortableColumnHeader
+                      label="Current Session"
+                      direction={headerDirection('enrolled')}
+                      onSort={() => handleSort('enrolled')}
+                      indicator={headerIndicator('enrolled')}
+                      buttonClassName="text-muted-foreground hover:text-foreground px-4 py-3 text-left font-medium"
+                    />
+                    <SortableColumnHeader
+                      label="Registered"
+                      direction={headerDirection('registration')}
+                      onSort={() => handleSort('registration')}
+                      indicator={headerIndicator('registration')}
+                      buttonClassName="text-muted-foreground hover:text-foreground px-4 py-3 text-left font-medium"
+                    />
+                    <SortableColumnHeader
+                      label="Cancelled"
+                      direction={headerDirection('cancelled')}
+                      onSort={() => handleSort('cancelled')}
+                      indicator={headerIndicator('cancelled')}
+                      buttonClassName="text-muted-foreground hover:text-foreground px-4 py-3 text-left font-medium"
+                    />
                   </>
                 )}
                 {!isWaitlistDrilldown && !isRetentionDrilldown && !isCancellationSpecial && (
-                  <th
-                    onClick={() => handleSort('registration')}
-                    className="text-muted-foreground hover:text-foreground cursor-pointer px-4 py-3 text-left font-medium"
-                  >
-                    <div className="flex items-center gap-1">
-                      Registered{' '}
-                      <SortIcon
-                        field="registration"
-                        activeField={sortField}
-                        direction={sortDirection}
-                        inactiveIcon={ArrowUpDown}
-                        inactiveClassName="h-3 w-3 opacity-50"
-                      />
-                    </div>
-                  </th>
+                  <SortableColumnHeader
+                    label="Registered"
+                    direction={headerDirection('registration')}
+                    onSort={() => handleSort('registration')}
+                    indicator={headerIndicator('registration')}
+                    buttonClassName="text-muted-foreground hover:text-foreground px-4 py-3 text-left font-medium"
+                  />
                 )}
-                <th
-                  onClick={() => handleSort('years')}
-                  className="text-muted-foreground hover:text-foreground cursor-pointer px-4 py-3 text-center font-medium"
-                >
-                  <div className="flex items-center justify-center gap-1">
-                    Years{' '}
-                    <SortIcon
-                      field="years"
-                      activeField={sortField}
-                      direction={sortDirection}
-                      inactiveIcon={ArrowUpDown}
-                      inactiveClassName="h-3 w-3 opacity-50"
-                    />
-                  </div>
-                </th>
+                <SortableColumnHeader
+                  label="Years"
+                  direction={headerDirection('years')}
+                  onSort={() => handleSort('years')}
+                  indicator={headerIndicator('years')}
+                  buttonClassName="text-muted-foreground hover:text-foreground justify-center px-4 py-3 text-center font-medium"
+                />
               </tr>
             </thead>
             <tbody>

--- a/frontend/src/pages/metrics/retention/StaffCabinAnalysisPage.test.tsx
+++ b/frontend/src/pages/metrics/retention/StaffCabinAnalysisPage.test.tsx
@@ -392,9 +392,10 @@ describe('StaffCabinAnalysisPage', () => {
       renderPage()
       const user = userEvent.setup()
 
-      // Click "Staff" header to toggle sort
-      const staffHeader = screen.getByRole('columnheader', { name: /staff/i })
-      await user.click(staffHeader)
+      // Sorting is triggered from the header's nested button, not the <th>
+      // itself — the button is what makes the control keyboard-reachable.
+      const staffButton = screen.getByRole('button', { name: /staff/i })
+      await user.click(staffButton)
 
       const table = screen.getByRole('table')
       const rows = within(table).getAllByRole('row')
@@ -415,15 +416,78 @@ describe('StaffCabinAnalysisPage', () => {
       renderPage()
       const user = userEvent.setup()
 
-      // Click "Overall" header
-      const overallHeader = screen.getByRole('columnheader', { name: /overall/i })
-      await user.click(overallHeader)
+      // Click "Overall" header's button
+      const overallButton = screen.getByRole('button', { name: /overall/i })
+      await user.click(overallButton)
 
       const table = screen.getByRole('table')
       const rows = within(table).getAllByRole('row')
       const firstDataRow = rows[1]!
       // Descending by default for overall: highest first
       expect(within(firstDataRow).getByText('Anna Chen')).toBeInTheDocument()
+    })
+
+    it('#2068: Staff header is keyboard-reachable and sortable with Enter', async () => {
+      ;(useStaffRetentionData as Mock).mockReturnValue({
+        staffRows: sortableRows,
+        sessions: ['Session 1'],
+        bunkStaff: new Map(),
+        isLoading: false,
+        error: null,
+      })
+
+      renderPage()
+
+      const staffButton = screen.getByRole('button', { name: /staff/i })
+      staffButton.focus()
+      await userEvent.keyboard('{Enter}')
+
+      const table = screen.getByRole('table')
+      const rows = within(table).getAllByRole('row')
+      const firstDataRow = rows[1]!
+      // Same toggle as the click test: descending puts Zara first
+      expect(within(firstDataRow).getByText('Zara Williams')).toBeInTheDocument()
+    })
+
+    it('#2068: Overall header is keyboard-reachable and sortable with Space', async () => {
+      ;(useStaffRetentionData as Mock).mockReturnValue({
+        staffRows: sortableRows,
+        sessions: ['Session 1'],
+        bunkStaff: new Map(),
+        isLoading: false,
+        error: null,
+      })
+
+      renderPage()
+
+      const overallButton = screen.getByRole('button', { name: /overall/i })
+      overallButton.focus()
+      await userEvent.keyboard(' ')
+
+      const table = screen.getByRole('table')
+      const rows = within(table).getAllByRole('row')
+      const firstDataRow = rows[1]!
+      expect(within(firstDataRow).getByText('Anna Chen')).toBeInTheDocument()
+    })
+
+    it('#2068: aria-sort reflects the active column and is omitted on the inactive one', () => {
+      ;(useStaffRetentionData as Mock).mockReturnValue({
+        staffRows: sortableRows,
+        sessions: ['Session 1'],
+        bunkStaff: new Map(),
+        isLoading: false,
+        error: null,
+      })
+
+      renderPage()
+
+      expect(screen.getByRole('columnheader', { name: /staff/i })).toHaveAttribute(
+        'aria-sort',
+        'ascending'
+      )
+      expect(screen.getByRole('columnheader', { name: /overall/i })).not.toHaveAttribute(
+        'aria-sort'
+      )
     })
   })
 

--- a/frontend/src/pages/metrics/retention/StaffCabinAnalysisPage.tsx
+++ b/frontend/src/pages/metrics/retention/StaffCabinAnalysisPage.tsx
@@ -15,7 +15,10 @@ import { useStaffRetentionData } from '../../../hooks/useStaffRetentionData'
 import type { StaffRetentionRow } from '../../../hooks/useStaffRetentionData'
 import { useMetricsSession } from '../../../hooks/useMetricsSession'
 import { MetricsQueryGuard } from '../../../components/metrics/MetricsQueryGuard'
-import { SortIcon } from '../../../components/metrics/SortIcon'
+import {
+  SortableColumnHeader,
+  type SortDirection,
+} from '../../../components/ui/SortableColumnHeader'
 import { BunkCellTooltip } from '../../../components/metrics/BunkStaffTooltip'
 import type { BunkStaffInfo } from '../../../hooks/useBunkStaff'
 import { getRetentionCellColor } from '../../../utils/retentionColors'
@@ -76,6 +79,9 @@ export default function StaffCabinAnalysisPage() {
       setSortDir(field === 'overall' ? 'desc' : 'asc')
     }
   }
+
+  const sortDirectionFor = (field: SortField): SortDirection | null =>
+    sortField === field ? (sortDir === 'desc' ? 'descending' : 'ascending') : null
 
   const handleMouseEnter = useCallback(
     (e: React.MouseEvent, rowPersonId: string, session: string, bunkName: string) => {
@@ -167,21 +173,14 @@ export default function StaffCabinAnalysisPage() {
             <div className="overflow-x-auto">
               <table className="w-full border-separate border-spacing-0 text-xs" role="table">
                 <thead>
-                  <tr>
-                    <th
-                      role="columnheader"
-                      className="bg-muted/50 text-muted-foreground sticky left-0 z-10 cursor-pointer px-3 py-2 text-left font-medium select-none"
-                      onClick={() => handleSort('name')}
-                      data-tour="retention-staff-sort-name"
-                    >
-                      Staff{' '}
-                      <SortIcon
-                        field="name"
-                        activeField={sortField}
-                        direction={sortDir}
-                        className="inline h-3 w-3"
-                      />
-                    </th>
+                  <tr data-tour="retention-staff-header-row">
+                    <SortableColumnHeader
+                      label="Staff"
+                      direction={sortDirectionFor('name')}
+                      onSort={() => handleSort('name')}
+                      className="bg-muted/50 sticky left-0 z-10"
+                      buttonClassName="text-muted-foreground hover:text-foreground px-3 py-2 font-medium select-none"
+                    />
                     {sortedSessions.map((session) => (
                       <th
                         key={session}
@@ -191,20 +190,13 @@ export default function StaffCabinAnalysisPage() {
                         {session}
                       </th>
                     ))}
-                    <th
-                      role="columnheader"
-                      className="bg-muted/50 text-muted-foreground sticky right-0 z-10 cursor-pointer px-3 py-2 text-center font-medium select-none"
-                      onClick={() => handleSort('overall')}
-                      data-tour="retention-staff-sort-overall"
-                    >
-                      Overall{' '}
-                      <SortIcon
-                        field="overall"
-                        activeField={sortField}
-                        direction={sortDir}
-                        className="inline h-3 w-3"
-                      />
-                    </th>
+                    <SortableColumnHeader
+                      label="Overall"
+                      direction={sortDirectionFor('overall')}
+                      onSort={() => handleSort('overall')}
+                      className="bg-muted/50 sticky right-0 z-10"
+                      buttonClassName="text-muted-foreground hover:text-foreground justify-center px-3 py-2 text-center font-medium select-none"
+                    />
                   </tr>
                 </thead>
                 <tbody>

--- a/frontend/src/tours/definitions/retentionStaffTour.ts
+++ b/frontend/src/tours/definitions/retentionStaffTour.ts
@@ -16,7 +16,10 @@ const retentionStaffTour: TourDefinition = {
       },
     },
     {
-      element: '[data-tour="retention-staff-sort-name"]',
+      // Anchored to the header row, not a single header cell — the two
+      // sortable columns (Staff, Overall) now render via the shared
+      // SortableColumnHeader, which doesn't accept a data-tour prop (kindred#2068).
+      element: '[data-tour="retention-staff-header-row"]',
       popover: {
         title: 'Sortable Columns',
         description: "Click 'Staff' or 'Overall' headers to sort.",


### PR DESCRIPTION
## Summary

Three sortable tables could not be sorted by keyboard at all — a bare `onClick` on a non-interactive element (`<th>`/`<div>`) with no `tabIndex` and no `aria-sort`. There was no key press that could sort them, which is worse than the discoverability gap #1897 fixed: those two shapes were both keyboard-*operable*.

- `DrillDownModal.tsx` — 14 sortable columns (`<th onClick>`)
- `StaffCabinAnalysisPage.tsx` — 2 sortable columns (`<th onClick>`)
- `RequestReviewPanel.tsx` — 4 sortable columns (`<div onClick>`, ARIA-grid)

All three now use the shared `SortableColumnHeader` from #2060 (`as="th"` for the two tables, `as="div"` for `RequestReviewPanel`'s grid) — a real `<button>` under the hood, so Tab/Enter/Space work for free, and `aria-sort` is set correctly (omitted on inactive columns, never `'none'`).

- `DrillDownModal` keeps its existing faint always-visible sort-affordance icon (`ArrowUpDown` at `opacity-50` when inactive) via `SortableColumnHeader`'s `indicator` prop — unlike the other two sites, which only show an icon once a column becomes active.
- `RequestReviewPanel`'s conversion only touches the 4 sortable columns (Requester, Request, Confidence, Status); the unsortable Type and Actions columns stay plain `<div>`s.
- `StaffCabinAnalysisPage`'s retention-staff onboarding tour anchored a step to one of the converted `<th>` cells via a `data-tour` attribute. `SortableColumnHeader` doesn't accept arbitrary attributes (deliberately, per the task — widening its shared API wasn't this PR's call to make), so the tour anchor moves from the header cell to the header `<tr>` instead (`retentionStaffTour.ts`).

Not touched: `SortableColumnHeader` itself. All three sites fit its existing API without modification.

Out of scope, pre-existing (mentioned per the issue, not fixed here): `PipelineBatchList`'s `role="row"`/`role="rowgroup"`/`role="columnheader"` have no `role="table"`/`role="grid"` ancestor — same orphaned-role smell now also present in `RequestReviewPanel`'s grid conversion, inherent to `as="div"` usage.

## Test plan

- [x] Failing tests written first for keyboard reachability/operability in all three files, confirmed red before implementation
- [x] `npx vitest run` — full suite, 414 files / 5909 tests passed
- [x] `npm run type-check` — clean
- [x] `./node_modules/.bin/eslint` on all changed files — 0 errors (pre-existing warnings elsewhere untouched)
- [x] Pre-push hook (ruff, go build, pb-js-lint, shellcheck, markdownlint, api-types-freshness, mypy, tsc, pytest) — all green

Closes #2068.