### PR TITLE
fix(sync): run-scoped Year/DryRun across the eleven individual-sync handlers, plus SyncTab pending guard

### DIFF
--- a/frontend/src/components/admin/SyncTab.test.tsx
+++ b/frontend/src/components/admin/SyncTab.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Regression test for #1881: SyncTab's generic sync card computed its Run button's `disabled`
+ * state from a hand-maintained list — `isRunning || isPending || runIndividualSync.isPending ||
+ * runOnDemandSync.isPending` — that never referenced any of the eleven type-specific mutation
+ * hooks (camper_history, family_camp_derived, lodging_assignments, staff_skills,
+ * financial_aid_applications, household_demographics, camper_dietary, camper_transportation,
+ * quest_registrations, staff_applications, staff_vehicle_info). A double-click on one of those
+ * cards could submit a second request before status polling flipped the card to "running".
+ */
+import { render, screen, within } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { SyncTab } from './SyncTab'
+
+vi.mock('../../hooks/useCurrentYear', () => ({
+  useYear: () => 2027,
+}))
+
+const idleStatus = { status: 'idle' } as const
+
+vi.mock('../../hooks/useSyncCompletionToasts', () => ({
+  useSyncCompletionToasts: () => ({
+    camper_history: idleStatus,
+    family_camp_derived: idleStatus,
+    lodging_assignments: idleStatus,
+    staff_skills: idleStatus,
+    financial_aid_applications: idleStatus,
+    household_demographics: idleStatus,
+    camper_dietary: idleStatus,
+    camper_transportation: idleStatus,
+    quest_registrations: idleStatus,
+    staff_applications: idleStatus,
+    staff_vehicle_info: idleStatus,
+  }),
+}))
+
+const notPending = { mutate: vi.fn(), isPending: false }
+
+vi.mock('../../hooks/useRunIndividualSync', () => ({ useRunIndividualSync: () => notPending }))
+vi.mock('../../hooks/useRunOnDemandSync', () => ({ useRunOnDemandSync: () => notPending }))
+vi.mock('../../hooks/useUnifiedSync', () => ({ useUnifiedSync: () => notPending }))
+vi.mock('../../hooks/useProcessRequests', () => ({ useProcessRequests: () => notPending }))
+vi.mock('../../hooks/useCamperHistorySync', () => ({ useCamperHistorySync: () => notPending }))
+vi.mock('../../hooks/useFamilyCampDerivedSync', () => ({
+  useFamilyCampDerivedSync: () => notPending,
+}))
+vi.mock('../../hooks/useLodgingAssignmentsSync', () => ({
+  useLodgingAssignmentsSync: () => notPending,
+}))
+vi.mock('../../hooks/useStaffSkillsSync', () => ({ useStaffSkillsSync: () => notPending }))
+vi.mock('../../hooks/useFinancialAidApplicationsSync', () => ({
+  useFinancialAidApplicationsSync: () => notPending,
+}))
+vi.mock('../../hooks/useHouseholdDemographicsSync', () => ({
+  useHouseholdDemographicsSync: () => notPending,
+}))
+// The mutation under test: camper_dietary was one of the six hooks missing from the disabled
+// condition entirely. Marking it pending must disable ONLY the Dietary card.
+vi.mock('../../hooks/useCamperDietarySync', () => ({
+  useCamperDietarySync: () => ({ mutate: vi.fn(), isPending: true }),
+}))
+vi.mock('../../hooks/useCamperTransportationSync', () => ({
+  useCamperTransportationSync: () => notPending,
+}))
+vi.mock('../../hooks/useQuestRegistrationsSync', () => ({
+  useQuestRegistrationsSync: () => notPending,
+}))
+vi.mock('../../hooks/useStaffApplicationsSync', () => ({
+  useStaffApplicationsSync: () => notPending,
+}))
+vi.mock('../../hooks/useStaffVehicleInfoSync', () => ({
+  useStaffVehicleInfoSync: () => notPending,
+}))
+vi.mock('../../hooks/useCancelQueuedSync', () => ({ useCancelQueuedSync: () => notPending }))
+vi.mock('../../hooks/useCancelRunningSync', () => ({ useCancelRunningSync: () => notPending }))
+vi.mock('../../hooks/useRunPhaseSync', () => ({ useRunPhaseSync: () => notPending }))
+
+function renderSyncTab() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SyncTab />
+    </QueryClientProvider>
+  )
+}
+
+function getCardRunButton(cardName: string) {
+  // The sync-year <select> also has an <option> with the same text as some card names
+  // (e.g. "Camper History"), so scope to the card's title <div> specifically.
+  const heading = screen.getByText(cardName, { selector: 'div' })
+  const card = heading.closest('.flex.flex-col')
+  if (!card) throw new Error(`could not find card for ${cardName}`)
+  return within(card as HTMLElement).getByRole('button', { name: /run/i })
+}
+
+describe('SyncTab generic card pending guard (#1881)', () => {
+  it('disables a card whose own type-specific mutation is pending', () => {
+    renderSyncTab()
+
+    expect(getCardRunButton('Dietary')).toBeDisabled()
+  })
+
+  it('leaves an unrelated type-specific card enabled', () => {
+    renderSyncTab()
+
+    expect(getCardRunButton('Camper History')).not.toBeDisabled()
+    expect(getCardRunButton('Staff Skills')).not.toBeDisabled()
+  })
+})

