### PR TITLE
docs(frontend): explain ShareRequestPanel lacks lodging.phi gate

### DIFF
--- a/frontend/src/components/weekend/ShareRequestPanel.tsx
+++ b/frontend/src/components/weekend/ShareRequestPanel.tsx
@@ -15,6 +15,17 @@
  * The verbatim text uses the same amber blockquote the camper details panel
  * uses for parent request text, so a request reads the same wherever staff
  * meet one. It arrives pre-joined from three source fields and is never split.
+ *
+ * ## No lodging.phi gate
+ *
+ * `request_text` has no permission check, while `MedicalNarrative` (rendered
+ * beside it in `FamilyDetailsPanel`) is gated on `lodging.phi`. The split is
+ * intentional: `bunking.manage` is the placement role, and `request_text` is a
+ * placement input—why a household wants a particular cabin or setting is a
+ * legitimate placement concern. The field is not modelled as PHI (it is free
+ * text, not a structured medical disclosure), even though it sometimes contains
+ * health detail. The gate on `MedicalNarrative` covers the field that IS
+ * structured PHI: the formal medical accommodations questionnaire.
  */
 import { AlertCircle, MapPin, Users } from 'lucide-react'
 


### PR DESCRIPTION
## Summary

Documents why `ShareRequestPanel` correctly has no `lodging.phi` permission gate while `MedicalNarrative` beside it does.

**Decision**: The split is intentional. `bunking.manage` is the placement role, and `request_text` is a placement input describing why a household wants a particular cabin. The field is not modelled as PHI (it is free text, not structured medical disclosure), even though it sometimes contains health details. The gate on `MedicalNarrative` covers the field that IS structured PHI.

Closes #2017.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>