### PR TITLE
fix(config): a11y severity overrides keep the recommended rule options

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -86,15 +86,6 @@ export default tseslint.config(
       // getByRole over 1,200 times, so a broken role breaks the query layer.
       ...jsxA11y.flatConfigs.recommended.rules,
 
-      // Violated today — warn, then promote. Counts as of 2026-08-07:
-      'jsx-a11y/click-events-have-key-events': 'warn', //           44
-      'jsx-a11y/no-static-element-interactions': 'warn', //         42
-      'jsx-a11y/label-has-associated-control': 'warn', //           27
-      'jsx-a11y/no-autofocus': 'warn', //                            9
-      'jsx-a11y/no-redundant-roles': 'warn', //                      7
-      'jsx-a11y/no-noninteractive-element-interactions': 'warn', //  2
-      'jsx-a11y/no-interactive-element-to-noninteractive-role': 'warn', // 2
-
       // React Hooks rules - core rules as errors, compiler rules as warnings
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'error',
@@ -137,6 +128,31 @@ export default tseslint.config(
       '@typescript-eslint/prefer-string-starts-ends-with': 'warn',
       '@typescript-eslint/prefer-includes': 'warn',
       '@typescript-eslint/prefer-reduce-type-parameter': 'warn',
+    },
+  },
+
+  // jsx-a11y severity overrides — hoisted into their own config object.
+  // ESLint flat config MERGES a severity-only override onto an earlier
+  // config's rule options rather than replacing them, but only across
+  // separate config objects; a later key inside the SAME object literal
+  // replaces the earlier value outright. Keeping these in the main
+  // TypeScript config's `rules` block (alongside the
+  // `...jsxA11y.flatConfigs.recommended.rules` spread) discarded the
+  // options on rules that carry them, e.g. `no-static-element-interactions`
+  // lost `allowExpressionValues`. This object must stay separate so the
+  // 'warn' string here layers onto the recommended `[error, {options}]`
+  // value instead of clobbering it.
+  {
+    files: ['**/*.{ts,tsx}'],
+    rules: {
+      // Violated today — warn, then promote. Counts as of 2026-08-07:
+      'jsx-a11y/click-events-have-key-events': 'warn', //           44
+      'jsx-a11y/no-static-element-interactions': 'warn', //         42
+      'jsx-a11y/label-has-associated-control': 'warn', //           27
+      'jsx-a11y/no-autofocus': 'warn', //                            9
+      'jsx-a11y/no-redundant-roles': 'warn', //                      7
+      'jsx-a11y/no-noninteractive-element-interactions': 'warn', //  2
+      'jsx-a11y/no-interactive-element-to-noninteractive-role': 'warn', // 2
     },
   },
 

--- a/frontend/src/config/eslintA11yLayering.guard.test.ts
+++ b/frontend/src/config/eslintA11yLayering.guard.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Pins the flat-config layering fix from kindred#2098 (root cause of
+ * kindred#2063 / kindred#2068, which #2097's jsx-a11y gate should have
+ * caught and didn't).
+ *
+ * ESLint flat config merges a LATER matching config object's severity-only
+ * rule value onto an EARLIER matching object's options for that rule — but
+ * only across separate config objects in the array. A later key inside the
+ * SAME object literal replaces the earlier value outright (plain JS object
+ * semantics, nothing ESLint-specific). The 7 jsx-a11y severity overrides in
+ * `eslint.config.js` must therefore live in their own config object, layered
+ * after the object that spreads `jsxA11y.flatConfigs.recommended.rules` —
+ * not folded back into that object's `rules` block alongside the spread.
+ *
+ * If they're ever folded back in, the options these rules carry (e.g.
+ * `no-static-element-interactions`'s `allowExpressionValues`) silently
+ * vanish: the rule falls back to its default options, which are stricter,
+ * and the effective violation count on unrelated code jumps (42 -> 50 for
+ * that rule, at the time of writing) — with no error, no warning, nothing
+ * but a bigger warning count next time someone happens to run `eslint`.
+ *
+ * This runs the real ESLint Node API against the project's actual
+ * `eslint.config.js` and inspects the resolved rule config directly — a
+ * jsdom render can't see config-resolution behavior, same rationale as
+ * `WeekendRosterPage.chunkGraph.test.ts` for the build's chunk graph.
+ */
+import { resolve } from 'path'
+import { describe, expect, it } from 'vitest'
+import { ESLint } from 'eslint'
+
+const FRONTEND_ROOT = resolve(import.meta.dirname, '../..')
+const CONFIG_PATH = resolve(FRONTEND_ROOT, 'eslint.config.js')
+
+async function calculateRules(): Promise<Record<string, unknown>> {
+  const eslint = new ESLint({ overrideConfigFile: CONFIG_PATH, cwd: FRONTEND_ROOT })
+  const config = (await eslint.calculateConfigForFile('src/App.tsx')) as {
+    rules: Record<string, unknown>
+  }
+  return config.rules
+}
+
+describe('eslint.config.js: jsx-a11y severity overrides layer onto recommended options', () => {
+  it('keeps no-static-element-interactions at warn without losing allowExpressionValues', async () => {
+    const rules = await calculateRules()
+    const rule = rules['jsx-a11y/no-static-element-interactions']
+    expect(Array.isArray(rule)).toBe(true)
+    const [severity, options] = rule as [number, Record<string, unknown> | undefined]
+    expect(severity).toBe(1) // warn — the override object's severity took effect
+    expect(options).toMatchObject({ allowExpressionValues: true }) // recommended's options survived it
+  })
+
+  it('keeps no-noninteractive-element-interactions at warn without losing its handlers option', async () => {
+    const rules = await calculateRules()
+    const rule = rules['jsx-a11y/no-noninteractive-element-interactions']
+    expect(Array.isArray(rule)).toBe(true)
+    const [severity, options] = rule as [number, Record<string, unknown> | undefined]
+    expect(severity).toBe(1)
+    expect(options).toHaveProperty('handlers')
+  })
+})


