### PR TITLE
fix(sync): fall through to name-based rules for unmapped session groups

### DIFF
--- a/pocketbase/sync/sessions.go
+++ b/pocketbase/sync/sessions.go
@@ -646,11 +646,11 @@ type sessionInfo struct {
 // (stable across years) but falling back to name-based rules when the GroupID either is
 // absent or doesn't resolve to a known group.
 //
-// An unrecognised GroupID (getSessionTypeFromGroupID's default arm, returning
+// An unrecognized GroupID (getSessionTypeFromGroupID's default arm, returning
 // sessionTypeOther) is not treated as a confident classification: some CampMinder groups
 // (e.g. a catch-all "Camp Sessions" bucket) hold real, differently-typed programs that
 // were never added to the switch. Falling through to getSessionTypeFromName recovers those
-// cases without touching a *recognised* group's result - which never equals
+// cases without touching a *recognized* group's result - which never equals
 // sessionTypeOther, so it is returned as-is. See issue #2114.
 func (s *SessionsSync) classifySessionType(info sessionInfo, groupID int, allSessionInfos []sessionInfo) string {
 	if groupID <= 0 {
@@ -666,7 +666,7 @@ func (s *SessionsSync) classifySessionType(info sessionInfo, groupID int, allSes
 	}
 
 	if sessionType == sessionTypeOther {
-		// Unrecognised group - defer to the name rules rather than accepting "other".
+		// Unrecognized group - defer to the name rules rather than accepting "other".
 		return s.getSessionTypeFromName(info.name)
 	}
 

--- a/pocketbase/sync/sessions.go
+++ b/pocketbase/sync/sessions.go
@@ -157,23 +157,12 @@ func (s *SessionsSync) Sync(ctx context.Context) error {
 		}
 	}
 
-	// Second pass: classify sessions using group-based classification
+	// Second pass: classify sessions using group-based classification, falling back to
+	// name-based rules when the GroupID doesn't resolve to a known group (see
+	// classifySessionType).
 	for _, info := range allSessionInfos {
 		groupID := sessionGroupIDs[info.cmID]
-		var sessionType string
-
-		if groupID > 0 {
-			// Use group-based classification (more reliable for historical data)
-			sessionType = s.getSessionTypeFromGroupID(groupID, info.name)
-
-			// Refine summer camp sessions to main/ag/embedded
-			if sessionType == "summer_candidate" {
-				sessionType = s.refineSummerSessionType(info, allSessionInfos)
-			}
-		} else {
-			// Fallback to name-based classification for sessions without groups
-			sessionType = s.getSessionTypeFromName(info.name)
-		}
+		sessionType := s.classifySessionType(info, groupID, allSessionInfos)
 
 		initialTypes[info.cmID] = sessionType
 
@@ -651,6 +640,37 @@ type sessionInfo struct {
 	name      string
 	startDate string
 	endDate   string
+}
+
+// classifySessionType determines a session's type, preferring group-based classification
+// (stable across years) but falling back to name-based rules when the GroupID either is
+// absent or doesn't resolve to a known group.
+//
+// An unrecognised GroupID (getSessionTypeFromGroupID's default arm, returning
+// sessionTypeOther) is not treated as a confident classification: some CampMinder groups
+// (e.g. a catch-all "Camp Sessions" bucket) hold real, differently-typed programs that
+// were never added to the switch. Falling through to getSessionTypeFromName recovers those
+// cases without touching a *recognised* group's result - which never equals
+// sessionTypeOther, so it is returned as-is. See issue #2114.
+func (s *SessionsSync) classifySessionType(info sessionInfo, groupID int, allSessionInfos []sessionInfo) string {
+	if groupID <= 0 {
+		// No GroupID on this session at all - fall back to name-based classification.
+		return s.getSessionTypeFromName(info.name)
+	}
+
+	sessionType := s.getSessionTypeFromGroupID(groupID, info.name)
+
+	// Refine summer camp sessions to main/ag/embedded.
+	if sessionType == "summer_candidate" {
+		return s.refineSummerSessionType(info, allSessionInfos)
+	}
+
+	if sessionType == sessionTypeOther {
+		// Unrecognised group - defer to the name rules rather than accepting "other".
+		return s.getSessionTypeFromName(info.name)
+	}
+
+	return sessionType
 }
 
 // getSessionTypeFromGroupID returns the session type based on the session group cm_id.

--- a/pocketbase/sync/sessions_test.go
+++ b/pocketbase/sync/sessions_test.go
@@ -775,6 +775,150 @@ func TestGetSessionTypeFromGroupID(t *testing.T) {
 	}
 }
 
+// TestClassifySessionType_UnmappedGroupFallsThroughToNameRules covers issue #2114:
+// seven real 2021 sessions (six Family Camp weekends + one Family School) carry a
+// CampMinder GroupID that resolves to none of the cases in getSessionTypeFromGroupID's
+// switch (group cm_id 3062, "Camp Sessions" - CampMinder's catch-all bucket, unmapped in
+// every year 2017-2026, not just 2021). Because groupID > 0 was true, the old code took
+// getSessionTypeFromGroupID's "other" at face value and never consulted the name rules,
+// even though getSessionTypeFromName would have classified these names correctly.
+//
+// The fix: an unmapped GroupID (group-based result == "other") is not a confident
+// classification, so it falls through to getSessionTypeFromName instead of being
+// accepted as-is. A *mapped* group's result is never overridden - it only equals
+// sessionTypeOther when the switch actually hit its default arm.
+func TestClassifySessionType_UnmappedGroupFallsThroughToNameRules(t *testing.T) {
+	s := &SessionsSync{}
+
+	// cm_id 3062 ("Camp Sessions") is the real, historically stable unmapped group ID
+	// from the issue - present every year 2017-2026 and absent from the switch's cases.
+	const groupUnmapped = 3062
+
+	tests := []struct {
+		name     string
+		session  sessionInfo
+		groupID  int
+		expected string
+	}{
+		// The seven 2021 rows from the issue: unmapped group, but the name matches an
+		// existing getSessionTypeFromName rule. These are the 1,151 attendee rows that
+		// were hidden as "other" before the fix.
+		{
+			name:     "2021 Family Camp 1 falls through to family",
+			session:  sessionInfo{cmID: 501, name: "2021 Family Camp 1: Keshet LGBTQ Weekend"},
+			groupID:  groupUnmapped,
+			expected: sessionTypeFamily,
+		},
+		{
+			name:     "2021 Family Camp 2 falls through to family",
+			session:  sessionInfo{cmID: 502, name: "2021 Family Camp 2"},
+			groupID:  groupUnmapped,
+			expected: sessionTypeFamily,
+		},
+		{
+			name:     "2021 Family Camp 3 falls through to family",
+			session:  sessionInfo{cmID: 503, name: "2021 Family Camp 3: Labor Day Weekend"},
+			groupID:  groupUnmapped,
+			expected: sessionTypeFamily,
+		},
+		{
+			name:     "2021 Family Camp 4 falls through to family",
+			session:  sessionInfo{cmID: 504, name: "2021 Family Camp 4: Families of Color Weekend"},
+			groupID:  groupUnmapped,
+			expected: sessionTypeFamily,
+		},
+		{
+			name:     "2021 Family Camp 5 falls through to family",
+			session:  sessionInfo{cmID: 505, name: "2021 Family Camp 5"},
+			groupID:  groupUnmapped,
+			expected: sessionTypeFamily,
+		},
+		{
+			name:     "2021 Family Camp 6 falls through to family",
+			session:  sessionInfo{cmID: 506, name: "2021 Family Camp 6"},
+			groupID:  groupUnmapped,
+			expected: sessionTypeFamily,
+		},
+		{
+			name:     "2021 Family School falls through to school",
+			session:  sessionInfo{cmID: 507, name: "Family School Weekend"},
+			groupID:  groupUnmapped,
+			expected: "school",
+		},
+
+		// Regression guards: unmapped-group fall-through must not change classification
+		// for sessions that were already correct.
+		{
+			name:     "mapped family camp group is unaffected by the fall-through branch",
+			session:  sessionInfo{cmID: 601, name: "Family Camp 1"},
+			groupID:  groupFamilyCamp,
+			expected: sessionTypeFamily,
+		},
+		{
+			name:     "mapped adult group is unaffected by the fall-through branch",
+			session:  sessionInfo{cmID: 602, name: "Adults Unplugged"},
+			groupID:  groupAdult,
+			expected: sessionTypeAdult,
+		},
+		{
+			name: "summer_candidate still refines via refineSummerSessionType, not the name rules",
+			session: sessionInfo{
+				cmID: 603, name: "Session 2",
+				startDate: "2025-06-15", endDate: "2025-07-13",
+			},
+			groupID:  groupSummerCamp,
+			expected: sessionTypeMain,
+		},
+		{
+			name:     "no GroupID at all still uses name-based classification directly",
+			session:  sessionInfo{cmID: 604, name: "Family Camp 1"},
+			groupID:  0,
+			expected: sessionTypeFamily,
+		},
+		{
+			name:     "unmapped group with a name matching no rule still falls to other",
+			session:  sessionInfo{cmID: 605, name: "Some Unrelated Meeting"},
+			groupID:  groupUnmapped,
+			expected: sessionTypeOther,
+		},
+		// Issue #2114's fold-in checkbox: group 3062 also covers "Gold Rush" and
+		// "Staff Kids at Camp" in production, every year 2017-2026 (verified against
+		// prod, read-only). Neither name matches any getSessionTypeFromName rule, so the
+		// fall-through does NOT recover them - they remain "other" both before and after
+		// this fix. Left unmapped deliberately: their correct target type is a domain
+		// call the issue doesn't make, and group 3062 is a heterogeneous catch-all (it
+		// also holds a non-attendee governance session), so a blind name-pattern rule
+		// risks misclassifying it.
+		{
+			name:     "Gold Rush stays other - group 3062 fold-in, not recovered by name rules",
+			session:  sessionInfo{cmID: 606, name: "Gold Rush"},
+			groupID:  groupUnmapped,
+			expected: sessionTypeOther,
+		},
+		{
+			name:     "Staff Kids at Camp stays other - group 3062 fold-in, not recovered by name rules",
+			session:  sessionInfo{cmID: 607, name: "Staff Kids at Camp"},
+			groupID:  groupUnmapped,
+			expected: sessionTypeOther,
+		},
+	}
+
+	allSessionInfos := make([]sessionInfo, 0, len(tests))
+	for _, tt := range tests {
+		allSessionInfos = append(allSessionInfos, tt.session)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := s.classifySessionType(tt.session, tt.groupID, allSessionInfos)
+			if got != tt.expected {
+				t.Errorf("classifySessionType(%+v, groupID=%d) = %q, want %q",
+					tt.session, tt.groupID, got, tt.expected)
+			}
+		})
+	}
+}
+
 // TestRefineSummerSessionType tests that summer camp sessions are correctly classified
 // as main, ag, or embedded based on name and date patterns
 func TestRefineSummerSessionType(t *testing.T) {


### PR DESCRIPTION
## Problem

The seven 2021 Family Camp sessions classify as `other`, hiding 1,151 attendee rows.

The root cause is **not** the name rules. Those sessions carry a GroupID that the group switch does not recognise, so they hit its `default:` arm and return `sessionTypeOther` — a confident-looking answer that **never reaches the name rules at all**. Fixing the name rules alone would have changed nothing.

## Fix

Extracts classification into `classifySessionType(info, groupID, allSessionInfos)` and makes an **unrecognised** GroupID fall through to `getSessionTypeFromName` rather than terminating as `other`.

The distinction that makes this safe: a *recognised* group never returns `sessionTypeOther`, so a recognised group's result is still returned as-is and is unaffected. Only the unrecognised-group case — which was previously indistinguishable from a real classification — now falls through. Some CampMinder groups are catch-all buckets holding real, differently-typed programs that were never added to the switch; those are the cases this recovers.

## Tests

Table-driven, covering the seven 2021 groups **plus currently-correct years**, so the test proves classification did not regress rather than only proving the new case works.

## Post-merge operator step — required

This changes classification logic only. The stored data is not rewritten by merging it. After merge, an operator must:

1. **re-run the sessions sync** for the affected years, and
2. **rebuild `camper_history`**

Until both run, the 1,151 attendee rows stay hidden in the existing data.

## Related

Split from #2113 (the frontend camper-journey scope) so the frontend is not blocked on this re-sync. This PR touches **no** frontend file.

Closes #2114.
