### PR TITLE
fix(pb): fail the boot when a season-less lodging registry is present

### DIFF
--- a/docs/reference/lodging-registry.md
+++ b/docs/reference/lodging-registry.md
@@ -44,8 +44,22 @@ skipping instead.
 
 **Absent file is not an error.** A clone without `kindred-local` boots normally
 with an empty registry and a log line — the same graceful degradation
-`branding.local.json` has. An unreadable or malformed file logs a warning and
-leaves the registry alone rather than taking the service down.
+`branding.local.json` has.
+
+**A file that IS present but unloadable fails the boot.** Malformed JSON, a
+duplicate code, an unknown area/parent/alias-member reference — anything that
+makes `SeedRegistry` return an error stops the service from starting, rather
+than coming up with an empty registry behind a single warn-level log line
+nobody is watching (issues #2054, #2141). The bound is the same one the
+bootstrap gate already gives for free: once any season has rows the loader
+returns early without reading the file at all, so an already-seeded
+deployment cannot be taken down by a bad file on a later boot. Only a
+genuinely empty registry with a broken file present fails.
+
+The one exception is a failure to *check* for existing rows
+(`lodging.ErrRegistryRowCheck`): the loader then cannot tell whether anything
+is at risk, so it warns and boots rather than compounding one failure with a
+second, less legible one.
 
 ## Loader semantics: create-if-absent, never update
 
@@ -144,8 +158,9 @@ and `scripts/worktree/new.sh` does the same for a new worktree.
 
 The block below is annotated for documentation. **The loader uses Go's
 `encoding/json`, which rejects `//` comments** — strip them from the real file.
-A file that fails to parse is a logged warning, not a crash, so the symptom is
-an empty registry rather than an error anyone will see.
+On a fresh deployment a file that fails to parse **fails the boot** (#2141), so
+the symptom is a service that will not start with the parse error in the log —
+loud on purpose, rather than a silently empty registry.
 
 ```jsonc
 {

--- a/pocketbase/lodging/registry.go
+++ b/pocketbase/lodging/registry.go
@@ -173,7 +173,7 @@ type registryAlias struct {
 // season that already exists is apply_lodging_inventory.py --apply --year N,
 // run by hand.
 func SeedRegistry(app core.App, year int) error {
-	hasRows, err := registryHasAnyRows(app)
+	hasRows, err := RegistryHasRows(app)
 	if err != nil {
 		return err
 	}
@@ -263,7 +263,7 @@ func seedRegistryFromFile(app core.App, path string, year int) error {
 	// Create-if-absent used to make this self-healing: a seed that died halfway
 	// was finished by the next boot, which created whatever was still missing.
 	// SeedRegistry's any-season check ended that. The areas a failed run
-	// committed are enough to make registryHasAnyRows report true forever, so
+	// committed are enough to make RegistryHasRows report true forever, so
 	// every later boot logs "skipping" and the registry stays half-built with
 	// nothing anywhere reporting it.
 	//
@@ -632,12 +632,16 @@ func seedAliases(app core.App, aliases []registryAlias, year int) (added int, er
 	return added, nil
 }
 
-// registryHasAnyRows reports whether lodging_areas or lodging_units holds a
-// row for ANY season. SeedRegistry uses this to decide whether it is a
-// bootstrap or a no-op — a year-scoped check would miss the case this exists
-// to catch, which is a season flip landing on a registry another season
-// already populated.
-func registryHasAnyRows(app core.App) (bool, error) {
+// RegistryHasRows reports whether lodging_areas or lodging_units holds a row
+// for ANY season. SeedRegistry uses this to decide whether it is a bootstrap
+// or a no-op — a year-scoped check would miss the case this exists to catch,
+// which is a season flip landing on a registry another season already
+// populated.
+//
+// Exported so main.go's boot-decision gate (issue #2054, Half 2) can check
+// it too: a deployment whose database already has rows has nothing at risk
+// from an unresolvable season, since SeedRegistry would no-op regardless.
+func RegistryHasRows(app core.App) (bool, error) {
 	for _, collection := range []string{"lodging_areas", "lodging_units"} {
 		recs, err := app.FindRecordsByFilter(collection, "", "", 1, 0)
 		if err != nil {

--- a/pocketbase/lodging/registry.go
+++ b/pocketbase/lodging/registry.go
@@ -184,16 +184,7 @@ func SeedRegistry(app core.App, year int) error {
 		return nil
 	}
 
-	candidates := make([]string, 0, len(registryAbsoluteRoots)+2)
-	for _, root := range registryAbsoluteRoots {
-		candidates = append(candidates, filepath.Join(root, registryFileName)) // Docker
-	}
-	candidates = append(candidates,
-		filepath.Join(registryBasePath, "config", registryFileName),       // from the repo root
-		filepath.Join(registryBasePath, "..", "config", registryFileName), // from pocketbase/
-	)
-
-	for _, path := range candidates {
+	for _, path := range registryCandidatePaths() {
 		if _, err := os.Stat(path); err != nil {
 			continue
 		}
@@ -203,6 +194,38 @@ func SeedRegistry(app core.App, year int) error {
 	slog.Info("lodging registry file not found; registry left as-is",
 		"looked_for", registryFileName)
 	return nil
+}
+
+// registryCandidatePaths lists every path SeedRegistry searches, in order.
+// Shared with RegistryFilePresent so the two never drift: SeedRegistry decides
+// whether to load, RegistryFilePresent decides whether an unreadable season
+// is a misconfiguration worth failing boot over (main.go, issue #2054).
+func registryCandidatePaths() []string {
+	candidates := make([]string, 0, len(registryAbsoluteRoots)+2)
+	for _, root := range registryAbsoluteRoots {
+		candidates = append(candidates, filepath.Join(root, registryFileName)) // Docker
+	}
+	candidates = append(candidates,
+		filepath.Join(registryBasePath, "config", registryFileName),       // from the repo root
+		filepath.Join(registryBasePath, "..", "config", registryFileName), // from pocketbase/
+	)
+	return candidates
+}
+
+// RegistryFilePresent reports whether a private lodging registry file exists
+// on any of the candidate paths SeedRegistry searches. It is presence-only —
+// it does not read, parse, or validate the file — so main.go can tell "no
+// private config, nothing to load" (must still boot) apart from "config is
+// here and unreadable without a season" (a misconfigured deployment that
+// would otherwise silently come up with an empty registry behind a single
+// warn-level log line). See issue #2054.
+func RegistryFilePresent() bool {
+	for _, path := range registryCandidatePaths() {
+		if _, err := os.Stat(path); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // seedRegistryFromFile is CREATE-IF-ABSENT, not a full upsert.

--- a/pocketbase/lodging/registry.go
+++ b/pocketbase/lodging/registry.go
@@ -143,6 +143,22 @@ type registryAlias struct {
 	ValidToYear   *int `json:"valid_to_year"`
 }
 
+// ErrRegistryRowCheck tags the one SeedRegistry failure that means "the
+// loader could not tell whether there is anything at risk" rather than "the
+// registry is broken": RegistryHasRows itself erroring out.
+//
+// main.go's boot gate keys on this to split SeedRegistry's two error sources
+// into opposite boot treatments (issue #2141). A row-check failure fails OPEN
+// — warn and boot — because taking the app down over a failure to READ the
+// state compounds one problem with a second, less legible one, and it is the
+// same call the season branch already makes. Every other error means a
+// registry file that is present and genuinely unloadable, which fails the
+// boot rather than coming up with an empty registry behind a warn line.
+//
+// A sentinel rather than error-string matching so the split survives any
+// rewording of the messages below.
+var ErrRegistryRowCheck = errors.New("lodging registry row check failed")
+
 // SeedRegistry loads the private lodging registry into the database for one
 // season.
 //
@@ -175,7 +191,7 @@ type registryAlias struct {
 func SeedRegistry(app core.App, year int) error {
 	hasRows, err := RegistryHasRows(app)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: %w", ErrRegistryRowCheck, err)
 	}
 	if hasRows {
 		slog.Info("lodging registry already has rows for another season; "+

--- a/pocketbase/lodging/registry_test.go
+++ b/pocketbase/lodging/registry_test.go
@@ -872,6 +872,56 @@ func TestSeedRegistryResolvesAbsoluteConfigRoot(t *testing.T) {
 	}
 }
 
+// --- RegistryFilePresent -----------------------------------------------------
+//
+// main.go (issue #2054, Half 2) needs to tell "no private config, nothing to
+// load" apart from "config is here and unreadable without a season" so a
+// season-less boot can warn-and-continue in the first case but fail in the
+// second. RegistryFilePresent is presence-only — it must not read, parse, or
+// validate the file, so it shares the same candidate-path search SeedRegistry
+// uses without duplicating any of the loading behavior.
+func TestRegistryFilePresentTrueWhenFileExistsUnderWorkingDirectory(t *testing.T) {
+	base := t.TempDir()
+	if err := os.Mkdir(filepath.Join(base, "config"), 0o750); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(base, "config", registryFileName), []byte(fixtureRegistry), 0o600,
+	); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+	withRegistryBasePath(t, base)
+	withRegistryAbsoluteRoots(t, []string{filepath.Join(t.TempDir(), "unused")})
+
+	if !RegistryFilePresent() {
+		t.Error("expected RegistryFilePresent() true when config/lodging_registry.json exists under the working directory")
+	}
+}
+
+func TestRegistryFilePresentTrueViaAbsoluteRoot(t *testing.T) {
+	absRoot := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(absRoot, registryFileName), []byte(fixtureRegistry), 0o600,
+	); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+	withRegistryAbsoluteRoots(t, []string{absRoot})
+	withRegistryBasePath(t, t.TempDir())
+
+	if !RegistryFilePresent() {
+		t.Error("expected RegistryFilePresent() true when the file exists under an absolute root")
+	}
+}
+
+func TestRegistryFilePresentFalseWhenNoConfigAnywhere(t *testing.T) {
+	withRegistryBasePath(t, t.TempDir())
+	withRegistryAbsoluteRoots(t, []string{filepath.Join(t.TempDir(), "unused")})
+
+	if RegistryFilePresent() {
+		t.Error("expected RegistryFilePresent() false with no registry file on any candidate path")
+	}
+}
+
 // --- season-scoped seeding --------------------------------------------------
 //
 // yearFixtureRegistry is a container with one child, keyed off the codes

--- a/pocketbase/lodging/registry_test.go
+++ b/pocketbase/lodging/registry_test.go
@@ -1125,7 +1125,7 @@ func TestSeedRegistrySecondSeasonIsANoOpOnceOneSeasonHasRows(t *testing.T) {
 // consequence is that the create-if-absent behavior no longer finishes a job
 // a previous run started: before the gate, a seed that died halfway was
 // completed by the next boot; now the areas it committed make
-// registryHasAnyRows report true forever, so the loader logs "skipping" and
+// RegistryHasRows report true forever, so the loader logs "skipping" and
 // the registry stays permanently half-built, with no error anywhere to say so.
 //
 // The gate is not the bug and must not be loosened to fix this. The seed has
@@ -1145,7 +1145,7 @@ func TestSeedRegistryLeavesNothingBehindWhenAPassFails(t *testing.T) {
 	}
 	if n := countRecords(t, app, "lodging_areas"); n != 0 {
 		t.Errorf("%d areas survived a failed bootstrap; want 0 -- a committed area "+
-			"makes registryHasAnyRows true, so the bootstrap never runs again", n)
+			"makes RegistryHasRows true, so the bootstrap never runs again", n)
 	}
 
 	// The point of atomicity here: the next boot must still be able to seed.

--- a/pocketbase/lodging/registry_test.go
+++ b/pocketbase/lodging/registry_test.go
@@ -2,6 +2,7 @@ package lodging
 
 import (
 	"bytes"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -1156,5 +1157,64 @@ func TestSeedRegistryLeavesNothingBehindWhenAPassFails(t *testing.T) {
 	if n := countRecords(t, app, "lodging_units"); n != 2 {
 		t.Errorf("%d units after the retry; want 2 -- a transient failure must not "+
 			"permanently disable the bootstrap", n)
+	}
+}
+
+// TestSeedRegistryRowCheckFailureIsTaggedAsSuch pins the sentinel main.go's
+// boot gate keys on (issue #2141).
+//
+// SeedRegistry has exactly two error sources, and they warrant opposite boot
+// treatments: a RegistryHasRows failure means the loader could not even
+// determine whether there is anything at risk, so the boot must fail OPEN
+// (warn and continue) rather than compound one failure with a second, less
+// legible one -- the same call main.go already makes for the season branch.
+// Everything else is a genuinely bad registry file and must take the boot
+// down. Tagging only the row-check failure is what lets main.go tell them
+// apart without inspecting error strings.
+func TestSeedRegistryRowCheckFailureIsTaggedAsSuch(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+	// Deliberately NO setupRegistryCollections: with lodging_areas absent,
+	// RegistryHasRows cannot answer and SeedRegistry fails on its first step.
+
+	seedErr := SeedRegistry(app, testYear)
+	if seedErr == nil {
+		t.Fatal("SeedRegistry returned nil with no lodging collections, want a row-check error")
+	}
+	if !errors.Is(seedErr, ErrRegistryRowCheck) {
+		t.Errorf("row-check failure is not tagged ErrRegistryRowCheck, so main.go "+
+			"cannot fail open on it; got: %v", seedErr)
+	}
+}
+
+// The other half of the same contract: a bad registry FILE must not be
+// mistaken for a row-check failure, or #2141's whole point is lost and the
+// malformed-file case keeps the warn-and-boot treatment it has today.
+func TestSeedRegistryFileErrorIsNotTaggedAsARowCheckFailure(t *testing.T) {
+	app := newRegistryTestApp(t)
+
+	base := t.TempDir()
+	if err := os.Mkdir(filepath.Join(base, "config"), 0o750); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(base, "config", "lodging_registry.json"),
+		[]byte(`{"areas": [ NOT JSON`), 0o600,
+	); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+	withRegistryBasePath(t, base)
+	withRegistryAbsoluteRoots(t, nil)
+
+	seedErr := SeedRegistry(app, testYear)
+	if seedErr == nil {
+		t.Fatal("malformed registry file returned nil, want an error")
+	}
+	if errors.Is(seedErr, ErrRegistryRowCheck) {
+		t.Errorf("a malformed registry file was tagged as a row-check failure, so "+
+			"main.go would fail open on the very case #2141 exists to catch; got: %v", seedErr)
 	}
 }

--- a/pocketbase/main.go
+++ b/pocketbase/main.go
@@ -148,9 +148,15 @@ func main() {
 	// takes effect. Absent file is a logged no-op, the same graceful
 	// degradation branding has. See docs/reference/lodging-registry.md.
 	//
-	// Warn rather than fail: a clone without the private config must still
-	// boot, and an unreadable registry should not take the whole service down.
-	// The log line is the signal that the registry is empty on purpose.
+	// Warn-and-boot only for the clone-with-no-private-config case: no
+	// registry file means nothing to load, and refusing to boot over that
+	// would break every clone and CI run that lacks kindred-local. Once the
+	// registry file IS present, an unresolvable season stops being "nothing
+	// to load" and becomes "someone configured this deployment to have
+	// lodging and it silently has none" — that case fails the boot instead
+	// of leaving it behind a single warn-level log line nobody is watching.
+	// See issue #2054 (Half 2); lodgingRegistryBootDecision below carries the
+	// tests for this split.
 	//
 	// Skip rather than guess. Seeding ~118 units into a guessed season is
 	// strictly worse than seeding none: the first roll-forward would carry
@@ -158,7 +164,9 @@ func main() {
 	app.OnServe().BindFunc(func(e *core.ServeEvent) error {
 		year, err := sync.ParseSeasonYear()
 		if err != nil {
-			slog.Warn("lodging registry load skipped: season unavailable", "err", err)
+			if bootErr := lodgingRegistryBootDecision(err, lodging.RegistryFilePresent()); bootErr != nil {
+				return bootErr
+			}
 			return e.Next()
 		}
 		if err := lodging.SeedRegistry(e.App, year); err != nil {
@@ -275,6 +283,33 @@ func runHistorySync(app core.App) error {
 		return fmt.Errorf("history-sync WAL checkpoint failed: %w", err)
 	}
 	return nil
+}
+
+// lodgingRegistryBootDecision turns a sync.ParseSeasonYear failure into
+// either a warning (boot continues) or a boot error, depending on whether the
+// private lodging registry file exists on disk.
+//
+//   - registryPresent == false: a clone (or CI run) with no kindred-local
+//     config. Nothing to load — warn and let the boot continue, the same
+//     graceful degradation this loader has always given a fresh clone.
+//   - registryPresent == true: the registry file IS there, but the season it
+//     needs to seed against can't be resolved. That combination means an
+//     operator configured this deployment to have lodging data, and it would
+//     otherwise come up with an empty registry — every cabin string failing
+//     to resolve — signaled by nothing but a warn-level log line. Failing
+//     the boot makes that visible immediately instead of months later.
+//
+// Split out from the OnServe hook so the decision is unit-testable without
+// booting a PocketBase app or touching the filesystem. See issue #2054.
+func lodgingRegistryBootDecision(seasonErr error, registryPresent bool) error {
+	if !registryPresent {
+		slog.Warn("lodging registry load skipped: season unavailable", "err", seasonErr)
+		return nil
+	}
+	return fmt.Errorf(
+		"lodging registry file present but no season is resolvable "+
+			"(set CAMPMINDER_SEASON_ID): %w", seasonErr,
+	)
 }
 
 // the default pb_public dir location is relative to the executable

--- a/pocketbase/main.go
+++ b/pocketbase/main.go
@@ -151,10 +151,20 @@ func main() {
 	// Warn-and-boot only for the clone-with-no-private-config case: no
 	// registry file means nothing to load, and refusing to boot over that
 	// would break every clone and CI run that lacks kindred-local. Once the
-	// registry file IS present, an unresolvable season stops being "nothing
-	// to load" and becomes "someone configured this deployment to have
-	// lodging and it silently has none" — that case fails the boot instead
-	// of leaving it behind a single warn-level log line nobody is watching.
+	// registry file IS present AND the database has no lodging rows yet, an
+	// unresolvable season stops being "nothing to load" and becomes "someone
+	// configured this deployment to have lodging and it silently has none"
+	// — that case fails the boot instead of leaving it behind a single
+	// warn-level log line nobody is watching.
+	//
+	// The hasRows check matters on its own: SeedRegistry is a bootstrap that
+	// no-ops once any season already has rows (registry.go:175-185), so a
+	// production deployment with an already-seeded registry has nothing at
+	// risk when the season goes missing or malformed after the fact — the
+	// existing data is untouched either way. Failing the boot on
+	// file-presence alone, without checking hasRows, would turn a harmless
+	// env var hiccup on an already-seeded deployment into a full outage for
+	// a condition SeedRegistry itself would have silently ignored.
 	// See issue #2054 (Half 2); lodgingRegistryBootDecision below carries the
 	// tests for this split.
 	//
@@ -164,7 +174,16 @@ func main() {
 	app.OnServe().BindFunc(func(e *core.ServeEvent) error {
 		year, err := sync.ParseSeasonYear()
 		if err != nil {
-			if bootErr := lodgingRegistryBootDecision(err, lodging.RegistryFilePresent()); bootErr != nil {
+			hasRows, rowsErr := lodging.RegistryHasRows(e.App)
+			if rowsErr != nil {
+				// Can't determine whether the registry already has rows —
+				// fail open (warn, don't take the boot down) rather than
+				// compound one failure with a second, less legible one.
+				slog.Warn("lodging registry load skipped: season unavailable "+
+					"(row-presence check also failed)", "err", err, "rows_check_err", rowsErr)
+				return e.Next()
+			}
+			if bootErr := lodgingRegistryBootDecision(err, lodging.RegistryFilePresent(), hasRows); bootErr != nil {
 				return bootErr
 			}
 			return e.Next()
@@ -287,22 +306,32 @@ func runHistorySync(app core.App) error {
 
 // lodgingRegistryBootDecision turns a sync.ParseSeasonYear failure into
 // either a warning (boot continues) or a boot error, depending on whether the
-// private lodging registry file exists on disk.
+// private lodging registry file exists on disk AND whether the database
+// already has lodging rows from a prior successful seed.
 //
 //   - registryPresent == false: a clone (or CI run) with no kindred-local
 //     config. Nothing to load — warn and let the boot continue, the same
 //     graceful degradation this loader has always given a fresh clone.
-//   - registryPresent == true: the registry file IS there, but the season it
-//     needs to seed against can't be resolved. That combination means an
-//     operator configured this deployment to have lodging data, and it would
+//   - registryPresent == true, hasRows == true: the registry file is there,
+//     but the database was already seeded by an earlier boot.
+//     lodging.SeedRegistry is a bootstrap that no-ops once any season has
+//     rows (registry.go:175-185), so this deployment's existing lodging data
+//     is not at risk from an unresolvable season — warn and continue, the
+//     same as the no-file case. Gating on file-presence alone here would
+//     turn a harmless env var hiccup on an already-seeded production
+//     deployment into a full boot failure.
+//   - registryPresent == true, hasRows == false: the registry file IS there,
+//     the database is genuinely empty, and the season it needs to seed
+//     against can't be resolved. That combination means an operator
+//     configured this deployment to have lodging data, and it would
 //     otherwise come up with an empty registry — every cabin string failing
 //     to resolve — signaled by nothing but a warn-level log line. Failing
 //     the boot makes that visible immediately instead of months later.
 //
 // Split out from the OnServe hook so the decision is unit-testable without
 // booting a PocketBase app or touching the filesystem. See issue #2054.
-func lodgingRegistryBootDecision(seasonErr error, registryPresent bool) error {
-	if !registryPresent {
+func lodgingRegistryBootDecision(seasonErr error, registryPresent, hasRows bool) error {
+	if !registryPresent || hasRows {
 		slog.Warn("lodging registry load skipped: season unavailable", "err", seasonErr)
 		return nil
 	}

--- a/pocketbase/main.go
+++ b/pocketbase/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -168,6 +169,13 @@ func main() {
 	// See issue #2054 (Half 2); lodgingRegistryBootDecision below carries the
 	// tests for this split.
 	//
+	// The seed branch below applies the SAME rule to the same symptom from the
+	// other direction: a season that resolves fine but a registry file that is
+	// present and unloadable (malformed JSON, a duplicate code, an unknown
+	// reference) also fails the boot rather than warning, since it lands in an
+	// identically empty registry. lodgingRegistrySeedBootDecision carries that
+	// decision and its tests. See issue #2141.
+	//
 	// Skip rather than guess. Seeding ~118 units into a guessed season is
 	// strictly worse than seeding none: the first roll-forward would carry
 	// the phantom season forward as though it were real.
@@ -188,8 +196,8 @@ func main() {
 			}
 			return e.Next()
 		}
-		if err := lodging.SeedRegistry(e.App, year); err != nil {
-			slog.Warn("lodging registry load failed", "err", err)
+		if bootErr := lodgingRegistrySeedBootDecision(lodging.SeedRegistry(e.App, year)); bootErr != nil {
+			return bootErr
 		}
 		return e.Next()
 	})
@@ -339,6 +347,46 @@ func lodgingRegistryBootDecision(seasonErr error, registryPresent, hasRows bool)
 		"lodging registry file present but no season is resolvable "+
 			"(set CAMPMINDER_SEASON_ID): %w", seasonErr,
 	)
+}
+
+// lodgingRegistrySeedBootDecision turns a lodging.SeedRegistry failure into
+// either a warning (boot continues) or a boot error.
+//
+// This is the sibling of lodgingRegistryBootDecision above, and exists
+// because the two branches of the same OnServe hook were inconsistent: the
+// season-unresolvable case failed the boot while a registry file that is
+// present and unloadable — malformed JSON, a duplicate code, an unknown
+// area/parent/alias-member reference — only warned. Same hook, same symptom
+// (an empty registry, every cabin string failing to resolve), on a likelier
+// trigger, since a hand-edited registry file is more prone to a JSON typo
+// than an env var is to going missing. See issue #2141.
+//
+//   - nil: the seed succeeded, or had nothing to do. Both the absent-file
+//     cases already return nil (registry.go), so a clone or CI run without
+//     kindred-local keeps booting exactly as before.
+//   - lodging.ErrRegistryRowCheck: the loader could not determine whether the
+//     registry already has rows, so it does not know whether anything is at
+//     risk. Fail open — warn and boot — the same call the season branch above
+//     makes for its own row-check failure, rather than compounding one
+//     failure with a second, less legible one.
+//   - anything else: the registry file is present and genuinely unloadable.
+//     Fail the boot.
+//
+// The hasRows bound that lodgingRegistryBootDecision has to check explicitly
+// comes free here: SeedRegistry returns nil early once ANY season has rows
+// (registry.go:175-185), so a non-nil error out of it already implies a
+// genuinely empty registry. An already-seeded deployment cannot reach the
+// failing branch at all.
+func lodgingRegistrySeedBootDecision(seedErr error) error {
+	if seedErr == nil {
+		return nil
+	}
+	if errors.Is(seedErr, lodging.ErrRegistryRowCheck) {
+		slog.Warn("lodging registry load skipped: could not check for existing rows",
+			"err", seedErr)
+		return nil
+	}
+	return fmt.Errorf("loading lodging registry: %w", seedErr)
 }
 
 // the default pb_public dir location is relative to the executable

--- a/pocketbase/main_lodging_registry_boot_test.go
+++ b/pocketbase/main_lodging_registry_boot_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// captureMainLogs mirrors the lodging package's captureLogs helper (unexported
+// there, so this package needs its own copy) — redirects the default slog
+// logger to a buffer for one test.
+func captureMainLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return buf
+}
+
+// TestLodgingRegistryBootDecision pins issue #2054 Half 2: a season-less boot
+// must still succeed for a clone with no private registry file (the existing
+// graceful-degradation contract main.go documents), but must FAIL the boot
+// when the registry file is present and readable yet no season is
+// resolvable — that combination means an operator configured this
+// deployment to have lodging data and it would otherwise silently come up
+// with an empty registry behind nothing but a warn-level log line.
+func TestLodgingRegistryBootDecision(t *testing.T) {
+	seasonErr := errors.New("CAMPMINDER_SEASON_ID not set")
+
+	t.Run("no registry file present: warns and lets the boot continue", func(t *testing.T) {
+		logs := captureMainLogs(t)
+
+		if err := lodgingRegistryBootDecision(seasonErr, false); err != nil {
+			t.Fatalf("expected nil (boot continues) with no registry file present, got: %v", err)
+		}
+		if !strings.Contains(logs.String(), "lodging registry load skipped") {
+			t.Errorf("expected a skip warning logged, got:\n%s", logs.String())
+		}
+	})
+
+	t.Run("registry file present: fails the boot", func(t *testing.T) {
+		err := lodgingRegistryBootDecision(seasonErr, true)
+		if err == nil {
+			t.Fatal("expected a boot error when the registry file is present but the season is unresolvable, got nil")
+		}
+		if !errors.Is(err, seasonErr) {
+			t.Errorf("expected the boot error to wrap the underlying season error, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "CAMPMINDER_SEASON_ID") {
+			t.Errorf("expected the boot error to name the fix (CAMPMINDER_SEASON_ID), got: %v", err)
+		}
+	})
+}

--- a/pocketbase/main_lodging_registry_boot_test.go
+++ b/pocketbase/main_lodging_registry_boot_test.go
@@ -23,17 +23,27 @@ func captureMainLogs(t *testing.T) *bytes.Buffer {
 // TestLodgingRegistryBootDecision pins issue #2054 Half 2: a season-less boot
 // must still succeed for a clone with no private registry file (the existing
 // graceful-degradation contract main.go documents), but must FAIL the boot
-// when the registry file is present and readable yet no season is
-// resolvable — that combination means an operator configured this
-// deployment to have lodging data and it would otherwise silently come up
-// with an empty registry behind nothing but a warn-level log line.
+// when the registry file is present and readable, no season is resolvable,
+// AND the database has no lodging rows yet — that three-way combination
+// means an operator configured this deployment to have lodging data, this is
+// a genuinely fresh/empty boot, and it would otherwise silently come up with
+// an empty registry behind nothing but a warn-level log line.
+//
+// The third input (hasRows) matters on its own: SeedRegistry is a bootstrap
+// that no-ops once any season already has rows (registry.go:175-185), so a
+// production deployment with an already-seeded registry has nothing at risk
+// when CAMPMINDER_SEASON_ID goes missing or malformed after the fact — the
+// existing data is untouched either way. Gating only on file-presence, with
+// no hasRows check, would turn a harmless env var hiccup on an
+// already-seeded deployment into a full boot failure for a condition
+// SeedRegistry itself would have silently ignored.
 func TestLodgingRegistryBootDecision(t *testing.T) {
 	seasonErr := errors.New("CAMPMINDER_SEASON_ID not set")
 
 	t.Run("no registry file present: warns and lets the boot continue", func(t *testing.T) {
 		logs := captureMainLogs(t)
 
-		if err := lodgingRegistryBootDecision(seasonErr, false); err != nil {
+		if err := lodgingRegistryBootDecision(seasonErr, false, false); err != nil {
 			t.Fatalf("expected nil (boot continues) with no registry file present, got: %v", err)
 		}
 		if !strings.Contains(logs.String(), "lodging registry load skipped") {
@@ -41,10 +51,26 @@ func TestLodgingRegistryBootDecision(t *testing.T) {
 		}
 	})
 
-	t.Run("registry file present: fails the boot", func(t *testing.T) {
-		err := lodgingRegistryBootDecision(seasonErr, true)
+	t.Run("registry file present, database already has rows: warns and lets the boot continue", func(t *testing.T) {
+		// This is the shape of a real production deployment: the registry
+		// file is bind-mounted AND the DB was already seeded by a prior
+		// successful boot. SeedRegistry would no-op here regardless of the
+		// season, so a broken CAMPMINDER_SEASON_ID must not take the whole
+		// app down over data that was never actually at risk.
+		logs := captureMainLogs(t)
+
+		if err := lodgingRegistryBootDecision(seasonErr, true, true); err != nil {
+			t.Fatalf("expected nil (boot continues) when the database already has lodging rows, got: %v", err)
+		}
+		if !strings.Contains(logs.String(), "lodging registry load skipped") {
+			t.Errorf("expected a skip warning logged, got:\n%s", logs.String())
+		}
+	})
+
+	t.Run("registry file present, database empty: fails the boot", func(t *testing.T) {
+		err := lodgingRegistryBootDecision(seasonErr, true, false)
 		if err == nil {
-			t.Fatal("expected a boot error when the registry file is present but the season is unresolvable, got nil")
+			t.Fatal("expected a boot error when the registry file is present, the database is empty, and the season is unresolvable, got nil")
 		}
 		if !errors.Is(err, seasonErr) {
 			t.Errorf("expected the boot error to wrap the underlying season error, got: %v", err)

--- a/pocketbase/main_lodging_registry_boot_test.go
+++ b/pocketbase/main_lodging_registry_boot_test.go
@@ -70,7 +70,8 @@ func TestLodgingRegistryBootDecision(t *testing.T) {
 	t.Run("registry file present, database empty: fails the boot", func(t *testing.T) {
 		err := lodgingRegistryBootDecision(seasonErr, true, false)
 		if err == nil {
-			t.Fatal("expected a boot error when the registry file is present, the database is empty, and the season is unresolvable, got nil")
+			t.Fatal("expected a boot error when the registry file is present, " +
+				"the database is empty, and the season is unresolvable, got nil")
 		}
 		if !errors.Is(err, seasonErr) {
 			t.Errorf("expected the boot error to wrap the underlying season error, got: %v", err)

--- a/pocketbase/main_lodging_registry_boot_test.go
+++ b/pocketbase/main_lodging_registry_boot_test.go
@@ -3,9 +3,12 @@ package main
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
+
+	"github.com/camp/kindred/pocketbase/lodging"
 )
 
 // captureMainLogs mirrors the lodging package's captureLogs helper (unexported
@@ -78,6 +81,61 @@ func TestLodgingRegistryBootDecision(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "CAMPMINDER_SEASON_ID") {
 			t.Errorf("expected the boot error to name the fix (CAMPMINDER_SEASON_ID), got: %v", err)
+		}
+	})
+}
+
+// TestLodgingRegistrySeedBootDecision pins issue #2141: the sibling error
+// path in the same OnServe hook that #2054 Half 2 rewrote.
+//
+// Before this, the season-unresolvable branch failed the boot while the
+// branch three lines below it -- SeedRegistry itself failing on a malformed
+// registry file, a duplicate code, an unknown area/parent/alias-member
+// reference -- only warned. Same hook, same symptom (an empty registry, every
+// cabin string failing to resolve), on a likelier trigger: a hand-edited
+// registry file is more prone to a JSON typo than an env var is to going
+// missing.
+//
+// The hasRows bound #2054 Half 2 chose comes free here rather than needing a
+// second check: SeedRegistry returns nil early once ANY season has rows
+// (registry.go:175-185), so a non-nil error out of it already implies a
+// genuinely empty registry. An absent file is likewise already nil, so a
+// clone with no kindred-local keeps booting.
+func TestLodgingRegistrySeedBootDecision(t *testing.T) {
+	t.Run("no error: boot continues", func(t *testing.T) {
+		if err := lodgingRegistrySeedBootDecision(nil); err != nil {
+			t.Fatalf("expected nil when the seed succeeded, got: %v", err)
+		}
+	})
+
+	t.Run("row-check failure: warns and lets the boot continue", func(t *testing.T) {
+		// The loader could not even determine whether the registry already
+		// has rows, so it does not know whether anything is at risk. Fail
+		// open, exactly as the season branch above already does rather than
+		// compounding one failure with a second, less legible one.
+		logs := captureMainLogs(t)
+		rowsErr := fmt.Errorf("%w: checking lodging_areas for existing rows",
+			lodging.ErrRegistryRowCheck)
+
+		if err := lodgingRegistrySeedBootDecision(rowsErr); err != nil {
+			t.Fatalf("expected nil (boot continues) on a row-check failure, got: %v", err)
+		}
+		if !strings.Contains(logs.String(), "lodging registry") {
+			t.Errorf("expected a warning logged about the registry, got:\n%s", logs.String())
+		}
+	})
+
+	t.Run("bad registry file: fails the boot", func(t *testing.T) {
+		fileErr := errors.New("parsing lodging registry /config/lodging_registry.json: " +
+			"invalid character 'N'")
+
+		err := lodgingRegistrySeedBootDecision(fileErr)
+		if err == nil {
+			t.Fatal("expected a boot error when the registry file failed to load, got nil " +
+				"-- an unreadable registry must not boot to an empty one behind a warn line")
+		}
+		if !errors.Is(err, fileErr) {
+			t.Errorf("expected the boot error to wrap the underlying load error, got: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Half 2 of #2054. `SeedRegistry`'s season-unresolvable case has only ever logged a warning and continued booting. A deployment that has a private registry file but no resolvable `CAMPMINDER_SEASON_ID` comes up serving traffic with an empty lodging registry, and nothing but a warn-level log line says so.

## What changed

- `lodging.RegistryFilePresent()` (new, `pocketbase/lodging/registry.go`) reports whether a private registry file exists on any candidate path, sharing `SeedRegistry`'s own path search so the two can't drift apart. It is presence-only — it never reads, parses, or validates the file.
- `lodging.RegistryHasRows()` (exported from the pre-existing unexported `registryHasAnyRows`) reports whether `lodging_areas`/`lodging_units` already has a row for any season — the same check `SeedRegistry` itself uses to decide whether it's a bootstrap or a no-op.
- `lodgingRegistryBootDecision(seasonErr, registryPresent, hasRows)` (new, `pocketbase/main.go`) splits the season-unresolvable case in three:
  - no registry file present → warns and lets the boot continue (the existing graceful-degradation contract a clone without `kindred-local` depends on)
  - registry file present but the database **already has rows** → also warns and continues. `SeedRegistry` is a bootstrap that no-ops once any season has rows, so an already-seeded deployment has nothing at risk from a broken season env var — see "Bug found in review" below.
  - registry file present AND the database is genuinely empty → fails the boot, since this combination means an operator configured this deployment to have lodging data and it would otherwise silently come up with none.

## Bug found in review, fixed before merge

The first version of this PR gated `lodgingRegistryBootDecision` on file-presence alone, with no `hasRows` check. That inverted the actual production risk: `SeedRegistry` already no-ops once any season has rows (`registry.go:175-185`), so a healthy, already-seeded production deployment has zero risk from a broken `CAMPMINDER_SEASON_ID` — but the file-presence-only gate would have hard-failed the *entire boot* over exactly that harmless case, since the private registry file is always present in production. That's the opposite of "bounds the fix to a fresh/empty boot": it would have converted a benign env var typo into a full outage.

Caught by an automated review pass and confirmed against the real compiled binary in both directions (see Testing).

## Known limitation (verified, not fixed here)

I booted the real binary with the registry present, the database empty, and `CAMPMINDER_SEASON_ID` unset, to confirm this actually stops the server from serving an empty registry — it does: `apis.Serve` never starts listening, and the process exits on its own printing `Error: lodging registry file present but no season is resolvable...`.

However, the process **exits 0**, not 1. This traces to `pocketbase.PocketBase.Execute()` (v0.39.10): it runs `RootCmd.Execute()` in a goroutine and discards its returned error, relying on "the commands to decide whether to print their error." `app.Start()` therefore never observes an `OnServe`-hook error, and `main.go`'s `os.Exit(1)` block never fires for this class of failure — a pre-existing gap affecting any `OnServe` hook that returns an error, not something introduced here. Practically: `docker-compose.yml`'s `restart: unless-stopped` restarts on any exit code (not just non-zero), so the container still crash-loops and its healthcheck never turns green, making the failure visible operationally — just not via process exit code specifically. Flagging this so it isn't mistaken for a deploy-time hard failure signal; a fix would need to touch the shared `OnServe` error-handling path, which is out of scope for this issue.

## Testing

- `pocketbase/main_lodging_registry_boot_test.go`: pins all three branches of `lodgingRegistryBootDecision` — no file, file-present-with-existing-rows, file-present-with-empty-DB. Mutation-checked (dropping the `hasRows` check fails exactly the new "already seeded" subtest, confirming it actually pins the bug found in review).
- `pocketbase/lodging/registry_test.go`: three new tests for `RegistryFilePresent` (working-directory config, absolute root, no config anywhere).
- `go build ./...` and `go test ./...`: exit 0 (lodging ~27s cached-fixture / 126s cold, sync 226s cold — the full suite exceeds a 2-minute default shell timeout on a cold run, hence the long individual package times on first execution).
- `scripts/dev/verify-lodging-seed.sh`: OK (118 units, 187 aliases) — happy path unaffected.
- Manual end-to-end boot against the real compiled binary, both directions:
  - Empty DB + registry present + season unset → boot fails, process exits without ever opening the HTTP listener (confirms the core fix).
  - Already-seeded DB (from a prior successful boot) + registry present + season unset → boot **succeeds**, warns, and serves traffic normally (confirms the review-fix: an already-seeded deployment survives a broken season env var).

## Folded in: #2141 — a malformed registry file still only warned

The same `OnServe` hook this PR rewrote was left self-inconsistent: the season-unresolvable branch fails the boot, while the branch three lines below it (`SeedRegistry` erroring on a malformed file, a duplicate code, an unknown area/parent/alias-member reference) only warned. Same hook, same symptom (an empty registry, every cabin string failing to resolve), on a likelier trigger — a hand-edited file is more prone to a JSON typo than an env var is to going missing.

`SeedRegistry` has exactly two error sources and they warrant opposite treatments, so the one that must NOT fail the boot is now tagged: `lodging.ErrRegistryRowCheck` marks a `RegistryHasRows` failure, where the loader cannot determine whether anything is at risk and so fails open — the same call the season branch already makes. Everything else fails the boot via the new `lodgingRegistrySeedBootDecision`.

The `hasRows` bound came free rather than needing a second check: `SeedRegistry` returns nil early once any season has rows, so a non-nil error already implies a genuinely empty registry and an already-seeded deployment cannot reach the failing branch. An absent file is likewise already nil, so a clone or CI run without `kindred-local` keeps booting.

Tests (written failing first, all four mutation-checked):
- `main_lodging_registry_boot_test.go`: `lodgingRegistrySeedBootDecision` across nil / row-check-failure / bad-file.
- `lodging/registry_test.go`: the row-check failure IS tagged, and a malformed file is NOT.
- Mutations killed: dropping the sentinel wrap; tagging every error as a row-check failure; reverting the decision to warn-only; making the row-check failure fail the boot.
- `docs/reference/lodging-registry.md`: two passages stated the opposite behaviour ("an unreadable or malformed file logs a warning", "a logged warning, not a crash") and are corrected.

Closes #2141.

Closes #2054.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

