### PR TITLE
fix(frontend): a11y interaction gaps in modal family

### DIFF
--- a/frontend/src/components/BunkSocialGraphModal.tsx
+++ b/frontend/src/components/BunkSocialGraphModal.tsx
@@ -468,16 +468,24 @@ export default function BunkSocialGraphModal({
   // Use Activity to preserve state when hidden while unmounting effects
   // The backdrop transitions in/out based on isOpen
   return (
-    <div
-      className={clsx(
-        'fixed inset-0 z-50 flex items-center justify-start p-0 transition-all duration-300 sm:p-4',
-        isOpen ? 'pointer-events-auto bg-black/50' : 'pointer-events-none bg-transparent opacity-0'
-      )}
-      onClick={(e) => e.target === e.currentTarget && onClose()}
-    >
+    <div className="fixed inset-0 z-50 flex items-center justify-start p-0 sm:p-4">
+      {/* Decorative backdrop: click-to-close is a mouse convenience, not the
+          only path to close (see the header's real close button), so this
+          stays a plain non-interactive div rather than growing keyboard
+          handling that would duplicate the close button. */}
+      <div
+        aria-hidden="true"
+        className={clsx(
+          'absolute inset-0 transition-all duration-300',
+          isOpen
+            ? 'pointer-events-auto bg-black/50'
+            : 'pointer-events-none bg-transparent opacity-0'
+        )}
+        onClick={onClose}
+      />
       <Activity mode={isOpen ? 'visible' : 'hidden'}>
         <div
-          className={`bg-card shadow-lodge-xl overflow-hidden rounded-none transition-all duration-300 sm:ml-4 sm:rounded-2xl ${
+          className={`bg-card shadow-lodge-xl relative overflow-hidden rounded-none transition-all duration-300 sm:ml-4 sm:rounded-2xl ${
             selectedCamperId
               ? 'h-full w-full sm:max-h-[95vh] sm:w-[calc(95vw-20rem)] md:w-[calc(95vw-26rem)]'
               : 'h-full w-full sm:max-h-[95vh] sm:w-[95vw]'

--- a/frontend/src/components/BunkSwapModal.tsx
+++ b/frontend/src/components/BunkSwapModal.tsx
@@ -35,16 +35,16 @@ export default function BunkSwapModal({
   const selected = candidates.find((b) => b.id === selectedId) ?? null
 
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="bunk-swap-title"
-      className="fixed inset-0 z-[70] flex items-center justify-center bg-black/40"
-      onClick={onCancel}
-    >
+    <div className="fixed inset-0 z-[70] flex items-center justify-center">
+      {/* Decorative backdrop: click-to-close is a mouse convenience, not the
+          only path to close (the header carries a real close button), so
+          this stays a plain non-interactive div. */}
+      <div aria-hidden="true" className="absolute inset-0 bg-black/40" onClick={onCancel} />
       <div
-        className="bg-card border-border shadow-lodge-xl w-full max-w-md rounded-2xl border p-5"
-        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="bunk-swap-title"
+        className="bg-card border-border shadow-lodge-xl relative w-full max-w-md rounded-2xl border p-5"
       >
         <div className="mb-3 flex items-center justify-between">
           <h2 id="bunk-swap-title" className="text-base font-semibold">

--- a/frontend/src/components/FeedbackModal.tsx
+++ b/frontend/src/components/FeedbackModal.tsx
@@ -126,10 +126,21 @@ export function FeedbackModal({ isOpen, onClose }: FeedbackModalProps) {
 
   return (
     <Modal isOpen={isOpen} onClose={handleClose} title="Report a Problem" size="md">
-      {/* Category picker */}
+      {/* Category picker — a button group, not a single form control, so this
+          is a group label (span + aria-labelledby) rather than a <label>,
+          which would need a control to associate with. */}
       <div className="mb-4">
-        <label className="text-foreground mb-2 block text-sm font-medium">Category</label>
-        <div className="grid grid-cols-2 gap-2">
+        <span
+          id="feedback-category-label"
+          className="text-foreground mb-2 block text-sm font-medium"
+        >
+          Category
+        </span>
+        <div
+          role="group"
+          aria-labelledby="feedback-category-label"
+          className="grid grid-cols-2 gap-2"
+        >
           {CATEGORIES.map((cat) => (
             <button
               key={cat.value}

--- a/frontend/src/components/NewScenarioModal.tsx
+++ b/frontend/src/components/NewScenarioModal.tsx
@@ -157,6 +157,7 @@ export default function NewScenarioModal({
             onChange={(e) => setName(e.target.value)}
             placeholder="e.g., Option A - Mixed Age Groups"
             className="bg-background border-input focus:ring-primary w-full rounded-lg border px-4 py-2 focus:ring-2 focus:outline-none"
+            // eslint-disable-next-line jsx-a11y/no-autofocus -- deliberate: this is the first field of a create-scenario modal, so taking focus on open lets the user start typing the name immediately
             autoFocus
           />
         </div>
@@ -176,8 +177,12 @@ export default function NewScenarioModal({
         </div>
 
         <div>
-          <label className="mb-2 block text-sm font-medium">Copy Assignments From</label>
-          <div className="space-y-2">
+          {/* Group label for the radio set below — not a single-control
+              <label>, since there's no one input to associate it with. */}
+          <span id="copy-from-label" className="mb-2 block text-sm font-medium">
+            Copy Assignments From
+          </span>
+          <div role="radiogroup" aria-labelledby="copy-from-label" className="space-y-2">
             <label className="flex cursor-pointer items-center space-x-2">
               <input
                 type="radio"

--- a/frontend/src/components/PostValidationResultsModal.render.test.tsx
+++ b/frontend/src/components/PostValidationResultsModal.render.test.tsx
@@ -459,7 +459,12 @@ describe('PostValidationResultsModal — unmet parent requests drill-down remove
 
 vi.mock('./CamperDetailsPanel', () => ({
   default: ({ camperId, onClose }: { camperId: string; onClose: () => void }) => (
-    <div data-testid="camper-details-panel" data-camper-id={camperId} onClick={onClose} />
+    <button
+      type="button"
+      data-testid="camper-details-panel"
+      data-camper-id={camperId}
+      onClick={onClose}
+    />
   ),
 }))
 
@@ -635,8 +640,8 @@ describe('PostValidationResultsModal — impossibility section (#1442 part 2)', 
       />
     )
     const user = userEvent.setup()
-    // Camper name is now a clickable span inside the family-row expand toggle,
-    // not a standalone button — use getByText to target the span directly.
+    // Camper name in a "Families to contact" row is a real <button> (a11y
+    // fix); getByText still matches since it's the button's only text child.
     await user.click(screen.getByText('Olivia Chen'))
     expect(await screen.findByTestId('camper-details-panel')).toHaveAttribute(
       'data-camper-id',

--- a/frontend/src/components/PostValidationResultsModal.tsx
+++ b/frontend/src/components/PostValidationResultsModal.tsx
@@ -1055,12 +1055,13 @@ export function PostCheckContents({
                           <span
                             className={`inline-block h-2 w-2 rounded-full ${sev === 'red' ? 'bg-red-600' : 'bg-amber-500'}`}
                           />
-                          <span
+                          <button
+                            type="button"
                             className="cursor-pointer font-medium text-stone-900 hover:text-red-700"
                             onClick={() => handleCamperClick(row.cm_id)}
                           >
                             {row.name}
-                          </span>
+                          </button>
                           {row.grade > 0 && (
                             <span className="text-xs text-stone-500">
                               · {row.grade}

--- a/frontend/src/components/PreValidationResultsModal.test.tsx
+++ b/frontend/src/components/PreValidationResultsModal.test.tsx
@@ -6,7 +6,12 @@ import { makeImpossibilityReport } from '../test/impossibilityReport'
 
 vi.mock('./CamperDetailsPanel', () => ({
   default: ({ camperId, onClose }: { camperId: string; onClose: () => void }) => (
-    <div data-testid="camper-details-panel" data-camper-id={camperId} onClick={onClose} />
+    <button
+      type="button"
+      data-testid="camper-details-panel"
+      data-camper-id={camperId}
+      onClick={onClose}
+    />
   ),
 }))
 

--- a/frontend/src/components/ScenarioEditModal.tsx
+++ b/frontend/src/components/ScenarioEditModal.tsx
@@ -60,7 +60,7 @@ export default function ScenarioEditModal({ scenario, onClose, onSave }: Scenari
             onChange={(e) => setName(e.target.value)}
             placeholder="e.g., Option A - Mixed Age Groups"
             className="bg-background border-input focus:ring-primary w-full rounded-lg border px-4 py-2 focus:ring-2 focus:outline-none"
-            // eslint-disable-next-line jsx-a11y/no-autofocus -- deliberate: this is the only field of an edit-scenario modal, so taking focus on open lets the user start editing the name immediately
+            // eslint-disable-next-line jsx-a11y/no-autofocus -- deliberate: this is the first field of an edit-scenario modal, so taking focus on open lets the user start editing the name immediately
             autoFocus
           />
         </div>

--- a/frontend/src/components/ScenarioEditModal.tsx
+++ b/frontend/src/components/ScenarioEditModal.tsx
@@ -60,6 +60,7 @@ export default function ScenarioEditModal({ scenario, onClose, onSave }: Scenari
             onChange={(e) => setName(e.target.value)}
             placeholder="e.g., Option A - Mixed Age Groups"
             className="bg-background border-input focus:ring-primary w-full rounded-lg border px-4 py-2 focus:ring-2 focus:outline-none"
+            // eslint-disable-next-line jsx-a11y/no-autofocus -- deliberate: this is the only field of an edit-scenario modal, so taking focus on open lets the user start editing the name immediately
             autoFocus
           />
         </div>

--- a/frontend/src/components/ScenarioManagementModal.tsx
+++ b/frontend/src/components/ScenarioManagementModal.tsx
@@ -131,13 +131,22 @@ export default function ScenarioManagementModal({
           {/* Production Mode Card */}
           <div className="p-6 pb-0">
             <div
-              className={`rounded-xl border-2 p-4 ${
+              className={`relative rounded-xl border-2 p-4 ${
                 !currentScenario
                   ? 'border-primary bg-primary/5'
                   : 'border-border bg-muted/30 hover:bg-muted/50'
-              } cursor-pointer transition-all`}
-              onClick={() => selectScenario(null)}
+              } transition-all`}
             >
+              {/* Full-card hit target: keeps the card's own markup as plain
+                  divs (button content is phrasing-only, and this card nests
+                  a heading + paragraph + badge) while still giving the whole
+                  card a native, keyboard-operable control. */}
+              <button
+                type="button"
+                onClick={() => selectScenario(null)}
+                aria-label="Switch to CampMinder production mode"
+                className="absolute inset-0 h-full w-full cursor-pointer rounded-xl"
+              />
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-3">
                   <Package className="text-primary h-5 w-5" />
@@ -182,10 +191,18 @@ export default function ScenarioManagementModal({
                   } transition-all`}
                 >
                   <div className="flex items-start justify-between gap-4">
-                    <div
-                      className="flex-1 cursor-pointer"
-                      onClick={() => selectScenario(scenario.id)}
-                    >
+                    <div className="relative flex-1">
+                      {/* Full-row hit target, scoped to this flex-1 column so
+                          it doesn't cover the Edit/Clear/Delete buttons in
+                          the sibling column. See the CampMinder card above
+                          for why this is an overlay button rather than
+                          wrapping the (block-content) row in a <button>. */}
+                      <button
+                        type="button"
+                        onClick={() => selectScenario(scenario.id)}
+                        aria-label={`Switch to ${scenario.name}`}
+                        className="absolute inset-0 h-full w-full cursor-pointer rounded-xl"
+                      />
                       <div className="mb-1 flex items-center gap-3">
                         <FlaskConical className="text-accent h-5 w-5" />
                         <h3 className="font-semibold">{scenario.name}</h3>

--- a/frontend/src/components/SolverProgressModal.tsx
+++ b/frontend/src/components/SolverProgressModal.tsx
@@ -299,8 +299,11 @@ export default function SolverProgressModal({
 
   return createPortal(
     <div className="fixed inset-0 z-[9999] flex items-center justify-center">
-      {/* Backdrop with blur */}
+      {/* Backdrop with blur — decorative; click-to-close (when not
+          in-progress) is a mouse convenience on top of the real close
+          control, not the only path to close. */}
       <div
+        aria-hidden="true"
         className="animate-in fade-in absolute inset-0 bg-black/40 backdrop-blur-sm duration-200"
         onClick={isInProgress ? undefined : onClose}
       />


### PR DESCRIPTION
## What

Sweeps the `modal-family` chunk of the jsx-a11y backlog (21 warnings across 10 files, all fixed with real interaction fixes except two justified `no-autofocus` suppressions).

## Before / after

```text
./node_modules/.bin/eslint <chunk files> 2>/dev/null | grep -c jsx-a11y
```

| | jsx-a11y warnings |
|---|---|
| Before | 21 |
| After | 0 |

Full tree still has **0 errors** after the change (`./node_modules/.bin/eslint src` → 489 pre-existing `@typescript-eslint` warnings, untouched, 0 errors).

## Files

- `src/components/BunkSocialGraphModal.tsx`
- `src/components/BunkSwapModal.tsx`
- `src/components/FeedbackModal.tsx`
- `src/components/NewScenarioModal.tsx`
- `src/components/PostValidationResultsModal.tsx`
- `src/components/PostValidationResultsModal.render.test.tsx`
- `src/components/PreValidationResultsModal.test.tsx`
- `src/components/ScenarioEditModal.tsx`
- `src/components/ScenarioManagementModal.tsx`
- `src/components/SolverProgressModal.tsx`

## Fixed (19) vs suppressed (2)

**Fixed — backdrop split** (`click-events-have-key-events` + `no-static-element-interactions` / `no-noninteractive-element-interactions`):
`BunkSocialGraphModal.tsx` and `BunkSwapModal.tsx` each combined "backdrop click-to-close" and "dialog content" into one element with a raw `onClick`. Split each into a decorative `aria-hidden="true"` backdrop div (click-to-close is a mouse convenience; the real close path is the header's close button) and a content wrapper with no handler — mirrors the split already used by the shared `ui/Modal.tsx` primitive (not touched here — owned by a sibling chunk).

`SolverProgressModal.tsx` already had this split; it only needed `aria-hidden="true"` added to its existing backdrop div.

**Fixed — clickable text became a real `<button>`** (`click-events-have-key-events` + `no-static-element-interactions`):
- `PostValidationResultsModal.tsx`: a clickable camper-name `<span>` in the "Families to contact" list → `<button type="button">`.
- `PostValidationResultsModal.render.test.tsx` / `PreValidationResultsModal.test.tsx`: the `CamperDetailsPanel` test mock (`<div onClick={onClose}>`) → `<button>`. Fixture JSX, not real UI — the mock stands in for the real close affordance in tests that assert on it via `data-testid`. Updated a stale test comment that described this as "not a standalone button."

**Fixed — clickable "card" became an overlay `<button>`** (same two rules), `ScenarioManagementModal.tsx`:
Two selectable cards (the "CampMinder production mode" tile, and each scenario row's name/description column) had `onClick` directly on a `<div>` with nested block content (heading, paragraph, badge). Per house style (a `<button>`'s content model is phrasing-only — see #2094), rather than converting all the nested `<div>`/`<h3>`/`<p>` to `<span>`, each card got a `position:relative` wrapper with a full-cover `absolute inset-0` `<button aria-label="...">` as the actual hit target — same visual result, real keyboard operability, no content-model violation. The scenario-row overlay is scoped to its own flex column so it doesn't cover the sibling Edit/Clear/Delete buttons.

**Fixed — mislabeled `<label>` → group label** (`label-has-associated-control`):
`FeedbackModal.tsx` ("Category") and `NewScenarioModal.tsx` ("Copy Assignments From") both had a `<label>` heading a button/radio group rather than a single control. Neither has one input to associate via `htmlFor`, so both became a `<span id="...">` + `role="group"`/`role="radiogroup"` + `aria-labelledby` on the group container — the semantically correct pattern for a group heading.

**Suppressed (2) — `no-autofocus`, justified:**
- `NewScenarioModal.tsx` (scenario name field) and `ScenarioEditModal.tsx` (scenario name field): both are the single/first field of a short create/edit form opened as a modal. Autofocus here is the correct, deliberate UX — the user should be able to start typing immediately — not an accident. Each carries an `eslint-disable-next-line jsx-a11y/no-autofocus` with a one-line reason on the preceding line.

Zero warnings silenced without a fix. All 21 either got a structural fix or a justified, commented suppression.

## Verification

- Chunk eslint: 21 → 0 (`grep -c jsx-a11y`)
- Tree-wide `eslint src`: 0 errors, 489 pre-existing warnings (unchanged rule set, untouched by this PR)
- `npm run type-check` (`tsc --noEmit` ×2): clean
- `./node_modules/.bin/prettier --check` on changed files: clean
- Full `./node_modules/.bin/vitest run`: 5921/5928 passed, 6 files / 7 tests failed. All 6 failing files are outside this chunk and untouched by it (`AllCampersView.test.tsx`, `CamperDetail.test.tsx`, `SplitRequestModal.test.tsx`, `eslintA11yLayering.guard.test.ts`, `WeekendRosterPage.scenario.test.tsx`, `DrillDownModal.test.tsx`), every failure is `Error: Test timed out in 5000ms`, and re-running the same 6 files in isolation (outside full-suite resource contention) passes 5 of them cleanly. The 6th (`eslintA11yLayering.guard.test.ts`) makes a real ESLint Node API call to resolve `eslint.config.js` and times out even alone on this machine under concurrent sibling-agent load (7 parallel jsx-a11y chunk worktrees running builds/tests simultaneously); `eslint.config.js` is untouched by this PR. All 10 of this chunk's own component test files pass cleanly (184/184 tests) run together in isolation.
- Pre-push hook (ruff, go build, pb-js-lint, shellcheck, markdownlint, api-types-freshness, mypy, pytest 6013 passed, tsc) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
