### PR TITLE
feat(frontend): ring a shared lodging card in its area hue

### DIFF
--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -12,7 +12,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
 import type { BoardSlot } from './boardLayout'
-import { unitDroppableId } from './dragPlacement'
+import { mergeDragId, unitDroppableId } from './dragPlacement'
 import { LodgingUnitCard } from './LodgingUnitCard'
 
 /**
@@ -514,11 +514,25 @@ describe('LodgingUnitCard — the shared-space mark (#2091)', () => {
     return el as HTMLElement
   }
 
-  it('rings a shared unit in the area hue when nobody has flagged it', () => {
+  // `.card-lodge`'s own elevation shadow (`index.css:440-443`), pinned here
+  // independently of the implementation's own constant name — this is the
+  // exact value a shared card must NOT lose (review finding 1 on #2119).
+  const cardElevationShadow =
+    '0 1px 2px hsl(var(--shadow-color) / 0.06), 0 4px 16px hsl(var(--shadow-color) / 0.08)'
+
+  it('rings a shared unit in the area hue AND keeps the card elevation shadow', () => {
+    // An inline `boxShadow` beats `.card-lodge`'s own stylesheet box-shadow
+    // for the same property outright — setting ONLY the ring here (as the
+    // code did before this fix) silently drops the elevation every other
+    // card keeps, so a shared card reads as flat against its neighbours.
+    // The fix composes both shadows into the one inline value rather than
+    // letting the ring replace the elevation.
     const { container } = render(
       <LodgingUnitCard slot={slot({ parties: sharedParties })} hue={hue} onOpenParty={vi.fn()} />
     )
-    expect(card(container)).toHaveStyle({ boxShadow: `0 0 0 2px ${hue}` })
+    expect(card(container)).toHaveStyle({
+      boxShadow: `0 0 0 2px ${hue}, ${cardElevationShadow}`,
+    })
   })
 
   it('leaves a single-party unit without the shared ring', () => {
@@ -595,6 +609,88 @@ describe('LodgingUnitCard — the shared-space mark (#2091)', () => {
     )
     expect(card(container)).toHaveClass('opacity-40')
     expect(card(container)).not.toHaveStyle({ boxShadow: `0 0 0 2px ${hue}` })
+  })
+
+  it('lets an active drop target outrank a CONSENT-flagged room too', () => {
+    // The existing "outranks the shared-space ring" test above only ever
+    // combines an active drop target with `sharedParties` (no `consent`).
+    // Consent has its own ring (`border-amber-400`), which is what a drop
+    // target actually has to fight over the shared CSS slot with here.
+    overDroppableId = unitDroppableId('cedar-1')
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ parties: sharedParties, consent: declinedConsent })}
+        hue={hue}
+        canPlace
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(card(container)).toHaveClass('border-primary')
+    expect(card(container)).not.toHaveClass('border-amber-400')
+  })
+
+  it('treats a merge-handle drop (isMergeOver) as an active drop target on its own', () => {
+    // Isolates `isMergeOver` from `isUnitOver`: no `canPlace`, so the party
+    // droppable never activates, and no party is being dragged either. Only
+    // the merge droppable is over. If `isUnitOver || isMergeOver` ever lost
+    // its `isMergeOver` half, this card would fall all the way through to
+    // the empty-room dashed state instead of the drop-target ring.
+    const room = unit({ code: 'cedar-1', parent_code: 'east-wing' })
+    const validSibling = unit({ code: 'other-1', parent_code: 'east-wing' })
+    overDroppableId = mergeDragId('cedar-1')
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: room })}
+        hue={hue}
+        mergeSourceUnit={validSibling}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(card(container)).toHaveClass('border-primary')
+  })
+
+  it('keeps the consent amber accent visible while an invalid merge drag dims the card', () => {
+    // Pre-existing (pre-refactor) behaviour this PR's ordered `cardState`
+    // switch silently dropped: dimming and the consent ring are ORTHOGONAL
+    // CSS properties (opacity/pointer-events vs border-color/box-shadow), so
+    // an invalid merge target should not blank out a real consent warning —
+    // it just dims the whole card, warning included.
+    const room = unit({ code: 'cedar-1', parent_code: 'east-wing' })
+    const draggedSibling = unit({ code: 'other-1', parent_code: 'west-wing' })
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: room, parties: sharedParties, consent: declinedConsent })}
+        hue={hue}
+        mergeSourceUnit={draggedSibling}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(card(container)).toHaveClass('opacity-40')
+    expect(card(container)).toHaveClass('border-amber-400')
+  })
+
+  it('keeps the empty-room dashed cue visible while an invalid merge drag dims the card', () => {
+    const room = unit({ code: 'cedar-1', parent_code: 'east-wing' })
+    const draggedSibling = unit({ code: 'other-1', parent_code: 'west-wing' })
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: room })}
+        hue={hue}
+        mergeSourceUnit={draggedSibling}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(card(container)).toHaveClass('opacity-40')
+    expect(card(container)).toHaveClass('border-dashed')
+  })
+
+  it('keeps the empty-room dashed cue visible under an active drop target', () => {
+    overDroppableId = unitDroppableId('cedar-1')
+    const { container } = render(
+      <LodgingUnitCard slot={slot()} hue={hue} canPlace onOpenParty={vi.fn()} />
+    )
+    expect(card(container)).toHaveClass('border-primary')
+    expect(card(container)).toHaveClass('border-dashed')
   })
 })
 

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -692,6 +692,24 @@ describe('LodgingUnitCard — the shared-space mark (#2091)', () => {
     expect(card(container)).toHaveClass('border-primary')
     expect(card(container)).toHaveClass('border-dashed')
   })
+
+  it('drops the empty-room background wash under an active drop target, so the two never race', () => {
+    // `.bg-muted/25` (the dashed wash) and `.bg-primary/5` (the drop-target
+    // wash) both set `background-color` — a `toHaveClass('border-dashed')`
+    // check alone (the test above) cannot see this, because jsdom parses no
+    // Tailwind and a class string proves nothing about which declaration a
+    // real browser's cascade would pick. This is the same pairing the file's
+    // own top-of-diff comment names as the SECOND byte-offset race this
+    // refactor exists to kill (the first being `.border-amber-400` vs
+    // `.border-primary`) — this is the case of it that mattered for a real,
+    // high-frequency gesture: hovering a family drag over an empty room.
+    overDroppableId = unitDroppableId('cedar-1')
+    const { container } = render(
+      <LodgingUnitCard slot={slot()} hue={hue} canPlace onOpenParty={vi.fn()} />
+    )
+    expect(card(container)).toHaveClass('bg-primary/5')
+    expect(card(container)).not.toHaveClass('bg-muted/25')
+  })
 })
 
 /*

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -8,11 +8,37 @@
  */
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
 import type { BoardSlot } from './boardLayout'