### PR DESCRIPTION
## What changed

`frontend/eslint.config.js` had 7 jsx-a11y severity overrides sitting in the SAME object literal as the `...jsxA11y.flatConfigs.recommended.rules` spread. A later key in one object literal replaces the earlier value outright, so a bare `'warn'` string discarded the recommended `[error, {options}]` value and stripped the options from 3 of the 7 rules — most importantly `no-static-element-interactions` lost `allowExpressionValues`.

Hoisted the 7 overrides into a separate, later config object in the `tseslint.config(...)` array, carrying the same `files: ['**/*.{ts,tsx}']` glob, placed after the main TypeScript config and before the test-file override and `eslintConfigPrettier` (prettier stays last). ESLint flat config merges a severity-only override from a later config object onto an earlier object's rule options rather than replacing them — which is exactly the behavior this needs. The explanatory comment block and per-rule counts moved with the rules.

No rule severities, new rules, other config objects, or `src/` files changed.

## Why

The gate's own ratchet documentation says the promotion threshold is "0 violations." With the options stripped, `no-static-element-interactions` was measuring 50 violations against a codebase that actually only has 42 — the comment's own claimed count. The promotion ratchet as originally written would have failed its first attempt against a phantom 8-violation gap that the config itself introduced.

## Verification (measured on the pristine tree before/after, `eslint src -f json`)

| rule | before | after |
|---|---|---|
| `no-static-element-interactions` | **50** | **42** |
| `no-noninteractive-element-interactions` | 3 | 2 |
| `no-interactive-element-to-noninteractive-role` | 2 | 2 (unaffected — no lost options at this count) |
| `click-events-have-key-events` | 44 | 44 (unaffected — no options to lose) |
| `label-has-associated-control` | 27 | 27 (unaffected) |
| `no-autofocus` | 9 | 9 (unaffected) |
| `no-redundant-roles` | 7 | 7 (unaffected) |
| **total warnings** | **516** | **507** |
| **total errors** | 0 | 0 |

The mutation-check this PR was gated on: `no-static-element-interactions` had to drop from 50 to 42 for the fix to be correct. It did, exactly.

```
$ ./node_modules/.bin/eslint src ; echo exit=$?
✖ 507 problems (0 errors, 507 warnings)
exit=0
```

Gates run and passed on push (pre-push hook): ruff-check, go-build, pb-js-lint, shellcheck, markdownlint, api-types-freshness, mypy, `tsc --noEmit` (both tsconfigs), pytest (6010 passed, 41 skipped, 0 failed).

No source-grep tests reference `eslint.config.js` or `jsx-a11y` (checked `frontend/src/**/*.test.{ts,tsx}`), so nothing needed updating there.

## Scope note

This is the prerequisite fix for the planned Wave 2 a11y sweep — it corrects the baseline the sweep's promotion ratchet will measure against. The sweep itself is out of scope for this PR and was not started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to apply accessibility warning overrides correctly for TypeScript files.
  * Preserved recommended linting rule options when adjusting rule severity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->