### PR TITLE
fix(api): weekend roster ages carry CampMinder's yy.mm precision

### DIFF
--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -171,7 +171,7 @@ class PartyChild(BaseModel):
 
     person_cm_id: int = 0
     display_name: str = ""
-    age: int | None = None
+    age: float | None = None
     grade: int | None = None
 
 

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -829,7 +829,7 @@ class LodgingRosterService:
             registration = registrations.get(household_pb_id)
             adults = adults_by_household.get(household_pb_id, [])
             placement = placement_by_household.get(household_cm_id, _NO_PLACEMENT)
-            children_oldest_first = sorted(children, key=lambda c: -_i(c, "age"))
+            children_oldest_first = sorted(children, key=lambda c: -(_f(c, "age") or 0.0))
 
             parties.append(
                 RosterParty(
@@ -852,7 +852,12 @@ class LodgingRosterService:
                         PartyChild(
                             person_cm_id=_i(child, "cm_id"),
                             display_name=_person_display_name(child),
-                            age=_i(child, "age") or None,
+                            # persons.age is CampMinder's yy.mm as a REAL (kindred#2088):
+                            # 0.06 is a real 1-month-old, not a rounding artifact, so this
+                            # must read the raw float, not _i()'s truncated int. `or None`
+                            # is still deliberate here -- age == 0.0 is the UNKNOWN-AGE
+                            # population (no birthdate on file), not a newborn.
+                            age=_f(child, "age") or None,
                             grade=_i(child, "grade") or None,
                         )
                         for child in children_oldest_first

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -853,7 +853,7 @@ class LodgingRosterService:
                             person_cm_id=_i(child, "cm_id"),
                             display_name=_person_display_name(child),
                             # persons.age is CampMinder's yy.mm as a REAL (kindred#2088):
-                            # 0.06 is a real 1-month-old, not a rounding artifact, so this
+                            # 0.06 is a real 6-month-old, not a rounding artifact, so this
                             # must read the raw float, not _i()'s truncated int. `or None`
                             # is still deliberate here -- age == 0.0 is the UNKNOWN-AGE
                             # population (no birthdate on file), not a newborn.

--- a/frontend/src/components/weekend/FamilyCard.test.tsx
+++ b/frontend/src/components/weekend/FamilyCard.test.tsx
@@ -88,6 +88,25 @@ describe('FamilyCard — what it shows', () => {
     expect(screen.getByText(/5/)).toBeInTheDocument()
   })
 
+  it('renders age in CampMinder yy.mm format through displayCampMinderAge', () => {
+    // kindred#2088: `String(child.age)` printed a raw float verbatim (or
+    // truncated one on the backend). Both sites must go through the shared
+    // helper summer already uses -- two-digit months, no leading-zero years.
+    render(
+      <FamilyCard
+        party={party({
+          children: [
+            { person_cm_id: 9001, display_name: 'Noah', age: 1.5, grade: 0 },
+            { person_cm_id: 9002, display_name: 'Ava', age: 0.06, grade: 0 },
+          ],
+        })}
+        onOpen={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Noah (1.50)')).toBeInTheDocument()
+    expect(screen.getByText('Ava (0.06)')).toBeInTheDocument()
+  })
+
   it('omits an age it does not have rather than inventing one', () => {
     render(
       <FamilyCard
@@ -318,7 +337,7 @@ describe('FamilyCardPreview — the drag overlay', () => {
     // It is the card being dragged, so it has to LOOK like the card. Sharing
     // the body is what keeps that true without a second copy to maintain.
     render(<FamilyCardPreview party={party()} />)
-    expect(screen.getByText(/Noah Johnson \(8\)/)).toBeInTheDocument()
+    expect(screen.getByText(/Noah Johnson \(8\.00\)/)).toBeInTheDocument()
   })
 })
 
@@ -413,8 +432,8 @@ describe('FamilyCard — summer’s type scale', () => {
     // Each child gets its own `<span>`, so walk up one to the line that holds
     // them all — asserting on the inner span would pin nothing, since the size
     // is set on the line.
-    const line = screen.getByText(/Noah Johnson \(8\)/).parentElement
-    expect(line).toHaveTextContent('Ava Johnson (5)')
+    const line = screen.getByText(/Noah Johnson \(8\.00\)/).parentElement
+    expect(line).toHaveTextContent('Ava Johnson (5.00)')
     expect(line).toHaveClass('text-xs')
   })
 

--- a/frontend/src/components/weekend/FamilyCard.tsx
+++ b/frontend/src/components/weekend/FamilyCard.tsx
@@ -32,6 +32,7 @@ import { Repeat, Users } from 'lucide-react'
 import { Fragment } from 'react'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+import { displayCampMinderAge } from '../../utils/age'
 import { partySize, SHARE_WORDING, shareWordingChip } from './boardLayout'
 import { partyKey } from './partyKey'
 import { ATTENTION_LABEL, partyAttention } from './rosterAttention'
@@ -135,7 +136,7 @@ function FamilyCardBody({
               <span>
                 {child.age === null || child.age === undefined
                   ? child.display_name
-                  : `${String(child.display_name)} (${String(child.age)})`}
+                  : `${String(child.display_name)} (${displayCampMinderAge(child.age)})`}
               </span>
             </Fragment>
           ))}

--- a/frontend/src/components/weekend/FamilyDetailsPanel.test.tsx
+++ b/frontend/src/components/weekend/FamilyDetailsPanel.test.tsx
@@ -214,6 +214,27 @@ describe('FamilyDetailsPanel — household identity', () => {
     expect(screen.getByText(/Age 8/)).toBeInTheDocument()
   })
 
+  it('renders age in CampMinder yy.mm format through displayCampMinderAge', () => {
+    // kindred#2088: the panel printed `String(child.age)` verbatim. Both
+    // fractional and whole ages must go through the shared helper summer
+    // already uses -- two-digit months, no leading-zero years.
+    render(
+      <FamilyDetailsPanel
+        party={party({
+          children: [
+            { person_cm_id: 9001, display_name: 'Noah Johnson', age: 1.5, grade: 0 },
+            { person_cm_id: 9002, display_name: 'Ava Johnson', age: 0.06, grade: 0 },
+          ],
+        })}
+        year={2026}
+        onClose={vi.fn()}
+      />,
+      { wrapper }
+    )
+    expect(screen.getByText('Age 1.50')).toBeInTheDocument()
+    expect(screen.getByText('Age 0.06')).toBeInTheDocument()
+  })
+
   it('reports party size, arrival and returning status', () => {
     render(<FamilyDetailsPanel party={party()} year={2026} onClose={vi.fn()} />, { wrapper })
     expect(screen.getByText(/Friday 6pm/)).toBeInTheDocument()

--- a/frontend/src/components/weekend/FamilyDetailsPanel.tsx
+++ b/frontend/src/components/weekend/FamilyDetailsPanel.tsx
@@ -27,6 +27,7 @@ import type {
   RosterPartyRow,
   ShareRequest,
 } from '../../types/lodging'
+import { displayCampMinderAge } from '../../utils/age'
 import { AccessibilityFlagList } from './AccessibilityFlagList'
 import { MedicalNarrative } from './MedicalNarrative'
 import { partyKey } from './partyKey'
@@ -214,7 +215,9 @@ export function FamilyDetailsPanel({
                 <span className="text-muted-foreground text-xs">
                   {/* An age or grade we do not have is omitted, never zero. */}
                   {[
-                    child.age === null || child.age === undefined ? '' : `Age ${String(child.age)}`,
+                    child.age === null || child.age === undefined
+                      ? ''
+                      : `Age ${displayCampMinderAge(child.age)}`,
                     child.grade === null || child.grade === undefined || child.grade === 0
                       ? ''
                       : `Grade ${String(child.grade)}`,

--- a/frontend/src/components/weekend/HouseholdRosterRow.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterRow.tsx
@@ -20,6 +20,7 @@ import type {
   RosterPartyRow,
   ShareRequest,
 } from '../../types/lodging'
+import { displayCampMinderAge } from '../../utils/age'
 import { AccessibilityFlagList } from './AccessibilityFlagList'
 import type { AttentionLevel } from './rosterAttention'
 import { partyAttention } from './rosterAttention'
@@ -166,7 +167,7 @@ export function HouseholdRosterRow({ party, showRequests, unit, onOpen }: Househ
                 <span>
                   {child.age === null || child.age === undefined
                     ? child.display_name
-                    : `${String(child.display_name)} (${String(child.age)})`}
+                    : `${String(child.display_name)} (${displayCampMinderAge(child.age)})`}
                 </span>
               </Fragment>
             ))}

--- a/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
@@ -151,7 +151,29 @@ describe('HouseholdRosterTable', () => {
     expect(screen.getByText('The Johnson Family')).toBeInTheDocument()
     expect(screen.getByText('1 adult · 1 child')).toBeInTheDocument()
     expect(screen.getByText('Samuel Johnson')).toBeInTheDocument()
-    expect(screen.getByText('Emma Johnson (9)')).toBeInTheDocument()
+    expect(screen.getByText('Emma Johnson (9.00)')).toBeInTheDocument()
+  })
+
+  it('renders age in CampMinder yy.mm format through displayCampMinderAge', () => {
+    // kindred#2088: the row printed `String(child.age)` verbatim. Both
+    // fractional and whole ages must go through the shared helper summer
+    // already uses -- two-digit months, no leading-zero years.
+    render(
+      <HouseholdRosterTable
+        year={2026}
+        parties={[
+          party({
+            children: [
+              { person_cm_id: 1000001, display_name: 'Noah', age: 1.5, grade: 0 },
+              { person_cm_id: 1000002, display_name: 'Ava', age: 0.06, grade: 0 },
+            ],
+          }),
+        ]}
+      />,
+      { wrapper }
+    )
+    expect(screen.getByText('Noah (1.50)')).toBeInTheDocument()
+    expect(screen.getByText('Ava (0.06)')).toBeInTheDocument()
   })
 
   it('pluralises adults and children correctly', () => {

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -148,7 +148,7 @@ def _child(
     cm_id: int = 1000001,
     first: str = "Emma",
     last: str = "Johnson",
-    age: int = 9,
+    age: float = 9,
     grade: int = 4,
     household_pb_id: str = "hh_1",
 ) -> SimpleNamespace:
@@ -221,6 +221,69 @@ class TestFamilyCampParties:
         assert [a.display_name for a in party.adults] == ["Olivia Johnson", "Noah Johnson"]
         assert [c.display_name for c in party.children] == ["Emma Johnson"]
         assert party.party_size == 3
+
+    @pytest.mark.asyncio
+    async def test_fractional_age_survives_as_the_raw_float(self) -> None:
+        """kindred#2088: persons.age is CampMinder's yy.mm as a REAL --
+
+        7 years 4 months is literally 7.04. `int()` truncated an infant's
+        0.06 to 0 before `or None` ever saw it, so it rendered blank. The
+        fix is to stop truncating: the raw float must pass through whole.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_households={"hh_1": _household()},
+            fetch_attendees_for_session=[_child(age=0.06)],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.parties[0].children[0].age == 0.06
+
+    @pytest.mark.asyncio
+    async def test_zero_age_is_unknown_not_a_newborn(self) -> None:
+        """age == 0.0 is the UNKNOWN-AGE population (no birthdate on file),
+
+        not a newborn -- `or None` deliberately collapses it to None. Do
+        NOT "fix" this into `is not None`; that would turn 18 unknown-age
+        rows into fake newborns.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_households={"hh_1": _household()},
+            fetch_attendees_for_session=[_child(age=0.0)],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.parties[0].children[0].age is None
+
+    @pytest.mark.asyncio
+    async def test_children_sort_oldest_first_by_the_raw_float(self) -> None:
+        """1.11 (1 year 11 months) must sort above 1.02 (1 year 2 months).
+
+        Truncated to int they both round to 1 and the sort becomes a coin
+        flip on input order -- the sort key has to compare the float, not
+        the int() of it.
+        """
+        # Leo (1.02) is listed BEFORE Mia (1.11) deliberately: truncated to
+        # int they tie at 1, and a stable sort on the tied int key would
+        # leave Leo ahead of Mia -- the wrong order. Only comparing the raw
+        # float breaks the tie correctly.
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_households={"hh_1": _household()},
+            fetch_attendees_for_session=[
+                _child(cm_id=1000003, first="Leo", last="Nguyen", age=1.02),
+                _child(cm_id=1000002, first="Mia", last="Nguyen", age=1.11),
+                _child(cm_id=1000001, first="Ava", last="Nguyen", age=0.06),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert [c.display_name for c in roster.parties[0].children] == [
+            "Mia Nguyen",
+            "Leo Nguyen",
+            "Ava Nguyen",
+        ]
 
     @pytest.mark.asyncio
     async def test_returning_family_flag_from_prior_year_household(self) -> None:


### PR DESCRIPTION
## What changed

`persons.age` already stores CampMinder's yy.mm as a REAL (`onlyInt: false`) — 7 years 4 months is literally `7.04`. `int()` at `api/services/lodging_roster_service.py:855` truncated the fractional months off before `or None` ever saw the value, so infants at 0.01–0.11 years were truncated to 0 and rendered blank. That collapse is correct and deliberate for the genuinely *unknown-age* population (raw `age` exactly `0.0`, no birthdate on file) — it is wrong only for real infants whose float never had a chance to reach `or None` intact.

**Python (api):**
- `api/services/lodging_roster_service.py:855` — removed the `int()` wrapper, kept `or None`. On the raw float, `0.06 or None -> 0.06` (an infant keeps its age) and `0.0 or None -> None` (unknown age stays unknown).
- `api/services/lodging_roster_service.py:832` — fixed the oldest-first sort key to compare the float instead of the truncated int, so e.g. `1.11` correctly sorts above `1.02` (both truncate to `1` and tie under the old key).
- `api/schemas/lodging.py:174` — `PartyChild.age` moves from `int | None` to `float | None`. This was **not named in the original three-part fix** but is required for it to function: Pydantic's strict int coercion rejects a fractional float (`ValidationError: int_from_float`) rather than silently truncating it, so leaving the schema as `int` would 500 for every fractional age. The generated frontend type stays `number | null` either way (TypeScript doesn't distinguish int/float), so **no api-types regeneration was needed** — verified by running `type-check`/`tsc` clean and confirming `types.gen.ts` is unaffected.

**Frontend:**
Rendered all three sites through the existing `displayCampMinderAge` helper (`frontend/src/utils/age.ts:23`, `.toFixed(2)` formatting) instead of hand-rolled `String(child.age)`:
- `FamilyCard.tsx`
- `HouseholdRosterRow.tsx`
- `FamilyDetailsPanel.tsx`

This is a genuine format change for every age, not just fractional ones (integer ages now render `8.00` instead of `8`), matching what summer already does. Updated three pre-existing tests that pinned the old bare-integer format to match.

## Why

Fixes #2088. 17 real infants (age 0.01–0.11, all with a birthdate on file) were rendering with no age at all on the weekend/family-camp roster, indistinguishable from the 18 genuinely unknown-age rows.

## How verified

- TDD: wrote 3 new pytest tests against the **unfixed** code first (fractional age survives, zero age becomes `None`, sort orders by float) — 2 of 3 failed as expected; the third (`0.0 -> None`) passed incidentally on old code (int-truncation gives the same answer for `0.0`), so it was mutation-checked separately (see below).
- Mutation check: temporarily removed `or None` from the age line and reran `test_zero_age_is_unknown_not_a_newborn` — it went red (`assert 0.0 is None` failed), then restored. Confirms the test actually pins the collapse.
- `uv run pytest tests/unit/api/services/test_lodging_roster_service.py -q` → `93 passed`, `exit=0`
- `uv run pytest tests/unit/api/ -q` → `1956 passed`, `exit=0`
- `uv run mypy . --explicit-package-bases` → `Success: no issues found in 803 source files`, `exit=0`
- Frontend: wrote 3 new vitest tests against the **unfixed** code first (one per component, asserting the exact `displayCampMinderAge` output for `1.5` and `0.06`) — all failed as expected, then passed after the fix.
- `./node_modules/.bin/vitest run` (full suite) → `5914 passed`, `exit=0`
- `./node_modules/.bin/tsc --noEmit` → clean, `exit=0`
- `./node_modules/.bin/eslint <changed files>` → `0 errors` (2 pre-existing, unrelated `jsx-a11y/no-redundant-roles` warnings on untouched lines)
- Pre-push hooks (ruff, go build, mypy, shellcheck, pb-js-lint, markdownlint, api-types-freshness, tsc, pytest) all green on push.
- Push confirmed landed: `git fetch -q && git rev-list --count origin/feature/age-yy-mm-2088..HEAD` → `0`

## Scope note

No real names, camp names, or CampMinder IDs used anywhere (fictional set: Emma Johnson, Ava/Mia/Leo Nguyen, etc.). No files touched outside the three named plus their test files and the one required schema-type corollary explained above.

Closes #2088.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Child ages now support fractional values and display in CampMinder `yy.mm` format.
  * Age values preserve fractional years and months, including leading-zero months.
  * Children with an age of zero continue to display as unknown.

* **Bug Fixes**
  * Corrected child sorting and age display where fractional ages were previously truncated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->