### PR TITLE
fix(scripts): validate CAMPMINDER_SEASON_ID as numeric before converting to int

### DIFF
--- a/scripts/dev/apply_lodging_inventory.py
+++ b/scripts/dev/apply_lodging_inventory.py
@@ -314,10 +314,13 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="also apply bathroom/container/parent corrections, which OVERWRITE existing values",
     )
+    # Compute default year: use CAMPMINDER_SEASON_ID if it's numeric, else fall back to calendar year
+    season_id = os.getenv("CAMPMINDER_SEASON_ID", "")
+    default_year = int(season_id) if season_id.isdigit() else datetime.now().year
     parser.add_argument(
         "--year",
         type=int,
-        default=int(os.getenv("CAMPMINDER_SEASON_ID", datetime.now().year)),
+        default=default_year,
         help="Season to apply against. Defaults to CAMPMINDER_SEASON_ID.",
     )
     args = parser.parse_args(argv)

--- a/scripts/dev/confirm_lodging_units.py
+++ b/scripts/dev/confirm_lodging_units.py
@@ -97,10 +97,13 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="required for a non-loopback URL; confirming cabins nobody checked is a lie to staff",
     )
+    # Compute default year: use CAMPMINDER_SEASON_ID if it's numeric, else fall back to calendar year
+    season_id = os.getenv("CAMPMINDER_SEASON_ID", "")
+    default_year = int(season_id) if season_id.isdigit() else datetime.now().year
     parser.add_argument(
         "--year",
         type=int,
-        default=int(os.getenv("CAMPMINDER_SEASON_ID", str(datetime.now().year))),
+        default=default_year,
         help="Season to confirm. Defaults to CAMPMINDER_SEASON_ID.",
     )
     args = parser.parse_args(argv)

--- a/scripts/prepare_for_new_year.py
+++ b/scripts/prepare_for_new_year.py
@@ -18,9 +18,13 @@ def load_env_config() -> dict[str, Any] | None:
     """Load current configuration from .env file."""
     load_dotenv()
 