--- a/frontend/src/components/admin/SyncTab.test.tsx
+++ b/frontend/src/components/admin/SyncTab.test.tsx
@@ -54,7 +54,7 @@ vi.mock('../../hooks/useFinancialAidApplicationsSync', () => ({
 vi.mock('../../hooks/useHouseholdDemographicsSync', () => ({
   useHouseholdDemographicsSync: () => notPending,
 }))
-// The mutation under test: camper_dietary was one of the six hooks missing from the disabled
+// The mutation under test: camper_dietary was one of the eleven hooks missing from the disabled
 // condition entirely. Marking it pending must disable ONLY the Dietary card.
 vi.mock('../../hooks/useCamperDietarySync', () => ({
   useCamperDietarySync: () => ({ mutate: vi.fn(), isPending: true }),

--- a/frontend/src/components/admin/SyncTab.tsx
+++ b/frontend/src/components/admin/SyncTab.tsx
@@ -96,6 +96,26 @@ export function SyncTab() {
   const cancelRunningSync = useCancelRunningSync()
   const runPhaseSync = useRunPhaseSync()
 
+  // One derived "is this card's own type-specific mutation pending" lookup, keyed by
+  // syncType.id, instead of a hand-maintained list of `.isPending` references in the disabled
+  // condition below. None of these eleven hooks had ever been wired into that condition
+  // (#1881), so a double-click on one of their cards could submit a second request before
+  // status polling flipped that card to "running". Keying by id means a newly-added per-type
+  // mutation hook just needs one entry here, not a new clause at every disabled= call site.
+  const typeSyncPendingById: Record<string, boolean> = {
+    camper_history: camperHistorySync.isPending,
+    family_camp_derived: familyCampDerivedSync.isPending,
+    lodging_assignments: lodgingAssignmentsSync.isPending,
+    staff_skills: staffSkillsSync.isPending,
+    financial_aid_applications: faApplicationsSync.isPending,
+    household_demographics: householdDemographicsSync.isPending,
+    camper_dietary: camperDietarySync.isPending,
+    camper_transportation: camperTransportationSync.isPending,
+    quest_registrations: questRegistrationsSync.isPending,
+    staff_applications: staffApplicationsSync.isPending,
+    staff_vehicle_info: staffVehicleInfoSync.isPending,
+  }
+
   // Get queue from status
   const queue: QueuedSyncItem[] = syncStatus?._queue ?? []
   const hasQueuedItems = queue.length > 0
@@ -172,6 +192,7 @@ export function SyncTab() {
     const Icon = syncType.icon
     const isRunning = status.status === 'running'
     const isPending = status.status === 'pending'
+    const isTypeSyncPending = typeSyncPendingById[syncType.id] ?? false
 
     // Determine which hook to use based on sync type
     const handleRun = () => {
@@ -317,7 +338,11 @@ export function SyncTab() {
           <button
             onClick={handleRun}
             disabled={
-              isRunning || isPending || runIndividualSync.isPending || runOnDemandSync.isPending
+              isRunning ||
+              isPending ||
+              runIndividualSync.isPending ||
+              runOnDemandSync.isPending ||
+              isTypeSyncPending
             }
             className="bg-muted/50 dark:bg-muted hover:bg-muted text-muted-foreground hover:text-foreground mt-3 flex w-full items-center justify-center gap-1.5 rounded-lg py-2 text-xs font-medium transition-colors disabled:opacity-50 sm:text-sm"
           >

--- a/pocketbase/sync/api.go
+++ b/pocketbase/sync/api.go
@@ -1863,15 +1863,6 @@ func handleCamperHistorySync(e *core.RequestEvent, scheduler *Scheduler) error {
 	orchestrator := scheduler.GetOrchestrator()
 	syncType := "camper_history"
 
-	// Check if already running
-	if orchestrator.IsRunning(syncType) {
-		return e.JSON(http.StatusConflict, map[string]any{
-			"error":    "Camper history computation already in progress",
-			"status":   "running",
-			"syncType": syncType,
-		})
-	}
-
 	// Parse required year parameter
 	yearParam := e.Request.URL.Query().Get("year")
 	if yearParam == "" {
@@ -1891,37 +1882,26 @@ func handleCamperHistorySync(e *core.RequestEvent, scheduler *Scheduler) error {
 	dryRunParam := e.Request.URL.Query().Get("dry_run")
 	dryRun := dryRunParam == boolTrueStr || dryRunParam == "1"
 
-	// Get the service and set options
-	service, ok := orchestrator.GetService(syncType).(*CamperHistorySync)
-	if !ok || service == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]any{
-			"error": "Camper history sync service not found",
-		})
-	}
+	// Request-scoped instance — never the shared registered singleton. Mutating the
+	// singleton let DryRun stick past its own run and let concurrent requests race on Year
+	// (#1881); RunSingleSyncWithService also reserves the run atomically, closing the gap
+	// between the old up-front IsRunning check and the field writes that followed it.
+	service := NewCamperHistorySync(e.App)
 	service.Year = year
 	service.DryRun = dryRun
 
-	// Run in background
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-		defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
 
-		slog.Info("Starting camper_history computation",
-			"year", year,
-			"dry_run", dryRun,
-		)
-		if err := orchestrator.RunSingleSync(ctx, syncType); err != nil {
-			slog.Error("Camper history computation failed", "year", year, "error", err)
-		} else {
-			stats := service.GetStats()
-			slog.Info("Camper history computation completed",
-				"year", year,
-				"created", stats.Created,
-				"deleted", stats.Deleted,
-				"errors", stats.Errors,
-			)
-		}
-	}()
+	if err := orchestrator.RunSingleSyncWithService(ctx, syncType, service); err != nil {
+		return e.JSON(http.StatusConflict, map[string]any{
+			"error":    "Camper history computation already in progress",
+			"status":   "running",
+			"syncType": syncType,
+		})
+	}
+
+	slog.Info("Starting camper_history computation", "year", year, "dry_run", dryRun)
 
 	return e.JSON(http.StatusOK, map[string]any{
 		"message":  "Camper history computation started",
@@ -1938,15 +1918,6 @@ func handleFamilyCampDerivedSync(e *core.RequestEvent, scheduler *Scheduler) err
 	orchestrator := scheduler.GetOrchestrator()
 	syncType := serviceNameFamilyCampDerived
 
-	// Check if already running
-	if orchestrator.IsRunning(syncType) {
-		return e.JSON(http.StatusConflict, map[string]any{
-			"error":    "Family camp derived computation already in progress",
-			"status":   "running",
-			"syncType": syncType,
-		})
-	}
-
 	// Parse required year parameter
 	yearParam := e.Request.URL.Query().Get("year")
 	if yearParam == "" {
@@ -1966,37 +1937,23 @@ func handleFamilyCampDerivedSync(e *core.RequestEvent, scheduler *Scheduler) err
 	dryRunParam := e.Request.URL.Query().Get("dry_run")
 	dryRun := dryRunParam == boolTrueStr || dryRunParam == "1"
 
-	// Get the service and set options
-	service, ok := orchestrator.GetService(syncType).(*FamilyCampDerivedSync)
-	if !ok || service == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]any{
-			"error": "Family camp derived sync service not found",
-		})
-	}
+	// Request-scoped instance — never the shared registered singleton (#1881).
+	service := NewFamilyCampDerivedSync(e.App)
 	service.Year = year
 	service.DryRun = dryRun
 
-	// Run in background
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-		defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
 
-		slog.Info("Starting family_camp_derived computation",
-			"year", year,
-			"dry_run", dryRun,
-		)
-		if err := orchestrator.RunSingleSync(ctx, syncType); err != nil {
-			slog.Error("Family camp derived computation failed", "year", year, "error", err)
-		} else {
-			stats := service.GetStats()
-			slog.Info("Family camp derived computation completed",
-				"year", year,
-				"created", stats.Created,
-				"deleted", stats.Deleted,
-				"errors", stats.Errors,
-			)
-		}
-	}()
+	if err := orchestrator.RunSingleSyncWithService(ctx, syncType, service); err != nil {
+		return e.JSON(http.StatusConflict, map[string]any{
+			"error":    "Family camp derived computation already in progress",
+			"status":   "running",
+			"syncType": syncType,
+		})
+	}
+
+	slog.Info("Starting family_camp_derived computation", "year", year, "dry_run", dryRun)
 
 	return e.JSON(http.StatusOK, map[string]any{
 		"message":  "Family camp derived computation started",
@@ -2013,14 +1970,6 @@ func handleLodgingAssignmentsSync(e *core.RequestEvent, scheduler *Scheduler) er
 	orchestrator := scheduler.GetOrchestrator()
 	syncType := serviceNameLodgingAssignments
 
-	if orchestrator.IsRunning(syncType) {
-		return e.JSON(http.StatusConflict, map[string]any{
-			"error":    "Lodging assignment ingest already in progress",
-			"status":   "running",
-			"syncType": syncType,
-		})
-	}
-
 	yearParam := e.Request.URL.Query().Get("year")
 	if yearParam == "" {
 		return e.JSON(http.StatusBadRequest, map[string]any{
@@ -2037,33 +1986,23 @@ func handleLodgingAssignmentsSync(e *core.RequestEvent, scheduler *Scheduler) er
 	dryRunParam := e.Request.URL.Query().Get("dry_run")
 	dryRun := dryRunParam == boolTrueStr || dryRunParam == "1"
 
-	service, ok := orchestrator.GetService(syncType).(*LodgingAssignmentsSync)
-	if !ok || service == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]any{
-			"error": "Lodging assignments sync service not found",
-		})
-	}
+	// Request-scoped instance — never the shared registered singleton (#1881).
+	service := NewLodgingAssignmentsSync(e.App)
 	service.Year = year
 	service.DryRun = dryRun
 
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-		defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
 
-		slog.Info("Starting lodging_assignments ingest", "year", year, "dry_run", dryRun)
-		if err := orchestrator.RunSingleSync(ctx, syncType); err != nil {
-			slog.Error("Lodging assignment ingest failed", "year", year, "error", err)
-			return
-		}
-		stats := service.GetStats()
-		slog.Info("Lodging assignment ingest completed",
-			"year", year,
-			"created", stats.Created,
-			"updated", stats.Updated,
-			"skipped", stats.Skipped,
-			"errors", stats.Errors,
-		)
-	}()
+	if err := orchestrator.RunSingleSyncWithService(ctx, syncType, service); err != nil {
+		return e.JSON(http.StatusConflict, map[string]any{
+			"error":    "Lodging assignment ingest already in progress",
+			"status":   "running",
+			"syncType": syncType,
+		})
+	}
+
+	slog.Info("Starting lodging_assignments ingest", "year", year, "dry_run", dryRun)
 
 	return e.JSON(http.StatusOK, map[string]any{
 		"message":  "Lodging assignment ingest started",
@@ -2080,15 +2019,6 @@ func handleStaffSkillsSync(e *core.RequestEvent, scheduler *Scheduler) error {
 	orchestrator := scheduler.GetOrchestrator()
 	syncType := "staff_skills"
 
-	// Check if already running
-	if orchestrator.IsRunning(syncType) {
-		return e.JSON(http.StatusConflict, map[string]any{
-			"error":    "Staff skills sync already in progress",
-			"status":   "running",
-			"syncType": syncType,
-		})
-	}
-
 	// Parse required year parameter
 	yearParam := e.Request.URL.Query().Get("year")
 	if yearParam == "" {
@@ -2108,38 +2038,23 @@ func handleStaffSkillsSync(e *core.RequestEvent, scheduler *Scheduler) error {
 	dryRunParam := e.Request.URL.Query().Get("dry_run")
 	dryRun := dryRunParam == boolTrueStr || dryRunParam == "1"
 
-	// Get the service and set options
-	service, ok := orchestrator.GetService(syncType).(*StaffSkillsSync)
-	if !ok || service == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]any{
-			"error": "Staff skills sync service not found",
-		})
-	}
+	// Request-scoped instance — never the shared registered singleton (#1881).
+	service := NewStaffSkillsSync(e.App)
 	service.Year = year
 	service.DryRun = dryRun
 
-	// Run in background
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-		defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
 
-		slog.Info("Starting staff_skills extraction",
-			"year", year,
-			"dry_run", dryRun,
-		)
-		if err := orchestrator.RunSingleSync(ctx, syncType); err != nil {
-			slog.Error("Staff skills extraction failed", "year", year, "error", err)
-		} else {
-			stats := service.GetStats()
-			slog.Info("Staff skills extraction completed",
-				"year", year,
-				"created", stats.Created,
-				"updated", stats.Updated,
-				"deleted", stats.Deleted,
-				"errors", stats.Errors,
-			)
-		}
-	}()
+	if err := orchestrator.RunSingleSyncWithService(ctx, syncType, service); err != nil {
+		return e.JSON(http.StatusConflict, map[string]any{
+			"error":    "Staff skills sync already in progress",
+			"status":   "running",
+			"syncType": syncType,
+		})
+	}
+
+	slog.Info("Starting staff_skills extraction", "year", year, "dry_run", dryRun)
 
 	return e.JSON(http.StatusOK, map[string]any{
 		"message":  "Staff skills extraction started",
@@ -2156,15 +2071,6 @@ func handleFinancialAidApplicationsSync(e *core.RequestEvent, scheduler *Schedul
 	orchestrator := scheduler.GetOrchestrator()
 	syncType := serviceNameFinancialAidApplications
 
-	// Check if already running
-	if orchestrator.IsRunning(syncType) {
-		return e.JSON(http.StatusConflict, map[string]any{
-			"error":    "Financial aid applications sync already in progress",
-			"status":   "running",
-			"syncType": syncType,
-		})
-	}
-
 	// Parse required year parameter
 	yearParam := e.Request.URL.Query().Get("year")
 	if yearParam == "" {
@@ -2184,37 +2090,23 @@ func handleFinancialAidApplicationsSync(e *core.RequestEvent, scheduler *Schedul
 	dryRunParam := e.Request.URL.Query().Get("dry_run")
 	dryRun := dryRunParam == boolTrueStr || dryRunParam == "1"
 
-	// Get the service and set options
-	service, ok := orchestrator.GetService(syncType).(*FinancialAidApplicationsSync)
-	if !ok || service == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]any{
-			"error": "Financial aid applications sync service not found",
-		})
-	}
+	// Request-scoped instance — never the shared registered singleton (#1881).
+	service := NewFinancialAidApplicationsSync(e.App)
 	service.Year = year
 	service.DryRun = dryRun
 
-	// Run in background
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-		defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
 
-		slog.Info("Starting financial_aid_applications extraction",
-			"year", year,
-			"dry_run", dryRun,
-		)
-		if err := orchestrator.RunSingleSync(ctx, syncType); err != nil {
-			slog.Error("Financial aid applications extraction failed", "year", year, "error", err)
-		} else {
-			stats := service.GetStats()
-			slog.Info("Financial aid applications extraction completed",
-				"year", year,
-				"created", stats.Created,
-				"updated", stats.Updated,
-				"errors", stats.Errors,
-			)
-		}
-	}()
+	if err := orchestrator.RunSingleSyncWithService(ctx, syncType, service); err != nil {
+		return e.JSON(http.StatusConflict, map[string]any{
+			"error":    "Financial aid applications sync already in progress",
+			"status":   "running",
+			"syncType": syncType,
+		})
+	}
+
+	slog.Info("Starting financial_aid_applications extraction", "year", year, "dry_run", dryRun)
 
 	return e.JSON(http.StatusOK, map[string]any{
 		"message":  "Financial aid applications extraction started",
@@ -2231,15 +2123,6 @@ func handleHouseholdDemographicsSync(e *core.RequestEvent, scheduler *Scheduler)
 	orchestrator := scheduler.GetOrchestrator()
 	syncType := serviceNameHouseholdDemographics
 
-	// Check if already running
-	if orchestrator.IsRunning(syncType) {
-		return e.JSON(http.StatusConflict, map[string]any{
-			"error":    "Household demographics computation already in progress",
-			"status":   "running",
-			"syncType": syncType,
-		})
-	}
-
 	// Parse required year parameter
 	yearParam := e.Request.URL.Query().Get("year")
 	if yearParam == "" {
@@ -2259,38 +2142,23 @@ func handleHouseholdDemographicsSync(e *core.RequestEvent, scheduler *Scheduler)
 	dryRunParam := e.Request.URL.Query().Get("dry_run")
 	dryRun := dryRunParam == boolTrueStr || dryRunParam == "1"
 
-	// Get the service and set options
-	service, ok := orchestrator.GetService(syncType).(*HouseholdDemographicsSync)
-	if !ok || service == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]any{
-			"error": "Household demographics sync service not found",
-		})
-	}
+	// Request-scoped instance — never the shared registered singleton (#1881).
+	service := NewHouseholdDemographicsSync(e.App)
 	service.Year = year
 	service.DryRun = dryRun
 
-	// Run in background
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-		defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
 
-		slog.Info("Starting household_demographics computation",
-			"year", year,
-			"dry_run", dryRun,
-		)
-		if err := orchestrator.RunSingleSync(ctx, syncType); err != nil {
-			slog.Error("Household demographics computation failed", "year", year, "error", err)
-		} else {
-			stats := service.GetStats()
-			slog.Info("Household demographics computation completed",
-				"year", year,
-				"created", stats.Created,
-				"updated", stats.Updated,
-				"deleted", stats.Deleted,
-				"errors", stats.Errors,
-			)
-		}
-	}()
+	if err := orchestrator.RunSingleSyncWithService(ctx, syncType, service); err != nil {
+		return e.JSON(http.StatusConflict, map[string]any{
+			"error":    "Household demographics computation already in progress",
+			"status":   "running",
+			"syncType": syncType,
+		})
+	}
+
+	slog.Info("Starting household_demographics computation", "year", year, "dry_run", dryRun)
 
 	return e.JSON(http.StatusOK, map[string]any{
 		"message":  "Household demographics computation started",
@@ -2518,15 +2386,6 @@ func handleCamperDietarySync(e *core.RequestEvent, scheduler *Scheduler) error {
 	orchestrator := scheduler.GetOrchestrator()
 	syncType := "camper_dietary"
 
-	// Check if already running
-	if orchestrator.IsRunning(syncType) {
-		return e.JSON(http.StatusConflict, map[string]any{
-			"error":    "Camper dietary sync already in progress",
-			"status":   "running",
-			"syncType": syncType,
-		})
-	}
-
 	// Parse required year parameter
 	yearParam := e.Request.URL.Query().Get("year")
 	if yearParam == "" {
@@ -2542,34 +2401,22 @@ func handleCamperDietarySync(e *core.RequestEvent, scheduler *Scheduler) error {
 		})
 	}
 
-	// Get the service and set options
-	service, ok := orchestrator.GetService(syncType).(*CamperDietarySync)
-	if !ok || service == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]any{
-			"error": "Camper dietary sync service not found",
-		})
-	}
+	// Request-scoped instance — never the shared registered singleton (#1881).
+	service := NewCamperDietarySync(e.App)
 	service.Year = year
 
-	// Run in background
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-		defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
 
-		slog.Info("Starting camper_dietary extraction", "year", year)
-		if err := orchestrator.RunSingleSync(ctx, syncType); err != nil {
-			slog.Error("Camper dietary extraction failed", "year", year, "error", err)
-		} else {
-			stats := service.GetStats()
-			slog.Info("Camper dietary extraction completed",
-				"year", year,
-				"created", stats.Created,
-				"updated", stats.Updated,
-				"deleted", stats.Deleted,
-				"errors", stats.Errors,
-			)
-		}
-	}()
+	if err := orchestrator.RunSingleSyncWithService(ctx, syncType, service); err != nil {
+		return e.JSON(http.StatusConflict, map[string]any{
+			"error":    "Camper dietary sync already in progress",
+			"status":   "running",
+			"syncType": syncType,
+		})
+	}
+
+	slog.Info("Starting camper_dietary extraction", "year", year)
 
 	return e.JSON(http.StatusOK, map[string]any{
 		"message":  "Camper dietary extraction started",
@@ -2585,15 +2432,6 @@ func handleCamperTransportationSync(e *core.RequestEvent, scheduler *Scheduler) 
 	orchestrator := scheduler.GetOrchestrator()
 	syncType := "camper_transportation"
 
-	// Check if already running
-	if orchestrator.IsRunning(syncType) {
-		return e.JSON(http.StatusConflict, map[string]any{
-			"error":    "Camper transportation sync already in progress",
-			"status":   "running",
-			"syncType": syncType,
-		})
-	}
-
 	// Parse required year parameter
 	yearParam := e.Request.URL.Query().Get("year")
 	if yearParam == "" {
@@ -2609,34 +2447,22 @@ func handleCamperTransportationSync(e *core.RequestEvent, scheduler *Scheduler) 
 		})
 	}
 
-	// Get the service and set options
-	service, ok := orchestrator.GetService(syncType).(*CamperTransportationSync)
-	if !ok || service == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]any{
-			"error": "Camper transportation sync service not found",
-		})
-	}
+	// Request-scoped instance — never the shared registered singleton (#1881).
+	service := NewCamperTransportationSync(e.App)
 	service.Year = year
 
-	// Run in background
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-		defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
 
-		slog.Info("Starting camper_transportation extraction", "year", year)
-		if err := orchestrator.RunSingleSync(ctx, syncType); err != nil {
-			slog.Error("Camper transportation extraction failed", "year", year, "error", err)
-		} else {
-			stats := service.GetStats()
-			slog.Info("Camper transportation extraction completed",
-				"year", year,
-				"created", stats.Created,
-				"updated", stats.Updated,
-				"deleted", stats.Deleted,
-				"errors", stats.Errors,
-			)
-		}
-	}()
+	if err := orchestrator.RunSingleSyncWithService(ctx, syncType, service); err != nil {
+		return e.JSON(http.StatusConflict, map[string]any{
+			"error":    "Camper transportation sync already in progress",
+			"status":   "running",
+			"syncType": syncType,
+		})
+	}
+
+	slog.Info("Starting camper_transportation extraction", "year", year)
 
 	return e.JSON(http.StatusOK, map[string]any{
 		"message":  "Camper transportation extraction started",
@@ -2652,15 +2478,6 @@ func handleQuestRegistrationsSync(e *core.RequestEvent, scheduler *Scheduler) er
 	orchestrator := scheduler.GetOrchestrator()
 	syncType := "quest_registrations"
 
-	// Check if already running
-	if orchestrator.IsRunning(syncType) {
-		return e.JSON(http.StatusConflict, map[string]any{
-			"error":    "Quest registrations sync already in progress",
-			"status":   "running",
-			"syncType": syncType,
-		})
-	}
-
 	// Parse required year parameter
 	yearParam := e.Request.URL.Query().Get("year")
 	if yearParam == "" {
@@ -2676,34 +2493,22 @@ func handleQuestRegistrationsSync(e *core.RequestEvent, scheduler *Scheduler) er
 		})
 	}
 
-	// Get the service and set options
-	service, ok := orchestrator.GetService(syncType).(*QuestRegistrationsSync)
-	if !ok || service == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]any{
-			"error": "Quest registrations sync service not found",
-		})
-	}
+	// Request-scoped instance — never the shared registered singleton (#1881).
+	service := NewQuestRegistrationsSync(e.App)
 	service.Year = year
 
-	// Run in background
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-		defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
 
-		slog.Info("Starting quest_registrations extraction", "year", year)
-		if err := orchestrator.RunSingleSync(ctx, syncType); err != nil {
-			slog.Error("Quest registrations extraction failed", "year", year, "error", err)
-		} else {
-			stats := service.GetStats()
-			slog.Info("Quest registrations extraction completed",
-				"year", year,
-				"created", stats.Created,
-				"updated", stats.Updated,
-				"deleted", stats.Deleted,
-				"errors", stats.Errors,
-			)
-		}
-	}()
+	if err := orchestrator.RunSingleSyncWithService(ctx, syncType, service); err != nil {
+		return e.JSON(http.StatusConflict, map[string]any{
+			"error":    "Quest registrations sync already in progress",
+			"status":   "running",
+			"syncType": syncType,
+		})
+	}
+
+	slog.Info("Starting quest_registrations extraction", "year", year)
 
 	return e.JSON(http.StatusOK, map[string]any{
 		"message":  "Quest registrations extraction started",
@@ -2719,15 +2524,6 @@ func handleStaffApplicationsSync(e *core.RequestEvent, scheduler *Scheduler) err
 	orchestrator := scheduler.GetOrchestrator()
 	syncType := "staff_applications"
 
-	// Check if already running
-	if orchestrator.IsRunning(syncType) {
-		return e.JSON(http.StatusConflict, map[string]any{
-			"error":    "Staff applications sync already in progress",
-			"status":   "running",
-			"syncType": syncType,
-		})
-	}
-
 	// Parse required year parameter
 	yearParam := e.Request.URL.Query().Get("year")
 	if yearParam == "" {
@@ -2743,34 +2539,22 @@ func handleStaffApplicationsSync(e *core.RequestEvent, scheduler *Scheduler) err
 		})
 	}
 
