### PR TITLE
fix(frontend): the unit sort tiebreak respects the sort direction

### DIFF
--- a/frontend/src/components/admin/lodging/unitSort.test.ts
+++ b/frontend/src/components/admin/lodging/unitSort.test.ts
@@ -93,6 +93,23 @@ describe('sortUnits', () => {
     sortUnits(rows, { field: 'name', desc: false })
     expect(rows.map((u) => u.id)).toEqual(['b', 'a'])
   })
+
+  it('respects sort direction in tiebreak when all sort keys are equal', () => {
+    // All three units have is_confirmed: true, so they all have the same sort key (1).
+    // The tiebreak should use the name sort, but in the correct direction.
+    const rows = [
+      unit({ id: 'a', name: 'Alpha', is_confirmed: true }),
+      unit({ id: 'b', name: 'Beta', is_confirmed: true }),
+      unit({ id: 'c', name: 'Gamma', is_confirmed: true }),
+    ]
+    const ascending = sortUnits(rows, { field: 'is_confirmed', desc: false })
+    const descending = sortUnits(rows, { field: 'is_confirmed', desc: true })
+
+    // Ascending tiebreak should be alphabetical by name
+    expect(ascending.map((u) => u.id)).toEqual(['a', 'b', 'c'])
+    // Descending tiebreak should be reverse alphabetical by name
+    expect(descending.map((u) => u.id)).toEqual(['c', 'b', 'a'])
+  })
 })
 
 describe('groupUnitsByArea', () => {

--- a/frontend/src/components/admin/lodging/unitSort.ts
+++ b/frontend/src/components/admin/lodging/unitSort.ts
@@ -67,7 +67,7 @@ export function sortUnits(units: LodgingUnitRecord[], sort: UnitSort): LodgingUn
     if (ka < kb) return -1 * direction
     if (ka > kb) return 1 * direction
     // Stable tiebreak so equal keys never reshuffle between renders.
-    return a.name.localeCompare(b.name)
+    return a.name.localeCompare(b.name) * direction
   })
 }
 


### PR DESCRIPTION
## Summary

Fixed a one-character bug in the unit sort tiebreak. When all units share the same sort key (e.g., all confirmed), the stable tiebreak on line 70 was ignoring the sort direction toggle and always sorting by name ascending.

## Test Plan

Added a new test that verifies the tiebreak respects sort direction when all sort keys are equal. The test creates three units with identical `is_confirmed` values and confirms the name order reverses between ascending and descending sorts.

**Initial test run (before fix):**
```
 FAIL  src/components/admin/lodging/unitSort.test.ts > sortUnits > respects sort direction in tiebreak when all sort keys are equal
AssertionError: expected [ 'a', 'b', 'c' ] to deeply equal [ 'c', 'b', 'a' ]

- Expected
+ Received

  [
-   "c",
-   "b",
    "a",
+   "b",
+   "c",
  ]

 Test Files  1 failed (1)
      Tests  1 failed | 10 passed (11)
```

**After applying the fix (`return a.name.localeCompare(b.name) * direction`):**
```
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

**Mutation check (removed the fix to confirm test catches the bug):**
```
 FAIL  src/components/admin/lodging/unitSort.test.ts > sortUnits > respects sort direction in tiebreak when all sort keys are equal
AssertionError: expected [ 'a', 'b', 'c' ] to deeply equal [ 'c', 'b', 'a' ]

Test Files  1 failed (1)
      Tests  1 failed | 10 passed (11)
```

**Re-applied the fix and verified all tests pass:**
```
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

All pre-push gates passed:
- ruff-check ✔
- go-build ✔
- shellcheck ✔
- pb-js-lint ✔
- markdownlint ✔
- api-types-freshness ✔
- mypy ✔
- type-check ✔
- pytest (6010 passed, 41 skipped) ✔

🤖 Generated with [Claude Code](https://claude.com/claude-code)
