### PR TITLE
fix(api): score a merged pair as having the bathroom it actually shares

### DIFF
--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -273,6 +273,13 @@ class RosterParty(BaseModel):
     # for a caller -- the map view -- that needs to know WHICH units a merged
     # party spans, not just how many.
     unit_codes: list[str] = Field(default_factory=list)
+    # The bathroom this party ends up with once every code in unit_codes
+    # counts toward ONE merge -- lodging_rules.effective_bathroom resolved
+    # against the OCCUPYING placement, not any single unit's own view
+    # (kindred#2022). "unknown" when unplaced. SCORING ONLY: this feeds
+    # matching, and is not itself surfaced as a claim to staff on any card
+    # or panel -- see LodgingRosterService._resolve_party_bathroom.
+    effective_bathroom: EffectiveBathroom = "unknown"
     arrival_eta: str = ""
     # The household's cm_id was seen in an earlier year.
     is_returning: bool = False

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple, cast
 from api.schemas.lodging import (
     PHI_FIELD_NAMES,
     AccessibilityFlagSummary,
+    EffectiveBathroom,
     HouseholdMedicalResponse,
     LodgingUnitSummary,
     PartyAdult,
@@ -38,6 +39,7 @@ from api.schemas.lodging import (
     WeekendSummaryResponse,
 )
 from api.services.lodging_rules import (
+    container_bathroom,
     effective_bathroom,
     is_family_available,
     unit_capacity,
@@ -364,6 +366,114 @@ def drawn_units(units: list[LodgingUnitSummary]) -> list[LodgingUnitSummary]:
     return drawn
 
 
+class _BathroomIndex(NamedTuple):
+    """Lookups `_resolve_party_bathroom` needs, built ONCE per roster/summary
+    call from the unit registry rather than once per party -- the same
+    "compute across all units, read per party" split `_build_units` already
+    uses for `group_members`.
+    """
+
+    units_by_code: dict[str, LodgingUnitSummary]
+    # Immediate children only, keyed by the PARENT's code. Nesting (a
+    # container inside a container, e.g. Doctor's House under a larger
+    # block) is walked at read time in `leaf_codes_under`, mirroring
+    # `drawn_units`' own upward walk of the same `parent_code` relation.
+    children_by_parent: dict[str, tuple[LodgingUnitSummary, ...]]
+    group_members: dict[str, frozenset[str]]
+
+    @classmethod
+    def build(cls, units: list[LodgingUnitSummary]) -> _BathroomIndex:
+        units_by_code = {unit.code: unit for unit in units}
+
+        children: dict[str, list[LodgingUnitSummary]] = {}
+        for unit in units:
+            if unit.parent_code:
+                children.setdefault(unit.parent_code, []).append(unit)
+
+        group_members: dict[str, set[str]] = {}
+        for unit in units:
+            if unit.bathroom_group:
+                group_members.setdefault(unit.bathroom_group, set()).add(unit.code)
+
+        return cls(
+            units_by_code=units_by_code,
+            children_by_parent={code: tuple(rows) for code, rows in children.items()},
+            group_members={group: frozenset(codes) for group, codes in group_members.items()},
+        )
+
+    def leaf_codes_under(self, container_code: str) -> frozenset[str]:
+        """Every LEAF unit code under a container, walking the tree.
+
+        Recurses rather than reading one level, because a container's own
+        children may themselves be containers. Cycle-guarded for the same
+        reason `drawn_units` guards its walk: a cycle already in the data
+        must not hang a request.
+        """
+        leaves: set[str] = set()
+        seen: set[str] = {container_code}
+        stack = list(self.children_by_parent.get(container_code, ()))
+        while stack:
+            child = stack.pop()
+            if child.code in seen:
+                continue
+            seen.add(child.code)
+            if child.is_container:
+                stack.extend(self.children_by_parent.get(child.code, ()))
+            else:
+                leaves.add(child.code)
+        return frozenset(leaves)
+
+
+def _resolve_party_bathroom(unit_codes: list[str], index: _BathroomIndex) -> str:
+    """The bathroom a party ends up with once every code it occupies counts
+    toward ONE merge -- kindred#2022.
+
+    `effective_bathroom`'s exclusivity branch is unreachable at its one
+    existing call site (`_build_units`, below) because that call always
+    passes a one-element `frozenset({code})`: the units INVENTORY has no
+    occupant, so it is evaluated one unit at a time and stays that way (see
+    the comment there). This is the OTHER caller, added for exactly this
+    fix: it passes the full set of codes the placement actually covers, so
+    a real multi-unit merge can clear the bar.
+
+    A container in `unit_codes` (a whole-let placement naming the building
+    rather than its rooms) is expanded to its leaf descendants via
+    `container_bathroom`, rather than read from its own registry row, which
+    is always "none" -- see that function's docstring.
+
+    The FIRST occupied code supplies the representative bathroom/group fed
+    to `effective_bathroom`; every registry bathroom_group's members share
+    one physical bathroom by construction, so any member speaks for the
+    group. `unit_codes` naming units from two DIFFERENT groups is not a
+    case any registry data produces today.
+    """
+    if not unit_codes:
+        return "unknown"
+
+    occupied: set[str] = set()
+    bathroom = ""
+    group = ""
+    for code in unit_codes:
+        unit = index.units_by_code.get(code)
+        if unit is None:
+            continue
+        if unit.is_container:
+            leaves = index.leaf_codes_under(code)
+            occupied |= leaves
+            leaf_groups = frozenset(index.units_by_code[leaf].bathroom_group for leaf in leaves)
+            inherited_bathroom, inherited_group = container_bathroom(leaf_groups)
+            if not bathroom:
+                bathroom, group = inherited_bathroom, inherited_group
+        else:
+            occupied.add(code)
+            if not bathroom:
+                bathroom, group = unit.bathroom, unit.bathroom_group
+
+    if not bathroom:
+        return "unknown"
+    return effective_bathroom(bathroom, group, index.group_members.get(group, frozenset()), frozenset(occupied))
+
+
 class LodgingRosterService:
     """Builds the read-only weekend roster from repository output."""
 
@@ -469,6 +579,7 @@ class LodgingRosterService:
             adults_by_household=adults_task.result(),
             registrations=registrations_task.result(),
             assignments=placements_task.result(),
+            units=unit_summaries,
         )
         counts = self._build_counts(unit_summaries, parties, aliases_task.result())
 
@@ -565,6 +676,7 @@ class LodgingRosterService:
                 adults_by_household=adults_by_household,
                 registrations=registrations,
                 assignments=placements_task.result(),
+                units=unit_summaries,
             )
             return WeekendSummaryEntry(
                 session=self._session_summary(session),
@@ -709,11 +821,13 @@ class LodgingRosterService:
         adults_by_household: dict[str, list[Any]],
         registrations: dict[str, Any],
         assignments: list[Any],
+        units: list[LodgingUnitSummary],
     ) -> list[RosterParty]:
         placement_by_household, placement_by_person = self._index_assignments(assignments)