-	// Get the service and set options
-	service, ok := orchestrator.GetService(syncType).(*StaffApplicationsSync)
-	if !ok || service == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]any{
-			"error": "Staff applications sync service not found",
-		})
-	}
+	// Request-scoped instance — never the shared registered singleton (#1881).
+	service := NewStaffApplicationsSync(e.App)
 	service.Year = year
 
-	// Run in background
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-		defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
 
-		slog.Info("Starting staff_applications extraction", "year", year)
-		if err := orchestrator.RunSingleSync(ctx, syncType); err != nil {
-			slog.Error("Staff applications extraction failed", "year", year, "error", err)
-		} else {
-			stats := service.GetStats()
-			slog.Info("Staff applications extraction completed",
-				"year", year,
-				"created", stats.Created,
-				"updated", stats.Updated,
-				"deleted", stats.Deleted,
-				"errors", stats.Errors,
-			)
-		}
-	}()
+	if err := orchestrator.RunSingleSyncWithService(ctx, syncType, service); err != nil {
+		return e.JSON(http.StatusConflict, map[string]any{
+			"error":    "Staff applications sync already in progress",
+			"status":   "running",
+			"syncType": syncType,
+		})
+	}
+
+	slog.Info("Starting staff_applications extraction", "year", year)
 
 	return e.JSON(http.StatusOK, map[string]any{
 		"message":  "Staff applications extraction started",
@@ -2786,15 +2570,6 @@ func handleStaffVehicleInfoSync(e *core.RequestEvent, scheduler *Scheduler) erro
 	orchestrator := scheduler.GetOrchestrator()
 	syncType := "staff_vehicle_info"
 
-	// Check if already running
-	if orchestrator.IsRunning(syncType) {
-		return e.JSON(http.StatusConflict, map[string]any{
-			"error":    "Staff vehicle info sync already in progress",
-			"status":   "running",
-			"syncType": syncType,
-		})
-	}
-
 	// Parse required year parameter
 	yearParam := e.Request.URL.Query().Get("year")
 	if yearParam == "" {
@@ -2810,34 +2585,22 @@ func handleStaffVehicleInfoSync(e *core.RequestEvent, scheduler *Scheduler) erro
 		})
 	}
 
