### PR TITLE
fix(frontend): a11y interaction gaps in metrics pages

### DIFF
--- a/frontend/src/pages/metrics/registration/SessionAvailability.test.tsx
+++ b/frontend/src/pages/metrics/registration/SessionAvailability.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter } from 'react-router'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
@@ -588,7 +589,7 @@ describe('SessionAvailability', () => {
     })
 
     // Find the WL pill (shows "3" as the total count)
-    const pill = screen.getByText('3', { selector: 'span.inline-flex' })
+    const pill = screen.getByText('3', { selector: 'button.inline-flex' })
     fireEvent.mouseEnter(pill)
 
     await waitFor(() => {
@@ -599,6 +600,111 @@ describe('SessionAvailability', () => {
 
     await waitFor(() => {
       expect(screen.queryByText(/3 girls waitlisted/)).not.toBeInTheDocument()
+    })
+  })
+
+  // #2100-series a11y sweep: the WL pill was a <span onClick> with no keyboard
+  // path at all. It is now a real <button>, so Tab reaches it and Enter/Space
+  // fire the same drilldown as a mouse click — for free, from the browser.
+  it('opens the drilldown via keyboard (Enter) on the WL pill', async () => {
+    const interactionResponse = {
+      sessions: [
+        {
+          session_cm_id: 1001,
+          session_name: 'Session 1',
+          session_type: 'main',
+          sort_order: 0,
+          girls: {
+            min_grade: 2,
+            max_grade: 10,
+            enrolled: 50,
+            waitlisted: 5,
+            capacity: 50,
+            status: 'full',
+            waitlisted_by_grade: { 4: 3, 6: 2 },
+            waitlisted_persons: [],
+          },
+          boys: {
+            min_grade: 2,
+            max_grade: 10,
+            enrolled: 40,
+            waitlisted: 0,
+            capacity: 50,
+            status: 'open',
+            waitlisted_by_grade: {},
+            waitlisted_persons: [],
+          },
+        },
+      ],
+      ag_sessions: [],
+      teen_sessions: [],
+      limited_threshold: 80,
+    }
+
+    // The DrillDownModal that opens on click/keypress fetches its own attendee
+    // list — respond to that call distinctly so it doesn't choke on the
+    // session-availability shape (`res.json()` there must resolve to an array).
+    mockFetch.mockImplementation(async (url: string) => {
+      if (String(url).includes('/api/metrics/drilldown')) {
+        return { ok: true, json: async () => [] }
+      }
+      return { ok: true, json: async () => interactionResponse }
+    })
+    renderWithProviders(<SessionAvailability />)
+    await waitFor(() => expect(screen.getByText('Session 1')).toBeInTheDocument())
+
+    const pill = screen.getByRole('button', { name: '5' })
+    pill.focus()
+    await userEvent.keyboard('{Enter}')
+
+    await waitFor(() => {
+      const drilldownCall = mockFetch.mock.calls
+        .map((c) => String(c[0]))
+        .find((u) => u.includes('/api/metrics/drilldown'))
+      expect(drilldownCall).toBeDefined()
+    })
+  })
+
+  it('opens the drilldown via keyboard (Space) on the AG WL pill', async () => {
+    const interactionResponse = {
+      sessions: [],
+      ag_sessions: [
+        {
+          session_cm_id: 2001,
+          session_name: 'AG Session 2',
+          parent_session_name: 'Session 2',
+          min_grade: 4,
+          max_grade: 10,
+          enrolled: 10,
+          waitlisted: 6,
+          capacity: 24,
+          status: 'open',
+          waitlisted_by_grade: {},
+          waitlisted_persons: [],
+        },
+      ],
+      teen_sessions: [],
+      limited_threshold: 80,
+    }
+
+    mockFetch.mockImplementation(async (url: string) => {
+      if (String(url).includes('/api/metrics/drilldown')) {
+        return { ok: true, json: async () => [] }
+      }
+      return { ok: true, json: async () => interactionResponse }
+    })
+    renderWithProviders(<SessionAvailability />)
+    await waitFor(() => expect(screen.getByText('AG Session 2')).toBeInTheDocument())
+
+    const pill = screen.getByRole('button', { name: '6' })
+    pill.focus()
+    await userEvent.keyboard(' ')
+
+    await waitFor(() => {
+      const drilldownCall = mockFetch.mock.calls
+        .map((c) => String(c[0]))
+        .find((u) => u.includes('/api/metrics/drilldown'))
+      expect(drilldownCall).toBeDefined()
     })
   })
 
@@ -706,7 +812,7 @@ describe('SessionAvailability', () => {
     })
 
     // WL pill always has cursor-pointer (always opens drilldown)
-    const pill = screen.getByText('3', { selector: 'span.inline-flex' })
+    const pill = screen.getByText('3', { selector: 'button.inline-flex' })
     expect(pill).toHaveClass('cursor-pointer')
   })
 