+        bathroom_index = _BathroomIndex.build(units)
 
         if session_type == "adult":
-            return self._build_person_parties(attendees, placement_by_person)
+            return self._build_person_parties(attendees, placement_by_person, bathroom_index)
 
         return self._build_household_parties(
             attendees=attendees,
@@ -722,6 +836,7 @@ class LodgingRosterService:
             adults_by_household=adults_by_household,
             registrations=registrations,
             placement_by_household=placement_by_household,
+            bathroom_index=bathroom_index,
         )
 
     @staticmethod
@@ -776,7 +891,10 @@ class LodgingRosterService:
         return by_household, by_person
 
     def _build_person_parties(
-        self, attendees: list[Any], placement_by_person: dict[int, _Placement]
+        self,
+        attendees: list[Any],
+        placement_by_person: dict[int, _Placement],
+        bathroom_index: _BathroomIndex,
     ) -> list[RosterParty]:
         parties: list[RosterParty] = []
         for attendee in attendees:
@@ -797,6 +915,9 @@ class LodgingRosterService:
                     unit_name=placement.unit_name,
                     is_merged_slot=placement.is_merged_slot,
                     unit_codes=list(placement.unit_codes),
+                    effective_bathroom=cast(
+                        EffectiveBathroom, _resolve_party_bathroom(list(placement.unit_codes), bathroom_index)
+                    ),
                 )
             )
         parties.sort(key=lambda p: (p.sort_name.casefold(), p.display_name.casefold()))