-	// Get the service and set options
-	service, ok := orchestrator.GetService(syncType).(*StaffVehicleInfoSync)
-	if !ok || service == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]any{
-			"error": "Staff vehicle info sync service not found",
-		})
-	}
+	// Request-scoped instance — never the shared registered singleton (#1881).
+	service := NewStaffVehicleInfoSync(e.App)
 	service.Year = year
 
-	// Run in background
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-		defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
 
-		slog.Info("Starting staff_vehicle_info extraction", "year", year)
-		if err := orchestrator.RunSingleSync(ctx, syncType); err != nil {
-			slog.Error("Staff vehicle info extraction failed", "year", year, "error", err)
-		} else {
-			stats := service.GetStats()
-			slog.Info("Staff vehicle info extraction completed",
-				"year", year,
-				"created", stats.Created,
-				"updated", stats.Updated,
-				"deleted", stats.Deleted,
-				"errors", stats.Errors,
-			)
-		}
-	}()
+	if err := orchestrator.RunSingleSyncWithService(ctx, syncType, service); err != nil {
+		return e.JSON(http.StatusConflict, map[string]any{
+			"error":    "Staff vehicle info sync already in progress",
+			"status":   "running",
+			"syncType": syncType,
+		})
+	}
+
+	slog.Info("Starting staff_vehicle_info extraction", "year", year)
 
 	return e.JSON(http.StatusOK, map[string]any{
 		"message":  "Staff vehicle info extraction started",

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -611,6 +611,100 @@ func (o *Orchestrator) runSingleSyncInternal(parentCtx context.Context, syncType
 	return runToken, nil
 }
 
+// RunSingleSyncWithService atomically checks that syncType is not already running and, if
+// free, marks it running and executes the given service instance in the background. Unlike
+// RunSingleSync, it never looks the service up from the orchestrator's registry — it runs
+// exactly the instance the caller passed in, and never registers it.
+//
+// This exists for handlers whose parameters (year, dry_run) are per-request: they build a
+// private instance — e.g. NewCamperHistorySync(app) — configured for just this request, and
+// hand it here instead of writing those fields onto the shared singleton returned by
+// GetService. That older pattern (see #1881) let DryRun stick on the singleton after a run
+// with nothing to reset it, and let two concurrent requests race on Year, because the
+// IsRunning check a handler did up front was never atomic with the field writes that followed
+// it. Here the "already running" check and the "mark running" write happen under a single
+// lock, so two concurrent callers for the same syncType can never both pass.
+//
+// Returns an error immediately, before starting anything, if syncType is already running.
+func (o *Orchestrator) RunSingleSyncWithService(parentCtx context.Context, syncType string, service Service) error {
+	o.mu.Lock()
+	if existing, exists := o.runningJobs[syncType]; exists && existing.Status == statusRunning {
+		o.mu.Unlock()
+		return fmt.Errorf("sync already in progress: %s", syncType)
+	}
+
+	status := &Status{
+		Type:      syncType,
+		Status:    statusRunning,
+		StartTime: time.Now(),
+		Summary:   Stats{},
+		Year:      o.currentSyncYear,
+		RunToken:  generateRunToken(),
+	}
+	o.runningJobs[syncType] = status
+	o.mu.Unlock()
+
+	// Run sync with panic recovery — mirrors runSingleSyncInternal's goroutine below, but
+	// against the caller-supplied `service` rather than a registry lookup.
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("Sync panicked", "syncType", syncType, "panic", r)
+				endTime := time.Now()
+				panicStatus := *status
+				panicStatus.Status = statusFailed
+				panicStatus.Error = fmt.Sprintf("panic: %v", r)
+				panicStatus.EndTime = &endTime
+
+				o.mu.Lock()
+				o.lastCompletedStatus[syncType] = &panicStatus
+				delete(o.runningJobs, syncType)
+				o.mu.Unlock()
+			}
+		}()
+
+		// Independent timeout, not derived from parentCtx — see the identical comment in
+		// runSingleSyncInternal for why: a handler's own deferred cancel() must never cascade
+		// into this goroutine once the handler has responded.
+		timeout := 2 * time.Hour
+		if parentDeadline, hasDeadline := parentCtx.Deadline(); hasDeadline {
+			timeout = max(timeout, time.Until(parentDeadline))
+		}
+		syncCtx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+
+		err := service.Sync(syncCtx)
+
+		// Build completed status as a copy — never mutate the shared pointer
+		endTime := time.Now()
+		completed := *status
+		completed.EndTime = &endTime
+
+		duration := int(endTime.Sub(completed.StartTime).Seconds())
+		stats := service.GetStats()
+		stats.Duration = duration
+		completed.Summary = stats
+
+		if err != nil {
+			completed.Status = statusFailed
+			completed.Error = err.Error()
+			slog.Error("Sync failed", "syncType", syncType, "error", err)
+		} else {
+			completed.Status = statusSuccess
+			slog.Info("Sync completed successfully", "syncType", syncType,
+				"created", stats.Created, "updated", stats.Updated,
+				"deleted", stats.Deleted, "errors", stats.Errors)
+		}
+
+		o.mu.Lock()
+		o.lastCompletedStatus[syncType] = &completed
+		delete(o.runningJobs, syncType)
+		o.mu.Unlock()
+	}()
+
+	return nil
+}
+
 // MarkSyncRunning sets a sync's status to "running" without starting it.
 // Used by API handlers to ensure status is visible before the goroutine executes.
 // This prevents the race condition where the frontend polls before the status is set.

