### PR TITLE
fix(scripts): the lodging seed verifier sets CAMPMINDER_SEASON_ID

### DIFF
--- a/scripts/dev/verify-lodging-seed.sh
+++ b/scripts/dev/verify-lodging-seed.sh
@@ -55,6 +55,12 @@ fi
 # harness's `pocketbase serve` has to be started from the repo root.
 cd "$REPO_ROOT"
 
+# The loader (pocketbase/main.go) calls ParseSeasonYear() which reads
+# CAMPMINDER_SEASON_ID before seeding anything. If unset, the loader skips
+# loading the registry and the database ends up empty. We provide a fixed
+# year and assert the seeded rows carry it.
+export CAMPMINDER_SEASON_ID=2026
+
 SCRATCH=$(mktemp -d)
 # shellcheck disable=SC2016  # deliberate: $SCRATCH expands when the trap fires, not here
 pb_harness_install_trap 'rm -rf "$SCRATCH"'
@@ -80,6 +86,15 @@ if [[ "$n" -eq 0 ]]; then
   echo "verify-lodging-seed: FAILED" >&2
   exit 1
 fi
+
+# --- seeded rows carry the correct year ---
+# Since the registry became year-scoped, the boot loader must resolve a year
+# before seeding anything. We provide CAMPMINDER_SEASON_ID=2026 above and
+# assert that all seeded rows carry that year — if the loader set a different
+# year or skipped the field entirely, we catch it here rather than as a
+# per-row mismatch below.
+n=$(q "SELECT COUNT(*) FROM lodging_units WHERE year IS NULL OR year != 2026")
+[[ "$n" -eq 0 ]] || note "$n units have year != 2026 or NULL"
 
 # --- the database matches the private registry file, field by field ---
 if ! python3 "$HERE/lib/diff_lodging_registry.py" "$REGISTRY" "$DB"; then


### PR DESCRIPTION
## Summary

Fixes the `verify-lodging-seed.sh` script which was reporting a false FAIL since the lodging loader became season-gated.

## What Changed

- Set `CAMPMINDER_SEASON_ID=2026` in the script harness, which the loader requires to seed the registry
- Added an assertion that all seeded rows carry `year=2026`, catching any mismatch or NULL values

## Why

The loader (pocketbase/main.go) calls `ParseSeasonYear()` before seeding anything. If `CAMPMINDER_SEASON_ID` is unset, the loader skips loading the registry and the database ends up empty, causing the script to report a false FAIL.

## Verification

- Shellcheck passes (exit=0)
- Script now passes without requiring manual environment setup (exit=0)
- All pre-push hooks passed: ruff, go-build, shellcheck, pb-js-lint, markdownlint, api-types-freshness, mypy, type-check, pytest

Part of #2054. (Half 2, making missing season a hard boot failure, is deliberately deferred to a separate PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