@@ -811,6 +932,7 @@ class LodgingRosterService:
         adults_by_household: dict[str, list[Any]],
         registrations: dict[str, Any],
         placement_by_household: dict[int, _Placement],
+        bathroom_index: _BathroomIndex,
     ) -> list[RosterParty]:
         children_by_household: dict[str, list[Any]] = {}
         for attendee in attendees:
@@ -867,6 +989,9 @@ class LodgingRosterService:
                     unit_name=placement.unit_name,
                     is_merged_slot=placement.is_merged_slot,
                     unit_codes=list(placement.unit_codes),
+                    effective_bathroom=cast(
+                        EffectiveBathroom, _resolve_party_bathroom(list(placement.unit_codes), bathroom_index)
+                    ),
                     arrival_eta=_s(registration, "arrival_eta") if registration is not None else "",
                     is_returning=household_cm_id in prior_cm_ids,
                     share=self._build_share(registration),

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -456,7 +456,12 @@ def _resolve_party_bathroom(unit_codes: list[str], index: _BathroomIndex) -> str
     for code in unit_codes:
         unit = index.units_by_code.get(code)
         if unit is None:
-            continue
+            # A code the registry cannot resolve makes the WHOLE placement
+            # unknown, rather than scoring from whatever else resolved.
+            # Continuing here would answer "private"/"shared" on the strength
+            # of a placement we can only partly see -- the same claim the
+            # empty-`unit_codes` guard above already refuses to make.
+            return "unknown"
         if unit.is_container:
             leaves = index.leaf_codes_under(code)
             occupied |= leaves