--- a/pocketbase/sync/orchestrator_test.go
+++ b/pocketbase/sync/orchestrator_test.go
@@ -20,6 +20,37 @@ type MockService struct {
 	callCount  atomic.Int32
 }
 
+// mockYearService is a Service that carries a Year field, mirroring the shape of the real
+// per-type sync structs (CamperHistorySync, StaffSkillsSync, ...) that #1881 found being
+// mutated in place on the orchestrator's registered singleton. Used to prove that
+// RunSingleSyncWithService runs the caller's own instance and never touches the registry.
+type mockYearService struct {
+	name      string
+	year      int
+	delay     time.Duration
+	shouldErr bool
+	stats     Stats
+	callCount atomic.Int32
+}
+
+func (m *mockYearService) Sync(ctx context.Context) error {
+	m.callCount.Add(1)
+	if m.delay > 0 {
+		select {
+		case <-time.After(m.delay):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	if m.shouldErr {
+		return context.DeadlineExceeded
+	}
+	return nil
+}
+
+func (m *mockYearService) Name() string    { return m.name }
+func (m *mockYearService) GetStats() Stats { return m.stats }
+
 func (m *MockService) Sync(ctx context.Context) error {
 	m.callCount.Add(1)
 
@@ -3376,4 +3407,142 @@ func TestGenerateRunToken(t *testing.T) {
 			}
 		}
 	})