+    # Compute default year: use CAMPMINDER_SEASON_ID if it's numeric, else fall back to calendar year
+    season_id = os.getenv("CAMPMINDER_SEASON_ID", "")
+    default_year = int(season_id) if season_id.isdigit() else datetime.now().year
+
     config = {
-        "season_id": int(os.getenv("CAMPMINDER_SEASON_ID", datetime.now().year)),
-        "active_year": int(os.getenv("CAMPMINDER_SEASON_ID", datetime.now().year)),
+        "season_id": default_year,
+        "active_year": default_year,
         "api_key": os.getenv("CAMPMINDER_API_KEY"),
         "primary_key": os.getenv("CAMPMINDER_PRIMARY_KEY"),
         "client_id": os.getenv("CAMPMINDER_CLIENT_ID"),

--- a/tests/unit/scripts/test_apply_lodging_inventory.py
+++ b/tests/unit/scripts/test_apply_lodging_inventory.py
@@ -93,3 +93,23 @@ def test_an_explicit_year_flag_beats_the_environment(monkeypatch: pytest.MonkeyP
     """The operator's flag is the whole reason the season is not read directly."""
     monkeypatch.setenv("CAMPMINDER_SEASON_ID", "2031")
     assert _drive_main(monkeypatch, tmp_path, ["--year", "2033"]) == [2033]
+
+
+def test_the_year_falls_back_to_calendar_year_when_season_id_is_blank(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A blank CAMPMINDER_SEASON_ID (empty string) should fall back to calendar year, not raise."""
+    monkeypatch.setenv("CAMPMINDER_SEASON_ID", "")
+    before = datetime.now().year
+    seen = _drive_main(monkeypatch, tmp_path, [])
+    assert seen[0] in {before, datetime.now().year}
+
+
+def test_the_year_falls_back_to_calendar_year_when_season_id_is_non_numeric(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A non-numeric CAMPMINDER_SEASON_ID should fall back to calendar year, not raise."""
+    monkeypatch.setenv("CAMPMINDER_SEASON_ID", "abc")
+    before = datetime.now().year
+    seen = _drive_main(monkeypatch, tmp_path, [])
+    assert seen[0] in {before, datetime.now().year}

--- a/tests/unit/scripts/test_confirm_lodging_units.py
+++ b/tests/unit/scripts/test_confirm_lodging_units.py
@@ -1,0 +1,70 @@
+"""Tests for the confirm_lodging_units script."""
+
+from datetime import datetime
+from typing import Any
+
+import pytest
+
+from scripts.dev.confirm_lodging_units import main
+
+
+def _drive_main(monkeypatch: pytest.MonkeyPatch, extra: list[str]) -> list[int]:
+    """Run `main` with the network stubbed and report the year it fetched.
+
+    The `--year` default is resolved by argparse inside `main`, so the only
+    faithful way to see it is to let `main` run and watch what reaches the
+    _units function. A helper tested in isolation would prove the year is
+    computed, not that the parser hands it to `_units` — which is the half
+    that breaks.
+    """
+    seen: list[int] = []
+
+    def fake_auth(_base: str, _identity: str, _password: str) -> str:
+        return "tok"
+
+    def fake_units(_base: str, _token: str, year: int) -> list[dict[str, Any]]:
+        seen.append(year)
+        return []
+
+    monkeypatch.setattr("scripts.dev.confirm_lodging_units._auth", fake_auth)
+    monkeypatch.setattr("scripts.dev.confirm_lodging_units._units", fake_units)
+
+    rc = main(["--password", "x", *extra])
+    assert rc == 0
+    return seen
+
+
+def test_the_year_defaults_to_the_campminder_season_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CAMPMINDER_SEASON_ID", "2031")
+    assert _drive_main(monkeypatch, []) == [2031]
+
+
+def test_the_year_falls_back_to_the_calendar_year_when_the_env_is_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No season configured means the clock, not a hardcoded year."""
+    monkeypatch.delenv("CAMPMINDER_SEASON_ID", raising=False)
+    before = datetime.now().year
+    seen = _drive_main(monkeypatch, [])
+    # A window, not an equality: the run must not flake across midnight on 31 Dec.
+    assert seen[0] in {before, datetime.now().year}
+
+
+def test_an_explicit_year_flag_beats_the_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The operator's flag is the whole reason the season is not read directly."""
+    monkeypatch.setenv("CAMPMINDER_SEASON_ID", "2031")
+    assert _drive_main(monkeypatch, ["--year", "2033"]) == [2033]
+
+
+def test_the_year_falls_back_to_calendar_year_when_season_id_is_blank(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A blank CAMPMINDER_SEASON_ID (empty string) should fall back to calendar year, not raise."""
+    monkeypatch.setenv("CAMPMINDER_SEASON_ID", "")
+    before = datetime.now().year
+    seen = _drive_main(monkeypatch, [])
+    assert seen[0] in {before, datetime.now().year}
+
+
+def test_the_year_falls_back_to_calendar_year_when_season_id_is_non_numeric(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-numeric CAMPMINDER_SEASON_ID should fall back to calendar year, not raise."""
+    monkeypatch.setenv("CAMPMINDER_SEASON_ID", "abc")
+    before = datetime.now().year
+    seen = _drive_main(monkeypatch, [])
+    assert seen[0] in {before, datetime.now().year}


### PR DESCRIPTION
## Summary
- Validates CAMPMINDER_SEASON_ID is numeric before int() conversion in three scripts
- Falls back to calendar year for blank or non-numeric values
- Aligns Python and Go implementations using .isdigit() pattern

Fixes #2064

## Files Changed
- scripts/dev/apply_lodging_inventory.py (line 320)
- scripts/dev/confirm_lodging_units.py (line 103)  
- scripts/prepare_for_new_year.py (lines 22-23, two occurrences)
- tests/unit/scripts/test_apply_lodging_inventory.py (added 2 tests)
- tests/unit/scripts/test_confirm_lodging_units.py (new file, 5 tests)

## Test Coverage
All 12 script tests pass, including new tests for:
- Blank CAMPMINDER_SEASON_ID
- Non-numeric CAMPMINDER_SEASON_ID

Closes #2064.