--- a/api/services/lodging_rules.py
+++ b/api/services/lodging_rules.py
@@ -112,3 +112,43 @@ def effective_bathroom(
     if group_member_codes and group_member_codes <= merged_codes:
         return "private"
     return "shared"
+
+
+def container_bathroom(leaf_bathroom_groups: frozenset[str]) -> tuple[str, str]:
+    """A container's bathroom, inherited from its leaf descendants.
+
+    Containers (buildings, apartments) store `bathroom = "none"` on the
+    registry row itself -- the field describes a ROOM, and a building is
+    not one. That is correct for the units inventory, which has no
+    occupant to resolve the ambiguity for. It is wrong for a party that has
+    booked the WHOLE container: the health-center apartments are two
+    bedrooms over one shared bath, normally let whole, which is exactly the
+    case `effective_bathroom`'s exclusivity branch exists for -- except the
+    container's own "none" short-circuits that branch (line 108-109) before
+    it ever runs.
+
+    This resolves what "bathroom" and "bathroom_group" to FEED
+    `effective_bathroom` on the container's behalf, rather than widening
+    that function's signature to know about children. `effective_bathroom`
+    stays the same four-argument pure test the class above already pins;
+    the inheritance a container needs is a fact about its children, computed
+    here and handed in as an ordinary "shared" input.
+
+    Args:
+        leaf_bathroom_groups: the `bathroom_group` of every LEAF unit
+            directly or indirectly under the container ("" for a leaf with
+            no group).
+
+    Returns:
+        ("shared", group) when every leaf agrees on the same non-empty
+        group -- the children physically share one bathroom, so booking the
+        whole container definitionally covers that group. ("none", "")
+        when the leaves disagree, carry no group, or there are none at all:
+        nothing to inherit, so the container reports exactly what its own
+        registry row already says.
+    """
+    if len(leaf_bathroom_groups) == 1:
+        (group,) = leaf_bathroom_groups
+        if group:
+            return "shared", group
+    return "none", ""

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -4898,6 +4898,10 @@ export type RosterParty = {
    */
   unit_codes?: Array<string>
   /**
+   * Effective Bathroom
+   */
+  effective_bathroom?: 'unknown' | 'none' | 'private' | 'shared'
+  /**
    * Arrival Eta
    */
   arrival_eta?: string

--- a/frontend/src/types/lodging.test.ts
+++ b/frontend/src/types/lodging.test.ts
@@ -45,6 +45,7 @@ const _exhaustiveRosterParty: Required<RosterPartyRow> = {
   unit_name: 'Ridge 1',
   is_merged_slot: false,
   unit_codes: ['ridge-1'],
+  effective_bathroom: 'unknown',
   arrival_eta: '',
   is_returning: false,
   share: {

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -1100,6 +1100,264 @@ class TestSlotMergeTiers:
         assert {u.bathroom for u in roster.units} == {"shared"}
 
 
+class TestPartyEffectiveBathroom:
+    """kindred#2022 -- `RosterParty.effective_bathroom`, resolved against the
+    OCCUPYING placement rather than any single unit's own view.
+
+    `TestUnitsAndCounts.test_full_bathroom_group_merge_is_not_assumed_for_a_lone_unit`
+    above pins that the units INVENTORY is unaffected by this fix -- it has
+    no occupant, so `roster.units[*].bathroom` keeps evaluating one unit at
+    a time. This class is the party-level half: the same exclusivity rule,
+    now reachable, plus the container-inheritance arm #2022's re-measurement
+    widened the issue to cover.
+
+    SCORE ONLY: this field feeds matching/scoring. It is not surfaced as a
+    claim to staff on any card or panel in this PR -- that is #1982's.
+    """
+
+    @pytest.mark.asyncio
+    async def test_full_group_merge_upgrades_the_party_to_private(self) -> None:
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_households={"hh_1": _household(title="The Garcia Family")},
+            fetch_attendees_for_session=[_child(cm_id=1000002, first="Liam", last="Garcia")],
+            fetch_units=[
+                _unit("u1", "gt-tioga-1", "Tioga 1", sleeps=4, bathroom="shared", bathroom_group="gt-tioga-12"),
+                _unit("u2", "gt-tioga-2", "Tioga 2", sleeps=4, bathroom="shared", bathroom_group="gt-tioga-12"),
+            ],
+            fetch_assignments=[
+                _rec(
+                    household_cm_id=2000001,
+                    person_cm_id=0,
+                    units=["u1", "u2"],
+                    expand={
+                        "units": [
+                            _rec(id="u1", code="gt-tioga-1", name="Tioga 1"),
+                            _rec(id="u2", code="gt-tioga-2", name="Tioga 2"),
+                        ]
+                    },
+                ),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        party = roster.parties[0]
+        assert party.is_merged_slot is True
+        assert party.effective_bathroom == "private"
+        # The units inventory has no occupant and is untouched by this fix.
+        assert {u.bathroom for u in roster.units} == {"shared"}
+
+    @pytest.mark.asyncio
+    async def test_partial_group_merge_stays_shared(self) -> None:
+        """merge{Upstairs 1, Upstairs 2} leaves a third member of the group
+        out, so the party does not clear the bar -- same fixture shape as
+        `TestEffectiveBathroom.test_partial_group_merge_stays_shared`."""
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_households={"hh_1": _household()},
+            fetch_attendees_for_session=[_child()],
+            fetch_units=[
+                _unit("u1", "hc-upstairs-1", "Upstairs 1", bathroom="shared", bathroom_group="hc-upstairs-hall"),
+                _unit("u2", "hc-upstairs-2", "Upstairs 2", bathroom="shared", bathroom_group="hc-upstairs-hall"),
+                _unit("u3", "hc-upstairs-3", "Upstairs 3", bathroom="shared", bathroom_group="hc-upstairs-hall"),
+            ],
+            fetch_assignments=[
+                _rec(
+                    household_cm_id=2000001,
+                    person_cm_id=0,
+                    units=["u1", "u2"],
+                    expand={
+                        "units": [
+                            _rec(id="u1", code="hc-upstairs-1", name="Upstairs 1"),
+                            _rec(id="u2", code="hc-upstairs-2", name="Upstairs 2"),
+                        ]
+                    },
+                ),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.parties[0].effective_bathroom == "shared"
+
+    @pytest.mark.asyncio
+    async def test_lone_leaf_in_a_group_stays_shared(self) -> None:
+        """One occupant does not clear the bar alone. Party-level mirror of
+        `test_full_bathroom_group_merge_is_not_assumed_for_a_lone_unit`."""
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_households={"hh_1": _household()},
+            fetch_attendees_for_session=[_child()],
+            fetch_units=[
+                _unit("u1", "gt-tioga-1", "Tioga 1", bathroom="shared", bathroom_group="gt-tioga-12"),
+                _unit("u2", "gt-tioga-2", "Tioga 2", bathroom="shared", bathroom_group="gt-tioga-12"),
+            ],
+            fetch_assignments=[
+                _rec(
+                    household_cm_id=2000001,
+                    person_cm_id=0,
+                    units=["u1"],
+                    expand={"units": [_rec(id="u1", code="gt-tioga-1", name="Tioga 1")]},
+                ),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.parties[0].effective_bathroom == "shared"
+
+    @pytest.mark.asyncio
+    async def test_genuinely_private_single_unit_passes_through(self) -> None:
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_households={"hh_1": _household()},
+            fetch_attendees_for_session=[_child()],
+            fetch_units=[_unit("u1", "hc-upstairs-5", "Upstairs 5", bathroom="private")],
+            fetch_assignments=[
+                _rec(
+                    household_cm_id=2000001,
+                    person_cm_id=0,
+                    units=["u1"],
+                    expand={"units": [_rec(id="u1", code="hc-upstairs-5", name="Upstairs 5")]},
+                ),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.parties[0].effective_bathroom == "private"
+
+    @pytest.mark.asyncio
+    async def test_whole_container_let_covering_its_bathroom_group_is_private(self) -> None:
+        """A party placed on the CONTAINER id alone -- staff booked the whole
+        Doctor's House rather than naming its two bedrooms. The container's
+        own row is bathroom="none" (a building is not a room), so without
+        inheritance from its leaves this reads as no bathroom at all -- the
+        "container whole-let" gap #2022's re-measurement widened the issue
+        to cover, separate from the plain multi-leaf merge above.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_households={"hh_1": _household()},
+            fetch_attendees_for_session=[_child()],
+            fetch_units=[
+                _unit("u1", "hc-dh", "Doctor's House", sleeps=6, is_container=True, default_combined=True),
+                _unit(
+                    "u2",
+                    "hc-dh-a",
+                    "Doctor's House A",
+                    sleeps=3,
+                    bathroom="shared",
+                    bathroom_group="hc-dh-bath",
+                    parent_unit="u1",
+                ),
+                _unit(
+                    "u3",
+                    "hc-dh-b",
+                    "Doctor's House B",
+                    sleeps=3,
+                    bathroom="shared",
+                    bathroom_group="hc-dh-bath",
+                    parent_unit="u1",
+                ),
+            ],
+            fetch_assignments=[
+                _rec(
+                    household_cm_id=2000001,
+                    person_cm_id=0,
+                    units=["u1"],
+                    expand={"units": [_rec(id="u1", code="hc-dh", name="Doctor's House")]},
+                ),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        party = roster.parties[0]
+        assert party.is_merged_slot is False  # one unit named -- the container itself
+        assert party.effective_bathroom == "private"
+
+    @pytest.mark.asyncio
+    async def test_partial_container_stays_at_its_own_value(self) -> None:
+        """A container whose leaves DISAGREE on a group has nothing to
+        inherit, and reports its own registry row -- "none" -- unchanged."""
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_households={"hh_1": _household()},
+            fetch_attendees_for_session=[_child()],
+            fetch_units=[
+                _unit("u1", "block", "The Block", sleeps=6, is_container=True, default_combined=True),
+                _unit(
+                    "u2", "block-a", "Block A", sleeps=3, bathroom="shared", bathroom_group="group-a", parent_unit="u1"
+                ),
+                _unit(
+                    "u3", "block-b", "Block B", sleeps=3, bathroom="shared", bathroom_group="group-b", parent_unit="u1"
+                ),
+            ],
+            fetch_assignments=[
+                _rec(
+                    household_cm_id=2000001,
+                    person_cm_id=0,
+                    units=["u1"],
+                    expand={"units": [_rec(id="u1", code="block", name="The Block")]},
+                ),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.parties[0].effective_bathroom == "none"
+
+    @pytest.mark.asyncio
+    async def test_unplaced_party_is_unknown(self) -> None:
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_households={"hh_1": _household()},
+            fetch_attendees_for_session=[_child()],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.parties[0].effective_bathroom == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_adult_weekend_party_gets_the_same_scoring(self) -> None:
+        """Adult weekends place PERSONS, not households -- the resolver must
+        not be wired to the household branch alone."""
+        attendee = _rec(
+            person_id=1000004,
+            expand={
+                "person": _rec(
+                    cm_id=1000004,
+                    first_name="Olivia",
+                    last_name="Chen",
+                    preferred_name="",
+                    age=41,
+                    grade=None,
+                    household="hh_9",
+                )
+            },
+        )
+        repo = _repo(
+            fetch_session=ADULT_SESSION,
+            fetch_attendees_for_session=[attendee],
+            fetch_units=[
+                _unit("u1", "gt-tioga-1", "Tioga 1", bathroom="shared", bathroom_group="gt-tioga-12"),
+                _unit("u2", "gt-tioga-2", "Tioga 2", bathroom="shared", bathroom_group="gt-tioga-12"),
+            ],
+            fetch_assignments=[
+                _rec(
+                    household_cm_id=0,
+                    person_cm_id=1000004,
+                    units=["u1", "u2"],
+                    expand={
+                        "units": [
+                            _rec(id="u1", code="gt-tioga-1", name="Tioga 1"),
+                            _rec(id="u2", code="gt-tioga-2", name="Tioga 2"),
+                        ]
+                    },
+                ),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000002)
+
+        assert roster.parties[0].effective_bathroom == "private"
+
+
 class TestPlacementOf:
     """`_placement_of` in isolation.
 

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -1148,6 +1148,45 @@ class TestPartyEffectiveBathroom:
         assert {u.bathroom for u in roster.units} == {"shared"}
 
     @pytest.mark.asyncio
+    async def test_a_placement_naming_an_unindexed_code_is_unknown_not_scored_on_the_rest(self) -> None:
+        """A code the index cannot resolve makes the WHOLE placement unknown.
+
+        Skipping the absent code and scoring from whatever is left asserts a
+        bathroom for a placement we cannot see all of: the party below spans
+        two units, only one of which is in the registry, and that one is
+        private. Answering "private" would claim exclusivity on the strength
+        of half the evidence. `unknown` is the same answer the function
+        already gives for an empty `unit_codes` -- absence of evidence, not
+        evidence of a private bathroom.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_households={"hh_1": _household()},
+            fetch_attendees_for_session=[_child()],
+            # Only u1 is in the registry. u2's code is named by the placement
+            # but resolves to nothing -- a stale or not-yet-rolled-forward row.
+            fetch_units=[
+                _unit("u1", "gt-tioga-1", "Tioga 1", sleeps=4, bathroom="private", bathroom_group=""),
+            ],
+            fetch_assignments=[
+                _rec(
+                    household_cm_id=2000001,
+                    person_cm_id=0,
+                    units=["u1", "u2"],
+                    expand={
+                        "units": [
+                            _rec(id="u1", code="gt-tioga-1", name="Tioga 1"),
+                            _rec(id="u2", code="gt-absent-9", name="Absent 9"),
+                        ]
+                    },
+                ),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.parties[0].effective_bathroom == "unknown"
+
+    @pytest.mark.asyncio
     async def test_partial_group_merge_stays_shared(self) -> None:
         """merge{Upstairs 1, Upstairs 2} leaves a third member of the group
         out, so the party does not clear the bar -- same fixture shape as

--- a/tests/unit/api/services/test_lodging_rules.py
+++ b/tests/unit/api/services/test_lodging_rules.py
@@ -16,6 +16,7 @@ Python would regress two fixes that live only on the Go side.
 import pytest
 
 from api.services.lodging_rules import (
+    container_bathroom,
     effective_bathroom,
     is_family_available,
     unit_capacity,
@@ -115,3 +116,32 @@ class TestEffectiveBathroom:
 
     def test_shared_without_a_group_stays_shared(self) -> None:
         assert effective_bathroom("shared", "", frozenset(), frozenset({"x"})) == "shared"
+
+
+class TestContainerBathroom:
+    """kindred#2022's second gap. All 15 registry containers store
+    bathroom = "none" on their own row -- a building is not a room -- which
+    short-circuits `effective_bathroom`'s exclusivity branch (line 108-109)
+    before it ever runs. A party that books the whole container (the
+    health-center apartments: two bedrooms over one shared bath, normally
+    let whole) needs the container's input substituted from its leaves
+    instead. This is that substitution, kept OUTSIDE `effective_bathroom`
+    itself -- that function stays the same four-argument pure test the
+    class above already pins, rather than growing a fifth argument to know
+    about children it has no way to walk.
+    """
+
+    def test_leaves_sharing_one_group_inherit_shared(self) -> None:
+        assert container_bathroom(frozenset({"hc-dh-bath"})) == ("shared", "hc-dh-bath")
+
+    def test_leaves_with_no_group_inherit_nothing(self) -> None:
+        assert container_bathroom(frozenset({""})) == ("none", "")
+
+    def test_leaves_split_across_groups_inherit_nothing(self) -> None:
+        """Ambiguous -- rooms that don't share one physical bathroom have no
+        single answer, so the container reports exactly what its own
+        registry row already says."""
+        assert container_bathroom(frozenset({"group-a", "group-b"})) == ("none", "")
+
+    def test_no_leaves_inherit_nothing(self) -> None:
+        assert container_bathroom(frozenset()) == ("none", "")


### PR DESCRIPTION
## Problem

A party booked into a whole container is never scored as having the bathroom its leaf rooms physically share.

Containers store `bathroom = "none"` on the registry row, because the field describes a **room** and a building is not one. That is correct for the units inventory, which has no occupant to resolve the ambiguity for. But the container's own `"none"` short-circuits `effective_bathroom`'s exclusivity branch before it can run — so the branch that exists precisely for "two bedrooms over one shared bath, let whole" never fires.

All 15 containers carry `bathroom = 'none'`, so this is not an edge case.

## Fix

Adds `container_bathroom(leaf_bathroom_groups)`, which resolves what to **feed** `effective_bathroom` on a container's behalf, inherited from its **leaf descendants**:

- every leaf agrees on one non-empty group → `("shared", group)` — booking the whole container definitionally covers that group
- leaves disagree, carry no group, or there are none → `("none", "")` — nothing to inherit, so the container reports what its own row already says

Inheritance is computed here and handed in as an ordinary `"shared"` input, **rather than widening `effective_bathroom`'s signature to know about children**. `effective_bathroom` stays the same four-argument pure test its existing tests already pin.

The resolved value rides on `RosterParty.effective_bathroom`.

## Scoring only

`effective_bathroom` **feeds matching and is never surfaced as a claim to staff** on any card or panel. The schema field carries that constraint as a comment so it survives the next reader.

## Note on the exclusivity branch

`lodging_rules.py:112`'s exclusivity branch is structurally unreachable from its only current caller, which passes `frozenset({code})` — a single-element set can never exercise a multi-code comparison. This PR does not delete it; it makes it reachable for the container case, which is what it was written for.

## Verification

- `pytest tests/unit/api/services/test_lodging_rules.py tests/unit/api/services/test_lodging_roster_service.py` — **124 passed**, exit 0
- `ruff check .` — exit 0
- `mypy` — clean, 267 source files
- `tsc --noEmit` — exit 0
- pre-push (forced, all commands): `api-types-freshness` ✔ · `pytest` ✔ · `type-check` ✔

`api/schemas/lodging.py` gained a field, so `types.gen.ts` was regenerated and the `Required<RosterPartyRow>` exhaustive fixture in `frontend/src/types/lodging.test.ts` updated to match.

Closes #2022.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bathroom information to roster parties, indicating whether facilities are unknown, unavailable, private, or shared.
  * Bathroom status now reflects occupied rooms, combined placements, and whole-container assignments for more accurate lodging matching.

* **Bug Fixes**
  * Improved handling of mixed, partial, and unplaced lodging assignments to prevent inaccurate bathroom classifications.

* **Tests**
  * Added coverage for bathroom resolution across individual rooms, shared groups, containers, and adult weekend assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->