+}
+
+// TestRunSingleSyncWithServiceIgnoresRegisteredSingleton pins the fix for #1881: the eleven
+// individual-sync handlers (camper_history, family_camp_derived, lodging_assignments,
+// staff_skills, financial_aid_applications, household_demographics, camper_dietary,
+// camper_transportation, quest_registrations, staff_applications, staff_vehicle_info) used to
+// fetch the orchestrator's registered singleton and mutate its Year/DryRun fields in place —
+// which let DryRun stick across runs and let concurrent requests race on Year. The fix has
+// handlers build a private, request-scoped instance and hand it to
+// RunSingleSyncWithService, which must run *that* instance and never touch (or even require)
+// a registered singleton.
+func TestRunSingleSyncWithServiceIgnoresRegisteredSingleton(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		o := NewOrchestrator(nil)
+
+		// The registered singleton, as left over from server startup. Its Year must stay at
+		// its zero-value default — a request-scoped run must never write onto shared state.
+		registered := &mockYearService{name: "test", year: 0}
+		o.RegisterService("test", registered)
+
+		// A private instance built fresh per request, carrying only this request's Year —
+		// exactly what a fixed handler does with e.g. NewCamperHistorySync(e.App).
+		requestScoped := &mockYearService{name: "test", year: 2027, stats: Stats{Created: 5}}
+
+		if err := o.RunSingleSyncWithService(context.Background(), "test", requestScoped); err != nil {
+			t.Fatalf("RunSingleSyncWithService failed: %v", err)
+		}
+
+		time.Sleep(50 * time.Millisecond)
+
+		if requestScoped.callCount.Load() != 1 {
+			t.Errorf("expected the request-scoped instance's Sync to run once, got %d",
+				requestScoped.callCount.Load())
+		}
+		if registered.callCount.Load() != 0 {
+			t.Errorf("the registered singleton must never execute for a request-scoped run, got %d calls",
+				registered.callCount.Load())
+		}
+		if registered.year != 0 {
+			t.Errorf("the registered singleton's Year must stay at its default (0), got %d", registered.year)
+		}
+
+		// Status/stats visible to pollers (e.g. SyncTab) must come from the instance that
+		// actually ran, not from the untouched registered singleton.
+		o.mu.RLock()
+		completed := o.lastCompletedStatus["test"]
+		o.mu.RUnlock()
+		if completed == nil {
+			t.Fatal("expected a completed status to be recorded")
+		}
+		if completed.Summary.Created != 5 {
+			t.Errorf("expected completed status to reflect the request-scoped instance's stats, got %+v",
+				completed.Summary)
+		}
+		if completed.Status != statusSuccess {
+			t.Errorf("expected status %q, got %q", statusSuccess, completed.Status)
+		}
+	})
+}
+
+// TestRunSingleSyncWithServiceRejectsConcurrentRunForSameType checks the simple, sequential
+// case: once a run for syncType has been reserved, a later call for the same syncType is
+// rejected outright and its service instance is never executed.
+func TestRunSingleSyncWithServiceRejectsConcurrentRunForSameType(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		o := NewOrchestrator(nil)
+
+		first := &mockYearService{name: "test", year: 2026, delay: 100 * time.Millisecond}
+		if err := o.RunSingleSyncWithService(context.Background(), "test", first); err != nil {
+			t.Fatalf("first call should succeed, got: %v", err)
+		}
+
+		second := &mockYearService{name: "test", year: 2027}
+		err := o.RunSingleSyncWithService(context.Background(), "test", second)
+		if err == nil {
+			t.Fatal("expected the second concurrent call for the same syncType to be rejected")
+		}
+		if second.callCount.Load() != 0 {
+			t.Error("a rejected call must never execute Sync on its service instance")
+		}
+
+		// Let the first run finish so its status settles.
+		time.Sleep(200 * time.Millisecond)
+		if first.callCount.Load() != 1 {
+			t.Errorf("expected the first call to have run exactly once, got %d", first.callCount.Load())
+		}
+	})
+}
+
+// TestRunSingleSyncWithServiceConcurrentCallsExactlyOneWins pins the atomicity half of
+// #1881 under real concurrency: the old per-handler pattern checked
+// orchestrator.IsRunning(syncType) and only later, unguarded, wrote fields onto the shared
+// service — the check was not atomic with the write, so two concurrent requests could both
+// pass the check. RunSingleSyncWithService reserves the run under a single lock, so however
+// many goroutines race to start the same syncType at once, exactly one may win and execute —
+// everyone else must be rejected before their service instance ever runs.
+func TestRunSingleSyncWithServiceConcurrentCallsExactlyOneWins(t *testing.T) {
+	o := NewOrchestrator(nil)
+
+	const attempts = 50
+	services := make([]*mockYearService, attempts)
+	errs := make([]error, attempts)
+
+	var start sync.WaitGroup
+	start.Add(1)
+	var done sync.WaitGroup
+	done.Add(attempts)
+
+	for i := range attempts {
+		services[i] = &mockYearService{name: "test", year: i, delay: 20 * time.Millisecond}
+		go func(i int) {
+			defer done.Done()
+			start.Wait() // release all goroutines together to maximize interleaving
+			errs[i] = o.RunSingleSyncWithService(context.Background(), "test", services[i])
+		}(i)
+	}
+	start.Done()
+	done.Wait()
+
+	wins := 0
+	for i := range attempts {
+		if errs[i] == nil {
+			wins++
+		}
+	}
+	if wins != 1 {
+		t.Errorf("expected exactly 1 winning reservation among %d concurrent attempts, got %d", attempts, wins)
+	}
+
+	// Give the winner's background goroutine time to actually invoke Sync.
+	time.Sleep(200 * time.Millisecond)
+	ranCount := 0
+	for i := range attempts {
+		ranCount += int(services[i].callCount.Load())
+	}
+	if ranCount != 1 {
+		t.Errorf("expected exactly 1 service instance to have run, got %d", ranCount)
+	}
 }


