### PR TITLE
fix(frontend): clear stale party selection on weekend surfaces

### DIFF
--- a/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
@@ -467,3 +467,43 @@ describe('HouseholdRosterTable — the row opens FamilyDetailsPanel (kindred#199
     expect(screen.getByTestId('family-details-panel')).toHaveClass('animate-slide-out-right')
   })
 })
+
+describe('HouseholdRosterTable — clears a stale selection (kindred#2062)', () => {
+  // A weekend switch re-renders this table with a different `parties` prop
+  // but never unmounts it, so the previously-open household stayed open over
+  // the new weekend's roster — including its `FamilyDetailsPanel`, which
+  // shows a medical narrative that no longer belongs to anyone on screen.
+  it('closes the panel when the selected party is no longer in parties', async () => {
+    const { rerender } = render(
+      <HouseholdRosterTable
+        year={2026}
+        parties={[party({ display_name: 'Johnson Family', household_cm_id: 2000001 })]}
+      />,
+      { wrapper }
+    )
+    await userEvent.click(screen.getByRole('button', { name: /Johnson Family/ }))
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+
+    rerender(
+      <HouseholdRosterTable
+        year={2026}
+        parties={[party({ display_name: 'Chen Family', household_cm_id: 2000002 })]}
+      />
+    )
+    expect(screen.queryByTestId('family-details-panel')).not.toBeInTheDocument()
+  })
+
+  // The trap: a refetch that returns the SAME parties (new array identity,
+  // same content) must not close a panel out from under whoever has it open.
+  it('keeps the panel open when parties refetches with the same content', async () => {
+    const makeParties = () => [party({ display_name: 'Johnson Family', household_cm_id: 2000001 })]
+    const { rerender } = render(<HouseholdRosterTable year={2026} parties={makeParties()} />, {
+      wrapper,
+    })
+    await userEvent.click(screen.getByRole('button', { name: /Johnson Family/ }))
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+
+    rerender(<HouseholdRosterTable year={2026} parties={makeParties()} />)
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/weekend/HouseholdRosterTable.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.tsx
@@ -14,6 +14,7 @@ import { useDismissOnDeadSpace } from '../../hooks/useDismissOnDeadSpace'
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
 import { FamilyDetailsPanel } from './FamilyDetailsPanel'
 import { HouseholdRosterRow } from './HouseholdRosterRow'
+import { partyKey } from './partyKey'
 import { attentionSections, indexUnitsByCode } from './rosterAttention'
 
 export interface HouseholdRosterTableProps {
@@ -61,7 +62,20 @@ export function HouseholdRosterTable({ parties, units = [], year }: HouseholdRos
     setRequestClose(false)
   }, [])
 
-  useDismissOnDeadSpace(selected !== null, () => {
+  // DERIVED, not effect-cleared (kindred#2062). A weekend switch re-renders
+  // this table with a different `parties` prop but never unmounts it, so a
+  // `selected` that outlived its own row's departure kept the panel — and
+  // its medical narrative — open over the new weekend's roster. Computing
+  // this at render time, rather than in a useEffect that calls setState,
+  // avoids the extra render pass React's docs warn an Effect would add here
+  // (`selected` itself is untouched; only what gets rendered changes). A
+  // refetch that returns the SAME parties (new array identity, same
+  // content) still resolves to present, because `partyKey` compares
+  // content, not identity — see partyKey.ts's own docstring.
+  const panelParty =
+    selected !== null && parties.some((p) => partyKey(p) === partyKey(selected)) ? selected : null
+
+  useDismissOnDeadSpace(panelParty !== null, () => {
     setRequestClose(true)
   })
 
@@ -129,10 +143,10 @@ export function HouseholdRosterTable({ parties, units = [], year }: HouseholdRos
         </table>
       </div>
 
-      {selected !== null && (
+      {panelParty !== null && (
         <FamilyDetailsPanel
-          party={selected}
-          unit={unitsByCode.get(selected.unit_code ?? '')}
+          party={panelParty}
+          unit={unitsByCode.get(panelParty.unit_code ?? '')}
           year={year}
           requestClose={requestClose}
           onClose={closePanel}

--- a/frontend/src/components/weekend/LodgingBoard.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.test.tsx
@@ -651,3 +651,53 @@ describe('LodgingBoard — the details panel updates in place', () => {
     expect(second).toHaveTextContent('Chen Household')
   })
 })
+
+describe('LodgingBoard — clears a stale selection (kindred#2062)', () => {
+  // A weekend switch re-renders the board with a different `parties` prop
+  // without unmounting it, so the previously-open family's panel — including
+  // its medical narrative — stayed open over the new weekend's roster.
+  it('closes the panel when the selected party is no longer in parties', async () => {
+    const { rerender } = render(
+      <LodgingBoard
+        parties={[party({ unit_code: 'cedar-1', unit_name: 'Cedar 1' })]}
+        units={[unit()]}
+        year={2026}
+      />,
+      { wrapper }
+    )
+    await userEvent.click(screen.getByRole('button', { name: /Johnson/ }))
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+
+    rerender(
+      <LodgingBoard
+        parties={[
+          party({
+            household_cm_id: 102,
+            display_name: 'Chen',
+            sort_name: 'Chen',
+            unit_code: 'cedar-1',
+            unit_name: 'Cedar 1',
+          }),
+        ]}
+        units={[unit()]}
+        year={2026}
+      />
+    )
+    expect(screen.queryByTestId('family-details-panel')).not.toBeInTheDocument()
+  })
+
+  // The trap: a refetch that returns the SAME parties (new array identity,
+  // same content) must not close a panel out from under whoever has it open.
+  it('keeps the panel open when parties refetches with the same content', async () => {
+    const makeParties = () => [party({ unit_code: 'cedar-1', unit_name: 'Cedar 1' })]
+    const { rerender } = render(
+      <LodgingBoard parties={makeParties()} units={[unit()]} year={2026} />,
+      { wrapper }
+    )
+    await userEvent.click(screen.getByRole('button', { name: /Johnson/ }))
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+
+    rerender(<LodgingBoard parties={makeParties()} units={[unit()]} year={2026} />)
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -306,8 +306,21 @@ export function LodgingBoard({
     setRequestClose(false)
   }, [])
 
+  // DERIVED, not effect-cleared (kindred#2062). A weekend switch re-renders
+  // the board with a different `parties` prop but never unmounts it, so a
+  // `selected` that outlived its own card's departure kept the panel — and
+  // its medical narrative — open over the new weekend's roster. Computing
+  // this at render time, rather than in a useEffect that calls setState,
+  // avoids the extra render pass React's docs warn an Effect would add here
+  // (`selected` itself is untouched; only what gets rendered changes). A
+  // refetch that returns the SAME parties (new array identity, same
+  // content) still resolves to present, because `partyKey` compares
+  // content, not identity — see partyKey.ts's own docstring.
+  const panelParty =
+    selected !== null && parties.some((p) => partyKey(p) === partyKey(selected)) ? selected : null
+
   // Same dead-space dismissal the summer board uses, through the same hook.
-  useDismissOnDeadSpace(selected !== null, () => {
+  useDismissOnDeadSpace(panelParty !== null, () => {
     setRequestClose(true)
   })
 
@@ -512,14 +525,14 @@ export function LodgingBoard({
         <FloatingUnplacedBadge
           parties={board.unplaced}
           onOpenParty={openParty}
-          isPanelOpen={selected !== null}
+          isPanelOpen={panelParty !== null}
           canPlace={canPlace}
         />
 
-        {selected !== null && (
+        {panelParty !== null && (
           <FamilyDetailsPanel
-            party={selected}
-            unit={unitsByCode.get(selected.unit_code ?? '')}
+            party={panelParty}
+            unit={unitsByCode.get(panelParty.unit_code ?? '')}
             year={year}
             requestClose={requestClose}
             onClose={closePanel}

--- a/frontend/src/components/weekend/LodgingMap.test.tsx
+++ b/frontend/src/components/weekend/LodgingMap.test.tsx
@@ -806,3 +806,44 @@ describe('LodgingMap highlight controls', () => {
     expect(screen.getByRole('button', { name: /fit all/i })).toBeInTheDocument()
   })
 })
+
+describe('LodgingMap — clears a stale selection (kindred#2062)', () => {
+  // A weekend switch re-renders the map with a different `parties` prop
+  // without unmounting it, so the previously-open family's panel — including
+  // its medical narrative — stayed open over the new weekend's roster.
+  it('closes the panel when the selected party is no longer in parties', async () => {
+    const { rerender } = render(<LodgingMap parties={[PLACED]} units={UNITS} year={2026} />, {
+      wrapper,
+    })
+    await userEvent.click(screen.getAllByTestId('map-mark')[0] as HTMLElement)
+    await userEvent.click(screen.getByRole('button', { name: /Johnson/ }))
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+
+    const other = party({
+      display_name: 'Chen',
+      sort_name: 'Chen',
+      household_cm_id: 9002,
+      unit_code: 'cedar-1',
+      unit_name: 'Cedar 1',
+    })
+    rerender(<LodgingMap parties={[other]} units={UNITS} year={2026} />)
+    expect(screen.queryByTestId('family-details-panel')).not.toBeInTheDocument()
+  })
+
+  // The trap: a refetch that returns the SAME parties (new array identity,
+  // same content) must not close a panel out from under whoever has it open.
+  it('keeps the panel open when parties refetches with the same content', async () => {
+    const makeParties = () => [
+      party({ display_name: 'Johnson', unit_code: 'cedar-1', unit_name: 'Cedar 1' }),
+    ]
+    const { rerender } = render(<LodgingMap parties={makeParties()} units={UNITS} year={2026} />, {
+      wrapper,
+    })
+    await userEvent.click(screen.getAllByTestId('map-mark')[0] as HTMLElement)
+    await userEvent.click(screen.getByRole('button', { name: /Johnson/ }))
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+
+    rerender(<LodgingMap parties={makeParties()} units={UNITS} year={2026} />)
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/weekend/LodgingMap.tsx
+++ b/frontend/src/components/weekend/LodgingMap.tsx
@@ -280,6 +280,19 @@ export function LodgingMap({ parties, units, year }: LodgingMapProps) {
     setRequestClose(false)
   }, [])
 
+  // DERIVED, not effect-cleared (kindred#2062). A weekend switch re-renders
+  // the map with a different `parties` prop but never unmounts it, so a
+  // `selected` that outlived its own mark's departure kept the panel — and
+  // its medical narrative — open over the new weekend's roster. Computing
+  // this at render time, rather than in a useEffect that calls setState,
+  // avoids the extra render pass React's docs warn an Effect would add here
+  // (`selected` itself is untouched; only what gets rendered changes). A
+  // refetch that returns the SAME parties (new array identity, same
+  // content) still resolves to present, because `partyKey` compares
+  // content, not identity — see partyKey.ts's own docstring.
+  const panelParty =
+    selected !== null && parties.some((p) => partyKey(p) === partyKey(selected)) ? selected : null
+
   // Same dead-space dismissal the summer board and the weekend board use, and
   // deliberately the same one line they use. The canvas is a bare div that a
   // pan gesture ends with a click on, and that click matches none of
@@ -290,7 +303,7 @@ export function LodgingMap({ parties, units, year }: LodgingMapProps) {
   // rather than by teaching this callback to second-guess the clicks it does
   // get. A callback that remembers things about earlier gestures is a callback
   // that can be wrong about the current one.
-  useDismissOnDeadSpace(selected !== null, () => {
+  useDismissOnDeadSpace(panelParty !== null, () => {
     setRequestClose(true)
   })
 
@@ -1014,13 +1027,13 @@ export function LodgingMap({ parties, units, year }: LodgingMapProps) {
       <FloatingUnplacedBadge
         parties={model.unplaced}
         onOpenParty={openParty}
-        isPanelOpen={selected !== null}
+        isPanelOpen={panelParty !== null}
       />
 
-      {selected !== null && (
+      {panelParty !== null && (
         <FamilyDetailsPanel
-          party={selected}
-          unit={unitsByCode.get(selected.unit_code ?? '')}
+          party={panelParty}
+          unit={unitsByCode.get(panelParty.unit_code ?? '')}
           year={year}
           requestClose={requestClose}
           onClose={closePanel}


### PR DESCRIPTION
## Summary
- `HouseholdRosterTable`, `LodgingBoard`, and `LodgingMap` all kept a selected party's panel open across a weekend switch, because `selected` was never reconciled against a changed `parties` prop — the sticky-header `<select>` re-renders these components with a different roster without unmounting them.
- `FamilyDetailsPanel` renders `MedicalNarrative`, so this meant a `lodging.phi` holder switching weekends kept seeing the **previous weekend's** family and medical narrative attached to a roster that no longer contained them.
- Fixed by deriving what the panel renders (`panelParty`) from whether the selected party's `partyKey` is still present in `parties`, computed at render time rather than via a `useEffect`+`setState` that would add an extra render pass. `selected` state itself is untouched by a departure — only what gets rendered changes.
- Because `partyKey` compares content rather than array identity, a refetch that returns the same parties (new array reference, same content) correctly leaves an open panel open.

## Test plan
- [x] Added a test per surface pinning the departure case (selected party's key no longer in `parties` → panel closes)
- [x] Added a test per surface pinning the refetch-same-parties trap (new array identity, same content → panel stays open)
- [x] `npx vitest run src/components/weekend` — 28 files / 582 tests passed
- [x] Full frontend suite — passed except two failures unrelated to this diff and confirmed pre-existing/environmental (`eslintA11yLayering.guard.test.ts` timing out under machine load, passes with a longer timeout; `WeekendRosterPage.codeSplitting.test.tsx` flaked once, passed on retry). Neither imports the files this PR touches.
- [x] `npx tsc --noEmit` — clean
- [x] `./node_modules/.bin/eslint` on changed files — 0 errors, pre-existing warning classes only
- [x] Full pre-push hook suite (ruff, go build, pb-js-lint, shellcheck, markdownlint, api-types-freshness, mypy, full pytest, tsc) — all green

Closes #2062.