+import { unitDroppableId } from './dragPlacement'
 import { LodgingUnitCard } from './LodgingUnitCard'
+
+/**
+ * jsdom cannot perform a pointer drag, so `useDroppable`'s real `isOver`
+ * never goes true here. The settled idiom (`LodgingBoard.drag.test.tsx`) is
+ * to mock at the `@dnd-kit/core` boundary; this one only needs `isOver`
+ * itself, controlled by `overDroppableId`, to prove the drop-target state
+ * outranks the shared-space ring below. `useDraggable` stays real — the
+ * merge-handle tests click a plain `onClick`, which does not touch it.
+ */
+let overDroppableId: string | null = null
+
+vi.mock('@dnd-kit/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@dnd-kit/core')>()
+  return {
+    ...actual,
+    useDroppable: (args: { id: string; disabled?: boolean }) => ({
+      setNodeRef: vi.fn(),
+      isOver: args.disabled !== true && args.id === overDroppableId,
+    }),
+  }
+})
+
+beforeEach(() => {
+  overDroppableId = null
+})
 
 function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
   return {
@@ -157,6 +183,17 @@ describe('LodgingUnitCard', () => {
       />
     )
     expect(screen.getByText('1 family did not request sharing')).toBeInTheDocument()
+  })
+
+  it('keeps an empty unit dashed and washed out', () => {
+    // Pre-existing behaviour, preserved through the ordered-switch refactor
+    // below rather than displaced by it.
+    const { container } = render(
+      <LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />
+    )
+    const card = container.querySelector('[data-unit-card]')
+    expect(card).toHaveClass('bg-muted/25')
+    expect(card).toHaveClass('border-dashed')
   })
 
   it('badges a staff hold rather than hiding the room', () => {
@@ -453,6 +490,111 @@ describe('LodgingUnitCard — the per-party sharing chip follows ROOM overlap, n
       />
     )
     expect(screen.getAllByText('Did not request sharing')).toHaveLength(2)
+  })
+})
+
+describe('LodgingUnitCard — the shared-space mark (#2091)', () => {
+  // The master housing sheet's fill for "two families here", adopted as the
+  // ring `LodgingMap.tsx`'s `halo` already draws for the identical flag
+  // (`0 0 0 4.5px ${hue}` there, on a small circular mark; this card is a
+  // rectangle with its own 2px `.card-lodge` border, so `2px` is the ring
+  // weight rather than the map's offset-plus-ring pair).
+  const hue = 'hsl(160 45% 42%)'
+  const sharedParties = [party(), party({ household_cm_id: 102, display_name: 'Garcia' })]
+  const declinedConsent = {
+    declinedCount: 1,
+    unansweredCount: 0,
+    conflictCount: 0,
+    reason: '1 family did not request sharing',
+  }
+
+  function card(container: HTMLElement): HTMLElement {
+    const el = container.querySelector('[data-unit-card]')
+    if (!el) throw new Error('no card rendered')
+    return el as HTMLElement
+  }
+
+  it('rings a shared unit in the area hue when nobody has flagged it', () => {
+    const { container } = render(
+      <LodgingUnitCard slot={slot({ parties: sharedParties })} hue={hue} onOpenParty={vi.fn()} />
+    )
+    expect(card(container)).toHaveStyle({ boxShadow: `0 0 0 2px ${hue}` })
+  })
+
+  it('leaves a single-party unit without the shared ring', () => {
+    const { container } = render(
+      <LodgingUnitCard slot={slot({ parties: [party()] })} hue={hue} onOpenParty={vi.fn()} />
+    )
+    expect(card(container)).not.toHaveStyle({ boxShadow: `0 0 0 2px ${hue}` })
+  })
+
+  it('leaves an empty unit without the shared ring', () => {
+    const { container } = render(<LodgingUnitCard slot={slot()} hue={hue} onOpenParty={vi.fn()} />)
+    expect(card(container)).not.toHaveStyle({ boxShadow: `0 0 0 2px ${hue}` })
+  })
+
+  it('promotes the consent ring to ring-2', () => {
+    // Prerequisite named in #2091: the mark this test file is otherwise
+    // about needs a `ring-1` consent edge promoted first, so the new mark
+    // has a weight to lose to.
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ parties: sharedParties, consent: declinedConsent })}
+        hue={hue}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(card(container)).toHaveClass('ring-2')
+    expect(card(container)).not.toHaveClass('ring-1')
+  })
+
+  it('lets the consent flag outrank the shared-space ring', () => {
+    // Amber supersedes the hue ring, exactly as `LodgingMap.tsx`'s `halo`
+    // does for the same two flags — a consent flag only ever exists on a
+    // shared room, so the two never compete for meaning, only for the one
+    // ring a card can draw.
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ parties: sharedParties, consent: declinedConsent })}
+        hue={hue}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(card(container)).toHaveClass('border-amber-400')
+    expect(card(container)).not.toHaveStyle({ boxShadow: `0 0 0 2px ${hue}` })
+  })
+
+  it('lets an active drop target outrank the shared-space ring', () => {
+    // The hue ring lives OUTSIDE the Tailwind class switch as an inline
+    // `boxShadow` (`hue` is a runtime value), so nothing in the class
+    // cascade stops it from fighting the drop-target ring's own box-shadow
+    // — only the explicit precedence below does.
+    overDroppableId = unitDroppableId('cedar-1')
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ parties: sharedParties })}
+        hue={hue}
+        canPlace
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(card(container)).toHaveClass('border-primary')
+    expect(card(container)).not.toHaveStyle({ boxShadow: `0 0 0 2px ${hue}` })
+  })
+
+  it('lets an invalid merge target outrank the shared-space ring', () => {
+    const room = unit({ code: 'cedar-1', parent_code: 'east-wing' })
+    const draggedSibling = unit({ code: 'other-1', parent_code: 'west-wing' })
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: room, parties: sharedParties })}
+        hue={hue}
+        mergeSourceUnit={draggedSibling}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(card(container)).toHaveClass('opacity-40')
+    expect(card(container)).not.toHaveStyle({ boxShadow: `0 0 0 2px ${hue}` })
   })
 })
 

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -194,12 +194,71 @@ export function LodgingUnitCard({
     setMergeDropRef(node)
   }
 
+  /*
+   * The card's border/ring treatment, chosen from an ORDERED set of mutually
+   * exclusive states rather than four independently-true ternaries appended
+   * as strings. That used to matter: `.border-amber-400` (the consent flag)
+   * and `.border-primary` (an active drop target) could both be true at
+   * once, and which one painted depended on which utility Tailwind's
+   * generated stylesheet happened to emit LATER — a byte offset, not an
+   * intent. Same failure for `bg-muted/25` (empty) against `bg-primary/5`
+   * (drop target): two `background-color` declarations racing on generation
+   * order whenever an empty room was dragged over.
+   *
+   * Highest wins, and every check below assumes every state above it false:
+   *   1. an active drop target — dragging a family onto it, or a card onto
+   *      its merge-sibling. The placement affordance has to read clearly
+   *      even over a flagged or shared room.
+   *   2. an invalid merge target mid-drag — dims the card so a doomed drop
+   *      is not attempted, as summer's `isValidDropTarget()` does for
+   *      gender.
+   *   3. the consent flag (#1926) — a household sharing without having
+   *      agreed to.
+   *   4. two or more families sharing without a flag — the mark #2091 adds,
+   *      matching `LodgingMap.tsx`'s `halo` for the identical slot flag.
+   *   5. an empty room — the master sheet's "open" case (#2093).
+   */
+  let cardState:
+    'dropTarget' | 'invalidMergeTarget' | 'consentFlagged' | 'shared' | 'open' | 'plain' = 'plain'
+  if (isUnitOver || isMergeOver) {
+    cardState = 'dropTarget'
+  } else if (mergeDragActive && !isValidTarget) {
+    cardState = 'invalidMergeTarget'
+  } else if (consent) {
+    cardState = 'consentFlagged'
+  } else if (isShared) {
+    cardState = 'shared'
+  } else if (parties.length === 0) {
+    cardState = 'open'
+  }
+
+  const cardStateClasses: Record<typeof cardState, string> = {
+    dropTarget: 'border-primary ring-primary/50 bg-primary/5 ring-2',
+    invalidMergeTarget: 'pointer-events-none opacity-40',
+    // Promoted from `ring-1`: the mark below needs a weight to lose TO, and
+    // a 1px ring was not it.
+    consentFlagged: 'border-amber-400 ring-2 ring-amber-400/40 dark:border-amber-500',
+    // No class here — the ring itself is the inline `boxShadow` below.
+    // `hue` is a RUNTIME value (`LodgingBoard.tsx` passes `area.hue`), so it
+    // cannot live in a Tailwind class the way the other four states do.
+    shared: '',
+    open: 'bg-muted/25 border-dashed',
+    plain: '',
+  }
+  const cardStateClassName = cardStateClasses[cardState]
+
   return (
     <div
       data-unit-card
       data-unit-code={unit.code}
       ref={setCardRef}
-      style={{ borderTopColor: hue }}
+      style={{
+        borderTopColor: hue,
+        // Distinguishable from the amber consent edge by construction, not
+        // by colour alone: `cardState` above can only be `'shared'` once the
+        // `consentFlagged` branch has already been ruled out.
+        ...(cardState === 'shared' ? { boxShadow: `0 0 0 2px ${hue}` } : {}),
+      }}
       /*
        * `.card-lodge` is summer's card chrome, not a lookalike — the same
        * class `BunkCard` wears (CLAUDE.md §4, "Family Camp Models Summer").
@@ -208,12 +267,14 @@ export function LodgingUnitCard({
        * `bg-card rounded-xl border`, which is the same idea minus the shadow
        * and the hover — so it read as a table row rather than a card.
        *
-       * ORDER MATTERS BELOW. `.card-lodge` lives in `@layer components`, so
-       * every utility here outranks it whatever the string order: the amber
-       * consent edge, the empty-slot wash and the drop-target ring all still
-       * land. The hue top edge is an inline style and outranks both, which is
-       * what keeps §3.10's secondary channel through `card-lodge`'s own
-       * `border-border` and its `border-primary/50` hover.
+       * Every utility below outranks `.card-lodge` itself regardless of
+       * string order — it lives in `@layer components`, so `cardState`'s
+       * class always beats its `border-border` and `border-primary/50`
+       * hover. What is NOT order-independent is the state classes against
+       * EACH OTHER, which is exactly why `cardState` above picks one rather
+       * than concatenating five. The hue top edge is a separate inline style
+       * and outranks both, which is what keeps §3.10's secondary channel
+       * alive underneath whichever state wins.
        *
        * NO `hover:shadow-lodge-lg` HERE, though `BunkCard` carries one. That
        * class is inert: `.shadow-lodge-*` are hand-written rules in `@layer
@@ -229,17 +290,7 @@ export function LodgingUnitCard({
        * and roster with `mb-3`). This ran at a flat 8px, which left the title
        * sitting on top of the amenity row.
        */
-      className={`card-lodge flex flex-col gap-3 border-t-[3px] p-4 ${
-        consent ? 'border-amber-400 ring-1 ring-amber-400/40 dark:border-amber-500' : ''
-      } ${parties.length === 0 ? 'bg-muted/25 border-dashed' : ''} ${
-        isUnitOver || isMergeOver ? 'border-primary ring-primary/50 bg-primary/5 ring-2' : ''
-      } ${
-        // Invalid targets grey out mid-drag, as summer's `isValidDropTarget()`
-        // does for gender. Gated on `mergeDragActive` too: with no card drag
-        // in flight `isValidTarget` is trivially false for every card, and
-        // without this guard the whole board would sit permanently dimmed.
-        mergeDragActive && !isValidTarget ? 'pointer-events-none opacity-40' : ''
-      }`}
+      className={`card-lodge flex flex-col gap-3 border-t-[3px] p-4 ${cardStateClassName}`}
     >
       <div className="flex items-baseline gap-1.5">
         {/* Summer's scale, not a parallel one (CLAUDE.md §4): `text-lg` title

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -22,6 +22,57 @@ import { partyKey } from './partyKey'
 import { reservationBadge } from './unitBadges'
 import { UnitAvailabilityControl } from './UnitAvailabilityControl'
 
+/**
+ * `.card-lodge`'s own elevation shadow (`index.css:440-443`), duplicated here
+ * rather than imported: an inline `boxShadow` (the shared-space ring below)
+ * and this stylesheet rule occupy the SAME CSS property, and inline always
+ * wins outright regardless of specificity or layer order — box-shadow does
+ * not merge across the two, so setting the ring alone silently DELETES the
+ * elevation the class rule was supplying. Composing it back in here is what
+ * keeps a shared card from reading as flat against its unshared neighbours.
+ */
+const CARD_ELEVATION_SHADOW =
+  '0 1px 2px hsl(var(--shadow-color) / 0.06), 0 4px 16px hsl(var(--shadow-color) / 0.08)'
+
+/**
+ * The card's border/ring treatment, keyed off an ordered, MUTUALLY EXCLUSIVE
+ * `ringState` — these three (plus `plain`) fight over the same CSS slot
+ * (`border-color` plus a Tailwind `ring-*` box-shadow, or the inline
+ * `boxShadow` below for `shared`), so only one may ever paint at a time. That
+ * used to matter concretely: `.border-amber-400` (consent) and
+ * `.border-primary` (an active drop target) could both be true at once, and
+ * which one painted depended on which utility Tailwind's generated
+ * stylesheet happened to emit LATER — a byte offset, not an intent.
+ *
+ * Dimming (an invalid merge target mid-drag) and dashing (an empty room) are
+ * DELIBERATELY NOT in this table — they are additive booleans where this
+ * table is consulted, because neither occupies a property any ring state
+ * needs: `opacity`/`pointer-events` and `border-style`/`bg-muted` don't
+ * compete with `border-color` or `box-shadow`. Folding all five into one
+ * exclusive `cardState` string, as an earlier version of this file did,
+ * silently dropped real combinations that used to co-render: a
+ * consent-flagged room mid an invalid merge drag lost its amber accent
+ * entirely, and an empty room lost its dashed border both mid an invalid
+ * drag and under an active drop target. None of those pairs conflict, so
+ * none of them should have been exclusive.
+ *
+ * Module scope, not component state: this table references nothing per-card
+ * and would otherwise be rebuilt on every one of up to ~82 cards on a board.
+ */
+const RING_CLASSES: Record<'dropTarget' | 'consentFlagged' | 'shared' | 'plain', string> = {
+  dropTarget: 'border-primary ring-primary/50 bg-primary/5 ring-2',
+  // Promoted from `ring-1`: the shared-space mark below needs a weight to
+  // lose TO, and a 1px ring was not it.
+  consentFlagged: 'border-amber-400 ring-2 ring-amber-400/40 dark:border-amber-500',
+  // No class here — the ring itself is the inline `boxShadow` below. `hue`
+  // is a RUNTIME value (`LodgingBoard.tsx` passes `area.hue`), so it cannot
+  // live in a Tailwind class the way the other two do. This is the one
+  // exception to "the table is the source of truth", and it lives in
+  // `style` rather than here for exactly that reason.
+  shared: '',
+  plain: '',
+}
+
 /** What the reserve/release control asks the board to write. */
 export interface UnitAvailabilityWrite {
   familyAvailable: boolean | null
@@ -138,6 +189,21 @@ export function LodgingUnitCard({
   // The "N families" count chip below: a true statement about the CARD
   // regardless of which rooms anyone actually holds, so it stays keyed on
   // the card's whole party count.
+  //
+  // OPEN QUESTION, not yet decided (PR #2119 review, 2026-08-08): this same
+  // `parties.length > 1` also drives the shared-space ring below
+  // (`ringState`), and unlike `consent` the ring is NOT overlap-aware.
+  // `consent` was deliberately rewritten onto `overlappingPartyKeys` to stop
+  // conflating "two households on one merged card" with "two households in
+  // one ROOM" — see that function's doc in `boardLayout.ts`. A combined
+  // container holding two households in DISJOINT rooms (the Front/Back case
+  // pinned in `boardLayout.test.ts:985-1000`) correctly resolves `consent` to
+  // `null` for exactly that reason, but still draws the hue ring here, which
+  // may read to staff as "these two families share a ROOM" when they do not
+  // — even though the pre-existing "N families" chip already counts the
+  // same slot-wide way. Whether the ring should follow `consent`'s
+  // overlap-aware definition instead is a product call the PR owner has not
+  // made yet; see the PR discussion. Do not change this without that call.
   const isShared = parties.length > 1
   // Each FamilyCard's own "did not request sharing" chip, in contrast, must
   // be a true statement about that ONE party — whether it shares a ROOM with
@@ -195,57 +261,71 @@ export function LodgingUnitCard({
   }
 
   /*
-   * The card's border/ring treatment, chosen from an ORDERED set of mutually
-   * exclusive states rather than four independently-true ternaries appended
-   * as strings. That used to matter: `.border-amber-400` (the consent flag)
-   * and `.border-primary` (an active drop target) could both be true at
-   * once, and which one painted depended on which utility Tailwind's
-   * generated stylesheet happened to emit LATER — a byte offset, not an
-   * intent. Same failure for `bg-muted/25` (empty) against `bg-primary/5`
-   * (drop target): two `background-color` declarations racing on generation
-   * order whenever an empty room was dragged over.
+   * Which of the four mutually-exclusive RING states wins — see
+   * `RING_CLASSES` above for why exactly these four compete for one slot and
+   * why dimming/dashing are handled separately, additively, below rather
+   * than folded in here.
    *
    * Highest wins, and every check below assumes every state above it false:
    *   1. an active drop target — dragging a family onto it, or a card onto
    *      its merge-sibling. The placement affordance has to read clearly
    *      even over a flagged or shared room.
-   *   2. an invalid merge target mid-drag — dims the card so a doomed drop
-   *      is not attempted, as summer's `isValidDropTarget()` does for
-   *      gender.
-   *   3. the consent flag (#1926) — a household sharing without having
+   *   2. the consent flag (#1926) — a household sharing without having
    *      agreed to.
-   *   4. two or more families sharing without a flag — the mark #2091 adds,
+   *   3. two or more families sharing without a flag — the mark #2091 adds,
    *      matching `LodgingMap.tsx`'s `halo` for the identical slot flag.
-   *   5. an empty room — the master sheet's "open" case (#2093).
+   *   4. plain — none of the above.
    */
-  let cardState:
-    'dropTarget' | 'invalidMergeTarget' | 'consentFlagged' | 'shared' | 'open' | 'plain' = 'plain'
+  let ringState: 'dropTarget' | 'consentFlagged' | 'shared' | 'plain' = 'plain'
   if (isUnitOver || isMergeOver) {
-    cardState = 'dropTarget'
-  } else if (mergeDragActive && !isValidTarget) {
-    cardState = 'invalidMergeTarget'
+    ringState = 'dropTarget'
   } else if (consent) {
-    cardState = 'consentFlagged'
+    ringState = 'consentFlagged'
   } else if (isShared) {
-    cardState = 'shared'
-  } else if (parties.length === 0) {
-    cardState = 'open'
+    ringState = 'shared'
   }
 
-  const cardStateClasses: Record<typeof cardState, string> = {
-    dropTarget: 'border-primary ring-primary/50 bg-primary/5 ring-2',
-    invalidMergeTarget: 'pointer-events-none opacity-40',
-    // Promoted from `ring-1`: the mark below needs a weight to lose TO, and
-    // a 1px ring was not it.
-    consentFlagged: 'border-amber-400 ring-2 ring-amber-400/40 dark:border-amber-500',
-    // No class here — the ring itself is the inline `boxShadow` below.
-    // `hue` is a RUNTIME value (`LodgingBoard.tsx` passes `area.hue`), so it
-    // cannot live in a Tailwind class the way the other four states do.
-    shared: '',
-    open: 'bg-muted/25 border-dashed',
-    plain: '',
-  }
-  const cardStateClassName = cardStateClasses[cardState]
+  /*
+   * An invalid merge target mid-drag: dims the card so a doomed drop is not
+   * attempted, as summer's `isValidDropTarget()` does for gender. Additive
+   * rather than a `ringState` of its own — dimming and, say, the consent
+   * amber accent are ORTHOGONAL CSS properties (`opacity`/`pointer-events`
+   * vs `border-color`/`box-shadow`) with no reason to be mutually exclusive.
+   * Pre-refactor, the two used to co-render; folding them into one exclusive
+   * `cardState` string silently dropped that.
+   *
+   * The one ring this DOES still suppress is `shared`'s inline `boxShadow`
+   * below (`sharedRingActive`) — a deliberate exception, not an oversight: a
+   * doomed drop dims the card specifically to discourage it, and the hue
+   * ring is the first thing a staff member's eye goes to, so it goes dark
+   * with everything else. Consent's Tailwind ring stays lit through the same
+   * dim because it is warning about something the merge drag did not cause
+   * and will still be true once the drag ends.
+   */
+  const dimmed = mergeDragActive && !isValidTarget
+
+  /*
+   * An empty room — the master sheet's "open" case (#2093). Additive for the
+   * same reason as `dimmed`: `border-style`/`bg-muted` don't compete with
+   * `border-color` or `box-shadow`, so an empty room being dragged over, or
+   * caught in someone else's invalid merge drag, can show its dashed border
+   * AND whichever ring/dim state is active, rather than losing one to the
+   * other.
+   */
+  const dashed = parties.length === 0
+
+  // `ringState` alone can't gate the inline ring below: `dimmed` still wins
+  // against `shared` specifically (see the comment on `dimmed` above), and
+  // `ringState` does not know about `dimmed` by design.
+  const sharedRingActive = ringState === 'shared' && !dimmed
+
+  const cardStateClassName = [
+    RING_CLASSES[ringState],
+    dashed ? 'bg-muted/25 border-dashed' : '',
+    dimmed ? 'pointer-events-none opacity-40' : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
 
   return (
     <div
@@ -254,10 +334,21 @@ export function LodgingUnitCard({
       ref={setCardRef}
       style={{
         borderTopColor: hue,
-        // Distinguishable from the amber consent edge by construction, not
-        // by colour alone: `cardState` above can only be `'shared'` once the
-        // `consentFlagged` branch has already been ruled out.
-        ...(cardState === 'shared' ? { boxShadow: `0 0 0 2px ${hue}` } : {}),
+        // Distinguishable from the amber consent edge and an active drop
+        // target by construction, not by colour alone: `sharedRingActive`
+        // can only be true once both `ringState` branches above it have
+        // been ruled out, AND while not `dimmed` (see that comment).
+        //
+        // Composed with `CARD_ELEVATION_SHADOW` rather than replacing it —
+        // see that constant's comment for why a bare ring here would
+        // silently flatten every shared card. One piece of that loss is
+        // NOT recovered by composing: `.card-lodge:hover`'s deeper lift
+        // (`index.css:445-450`) is also the `box-shadow` property, so it
+        // stays defeated by this inline style regardless of hover state —
+        // there is no CSS-only way to hand that back without moving the
+        // ring out of `style` entirely. Only the baseline (at-rest)
+        // elevation is being restored here.
+        ...(sharedRingActive ? { boxShadow: `0 0 0 2px ${hue}, ${CARD_ELEVATION_SHADOW}` } : {}),
       }}
       /*
        * `.card-lodge` is summer's card chrome, not a lookalike — the same
@@ -268,12 +359,14 @@ export function LodgingUnitCard({
        * and the hover — so it read as a table row rather than a card.
        *
        * Every utility below outranks `.card-lodge` itself regardless of
-       * string order — it lives in `@layer components`, so `cardState`'s
-       * class always beats its `border-border` and `border-primary/50`
-       * hover. What is NOT order-independent is the state classes against
-       * EACH OTHER, which is exactly why `cardState` above picks one rather
-       * than concatenating five. The hue top edge is a separate inline style
-       * and outranks both, which is what keeps §3.10's secondary channel
+       * string order — it lives in `@layer components`, so `cardStateClassName`
+       * always beats its `border-border` and `border-primary/50` hover. What
+       * is NOT order-independent is `RING_CLASSES`' four entries against EACH
+       * OTHER, which is exactly why `ringState` above picks one rather than
+       * concatenating four; the dashed/dimmed fragments alongside it are
+       * additive on purpose (see their own comments) and never race anything
+       * in this table. The hue top edge is a separate inline style and
+       * outranks all of it, which is what keeps §3.10's secondary channel
        * alive underneath whichever state wins.
        *
        * NO `hover:shadow-lodge-lg` HERE, though `BunkCard` carries one. That

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -46,15 +46,21 @@ const CARD_ELEVATION_SHADOW =
  *
  * Dimming (an invalid merge target mid-drag) and dashing (an empty room) are
  * DELIBERATELY NOT in this table — they are additive booleans where this
- * table is consulted, because neither occupies a property any ring state
- * needs: `opacity`/`pointer-events` and `border-style`/`bg-muted` don't
- * compete with `border-color` or `box-shadow`. Folding all five into one
- * exclusive `cardState` string, as an earlier version of this file did,
- * silently dropped real combinations that used to co-render: a
- * consent-flagged room mid an invalid merge drag lost its amber accent
- * entirely, and an empty room lost its dashed border both mid an invalid
- * drag and under an active drop target. None of those pairs conflict, so
- * none of them should have been exclusive.
+ * table is consulted, because `opacity`/`pointer-events` (dimming) and
+ * `border-style` (dashing's dashed edge) don't compete with `border-color`
+ * or `box-shadow`. Folding all five into one exclusive `cardState` string, as
+ * an earlier version of this file did, silently dropped real combinations
+ * that used to co-render: a consent-flagged room mid an invalid merge drag
+ * lost its amber accent entirely, and an empty room lost its dashed border
+ * mid an invalid drag.
+ *
+ * One piece of dashing is NOT additive, and stays gated below rather than
+ * joining `border-dashed` in the unconditional list: `bg-muted/25`, dashing's
+ * background wash, targets the SAME `background-color` property as
+ * `dropTarget`'s own `bg-primary/5` — reintroducing, for exactly this one
+ * pairing, the identical byte-offset race this table exists to kill. An empty
+ * room being actively hovered for a drop keeps its dashed OUTLINE but not the
+ * muted wash, so `dropTarget`'s own background wins outright.
  *
  * Module scope, not component state: this table references nothing per-card
  * and would otherwise be rebuilt on every one of up to ~82 cards on a board.
@@ -306,13 +312,20 @@ export function LodgingUnitCard({
 
   /*
    * An empty room — the master sheet's "open" case (#2093). Additive for the
-   * same reason as `dimmed`: `border-style`/`bg-muted` don't compete with
-   * `border-color` or `box-shadow`, so an empty room being dragged over, or
-   * caught in someone else's invalid merge drag, can show its dashed border
-   * AND whichever ring/dim state is active, rather than losing one to the
-   * other.
+   * same reason as `dimmed`: `border-style` (the dashed outline) doesn't
+   * compete with `border-color` or `box-shadow`, so an empty room dragged
+   * over, or caught in someone else's invalid merge drag, keeps its dashed
+   * edge AND whichever ring/dim state is active, rather than losing one to
+   * the other.
    */
   const dashed = parties.length === 0
+
+  // The one piece of `dashed` that is NOT unconditionally additive — see
+  // `RING_CLASSES`'s doc above for why `bg-muted/25` has to stand down
+  // specifically against `dropTarget`'s own `bg-primary/5`, both being
+  // `background-color`. An empty room mid-hover shows the drop ring's own
+  // wash, not its own muted one.
+  const dashedWashActive = dashed && ringState !== 'dropTarget'
 
   // `ringState` alone can't gate the inline ring below: `dimmed` still wins
   // against `shared` specifically (see the comment on `dimmed` above), and
@@ -321,7 +334,8 @@ export function LodgingUnitCard({
 
   const cardStateClassName = [
     RING_CLASSES[ringState],
-    dashed ? 'bg-muted/25 border-dashed' : '',
+    dashed ? 'border-dashed' : '',
+    dashedWashActive ? 'bg-muted/25' : '',
     dimmed ? 'pointer-events-none opacity-40' : '',
   ]
     .filter(Boolean)


### PR DESCRIPTION
## Summary

- Marks a lodging card holding two or more families with a ring in its area hue — the master housing sheet's fill for the same fact, matching the treatment `LodgingMap.tsx`'s `halo` already draws for the identical flag on the map surface.
- Converts the card's border/ring treatment from four independently-true ternaries (order decided by Tailwind's generated-CSS byte offset, not intent) to an ordered switch over an explicit `cardState`, per the prerequisite named in #2091: drop target → invalid merge target → consent flagged → shared → open.
- Promotes the consent ring from `ring-1` to `ring-2` so the new shared-space ring has a weight to lose to.
- The hue ring is a runtime value (`LodgingBoard.tsx` passes `area.hue`), so it's an inline `boxShadow` outside the class switch, with an explicit branch (`cardState === 'shared'`, only reachable once `consentFlagged` has been ruled out) keeping it distinguishable from the amber consent edge.
- Reuses `parties.length > 1` (the same signal already backing the "N families" pill) rather than a leaf-only count, so a container card holding two households — the dominant real case per the issue's 2026-08-07 addendum — is marked too, with no new per-container logic needed.

## Review round 2 — findings applied

A floor-60 scan surfaced 11 findings. Fixed in this PR:

- **Elevation shadow.** The shared ring's inline `boxShadow` was fully replacing `.card-lodge`'s own elevation shadow (`index.css:436-443`) rather than composing with it — inline styles win outright over any stylesheet rule for the same property, so every card this PR marks "shared" permanently read as flat. Now composes both into one `boxShadow` value (`CARD_ELEVATION_SHADOW` in `LodgingUnitCard.tsx`). The card's `:hover` lift (`index.css:445-450`) is a separate, still-open gap — see below.
- **Composition losses from the ordered switch.** Converting four independently-true ternaries into one exclusive `cardState` string silently dropped real combinations that used to co-render: an invalid-merge-drag's dimming was fully suppressing the consent amber accent and the empty-room dashed border, and an active drop target's ring string never carried `border-dashed` at all. Restructured into an exclusive `ringState` (drop target / consent / shared / plain — these three genuinely compete for the same `border-color`/`box-shadow` slot) plus two independent, additive booleans (`dimmed`, `dashed`) for the properties that don't conflict with anything. Each restored combination has its own test.
- **Missing coverage.** Added a test proving an active drop target still outranks a *consent-flagged* room specifically (the prior test only combined a drop target with an unflagged shared room), and a test that isolates `isMergeOver` from `isUnitOver` (mutation-checked: fails if `|| isMergeOver` is removed).
- **Cleanup.** Hoisted the static ring-class lookup (`RING_CLASSES`) and the elevation-shadow constant to module scope — they reference no component state and were being rebuilt on every one of up to ~82 cards per board. Added a comment at `RING_CLASSES.shared`'s empty string explaining why the shared ring lives in `style` instead (runtime `hue`).

Filed as a follow-up (not fixed here — `LodgingMap.tsx` belongs to other in-flight work): **#2136**, "share the 'consent supersedes shared' rule between `LodgingUnitCard` and `LodgingMap`" — the precedence rule is implemented independently in both files with no shared helper.

## OPEN QUESTION FOR THE OWNER — not decided, behaviour unchanged

`isShared = parties.length > 1` (`LodgingUnitCard.tsx`, just above the ring-state computation) is **not** overlap-aware, unlike `consent`.

**Both readings:**
1. *Ring should mean "these people are in the same room."* `consent` was deliberately rewritten onto `overlappingPartyKeys` specifically to stop conflating "two households on one merged card" with "two households in one room" (`boardLayout.ts`'s `overlappingPartyKeys` doc). The ring, by staying on the raw card-wide count, doesn't get that same fix — a combined container card holding two households in **disjoint rooms** draws the ring even though `consent` correctly resolves to `null` for exactly that case. A staff member could read the ring as "these two families share a room," which is false here.
2. *Ring should mean "two families are on this card."* The issue asks to mark "a space that holds two families," and the pre-existing "N families" chip (which this PR's ring is meant to echo) already counts slot-wide, not room-wide. Changing the ring's definition would make it disagree with the chip it sits beside.

**Concrete case:** the Front/Back combined-house test, `boardLayout.test.ts:985-1000` (`'does not flag two households the merge rolled onto one card from DISJOINT rooms'`) — two households in separate rooms of one combined building. `consent` is `null` there (correctly, per the doc above); `isShared` is `true`, so the ring draws.

No behaviour changed here pending the call — see the inline comment at `isShared`'s definition in `LodgingUnitCard.tsx`.

## Verification

- `npx vitest run src/components/weekend` — 589/589 passed (5 new tests from the round-2 findings above).
- `npx tsc --noEmit` — clean.
- `./node_modules/.bin/eslint` on the two changed files — 0 errors, 1 pre-existing warning (`@typescript-eslint/consistent-type-imports` on the `importOriginal<typeof import(...)>()` idiom), unchanged from before this round.
- Confirmed the two pinned "no-hover-shadow" assertions in `LodgingUnitCard.test.tsx` (the `hover:shadow-lodge-lg` absence test) are untouched by the elevation-shadow fix — that test renders a plain, unshared card, so `sharedRingActive` is never true and no inline `boxShadow` is ever set on it.

## Test plan

- [x] `npx vitest run src/components/weekend`
- [x] `npx tsc --noEmit`
- [x] `./node_modules/.bin/eslint` on changed files
- [x] Mutation-checked the `isMergeOver` regression test

Closes #2091.