### PR DESCRIPTION
## What changed

Two halves of the same shape, per #1881.

**Backend (`pocketbase/sync/api.go`, `pocketbase/sync/orchestrator.go`):** every individual-sync
handler used to fetch the orchestrator's registered singleton via `orchestrator.GetService(syncType)`
and mutate its `Year`/`DryRun` fields in place before launching the sync in a background goroutine.
That let `DryRun` stick on the singleton after a run finished (nothing reset it — a later request
that didn't set it inherited whatever the last request chose), and let two concurrent requests race
on `Year`, because the handler's up-front `orchestrator.IsRunning(syncType)` check was never atomic
with the field writes that followed it.

Added `Orchestrator.RunSingleSyncWithService(ctx, syncType, service)`: it checks-and-reserves the run
for `syncType` under a single lock (closing the non-atomic gap), then executes exactly the `service`
instance it was handed — never looking anything up from the registry, never mutating shared state.
Each of the eleven handlers now builds a private, request-scoped instance per call
(`NewCamperHistorySync(e.App)`, etc.) with only that request's `Year`/`DryRun`, and hands it to the
new method instead of writing onto the shared singleton.

**Frontend (`frontend/src/components/admin/SyncTab.tsx`):** the generic sync card's `disabled`
condition — `isRunning || isPending || runIndividualSync.isPending || runOnDemandSync.isPending` —
never referenced any of the eleven type-specific mutation hooks, so a double-click on one of their
cards could submit a second request before status polling flipped that card to `running` (the
backend already returned 409 for the overlap — this was a UX gap, not a correctness one). Added a
single `typeSyncPendingById` lookup keyed by `syncType.id`, so a future twelfth type-specific hook
needs one map entry, not a new clause at the `disabled=` call site.

## Enumerated handlers (11, confirmed by grep against the tree — matches the issue's count)

1. `handleCamperHistorySync` — `camper_history`
2. `handleFamilyCampDerivedSync` — `family_camp_derived`
3. `handleLodgingAssignmentsSync` — `lodging_assignments`
4. `handleStaffSkillsSync` — `staff_skills`
5. `handleFinancialAidApplicationsSync` — `financial_aid_applications`
6. `handleHouseholdDemographicsSync` — `household_demographics`
7. `handleCamperDietarySync` — `camper_dietary`
8. `handleCamperTransportationSync` — `camper_transportation`
9. `handleQuestRegistrationsSync` — `quest_registrations`
10. `handleStaffApplicationsSync` — `staff_applications`
11. `handleStaffVehicleInfoSync` — `staff_vehicle_info`

All eleven changed identically. The frontend's `typeSyncPendingById` map has one entry per handler
above (11 entries) — same one-to-one correspondence the codebase already has between backend
handlers and `SyncTab`'s per-type mutation hooks.

Explicitly **not** touched, and not part of #1881's eleven: `handleIndividualSync` (generic,
year-from-env path shared by the source-phase syncs), `handlePersonCustomFieldValuesSync` /
`handleHouseholdCustomFieldValuesSync` (already use the `MarkSyncRunning` pre-reservation pattern),
and `handleFinancialTransactionsSync` (source-phase, uses a CampMinder client, not in the issue's
list).

