### PR TITLE
fix(frontend): complete forest-950 token and convert lodge shadows to @utility

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,6 +14,7 @@
    ============================================ */
 @theme {
   /* Camp Forest Palette - Deepened & Warmed */
+  --color-forest-950: oklch(14% 0.06 158); /* #061c13 - Twilight forest */
   --color-forest-900: oklch(18% 0.08 160); /* #0a2e1f - Deep forest shadow */
   --color-forest-800: oklch(23% 0.1 162); /* #0d3d28 - Night forest */
   --color-forest-700: oklch(28% 0.12 164); /* #124d33 - Dense canopy */
@@ -704,31 +705,6 @@
     border-radius: 9999px;
   }
 
-  /* Lodge shadows */
-  .shadow-lodge-sm {
-    box-shadow:
-      0 1px 2px hsl(var(--shadow-color) / 0.04),
-      0 2px 8px hsl(var(--shadow-color) / 0.06);
-  }
-
-  .shadow-lodge {
-    box-shadow:
-      0 1px 2px hsl(var(--shadow-color) / 0.04),
-      0 4px 16px hsl(var(--shadow-color) / 0.08);
-  }
-
-  .shadow-lodge-lg {
-    box-shadow:
-      0 2px 4px hsl(var(--shadow-color) / 0.04),
-      0 8px 32px hsl(var(--shadow-color) / 0.12);
-  }
-
-  .shadow-lodge-xl {
-    box-shadow:
-      0 4px 8px hsl(var(--shadow-color) / 0.05),
-      0 16px 48px hsl(var(--shadow-color) / 0.15);
-  }
-
   /* Glow effects */
   .glow-accent {
     box-shadow:
@@ -1096,6 +1072,32 @@
   .toast-exit {
     animation: toastSlideOut 0.25s ease-in forwards;
   }
+}
+
+/* Lodge shadows — @utility (not @layer utilities) so variants like
+   hover: and dark: generate; see #2027. */
+@utility shadow-lodge-sm {
+  box-shadow:
+    0 1px 2px hsl(var(--shadow-color) / 0.04),
+    0 2px 8px hsl(var(--shadow-color) / 0.06);
+}
+
+@utility shadow-lodge {
+  box-shadow:
+    0 1px 2px hsl(var(--shadow-color) / 0.04),
+    0 4px 16px hsl(var(--shadow-color) / 0.08);
+}
+
+@utility shadow-lodge-lg {
+  box-shadow:
+    0 2px 4px hsl(var(--shadow-color) / 0.04),
+    0 8px 32px hsl(var(--shadow-color) / 0.12);
+}
+
+@utility shadow-lodge-xl {
+  box-shadow:
+    0 4px 8px hsl(var(--shadow-color) / 0.05),
+    0 16px 48px hsl(var(--shadow-color) / 0.15);
 }
 
 /* ============================================

--- a/frontend/src/index.css.guard.test.ts
+++ b/frontend/src/index.css.guard.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Guards two "dead Tailwind utility" defects in index.css (#1894, #2027).
+ *
+ * Both bugs share a shape: a class string exists in source but Tailwind v4
+ * generates no rule for it, so the element silently keeps whatever styling
+ * it already had. Neither bug fails a render test — the class is present on
+ * the DOM node either way — so the only place that can catch it is the
+ * stylesheet source itself. This is a source-level assertion for the same
+ * reason manageTabs.guard.test.ts is: see reference_frontend_source_grep_tests.
+ *
+ * #1894 — the forest palette stops at --color-forest-900, so every
+ * `forest-950` utility (bg-forest-950, hover:bg-forest-950, etc.) across the
+ * 10 consumer files generates nothing.
+ *
+ * #2027 — .shadow-lodge-sm / .shadow-lodge / .shadow-lodge-lg / .shadow-lodge-xl
+ * are hand-written plain-CSS class rules inside @layer utilities, not
+ * Tailwind @utility declarations, so v4 has no definition to build a
+ * hover:/dark:/etc. variant from. hover:shadow-lodge-lg and friends resolve
+ * to no selector at all.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const css = readFileSync(resolve(__dirname, './index.css'), 'utf-8')
+
+function themeBlock(): string {
+  const match = css.match(/@theme\s*{([\s\S]*?)\n}/)
+  expect(match).not.toBeNull()
+  const captured = match?.[1]
+  expect(captured).toBeDefined()
+  return captured as string
+}
+
+describe('index.css — forest-950 token (#1894)', () => {
+  it('defines --color-forest-950 inside @theme so forest-950 utilities generate', () => {
+    expect(themeBlock()).toMatch(/--color-forest-950:\s*oklch\(/)
+  })
+})
+
+describe('index.css — lodge-shadow utilities (#2027)', () => {
+  const names = ['shadow-lodge-sm', 'shadow-lodge', 'shadow-lodge-lg', 'shadow-lodge-xl']
+
+  names.forEach((name) => {
+    it(`declares .${name} with @utility, not a plain class rule, so variants like hover: generate`, () => {
+      // Must be an @utility declaration...
+      expect(css).toMatch(new RegExp(`@utility ${name}\\s*{`))
+      // ...not left behind as a hand-written class selector. The negative
+      // lookahead keeps `shadow-lodge` from matching inside
+      // `shadow-lodge-sm`/`-lg`/`-xl`.
+      expect(css).not.toMatch(new RegExp(`\\n\\s*\\.${name}(?![\\w-])\\s*{`))
+    })
+  })
+})


### PR DESCRIPTION
## What

Two dead-Tailwind-utility bugs in `frontend/src/index.css`, both fixed the same way the issue authors suggested: complete the token/declaration Tailwind v4 needs so it can actually generate the CSS.

**#1894** — the forest palette stopped at `--color-forest-900`, so every `forest-950` utility (`bg-forest-950`, `dark:hover:bg-forest-950`, etc.) across 10 consumer files generated no CSS at all. Adds `--color-forest-950: oklch(14% 0.06 158)` to the `@theme` block, continuing the existing ramp.

**#2027** — `.shadow-lodge-sm` / `.shadow-lodge` / `.shadow-lodge-lg` / `.shadow-lodge-xl` were hand-written plain-CSS class rules inside `@layer utilities`, not Tailwind v4 `@utility` declarations, so Tailwind had no definition to build a `hover:`/`dark:`/etc. variant from. `hover:shadow-lodge-lg` and friends resolved to no selector at all. Converts all four to `@utility`, which makes every variant work for free.

## Scope

`frontend/src/index.css` only, plus a new guard test. Per the issue bodies and prior investigation, the 10 `forest-950` consumer files and the 6 `hover:shadow-lodge*` consumer files are **not** touched here — they already carry the class strings and start rendering correctly once the CSS can generate the rule, with no code change needed on their end.

`shadow-lodge-md` (the second root cause named in #2027, three sites with no defined class at all) is **out of scope for this PR** — fixing it means touching `LoginPage.tsx`, `GraphDisplayMenu.tsx`, and `GraphControls.tsx`, which falls outside `index.css`. Left for a follow-up.

`LodgingUnitCard.test.tsx:805-825` pins a deliberate absence of `hover:shadow-lodge-lg` on that component — untouched by this PR and still green, since the `@utility` conversion doesn't add the class to any component, it just makes the class Tailwind-buildable.

## Verification

- New `frontend/src/index.css.guard.test.ts` — source-level assertions that `--color-forest-950` exists in `@theme` and that each `shadow-lodge*` name is declared via `@utility` rather than a plain class selector. Written first, confirmed failing against the unfixed CSS (all 5 assertions red), then implementation made it green. Mutation-checked: reverting either fix independently (removing the token, reverting one `@utility` back to a plain class) reproduces exactly the expected failure.
- `LodgingUnitCard.test.tsx` — all 44 tests pass, including the pinned no-hover-shadow absence test.
- `npx tsc --noEmit` — clean.
- `./node_modules/.bin/eslint` — clean.
- Production build (`npm run build`) — succeeded; inspected the built CSS directly and confirmed real generated rules: `.dark\:bg-forest-950\/30:where(.dark,.dark *){background-color:...}`, `.dark\:hover\:bg-forest-950\/30...:hover{...}`, and `.hover\:shadow-lodge-lg:hover{box-shadow:...}` — none of which existed in the pre-fix build.
- `lefthook run pre-push --force` (ruff, pytest, mypy, go-build, shellcheck, pb-js-lint, markdownlint, api-types-freshness, type-check) — all green.

Closes #1894.
Closes #2027.