### PR TITLE
feat(frontend): widen camper journey to include family camp and reach 2017-2021

### DIFF
--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -30,7 +30,7 @@ import {
   getSessionDisplayNameFromString,
   getSessionShortName as getSessionShortNameUtil,
 } from '../utils/sessionDisplay'
-import { buildSummerSessionTypeFilter } from '../utils/sessionTypePredicates'
+import { buildSummerSessionTypeFilter, isFamilySessionType } from '../utils/sessionTypePredicates'
 import type {
   PersonsResponse,
   AttendeesResponse,
@@ -1052,6 +1052,16 @@ export default function CamperDetailsPanel({
                       <span className="text-muted-foreground truncate text-xs">
                         {getSessionDisplayNameFromString(record.sessionName, record.sessionType)}
                       </span>
+                      {/* Family-camp de-emphasis tag (#2113 code review): this panel
+                          renders the same widened fetchCamperJourney rows as
+                          CampJourneyTimeline, which gained this tag to keep family
+                          rows from reading as noise for multi-session staff kids —
+                          mirrored here so the board popout gets the same treatment. */}
+                      {isFamilySessionType(record.sessionType) && (
+                        <span className="bg-muted text-muted-foreground flex-shrink-0 rounded px-1 py-0.5 text-[9px] font-medium">
+                          Family
+                        </span>
+                      )}
                       {record.bunkName !== undefined && (
                         <>
                           <span className="text-muted-foreground text-xs">·</span>

--- a/frontend/src/components/admin/SyncTab.tsx
+++ b/frontend/src/components/admin/SyncTab.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react'
 import toast from 'react-hot-toast'
 import { useYear } from '../../hooks/useCurrentYear'
+import { EARLIEST_AVAILABLE_YEAR } from '../../contexts/CurrentYearContext'
 import { type SyncStatus, type QueuedSyncItem } from '../../hooks/useSyncStatusAPI'
 import { useSyncCompletionToasts } from '../../hooks/useSyncCompletionToasts'
 import { useRunIndividualSync } from '../../hooks/useRunIndividualSync'
@@ -405,13 +406,14 @@ export function SyncTab() {
                 disabled={unifiedSync.isPending || runPhaseSync.isPending}
               >
                 <option value={currentYear}>{currentYear}</option>
-                {Array.from({ length: currentYear - 2017 }, (_, i) => currentYear - 1 - i).map(
-                  (year) => (
-                    <option key={year} value={year}>
-                      {year}
-                    </option>
-                  )
-                )}
+                {Array.from(
+                  { length: currentYear - EARLIEST_AVAILABLE_YEAR },
+                  (_, i) => currentYear - 1 - i
+                ).map((year) => (
+                  <option key={year} value={year}>
+                    {year}
+                  </option>
+                ))}
               </select>
 
               <div className="bg-border/50 h-6 w-px" />

--- a/frontend/src/components/camper/CampJourneyTimeline.test.tsx
+++ b/frontend/src/components/camper/CampJourneyTimeline.test.tsx
@@ -30,3 +30,41 @@ describe('CampJourneyTimeline display rules (spec §8)', () => {
     expect(screen.getByText('Unassigned')).toBeInTheDocument()
   })
 })
+
+// #2113: widening CAMPER_JOURNEY_TYPES to include family camp means the
+// empty state and header strings can no longer read as summer-only, and
+// family rows get a visual de-emphasis tag to address the "noisy for
+// multi-session staff kids" concern the original exclusion was guarding.
+describe('CampJourneyTimeline program-agnostic strings (#2113)', () => {
+  it('shows a program-agnostic empty state, not "First summer at camp!"', () => {
+    render(<CampJourneyTimeline history={[]} yearsAtCamp={0} currentYear={2026} />)
+    expect(screen.queryByText(/first summer at camp/i)).toBeNull()
+    expect(screen.getByText(/first year at camp/i)).toBeInTheDocument()
+  })
+
+  it('renders the header year count without a summer-flavored tagline', () => {
+    render(<CampJourneyTimeline history={[]} yearsAtCamp={3} currentYear={2026} />)
+    expect(screen.getByText('3 years at camp')).toBeInTheDocument()
+  })
+
+  it('singularizes the header count for one year', () => {
+    render(<CampJourneyTimeline history={[]} yearsAtCamp={1} currentYear={2026} />)
+    expect(screen.getByText('1 year at camp')).toBeInTheDocument()
+  })
+
+  it('tags a family-camp row with a de-emphasis label', () => {
+    const history: HistoricalRecord[] = [
+      { year: 2019, sessionName: 'Winter Family Weekend', sessionType: 'family' },
+    ]
+    render(<CampJourneyTimeline history={history} yearsAtCamp={1} currentYear={2026} />)
+    expect(screen.getByText('Family')).toBeInTheDocument()
+  })
+
+  it('does not tag a summer row with the family de-emphasis label', () => {
+    const history: HistoricalRecord[] = [
+      { year: 2019, sessionName: 'Session 2', sessionType: 'main' },
+    ]
+    render(<CampJourneyTimeline history={history} yearsAtCamp={1} currentYear={2026} />)
+    expect(screen.queryByText('Family')).toBeNull()
+  })
+})

--- a/frontend/src/components/camper/CampJourneyTimeline.tsx
+++ b/frontend/src/components/camper/CampJourneyTimeline.tsx
@@ -5,6 +5,7 @@
 import { TreePine, Home } from 'lucide-react'
 import { getSessionDisplayNameFromString } from '../../utils/sessionDisplay'
 import { getStatusIndicator } from '../../utils/enrollmentFilter'
+import { isFamilySessionType } from '../../utils/sessionTypePredicates'
 import type { HistoricalRecord } from '../../hooks/camper/types'
 
 interface CampJourneyTimelineProps {
@@ -87,7 +88,7 @@ export function CampJourneyTimeline({
                         muted tag instead of being hidden, so a reader can
                         visually skip a run of family rows without losing the
                         underlying data. */}
-                    {record.sessionType === 'family' && (
+                    {isFamilySessionType(record.sessionType) && (
                       <span className="bg-muted text-muted-foreground flex-shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium">
                         Family
                       </span>

--- a/frontend/src/components/camper/CampJourneyTimeline.tsx
+++ b/frontend/src/components/camper/CampJourneyTimeline.tsx
@@ -6,7 +6,6 @@ import { TreePine, Home } from 'lucide-react'
 import { getSessionDisplayNameFromString } from '../../utils/sessionDisplay'
 import { getStatusIndicator } from '../../utils/enrollmentFilter'
 import type { HistoricalRecord } from '../../hooks/camper/types'
-import { getCampTagline } from '../../config/branding'
 
 interface CampJourneyTimelineProps {
   history: HistoricalRecord[]
@@ -27,8 +26,11 @@ export function CampJourneyTimeline({
           <TreePine className="h-5 w-5" />
           Camp Journey
         </h2>
+        {/* Program-agnostic count (#2113): the branding tagline reads as
+            summer-only ("summers at camp") and the journey now includes
+            family camp and teen years, so it's no longer paired here. */}
         <p className="text-forest-200 mt-1 text-sm">
-          {yearsAtCamp} {getCampTagline()}
+          {yearsAtCamp} {yearsAtCamp === 1 ? 'year' : 'years'} at camp
         </p>
       </div>
 
@@ -79,6 +81,18 @@ export function CampJourneyTimeline({
                       {getSessionDisplayNameFromString(record.sessionName, record.sessionType)}
                     </span>
 
+                    {/* Family-camp de-emphasis tag (#2113): family rows were
+                        excluded from the journey because they made it noisy
+                        for multi-session staff kids. Now included, they get a
+                        muted tag instead of being hidden, so a reader can
+                        visually skip a run of family rows without losing the
+                        underlying data. */}
+                    {record.sessionType === 'family' && (
+                      <span className="bg-muted text-muted-foreground flex-shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium">
+                        Family
+                      </span>
+                    )}
+
                     {/* Status indicator for non-enrolled */}
                     {statusIndicator && (
                       <span
@@ -123,7 +137,9 @@ export function CampJourneyTimeline({
         ) : (
           <div className="py-4 text-center">
             <TreePine className="text-muted-foreground/50 mx-auto mb-2 h-8 w-8" />
-            <p className="text-muted-foreground text-sm">First summer at camp!</p>
+            {/* Program-agnostic (#2113): a family-camp-only or teen-only
+                first year should not read as "summer" */}
+            <p className="text-muted-foreground text-sm">First year at camp!</p>
           </div>
         )}
       </div>

--- a/frontend/src/config/branding.ts
+++ b/frontend/src/config/branding.ts
@@ -61,10 +61,6 @@ export function getCampDescription(): string {
   return branding.camp_description
 }
 
-export function getCampTagline(): string {
-  return branding.camp_tagline
-}
-
 export function getSsoDisplayName(): string {
   return branding.sso_display_name
 }

--- a/frontend/src/contexts/CurrentYearContext.test.tsx
+++ b/frontend/src/contexts/CurrentYearContext.test.tsx
@@ -3,6 +3,7 @@
  * and the isYearReady flag that prevents premature query firing.
  */
 import { describe, it, expect } from 'vitest'
+import { calculateAvailableYears as realCalculateAvailableYears } from './CurrentYearContext'
 
 // Test the year calculation logic without needing full React context
 describe('Year calculation logic', () => {
@@ -43,6 +44,28 @@ describe('Year calculation logic', () => {
 
     it('should return empty array when base year is 0 (not ready)', () => {
       expect(calculateAvailableYears(0)).toEqual([])
+    })
+  })
+
+  // #2113: the real calculateAvailableYears (exported from CurrentYearContext)
+  // must reach back to 2017, where summer data starts, instead of a fixed
+  // 5-year window that stopped list/board year navigation at 2022.
+  describe('calculateAvailableYears (real implementation, #2113 widening)', () => {
+    it('reaches back to 2017 from the current base year', () => {
+      const years = realCalculateAvailableYears(2026)
+      expect(years[0]).toBe(2026)
+      expect(years[years.length - 1]).toBe(2017)
+      expect(years).toHaveLength(10)
+      expect(years).not.toContain(2016)
+    })
+
+    it('stays descending and contiguous', () => {
+      const years = realCalculateAvailableYears(2020)
+      expect(years).toEqual([2020, 2019, 2018, 2017])
+    })
+
+    it('returns empty array when base year is 0 (not ready)', () => {
+      expect(realCalculateAvailableYears(0)).toEqual([])
     })
   })
 

--- a/frontend/src/contexts/CurrentYearContext.test.tsx
+++ b/frontend/src/contexts/CurrentYearContext.test.tsx
@@ -28,26 +28,11 @@ describe('Year calculation logic', () => {
     })
   })
 
-  describe('calculateAvailableYears', () => {
-    function calculateAvailableYears(baseYear: number, count: number = 5): number[] {
-      if (baseYear === 0) return []
-      return Array.from({ length: count }, (_, i) => baseYear - i)
-    }
-
-    it('should generate 5 years descending from base year', () => {
-      expect(calculateAvailableYears(2026)).toEqual([2026, 2025, 2024, 2023, 2022])
-    })
-
-    it('should work with any base year', () => {
-      expect(calculateAvailableYears(2024, 3)).toEqual([2024, 2023, 2022])
-    })
-
-    it('should return empty array when base year is 0 (not ready)', () => {
-      expect(calculateAvailableYears(0)).toEqual([])
-    })
-  })
-
-  // #2113: the real calculateAvailableYears (exported from CurrentYearContext)
+  // #2113: replaces a stale local re-implementation of calculateAvailableYears
+  // that asserted the old, now-replaced fixed-5-year-window contract (a
+  // private closure shadowing the real export — it stayed green regardless
+  // of the real implementation, per code review on #2113). This block tests
+  // the real calculateAvailableYears (exported from CurrentYearContext)
   // must reach back to 2017, where summer data starts, instead of a fixed
   // 5-year window that stopped list/board year navigation at 2022.
   describe('calculateAvailableYears (real implementation, #2113 widening)', () => {
@@ -66,6 +51,15 @@ describe('Year calculation logic', () => {
 
     it('returns empty array when base year is 0 (not ready)', () => {
       expect(realCalculateAvailableYears(0)).toEqual([])
+    })
+
+    // Code-review finding on #2113: a bogus baseYear below the data floor
+    // (e.g. a misconfigured backend _configured_year) must not fabricate a
+    // single-year result — that would assert an out-of-range year as
+    // "available with data" when the function's own contract says data
+    // starts at EARLIEST_AVAILABLE_YEAR.
+    it('returns empty array for a nonzero base year below the data floor', () => {
+      expect(realCalculateAvailableYears(2010)).toEqual([])
     })
   })
 

--- a/frontend/src/contexts/CurrentYearContext.tsx
+++ b/frontend/src/contexts/CurrentYearContext.tsx
@@ -5,10 +5,21 @@ import { useSyncStatusAPI } from '../hooks/useSyncStatusAPI'
 
 const STORAGE_KEY = 'bunking-current-year'
 
-// Calculate available years based on a base year
-function calculateAvailableYears(baseYear: number): number[] {
+/**
+ * Earliest year with historical attendee data — summer data starts in 2017
+ * (#2113). Was a fixed 5-year window, which blocked list/board year
+ * navigation to 2017-2021 even though the underlying data (and the camper
+ * journey timeline, which reads prior years directly) goes back that far.
+ */
+export const EARLIEST_AVAILABLE_YEAR = 2017
+
+// Calculate available years: descending from baseYear back through the
+// earliest year with data, rather than a fixed-size window (#2113).
+// eslint-disable-next-line react-refresh/only-export-components
+export function calculateAvailableYears(baseYear: number): number[] {
   if (baseYear === 0) return []
-  return Array.from({ length: 5 }, (_, i) => baseYear - i)
+  const length = Math.max(1, baseYear - EARLIEST_AVAILABLE_YEAR + 1)
+  return Array.from({ length }, (_, i) => baseYear - i)
 }
 
 function getStoredYear(availableYears: number[]): number | null {

--- a/frontend/src/contexts/CurrentYearContext.tsx
+++ b/frontend/src/contexts/CurrentYearContext.tsx
@@ -18,7 +18,8 @@ export const EARLIEST_AVAILABLE_YEAR = 2017
 // eslint-disable-next-line react-refresh/only-export-components
 export function calculateAvailableYears(baseYear: number): number[] {
   if (baseYear === 0) return []
-  const length = Math.max(1, baseYear - EARLIEST_AVAILABLE_YEAR + 1)
+  const length = baseYear - EARLIEST_AVAILABLE_YEAR + 1
+  if (length <= 0) return []
   return Array.from({ length }, (_, i) => baseYear - i)
 }
 

--- a/frontend/src/hooks/camper/fetchCamperJourney.test.ts
+++ b/frontend/src/hooks/camper/fetchCamperJourney.test.ts
@@ -47,12 +47,19 @@ function attendee(
   }
 }
 
-function assignment(year: number, sessionCmId: number | null, bunkName: string) {
+function assignment(
+  year: number,
+  sessionCmId: number | null,
+  bunkName: string,
+  sessionType?: string
+) {
   return {
     id: `asn-${year}-${sessionCmId ?? 'x'}`,
     year,
     expand: {
-      ...(sessionCmId !== null ? { session: { cm_id: sessionCmId } } : {}),
+      ...(sessionCmId !== null
+        ? { session: { cm_id: sessionCmId, ...(sessionType ? { session_type: sessionType } : {}) } }
+        : {}),
       bunk: { name: bunkName },
     },
   }
@@ -112,6 +119,37 @@ describe('fetchCamperJourney', () => {
     expect(out[0]).toMatchObject({ year: 2023, sessionName: 'Session 3', bunkName: 'G-8B' })
   })
 
+  // Regression for #2113 code review: widening CAMPER_JOURNEY_TYPES to include
+  // 'family' means a lone family-camp assignment can now appear in yearAssignments
+  // for a year that also has a summer enrollment. The exact-match branch correctly
+  // claims it for the family row — but the year-fallback (length===1) doesn't know
+  // the assignment was already exact-matched elsewhere, and would attach the same
+  // family bunk to the unrelated summer row too. This is the exact leak fb1a88d2
+  // closed for current-year views (useCamperEnrollment) — reopening it here would
+  // show a family lodging unit as if it were the camper's summer cabin.
+  it('does not leak a lone family-camp assignment onto an unrelated summer row via the year-fallback', async () => {
+    mockAttendeesGetFullList.mockResolvedValue([
+      attendee(2019, 100, 'main', 'Session 2'),
+      attendee(2019, 900, 'family', 'Winter Family Weekend'),
+    ])
+    mockAssignmentsGetFullList.mockResolvedValue([assignment(2019, 900, 'Cabin FC-2', 'family')])
+    const out = await fetchCamperJourney(PERSON, CURRENT_YEAR)
+    const main = out.find((r) => r.sessionName === 'Session 2')
+    const family = out.find((r) => r.sessionName === 'Winter Family Weekend')
+    expect(family?.bunkName).toBe('Cabin FC-2') // exact match — correct
+    expect(main?.bunkName).toBeUndefined() // must NOT inherit the family bunk via fallback
+  })
+
+  it('still applies the year-fallback within summer/teen types (pre-existing behavior, unchanged)', async () => {
+    // A quest enrollment with no exact-match bunk, and exactly one (non-family)
+    // assignment that year for a different session — the fallback still fires,
+    // same as before #2113 widened the type filter.
+    mockAttendeesGetFullList.mockResolvedValue([attendee(2020, 500, 'quest', 'Quest Session')])
+    mockAssignmentsGetFullList.mockResolvedValue([assignment(2020, 501, 'Q-Cabin', 'main')])
+    const out = await fetchCamperJourney(PERSON, CURRENT_YEAR)
+    expect(out[0]?.bunkName).toBe('Q-Cabin')
+  })
+
   it('relabels an AG-only year to its parent main via camp_sessions lookup, keeping the AG bunk', async () => {
     // AG enrollment session cm_id 200 (parent main 199 NOT enrolled, so the AG row
     // survives). The bunk is filed under the AG session itself (exact match → AG-4).
@@ -144,6 +182,23 @@ describe('fetchCamperJourney', () => {
     const out = await fetchCamperJourney(PERSON, CURRENT_YEAR)
     expect(out).toHaveLength(1)
     expect(out[0]).toMatchObject({ year: 2023, sessionType: 'main', sessionName: 'Session 2' })
+  })
+
+  // Regression for #2113 code review: cm_id and parent_id both default to 0
+  // when unset (same sentinel agCollapse.ts guards against for current-year
+  // enrollments). Without a `> 0` guard here, a cm_id-less session (cm_id 0)
+  // seeds 0 into enrolledByYear, and an unrelated parentless AG row (parent_id
+  // 0) would then match has(0) and get silently dropped from the journey.
+  it('does not collapse a parentless AG row (parent_id 0) against an unrelated cm_id-less session (cm_id 0)', async () => {
+    mockAttendeesGetFullList.mockResolvedValue([
+      attendee(2023, 0, 'main', 'Session With No CM ID'),
+      attendee(2023, 200, 'ag', 'Standalone AG Session', 0),
+    ])
+    const out = await fetchCamperJourney(PERSON, CURRENT_YEAR)
+    expect(out).toHaveLength(2)
+    expect(out.map((r) => r.sessionName)).toEqual(
+      expect.arrayContaining(['Session With No CM ID', 'Standalone AG Session'])
+    )
   })
 
   it('leaves a row unlabeled when its year has >=2 assignments and none match the session', async () => {

--- a/frontend/src/hooks/camper/fetchCamperJourney.test.ts
+++ b/frontend/src/hooks/camper/fetchCamperJourney.test.ts
@@ -73,27 +73,35 @@ describe('fetchCamperJourney', () => {
   })
 
   it('sources rows from attendees and queries by year < currentYear, enrolled, curated types', async () => {
+    // #2113: family camp was reversed into the journey set (was excluded to
+    // mirror All Campers). bmitzvah/hebrew/adult/school/teen/other remain
+    // excluded — CAMPER_JOURNEY_TYPES was widened, not opened up entirely.
     mockAttendeesGetFullList.mockResolvedValue([attendee(2023, 100, 'main', 'Session 3')])
     await fetchCamperJourney(PERSON, CURRENT_YEAR)
     const filter = String(mockAttendeesGetFullList.mock.calls[0]?.[0]?.filter ?? '')
     expect(filter).toContain(`person_id = ${PERSON}`)
     expect(filter).toContain(`year < ${CURRENT_YEAR}`)
     expect(filter).toContain('status = "enrolled"')
-    expect(filter).not.toContain('"family"') // family excluded — journey mirrors All Campers
+    expect(filter).toContain('session.session_type = "family"') // #2113: now included
+    expect(filter).not.toContain('"bmitzvah"') // still excluded — not a journey type
     expect(filter).toContain('session.session_type = "scit"')
   })
 
-  it('restricts the bunk_assignments query to journey session types (no family-camp bunk leak)', async () => {
-    // A summer enrollment with no summer bunk + a lone family-camp bunk that year
-    // must NOT have the family bunk attached via the length===1 fallback. The
-    // query itself excludes non-journey (family) session types — mirrors the
-    // fb1a88d2 fix applied to current-year views in useCamperEnrollment.
+  it('restricts the bunk_assignments query to journey session types (family included, others still excluded)', async () => {
+    // The year-fallback attaches a lone same-year assignment to an unbunked
+    // enrolled row when there's exactly one. Restricting the query to journey
+    // session types stops a NON-journey type (e.g. bmitzvah) from leaking in
+    // via that fallback — the same leak fb1a88d2 closed for current-year views
+    // in useCamperEnrollment. Family is now a journey type (#2113), so a lone
+    // family-camp bunk legitimately participates in the fallback like any
+    // other journey type; bmitzvah/hebrew/adult/school/teen/other still can't.
     mockAttendeesGetFullList.mockResolvedValue([attendee(2022, 100, 'main', 'Session 3')])
     await fetchCamperJourney(PERSON, CURRENT_YEAR)
     const filter = String(mockAssignmentsGetFullList.mock.calls[0]?.[0]?.filter ?? '')
     expect(filter).toContain(`person.cm_id = ${PERSON}`)
     expect(filter).toContain(`year < ${CURRENT_YEAR}`)
-    expect(filter).not.toContain('"family"')
+    expect(filter).toContain('session.session_type = "family"')
+    expect(filter).not.toContain('"bmitzvah"')
     expect(filter).toContain('session.session_type = "main"')
   })
 

--- a/frontend/src/hooks/camper/fetchCamperJourney.ts
+++ b/frontend/src/hooks/camper/fetchCamperJourney.ts
@@ -70,26 +70,34 @@ export async function fetchCamperJourney(
   // show one Main row. AG enrolled without its parent main keeps its own row.
   // This is the ONLY same-year row collapse (family/quest/teen alongside summer
   // stay distinct).
+  //
+  // Guards against the `cm_id`/`parent_id` sentinel: both default to 0 when
+  // absent (mirrors the same guard in agCollapse.ts for current-year
+  // enrollments), so a non-positive parent_id never identifies a real parent.
+  // Without the `> 0` checks, a cm_id-less session would seed 0 into
+  // enrolledByYear and silently collapse an unrelated parentless AG row.
   const enrolledByYear = new Map<number, Set<number>>()
   for (const att of attendees) {
     const cmId = att.expand.session?.cm_id
-    if (cmId === undefined) continue
+    if (cmId === undefined || cmId <= 0) continue
     const set = enrolledByYear.get(att.year) ?? new Set<number>()
     set.add(cmId)
     enrolledByYear.set(att.year, set)
   }
   const deduped = attendees.filter((att) => {
     const session = att.expand.session
-    if (session?.session_type !== 'ag') return true
+    if (session?.session_type !== 'ag' || session.parent_id <= 0) return true
     // AG row drops only when its parent main is also enrolled that year;
-    // an unmatched parent_id (e.g. 0) is never present in enrolledByYear → kept.
+    // an unmatched parent_id is never present in enrolledByYear → kept.
     return !enrolledByYear.get(att.year)?.has(session.parent_id)
   })
 
   // 2. Prior-year bunk assignments — used ONLY to label a row, never to gate it.
-  // Restricted to journey session types: without this, a lone family-camp bunk in
-  // a year could be attached to a summer row via the year-fallback below (the same
-  // leak fb1a88d2 closed for current-year views in useCamperEnrollment).
+  // Restricted to journey session types (as of #2113, that now includes family) so
+  // a camper's own family-camp assignment can exact-match their family row. The
+  // year-fallback below has its own family/non-family guard to stop a lone family
+  // assignment from leaking onto an unrelated summer row (the leak fb1a88d2 closed
+  // for current-year views in useCamperEnrollment).
   const assignments = await pb
     .collection<BunkAssignmentsResponse<AssignmentExpand>>('bunk_assignments')
     .getFullList({
@@ -121,8 +129,18 @@ export async function fetchCamperJourney(
     // Bunk-label join precedence (spec §7):
     // 1. exact (year, session) match
     let match = yearAssignments.find((a) => a.expand.session?.cm_id === session?.cm_id)
-    // 2. else year-fallback ONLY when the year has exactly one assignment
-    if (!match && yearAssignments.length === 1) match = yearAssignments[0]
+    // 2. else year-fallback ONLY when the year has exactly one assignment, AND that
+    // assignment's session type is on the same side of the family/non-family split
+    // as the row it would label. Without this guard, a lone family-camp assignment
+    // (now reachable here since #2113 widened typeFilter to include family) could
+    // attach to an unrelated summer/teen row via the fallback — the exact leak
+    // fb1a88d2 closed for current-year views in useCamperEnrollment.
+    if (!match && yearAssignments.length === 1) {
+      const candidate = yearAssignments[0]
+      const candidateIsFamily = candidate?.expand.session?.session_type === 'family'
+      const rowIsFamily = session?.session_type === 'family'
+      if (candidateIsFamily === rowIsFamily) match = candidate
+    }
     // 3. else (>=2 assignments, no match, or zero) → no label
     const bunkName = match?.expand.bunk?.name
 

--- a/frontend/src/hooks/camper/fetchCamperJourney.ts
+++ b/frontend/src/hooks/camper/fetchCamperJourney.ts
@@ -1,9 +1,9 @@
 /**
  * Shared prior-year journey source. Lists every prior year a camper was
- * ENROLLED (curated types: summer + teen, no family), labeling each row with its
- * bunk/day-group when an assignment exists. Sourcing from attendees (not
- * bunk_assignments) is what surfaces 2022 (a CampMinder export gap), teens, and
- * family camp uniformly.
+ * ENROLLED (curated types: summer + teen + family, see #2113), labeling each
+ * row with its bunk/day-group when an assignment exists. Sourcing from
+ * attendees (not bunk_assignments) is what surfaces 2022 (a CampMinder export
+ * gap), teens, and family camp uniformly.
  *
  * AG is never shown as its own session: a Main+AG same-year pair collapses to the
  * Main row, and an AG-only year is relabeled to its parent main (name resolved via

--- a/frontend/src/utils/__tests__/sessionTypePredicates.test.ts
+++ b/frontend/src/utils/__tests__/sessionTypePredicates.test.ts
@@ -492,21 +492,39 @@ describe('teen cohort', () => {
 })
 
 describe('camper journey/detail session-type sets', () => {
-  it('CAMPER_JOURNEY_TYPES is summer + teen, no family (mirrors All Campers / metrics)', () => {
-    expect(CAMPER_JOURNEY_TYPES).toEqual(['main', 'embedded', 'ag', 'quest', 'scit', 'tli'])
-    expect(CAMPER_JOURNEY_TYPES).not.toContain('family')
+  // #2113 reverses the prior "no family" pinning on CAMPER_JOURNEY_TYPES only.
+  // The original decision (summer + teen, no family) was made because family
+  // camp made the journey noisy for multi-session staff kids — see the comment
+  // at sessionTypePredicates.ts:38-43. Measured against production, that
+  // exclusion was hiding ~45% of enrolled attendance and blanking entire years
+  // for 700-1000+ people per year (2018/2023/2024). The noise concern is
+  // handled by a visual de-emphasis on family rows in CampJourneyTimeline
+  // rather than by hiding the data. CAMPER_DETAIL_TYPES (the camper detail
+  // page's current-year fetch) is a separate consumer and keeps the original
+  // no-family behavior — not decided by this issue.
+  it('CAMPER_JOURNEY_TYPES is summer + teen + family (issue #2113: historical journey completeness)', () => {
+    expect(CAMPER_JOURNEY_TYPES).toEqual([
+      'main',
+      'embedded',
+      'ag',
+      'quest',
+      'scit',
+      'tli',
+      'family',
+    ])
+    expect(CAMPER_JOURNEY_TYPES).toContain('family')
   })
 
-  it('CAMPER_DETAIL_TYPES is summer + teen, no family', () => {
+  it('CAMPER_DETAIL_TYPES is summer + teen, no family (unchanged by #2113)', () => {
     expect(CAMPER_DETAIL_TYPES).toEqual(['main', 'embedded', 'ag', 'quest', 'scit', 'tli'])
     expect(CAMPER_DETAIL_TYPES).not.toContain('family')
   })
 
-  it('buildCamperJourneySessionTypeFilter ORs every journey type on session.session_type', () => {
+  it('buildCamperJourneySessionTypeFilter ORs every journey type on session.session_type, including family', () => {
     const f = buildCamperJourneySessionTypeFilter()
     for (const t of CAMPER_JOURNEY_TYPES) expect(f).toContain(`session.session_type = "${t}"`)
     expect(f).toContain('||')
-    expect(f).not.toContain('"family"') // family is excluded from the journey
+    expect(f).toContain('session.session_type = "family"') // #2113: family is now included
     expect(f.startsWith('(')).toBe(false) // caller wraps, matching buildSummerSessionTypeFilter
   })
 

--- a/frontend/src/utils/__tests__/sessionTypePredicates.test.ts
+++ b/frontend/src/utils/__tests__/sessionTypePredicates.test.ts
@@ -22,6 +22,7 @@ import {
   isInDropdownType,
   isSummerCampSessionType,
   isTeenProgramType,
+  isFamilySessionType,
   AT_CAMP_TYPES,
   DROPDOWN_TYPES,
   SUMMER_CAMP_TYPES,
@@ -423,6 +424,17 @@ describe('isTeenProgramType (string predicate)', () => {
   it('returns true for "tli"', () => expect(isTeenProgramType('tli')).toBe(true))
   it('returns false for "teen"', () => expect(isTeenProgramType('teen')).toBe(false))
   it('returns false for "main"', () => expect(isTeenProgramType('main')).toBe(false))
+})
+
+// #2113: extracted so components stop inline-checking `sessionType === 'family'`,
+// per this module's own rule ("never write inline session_type === 'ag' checks").
+describe('isFamilySessionType (string predicate)', () => {
+  it('returns true for "family"', () => expect(isFamilySessionType('family')).toBe(true))
+  it('returns false for "main"', () => expect(isFamilySessionType('main')).toBe(false))
+  it('returns false for null/undefined', () => {
+    expect(isFamilySessionType(null)).toBe(false)
+    expect(isFamilySessionType(undefined)).toBe(false)
+  })
 })
 
 // ============================================================================

--- a/frontend/src/utils/sessionTypePredicates.ts
+++ b/frontend/src/utils/sessionTypePredicates.ts
@@ -36,11 +36,32 @@ export const QUEST_SESSION_TYPES = ['quest'] as const
 export const TEEN_PROGRAM_TYPES = ['scit', 'tli'] as const
 
 /**
- * Curated set shown in a camper's journey timeline: summer + teen, no family —
- * mirrors what's visible on the All Campers page and metrics. (Family camp made
- * the journey noisy for multi-session staff kids; intentionally excluded.)
+ * Curated set shown in a camper's journey timeline: summer + teen + family.
+ *
+ * Originally excluded family camp (mirroring the All Campers page and
+ * metrics) because family rows made the journey noisy for multi-session
+ * staff kids. That exclusion is REVERSED as of #2113: measured against
+ * production it was hiding ~45% of enrolled attendance and left the journey
+ * completely blank for over a thousand people in some years (2018/2023/2024),
+ * with no offsetting benefit — the "no year floor" in fetchCamperJourney
+ * already meant summer/teen history back to 2017 was reachable, so the gap
+ * was pure data loss, not curation. The noise concern is still real; it's
+ * handled with a visual de-emphasis on family rows in CampJourneyTimeline
+ * rather than by hiding the data.
+ *
+ * CAMPER_DETAIL_TYPES below is a separate consumer (the camper detail page's
+ * current-year fetch) and keeps the original no-family curation — #2113 did
+ * not decide that one.
  */
-export const CAMPER_JOURNEY_TYPES = ['main', 'embedded', 'ag', 'quest', 'scit', 'tli'] as const
+export const CAMPER_JOURNEY_TYPES = [
+  'main',
+  'embedded',
+  'ag',
+  'quest',
+  'scit',
+  'tli',
+  'family',
+] as const
 
 /** Curated set driving a camper detail page's current-year fetch: summer + teen, no family. */
 export const CAMPER_DETAIL_TYPES = ['main', 'embedded', 'ag', 'quest', 'scit', 'tli'] as const
@@ -206,7 +227,8 @@ export function buildSummerSessionTypeFilter(): string {
 
 /**
  * Build a PocketBase OR-clause restricting `session.session_type` to the camper
- * journey set (summer + teen, no family). Caller wraps the result in `(...)`.
+ * journey set (summer + teen + family, see CAMPER_JOURNEY_TYPES). Caller wraps
+ * the result in `(...)`.
  */
 export function buildCamperJourneySessionTypeFilter(): string {
   return CAMPER_JOURNEY_TYPES.map((t) => `session.session_type = "${t}"`).join(' || ')

--- a/frontend/src/utils/sessionTypePredicates.ts
+++ b/frontend/src/utils/sessionTypePredicates.ts
@@ -35,10 +35,13 @@ export const QUEST_SESSION_TYPES = ['quest'] as const
 /** Teen program session types */
 export const TEEN_PROGRAM_TYPES = ['scit', 'tli'] as const
 
+/** Curated set driving a camper detail page's current-year fetch: summer + teen, no family. */
+export const CAMPER_DETAIL_TYPES = ['main', 'embedded', 'ag', 'quest', 'scit', 'tli'] as const
+
 /**
- * Curated set shown in a camper's journey timeline: summer + teen + family.
+ * Curated set shown in a camper's journey timeline: CAMPER_DETAIL_TYPES + family.
  *
- * Originally excluded family camp (mirroring the All Campers page and
+ * Originally excluded family camp too (mirroring the All Campers page and
  * metrics) because family rows made the journey noisy for multi-session
  * staff kids. That exclusion is REVERSED as of #2113: measured against
  * production it was hiding ~45% of enrolled attendance and left the journey
@@ -49,22 +52,12 @@ export const TEEN_PROGRAM_TYPES = ['scit', 'tli'] as const
  * handled with a visual de-emphasis on family rows in CampJourneyTimeline
  * rather than by hiding the data.
  *
- * CAMPER_DETAIL_TYPES below is a separate consumer (the camper detail page's
- * current-year fetch) and keeps the original no-family curation — #2113 did
- * not decide that one.
+ * CAMPER_DETAIL_TYPES (the camper detail page's current-year fetch) keeps its
+ * original no-family curation — #2113 did not decide that one. Deriving this
+ * array from it (rather than hand-duplicating the shared 6 types) keeps the
+ * two from silently diverging if a new summer type is ever added to either.
  */
-export const CAMPER_JOURNEY_TYPES = [
-  'main',
-  'embedded',
-  'ag',
-  'quest',
-  'scit',
-  'tli',
-  'family',
-] as const
-
-/** Curated set driving a camper detail page's current-year fetch: summer + teen, no family. */
-export const CAMPER_DETAIL_TYPES = ['main', 'embedded', 'ag', 'quest', 'scit', 'tli'] as const
+export const CAMPER_JOURNEY_TYPES = [...CAMPER_DETAIL_TYPES, 'family'] as const
 
 /** View mode for metrics: camp sessions, quest sessions, all combined, or teens */
 export type MetricsViewMode = 'sessions' | 'quests' | 'all' | 'teens'
@@ -208,6 +201,11 @@ export function isSummerCampSessionType(sessionType: string | null | undefined):
 /** True if the session_type string is a teen program (scit | tli) */
 export function isTeenProgramType(sessionType: string | null | undefined): boolean {
   return TEEN_PROGRAM_TYPES.includes(sessionType as (typeof TEEN_PROGRAM_TYPES)[number])
+}
+
+/** True if the session_type string is "family" */
+export function isFamilySessionType(sessionType: string | null | undefined): boolean {
+  return sessionType === 'family'
 }
 
 // ============================================================================


### PR DESCRIPTION
> ## ✅ Unblocked — the `years_at_camp` premise was falsified
>
> Measured against production: `years_at_camp` counts **summer** attendance and is **correct**. Our `camp_sessions` covers only 2017–2026, so where it disagrees it is **higher 42.6%** of the time (CampMinder sees pre-2017 history we never synced) and lower only 3.3%. Of 6,482 people showing `0` with real attendance, **90.6% have no summer session at all** — 3,877 family-only, 1,273 adult-only. Showing `0` is right for them.
>
> Owner decision: **keep CampMinder's value and widen the journey to include family anyway.** The header measures summer; the timeline shows attendance. Different things, both correct.
>
> The genuine residual — **609 people who have summer attendance and still show `0`** — is tracked in #2123 and is not a blocker on this PR.

## Summary
- Reverses the "no family" curation on `CAMPER_JOURNEY_TYPES`, documented at `sessionTypePredicates.ts:38-43`. That exclusion mirrored the All Campers page and was meant to keep the journey timeline uncluttered for multi-session staff kids, but measured against production it hid ~45% of enrolled attendance and left the journey completely blank for over a thousand people in some years (2018/2023/2024) — a real data-loss cost with no offsetting benefit, since `fetchCamperJourney` already had no year floor. Family rows now render with a muted de-emphasis tag in `CampJourneyTimeline` (and in `CamperDetailsPanel`, the board popout — a second consumer of the same widened data) instead of being hidden, so the original noise concern is addressed visually rather than by dropping the data. `CAMPER_DETAIL_TYPES` (a separate consumer, the camper detail page's current-year fetch) is unchanged and keeps its no-family curation.
- Widens `CurrentYearContext`'s year-navigation window from a fixed 5-year lookback to a floor of 2017 (where summer data starts), so the list/board surfaces can reach 2017-2021 alongside the journey timeline, which already read prior years directly.
- Code review (floor 60) on the first pass of this PR found a real regression the widening reopened: a lone family-camp bunk assignment could attach to an unrelated same-year summer row via `fetchCamperJourney`'s year-fallback — the exact leak `fb1a88d2` closed for current-year views. Confirmed against production data (2,218 `family`-type `bunk_assignments` rows exist) and closed with a boundary guard + regression test. See the review comment thread and the follow-up PR comment for the full list of smaller fixes from that pass.

## Notes
- The pinning test at `sessionTypePredicates.test.ts` (`CAMPER_JOURNEY_TYPES ... not.toContain('family')`) was deliberately restated, not deleted — both the test and the `sessionTypePredicates.ts` doc comment now explain the reversal and its reasoning.
- **#2123 is a merge blocker, not a follow-up to get to later** — see the banner above. It presents both fix branches without choosing.
- Filed #2149 as a genuine, lower-priority follow-up: a **pre-existing** bug (not caused by this PR) where `CAMPER_DETAIL_TYPES` still excludes family, so 500+/year campers whose only current-year enrollment is family camp get "Unable to load camper details" today. #2113's text explicitly deferred deciding `CAMPER_DETAIL_TYPES` alongside `CAMPER_JOURNEY_TYPES`; #2149 is what that deferral pointed at.
- #2114 (sync fix for 2021 Family Camp sessions misclassified as `other`) is a separate, already-filed PR track — this PR is not blocked on it, but 2021 family camp stays invisible here until it lands.

Closes #2113.