## Why

Per #1881: fixing one sync type and leaving the other ten on the old pattern would have made the
inconsistency worse, not better — the whole reason this was filed rather than folded into #1880.

## How verified

**Go, TDD with mutation-check** (`pocketbase/sync/orchestrator_test.go`):
- Wrote 3 failing tests first against the not-yet-existing `RunSingleSyncWithService` — confirmed
  compile-error red (`exit=1`).
- Implemented the method; all 3 went green (`exit=0`).
- Mutation-checked each: reintroduced the exact bug each test claims to pin (ran the registered
  singleton instead of the passed instance; split the atomic check-and-reserve back into two lock
  acquisitions with the gap widened to make the race deterministic) — each mutation drove its test
  red, then was reverted and reconfirmed green.
- `go build ./...`: `exit=0`
- `go vet ./sync/...`: `exit=0`
- `go test ./sync/... -count=1`: `exit=0` (full package, 41.8s)
- `go test ./sync/... -race -count=1 -run TestRunSingleSyncWithService`: `exit=0` (no data races)
- `rtk proxy golangci-lint run ./...` (not in pre-push, run manually per the extra gate): `exit=0`,
  "0 issues."

**Frontend, TDD with mutation-check** (`frontend/src/components/admin/SyncTab.test.tsx`, new file —
no prior test existed for this component):
- Wrote 2 failing tests first (mocking all SyncTab hooks, marking `camper_dietary`'s mutation
  pending) — confirmed red (`exit=1`, the Dietary card's Run button was not disabled).
- Implemented `typeSyncPendingById`; both went green (`exit=0`).
- Mutation-checked: reverted the `disabled=` wiring to the pre-fix expression — test went red again
  (`exit=1`) — then restored.
- `./node_modules/.bin/tsc --noEmit`: `exit=0`
- `./node_modules/.bin/eslint src/components/admin/SyncTab.tsx src/components/admin/SyncTab.test.tsx`:
  `exit=0`
- `./node_modules/.bin/vitest run src/components/admin/`: `exit=0` (33 files, 495 tests)
- `./node_modules/.bin/vitest run` (full suite): `exit=0` (415 files, 5913 tests)

**Full pre-push hook** (mypy, tsc, go build, ruff, shellcheck, pb-js-lint, mockable pytest): all
green, `exit=0`. Push confirmed landed via `git fetch -q && git rev-list --count
origin/feature/run-scoped-sync-1881..HEAD` → `0`.

Closes #1881.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
