### PR TITLE
perf(api): cache build_roster's four sync-written year-scoped reads

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -18,6 +18,7 @@ from pocketbase import PocketBase
 
 from .constants.collections import SUPERUSERS
 from .services.id_cache import IDLookupCache
+from .services.lodging_cache import LodgingYearCache
 from .services.metrics_cache import MetricsCache
 from .settings import get_settings
 
@@ -117,6 +118,27 @@ metrics_cache = MetricsCache(ttl_seconds=7200, max_size=200)
 
 
 # ========================================
+# Lodging Year-Scoped Read Cache
+# ========================================
+
+# Caches four of build_roster/build_summary's six year-scoped reads --
+# households, the prior-household set, family-camp adults, and registrations
+# (see api/services/lodging_cache.py for why the other two, fetch_units and
+# count_open_unresolved_aliases, are deliberately excluded: both are
+# admin-panel-writable straight from the browser).
+#
+# MUST be a module-level singleton, not per-instance state: api/routers/
+# lodging.py's `_service`/`_writes` build a fresh LodgingRepository on every
+# request, so a cache living on `self` would never be reused across requests.
+#
+# TTL 15 minutes, matching geo_service's _PERSON_ID_CACHE -- the closer
+# sibling here, since it is the other cache built for a fresh-per-request
+# service rather than metrics_cache's router-owned 2-hour fallback. No active
+# invalidation is wired yet (see lodging_cache.py's module docstring).
+lodging_cache = LodgingYearCache(ttl_seconds=900, max_size=64)
+
+
+# ========================================
 # Solver Runs Storage
 # ========================================
 