@@ -798,7 +904,7 @@ describe('SessionAvailability', () => {
 
     await waitFor(() => expect(screen.getByText('SCIT')).toBeInTheDocument())
 
-    fireEvent.click(screen.getByText('4', { selector: 'span.inline-flex' }))
+    fireEvent.click(screen.getByText('4', { selector: 'button.inline-flex' }))
 
     await waitFor(() => {
       const drilldownCall = mockFetch.mock.calls

--- a/frontend/src/pages/metrics/registration/SessionAvailability.tsx
+++ b/frontend/src/pages/metrics/registration/SessionAvailability.tsx
@@ -146,7 +146,8 @@ function SessionRow({
       {/* WL pill column */}
       <td className="border-border/50 min-w-[2.5rem] border px-2 py-2 text-center">
         {hasWaitlist ? (
-          <span
+          <button
+            type="button"
             className="inline-flex cursor-pointer items-center justify-center rounded-full border border-amber-400 bg-amber-50 px-1.5 text-[10px] font-bold text-amber-800 dark:border-amber-600 dark:bg-amber-900/30 dark:text-amber-400"
             onMouseEnter={(e) =>
               onHover?.(e, genderData.waitlisted, gender, genderData.waitlisted_persons)
@@ -164,7 +165,7 @@ function SessionRow({
             }
           >
             {genderData.waitlisted}
-          </span>
+          </button>
         ) : (
           <span className="text-muted-foreground">&mdash;</span>
         )}
@@ -230,7 +231,8 @@ function AGSessionRow({
       {/* WL pill column */}
       <td className="border-border/50 min-w-[2.5rem] border px-2 py-2 text-center">
         {hasWaitlist ? (
-          <span
+          <button
+            type="button"
             className="inline-flex cursor-pointer items-center justify-center rounded-full border border-amber-400 bg-amber-50 px-1.5 text-[10px] font-bold text-amber-800 dark:border-amber-600 dark:bg-amber-900/30 dark:text-amber-400"
             onMouseEnter={(e) => onHover?.(e, session.waitlisted, '', session.waitlisted_persons)}
             onMouseMove={(e) => onMove?.(e)}
@@ -240,7 +242,7 @@ function AGSessionRow({
             }
           >
             {session.waitlisted}
-          </span>
+          </button>
         ) : (
           <span className="text-muted-foreground">&mdash;</span>
         )}
@@ -300,7 +302,8 @@ function TeenSessionRow({
       {/* WL pill column */}
       <td className="border-border/50 min-w-[2.5rem] border px-2 py-2 text-center">
         {hasWaitlist ? (
-          <span
+          <button
+            type="button"
             className="inline-flex cursor-pointer items-center justify-center rounded-full border border-amber-400 bg-amber-50 px-1.5 text-[10px] font-bold text-amber-800 dark:border-amber-600 dark:bg-amber-900/30 dark:text-amber-400"
             onMouseEnter={(e) => onHover?.(e, session.waitlisted, '', session.waitlisted_persons)}
             onMouseMove={(e) => onMove?.(e)}
@@ -308,7 +311,7 @@ function TeenSessionRow({
             onClick={() => onTeenCellClick?.(session.session_type, session.session_name)}
           >
             {session.waitlisted}
-          </span>
+          </button>
         ) : (
           <span className="text-muted-foreground">&mdash;</span>
         )}

--- a/frontend/src/pages/metrics/trends/CancellationVelocityPage.tsx
+++ b/frontend/src/pages/metrics/trends/CancellationVelocityPage.tsx
@@ -432,8 +432,14 @@ export default function CancellationVelocityPage() {
         {useDailyChart
           ? chartData.dailyZoomMilestones.length > 0 && (
               <div className="mb-3 flex flex-wrap items-center gap-3 text-sm">
-                <label className="text-muted-foreground text-xs font-medium">Zoom:</label>
+                <label
+                  htmlFor="cancellation-daily-zoom-start"
+                  className="text-muted-foreground text-xs font-medium"
+                >
+                  Zoom:
+                </label>
                 <select
+                  id="cancellation-daily-zoom-start"
                   className="border-border bg-card text-foreground rounded border px-2 py-1 text-xs"
                   value={dailyZoom.zoomRange?.[0] ?? 0}
                   onChange={(e) => {
@@ -476,8 +482,14 @@ export default function CancellationVelocityPage() {
             )
           : chartData.weeklyChartData.length > 0 && (
               <div className="mb-3 flex flex-wrap items-center gap-3 text-sm">
-                <label className="text-muted-foreground text-xs font-medium">Zoom:</label>
+                <label
+                  htmlFor="cancellation-weekly-zoom-start"
+                  className="text-muted-foreground text-xs font-medium"
+                >
+                  Zoom:
+                </label>
                 <select
+                  id="cancellation-weekly-zoom-start"
                   className="border-border bg-card text-foreground rounded border px-2 py-1 text-xs"
                   value={weeklyZoom.zoomRange?.[0] ?? 0}
                   onChange={(e) => {

--- a/frontend/src/pages/metrics/trends/VelocityPage.tsx
+++ b/frontend/src/pages/metrics/trends/VelocityPage.tsx
@@ -482,8 +482,14 @@ export default function VelocityPage() {
         {viewMode === 'delta'
           ? chartData.weeklyChartData.length > 0 && (
               <div className="mb-3 flex flex-wrap items-center gap-3 text-sm">
-                <label className="text-muted-foreground text-xs font-medium">Zoom:</label>
+                <label
+                  htmlFor="velocity-weekly-zoom-start"
+                  className="text-muted-foreground text-xs font-medium"
+                >
+                  Zoom:
+                </label>
                 <select
+                  id="velocity-weekly-zoom-start"
                   className="border-border bg-card text-foreground rounded border px-2 py-1 text-xs"
                   value={weeklyZoom.zoomRange?.[0] ?? 0}
                   onChange={(e) => {
@@ -526,8 +532,14 @@ export default function VelocityPage() {
             )
           : chartData.dailyZoomMilestones.length > 0 && (
               <div className="mb-3 flex flex-wrap items-center gap-3 text-sm">
-                <label className="text-muted-foreground text-xs font-medium">Zoom:</label>
+                <label
+                  htmlFor="velocity-daily-zoom-start"
+                  className="text-muted-foreground text-xs font-medium"
+                >
+                  Zoom:
+                </label>
                 <select
+                  id="velocity-daily-zoom-start"
                   className="border-border bg-card text-foreground rounded border px-2 py-1 text-xs"
                   value={dailyZoom.zoomRange?.[0] ?? 0}
                   onChange={(e) => {


### PR DESCRIPTION
## Summary

One file-disjoint chunk of the jsx-a11y backlog sweep (10 of the tree's 133 warnings), scoped to the metrics pages:

- `frontend/src/pages/metrics/registration/SessionAvailability.tsx`
- `frontend/src/pages/metrics/trends/CancellationVelocityPage.tsx`
- `frontend/src/pages/metrics/trends/VelocityPage.tsx`

**Before → after: 10 → 0** jsx-a11y warnings in this chunk. **10 fixed, 0 suppressed.**

```
./node_modules/.bin/eslint <chunk files>   # before: 10 jsx-a11y warnings, after: 0
```

## What changed

### `SessionAvailability.tsx` — 6 warnings (`click-events-have-key-events` × 3, `no-static-element-interactions` × 3)

The waitlist-total "WL pill" — a clickable badge that opens a drilldown modal on click and shows a tooltip on hover — was a `<span onClick>` with no keyboard path at all. Following the house pattern from #2094/#2095 (move the handler onto a real interactive element rather than bolting `role="button"` + `tabIndex` + `onKeyDown` onto a non-interactive one), converted all three row variants that render this pill — `SessionRow` (main/embedded sessions), `AGSessionRow`, `TeenSessionRow` — from `<span>` to `<button type="button">`, keeping the same classes/handlers. Tab now reaches it and Enter/Space fire the same drilldown as a click, for free, from the browser.

Note: the per-grade `<td onClick>` cells in the same file are *not* touched — they weren't flagged by the linter (table cells have an exception here) and are out of this chunk's 10.

### `CancellationVelocityPage.tsx` + `VelocityPage.tsx` — 2 warnings each (`label-has-associated-control`)

Both pages have an identical "Zoom:" `<label>` in front of a pair of `<select>` elements (start/end of a chart zoom range, joined by "to") with no `htmlFor`/`id` association. Associated each label with the range's *start* `<select>` via `htmlFor`/`id` (e.g. `cancellation-daily-zoom-start`, `velocity-weekly-zoom-start`). Both daily and weekly variants in both files get the identical treatment since they're siblings by design.

## Suppressions

None. All 10 warnings got a real fix — no `eslint-disable` added.

## Tests

TDD for the behavioural change: added two new tests to `SessionAvailability.test.tsx` that were written and verified failing *before* the `<button>` conversion — Enter and Space on the WL pill now trigger the drilldown fetch (they couldn't before; there was no keyboard event listener). Updated three pre-existing tests whose `getByText(..., { selector: 'span.inline-flex' })` queries needed to become `'button.inline-flex'` to match the new element — same assertions, no behavior change. The label fixes are purely structural (`htmlFor`/`id`) and needed no new tests.

Full `vitest run`: **6013 backend pytest / 5930 frontend tests green**, one pre-existing unrelated flake (`eslintA11yLayering.guard.test.ts`, a 5s timeout under full-suite parallel load — it tests `eslint.config.js`, which this PR never touches, and passes cleanly standalone).

## Verification

- `./node_modules/.bin/eslint <chunk files>`: 10 → 0 jsx-a11y warnings (1 pre-existing, out-of-scope `@typescript-eslint/no-unnecessary-condition` warning remains in `VelocityPage.tsx`, untouched per campaign rules)
- `./node_modules/.bin/eslint src`: 0 errors tree-wide (500 warnings, unrelated to this chunk)
- `./node_modules/.bin/tsc --noEmit`: clean
- `./node_modules/.bin/prettier --check`: clean
- Pre-push hooks all green: ruff, go-build, pb-js-lint, shellcheck, markdownlint, api-types-freshness, mypy, pytest, type-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
