### PR TITLE
fix(sync): guard the lodging sync when a season has no registry

### DIFF
--- a/pocketbase/sync/lodging_alias_resolver.go
+++ b/pocketbase/sync/lodging_alias_resolver.go
@@ -60,8 +60,8 @@ type AliasResolver struct {
 }
 
 // NewAliasResolver loads the unit and alias tables into memory. Build one per
-// sync run: the tables are small (89 units, 100 aliases) and Resolve is called
-// once per observed cabin value.
+// sync run: the tables are small (118 units, 187 aliases) and Resolve is
+// called once per observed cabin value.
 func NewAliasResolver(app core.App) (*AliasResolver, error) {
 	r := &AliasResolver{
 		byString: make(map[string][]aliasRow),
@@ -95,6 +95,30 @@ func NewAliasResolver(app core.App) (*AliasResolver, error) {
 		r.byString[key] = append(r.byString[key], row)
 	}
 	return r, nil
+}
+
+// HasUnitsForYear reports whether the registry holds at least one
+// lodging_units row for the given year. Resolve is all-or-nothing on
+// (code, year) -- a stored member id that cannot find its code's row in the
+// requested year never resolves -- so Sync's year guard uses this to detect a
+// season with no registry loaded before it lets every cabin string unresolve.
+// See #2061.
+func (r *AliasResolver) HasUnitsForYear(year int) bool {
+	for key := range r.idByCodeYear {
+		if key.year == year {
+			return true
+		}
+	}
+	return false
+}
+
+// HasAnyUnits reports whether the registry holds a lodging_units row for any
+// year at all. Paired with HasUnitsForYear, it lets the year guard tell "no
+// registry has ever been loaded" apart from "a prior season exists but this
+// one has not been rolled forward yet" -- the two cases call for different
+// action from whoever reads the log. See #2061.
+func (r *AliasResolver) HasAnyUnits() bool {
+	return len(r.idByCodeYear) > 0
 }
 
 // aliasLookupKey normalises outer whitespace and case only.

--- a/pocketbase/sync/lodging_assignments_sync.go
+++ b/pocketbase/sync/lodging_assignments_sync.go
@@ -92,6 +92,31 @@ func (s *LodgingAssignmentsSync) Sync(ctx context.Context) error {
 	if s.resolver, err = NewAliasResolver(s.App); err != nil {
 		return fmt.Errorf("building alias resolver: %w", err)
 	}
+
+	// A season with no lodging_units rows at all cannot resolve anything:
+	// Resolve is all-or-nothing on (code, year), so every alias's stored
+	// member id -- still pointing at whatever year it was last authored
+	// against -- misses. Left unguarded that unresolves every cabin: each
+	// distinct raw string queues an unresolved_alias work-queue item that
+	// never self-clears (IssueRecorder.Flush only sets is_resolved on
+	// create), and writeHistory on the unresolved path is unconditional, so
+	// every run appends another lodging_assignment_history row per household.
+	// Skip and return nil -- one unseeded season must not fail the whole sync
+	// run. Two distinguishable messages, because they call for different
+	// action: nothing has ever been loaded for this year, vs. a prior season
+	// exists but this one has not been carried forward yet. See #2061.
+	if !s.resolver.HasUnitsForYear(year) {
+		if s.resolver.HasAnyUnits() {
+			slog.Warn("lodging_assignments_sync: skipping -- registry has not been rolled forward to this season yet",
+				"year", year)
+		} else {
+			slog.Warn("lodging_assignments_sync: skipping -- no lodging registry has ever been loaded for this season",
+				"year", year)
+		}
+		s.SyncSuccessful = true
+		return nil
+	}
+
 	s.issues = NewIssueRecorder(s.App, year)
 
 	fieldTargets, err := LodgingFieldDefIDs(s.App)

--- a/pocketbase/sync/lodging_assignments_sync_test.go
+++ b/pocketbase/sync/lodging_assignments_sync_test.go
@@ -270,6 +270,12 @@ func TestLodgingAssignmentsSyncQueuesUnresolvedAlias(t *testing.T) {
 	app := newLodgingTestApp(t)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
+	// Unrelated to "Tuolumne 7" below -- this only gives 2025 a registry, so
+	// Sync's #2061 year guard (no lodging_units rows for the year) does not
+	// intercept before reaching alias resolution. Without it, this fixture is
+	// indistinguishable from "no registry loaded at all," and the case this
+	// test means to cover -- one string that matches no alias -- never runs.
+	addUnit(t, app, "ridge-a", 2025)
 	cabinDef := addFieldDef(t, app, cmIDFamilyCampCabin, fieldNameFamilyCampCabin)
 	hh := addHousehold(t, app, 9001, 2025)
 	emma := addPerson(t, app, 5001, 9001, 2025, hh)

--- a/pocketbase/sync/lodging_testsupport_test.go
+++ b/pocketbase/sync/lodging_testsupport_test.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"context"
 	"testing"
 
 	"github.com/pocketbase/pocketbase/core"
@@ -374,4 +375,119 @@ func addHouseholdValue(
 		"household": householdPBID, "field_definition": fieldDefPBID,
 		"value": value, "last_updated": lastUpdated, "year": year,
 	})
+}
+
+// assertLodgingCollectionsEmpty fails the test if any of the three tables the
+// unguarded #2061 bug churns -- placements, the work queue, and the audit
+// trail -- hold a row. A guarded skip must leave all three untouched.
+func assertLodgingCollectionsEmpty(t *testing.T, app core.App) {
+	t.Helper()
+	for _, collection := range []string{
+		"lodging_assignments", "lodging_ingest_issues", "lodging_assignment_history",
+	} {
+		rows, err := app.FindRecordsByFilter(collection, "", "", 0, 0)
+		if err != nil {
+			t.Fatalf("find %s: %v", collection, err)
+		}
+		if len(rows) != 0 {
+			t.Errorf("%s: got %d rows, want 0 -- the year guard must skip before any lodging write", collection, len(rows))
+		}
+	}
+}
+
+// TestLodgingAssignmentsSyncSkipsWhenRegistryNeverLoaded is #2061: with zero
+// lodging_units rows for ANY year, AliasResolver.Resolve can never succeed --
+// it is all-or-nothing on (code, year), per its own doc comment -- so every
+// cabin string in the household/person grains would otherwise queue an
+// unresolved_alias issue and grow lodging_assignment_history forever, on a
+// season nobody has loaded a registry for at all. Sync must skip the lodging
+// portion and return nil, not fail the whole run.
+func TestLodgingAssignmentsSyncSkipsWhenRegistryNeverLoaded(t *testing.T) {
+	app := newLodgingTestApp(t)
+	// No addUnit call anywhere: lodging_units is empty for every year.
+
+	sessionID := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
+		testSessionStart, testSessionEnd, 2027)
+	cabinDef := addFieldDef(t, app, cmIDFamilyCampCabin, fieldNameFamilyCampCabin)
+	hh := addHousehold(t, app, 9001, 2027)
+	emma := addPerson(t, app, 5001, 9001, 2027, hh)
+	addAttendee(t, app, emma, sessionID, 5001, 2, 2027)
+	addHouseholdValue(t, app, hh, cabinDef, "Ridge A", testLastUpdated, 2027)
+
+	s := NewLodgingAssignmentsSync(app)
+	s.Year = 2027
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v, want nil -- a registryless season must skip, not fail the run", err)
+	}
+	if !s.SyncSuccessful {
+		t.Error("SyncSuccessful = false, want true -- a guarded skip is not a failure")
+	}
+	assertLodgingCollectionsEmpty(t, app)
+}
+
+// TestLodgingAssignmentsSyncSkipsWhenSeasonNotRolledForward is the shape #2061
+// describes production actually hitting: a prior season's registry exists,
+// this one has not been carried forward yet. The alias's stored member id
+// still points at the prior year's unit row -- "authored once and never
+// re-pointed", per AliasResolver's own doc comment -- so idByCodeYear misses
+// for the new year and every cabin unresolves unless the guard catches it
+// first.
+func TestLodgingAssignmentsSyncSkipsWhenSeasonNotRolledForward(t *testing.T) {
+	app := newLodgingTestApp(t)
+	priorYearUnit := addUnit(t, app, "ridge-a", 2026)
+	addAlias(t, app, "Ridge A", []string{priorYearUnit}, 0, 0)
+	// No lodging_units row for 2027: roll-forward has not run yet.
+
+	sessionID := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
+		testSessionStart, testSessionEnd, 2027)
+	cabinDef := addFieldDef(t, app, cmIDFamilyCampCabin, fieldNameFamilyCampCabin)
+	hh := addHousehold(t, app, 9001, 2027)
+	emma := addPerson(t, app, 5001, 9001, 2027, hh)
+	addAttendee(t, app, emma, sessionID, 5001, 2, 2027)
+	addHouseholdValue(t, app, hh, cabinDef, "Ridge A", testLastUpdated, 2027)
+
+	s := NewLodgingAssignmentsSync(app)
+	s.Year = 2027
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v, want nil", err)
+	}
+	assertLodgingCollectionsEmpty(t, app)
+}
+
+// TestAliasResolverHasUnitsForYear exercises the two lookups Sync's year guard
+// depends on, distinguishing "never loaded" from "not this year".
+func TestAliasResolverHasUnitsForYear(t *testing.T) {
+	app := newLodgingTestApp(t)
+	addUnit(t, app, "ridge-a", 2026)
+
+	r, err := NewAliasResolver(app)
+	if err != nil {
+		t.Fatalf("NewAliasResolver: %v", err)
+	}
+	if !r.HasAnyUnits() {
+		t.Error("HasAnyUnits() = false, want true -- 2026 has a row")
+	}
+	if !r.HasUnitsForYear(2026) {
+		t.Error("HasUnitsForYear(2026) = false, want true")
+	}
+	if r.HasUnitsForYear(2027) {
+		t.Error("HasUnitsForYear(2027) = true, want false -- no row seeded for 2027")
+	}
+}
+
+// TestAliasResolverHasAnyUnitsFalseWhenEmpty covers the other guard branch:
+// no registry loaded for any season at all.
+func TestAliasResolverHasAnyUnitsFalseWhenEmpty(t *testing.T) {
+	app := newLodgingTestApp(t)
+
+	r, err := NewAliasResolver(app)
+	if err != nil {
+		t.Fatalf("NewAliasResolver: %v", err)
+	}
+	if r.HasAnyUnits() {
+		t.Error("HasAnyUnits() = true, want false -- no lodging_units rows seeded")
+	}
+	if r.HasUnitsForYear(2027) {
+		t.Error("HasUnitsForYear(2027) = true, want false")
+	}
 }


