### PR TITLE
fix(frontend): a11y interaction gaps in admin debug ui

### DIFF
--- a/frontend/src/components/admin/ProcessRequestOptions.tsx
+++ b/frontend/src/components/admin/ProcessRequestOptions.tsx
@@ -118,9 +118,9 @@ export default function ProcessRequestOptions({
             <Brain className="h-5 w-5 text-teal-600 dark:text-teal-400" />
           </div>
           <div>
-            <h2 className="font-display text-lg font-semibold" role="heading" aria-level={2}>
-              Process Requests
-            </h2>
+            {/* <h2> already implies role="heading" aria-level="2" — the explicit
+                props were redundant. */}
+            <h2 className="font-display text-lg font-semibold">Process Requests</h2>
             <p className="text-muted-foreground text-sm">
               Process original bunk requests with AI parsing
             </p>
@@ -152,9 +152,11 @@ export default function ProcessRequestOptions({
             </div>
           </div>
 
-          {/* Source Fields */}
-          <div>
-            <label className="mb-1.5 block text-sm font-medium">Source Fields</label>
+          {/* Source Fields — fieldset/legend, not a <label>, because the
+              caption applies to a whole group of checkboxes rather than one
+              associable control. */}
+          <fieldset className="m-0 min-w-0 border-0 p-0">
+            <legend className="mb-1.5 block text-sm font-medium">Source Fields</legend>
             <p className="text-muted-foreground mb-2 text-xs">
               Filter by field type (empty = all fields)
             </p>
@@ -173,7 +175,7 @@ export default function ProcessRequestOptions({
                 </label>
               ))}
             </div>
-          </div>
+          </fieldset>
 
           {/* Limit Input */}
           <div>
@@ -226,7 +228,10 @@ export default function ProcessRequestOptions({
             )}
           </div>
 
-          {/* Collect Traces Checkbox */}
+          {/* Collect Traces Checkbox — the visible text sits two levels below
+              the label's wrapped <div>, past the a11y linter's nesting-depth
+              check, so the checkbox also carries an aria-label mirroring it
+              (matching the per-field checkboxes above). */}
           <label className="group flex cursor-pointer items-center gap-3">
             <input
               type="checkbox"
@@ -234,6 +239,7 @@ export default function ProcessRequestOptions({
               onChange={(e) => setCollectTraces(e.target.checked)}
               disabled={isProcessing}
               className="border-border text-primary focus:ring-primary/30 h-4 w-4 rounded focus:ring-offset-0 disabled:opacity-50"
+              aria-label="Collect pipeline traces"
             />
             <div>
               <span className="group-hover:text-foreground text-sm font-medium transition-colors">
@@ -245,9 +251,11 @@ export default function ProcessRequestOptions({
             </div>
           </label>
 
-          {/* Debug/Trace Checkboxes */}
-          <div className="space-y-3">
-            <label className="block text-sm font-medium">Logging Level</label>
+          {/* Debug/Trace Checkboxes — fieldset/legend, not a <label>, because
+              the caption applies to the pair of mutually exclusive
+              checkboxes below rather than one associable control. */}
+          <fieldset className="m-0 min-w-0 space-y-3 border-0 p-0">
+            <legend className="block text-sm font-medium">Logging Level</legend>
             <div className="flex gap-6">
               <label className="group flex cursor-pointer items-center gap-2">
                 <input
@@ -280,7 +288,7 @@ export default function ProcessRequestOptions({
               Debug: AI prompts & resolution details. Trace: Very verbose (API params, SDK
               internals)
             </p>
-          </div>
+          </fieldset>
         </div>
 
         {/* Actions */}

--- a/frontend/src/components/admin/RolesTab.tsx
+++ b/frontend/src/components/admin/RolesTab.tsx
@@ -170,8 +170,11 @@ export function RolesTab() {
           </h3>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div>
-              <label className="text-foreground mb-1 block text-sm font-medium">Name</label>
+              <label htmlFor="role-name" className="text-foreground mb-1 block text-sm font-medium">
+                Name
+              </label>
               <input
+                id="role-name"
                 type="text"
                 value={formData.name}
                 onChange={(e) => setFormData((p) => ({ ...p, name: e.target.value }))}
@@ -180,8 +183,11 @@ export function RolesTab() {
               />
             </div>
             <div>
-              <label className="text-foreground mb-1 block text-sm font-medium">Slug</label>
+              <label htmlFor="role-slug" className="text-foreground mb-1 block text-sm font-medium">
+                Slug
+              </label>
               <input
+                id="role-slug"
                 type="text"
                 value={formData.slug}
                 onChange={(e) => setFormData((p) => ({ ...p, slug: e.target.value }))}
@@ -192,8 +198,14 @@ export function RolesTab() {
             </div>
           </div>
           <div>
-            <label className="text-foreground mb-1 block text-sm font-medium">Description</label>
+            <label
+              htmlFor="role-description"
+              className="text-foreground mb-1 block text-sm font-medium"
+            >
+              Description
+            </label>
             <input
+              id="role-description"
               type="text"
               value={formData.description}
               onChange={(e) => setFormData((p) => ({ ...p, description: e.target.value }))}
@@ -201,12 +213,15 @@ export function RolesTab() {
               placeholder="What this role is for"
             />
           </div>
-          <div>
-            <label className="text-foreground mb-2 block text-sm font-medium">Permissions</label>
+          {/* A fieldset/legend, not a <label> — "Permissions" captions a group of
+              toggle buttons, not a single associable control. */}
+          <fieldset className="m-0 min-w-0 border-0 p-0">
+            <legend className="text-foreground mb-2 block text-sm font-medium">Permissions</legend>
             <div className="flex flex-wrap gap-2">
               {ALL_PERMISSIONS.map((perm) => (
                 <button
                   key={perm}
+                  type="button"
                   onClick={() => togglePermission(perm)}
                   className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors ${
                     formData.permissions.includes(perm)
@@ -218,7 +233,7 @@ export function RolesTab() {
                 </button>
               ))}
             </div>
-          </div>
+          </fieldset>
           <div className="flex items-center gap-2">
             <button
               onClick={handleSave}

--- a/frontend/src/components/admin/ScaleGuideSidebar.tsx
+++ b/frontend/src/components/admin/ScaleGuideSidebar.tsx
@@ -210,12 +210,16 @@ export function ScaleGuideSidebar({ activeCategory }: ScaleGuideSidebarProps) {
         </div>
       </div>
 
-      {/* Backdrop for mobile */}
+      {/* Backdrop for mobile — decorative click-to-dismiss surface, aria-hidden
+          because the header's X button (above) is already a real, keyboard-
+          reachable way to close the sidebar; this div adds nothing for
+          keyboard/AT users beyond that (matches ui/Modal.tsx's own backdrop). */}
       {isOpen && (
         <div
           className="fixed inset-0 z-20 bg-black/20 lg:hidden"
           style={{ top: '64px' }}
           onClick={() => setIsOpen(false)}
+          aria-hidden="true"
         />
       )}
     </>

--- a/frontend/src/components/admin/geo/CanonicalReferenceList.tsx
+++ b/frontend/src/components/admin/geo/CanonicalReferenceList.tsx
@@ -227,45 +227,52 @@ function CanonicalRow({
   return (
     <div
       data-testid="canonical-row"
-      className={`border-border cursor-pointer rounded-md border ${dimmed ? 'opacity-50' : ''}`}
-      onClick={onToggle}
+      className={`border-border rounded-md border ${dimmed ? 'opacity-50' : ''}`}
     >
-      {/* Collapsed row */}
-      <div className="hover:bg-muted/50 flex w-full items-center gap-2 px-3 py-2 text-left transition-colors">
-        <span
-          data-testid="canonical-name"
-          className="text-foreground min-w-0 flex-1 truncate text-sm"
+      {/* Collapsed row — the toggle affordance is a real <button> wrapping the
+          name/badges (kindred#2063 pattern), not a click handler on this
+          `<div>`. The Merge button is a sibling rather than nested inside it,
+          since a <button> can't contain another button. */}
+      <div className="hover:bg-muted/50 flex w-full items-center gap-2 transition-colors">
+        <button
+          type="button"
+          onClick={onToggle}
+          className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 px-3 py-2 text-left"
         >
-          {entry.canonical_name}
-        </span>
-
-        {/* Location badge */}
-        {(entry.city || entry.state || entry.country) && (
           <span
-            className={`shrink-0 rounded bg-stone-100 px-1.5 py-0.5 text-xs text-stone-600 dark:bg-stone-800 dark:text-stone-400 ${
-              entry.source === 'suggested' ? 'italic' : ''
-            }`}
+            data-testid="canonical-name"
+            className="text-foreground min-w-0 flex-1 truncate text-sm"
           >
-            {formatLocation(entry.city, entry.state, entry.country, entry.canonical_name) ||
-              entry.state}
+            {entry.canonical_name}
           </span>
-        )}
 
-        {/* Source badge */}
-        <span
-          data-testid="source-badge"
-          className={`shrink-0 rounded px-1.5 py-0.5 text-xs font-medium ${sourceBadgeClasses(entry.source)}`}
-        >
-          {sourceLabel(entry.source)}
-        </span>
+          {/* Location badge */}
+          {(entry.city || entry.state || entry.country) && (
+            <span
+              className={`shrink-0 rounded bg-stone-100 px-1.5 py-0.5 text-xs text-stone-600 dark:bg-stone-800 dark:text-stone-400 ${
+                entry.source === 'suggested' ? 'italic' : ''
+              }`}
+            >
+              {formatLocation(entry.city, entry.state, entry.country, entry.canonical_name) ||
+                entry.state}
+            </span>
+          )}
+
+          {/* Source badge */}
+          <span
+            data-testid="source-badge"
+            className={`shrink-0 rounded px-1.5 py-0.5 text-xs font-medium ${sourceBadgeClasses(entry.source)}`}
+          >
+            {sourceLabel(entry.source)}
+          </span>
+        </button>
 
         {/* Merge button */}
         {onMerge && (
           <button
             type="button"
             className="text-muted-foreground hover:text-forest-700 hover:bg-forest-100 dark:hover:text-forest-400 dark:hover:bg-forest-800 shrink-0 rounded p-1 transition-colors"
-            onClick={(e) => {
-              e.stopPropagation()
+            onClick={() => {
               onMerge(entry)
             }}
             aria-label="Merge canonical"
@@ -275,7 +282,7 @@ function CanonicalRow({
         )}
 
         {/* Camper count */}
-        <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
+        <span className="text-muted-foreground shrink-0 pr-3 text-xs tabular-nums">
           {entry.camper_count}
         </span>
       </div>

--- a/frontend/src/components/admin/geo/MergeDialog.tsx
+++ b/frontend/src/components/admin/geo/MergeDialog.tsx
@@ -90,6 +90,9 @@ export function MergeDialog({ open, onClose, sourceCanonical, category, year }: 
             }}
             placeholder="Search canonicals..."
             className="bg-muted/50 border-border focus:ring-forest-500 w-full rounded-lg border py-2 pr-4 pl-10 text-sm focus:ring-2 focus:outline-none"
+            // Deliberate: this dialog's entire purpose is searching for a merge target, so
+            // taking focus on open lets the user start typing immediately.
+            // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus
           />
         </div>

--- a/frontend/src/components/admin/geo/ResolveDialog.tsx
+++ b/frontend/src/components/admin/geo/ResolveDialog.tsx
@@ -207,6 +207,10 @@ export function ResolveDialog({
               }}
               placeholder="Search existing entries..."
               className="bg-muted/50 border-border focus:ring-forest-500 w-full rounded-lg border py-2 pr-4 pl-10 text-sm focus:ring-2 focus:outline-none"
+              // Deliberate: this dialog's entire purpose is searching for a canonical to
+              // resolve the gap into, so taking focus on open lets the user start typing
+              // immediately.
+              // eslint-disable-next-line jsx-a11y/no-autofocus
               autoFocus
             />
           </div>
@@ -319,6 +323,10 @@ export function ResolveDialog({
               value={newCanonicalName}
               onChange={(e) => setNewCanonicalName(e.target.value)}
               className="bg-muted/50 border-border focus:ring-forest-500 w-full rounded-lg border px-3 py-2 text-sm focus:ring-2 focus:outline-none"
+              // Deliberate: this form only appears once the user has chosen "Create new",
+              // so taking focus on the Name field lets them start typing immediately
+              // instead of re-clicking into it.
+              // eslint-disable-next-line jsx-a11y/no-autofocus
               autoFocus
             />
           </div>

--- a/frontend/src/components/admin/geo/__tests__/CanonicalReferenceList.test.tsx
+++ b/frontend/src/components/admin/geo/__tests__/CanonicalReferenceList.test.tsx
@@ -186,7 +186,10 @@ describe('CanonicalReferenceList', () => {
 
     // Click first row to expand
     const rows = screen.getAllByTestId('canonical-row')
-    await user.click(rows[0]!)
+    // The toggle affordance is a real <button> wrapping the row's name/badges
+    // (kindred#2063 pattern) rather than a click handler on the row `<div>`
+    // itself, so the click targets the name inside it.
+    await user.click(within(rows[0]!).getByTestId('canonical-name'))
 
     // Source variants shown
     expect(screen.getByText('Riverside Elem')).toBeInTheDocument()
@@ -195,6 +198,37 @@ describe('CanonicalReferenceList', () => {
     // Confidence %
     expect(screen.getByText('92%')).toBeInTheDocument()
     expect(screen.getByText('100%')).toBeInTheDocument()
+  })
+
+  // Row expansion used to be a click handler on a non-interactive `<div>`
+  // (kindred#2063-style gap: no keyboard listener at all). It is now a real
+  // <button>, so Tab + Enter reaches and activates it for free.
+  it('expands a row via keyboard (Tab + Enter reaches the row toggle button)', async () => {
+    mockUseCanonicalSources.mockReturnValue({
+      data: {
+        canonical_name: 'Riverside Elementary',
+        city: 'Oakland',
+        state: 'CA',
+        country: '',
+        sources: [
+          { original_value: 'Riverside Elem', count: 7, confidence: 0.92, state_distribution: {} },
+        ],
+      },
+      isLoading: false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+
+    const user = userEvent.setup()
+    render(<CanonicalReferenceList category="school" year={2025} onReassignSource={vi.fn()} />)
+
+    const rows = screen.getAllByTestId('canonical-row')
+    const toggleButton = within(rows[0]!).getByTestId('canonical-name').closest('button')
+    expect(toggleButton).not.toBeNull()
+
+    toggleButton!.focus()
+    await user.keyboard('{Enter}')
+
+    expect(screen.getByText('Source Variants')).toBeInTheDocument()
   })
 
   // ---------- [Fix] button ----------
@@ -225,7 +259,10 @@ describe('CanonicalReferenceList', () => {
 
     // Expand the first row
     const rows = screen.getAllByTestId('canonical-row')
-    await user.click(rows[0]!)
+    // The toggle affordance is a real <button> wrapping the row's name/badges
+    // (kindred#2063 pattern) rather than a click handler on the row `<div>`
+    // itself, so the click targets the name inside it.
+    await user.click(within(rows[0]!).getByTestId('canonical-name'))
 
     // Only one Fix button (for the 0.92 confidence match)
     const fixButtons = screen.getAllByRole('button', { name: /fix/i })
@@ -256,7 +293,10 @@ describe('CanonicalReferenceList', () => {
 
     // Expand the first row
     const rows = screen.getAllByTestId('canonical-row')
-    await user.click(rows[0]!)
+    // The toggle affordance is a real <button> wrapping the row's name/badges
+    // (kindred#2063 pattern) rather than a click handler on the row `<div>`
+    // itself, so the click targets the name inside it.
+    await user.click(within(rows[0]!).getByTestId('canonical-name'))
 
     // Click Fix button
     await user.click(screen.getByRole('button', { name: /fix/i }))
@@ -371,7 +411,10 @@ describe('CanonicalReferenceList', () => {
     render(<CanonicalReferenceList category="school" year={2025} onReassignSource={vi.fn()} />)
 
     const rows = screen.getAllByTestId('canonical-row')
-    await user.click(rows[0]!)
+    // The toggle affordance is a real <button> wrapping the row's name/badges
+    // (kindred#2063 pattern) rather than a click handler on the row `<div>`
+    // itself, so the click targets the name inside it.
+    await user.click(within(rows[0]!).getByTestId('canonical-name'))
 
     // Source variants should appear
     expect(screen.getByText('Source Variants')).toBeInTheDocument()
@@ -470,7 +513,10 @@ describe('CanonicalReferenceList', () => {
 
     // Expand the suggested row
     const rows = screen.getAllByTestId('canonical-row')
-    await user.click(rows[0]!)
+    // The toggle affordance is a real <button> wrapping the row's name/badges
+    // (kindred#2063 pattern) rather than a click handler on the row `<div>`
+    // itself, so the click targets the name inside it.
+    await user.click(within(rows[0]!).getByTestId('canonical-name'))
 
     expect(screen.getByRole('button', { name: /approve/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /reject/i })).toBeInTheDocument()
@@ -501,7 +547,10 @@ describe('CanonicalReferenceList', () => {
 
     // Expand an nces entry (first in popular sort)
     const rows = screen.getAllByTestId('canonical-row')
-    await user.click(rows[0]!)
+    // The toggle affordance is a real <button> wrapping the row's name/badges
+    // (kindred#2063 pattern) rather than a click handler on the row `<div>`
+    // itself, so the click targets the name inside it.
+    await user.click(within(rows[0]!).getByTestId('canonical-name'))
 
     expect(screen.queryByRole('button', { name: /approve/i })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /reject/i })).not.toBeInTheDocument()
@@ -550,7 +599,10 @@ describe('CanonicalReferenceList', () => {
     )
 
     const rows = screen.getAllByTestId('canonical-row')
-    await user.click(rows[0]!)
+    // The toggle affordance is a real <button> wrapping the row's name/badges
+    // (kindred#2063 pattern) rather than a click handler on the row `<div>`
+    // itself, so the click targets the name inside it.
+    await user.click(within(rows[0]!).getByTestId('canonical-name'))
     await user.click(screen.getByRole('button', { name: /approve/i }))
 
     expect(onApprove).toHaveBeenCalledWith(suggestedEntry)
@@ -599,7 +651,10 @@ describe('CanonicalReferenceList', () => {
     )
 
     const rows = screen.getAllByTestId('canonical-row')
-    await user.click(rows[0]!)
+    // The toggle affordance is a real <button> wrapping the row's name/badges
+    // (kindred#2063 pattern) rather than a click handler on the row `<div>`
+    // itself, so the click targets the name inside it.
+    await user.click(within(rows[0]!).getByTestId('canonical-name'))
     await user.click(screen.getByRole('button', { name: /reject/i }))
 
     expect(onReject).toHaveBeenCalledWith(suggestedEntry)
@@ -683,7 +738,10 @@ describe('CanonicalReferenceList', () => {
     render(<CanonicalReferenceList category="school" year={2025} onReassignSource={vi.fn()} />)
 
     const rows = screen.getAllByTestId('canonical-row')
-    await user.click(rows[0]!)
+    // The toggle affordance is a real <button> wrapping the row's name/badges
+    // (kindred#2063 pattern) rather than a click handler on the row `<div>`
+    // itself, so the click targets the name inside it.
+    await user.click(within(rows[0]!).getByTestId('canonical-name'))
 
     expect(screen.getByText('Inferred: Portland, OR')).toBeInTheDocument()
   })

--- a/frontend/src/components/debug/ParseAnalysisGroupedList.test.tsx
+++ b/frontend/src/components/debug/ParseAnalysisGroupedList.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { ParseAnalysisGroupedList } from './ParseAnalysisGroupedList'
+import type { CamperGroupedRequests } from './types'
+
+const campers: CamperGroupedRequests[] = [
+  {
+    requester_cm_id: 1001,
+    requester_name: 'Emma Johnson',
+    fields: [
+      {
+        original_request_id: 'req-1',
+        source_field: 'bunk_request_form',
+        original_text: 'Please bunk with Sofia',
+        has_debug_result: false,
+        has_production_result: true,
+      },
+    ],
+  },
+  {
+    requester_cm_id: 1002,
+    requester_name: 'Liam Garcia',
+    fields: [],
+  },
+]
+
+function baseProps() {
+  return {
+    items: campers,
+    isLoading: false,
+    reparsingCmIds: new Set<number>(),
+    clearingCmIds: new Set<number>(),
+    onReparseCamper: vi.fn(),
+    onClearCamper: vi.fn(),
+    searchQuery: '',
+    selectedCamperCmId: null,
+    onCamperSelect: vi.fn(),
+  }
+}
+
+// Camper selection used to live on a click handler on a non-interactive
+// `<div>` card (kindred#2063-style gap: no keyboard listener at all). It is
+// now a real <button> around the name, so mouse click and Tab+Enter both work.
+describe('ParseAnalysisGroupedList', () => {
+  it('selects a camper when the name is clicked', async () => {
+    const onCamperSelect = vi.fn()
+    const user = userEvent.setup()
+    render(<ParseAnalysisGroupedList {...baseProps()} onCamperSelect={onCamperSelect} />)
+
+    await user.click(screen.getByRole('button', { name: 'Emma Johnson' }))
+
+    expect(onCamperSelect).toHaveBeenCalledWith(1001)
+  })
+
+  it('selects a camper via keyboard (Tab + Enter reaches the name button)', async () => {
+    const onCamperSelect = vi.fn()
+    const user = userEvent.setup()
+    render(<ParseAnalysisGroupedList {...baseProps()} onCamperSelect={onCamperSelect} />)
+
+    screen.getByRole('button', { name: 'Emma Johnson' }).focus()
+    await user.keyboard('{Enter}')
+
+    expect(onCamperSelect).toHaveBeenCalledWith(1001)
+  })
+
+  it('reparsing a camper does not also select it', async () => {
+    const onCamperSelect = vi.fn()
+    const onReparseCamper = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <ParseAnalysisGroupedList
+        {...baseProps()}
+        onCamperSelect={onCamperSelect}
+        onReparseCamper={onReparseCamper}
+      />
+    )
+
+    // Both campers lack debug results, so only the Reparse button shows for
+    // either; the first one in list order belongs to Emma Johnson (1001).
+    await user.click(screen.getAllByTitle('Reparse visible fields')[0]!)
+
+    expect(onReparseCamper).toHaveBeenCalledWith(1001)
+    expect(onCamperSelect).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/debug/ParseAnalysisGroupedList.tsx
+++ b/frontend/src/components/debug/ParseAnalysisGroupedList.tsx
@@ -116,8 +116,7 @@ export function ParseAnalysisGroupedList({
           return (
             <div
               key={camper.requester_cm_id}
-              onClick={() => onCamperSelect(camper.requester_cm_id)}
-              className={`cursor-pointer rounded-xl border-2 transition-all duration-200 ${
+              className={`rounded-xl border-2 transition-all duration-200 ${
                 isSelected
                   ? 'dark:bg-bark-800 border-forest-300 dark:border-forest-600 ring-forest-500/20 bg-white shadow-sm ring-2'
                   : 'dark:bg-bark-800 hover:border-bark-200 dark:hover:border-bark-600 border-transparent bg-white'
@@ -125,17 +124,24 @@ export function ParseAnalysisGroupedList({
             >
               {/* Camper row: name + refresh button on top, badges below */}
               <div className="p-3">
-                {/* Top row: name and action buttons */}
+                {/* Top row: name and action buttons. Selection lives on a real
+                    <button> around the name (kindred#2063 pattern) rather than
+                    a click handler on the card `<div>` — the Clear/Reparse
+                    buttons are siblings, not nested inside it, since a
+                    <button> can't contain another button. */}
                 <div className="flex items-center justify-between gap-2">
-                  <span className="text-foreground font-semibold">{camper.requester_name}</span>
+                  <button
+                    type="button"
+                    onClick={() => onCamperSelect(camper.requester_cm_id)}
+                    className="text-foreground min-w-0 flex-1 cursor-pointer truncate text-left font-semibold"
+                  >
+                    {camper.requester_name}
+                  </button>
                   <div className="flex items-center gap-1">
                     {/* Clear debug results button - only show if has debug results */}
                     {hasDebugResults && (
                       <button
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          onClearCamper(camper.requester_cm_id)
-                        }}
+                        onClick={() => onClearCamper(camper.requester_cm_id)}
                         disabled={isClearing || isReparsing}
                         className="text-bark-400 rounded-lg p-1.5 transition-all duration-200 hover:bg-rose-50 hover:text-rose-600 disabled:opacity-50 dark:hover:bg-rose-900/20"
                         title="Clear debug results"
@@ -149,10 +155,7 @@ export function ParseAnalysisGroupedList({
                     )}
                     {/* Reparse button */}
                     <button
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        onReparseCamper(camper.requester_cm_id)
-                      }}
+                      onClick={() => onReparseCamper(camper.requester_cm_id)}
                       disabled={isReparsing || isClearing}
                       className="text-bark-400 hover:text-forest-600 hover:bg-forest-50 dark:hover:bg-forest-900/20 rounded-lg p-1.5 transition-all duration-200 disabled:opacity-50"
                       title="Reparse visible fields"

--- a/frontend/src/components/debug/ParseAnalysisList.tsx
+++ b/frontend/src/components/debug/ParseAnalysisList.tsx
@@ -69,61 +69,68 @@ export function ParseAnalysisList({
           return (
             <div
               key={item.id}
-              className={`group relative flex cursor-pointer items-center gap-3 rounded-xl border-2 p-3 transition-all duration-200 ${
+              className={`group relative flex items-center gap-3 rounded-xl border-2 p-3 transition-all duration-200 ${
                 isSelected
                   ? 'bg-forest-50 dark:bg-forest-900/30 border-forest-300 dark:border-forest-700 shadow-sm'
                   : 'dark:bg-bark-800 hover:bg-parchment-200/70 dark:hover:bg-bark-700/50 hover:border-bark-200 dark:hover:border-bark-600 border-transparent bg-white'
               } `}
-              onClick={() => onSelect(item)}
             >
-              {/* Selection indicator */}
-              <div
-                className={`flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full border-2 transition-all duration-200 ${isSelected ? 'border-forest-500 bg-forest-500' : 'border-bark-300 dark:border-bark-600'} `}
+              {/* Selection lives on a real <button> around the indicator +
+                  content (kindred#2063 pattern) rather than a click handler on
+                  the row `<div>` — the Reparse button is a sibling, not
+                  nested inside it, since a <button> can't contain another
+                  button. */}
+              <button
+                type="button"
+                onClick={() => onSelect(item)}
+                className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 text-left"
               >
-                {isSelected && <div className="h-1.5 w-1.5 rounded-full bg-white" />}
-              </div>
+                {/* Selection indicator */}
+                <div
+                  className={`flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full border-2 transition-all duration-200 ${isSelected ? 'border-forest-500 bg-forest-500' : 'border-bark-300 dark:border-bark-600'} `}
+                >
+                  {isSelected && <div className="h-1.5 w-1.5 rounded-full bg-white" />}
+                </div>
 
-              {/* Content */}
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2">
-                  <span className="text-foreground truncate font-medium">
-                    {item.requester_name ?? 'Unknown'}
-                  </span>
-                  {/* Parse status badge */}
-                  {item.has_debug_result ? (
-                    <span
-                      className="inline-flex items-center gap-1 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700 dark:bg-amber-900/40 dark:text-amber-400"
-                      title="Debug result available"
-                    >
-                      <FlaskConical className="h-2.5 w-2.5" />
+                {/* Content */}
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-foreground truncate font-medium">
+                      {item.requester_name ?? 'Unknown'}
                     </span>
-                  ) : item.has_production_result ? (
+                    {/* Parse status badge */}
+                    {item.has_debug_result ? (
+                      <span
+                        className="inline-flex items-center gap-1 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700 dark:bg-amber-900/40 dark:text-amber-400"
+                        title="Debug result available"
+                      >
+                        <FlaskConical className="h-2.5 w-2.5" />
+                      </span>
+                    ) : item.has_production_result ? (
+                      <span
+                        className="bg-forest-100 text-forest-700 dark:bg-forest-900/40 dark:text-forest-400 inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold"
+                        title="Production result available"
+                      >
+                        <Database className="h-2.5 w-2.5" />
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="mt-1 flex items-center gap-2">
                     <span
-                      className="bg-forest-100 text-forest-700 dark:bg-forest-900/40 dark:text-forest-400 inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold"
-                      title="Production result available"
+                      className={`inline-flex rounded-md px-2 py-0.5 text-[10px] font-semibold ${item.source_field === SourceField.BUNK_REQUEST_FORM ? 'bg-forest-100 text-forest-700 dark:bg-forest-900/40 dark:text-forest-400' : ''} ${item.source_field === SourceField.STAFF_NOT_BUNK_WITH ? 'bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-400' : ''} ${item.source_field === SourceField.BUNKING_NOTES ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400' : ''} ${item.source_field === SourceField.INTERNAL_NOTES ? 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-400' : ''} `}
                     >
-                      <Database className="h-2.5 w-2.5" />
+                      {sourceLabel}
                     </span>
-                  ) : null}
+                    {!hasAnyResult && (
+                      <span className="text-muted-foreground text-xs italic">Not parsed</span>
+                    )}
+                  </div>
                 </div>
-                <div className="mt-1 flex items-center gap-2">
-                  <span
-                    className={`inline-flex rounded-md px-2 py-0.5 text-[10px] font-semibold ${item.source_field === SourceField.BUNK_REQUEST_FORM ? 'bg-forest-100 text-forest-700 dark:bg-forest-900/40 dark:text-forest-400' : ''} ${item.source_field === SourceField.STAFF_NOT_BUNK_WITH ? 'bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-400' : ''} ${item.source_field === SourceField.BUNKING_NOTES ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400' : ''} ${item.source_field === SourceField.INTERNAL_NOTES ? 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-400' : ''} `}
-                  >
-                    {sourceLabel}
-                  </span>
-                  {!hasAnyResult && (
-                    <span className="text-muted-foreground text-xs italic">Not parsed</span>
-                  )}
-                </div>
-              </div>
+              </button>
 
               {/* Reparse button */}
               <button
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onReparse(item)
-                }}
+                onClick={() => onReparse(item)}
                 disabled={isReparsing}
                 className={`flex-shrink-0 rounded-lg p-2 transition-all duration-200 ${
                   isReparsing

--- a/frontend/src/components/debug/PromptEditorTab.tsx
+++ b/frontend/src/components/debug/PromptEditorTab.tsx
@@ -261,7 +261,16 @@ export function PromptEditorTab() {
           {/* Dropdown menu */}
           {isDropdownOpen && promptsData?.prompts && (
             <>
-              <div className="fixed inset-0 z-10" onClick={() => setIsDropdownOpen(false)} />
+              {/* Decorative click-away overlay, aria-hidden because the
+                  dropdown trigger button above is already a real,
+                  keyboard-reachable way to close it (toggle), same as
+                  selecting any option; this div adds nothing for keyboard/AT
+                  users beyond that (matches ui/Modal.tsx's own backdrop). */}
+              <div
+                className="fixed inset-0 z-10"
+                onClick={() => setIsDropdownOpen(false)}
+                aria-hidden="true"
+              />
               <div className="dark:bg-bark-800 border-bark-200 dark:border-bark-600 shadow-lodge absolute top-full left-0 z-20 mt-2 w-full min-w-[280px] overflow-hidden rounded-xl border-2 bg-white">
                 {promptsData.prompts.map((prompt) => (
                   <button

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -120,6 +120,14 @@ export function Modal({
       />
 
       {/* Modal content */}
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions --
+          onClick here only calls stopPropagation() to keep a backdrop click from
+          bubbling up and closing the modal — it is not a user-facing affordance a
+          keyboard user needs to reach or activate, so no role/keyboard handler
+          applies. The actual dismiss controls are the Escape-key listener above and
+          the close <button>s below; the backdrop itself is aria-hidden and
+          click-only by design, which is why it and this rule are exempted here but
+          not elsewhere in this wave. */}
       <div
         data-testid="modal-content"
         className={`bg-card relative overflow-hidden rounded-2xl ${


### PR DESCRIPTION
## Summary

One file-disjoint chunk of the tree-wide jsx-a11y backlog (baseline: 133 warnings / 51 files / 7 rules on `main` at `98718af7`, gated by #2097). This chunk: **admin-debug-ui**, 10 files.

**Before → after (this chunk): 23 → 0 jsx-a11y warnings.**

```
./node_modules/.bin/eslint <chunk files> 2>/dev/null | grep -c jsx-a11y
# before: 23
# after:  0
```

Tree-wide `./node_modules/.bin/eslint src`: **0 errors** (487 pre-existing `@typescript-eslint` warnings, untouched — out of scope per the campaign rules).

## Files

- `src/components/admin/ProcessRequestOptions.tsx`
- `src/components/admin/RolesTab.tsx`
- `src/components/admin/ScaleGuideSidebar.tsx`
- `src/components/admin/geo/CanonicalReferenceList.tsx` (+ its test file)
- `src/components/admin/geo/MergeDialog.tsx`
- `src/components/admin/geo/ResolveDialog.tsx`
- `src/components/debug/ParseAnalysisGroupedList.tsx` (+ new test file — previously had zero coverage)
- `src/components/debug/ParseAnalysisList.tsx`
- `src/components/debug/PromptEditorTab.tsx`
- `src/components/ui/Modal.tsx` (shared primitive, ~20 call sites — see note below)

## Fixed (18) vs suppressed (5)

**Fixed structurally — 18:**

- **Clickable rows → real `<button>`** (`jsx-a11y/click-events-have-key-events` + `no-static-element-interactions`, 6 pairs = 12 warnings), following the house pattern from #2094/#2095: the click handler moves onto a real `<button>` wrapping the row's name/summary content; sibling action buttons (Merge, Clear, Reparse) stay outside it since a `<button>` can't nest another `<button>`.
  - `CanonicalReferenceList.tsx` — row toggle button; its existing test file's `user.click(rows[0])` calls now target the name inside the new button (a real DOM-target change, not a rewrite of intent), plus a new keyboard-activation regression test.
  - `ParseAnalysisGroupedList.tsx` — camper-select button; added a full test file (component had zero prior coverage) covering mouse click, keyboard Tab+Enter, and that Reparse doesn't double-fire selection.
  - `ParseAnalysisList.tsx` — same pattern (component has no current consumer/test file; verified via full-tree grep).
- **Decorative click-away overlays → `aria-hidden="true"`** (2 pairs = 4 warnings): `ScaleGuideSidebar.tsx`'s mobile backdrop and `PromptEditorTab.tsx`'s dropdown click-catcher. Both already have a real, keyboard-reachable close control (a header X button / the dropdown trigger toggle), so the overlay is purely a mouse convenience — the same shape `ui/Modal.tsx`'s own backdrop already used before this PR.
- **`label-has-associated-control` (4 warnings, `ProcessRequestOptions.tsx`):**
  - Redundant `role="heading" aria-level={2}` removed from an `<h2>` (also fixes 1 `no-redundant-roles` warning on the same element).
  - "Source Fields" and "Logging Level" group captions become `<fieldset>`/`<legend>` — they caption a *group* of checkboxes, not one associable control, which is what `<label>` requires.
  - "Collect pipeline traces" label's visible text sat 3 JSX levels deep (past the rule's depth-2 default), so the checkbox also carries a mirroring `aria-label`, matching the per-field checkboxes right above it in the same file.
- **`label-has-associated-control` (4 warnings, `RolesTab.tsx`):** Name/Slug/Description labels gained `htmlFor`/`id` pairs; "Permissions" (captions a group of toggle buttons) became `fieldset`/`legend`.

**Suppressed with justification — 5:**

- **3× `no-autofocus`** (`MergeDialog.tsx` ×1, `ResolveDialog.tsx` ×2): each is a search-target or name field on a dialog whose entire purpose is that one field — taking focus on open is the deliberate, correct UX (rule 7 of the campaign). Justification comment precedes each `eslint-disable-next-line`.
- **2× on `Modal.tsx`'s content wrapper** (`click-events-have-key-events` + `no-static-element-interactions`): its `onClick={(e) => e.stopPropagation()}` only stops a backdrop click from bubbling up and closing the modal — it isn't a user-facing affordance a keyboard user needs to reach. The actual dismiss paths (Escape-key listener, close `<button>`s) are untouched. Read this diff twice given the ~20 call sites; it's comment-only, no structural change.

No headlessui-migration punt was needed (#2025) — every `Modal.tsx` warning had a real, narrow fix.

## Verification

- Chunk eslint: 23 → 0 (`grep -c jsx-a11y`)
- Tree-wide `eslint src`: 0 errors, 487 pre-existing warnings (unchanged rule set, untouched by this PR)
- `tsc --noEmit -p .`: clean
- Prettier: clean
- Full `vitest run`: 5927/5929 passed. The 2 failures are pre-existing and unrelated to this chunk — confirmed by running each in isolation (both pass alone):
  - `src/config/eslintA11yLayering.guard.test.ts` — a 5000ms test-timeout on a loaded machine (7 sibling agents' worktrees running concurrently), not a content assertion failure; `eslint.config.js` is untouched by this PR.
  - `src/pages/WeekendRosterPage.codeSplitting.test.tsx` — a lazy-chunk timing test; `WeekendRosterPage` doesn't import `Modal` or any file in this chunk.
- Full pre-push hook (ruff, go build, pb-js-lint, shellcheck, markdownlint, api-types-freshness, mypy, pytest 6013 passed, tsc) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