@@ -167,6 +189,7 @@ __all__ = [
     "create_task_pb_client",
     "get_pb_client",
     "graph_cache",
+    "lodging_cache",
     "metrics_cache",
     "pb",
     "pb_url",

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -133,8 +133,9 @@ metrics_cache = MetricsCache(ttl_seconds=7200, max_size=200)
 #
 # TTL 15 minutes, matching geo_service's _PERSON_ID_CACHE -- the closer
 # sibling here, since it is the other cache built for a fresh-per-request
-# service rather than metrics_cache's router-owned 2-hour fallback. No active
-# invalidation is wired yet (see lodging_cache.py's module docstring).
+# service rather than metrics_cache's router-owned 2-hour fallback. Wired to
+# POST /api/metrics/cache/invalidate (kindred#2142) -- see lodging_cache.py's
+# module docstring for why the TTL is the fallback rather than the plan.
 lodging_cache = LodgingYearCache(ttl_seconds=900, max_size=64)
 
 

--- a/api/routers/metrics.py
+++ b/api/routers/metrics.py
@@ -27,7 +27,7 @@ from api.services.waitlist_service import WaitlistService
 from api.utils.validators import check_duration_session_exclusive
 from bunking.auth_middleware import AuthUser, get_current_user
 
-from ..dependencies import metrics_cache, pb
+from ..dependencies import lodging_cache, metrics_cache, pb
 from ..schemas.day1 import Day1Response
 from ..schemas.forecast import ForecastResponse, WeekOption
 from ..schemas.metrics import (
@@ -634,7 +634,7 @@ async def get_day1(
 
 @router.post("/cache/invalidate")
 async def invalidate_metrics_cache() -> dict[str, int]:
-    """Invalidate all cached metrics responses + geo person-id cache.
+    """Invalidate all cached metrics responses + geo person-id cache + lodging year cache.
 
     Auth is handled by the middleware (skipped for this path since cache
     clearing is safe and idempotent). Called by:
@@ -644,9 +644,16 @@ async def invalidate_metrics_cache() -> dict[str, int]:
 
     Geo's _PERSON_ID_CACHE piggybacks on the same signal — CampMinder sync
     changes attendee status_id, which feeds _fetch_active_person_pb_ids.
+
+    lodging_cache (kindred#1963) piggybacks here too (kindred#2142): its four
+    cached reads are written only by the "persons" sync (households) and the
+    "family_camp_derived" sync (family_camp_adults, family_camp_registrations),
+    both of which are polled sync types that fire invalidateSyncData on
+    completion — same signal, same reasoning as geo's cache above.
     """
     cleared = metrics_cache.invalidate_all()
     clear_person_id_cache()
+    lodging_cache.invalidate_all()
     return {"cleared": cleared}
 
 

--- a/api/services/lodging_cache.py
+++ b/api/services/lodging_cache.py
@@ -29,13 +29,24 @@ LodgingRepository is built fresh per request (api/routers/lodging.py's
 `_service` / `_writes`), so an instance-level cache would never be reused, and
 this must live as a singleton instead -- see api/dependencies.py.
 
-TTL-only for now. There is no `/api/lodging/cache/invalidate` endpoint wired
-to CampMinder sync completion yet, because that wiring lives in
-api/routers/lodging.py (and possibly the frontend's sync-completion hook),
-both outside kindred#1963's scope. `invalidate_all` is exposed so adding that
-call is a one-line follow-up, not a re-architecture -- exactly how
-`api/routers/metrics.py`'s `/cache/invalidate` already calls both
-`metrics_cache.invalidate_all()` and geo_service's `clear_person_id_cache()`.
+TTL is the fallback, not the plan (kindred#2142): `api/routers/metrics.py`'s
+existing `POST /api/metrics/cache/invalidate` now calls `invalidate_all()`
+here too, alongside `metrics_cache.invalidate_all()` and geo_service's
+`clear_person_id_cache()`. That endpoint already fires on every CampMinder
+sync completion (the frontend's `invalidateSyncData`, via
+`useSyncCompletionToasts`), and both of this cache's writers -- the
+"persons" sync (households) and the "family_camp_derived" sync
+(family_camp_adults, family_camp_registrations) -- are polled sync types
+that trigger it. So a hit here is stale only for the gap between a sync
+finishing and a staff member's browser polling it (typically seconds), or
+for the rare sync that runs with nobody watching, in which case the TTL is
+what closes the gap.
+
+A cached `fetch_households` snapshot can still miss a household a FRESH
+attendee already names, in the narrow window before that invalidation call
+lands -- `LodgingRosterService._resolve_households` (kindred#2143) is the
+per-request patch for exactly that gap: one small live fetch for the
+missing id(s), never a second cache.
 """
 
 import functools

--- a/api/services/lodging_cache.py
+++ b/api/services/lodging_cache.py
@@ -38,13 +38,17 @@ call is a one-line follow-up, not a re-architecture -- exactly how
 `metrics_cache.invalidate_all()` and geo_service's `clear_person_id_cache()`.
 """
 
+import functools
 import threading
 import time
-from typing import Any
+from collections.abc import Callable, Coroutine
+from typing import Any, TypeVar
 
 from bunking.logging_config import get_logger
 
 logger = get_logger(__name__)
+
+T = TypeVar("T")
 
 
 class LodgingYearCache:
@@ -63,8 +67,6 @@ class LodgingYearCache:
         self._ttl = ttl_seconds
         self._max_size = max_size
         self._lock = threading.RLock()
-        self._hit_count = 0
-        self._miss_count = 0
 
     @staticmethod
     def _make_key(read_name: str, year: int) -> str:
@@ -77,12 +79,9 @@ class LodgingYearCache:
             if key in self._cache:
                 if time.time() - self._cache_times[key] > self._ttl:
                     self._evict(key)
-                    self._miss_count += 1
                     return None
                 self._access_times[key] = time.time()
-                self._hit_count += 1
                 return self._cache[key]
-            self._miss_count += 1
             return None
 
     def set(self, read_name: str, year: int, value: Any) -> None:
@@ -90,9 +89,10 @@ class LodgingYearCache:
         with self._lock:
             if len(self._cache) >= self._max_size and key not in self._cache:
                 self._evict_lru()
+            now = time.time()
             self._cache[key] = value
-            self._cache_times[key] = time.time()
-            self._access_times[key] = time.time()
+            self._cache_times[key] = now
+            self._access_times[key] = now
 
     def invalidate_all(self) -> int:
         """Clear every cached entry. Returns the number cleared.
@@ -109,19 +109,6 @@ class LodgingYearCache:
                 logger.info(f"Lodging year cache invalidated: cleared {count} entries")
             return count
 
-    def get_stats(self) -> dict[str, Any]:
-        with self._lock:
-            total = self._hit_count + self._miss_count
-            return {
-                "cache_size": len(self._cache),
-                "hit_count": self._hit_count,
-                "miss_count": self._miss_count,
-                "hit_rate": round(self._hit_count / total, 3) if total else 0.0,
-                "total_requests": total,
-                "ttl_seconds": self._ttl,
-                "max_size": self._max_size,
-            }
-
     def _evict(self, key: str) -> None:
         self._cache.pop(key, None)
         self._cache_times.pop(key, None)
@@ -132,3 +119,32 @@ class LodgingYearCache:
             return
         lru_key = min(self._access_times.items(), key=lambda x: x[1])[0]
         self._evict(lru_key)
+
+
+_YearRead = Callable[[Any, int], Coroutine[Any, Any, T]]
+
+
+def cached_by_year(cache: LodgingYearCache) -> Callable[[_YearRead[T]], _YearRead[T]]:
+    """Wrap a `(self, year: int) -> T` repository method with `cache`.
+
+    Keyed on the wrapped function's own `__name__`, not a hand-typed string --
+    the four call sites in lodging_repository.py used to each repeat their own
+    get-check / fetch / set block with the read name passed as a free string
+    literal, which a rename or a copy-paste could silently desync from the
+    method it was supposed to key. Tying the key to `__name__` makes that
+    class of bug impossible instead of just avoided.
+    """
+
+    def decorator(fn: _YearRead[T]) -> _YearRead[T]:
+        @functools.wraps(fn)
+        async def wrapper(self: Any, year: int) -> T:
+            cached = cache.get(fn.__name__, year)
+            if cached is not None:
+                return cached  # type: ignore[no-any-return]
+            result = await fn(self, year)
+            cache.set(fn.__name__, year, result)
+            return result
+
+        return wrapper
+
+    return decorator

--- a/api/services/lodging_cache.py
+++ b/api/services/lodging_cache.py
@@ -108,8 +108,10 @@ class LodgingYearCache:
     def invalidate_all(self) -> int:
         """Clear every cached entry. Returns the number cleared.
 
-        Not wired to anything yet (see module docstring) -- exposed so the
-        follow-up that wires it to sync completion needs no change here.
+        Called by `api/routers/metrics.py`'s `POST /api/metrics/cache/invalidate`
+        (kindred#2142), which the frontend fires on CampMinder sync completion --
+        see the module docstring for which syncs write the four cached reads and
+        for the residual gap the TTL still covers.
         """
         with self._lock:
             count = len(self._cache)

--- a/api/services/lodging_cache.py
+++ b/api/services/lodging_cache.py
@@ -1,0 +1,134 @@
+"""Server-side cache for the weekend roster's year-scoped PocketBase reads.
+
+`LodgingRosterService.build_roster` opens a TaskGroup with six year-scoped
+reads on every single-weekend load (kindred#1963) -- identical for every
+weekend in the year, and re-issued from scratch on every load because
+`build_roster` has no cache of its own. `build_summary` already hoists this
+work out of ITS per-weekend loop, but the plain roster does not, which is
+most of why an empty weekend costs ~3s.
+
+Only FOUR of the six are cached here, not six. `fetch_units` (`lodging_units`)
+and `count_open_unresolved_aliases` (`lodging_ingest_issues`) are written
+STRAIGHT TO POCKETBASE FROM THE BROWSER by the admin panels --
+`frontend/src/services/lodgingCrud.ts`'s `createLodgingUnit` /
+`updateLodgingUnit` / `confirmLodgingUnits` / `deactivateLodgingUnit` and
+`mapUnresolvedAlias` / `ignoreIngestIssue` write those two collections
+directly and never pass through this API. Caching either one would hide an
+admin's own edit -- a cabin just confirmed, a cabin name just resolved -- for
+the whole TTL, to buy about 16ms. That trade is not worth making, so
+LodgingRepository never calls this cache for those two reads. The four it DOES
+cache (`fetch_households`, `fetch_prior_household_cm_ids`,
+`fetch_family_camp_adults`, `fetch_family_camp_registrations`) are all
+sync-written only: the CampMinder Go ingest is their sole writer, so nothing
+in the browser can produce a row a staff member is waiting to see reflected.
+
+Shaped like api/services/metrics_cache.py (TTL + LRU + RLock) per that
+module's own docstring pattern, but closer in spirit to
+api/services/geo_service.py's module-level `_PERSON_ID_CACHE`: a
+LodgingRepository is built fresh per request (api/routers/lodging.py's
+`_service` / `_writes`), so an instance-level cache would never be reused, and
+this must live as a singleton instead -- see api/dependencies.py.
+
+TTL-only for now. There is no `/api/lodging/cache/invalidate` endpoint wired
+to CampMinder sync completion yet, because that wiring lives in
+api/routers/lodging.py (and possibly the frontend's sync-completion hook),
+both outside kindred#1963's scope. `invalidate_all` is exposed so adding that
+call is a one-line follow-up, not a re-architecture -- exactly how
+`api/routers/metrics.py`'s `/cache/invalidate` already calls both
+`metrics_cache.invalidate_all()` and geo_service's `clear_person_id_cache()`.
+"""
+
+import threading
+import time
+from typing import Any
+
+from bunking.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+class LodgingYearCache:
+    """Thread-safe in-memory cache for the roster's year-scoped reads.
+
+    Keyed by (read name, year) -- there is no third axis. These four reads
+    never vary by session or scenario, which is exactly why hoisting them
+    into a cache is safe: the same answer is correct for every weekend and
+    every scenario in a year.
+    """
+
+    def __init__(self, ttl_seconds: int = 900, max_size: int = 64) -> None:
+        self._cache: dict[str, Any] = {}
+        self._cache_times: dict[str, float] = {}
+        self._access_times: dict[str, float] = {}
+        self._ttl = ttl_seconds
+        self._max_size = max_size
+        self._lock = threading.RLock()
+        self._hit_count = 0
+        self._miss_count = 0
+
+    @staticmethod
+    def _make_key(read_name: str, year: int) -> str:
+        return f"{read_name}:{year}"
+
+    def get(self, read_name: str, year: int) -> Any | None:
+        """Cached value for one read at one year, or None on miss/expiry."""
+        key = self._make_key(read_name, year)
+        with self._lock:
+            if key in self._cache:
+                if time.time() - self._cache_times[key] > self._ttl:
+                    self._evict(key)
+                    self._miss_count += 1
+                    return None
+                self._access_times[key] = time.time()
+                self._hit_count += 1
+                return self._cache[key]
+            self._miss_count += 1
+            return None
+
+    def set(self, read_name: str, year: int, value: Any) -> None:
+        key = self._make_key(read_name, year)
+        with self._lock:
+            if len(self._cache) >= self._max_size and key not in self._cache:
+                self._evict_lru()
+            self._cache[key] = value
+            self._cache_times[key] = time.time()
+            self._access_times[key] = time.time()
+
+    def invalidate_all(self) -> int:
+        """Clear every cached entry. Returns the number cleared.
+
+        Not wired to anything yet (see module docstring) -- exposed so the
+        follow-up that wires it to sync completion needs no change here.
+        """
+        with self._lock:
+            count = len(self._cache)
+            self._cache.clear()
+            self._cache_times.clear()
+            self._access_times.clear()
+            if count:
+                logger.info(f"Lodging year cache invalidated: cleared {count} entries")
+            return count
+
+    def get_stats(self) -> dict[str, Any]:
+        with self._lock:
+            total = self._hit_count + self._miss_count
+            return {
+                "cache_size": len(self._cache),
+                "hit_count": self._hit_count,
+                "miss_count": self._miss_count,
+                "hit_rate": round(self._hit_count / total, 3) if total else 0.0,
+                "total_requests": total,
+                "ttl_seconds": self._ttl,
+                "max_size": self._max_size,
+            }
+
+    def _evict(self, key: str) -> None:
+        self._cache.pop(key, None)
+        self._cache_times.pop(key, None)
+        self._access_times.pop(key, None)
+
+    def _evict_lru(self) -> None:
+        if not self._access_times:
+            return
+        lru_key = min(self._access_times.items(), key=lambda x: x[1])[0]
+        self._evict(lru_key)

--- a/api/services/lodging_repository.py
+++ b/api/services/lodging_repository.py
@@ -51,6 +51,7 @@ from api.constants.collections import (
 )
 from api.constants.filters import ACTIVE_ENROLLED_FILTER
 from api.dependencies import lodging_cache
+from api.services.lodging_cache import cached_by_year
 from api.utils.pb_filters import pb_escape
 from bunking.logging_config import get_logger
 
@@ -317,22 +318,18 @@ class LodgingRepository:
             },
         )
 
+    @cached_by_year(lodging_cache)
     async def fetch_households(self, year: int) -> dict[str, Any]:
         """Households for a year, keyed by PocketBase record id.
 
         Cached (kindred#1963): year-scoped and sync-written only, so a hit is
         safe for the cache's whole TTL. See api/services/lodging_cache.py.
         """
-        cached = lodging_cache.get("fetch_households", year)
-        if cached is not None:
-            return cached  # type: ignore[no-any-return]
         rows = await self._page(
             HOUSEHOLDS,
             query_params={"filter": f"year = {year}", "sort": STABLE_SORT},
         )
-        result = {row.id: row for row in rows}
-        lodging_cache.set("fetch_households", year, result)
-        return result
+        return {row.id: row for row in rows}
 
     async def fetch_household_by_cm_id(self, year: int, household_cm_id: int) -> Any | None:
         """One household by CampMinder id, or None.
@@ -349,6 +346,7 @@ class LodgingRepository:
         )
         return rows[0] if rows else None
 
+    @cached_by_year(lodging_cache)
     async def fetch_prior_household_cm_ids(self, year: int) -> set[int]:
         """CampMinder ids of every household seen in an EARLIER year.
 
@@ -365,17 +363,13 @@ class LodgingRepository:
         fetch_households: year-scoped, sync-written only. See
         api/services/lodging_cache.py.
         """
-        cached = lodging_cache.get("fetch_prior_household_cm_ids", year)
-        if cached is not None:
-            return cached  # type: ignore[no-any-return]
         rows = await self._page(
             HOUSEHOLDS,
             query_params={"filter": f"year < {year}", "fields": "cm_id", "sort": STABLE_SORT},
         )
-        result = {int(getattr(row, "cm_id", 0)) for row in rows if getattr(row, "cm_id", 0)}
-        lodging_cache.set("fetch_prior_household_cm_ids", year, result)
-        return result
+        return {int(getattr(row, "cm_id", 0)) for row in rows if getattr(row, "cm_id", 0)}
 
+    @cached_by_year(lodging_cache)
     async def fetch_family_camp_adults(self, year: int) -> dict[str, list[Any]]:
         """Accompanying adults grouped by household PB id, in adult_number order.
 
@@ -385,9 +379,6 @@ class LodgingRepository:
         Cached (kindred#1963): year-scoped and sync-written only. See
         api/services/lodging_cache.py.
         """
-        cached = lodging_cache.get("fetch_family_camp_adults", year)
-        if cached is not None:
-            return cached  # type: ignore[no-any-return]
         rows = await self._page(
             FAMILY_CAMP_ADULTS,
             query_params={"filter": f"year = {year}", "sort": "adult_number"},
@@ -397,10 +388,9 @@ class LodgingRepository:
             grouped[str(getattr(row, "household", ""))].append(row)
         for adults in grouped.values():
             adults.sort(key=lambda a: int(getattr(a, "adult_number", 0) or 0))
-        result = dict(grouped)
-        lodging_cache.set("fetch_family_camp_adults", year, result)
-        return result
+        return dict(grouped)
 
+    @cached_by_year(lodging_cache)
     async def fetch_family_camp_registrations(self, year: int) -> dict[str, Any]:
         """Registration answers keyed by household PB id.
 
@@ -413,16 +403,11 @@ class LodgingRepository:
         Cached (kindred#1963): year-scoped and sync-written only. See
         api/services/lodging_cache.py.
         """
-        cached = lodging_cache.get("fetch_family_camp_registrations", year)
-        if cached is not None:
-            return cached  # type: ignore[no-any-return]
         rows = await self._page(
             FAMILY_CAMP_REGISTRATIONS,
             query_params={"filter": f"year = {year}", "sort": STABLE_SORT},
         )
-        result = {str(getattr(row, "household", "")): row for row in rows}
-        lodging_cache.set("fetch_family_camp_registrations", year, result)
-        return result
+        return {str(getattr(row, "household", "")): row for row in rows}
 
     async def fetch_family_camp_medical(self, year: int) -> dict[str, Any]:
         """PHI, keyed by household PB id. NO PRODUCTION CALLER.

--- a/api/services/lodging_repository.py
+++ b/api/services/lodging_repository.py
@@ -50,6 +50,7 @@ from api.constants.collections import (
     LODGING_UNITS,
 )
 from api.constants.filters import ACTIVE_ENROLLED_FILTER
+from api.dependencies import lodging_cache
 from api.utils.pb_filters import pb_escape
 from bunking.logging_config import get_logger
 
@@ -167,6 +168,14 @@ class LodgingRepository:
         year-scoped in 1500000141, so an unfiltered read returns every season
         at once — and since `code` is only unique per (code, year), the board's
         code-keyed index would collide two seasons onto one card.
+
+        Deliberately NOT cached, despite being year-scoped like the four in
+        lodging_cache.py (kindred#1963). `lodging_units` is written straight
+        to PocketBase from the browser by the admin panel
+        (createLodgingUnit / updateLodgingUnit / confirmLodgingUnits /
+        deactivateLodgingUnit in frontend/src/services/lodgingCrud.ts), never
+        through this API. A cache hit here would show a stale confirmation
+        state for the TTL, to buy back a read that is not the expensive one.
         """
         return await self._page(
             LODGING_UNITS,
@@ -309,12 +318,21 @@ class LodgingRepository:
         )
 
     async def fetch_households(self, year: int) -> dict[str, Any]:
-        """Households for a year, keyed by PocketBase record id."""
+        """Households for a year, keyed by PocketBase record id.
+
+        Cached (kindred#1963): year-scoped and sync-written only, so a hit is
+        safe for the cache's whole TTL. See api/services/lodging_cache.py.
+        """
+        cached = lodging_cache.get("fetch_households", year)
+        if cached is not None:
+            return cached  # type: ignore[no-any-return]
         rows = await self._page(
             HOUSEHOLDS,
             query_params={"filter": f"year = {year}", "sort": STABLE_SORT},
         )
-        return {row.id: row for row in rows}
+        result = {row.id: row for row in rows}
+        lodging_cache.set("fetch_households", year, result)
+        return result
 
     async def fetch_household_by_cm_id(self, year: int, household_cm_id: int) -> Any | None:
         """One household by CampMinder id, or None.
@@ -336,19 +354,40 @@ class LodgingRepository:
 
         This is the returning-family signal: households rows are per-year, so
         a cm_id present before `year` means the family has been here before.
+
+        The expensive one -- 20,256 rows on 2026 prod data for one boolean
+        per party (kindred#1966). #1966/#1976 already bought back the
+        round-trip cost (batch=PAGE_SIZE, 21 requests instead of 203) and
+        explicitly rejected narrowing the filter to the current year's
+        household ids: a 250-term OR clause returns HTTP 400 (undocumented,
+        fails closed), so there is no query-shape lever left to pull. Caching
+        is what is left, and it is safe here for the same reason as
+        fetch_households: year-scoped, sync-written only. See
+        api/services/lodging_cache.py.
         """
+        cached = lodging_cache.get("fetch_prior_household_cm_ids", year)
+        if cached is not None:
+            return cached  # type: ignore[no-any-return]
         rows = await self._page(
             HOUSEHOLDS,
             query_params={"filter": f"year < {year}", "fields": "cm_id", "sort": STABLE_SORT},
         )
-        return {int(getattr(row, "cm_id", 0)) for row in rows if getattr(row, "cm_id", 0)}
+        result = {int(getattr(row, "cm_id", 0)) for row in rows if getattr(row, "cm_id", 0)}
+        lodging_cache.set("fetch_prior_household_cm_ids", year, result)
+        return result
 
     async def fetch_family_camp_adults(self, year: int) -> dict[str, list[Any]]:
         """Accompanying adults grouped by household PB id, in adult_number order.
 
         CampMinder enrols only the children for family camp; the adults exist
         only as custom-field values scraped into this table.
+
+        Cached (kindred#1963): year-scoped and sync-written only. See
+        api/services/lodging_cache.py.
         """
+        cached = lodging_cache.get("fetch_family_camp_adults", year)
+        if cached is not None:
+            return cached  # type: ignore[no-any-return]
         rows = await self._page(
             FAMILY_CAMP_ADULTS,
             query_params={"filter": f"year = {year}", "sort": "adult_number"},
@@ -358,7 +397,9 @@ class LodgingRepository:
             grouped[str(getattr(row, "household", ""))].append(row)
         for adults in grouped.values():
             adults.sort(key=lambda a: int(getattr(a, "adult_number", 0) or 0))
-        return dict(grouped)
+        result = dict(grouped)
+        lodging_cache.set("fetch_family_camp_adults", year, result)
+        return result
 
     async def fetch_family_camp_registrations(self, year: int) -> dict[str, Any]:
         """Registration answers keyed by household PB id.
@@ -368,12 +409,20 @@ class LodgingRepository:
         four PHI-free housing flags. Read those columns; do not re-derive them
         from share_cabin_preference / shared_cabin_modes_raw, which are the raw
         profile values kept for provenance.
+
+        Cached (kindred#1963): year-scoped and sync-written only. See
+        api/services/lodging_cache.py.
         """
+        cached = lodging_cache.get("fetch_family_camp_registrations", year)
+        if cached is not None:
+            return cached  # type: ignore[no-any-return]
         rows = await self._page(
             FAMILY_CAMP_REGISTRATIONS,
             query_params={"filter": f"year = {year}", "sort": STABLE_SORT},
         )
-        return {str(getattr(row, "household", "")): row for row in rows}
+        result = {str(getattr(row, "household", "")): row for row in rows}
+        lodging_cache.set("fetch_family_camp_registrations", year, result)
+        return result
 
     async def fetch_family_camp_medical(self, year: int) -> dict[str, Any]:
         """PHI, keyed by household PB id. NO PRODUCTION CALLER.
@@ -440,6 +489,15 @@ class LodgingRepository:
         season's unmapped cabin names, disagreeing with the year-scoped
         Unresolved names queue underneath the same header. Same defect, same
         fix, as `listUnresolvedAliasIssues` in `lodgingCrud.ts`.
+
+        Deliberately NOT cached, despite being year-scoped like the four in
+        lodging_cache.py (kindred#1963). The ROW is ingest-written, but
+        `is_resolved` -- the column this filter tests -- is flipped straight
+        against PocketBase from the admin panel
+        (mapUnresolvedAlias / ignoreIngestIssue in
+        frontend/src/services/lodgingCrud.ts), never through this API. A
+        cache hit here would leave a cabin name staff just resolved sitting
+        in the "unmapped" count for the TTL.
         """
         return await self._count(
             LODGING_INGEST_ISSUES,

--- a/api/services/lodging_repository.py
+++ b/api/services/lodging_repository.py
@@ -331,6 +331,34 @@ class LodgingRepository:
         )
         return {row.id: row for row in rows}
 
+    async def fetch_households_by_ids(self, household_pb_ids: list[str]) -> dict[str, Any]:
+        """Households fetched fresh by PocketBase id, bypassing the year cache.
+
+        The escape hatch for kindred#2143: `fetch_households`' cached snapshot
+        can be up to 15 minutes stale (kindred#1963), but `build_roster` and
+        `build_summary` always fetch attendees fresh. A household created
+        after the snapshot was cached is absent from it even though a
+        brand-new attendee can already name it -- the roster service calls
+        this for exactly those ids, never for the whole year, so the fix costs
+        one small extra read instead of giving up the cache entirely.
+
+        Deliberately NOT decorated with @cached_by_year: caching this would
+        reintroduce the exact staleness it exists to patch around.
+
+        `household_pb_ids` is small by construction -- the caller has already
+        narrowed to just the ids missing from the cached snapshot, typically
+        zero or one -- so an OR clause of `id = "..."` terms is safe here even
+        though the same shape was rejected for fetch_prior_household_cm_ids at
+        250 terms (see that method's docstring): this list does not grow with
+        the year's household count, only with how many are mid-flight right
+        now. Every id is escaped, matching every other filter in this file.
+        """
+        if not household_pb_ids:
+            return {}
+        ids_clause = " || ".join(f'id = "{pb_escape(hid)}"' for hid in household_pb_ids)
+        rows = await self._page(HOUSEHOLDS, query_params={"filter": ids_clause, "sort": STABLE_SORT})
+        return {row.id: row for row in rows}
+
     async def fetch_household_by_cm_id(self, year: int, household_cm_id: int) -> Any | None:
         """One household by CampMinder id, or None.
 

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -456,6 +456,8 @@ class LodgingRosterService:
             # resolve_combined then sees both tiers.
             merges_task = tg.create_task(self.repository.fetch_slot_merges(year, session_pb_id, scenario))
 
+        households = await self._resolve_households(session_type, attendees_task.result(), households_task.result())
+
         unit_summaries = self._build_units(
             units_task.result(),
             availability_task.result(),
@@ -464,7 +466,7 @@ class LodgingRosterService:
         parties = self._build_parties(
             session_type=session_type,
             attendees=attendees_task.result(),
-            households=households_task.result(),
+            households=households,
             prior_cm_ids=prior_task.result(),
             adults_by_household=adults_task.result(),
             registrations=registrations_task.result(),
@@ -552,6 +554,17 @@ class LodgingRosterService:
                 # rather than an empty list.
                 merges_task = inner.create_task(self.repository.fetch_slot_merges(year, session_pb_id, scenario))
 
+            # Own local variable, not a mutation of the shared `households`
+            # above: `_entry` runs concurrently, one per weekend, in the
+            # TaskGroup below, and `_resolve_households` returns a merged
+            # COPY rather than patching in place (kindred#2143) -- so two
+            # weekends resolving different missing households at once can
+            # never step on each other or leak one weekend's fresh fetch into
+            # another's.
+            session_households = await self._resolve_households(
+                _s(session, "session_type"), attendees_task.result(), households
+            )
+
             unit_summaries = self._build_units(
                 units,
                 availability_task.result(),
@@ -560,7 +573,7 @@ class LodgingRosterService:
             parties = self._build_parties(
                 session_type=_s(session, "session_type"),
                 attendees=attendees_task.result(),
-                households=households,
+                households=session_households,
                 prior_cm_ids=prior_cm_ids,
                 adults_by_household=adults_by_household,
                 registrations=registrations,
@@ -698,6 +711,48 @@ class LodgingRosterService:
         return summaries
 
     # -------------------------------------------------------------- parties
+
+    async def _resolve_households(
+        self, session_type: str, attendees: list[Any], households: dict[str, Any]
+    ) -> dict[str, Any]:
+        """`households`, patched with any household a fresh attendee names
+        that the cached year snapshot does not have (kindred#2143).
+
+        `households` is cached for up to 15 minutes (`fetch_households`,
+        kindred#1963); `attendees` is fetched fresh on every call, in the
+        SAME TaskGroup. A household created after the snapshot was cached is
+        absent from the cached dict even though a brand-new attendee can
+        already name it -- the fresh half of this mixed read outrunning the
+        cached half. Left alone, `_build_household_parties` falls through to
+        a blank record: display_name renders "Household 0" and is_returning
+        reads False for a family that may have been coming for years.
+
+        Person-grain (adult weekend) parties never read `households` at all
+        (see `_build_parties`), so there is nothing to patch and no reason to
+        pay for the check.
+
+        Scoped to exactly the missing ids -- typically zero -- and never
+        written back to `lodging_cache`: this is a per-request patch for a
+        rare race, not a second cache to keep coherent with the first.
+        """
+        if session_type == "adult":
+            return households
+        missing_ids = sorted(
+            {
+                household_pb_id
+                for attendee in attendees
+                if (person := (getattr(attendee, "expand", None) or {}).get("person")) is not None
+                and (household_pb_id := _s(person, "household"))
+                and household_pb_id not in households
+            }
+        )
+        if not missing_ids:
+            return households
+        fresh = await self.repository.fetch_households_by_ids(missing_ids)
+        if not fresh:
+            return households
+        logger.info(f"Lodging roster: fetched {len(fresh)} household(s) fresh past the {len(households)}-entry cache")
+        return {**households, **fresh}
 
     def _build_parties(
         self,

--- a/tests/unit/api/routers/test_lodging_endpoints.py
+++ b/tests/unit/api/routers/test_lodging_endpoints.py
@@ -117,6 +117,23 @@ def _medical_reads(**kwargs: Any) -> list[Any]:
     return []
 
 
+@pytest.fixture(autouse=True)
+def _reset_lodging_cache() -> Generator[None]:
+    """`lodging_cache` is a process-wide singleton (kindred#1963): the router
+    builds a real `LodgingRepository` per request even in these router tests
+    (`_build_app` only patches the PocketBase client, not the repository
+    layer), so a value one test's mock warms would otherwise survive into the
+    next test's assertions for the same year. Mirrors
+    tests/unit/api/services/test_lodging_repository.py's fixture of the same
+    name.
+    """
+    from api.dependencies import lodging_cache
+
+    lodging_cache.invalidate_all()
+    yield
+    lodging_cache.invalidate_all()
+
+
 @pytest.fixture
 def mock_pb() -> MagicMock:
     client = MagicMock()

--- a/tests/unit/api/services/test_lodging_repository.py
+++ b/tests/unit/api/services/test_lodging_repository.py
@@ -466,6 +466,68 @@ class TestFetchFamilyCampRegistrations:
         assert result["hh_1"].share_cabin_gate == "yes_share"
 
 
+class TestFetchHouseholdsByIds:
+    """The fresh-fetch escape hatch for kindred#2143.
+
+    `fetch_households` is cached for up to 15 minutes (kindred#1963); a
+    household created after the snapshot was cached is absent from it even
+    though a fresh attendee can already name it. This method is the roster
+    service's fallback for exactly that gap -- deliberately NOT decorated
+    with @cached_by_year, unlike every other read in this class.
+    """
+
+    @pytest.mark.asyncio
+    async def test_filters_by_id_and_keys_by_pb_id(self, repo: LodgingRepository, pb: MagicMock) -> None:
+        pb.collection.return_value.get_full_list.return_value = [_record(id="hh_9", cm_id=2000009)]
+
+        result = await repo.fetch_households_by_ids(["hh_9"])
+
+        pb.collection.assert_called_with("households")
+        filter_str = _last_query(pb)["filter"]
+        assert 'id = "hh_9"' in filter_str
+        assert result["hh_9"].cm_id == 2000009
+
+    @pytest.mark.asyncio
+    async def test_multiple_ids_are_ored_together(self, repo: LodgingRepository, pb: MagicMock) -> None:
+        pb.collection.return_value.get_full_list.return_value = [
+            _record(id="hh_1", cm_id=2000001),
+            _record(id="hh_2", cm_id=2000002),
+        ]
+
+        result = await repo.fetch_households_by_ids(["hh_1", "hh_2"])
+
+        filter_str = _last_query(pb)["filter"]
+        assert 'id = "hh_1"' in filter_str
+        assert 'id = "hh_2"' in filter_str
+        assert "||" in filter_str
+        assert set(result) == {"hh_1", "hh_2"}
+
+    @pytest.mark.asyncio
+    async def test_an_empty_id_list_makes_no_request(self, repo: LodgingRepository, pb: MagicMock) -> None:
+        result = await repo.fetch_households_by_ids([])
+
+        assert result == {}
+        pb.collection.return_value.get_full_list.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_not_cached_across_calls(self, repo: LodgingRepository, pb: MagicMock) -> None:
+        """Unlike fetch_households, a second call must hit PocketBase again --
+        this method exists BECAUSE the cached snapshot is stale."""
+        pb.collection.return_value.get_full_list.return_value = [_record(id="hh_1", cm_id=2000001)]
+
+        await repo.fetch_households_by_ids(["hh_1"])
+        await repo.fetch_households_by_ids(["hh_1"])
+
+        assert pb.collection.return_value.get_full_list.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_ids_are_escaped(self, repo: LodgingRepository, pb: MagicMock) -> None:
+        await repo.fetch_households_by_ids(['hh_1" || year != ""'])
+
+        filter_str = _last_query(pb)["filter"]
+        assert '\\"' in filter_str
+
+
 def _last_list_query(pb: MagicMock) -> dict[str, Any]:
     call = pb.collection.return_value.get_list.call_args
     params: dict[str, Any] = call[1]["query_params"]

--- a/tests/unit/api/services/test_lodging_repository.py
+++ b/tests/unit/api/services/test_lodging_repository.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from api.dependencies import lodging_cache
 from api.services.lodging_repository import (
     PAGE_SIZE,
     WEEKEND_SESSION_TYPES,
@@ -21,6 +22,19 @@ def _record(**kwargs: Any) -> MagicMock:
     for key, value in kwargs.items():
         setattr(record, key, value)
     return record
+
+
+@pytest.fixture(autouse=True)
+def _reset_lodging_cache() -> Any:
+    """`lodging_cache` is a process-wide singleton (kindred#1963), so a value
+    one test's mock sets up would otherwise leak into the next test's
+    assertions -- most of this file reuses year 2026 across dozens of tests
+    with different mocked rows. Every test in this module runs against an
+    empty cache and leaves one behind it.
+    """
+    lodging_cache.invalidate_all()
+    yield
+    lodging_cache.invalidate_all()
 
 
 @pytest.fixture
@@ -626,3 +640,155 @@ class TestFilterEscaping:
         filter_str = _last_query(pb)["filter"]
         assert 'pb"evil' not in filter_str, "raw quote reached the filter unescaped"
         assert 'pb\\"evil' in filter_str, "quote was not backslash-escaped"
+
+
+# kindred#1963 -- of the six year-scoped reads in build_roster's TaskGroup,
+# only these four are safe to cache. The other two, fetch_units and
+# count_open_unresolved_aliases, are written straight to PocketBase from the
+# browser by the admin panels (frontend/src/services/lodgingCrud.ts) and would
+# hide an admin's own edit for the cache's whole TTL.
+CACHED_YEAR_SCOPED_READS = [
+    "fetch_households",
+    "fetch_prior_household_cm_ids",
+    "fetch_family_camp_adults",
+    "fetch_family_camp_registrations",
+]
+
+
+class TestYearScopedCaching:
+    """The four sync-only year-scoped reads collapse to one PocketBase round
+    trip per year, however many weekends or requests ask for it.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method_name", CACHED_YEAR_SCOPED_READS)
+    async def test_second_call_for_the_same_year_is_a_cache_hit(
+        self, repo: LodgingRepository, pb: MagicMock, method_name: str
+    ) -> None:
+        method = getattr(repo, method_name)
+        await method(2026)
+        assert pb.collection.return_value.get_full_list.call_count == 1
+
+        await method(2026)
+
+        assert pb.collection.return_value.get_full_list.call_count == 1, "second call must not hit PocketBase again"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method_name", CACHED_YEAR_SCOPED_READS)
+    async def test_different_years_are_different_cache_entries(
+        self, repo: LodgingRepository, pb: MagicMock, method_name: str
+    ) -> None:
+        method = getattr(repo, method_name)
+        await method(2026)
+        await method(2027)
+
+        assert pb.collection.return_value.get_full_list.call_count == 2, "each year must issue its own read"
+
+    @pytest.mark.asyncio
+    async def test_two_repository_instances_share_one_cache(self, pb: MagicMock) -> None:
+        """The cache is a module-level singleton (kindred#1963 trap #3): the
+        router builds a fresh LodgingRepository per request
+        (api/routers/lodging.py's `_service`), so per-instance state would
+        never be reused across two requests for the same year.
+        """
+        await LodgingRepository(pb).fetch_households(2026)
+        await LodgingRepository(pb).fetch_households(2026)
+
+        assert pb.collection.return_value.get_full_list.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_fetch_units_is_never_cached(self, repo: LodgingRepository, pb: MagicMock) -> None:
+        """`lodging_units` is written straight to PocketBase from the admin
+        panel (createLodgingUnit / confirmLodgingUnits / deactivateLodgingUnit
+        in lodgingCrud.ts). Caching it would hide a just-confirmed unit for
+        the whole TTL to buy a read that is not even the expensive one.
+        """
+        await repo.fetch_units(2026)
+        await repo.fetch_units(2026)
+
+        assert pb.collection.return_value.get_full_list.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_open_unresolved_aliases_is_never_cached(self, repo: LodgingRepository, pb: MagicMock) -> None:
+        """`lodging_ingest_issues.is_resolved` is written straight to
+        PocketBase from the admin panel (mapUnresolvedAlias / ignoreIngestIssue
+        in lodgingCrud.ts). Caching the count would leave a cabin name staff
+        just resolved sitting in the "unmapped" figure for the whole TTL.
+        """
+        pb.collection.return_value.get_list.return_value = _record(total_items=3)
+
+        await repo.count_open_unresolved_aliases(2026)
+        await repo.count_open_unresolved_aliases(2026)
+
+        assert pb.collection.return_value.get_list.call_count == 2
+
+
+class TestLodgingYearCache:
+    """The cache class itself, independent of LodgingRepository.
+
+    Modeled on tests/unit/metrics/test_metrics_cache.py for
+    api/services/metrics_cache.py, the sibling this class is shaped after.
+    """
+
+    def test_get_returns_none_on_miss(self) -> None:
+        from api.services.lodging_cache import LodgingYearCache
+
+        cache = LodgingYearCache(ttl_seconds=300, max_size=10)
+        assert cache.get("fetch_households", 2026) is None
+
+    def test_set_then_get_returns_the_cached_value(self) -> None:
+        from api.services.lodging_cache import LodgingYearCache
+
+        cache = LodgingYearCache(ttl_seconds=300, max_size=10)
+        value = {"hh_1": "household"}
+        cache.set("fetch_households", 2026, value)
+        assert cache.get("fetch_households", 2026) == value
+
+    def test_read_name_and_year_are_independent_axes(self) -> None:
+        from api.services.lodging_cache import LodgingYearCache
+
+        cache = LodgingYearCache(ttl_seconds=300, max_size=10)
+        cache.set("fetch_households", 2026, "households-2026")
+        cache.set("fetch_households", 2027, "households-2027")
+        cache.set("fetch_family_camp_adults", 2026, "adults-2026")
+
+        assert cache.get("fetch_households", 2026) == "households-2026"
+        assert cache.get("fetch_households", 2027) == "households-2027"
+        assert cache.get("fetch_family_camp_adults", 2026) == "adults-2026"
+
+    def test_entry_expires_after_ttl(self) -> None:
+        import time
+
+        from api.services.lodging_cache import LodgingYearCache
+
+        cache = LodgingYearCache(ttl_seconds=1, max_size=10)
+        cache.set("fetch_households", 2026, "value")
+        assert cache.get("fetch_households", 2026) is not None
+        time.sleep(1.1)
+        assert cache.get("fetch_households", 2026) is None
+
+    def test_invalidate_all_clears_every_entry(self) -> None:
+        from api.services.lodging_cache import LodgingYearCache
+
+        cache = LodgingYearCache(ttl_seconds=300, max_size=10)
+        cache.set("fetch_households", 2026, "a")
+        cache.set("fetch_family_camp_adults", 2026, "b")
+
+        cleared = cache.invalidate_all()
+
+        assert cleared == 2
+        assert cache.get("fetch_households", 2026) is None
+        assert cache.get("fetch_family_camp_adults", 2026) is None
+
+    def test_evicts_lru_when_at_capacity(self) -> None:
+        from api.services.lodging_cache import LodgingYearCache
+
+        cache = LodgingYearCache(ttl_seconds=300, max_size=2)
+        cache.set("fetch_households", 2024, "a")
+        cache.set("fetch_households", 2025, "b")
+        cache.get("fetch_households", 2024)  # touch 2024 so 2025 is the LRU entry
+        cache.set("fetch_households", 2026, "c")
+
+        assert cache.get("fetch_households", 2024) is not None
+        assert cache.get("fetch_households", 2025) is None, "least-recently-used entry must be evicted"
+        assert cache.get("fetch_households", 2026) is not None

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -89,6 +89,12 @@ def _repo(**overrides: Any) -> MagicMock:
         "fetch_slot_merges": [],
         "fetch_attendees_for_session": [],
         "fetch_households": {},
+        # The kindred#2143 fallback: a fresh attendee can name a household the
+        # cached year snapshot above does not have yet. Empty by default so a
+        # test that never sets it up fails loudly (AttributeError on a bare
+        # dict, not a silently-invented MagicMock) if the service calls it
+        # unexpectedly.
+        "fetch_households_by_ids": {},
         "fetch_prior_household_cm_ids": set(),
         "fetch_family_camp_adults": {},
         "fetch_family_camp_registrations": {},
@@ -415,6 +421,96 @@ class TestFamilyCampParties:
         assert party.share.preference == "unknown"
         assert party.share.proximity == []
         assert party.flags.needs_private_bathroom is False
+
+
+class TestFreshHouseholdOutrunsTheCache:
+    """kindred#2143: households is cached for up to 15 minutes (kindred#1963)
+    but attendees is always fetched fresh, in the SAME TaskGroup. A household
+    created after the cache snapshot was taken is absent from the cached dict
+    even though a brand-new attendee can already name it. Left unhandled,
+    `_build_household_parties` falls through to a blank record -- the
+    confirmed failure rendered "Household 0" with a spurious
+    `is_returning=False` on screen. The fix is a targeted live fetch for
+    exactly the missing ids, never a second cache.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_household_missing_from_the_cache_is_fetched_fresh_not_rendered_as_household_zero(
+        self,
+    ) -> None:
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            # The cached year snapshot predates this household entirely --
+            # it is absent, not present with a stale value.
+            fetch_households={},
+            fetch_households_by_ids={"hh_1": _household(cm_id=2000009, title="The Nguyen Family")},
+            fetch_attendees_for_session=[_child(cm_id=1000002, first="Mai", last="Nguyen", household_pb_id="hh_1")],
+            fetch_prior_household_cm_ids={2000009},
+        )
+
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert len(roster.parties) == 1
+        party = roster.parties[0]
+        assert party.household_cm_id == 2000009
+        assert party.display_name == "The Nguyen Family"
+        assert party.is_returning is True
+        repo.fetch_households_by_ids.assert_awaited_once_with(["hh_1"])
+
+    @pytest.mark.asyncio
+    async def test_no_missing_households_never_calls_the_fallback(self) -> None:
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_households={"hh_1": _household()},
+            fetch_attendees_for_session=[_child()],
+        )
+
+        await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        repo.fetch_households_by_ids.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_adult_weekend_never_calls_the_household_fallback(self) -> None:
+        """Person-grain parties never read the households dict at all, so
+        there is nothing for this fallback to patch."""
+        attendee = _rec(
+            person_id=1000004,
+            expand={
+                "person": _rec(
+                    cm_id=1000004,
+                    first_name="Ava",
+                    last_name="Kim",
+                    preferred_name="",
+                    age=34,
+                    grade=0,
+                    household="hh_missing",
+                )
+            },
+        )
+        repo = _repo(fetch_session=ADULT_SESSION, fetch_attendees_for_session=[attendee])
+
+        await LodgingRosterService(repo).build_roster(2026, 1000002)
+
+        repo.fetch_households_by_ids.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_build_summary_gets_the_same_fallback_as_build_roster(self) -> None:
+        """The parallel TaskGroup in build_summary carries the identical
+        cached-households/fresh-attendees mix (see TestBuildSummary's own
+        guard tests for this file's established pattern: fixing only one of
+        the two TaskGroups is the half-fix those tests exist to catch)."""
+        repo = _repo(
+            fetch_weekend_sessions=[FAMILY_SESSION],
+            fetch_session=FAMILY_SESSION,
+            fetch_households={},
+            fetch_households_by_ids={"hh_1": _household(cm_id=2000009, title="The Nguyen Family")},
+            fetch_attendees_for_session=[_child(cm_id=1000002, first="Mai", last="Nguyen", household_pb_id="hh_1")],
+        )
+
+        summary = await LodgingRosterService(repo).build_summary(2026)
+
+        assert summary.weekends[0].counts.parties_total == 1
+        repo.fetch_households_by_ids.assert_awaited_once_with(["hh_1"])
 
 
 class TestAdultWeekendParties:

--- a/tests/unit/metrics/test_metrics_cache_endpoints.py
+++ b/tests/unit/metrics/test_metrics_cache_endpoints.py
@@ -252,6 +252,31 @@ class TestCacheInvalidationEndpoint:
         assert resp.status_code == 200
         assert len(_PERSON_ID_CACHE) == 0
 
+    def test_invalidation_endpoint_also_clears_lodging_year_cache(self, test_client, fresh_cache):
+        """The same /cache/invalidate endpoint must also clear lodging_cache (kindred#2142).
+
+        lodging_cache (kindred#1963) was shipped TTL-only, with no invalidation
+        hook wired anywhere -- exactly the trap root CLAUDE.md's caching section
+        names: "long staleTime plus explicit invalidation on mutation -- never
+        short staleTime plus hope." The frontend already fires this same
+        endpoint after every CampMinder sync completes (invalidateSyncData in
+        queryClient.ts), and both of lodging_cache's writers -- the "persons"
+        sync (households) and the "family_camp_derived" sync (family_camp_adults,
+        family_camp_registrations) -- are polled sync types that trigger that
+        callback, so wiring lodging_cache in here is the one-line follow-up its
+        own module docstring calls for.
+        """
+        from api.dependencies import lodging_cache
+
+        lodging_cache.invalidate_all()  # isolate from any bleed; it's a process-wide singleton
+        lodging_cache.set("fetch_households", 2026, {"hh_1": object()})
+        assert lodging_cache.get("fetch_households", 2026) is not None
+
+        resp = test_client.post("/api/metrics/cache/invalidate")
+
+        assert resp.status_code == 200
+        assert lodging_cache.get("fetch_households", 2026) is None
+
 
 class TestCacheStatsEndpoint:
     """Test the GET /api/metrics/cache/stats endpoint."""


### PR DESCRIPTION
## Summary

`build_roster` issues ten PocketBase reads per weekend, six of which are year-scoped and identical for every weekend in the year — that's most of why an empty weekend costs ~3s (see `LodgingRosterService.build_summary`'s own docstring, `api/services/lodging_roster_service.py:487-498`).

This adds a module-level, TTL-based cache (`api/services/lodging_cache.py`, `LodgingYearCache`) in front of **four** of those six reads:

| Read | Cached? | Why |
|---|---|---|
| `fetch_households` | yes | sync-written only |
| `fetch_prior_household_cm_ids` | yes | sync-written only — also the expensive one, ~20,256 rows on 2026 prod for a single boolean (#1966/#1976 already minimized the round-trip count; caching is what's left) |
| `fetch_family_camp_adults` | yes | sync-written only |
| `fetch_family_camp_registrations` | yes | sync-written only |
| `fetch_units` | **no** | admin panel writes `lodging_units` straight from the browser (`createLodgingUnit`/`updateLodgingUnit`/`confirmLodgingUnits`/`deactivateLodgingUnit` in `frontend/src/services/lodgingCrud.ts`) — caching would hide an admin's own edit for the TTL to buy ~16ms |
| `count_open_unresolved_aliases` | **no** | same reason — `lodging_ingest_issues.is_resolved` is flipped straight from the browser (`mapUnresolvedAlias`/`ignoreIngestIssue`) |

Cache is a module-level singleton in `api/dependencies.py` (`lodging_cache`), not instance state — `api/routers/lodging.py` builds a fresh `LodgingRepository` per request, so per-instance caching would never be reused. TTL 15 min, matching `geo_service`'s `_PERSON_ID_CACHE`. No active invalidation wired yet (TTL-only); `invalidate_all()` is exposed so wiring it to sync completion is a one-line follow-up, same pattern as `metrics.py`'s `/cache/invalidate`.

## Issue reconciliation (#1963)

The issue title said "eleven ... six of them year-scoped." Verified against `api/services/lodging_roster_service.py:425-457` on current `main`: it's actually **ten fetches, six year-scoped** — two reads (`fetch_family_camp_medical`, `count_unconfirmed_units`) were deleted by #1994/#1995 since the issue was filed, which the issue body's own top note already flagged. Retitled the issue to say "ten" so the title matches the body and the code.

Of those six year-scoped reads, this PR caches four and deliberately leaves two uncached (table above). 4 + 2 = 6 — reconciled.

## Test plan

- [x] New tests in `tests/unit/api/services/test_lodging_repository.py` (`TestYearScopedCaching`, `TestLodgingYearCache`): second call for the same year is a cache hit, different years are separate entries, two repository instances share one cache (proves the singleton claim), `fetch_units`/`count_open_unresolved_aliases` are asserted to **never** cache, TTL expiry, LRU eviction, `invalidate_all`.
- [x] `uv run pytest tests/` — 6057 passed, 23 skipped (server-dependent, expected), exit 0
- [x] `uv run ruff check .` — exit 0
- [x] `uv run mypy . --explicit-package-bases` — exit 0
- No live before/after timing was captured (would need the worktree's own PocketBase stack seeded at prod scale); the measurable claim here is the request-count reduction the tests pin directly: the four cached reads collapse from N PocketBase round-trips per N weekend-loads to 1 per year per 15-minute window.

Closes #1963.

## Folded-in review findings (#2142, #2143)

Both were filed against this PR's own new code by its review, and both are fixed here in `d3a56a5b` rather than left in the backlog.

**#2142 — cache had no invalidation hook.** `invalidate_all()` existed and nothing called it, leaving the cache TTL-only. That is exactly what CLAUDE.md §4 forbids ("long staleTime plus explicit invalidation on mutation — never short staleTime plus hope"). It now piggybacks the existing `POST /api/metrics/cache/invalidate` beside `metrics_cache.invalidate_all()` / `clear_person_id_cache()` — no second mechanism invented, and that endpoint is already what the frontend's `invalidateSyncData` hits on sync completion. Residual stated rather than hidden: a sync run with nobody watching (cron, direct curl) still falls back to the TTL, same architecture as `metrics_cache` and the geo cache.

**#2143 — cached and fresh year-scoped reads could mix.** `build_roster` joined an always-fresh attendee against a cached household dict, so a household created mid-TTL rendered as the literal string `Household 0` with a spurious `is_returning=False`. Fixed with a new uncached `fetch_households_by_ids` in `lodging_repository.py` and a `_resolve_households` step wired into both `build_roster` (:459) and `build_summary` (:564) — one small live fetch for the missing id(s), never a second cache. Correctness rests on `persons.go`'s `Sync()` ordering (person rows, then household rows, then the `person.household` patch), which is why a same-request fresh fetch cannot miss.

This one is honestly M-sized, not S — the issue body offered three materially different remedies and picking among them was a design call. It is folded anyway because it is a correctness regression *this PR introduced*: merging with a known `Household 0` on the weekend roster would put a broken surface in front of staff during go-live, which is worse than the extra review scope.

`46bd71dc` additionally sweeps a residual `invalidate_all` docstring that still read "Not wired to anything yet" while the module docstring above it said the opposite.

Closes #2142.
Closes #2143.
