### PR TITLE
fix(frontend): a11y interaction gaps in request family

### DIFF
--- a/frontend/src/components/CreateRequestModal.tsx
+++ b/frontend/src/components/CreateRequestModal.tsx
@@ -158,8 +158,11 @@ export default function CreateRequestModal({ sessionId, year, onClose }: CreateR
           <div className="space-y-6">
             {/* Request Type */}
             <div>
-              <label className="mb-2 block text-sm font-semibold">Request Type</label>
+              <label htmlFor="create-request-type" className="mb-2 block text-sm font-semibold">
+                Request Type
+              </label>
               <select
+                id="create-request-type"
                 value={requestType}
                 onChange={(e) => {
                   setRequestType(e.target.value as RequestType)
@@ -175,10 +178,16 @@ export default function CreateRequestModal({ sessionId, year, onClose }: CreateR
 
             {/* Requester */}
             <div>
-              <label className="mb-2 block text-sm font-semibold">Requester</label>
+              <label
+                htmlFor="create-request-requester"
+                className="mb-2 block text-sm font-semibold"
+              >
+                Requester
+              </label>
               <div className="relative">
                 <Search className="text-muted-foreground absolute top-1/2 left-4 h-4 w-4 -translate-y-1/2 transform" />
                 <input
+                  id="create-request-requester"
                   type="text"
                   placeholder="Search for requester..."
                   value={requesterSearch}
@@ -219,10 +228,13 @@ export default function CreateRequestModal({ sessionId, year, onClose }: CreateR
             {/* Target (for non-age preference) */}
             {requestType !== 'age_preference' && (
               <div>
-                <label className="mb-2 block text-sm font-semibold">Target Person</label>
+                <label htmlFor="create-request-target" className="mb-2 block text-sm font-semibold">
+                  Target Person
+                </label>
                 <div className="relative">
                   <Search className="text-muted-foreground absolute top-1/2 left-4 h-4 w-4 -translate-y-1/2 transform" />
                   <input
+                    id="create-request-target"
                     type="text"
                     placeholder="Search for target person..."
                     value={targetSearch}
@@ -264,8 +276,14 @@ export default function CreateRequestModal({ sessionId, year, onClose }: CreateR
             {/* Age Preference Target */}
             {requestType === 'age_preference' && (
               <div>
-                <label className="mb-2 block text-sm font-semibold">Age Preference</label>
+                <label
+                  htmlFor="create-request-age-preference"
+                  className="mb-2 block text-sm font-semibold"
+                >
+                  Age Preference
+                </label>
                 <select
+                  id="create-request-age-preference"
                   value={agePreferenceTarget}
                   onChange={(e) => setAgePreferenceTarget(e.target.value as 'older' | 'younger')}
                   className="input-lodge"
@@ -278,8 +296,11 @@ export default function CreateRequestModal({ sessionId, year, onClose }: CreateR
 
             {/* Notes */}
             <div>
-              <label className="mb-2 block text-sm font-semibold">Notes (Optional)</label>
+              <label htmlFor="create-request-notes" className="mb-2 block text-sm font-semibold">
+                Notes (Optional)
+              </label>
               <textarea
+                id="create-request-notes"
                 value={notes}
                 onChange={(e) => setNotes(e.target.value)}
                 placeholder="Any additional notes about this request..."

--- a/frontend/src/components/ManualResolutionModal.tsx
+++ b/frontend/src/components/ManualResolutionModal.tsx
@@ -230,6 +230,11 @@ export default function ManualResolutionModal({
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               className="bg-background text-foreground focus:ring-primary focus:border-primary w-full rounded-xl border-2 py-2.5 pr-4 pl-10 transition-all focus:ring-2"
+              // Deliberate: this modal's entire purpose is "search for a camper to
+              // resolve", opened by an explicit staff click; focusing the search box
+              // on open lets them start typing immediately instead of needing an
+              // extra click.
+              // eslint-disable-next-line jsx-a11y/no-autofocus
               autoFocus
             />
           </div>

--- a/frontend/src/components/RequestEditableHeader.tsx
+++ b/frontend/src/components/RequestEditableHeader.tsx
@@ -27,7 +27,7 @@ export function RequestEditableHeader({
 }: RequestEditableHeaderProps) {
   return (
     <div className="flex flex-wrap items-center gap-2 text-sm">
-      <div onClick={(e) => e.stopPropagation()}>
+      <div>
         <EditableRequestType
           value={request.request_type}
           onChange={(newType) =>
@@ -36,7 +36,7 @@ export function RequestEditableHeader({
         />
       </div>
       <span className="text-muted-foreground">→</span>
-      <div onClick={(e) => e.stopPropagation()}>
+      <div>
         <EditableRequestTarget
           requestType={request.request_type}
           currentPersonId={request.requestee_id}

--- a/frontend/src/components/RequestForm.tsx
+++ b/frontend/src/components/RequestForm.tsx
@@ -67,7 +67,12 @@ export default function RequestForm({ campers, constraint, onSubmit, onCancel }:
     <form onSubmit={handleSubmit} className="space-y-4">
       {/* Constraint Type */}
       <div>
-        <label className="text-foreground mb-1 block text-sm font-medium">Constraint Type</label>
+        <label
+          htmlFor="constraint-type-button"
+          className="text-foreground mb-1 block text-sm font-medium"
+        >
+          Constraint Type
+        </label>
         <Listbox
           value={type}
           onChange={(v) => {
@@ -76,7 +81,7 @@ export default function RequestForm({ campers, constraint, onSubmit, onCancel }:
           }}
         >
           <div className="relative">
-            <ListboxButton className="listbox-button">
+            <ListboxButton id="constraint-type-button" className="listbox-button">
               <span>
                 {type === 'pair_together'
                   ? 'Pair Together'
@@ -126,13 +131,15 @@ export default function RequestForm({ campers, constraint, onSubmit, onCancel }:
                 }
                 className="mr-3 h-5 w-5 cursor-pointer sm:h-4 sm:w-4"
               />
-              <div className="flex-1">
-                <span className="font-medium">{camper.name}</span>
-                <span className="text-muted-foreground ml-2 text-sm">
-                  Age {(getDisplayAgeForYear(camper, viewingYear) ?? 0).toFixed(2)} •{' '}
-                  {formatGradeOrdinal(camper.grade)}
-                </span>
-              </div>
+              {/* Direct children, not wrapped in an intermediate div — jsx-a11y/
+                  label-has-associated-control only walks 2 levels deep by default,
+                  and the label's accessible text (inside these spans) needs to
+                  stay within that budget. */}
+              <span className="font-medium">{camper.name}</span>
+              <span className="text-muted-foreground ml-2 text-sm">
+                Age {(getDisplayAgeForYear(camper, viewingYear) ?? 0).toFixed(2)} •{' '}
+                {formatGradeOrdinal(camper.grade)}
+              </span>
             </label>
           ))}
         </div>
@@ -141,13 +148,18 @@ export default function RequestForm({ campers, constraint, onSubmit, onCancel }:
       {/* Type-specific fields */}
       {type === 'age_preference' && (
         <div>
-          <label className="text-foreground mb-1 block text-sm font-medium">Age Preference</label>
+          <label
+            htmlFor="age-preference-button"
+            className="text-foreground mb-1 block text-sm font-medium"
+          >
+            Age Preference
+          </label>
           <Listbox
             value={(metadata['preference'] as string) || 'similar'}
             onChange={(v) => setMetadata({ ...metadata, preference: v })}
           >
             <div className="relative">
-              <ListboxButton className="listbox-button">
+              <ListboxButton id="age-preference-button" className="listbox-button">
                 <span>
                   {(metadata['preference'] as string) === 'older'
                     ? 'Older Campers'
@@ -175,10 +187,14 @@ export default function RequestForm({ campers, constraint, onSubmit, onCancel }:
 
       {type === 'bunk_preference' && (
         <div>
-          <label className="text-foreground mb-1 block text-sm font-medium">
+          <label
+            htmlFor="bunk-preference-name"
+            className="text-foreground mb-1 block text-sm font-medium"
+          >
             Preferred Bunk Name (optional)
           </label>
           <input
+            id="bunk-preference-name"
             type="text"
             value={(metadata['bunkName'] as string) || ''}
             onChange={(e) => setMetadata({ ...metadata, bunkName: e.target.value })}

--- a/frontend/src/components/RequestForm.tsx
+++ b/frontend/src/components/RequestForm.tsx
@@ -1,4 +1,4 @@
-import { type FormEvent, useState } from 'react'
+import { type FormEvent, useId, useState } from 'react'
 import { ChevronDown } from 'lucide-react'
 import { Listbox, ListboxButton, ListboxOptions, ListboxOption } from '@headlessui/react'
 import type { Constraint, Camper, ConstraintType } from '../types/app-types'
@@ -15,6 +15,13 @@ interface RequestFormProps {
 
 export default function RequestForm({ campers, constraint, onSubmit, onCancel }: RequestFormProps) {
   const viewingYear = useYear()
+  // RequestsPanel can mount a "create" RequestForm and an "edit" RequestForm
+  // simultaneously (isCreating and editingId are independent state) — unique,
+  // instance-scoped ids keep each form's label/control pairing correct rather
+  // than colliding on a fixed string.
+  const constraintTypeId = useId()
+  const agePreferenceId = useId()
+  const bunkNameId = useId()
   const [type, setType] = useState<ConstraintType>(constraint?.type ?? 'pair_together')
   // Local mutable working copy; the source `constraint.campers` is readonly.
   const [selectedCampers, setSelectedCampers] = useState<string[]>([...(constraint?.campers ?? [])])
@@ -68,7 +75,7 @@ export default function RequestForm({ campers, constraint, onSubmit, onCancel }:
       {/* Constraint Type */}
       <div>
         <label
-          htmlFor="constraint-type-button"
+          htmlFor={constraintTypeId}
           className="text-foreground mb-1 block text-sm font-medium"
         >
           Constraint Type
@@ -81,7 +88,7 @@ export default function RequestForm({ campers, constraint, onSubmit, onCancel }:
           }}
         >
           <div className="relative">
-            <ListboxButton id="constraint-type-button" className="listbox-button">
+            <ListboxButton id={constraintTypeId} className="listbox-button">
               <span>
                 {type === 'pair_together'
                   ? 'Pair Together'
@@ -149,7 +156,7 @@ export default function RequestForm({ campers, constraint, onSubmit, onCancel }:
       {type === 'age_preference' && (
         <div>
           <label
-            htmlFor="age-preference-button"
+            htmlFor={agePreferenceId}
             className="text-foreground mb-1 block text-sm font-medium"
           >
             Age Preference
@@ -159,7 +166,7 @@ export default function RequestForm({ campers, constraint, onSubmit, onCancel }:
             onChange={(v) => setMetadata({ ...metadata, preference: v })}
           >
             <div className="relative">
-              <ListboxButton id="age-preference-button" className="listbox-button">
+              <ListboxButton id={agePreferenceId} className="listbox-button">
                 <span>
                   {(metadata['preference'] as string) === 'older'
                     ? 'Older Campers'
@@ -187,14 +194,11 @@ export default function RequestForm({ campers, constraint, onSubmit, onCancel }:
 
       {type === 'bunk_preference' && (
         <div>
-          <label
-            htmlFor="bunk-preference-name"
-            className="text-foreground mb-1 block text-sm font-medium"
-          >
+          <label htmlFor={bunkNameId} className="text-foreground mb-1 block text-sm font-medium">
             Preferred Bunk Name (optional)
           </label>
           <input
-            id="bunk-preference-name"
+            id={bunkNameId}
             type="text"
             value={(metadata['bunkName'] as string) || ''}
             onChange={(e) => setMetadata({ ...metadata, bunkName: e.target.value })}

--- a/frontend/src/components/RequestReviewPanel.test.tsx
+++ b/frontend/src/components/RequestReviewPanel.test.tsx
@@ -1372,8 +1372,11 @@ describe('RequestReviewPanel', () => {
    * decline, the just-processed row MUST collapse.
    */
   describe('Row collapse after approve/decline (feedback #11)', () => {
-    // Expand a request row by ID. Clicks the row container (desktop layout) and
-    // waits for the expanded content block to appear.
+    // Expand a request row by ID. Clicks the row's dedicated expand button
+    // (desktop layout) and waits for the expanded content block to appear.
+    // The click affordance lives on a real <button> (kindred#2094/#2095 house
+    // style), not on the row container itself, so it — not the container —
+    // is what gets clicked.
     async function expandRowById(requestId: string) {
       const rowContainers = await waitFor(() => {
         const found = document.querySelectorAll(`[data-request-row-id="${requestId}"]`)
@@ -1382,7 +1385,9 @@ describe('RequestReviewPanel', () => {
       })
       const rowContainer = rowContainers[0] as HTMLElement
       expect(rowContainer).toBeTruthy()
-      fireEvent.click(rowContainer)
+      const expandButton = rowContainer.querySelector('[data-testid="request-row-expand-button"]')
+      expect(expandButton).toBeTruthy()
+      fireEvent.click(expandButton as HTMLElement)
       await waitFor(() => {
         expect(
           rowContainers[0]?.querySelector('[data-testid="request-row-expanded-content"]')
@@ -1497,7 +1502,9 @@ describe('RequestReviewPanel', () => {
       })
       const mobileRowA = rowAContainers[0] as HTMLElement
       expect(mobileRowA).toBeTruthy()
-      fireEvent.click(mobileRowA)
+      const expandButtonA = mobileRowA.querySelector('[data-testid="request-row-expand-button"]')
+      expect(expandButtonA).toBeTruthy()
+      fireEvent.click(expandButtonA as HTMLElement)
 
       // Confirm row A is expanded
       await waitFor(() => {
@@ -1514,7 +1521,9 @@ describe('RequestReviewPanel', () => {
       })
       const mobileRowB = rowBContainers[0] as HTMLElement
       expect(mobileRowB).toBeTruthy()
-      fireEvent.click(mobileRowB)
+      const expandButtonB = mobileRowB.querySelector('[data-testid="request-row-expand-button"]')
+      expect(expandButtonB).toBeTruthy()
+      fireEvent.click(expandButtonB as HTMLElement)
 
       // Both rows expanded — two expanded-content blocks visible
       await waitFor(() => {
@@ -1543,6 +1552,69 @@ describe('RequestReviewPanel', () => {
         ).toBe(1)
       })
     }, 15000)
+  })
+
+  /**
+   * jsx-a11y sweep: the row's click-to-expand affordance used to live on a
+   * non-interactive <div onClick>, with no keyboard equivalent at all
+   * (jsx-a11y/click-events-have-key-events, no-static-element-interactions).
+   * It now lives on a real <button> in the row's first cell. These tests pin
+   * that the button is genuinely keyboard-operable, not just present.
+   */
+  describe('Row expand button is keyboard-operable (jsx-a11y sweep)', () => {
+    it('is a real button with aria-expanded reflecting state', async () => {
+      await renderPanelWithRequest({
+        id: 'req-kbd-expand-1',
+        requester_id: 500,
+        requestee_id: 501,
+        session_id: 1001,
+        year: 2025,
+        status: 'pending',
+        request_type: 'bunk_with',
+        confidence_score: 0.7,
+      })
+
+      const rowContainer = await waitFor(() => {
+        const found = document.querySelector('[data-request-row-id="req-kbd-expand-1"]')
+        if (!found) throw new Error('row not yet rendered')
+        return found as HTMLElement
+      })
+      const expandButton = within(rowContainer).getByTestId('request-row-expand-button')
+      expect(expandButton.tagName).toBe('BUTTON')
+      expect(expandButton).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    it('expands the row via Enter on the focused expand button, no mouse click', async () => {
+      const { user } = await renderPanelWithRequest({
+        id: 'req-kbd-expand-2',
+        requester_id: 502,
+        requestee_id: 503,
+        session_id: 1001,
+        year: 2025,
+        status: 'pending',
+        request_type: 'bunk_with',
+        confidence_score: 0.7,
+      })
+
+      const rowContainer = await waitFor(() => {
+        const found = document.querySelector('[data-request-row-id="req-kbd-expand-2"]')
+        if (!found) throw new Error('row not yet rendered')
+        return found as HTMLElement
+      })
+      const expandButton = within(rowContainer).getByTestId('request-row-expand-button')
+
+      expect(rowContainer.querySelector('[data-testid="request-row-expanded-content"]')).toBeNull()
+
+      expandButton.focus()
+      await user.keyboard('{Enter}')
+
+      await waitFor(() => {
+        expect(
+          rowContainer.querySelector('[data-testid="request-row-expanded-content"]')
+        ).toBeTruthy()
+      })
+      expect(expandButton).toHaveAttribute('aria-expanded', 'true')
+    })
   })
 
   /**

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -117,10 +117,38 @@ export default function RequestReviewPanel({
       bulkConfirmPreviousFocusRef.current = document.activeElement as HTMLElement | null
       const buttons = bulkConfirmRef.current?.querySelectorAll<HTMLElement>('button')
       buttons?.[buttons.length - 1]?.focus()
-    } else {
-      bulkConfirmPreviousFocusRef.current?.focus()
-      bulkConfirmPreviousFocusRef.current = null
+
+      // Escape-to-close + Tab focus trap, as a document-level listener rather
+      // than an inline onKeyDown on the role="dialog" element — matching
+      // ui/Modal.tsx's own pattern. jsx-a11y/no-noninteractive-element-interactions
+      // flags an onKeyDown JSX prop on a non-interactive role like "dialog";
+      // an imperative listener sidesteps that while keeping identical behavior
+      // (keydown bubbles from any focused button inside the dialog either way).
+      const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+          setBulkConfirm(null)
+          return
+        }
+        if (e.key === 'Tab') {
+          const dialogButtons = Array.from(
+            bulkConfirmRef.current?.querySelectorAll<HTMLElement>('button') ?? []
+          )
+          if (dialogButtons.length === 0) return
+          e.preventDefault()
+          const idx = dialogButtons.indexOf(document.activeElement as HTMLElement)
+          if (e.shiftKey) {
+            dialogButtons[idx <= 0 ? dialogButtons.length - 1 : idx - 1]?.focus()
+          } else {
+            dialogButtons[idx >= dialogButtons.length - 1 ? 0 : idx + 1]?.focus()
+          }
+        }
+      }
+      document.addEventListener('keydown', handleKeyDown)
+      return () => document.removeEventListener('keydown', handleKeyDown)
     }
+    bulkConfirmPreviousFocusRef.current?.focus()
+    bulkConfirmPreviousFocusRef.current = null
+    return undefined
   }, [bulkConfirm])
 
   const openConfirmPopover = useCallback(
@@ -977,7 +1005,6 @@ export default function RequestReviewPanel({
                           : [...prev.statuses, status],
                       }))
                     }}
-                    role="button"
                     aria-pressed={isSelected}
                     className={clsx(
                       'rounded-full border px-3 py-1 text-xs font-medium capitalize transition-all',
@@ -1009,7 +1036,6 @@ export default function RequestReviewPanel({
                           : [...prev.requestTypes, type],
                       }))
                     }}
-                    role="button"
                     aria-pressed={isSelected}
                     className={clsx(
                       'rounded-full border px-3 py-1 text-xs font-medium transition-all',
@@ -1148,18 +1174,18 @@ export default function RequestReviewPanel({
                         key={request.id}
                         data-request-row-id={request.id}
                         className={clsx(
-                          'cursor-pointer border-b transition-colors',
+                          'border-b transition-colors',
                           selectedRequests.has(request.id)
                             ? 'bg-primary/5 hover:bg-primary/10'
                             : 'hover:bg-muted/50'
                         )}
-                        onClick={() => toggleRowExpansion(request.id, request)}
                       >
                         <RequestRowDesktop
                           request={request}
                           requester={requester}
                           requestee={requestee}
                           isSelected={selectedRequests.has(request.id)}
+                          isExpanded={isExpanded}
                           sessionId={sessionId}
                           year={year}
                           sessionName={sessionName}
@@ -1170,12 +1196,12 @@ export default function RequestReviewPanel({
                           onValidatedUpdate={handleValidatedUpdate}
                           onSplit={handleSplitRow}
                           onConfirmAction={openConfirmPopover}
+                          onExpandRow={() => toggleRowExpansion(request.id, request)}
                         />
                         {isExpanded && (
                           <div
                             className="bg-parchment-50/50 dark:bg-forest-950/20 border-border border-t px-4 py-4"
                             data-testid="request-row-expanded-content"
-                            onClick={(e) => e.stopPropagation()}
                           >
                             <div className="ml-10 grid max-w-6xl grid-cols-1 gap-6 lg:grid-cols-2">
                               <div className="max-w-3xl space-y-3">
@@ -1606,32 +1632,17 @@ export default function RequestReviewPanel({
 
       {bulkConfirm && (
         <div className="fixed inset-0 z-50 flex items-center justify-center">
-          <div className="absolute inset-0 bg-black/50" onClick={() => setBulkConfirm(null)} />
+          <div
+            className="absolute inset-0 bg-black/50"
+            onClick={() => setBulkConfirm(null)}
+            aria-hidden="true"
+          />
           <div
             ref={bulkConfirmRef}
             role="dialog"
             aria-modal="true"
             aria-labelledby="bulk-confirm-label"
             className="bg-card border-border relative mx-4 w-full max-w-sm rounded-xl border p-6 shadow-xl"
-            onKeyDown={(e) => {
-              if (e.key === 'Escape') {
-                setBulkConfirm(null)
-                return
-              }
-              if (e.key === 'Tab') {
-                const buttons = Array.from(
-                  bulkConfirmRef.current?.querySelectorAll<HTMLElement>('button') ?? []
-                )
-                if (buttons.length === 0) return
-                e.preventDefault()
-                const idx = buttons.indexOf(document.activeElement as HTMLElement)
-                if (e.shiftKey) {
-                  buttons[idx <= 0 ? buttons.length - 1 : idx - 1]?.focus()
-                } else {
-                  buttons[idx >= buttons.length - 1 ? 0 : idx + 1]?.focus()
-                }
-              }
-            }}
           >
             <p id="bulk-confirm-label" className="text-foreground mb-5 text-base font-medium">
               {bulkConfirm.action === 'approve'

--- a/frontend/src/components/RequestRowDesktop.tsx
+++ b/frontend/src/components/RequestRowDesktop.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback } from 'react'
 import clsx from 'clsx'
-import { CheckCircle, CheckCheck, XCircle, Scissors } from 'lucide-react'
+import { CheckCircle, CheckCheck, ChevronDown, ChevronRight, XCircle, Scissors } from 'lucide-react'
 import type { BunkRequestsResponse, PersonsResponse } from '../types/pocketbase-types'
 import EditableRequestType from './EditableRequestType'
 import EditableRequestTarget from './EditableRequestTarget'
@@ -19,6 +19,7 @@ export interface RequestRowDesktopProps {
   requester: PersonsResponse | undefined
   requestee: PersonsResponse | undefined
   isSelected: boolean
+  isExpanded: boolean
   sessionId: number
   year: number
   sessionName?: string | undefined
@@ -33,6 +34,7 @@ export interface RequestRowDesktopProps {
     action: 'approve' | 'decline',
     id: string
   ) => void
+  onExpandRow: (id: string) => void
 }
 
 function getConfidenceColor(score: number) {
@@ -84,6 +86,7 @@ function RequestRowDesktop({
   requester,
   requestee,
   isSelected,
+  isExpanded,
   sessionId,
   year,
   sessionName,
@@ -94,12 +97,17 @@ function RequestRowDesktop({
   onValidatedUpdate,
   onSplit,
   onConfirmAction,
+  onExpandRow,
 }: RequestRowDesktopProps) {
   // Stable per-row callbacks so the memoized editable children skip re-renders
   // when the row's identity is unchanged.
   const handleToggleSelection = useCallback(() => {
     onToggleSelection(request.id)
   }, [onToggleSelection, request.id])
+
+  const handleExpandRow = useCallback(() => {
+    onExpandRow(request.id)
+  }, [onExpandRow, request.id])
 
   const handleSelectRequester = useCallback(
     (e: React.MouseEvent) => {
@@ -150,16 +158,31 @@ function RequestRowDesktop({
 
   return (
     <div className="request-table-grid">
-      <div
-        className="flex items-center justify-center px-3 py-3"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <div className="flex items-center justify-center gap-1 px-3 py-3">
         <input
           type="checkbox"
           checked={isSelected}
           onChange={handleToggleSelection}
           className="rounded"
         />
+        {/* The row's own click-to-expand affordance (a real, native button — see
+            kindred#2094/#2095 house style) rather than a click handler on the
+            surrounding row div. Living in the "checkbox+expand" column matches
+            this grid's own column comment in index.css. */}
+        <button
+          type="button"
+          data-testid="request-row-expand-button"
+          onClick={handleExpandRow}
+          aria-expanded={isExpanded}
+          aria-label={isExpanded ? 'Collapse request details' : 'Expand request details'}
+          className="text-muted-foreground hover:text-foreground hover:bg-muted rounded p-0.5 transition-colors"
+        >
+          {isExpanded ? (
+            <ChevronDown className="h-3.5 w-3.5" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5" />
+          )}
+        </button>
       </div>
       <div className="flex min-w-0 items-center gap-1.5 px-4 py-3">
         <button
@@ -178,7 +201,7 @@ function RequestRowDesktop({
         </button>
         {request.is_reciprocal && <span className={MUTUAL_BADGE_CLASSES}>mutual</span>}
       </div>
-      <div className="flex items-center px-4 py-3" onClick={(e) => e.stopPropagation()}>
+      <div className="flex items-center px-4 py-3">
         <EditableRequestTarget
           requestType={request.request_type}
           currentPersonId={request.requestee_id}
@@ -200,7 +223,7 @@ function RequestRowDesktop({
           </span>
         )}
       </div>
-      <div className="flex items-center px-4 py-3" onClick={(e) => e.stopPropagation()}>
+      <div className="flex items-center px-4 py-3">
         <EditableRequestType value={request.request_type} onChange={handleTypeChange} />
       </div>
       <div className="flex items-center justify-center px-4 py-3">
@@ -225,7 +248,7 @@ function RequestRowDesktop({
           </span>
         )}
       </div>
-      <div className="flex items-center justify-end px-4 py-3" onClick={(e) => e.stopPropagation()}>
+      <div className="flex items-center justify-end px-4 py-3">
         <div className="flex min-w-[100px] items-center justify-end gap-1">
           {hasMultipleSources && (
             <button


### PR DESCRIPTION
## Chunk: request-family

31 → 0 `jsx-a11y` warnings across the 6 files below. 0 suppressions that silence real gaps — every warning got a structural fix. The one `eslint-disable` in the chunk (`no-autofocus`) is a deliberate UX call, justified inline per rule 7.

| File | Before | After |
|---|---:|---:|
| `RequestEditableHeader.tsx` | 4 | 0 |
| `RequestForm.tsx` | 4 | 0 |
| `RequestReviewPanel.tsx` | 9 | 0 |
| `RequestRowDesktop.tsx` | 8 | 0 |
| `CreateRequestModal.tsx` | 5 | 0 |
| `ManualResolutionModal.tsx` | 1 | 0 |
| **Total** | **31** | **0** |

```
./node_modules/.bin/eslint <chunk files> 2>/dev/null | grep -c jsx-a11y
# before: 31   after: 0
```

Whole tree still 0 errors: `./node_modules/.bin/eslint src` → 0 errors (pre-existing `@typescript-eslint`/other warnings elsewhere, untouched, out of scope for this wave).

### Fixed (30 of 31) — real structural fixes, no suppression

**The row's click-to-expand affordance moved to a real button** (`RequestRowDesktop.tsx` + `RequestReviewPanel.tsx`, 10 warnings: 8 + 2 of the 9). The desktop request row was a plain `<div onClick={...}>` — a non-interactive element wired up as a click target with zero keyboard path (`click-events-have-key-events`, `no-static-element-interactions`). Following the house style set by kindred#2094/#2095 ("a clickable row keeps native row semantics, moving the click into a real button"):

- `RequestRowDesktop`'s first cell (the "checkbox+expand" column, per `index.css`'s own comment on `.request-table-grid`) gained a real `<button>` with `aria-expanded`/`aria-label`, wired via a new `onExpandRow` prop.
- The row's outer `<div onClick={...}>` in `RequestReviewPanel.tsx` lost its click handler entirely — the row can't be a literal `<button>` wrapper because it already contains a checkbox, two dropdown buttons, and three action buttons (nesting interactive elements is invalid HTML and the exact anti-pattern #2094 fixed, just one layer further out).
- That, in turn, made **four** `onClick={(e) => e.stopPropagation()}` cell wrappers in `RequestRowDesktop.tsx` (checkbox, target, type, actions cells) and **one** in `RequestReviewPanel.tsx` (the expanded-content block) genuinely vestigial — they existed only to stop clicks from bubbling into the row's now-deleted handler. Removed as dead code rather than left in place or suppressed.
- `RequestEditableHeader.tsx`'s two identical `stopPropagation`-only divs turned out to be leftover from a different context — its sole caller (`AllCamperRequestsModal.tsx`) has no ancestor click handler at all, so they were dead from a different angle. Removed.

New tests (TDD, written before/alongside the implementation, `RequestReviewPanel.test.tsx`): the expand button is a real `<button>` with `aria-expanded`, and it expands the row on `Enter` with no mouse click — a keyboard path that did not exist before this PR. Three pre-existing tests that drove row-expansion via `fireEvent.click` on the row container were updated to click the new button instead (that's the only test-breakage this chunk caused, and it's exactly the getByRole/click-target risk called out in the task brief).

**`label-has-associated-control`** (`RequestForm.tsx` ×4, `CreateRequestModal.tsx` ×5): real `htmlFor`/`id` pairings, not `aria-label` bolted on.
- `CreateRequestModal.tsx`: all 5 labels were siblings of a native `select`/`input`/`textarea` with no association at all — straightforward `id`+`htmlFor`.
- `RequestForm.tsx`: two labels wrap a Headless UI `Listbox` (renders a `<button>`, not a labelable native control the rule recognizes by default) — fixed with `htmlFor`+`id` on the `ListboxButton` (buttons are labelable elements per the HTML spec, and Headless UI forwards `id` to the underlying DOM node). One label/input pair were untouched siblings — added `id`+`htmlFor`. The camper-checklist label failed a *different* check ("must have accessible text") because its text sat 3 JSX levels deep (`label > div > span > {text}`) against the rule's default 2-level recursion budget — flattened one level of wrapping `div` so the text is reachable, no visual change.

**`no-redundant-roles`** (`RequestReviewPanel.tsx` ×2): two filter-chip `<button role="button">` elements — removed the redundant explicit role.

**Bulk-confirm dialog** (`RequestReviewPanel.tsx`, 3 warnings): a hand-rolled confirmation modal.
- Backdrop div (`click-events-have-key-events` + `no-static-element-interactions`): added `aria-hidden="true"`, matching `ui/Modal.tsx`'s own backdrop exactly — a decorative click-to-dismiss overlay should be invisible to assistive tech regardless; Escape is the real keyboard path.
- `role="dialog"` element with an inline `onKeyDown` (`no-noninteractive-element-interactions` — "dialog" isn't an interactive ARIA role): moved the Escape/Tab-focus-trap logic from an inline JSX handler into the existing focus-management `useEffect` as a `document.addEventListener('keydown', ...)`, again matching `ui/Modal.tsx`'s established pattern exactly (it handles Escape the same way, via effect + document listener, not inline `onKeyDown`). Behavior is unchanged — keydown already bubbled from any focused button inside the dialog to the same effect.

### Suppressed (1 of 31) — justified

**`ManualResolutionModal.tsx`'s search-input `autoFocus`** (`no-autofocus`): kept, per rule 7. This modal's entire purpose is "search for a camper to resolve" — it's opened by an explicit staff click, and autofocusing the search box lets them start typing immediately. Suppressed with a one-line justification directly above the prop.

### Verification

- `./node_modules/.bin/eslint <chunk files>` — 0 `jsx-a11y` warnings (31 → 0), 0 errors tree-wide
- `./node_modules/.bin/tsc --noEmit` — clean
- `./node_modules/.bin/prettier --check` — clean
- Full `./node_modules/.bin/vitest run` — chunk's own test files (`RequestReviewPanel.test.tsx`, `RequestReviewPanel.status.test.tsx`, `RequestEditableHeader.test.tsx`): 105/105 pass, including 2 new keyboard-accessibility tests. Full-suite run showed 9 unrelated files/12 tests failing (config-loading timeouts and cross-test-pollution in surfaces like `LodgingAliasForm`, `BunkRequestRow`, `eslintA11yLayering.guard`); verified pre-existing by reproducing the same failures with this branch's changes `git stash`ed against a clean checkout, and by re-running each flagged file in isolation (all pass standalone). None touch this chunk's files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