### PR DESCRIPTION
## Problem

When a season has no lodging registry loaded, the lodging assignments sync ran anyway: every cabin string resolved to nothing, so the sync unresolved every assignment and churned placement history.

## Fix

`Sync()` now checks for `lodging_units` rows for the requested year before doing any resolution work, and **skips with `nil` rather than returning an error** — one unseeded season must not fail the whole sync run. Two distinguishable log messages separate "no registry has ever been loaded" from "this season has not been rolled forward yet".

Adds `HasUnitsForYear(year)` and `HasAnyUnits()` to the alias resolver, and corrects a stale comment there that claimed `(89 units, 100 aliases)` — production carries **118 units / 187 aliases**.

## Why this PR also edits a sibling test fixture

`TestLodgingAssignmentsSyncQueuesUnresolvedAlias` in `lodging_assignments_sync_test.go` seeds household, session and attendee data but calls `addUnit(...)` **zero times** — it had no `lodging_units` row for any year. It passed before only because nothing checked for a registry.

With the guard in place that fixture became **indistinguishable from "no registry loaded at all"**, so `Sync()` correctly skipped before reaching the alias-resolution code the test exists to exercise.

The fixture was incomplete, and the incompleteness was invisible until the guard gave "no registry for this year" a distinct meaning. One seeded unit for the year restores the test's stated intent — proving that *one string matching no alias* becomes a work-queue item, as distinct from *the season having no registry at all*.

**The assertions are unchanged**: still 1 `unresolved_alias` work-queue item and 1 history row. Only the fixture gained a row, with a comment recording why it must stay.

## Verification

- `go build ./...` — exit 0
- `go test ./sync/...` — exit 0
- New tests written first and confirmed failing (compile failure) before implementation: 2 end-to-end guard tests + 2 direct resolver-method tests.

Closes #2061.
