### PR TITLE
fix(frontend): a11y interaction gaps in metrics charts

### DIFF
--- a/frontend/src/components/metrics/CompareYearSelector.tsx
+++ b/frontend/src/components/metrics/CompareYearSelector.tsx
@@ -48,7 +48,12 @@ export function CompareYearSelector({
       <div className="flex items-center gap-2 text-sm">
         <span className="text-foreground font-semibold">{primaryYear}</span>
         <span className="text-muted-foreground">vs</span>
+        {/* This select replaces the "Compare to..." button the user just
+            activated, so focus should move here the same way it would into
+            a newly opened menu; without it a keyboard user who just pressed
+            the button lands nowhere. */}
         <select
+          // eslint-disable-next-line jsx-a11y/no-autofocus -- deliberate, see comment above
           autoFocus
           value=""
           onChange={(e) => {

--- a/frontend/src/components/metrics/CssHorizontalBarChart.tsx
+++ b/frontend/src/components/metrics/CssHorizontalBarChart.tsx
@@ -96,51 +96,75 @@ export function CssHorizontalBarChart({
             handleMouseLeave()
           }}
         >
-          {data.map((item, index) => (
-            <div
-              key={index}
-              className={`flex items-center ${isDense ? 'gap-2' : 'gap-3'} rounded ${isClickable ? 'cursor-pointer' : ''}`}
-              onClick={() => isClickable && handleClick(item)}
-              onMouseEnter={() => setHoveredIndex(index)}
-              onMouseMove={(e) => handleMouseMove(e, item)}
-            >
-              {/* Label */}
-              <span
-                className="text-muted-foreground shrink-0 truncate text-right text-sm"
-                style={{ width: labelWidth }}
-              >
-                {item.name}
-              </span>
+          {data.map((item, index) => {
+            const rowClass = `flex items-center ${isDense ? 'gap-2' : 'gap-3'} rounded ${isClickable ? 'cursor-pointer' : ''}`
+            const rowContent = (
+              <>
+                {/* Label */}
+                <span
+                  className="text-muted-foreground shrink-0 truncate text-right text-sm"
+                  style={{ width: labelWidth }}
+                >
+                  {item.name}
+                </span>
 
-              {/* Bar track */}
+                {/* Bar track */}
+                <div
+                  className="relative flex-1 overflow-hidden rounded"
+                  style={{ height: barHeight }}
+                >
+                  {/* Background track */}
+                  <div
+                    className={`absolute inset-0 rounded transition-colors ${hoveredIndex === index ? 'bg-foreground/20' : 'bg-muted'}`}
+                  />
+                  {/* Bar fill */}
+                  <div
+                    className="relative h-full rounded transition-all duration-300"
+                    style={{
+                      width: `${(item.value / axisMax) * 100}%`,
+                      backgroundColor: color,
+                      minWidth: item.value > 0 ? '4px' : '0px',
+                    }}
+                  />
+                </div>
+
+                {/* Value label */}
+                <span
+                  className="text-muted-foreground shrink-0 text-center text-sm tabular-nums"
+                  style={{ width: valueWidth }}
+                >
+                  {item.value}
+                </span>
+              </>
+            )
+
+            // A clickable row becomes a real <button> so it's keyboard-
+            // operable and gets a discoverable accessible name — bolting
+            // role="button"/tabIndex/onKeyDown onto a <div> is exactly what
+            // this house style avoids (kindred#2094). Non-clickable rows
+            // stay plain <div>s.
+            return isClickable ? (
+              <button
+                key={index}
+                type="button"
+                className={`${rowClass} w-full text-left`}
+                onClick={() => handleClick(item)}
+                onMouseEnter={() => setHoveredIndex(index)}
+                onMouseMove={(e) => handleMouseMove(e, item)}
+              >
+                {rowContent}
+              </button>
+            ) : (
               <div
-                className="relative flex-1 overflow-hidden rounded"
-                style={{ height: barHeight }}
+                key={index}
+                className={rowClass}
+                onMouseEnter={() => setHoveredIndex(index)}
+                onMouseMove={(e) => handleMouseMove(e, item)}
               >
-                {/* Background track */}
-                <div
-                  className={`absolute inset-0 rounded transition-colors ${hoveredIndex === index ? 'bg-foreground/20' : 'bg-muted'}`}
-                />
-                {/* Bar fill */}
-                <div
-                  className="relative h-full rounded transition-all duration-300"
-                  style={{
-                    width: `${(item.value / axisMax) * 100}%`,
-                    backgroundColor: color,
-                    minWidth: item.value > 0 ? '4px' : '0px',
-                  }}
-                />
+                {rowContent}
               </div>
-
-              {/* Value label */}
-              <span
-                className="text-muted-foreground shrink-0 text-center text-sm tabular-nums"
-                style={{ width: valueWidth }}
-              >
-                {item.value}
-              </span>
-            </div>
-          ))}
+            )
+          })}
         </div>
 
         {/* X-axis line + tick labels */}

--- a/frontend/src/components/metrics/CssStackedHorizontalBarChart.tsx
+++ b/frontend/src/components/metrics/CssStackedHorizontalBarChart.tsx
@@ -94,14 +94,9 @@ export function CssStackedHorizontalBarChart({
           }}
         >
           {data.map((item, index) => {
-            return (
-              <div
-                key={index}
-                className={`flex items-center ${isDense ? 'gap-2' : 'gap-3'} rounded ${isClickable ? 'cursor-pointer' : ''}`}
-                onClick={() => onBarClick?.(item)}
-                onMouseEnter={() => setHoveredIndex(index)}
-                onMouseMove={(e) => handleMouseMove(e, item)}
-              >
+            const rowClass = `flex items-center ${isDense ? 'gap-2' : 'gap-3'} rounded ${isClickable ? 'cursor-pointer' : ''}`
+            const rowContent = (
+              <>
                 {/* Label */}
                 <span
                   className="text-muted-foreground shrink-0 truncate text-right text-sm"
@@ -153,6 +148,33 @@ export function CssStackedHorizontalBarChart({
                 >
                   {item.total}
                 </span>
+              </>
+            )
+
+            // A clickable row becomes a real <button> so it's keyboard-
+            // operable and gets a discoverable accessible name — bolting
+            // role="button"/tabIndex/onKeyDown onto a <div> is exactly what
+            // this house style avoids (kindred#2094). Non-clickable rows
+            // stay plain <div>s.
+            return isClickable ? (
+              <button
+                key={index}
+                type="button"
+                className={`${rowClass} w-full text-left`}
+                onClick={() => onBarClick(item)}
+                onMouseEnter={() => setHoveredIndex(index)}
+                onMouseMove={(e) => handleMouseMove(e, item)}
+              >
+                {rowContent}
+              </button>
+            ) : (
+              <div
+                key={index}
+                className={rowClass}
+                onMouseEnter={() => setHoveredIndex(index)}
+                onMouseMove={(e) => handleMouseMove(e, item)}
+              >
+                {rowContent}
               </div>
             )
           })}

--- a/frontend/src/components/metrics/CssVerticalBarChart.tsx
+++ b/frontend/src/components/metrics/CssVerticalBarChart.tsx
@@ -146,24 +146,15 @@ export function CssVerticalBarChart({
                 .filter(Boolean)
                 .join(' ')
 
-              return (
-                <div
-                  key={index}
-                  className={columnClass}
-                  style={{
-                    ...(columnSizing.maxWidth
-                      ? { maxWidth: `${columnSizing.maxWidth}px`, width: '100%' }
-                      : {}),
-                    paddingLeft: `${columnSizing.columnPadding + halfGap}px`,
-                    paddingRight: `${columnSizing.columnPadding + halfGap}px`,
-                  }}
-                  onMouseEnter={(e) =>
-                    handleColumnEnter(index, e.currentTarget.getBoundingClientRect())
-                  }
-                  onMouseMove={(e) => handleColumnMove(e, item)}
-                  onMouseLeave={handleColumnLeave}
-                  onClick={() => onBarClick?.(item)}
-                >
+              const columnStyle: React.CSSProperties = {
+                ...(columnSizing.maxWidth
+                  ? { maxWidth: `${columnSizing.maxWidth}px`, width: '100%' }
+                  : {}),
+                paddingLeft: `${columnSizing.columnPadding + halfGap}px`,
+                paddingRight: `${columnSizing.columnPadding + halfGap}px`,
+              }
+              const columnContent = (
+                <>
                   {/* Label above bar */}
                   <span className="text-muted-foreground relative z-[1] mb-1 text-xs tabular-nums">
                     {label}
@@ -179,6 +170,41 @@ export function CssVerticalBarChart({
                       ...(barWidthPercent ? { width: `${barWidthPercent}%` } : {}),
                     }}
                   />
+                </>
+              )
+
+              // A clickable column becomes a real <button> so it's
+              // keyboard-operable and gets a discoverable accessible name —
+              // bolting role="button"/tabIndex/onKeyDown onto a <div> is
+              // exactly what this house style avoids (kindred#2094).
+              // Non-clickable columns stay plain <div>s.
+              return isClickable ? (
+                <button
+                  key={index}
+                  type="button"
+                  className={`${columnClass} text-left`}
+                  style={columnStyle}
+                  onMouseEnter={(e) =>
+                    handleColumnEnter(index, e.currentTarget.getBoundingClientRect())
+                  }
+                  onMouseMove={(e) => handleColumnMove(e, item)}
+                  onMouseLeave={handleColumnLeave}
+                  onClick={() => onBarClick(item)}
+                >
+                  {columnContent}
+                </button>
+              ) : (
+                <div
+                  key={index}
+                  className={columnClass}
+                  style={columnStyle}
+                  onMouseEnter={(e) =>
+                    handleColumnEnter(index, e.currentTarget.getBoundingClientRect())
+                  }
+                  onMouseMove={(e) => handleColumnMove(e, item)}
+                  onMouseLeave={handleColumnLeave}
+                >
+                  {columnContent}
                 </div>
               )
             })}

--- a/frontend/src/components/metrics/CssVerticalGroupedBarChart.tsx
+++ b/frontend/src/components/metrics/CssVerticalGroupedBarChart.tsx
@@ -196,26 +196,34 @@ export function CssVerticalGroupedBarChart({
                         if (value === 0) return null
                         const barHeightPx = (value / axisMax) * drawingHeight
 
-                        return (
-                          <div
+                        const segmentClassName = 'relative z-[1] transition-all duration-300'
+                        const segmentStyle: React.CSSProperties = {
+                          width: `${100 / series.length}%`,
+                          height: `${barHeightPx}px`,
+                          minHeight: '4px',
+                          backgroundColor: s.color,
+                          borderRadius: '3px 3px 0 0',
+                          ...(effectiveBarWidthPercent
+                            ? { maxWidth: `${effectiveBarWidthPercent}%` }
+                            : {}),
+                        }
+
+                        // A clickable segment becomes a real <button> so
+                        // it's keyboard-operable and gets a discoverable
+                        // accessible name — bolting role="button" +
+                        // tabIndex + onKeyDown onto a <div> is exactly what
+                        // this house style avoids (kindred#2094).
+                        // Non-clickable segments stay plain <div>s.
+                        return isClickable ? (
+                          <button
                             key={s.key}
-                            className="relative z-[1] transition-all duration-300"
-                            style={{
-                              width: `${100 / series.length}%`,
-                              height: `${barHeightPx}px`,
-                              minHeight: '4px',
-                              backgroundColor: s.color,
-                              borderRadius: '3px 3px 0 0',
-                              ...(effectiveBarWidthPercent
-                                ? { maxWidth: `${effectiveBarWidthPercent}%` }
-                                : {}),
-                            }}
-                            onClick={
-                              isClickable
-                                ? () => handleBarClick(item as Record<string, unknown>, s.key)
-                                : undefined
-                            }
+                            type="button"
+                            className={segmentClassName}
+                            style={segmentStyle}
+                            onClick={() => handleBarClick(item as Record<string, unknown>, s.key)}
                           />
+                        ) : (
+                          <div key={s.key} className={segmentClassName} style={segmentStyle} />
                         )
                       })}
                     </div>

--- a/frontend/src/components/metrics/CssVerticalStackedBarChart.tsx
+++ b/frontend/src/components/metrics/CssVerticalStackedBarChart.tsx
@@ -184,24 +184,15 @@ export function CssVerticalStackedBarChart({
                 .filter(Boolean)
                 .join(' ')
 
-              return (
-                <div
-                  key={index}
-                  className={columnClass}
-                  style={{
-                    ...(columnSizing.maxWidth
-                      ? { maxWidth: `${columnSizing.maxWidth}px`, width: '100%' }
-                      : {}),
-                    paddingLeft: `${columnSizing.columnPadding + halfGap}px`,
-                    paddingRight: `${columnSizing.columnPadding + halfGap}px`,
-                  }}
-                  onMouseEnter={(e) =>
-                    handleColumnEnter(index, e.currentTarget.getBoundingClientRect())
-                  }
-                  onMouseMove={(e) => handleColumnMove(e, item)}
-                  onMouseLeave={handleColumnLeave}
-                  onClick={() => onBarClick?.(item)}
-                >
+              const columnStyle: React.CSSProperties = {
+                ...(columnSizing.maxWidth
+                  ? { maxWidth: `${columnSizing.maxWidth}px`, width: '100%' }
+                  : {}),
+                paddingLeft: `${columnSizing.columnPadding + halfGap}px`,
+                paddingRight: `${columnSizing.columnPadding + halfGap}px`,
+              }
+              const columnContent = (
+                <>
                   {/* Label above bar */}
                   {shouldShowLabel && (
                     <span className="text-muted-foreground relative z-[1] mb-1 text-sm tabular-nums">
@@ -233,6 +224,41 @@ export function CssVerticalStackedBarChart({
                       )
                     })}
                   </div>
+                </>
+              )
+
+              // A clickable column becomes a real <button> so it's
+              // keyboard-operable and gets a discoverable accessible name —
+              // bolting role="button"/tabIndex/onKeyDown onto a <div> is
+              // exactly what this house style avoids (kindred#2094).
+              // Non-clickable columns stay plain <div>s.
+              return isClickable ? (
+                <button
+                  key={index}
+                  type="button"
+                  className={`${columnClass} text-left`}
+                  style={columnStyle}
+                  onMouseEnter={(e) =>
+                    handleColumnEnter(index, e.currentTarget.getBoundingClientRect())
+                  }
+                  onMouseMove={(e) => handleColumnMove(e, item)}
+                  onMouseLeave={handleColumnLeave}
+                  onClick={() => onBarClick(item)}
+                >
+                  {columnContent}
+                </button>
+              ) : (
+                <div
+                  key={index}
+                  className={columnClass}
+                  style={columnStyle}
+                  onMouseEnter={(e) =>
+                    handleColumnEnter(index, e.currentTarget.getBoundingClientRect())
+                  }
+                  onMouseMove={(e) => handleColumnMove(e, item)}
+                  onMouseLeave={handleColumnLeave}
+                >
+                  {columnContent}
                 </div>
               )
             })}

--- a/frontend/src/components/metrics/SessionBunkHeatmap.tsx
+++ b/frontend/src/components/metrics/SessionBunkHeatmap.tsx
@@ -106,9 +106,15 @@ function BunkHeatmapTable({ title, sessions, bunks, lookup, bunkStaff }: BunkHea
                   const hasStaff = staffMap?.has(`${session}|${bunk}`)
                   if (!item) {
                     return (
+                      // No explicit role: <td> already has an implicit
+                      // "cell" role in a plain (non-grid) table — restating
+                      // it as role="cell" is what trips
+                      // no-interactive-element-to-noninteractive-role, since
+                      // aria-query's <td> schema is ambiguous between
+                      // "cell" and "gridcell". getByRole('cell') still
+                      // matches via the implicit role.
                       <td
                         key={bunk}
-                        role="cell"
                         className="bg-muted/30 text-muted-foreground border-border/50 min-w-[2.5rem] border px-2 py-2 text-center"
                       >
                         —
@@ -122,9 +128,11 @@ function BunkHeatmapTable({ title, sessions, bunks, lookup, bunkStaff }: BunkHea
                     hasStaff ? 'cursor-help' : 'cursor-default',
                   ].join(' ')
                   return (
+                    // See the empty-cell branch above: role="cell" is
+                    // redundant on a <td> and trips the interactive-role
+                    // check via aria-query's ambiguous gridcell/cell schema.
                     <td
                       key={bunk}
-                      role="cell"
                       className={cellClass}
                       onMouseEnter={(e) => handleMouseEnter(session, bunk, e)}
                       onMouseMove={handleMouseMove}

--- a/frontend/src/components/metrics/__tests__/RetentionRateLineChart.test.tsx
+++ b/frontend/src/components/metrics/__tests__/RetentionRateLineChart.test.tsx
@@ -25,7 +25,10 @@ vi.mock('recharts', () => ({
     capturedActiveDotClick = activeDot?.onClick
     capturedStrokeLinecap = strokeLinecap
     return activeDot?.onClick ? (
-      <div
+      // Real <button> stand-in for recharts' clickable dot — not a <div>
+      // with a bolted-on onClick, per house style.
+      <button
+        type="button"
         data-testid="line-dot-clickable"
         onClick={() =>
           activeDot.onClick!({

--- a/frontend/src/components/metrics/geo/GeoMap.test.tsx
+++ b/frontend/src/components/metrics/geo/GeoMap.test.tsx
@@ -36,9 +36,16 @@ vi.mock('react-leaflet', () => ({
       fillColor: pathOptions?.fillColor,
     })
     return (
-      <div data-testid="circle-marker" data-pane={pane ?? ''} onClick={eventHandlers?.click}>
+      // Real <button> stand-in for react-leaflet's CircleMarker click
+      // handler — not a <div> with a bolted-on onClick, per house style.
+      <button
+        type="button"
+        data-testid="circle-marker"
+        data-pane={pane ?? ''}
+        onClick={eventHandlers?.click}
+      >
         {children}
-      </div>
+      </button>
     )
   },
   Tooltip: ({ children }: { children: ReactNode }) => <div>{children}</div>,


### PR DESCRIPTION
## Chunk: metrics-charts

Part of the jsx-a11y backlog sweep (baseline: 133 warnings / 51 files / 7 rules / 0 errors on `main` at `98718af7`). This PR touches only the file-disjoint `metrics-charts` chunk; six sibling agents are covering the rest in parallel PRs.

**Before → After (this chunk): 17 → 0 jsx-a11y warnings**

```
./node_modules/.bin/eslint <chunk files> -f unix 2>/dev/null | grep -c jsx-a11y
# before: 17
# after:  0
```

### Files (9)
- `src/components/metrics/CompareYearSelector.tsx`
- `src/components/metrics/CssHorizontalBarChart.tsx`
- `src/components/metrics/CssStackedHorizontalBarChart.tsx`
- `src/components/metrics/CssVerticalBarChart.tsx`
- `src/components/metrics/CssVerticalGroupedBarChart.tsx`
- `src/components/metrics/CssVerticalStackedBarChart.tsx`
- `src/components/metrics/SessionBunkHeatmap.tsx`
- `src/components/metrics/__tests__/RetentionRateLineChart.test.tsx`
- `src/components/metrics/geo/GeoMap.test.tsx`

### Fixed: 17, Suppressed: 1 (justified)

**Real fixes (16 warnings, `click-events-have-key-events` + `no-static-element-interactions` + `no-interactive-element-to-noninteractive-role`):**

- **The five `Css*BarChart` siblings** (`CssHorizontalBarChart`, `CssStackedHorizontalBarChart`, `CssVerticalBarChart`, `CssVerticalGroupedBarChart`, `CssVerticalStackedBarChart`) each had exactly one clickable row/column/segment `<div>` with `onClick` but no keyboard listener, contributing 2 warnings apiece (`click-events-have-key-events` + `no-static-element-interactions`) — 10 total across the five. Moved the click handler onto a real `<button type="button">`, rendered only when the item is actually clickable (`isClickable`/`onBarClick` present); non-clickable items still render as plain, non-interactive `<div>`s so no dead focus stops are added. This matches the house style from #2094 ("a clickable row keeps native row semantics, moving the click into a real button") rather than bolting `role="button"`/`tabIndex`/`onKeyDown` onto the div.
  - The five files are near-identical siblings, and I fixed them identically. A shared `<ClickableRow>`/`<ClickableColumn>` wrapper genuinely would remove some duplication here (the row-content-as-fragment + button/div ternary pattern is repeated 4 times, plus a simpler leaf-node version in the 5th) — flagging it rather than building it, since restructuring five chart components' render internals is bigger than this a11y-only PR should take on.
  - `CssVerticalGroupedBarChart.tsx` is the one exception in shape: the click target is each individual color segment within a group (a leaf `<div>`, no children), not the whole row/column — converted the same way (button when clickable, div otherwise).
  - Moving the `onClick` inside the `isClickable ? <button> : <div>` ternary let TypeScript's aliased-condition narrowing (`isClickable = !!onBarClick`) prove `onBarClick` is always defined in the button branch, which turned `onBarClick?.(item)` into a **new** `@typescript-eslint/no-unnecessary-condition` warning in 3 of the 5 files. Fixed by dropping the now-redundant `?.` (`onBarClick(item)`) — this is cleanup of a warning my own refactor introduced, not a pre-existing type-quality warning from the backlog, so it's in scope per rule 3's spirit (leave *pre-existing* `@typescript-eslint` warnings alone; don't leave new ones behind).

- **`SessionBunkHeatmap.tsx`** (`no-interactive-element-to-noninteractive-role`, 2 warnings): removed a redundant `role="cell"` from two `<td>` elements. A `<td>` already has an implicit `cell` role in a plain (non-`grid`) table. The explicit `role="cell"` is what trips this rule — `aria-query`'s element-role schema for `<td>` is ambiguous between `cell` and `gridcell` (two schema entries, one per possible ancestor-table role, and jsx-a11y's static matcher can't evaluate the "ancestor has role=grid" constraint, so it treats `<td>` as inherently interactive). Removing the redundant role is the correct fix regardless of the lint quirk. `getByRole('cell')` in `SessionBunkHeatmap.test.tsx` (not in this chunk, not touched) still matches via the implicit role — verified by running that test file directly.

- **Two test fixtures** (`click-events-have-key-events` + `no-static-element-interactions`, 2 warnings each = 4): `RetentionRateLineChart.test.tsx` and `GeoMap.test.tsx` each `vi.mock()` a third-party chart/map library (`recharts`, `react-leaflet`) and their mock re-implements the library's clickable dot/marker as a `<div onClick>`. Per the chunk guidance, fixed the fixture markup itself rather than the assertions — both mocks now render a real `<button type="button">` instead. Verified neither test file uses `getByRole` anywhere (so no role-query collision risk), and both mocks' `data-testid` queries + `fireEvent.click` calls are unaffected by the tag change.

**Suppressed (1, justified) — `no-autofocus`:**

- **`CompareYearSelector.tsx`**: kept `autoFocus` on the comparison-year `<select>` that appears when "Compare to..." is clicked, suppressed with a one-line justification. This `<select>` *replaces* the button the user just activated (this file swaps between three return states based on `compareYear`/`isOpen`, so the button disappears from the DOM the moment the select mounts) — focus should move into it the same way it would into a newly opened menu. Without `autoFocus`, a keyboard user who just activated the button lands on nothing. No existing test (`CompareYearSelector.test.tsx`, not in this chunk) asserts on focus behavior, so nothing to update there.

### Full vitest suite

Ran multiple times (both isolated to the components this PR touches, and the full suite):

- **Isolated to touched components** (9 test files exercising every file in this PR): `188/188 passed`, every run.
- **Full suite** (`./node_modules/.bin/vitest run`): flaky across 4 consecutive runs under this environment's load (7 sibling agents running full test/type-check/lint suites concurrently on the same machine) — 6, 1, 7, then 1 failing tests, in **different, non-overlapping test files each time** (`LodgingAliasForm`, `LodgingUnitForm`, `WeekendRosterPage.codeSplitting`, `MetricsSubNav`, `MetricsTypeTabs`, `LodgingBoard.availability`, `MetricsLayout`, `SolverDebugPage`, `eslintA11yLayering.guard`). None of these files import or render anything this PR touches (verified by grep). Several are explicit `testTimeout`/lazy-chunk-resolution tests that are known-sensitive to CPU contention (e.g. `eslintA11yLayering.guard.test.ts` shells out to ESLint's API within a 5s test timeout, and flipped pass/fail across three isolated re-runs with no code changes in between). Root cause is environmental, not this PR.
- `tsc --noEmit` (both projects): clean.
- `prettier --check` on all 9 files: clean.

### Tree-wide

```
./node_modules/.bin/eslint src 2>&1 | tail -3
# ✖ 493 problems (0 errors, 493 warnings)
```

0 errors, confirmed after this chunk's changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
