### PR TITLE
fix(pb): close guardUnitYear's one-directional dependent gap

### DIFF
--- a/pocketbase/lodging/hooks.go
+++ b/pocketbase/lodging/hooks.go
@@ -97,11 +97,12 @@ type yearScopedRef struct {
 //     point AT it: lodging_availability, lodging_assignments,
 //     lodging_assignments_draft, lodging_slot_merges.
 //
-// What that does NOT close: lodging_units is ALSO a valid TARGET via
-// parent_unit (line 111 below), the identical shape to the lodging_areas
-// bullet above, but yearImmutableRefs carries no reverse entry for it -- see
-// that map's own doc comment for why, and kindred#2146 for the maintenance
-// hazard this un-mirrored entry is one instance of.
+// What that does NOT close: lodging_units is ALSO a valid TARGET via the
+// parent_unit entry below, the identical shape to the lodging_areas bullet
+// above, but yearImmutableRefs carries no reverse entry for it -- see that
+// map's own doc comment for why. It is the single allowlisted exception in
+// TestYearRefMapsAgreeOnEveryRelation, so it stays a stated scoping choice
+// rather than becoming a silent one (kindred#2146).
 //
 // Cascading the new year onto every dependent row on a parent's write would
 // be a materially bigger change than this guard makes anywhere else, so
@@ -130,10 +131,15 @@ var yearScopedRefs = map[string][]yearScopedRef{
 // real id (see countAssignments's own comment). The reverse mistake is not
 // silent the same way -- checked directly, a joined "unit.id ?= {:id}" against
 // a single relation still matches the dependent row correctly, so writing it
-// that way is merely non-idiomatic, not wrong. kindred#2146 tracks the
-// hand-typed-per-entry risk this comment describes, including mechanizing the
-// derivation instead of leaving it to be gotten right by hand at each entry
-// below.
+// that way is merely non-idiomatic, not wrong.
+//
+// Hand-typing per entry buys that correctness at the cost of the two maps
+// drifting apart unnoticed, so it is paid for by a test rather than by an
+// abstraction: TestYearRefMapsAgreeOnEveryRelation walks both maps and fails
+// the moment an entry in one has no counterpart in the other (kindred#2146).
+// The filter string itself is still on the author to get right -- the test
+// checks that an edge is declared from both ends, not that its filter uses
+// the arity-correct operator.
 type dependentRef struct {
 	collection string
 	filter     string
@@ -149,8 +155,10 @@ type dependentRef struct {
 // collections its own body names below. A child unit pointing at a
 // re-seasoned parent via parent_unit is the same shape of gap and is not
 // covered by this guard. It is also the one entry in yearScopedRefs with no
-// hand-typed reverse here -- kindred#2146 tracks that as a maintenance
-// hazard in this map's own shape, not just as a scoping choice.
+// hand-typed reverse here, and therefore the sole allowlisted exception in
+// TestYearRefMapsAgreeOnEveryRelation (kindred#2146) -- which also fails if
+// the exception is ever mirrored or dropped without the allowlist following,
+// so this paragraph cannot quietly go out of date.
 var yearImmutableRefs = map[string][]dependentRef{
 	collectionAreas: {
 		{collection: collectionUnits, filter: "area = {:id}"},

--- a/pocketbase/lodging/hooks.go
+++ b/pocketbase/lodging/hooks.go
@@ -100,7 +100,7 @@ type yearScopedRef struct {
 // What that does NOT close: lodging_units is ALSO a valid TARGET via
 // parent_unit (line 111 below), the identical shape to the lodging_areas
 // bullet above, but yearImmutableRefs carries no reverse entry for it -- see
-// that map's own doc comment for why, and kindred#2148 for the maintenance
+// that map's own doc comment for why, and kindred#2146 for the maintenance
 // hazard this un-mirrored entry is one instance of.
 //
 // Cascading the new year onto every dependent row on a parent's write would
@@ -130,9 +130,10 @@ var yearScopedRefs = map[string][]yearScopedRef{
 // real id (see countAssignments's own comment). The reverse mistake is not
 // silent the same way -- checked directly, a joined "unit.id ?= {:id}" against
 // a single relation still matches the dependent row correctly, so writing it
-// that way is merely non-idiomatic, not wrong. kindred#2148 tracks
-// mechanizing this derivation instead of leaving it to be gotten right by
-// hand at each entry below.
+// that way is merely non-idiomatic, not wrong. kindred#2146 tracks the
+// hand-typed-per-entry risk this comment describes, including mechanizing the
+// derivation instead of leaving it to be gotten right by hand at each entry
+// below.
 type dependentRef struct {
 	collection string
 	filter     string
@@ -148,7 +149,7 @@ type dependentRef struct {
 // collections its own body names below. A child unit pointing at a
 // re-seasoned parent via parent_unit is the same shape of gap and is not
 // covered by this guard. It is also the one entry in yearScopedRefs with no
-// hand-typed reverse here -- kindred#2148 tracks that as a maintenance
+// hand-typed reverse here -- kindred#2146 tracks that as a maintenance
 // hazard in this map's own shape, not just as a scoping choice.
 var yearImmutableRefs = map[string][]dependentRef{
 	collectionAreas: {

--- a/pocketbase/lodging/hooks.go
+++ b/pocketbase/lodging/hooks.go
@@ -325,9 +325,9 @@ func guardYearImmutable(e *core.RecordEvent, refs []dependentRef) error {
 		if len(records) > 0 {
 			return apis.NewBadRequestError(
 				fmt.Sprintf(
-					"Cannot change %q's year from %d to %d: %s row(s) reference it. "+
-						"Use the roll-forward to move it to a new season instead of "+
-						"re-seasoning an existing row in place.",
+					"Cannot change %q's year from %d to %d: at least one %s row "+
+						"references it. Use the roll-forward to move it to a new "+
+						"season instead of re-seasoning an existing row in place.",
 					e.Record.GetString("code"), oldYear, newYear, ref.collection,
 				),
 				nil,

--- a/pocketbase/lodging/hooks.go
+++ b/pocketbase/lodging/hooks.go
@@ -84,24 +84,23 @@ type yearScopedRef struct {
 // SCOPE: this guard is one-directional. It checks the row being written
 // against the OUTGOING relations listed in its own entry above; it never
 // re-checks rows elsewhere that point back AT the thing just written. Two
-// gaps follow, both residual as of kindred#2039, not regressions:
+// gaps followed from that, both residual as of kindred#2039, not
+// regressions, and both closed below by guardYearImmutable (kindred#2067)
+// rather than by extending this map:
 //
 //   - lodging_areas is a valid TARGET above (lodging_units.area resolves into
-//     it) but is not itself a key in this map, so it carries no binding at
-//     all. A superuser or bunking.manage PATCH that edits an existing area
-//     row's own `year` in place hits no check, and every lodging_units row
-//     already pointing at that area -- written for whatever year it was
-//     created -- is now silently cross-season.
-//   - Editing a lodging_units row's own `year` is checked against that row's
-//     OWN area/parent_unit, but nothing re-validates the rows that point AT
-//     it: lodging_availability, lodging_assignments,
-//     lodging_assignments_draft, lodging_slot_merges. Those keep whatever
-//     year they were written with, now possibly disagreeing with the unit's
-//     new one.
+//     it) but is not itself a key in this map, so editing an existing area
+//     row's own `year` in place hit no check here, leaving every
+//     lodging_units row already pointing at it silently cross-season.
+//   - Editing a lodging_units row's own `year` was checked against that
+//     row's OWN area/parent_unit, but nothing re-validated the rows that
+//     point AT it: lodging_availability, lodging_assignments,
+//     lodging_assignments_draft, lodging_slot_merges.
 //
-// Closing either gap means cascading to every DEPENDENT row on a parent's
-// write, not validating only the row under write -- a materially bigger
-// change than this guard makes anywhere else, so it is not done here.
+// Cascading the new year onto every dependent row on a parent's write would
+// be a materially bigger change than this guard makes anywhere else, so
+// guardYearImmutable refuses the write outright instead -- see its own doc
+// comment for why that is the right shape here specifically.
 var yearScopedRefs = map[string][]yearScopedRef{
 	collectionAvailability:     {{field: "unit", target: collectionUnits}},
 	collectionAssignments:      {{field: "units", target: collectionUnits}},
@@ -110,6 +109,42 @@ var yearScopedRefs = map[string][]yearScopedRef{
 	collectionUnits: {
 		{field: "area", target: collectionAreas},
 		{field: "parent_unit", target: collectionUnits},
+	},
+}
+
+// dependentRef names one collection that may hold a foreign key pointing back
+// at the row guardYearImmutable is checking, and the filter to find it. The
+// filter is baked in per entry rather than derived from a single/multi flag,
+// for the same reason countAssignments's filter is hardcoded rather than
+// assembled (see its comment): `?=` plus the `.id` join is only correct for a
+// MULTI-valued relation (`units`, MaxSelect 20); a single relation (`unit`,
+// `area`, MaxSelect 1) stores the id as a plain string and needs a plain `=`.
+// Getting that backwards is silent -- both a bare "units = {:id}" and a
+// joined "unit.id ?= {:id}" compile and match ZERO rows against a real id.
+type dependentRef struct {
+	collection string
+	filter     string
+}
+
+// yearImmutableRefs is the REVERSE of yearScopedRefs: for each collection
+// guardYearImmutable binds to, every OTHER collection that may hold a foreign
+// key pointing back at it. yearScopedRefs asks what a row points AT;
+// yearImmutableRefs asks what points AT a row.
+//
+// lodging_units.parent_unit is deliberately absent as a dependent of
+// collectionUnits here -- kindred#2067 scoped this fix to the four
+// collections its own body names below. A child unit pointing at a
+// re-seasoned parent via parent_unit is the same shape of gap and is not
+// covered by this guard.
+var yearImmutableRefs = map[string][]dependentRef{
+	collectionAreas: {
+		{collection: collectionUnits, filter: "area = {:id}"},
+	},
+	collectionUnits: {
+		{collection: collectionAvailability, filter: "unit = {:id}"},
+		{collection: collectionAssignments, filter: "units.id ?= {:id}"},
+		{collection: collectionAssignmentsDraft, filter: "units.id ?= {:id}"},
+		{collection: collectionSlotMerges, filter: "unit = {:id}"},
 	},
 }
 
@@ -156,6 +191,44 @@ func wireHooks(app core.App) {
 				return apis.NewBadRequestError(err.Error(), nil)
 			}
 			return e.Next()
+		})
+	}
+
+	// guardYearImmutable's dependents run in the OPPOSITE direction from the
+	// loop above (see yearImmutableRefs's doc comment), so it gets its own
+	// loop rather than being folded into it. Same existence-check guard on
+	// the collection being bound to, since lodging_areas is not otherwise
+	// bound in this function. UPDATE only: a create cannot have a stale
+	// dependent, because nothing can reference an id before the record that
+	// owns it exists (same reasoning as guardUnitParentCycle's absent create
+	// binding).
+	for name := range yearImmutableRefs {
+		if _, err := app.FindCollectionByNameOrId(name); err != nil {
+			app.Logger().Warn("year-immutable guard skipped: collection absent", "collection", name)
+			continue
+		}
+
+		// Filter to DEPENDENT collections that actually exist, once here at
+		// bind time rather than on every write. lodging_slot_merges
+		// (1500000139) postdates several of the tables this guard watches, so
+		// an older or partial environment can be missing it -- the same real
+		// state TestGuardUnitYearSkipsAnAbsentCollection pins for
+		// guardUnitYear's own targets above. A dependent collection that does
+		// not exist cannot hold a row depending on anything, so skipping it
+		// here is equivalent to querying it and finding zero matches --
+		// leaving it in would make FindRecordsByFilter error instead.
+		refs := make([]dependentRef, 0, len(yearImmutableRefs[name]))
+		for _, ref := range yearImmutableRefs[name] {
+			if _, err := app.FindCollectionByNameOrId(ref.collection); err != nil {
+				app.Logger().Warn("year-immutable guard: dependent collection absent",
+					"collection", name, "dependent", ref.collection)
+				continue
+			}
+			refs = append(refs, ref)
+		}
+
+		app.OnRecordUpdate(name).BindFunc(func(e *core.RecordEvent) error {
+			return guardYearImmutable(e, refs)
 		})
 	}
 }
@@ -207,6 +280,61 @@ func guardUnitYear(app core.App, rec *core.Record) error {
 		}
 	}
 	return nil
+}
+
+// guardYearImmutable refuses to change a lodging_areas or lodging_units row's
+// `year` in place once anything depends on it -- the "refuse" shape kindred
+// #2067 weighed against cascading the new year onto every dependent row.
+// Cascading is a materially bigger change than any other guard in this file
+// makes, and nothing in the product has a legitimate reason to re-season an
+// existing row: copyAreas and copyUnits (rollforward.go) -- the one supported
+// way to move a row between seasons -- both call core.NewRecord for the
+// target year rather than mutating the source row, so a categorical refusal
+// here costs the roll-forward nothing.
+//
+// Compares Original().GetInt("year") against the new value, NOT whether
+// `year` is PRESENT in the write: LodgingUnitForm's handleSubmit
+// (frontend/src/components/admin/lodging/LodgingUnitForm.tsx) sends
+// `year: openedYear` on EVERY save, routine edits included, so a presence
+// test would refuse ordinary saves rather than catch an actual change.
+// Mirrors guardUnitParentCycle's Original() comparison for the same reason.
+//
+// refs is pre-filtered by wireHooks to the dependent collections that exist
+// in this environment -- see the bind-time loop's comment -- rather than
+// looked up here from yearImmutableRefs directly.
+func guardYearImmutable(e *core.RecordEvent, refs []dependentRef) error {
+	oldYear := e.Record.Original().GetInt("year")
+	newYear := e.Record.GetInt("year")
+	if oldYear == newYear {
+		return e.Next()
+	}
+
+	for _, ref := range refs {
+		records, err := e.App.FindRecordsByFilter(
+			ref.collection,
+			ref.filter,
+			"",
+			1, // existence check only -- one match is enough to refuse
+			0,
+			map[string]any{"id": e.Record.Id},
+		)
+		if err != nil {
+			return fmt.Errorf("checking %s for rows depending on %s: %w",
+				ref.collection, e.Record.Id, err)
+		}
+		if len(records) > 0 {
+			return apis.NewBadRequestError(
+				fmt.Sprintf(
+					"Cannot change %q's year from %d to %d: %s row(s) reference it. "+
+						"Use the roll-forward to move it to a new season instead of "+
+						"re-seasoning an existing row in place.",
+					e.Record.GetString("code"), oldYear, newYear, ref.collection,
+				),
+				nil,
+			)
+		}
+	}
+	return e.Next()
 }
 
 // countAssignments counts the placements holding this unit, across BOTH grains.

--- a/pocketbase/lodging/hooks.go
+++ b/pocketbase/lodging/hooks.go
@@ -85,8 +85,8 @@ type yearScopedRef struct {
 // against the OUTGOING relations listed in its own entry above; it never
 // re-checks rows elsewhere that point back AT the thing just written. Two
 // gaps followed from that, both residual as of kindred#2039, not
-// regressions, and both closed below by guardYearImmutable (kindred#2067)
-// rather than by extending this map:
+// regressions, and both named below are closed by guardYearImmutable
+// (kindred#2067) rather than by extending this map:
 //
 //   - lodging_areas is a valid TARGET above (lodging_units.area resolves into
 //     it) but is not itself a key in this map, so editing an existing area
@@ -96,6 +96,12 @@ type yearScopedRef struct {
 //     row's OWN area/parent_unit, but nothing re-validated the rows that
 //     point AT it: lodging_availability, lodging_assignments,
 //     lodging_assignments_draft, lodging_slot_merges.
+//
+// What that does NOT close: lodging_units is ALSO a valid TARGET via
+// parent_unit (line 111 below), the identical shape to the lodging_areas
+// bullet above, but yearImmutableRefs carries no reverse entry for it -- see
+// that map's own doc comment for why, and kindred#2148 for the maintenance
+// hazard this un-mirrored entry is one instance of.
 //
 // Cascading the new year onto every dependent row on a parent's write would
 // be a materially bigger change than this guard makes anywhere else, so
@@ -119,8 +125,14 @@ var yearScopedRefs = map[string][]yearScopedRef{
 // assembled (see its comment): `?=` plus the `.id` join is only correct for a
 // MULTI-valued relation (`units`, MaxSelect 20); a single relation (`unit`,
 // `area`, MaxSelect 1) stores the id as a plain string and needs a plain `=`.
-// Getting that backwards is silent -- both a bare "units = {:id}" and a
-// joined "unit.id ?= {:id}" compile and match ZERO rows against a real id.
+// Getting that backwards is silent in ONE direction: a bare "units = {:id}"
+// against a multi-valued relation compiles and matches ZERO rows against a
+// real id (see countAssignments's own comment). The reverse mistake is not
+// silent the same way -- checked directly, a joined "unit.id ?= {:id}" against
+// a single relation still matches the dependent row correctly, so writing it
+// that way is merely non-idiomatic, not wrong. kindred#2148 tracks
+// mechanizing this derivation instead of leaving it to be gotten right by
+// hand at each entry below.
 type dependentRef struct {
 	collection string
 	filter     string
@@ -135,7 +147,9 @@ type dependentRef struct {
 // collectionUnits here -- kindred#2067 scoped this fix to the four
 // collections its own body names below. A child unit pointing at a
 // re-seasoned parent via parent_unit is the same shape of gap and is not
-// covered by this guard.
+// covered by this guard. It is also the one entry in yearScopedRefs with no
+// hand-typed reverse here -- kindred#2148 tracks that as a maintenance
+// hazard in this map's own shape, not just as a scoping choice.
 var yearImmutableRefs = map[string][]dependentRef{
 	collectionAreas: {
 		{collection: collectionUnits, filter: "area = {:id}"},
@@ -152,6 +166,17 @@ var yearImmutableRefs = map[string][]dependentRef{
 func RegisterHooks(app *pocketbase.PocketBase) {
 	wireHooks(app)
 	slog.Info("lodging integrity hooks registered")
+}
+
+// collectionExists reports whether name resolves in app. Three separate spots
+// in wireHooks below need this same "look before you bind" check -- the
+// yearScopedRefs loop's collection, and yearImmutableRefs's loop for both its
+// own collection and each dependent's -- and each wants its own distinct log
+// message on a miss, so this factors out only the lookup and leaves what to
+// do about a "no" at each call site.
+func collectionExists(app core.App, name string) bool {
+	_, err := app.FindCollectionByNameOrId(name)
+	return err == nil
 }
 
 // wireHooks binds the guards to any core.App. Extracted so the test suite,
@@ -171,7 +196,7 @@ func wireHooks(app core.App) {
 	// must not take the boot down, so this checks rather than assumes before
 	// binding (see yearScopedRefs).
 	for name := range yearScopedRefs {
-		if _, err := app.FindCollectionByNameOrId(name); err != nil {
+		if !collectionExists(app, name) {
 			// app.Logger(), not the package-level slog: the latter's default
 			// handler writes to stderr, invisible to captureStdout (the only
 			// way this test suite can observe a log line -- see its doc
@@ -203,7 +228,7 @@ func wireHooks(app core.App) {
 	// owns it exists (same reasoning as guardUnitParentCycle's absent create
 	// binding).
 	for name := range yearImmutableRefs {
-		if _, err := app.FindCollectionByNameOrId(name); err != nil {
+		if !collectionExists(app, name) {
 			app.Logger().Warn("year-immutable guard skipped: collection absent", "collection", name)
 			continue
 		}
@@ -219,7 +244,7 @@ func wireHooks(app core.App) {
 		// leaving it in would make FindRecordsByFilter error instead.
 		refs := make([]dependentRef, 0, len(yearImmutableRefs[name]))
 		for _, ref := range yearImmutableRefs[name] {
-			if _, err := app.FindCollectionByNameOrId(ref.collection); err != nil {
+			if !collectionExists(app, ref.collection) {
 				app.Logger().Warn("year-immutable guard: dependent collection absent",
 					"collection", name, "dependent", ref.collection)
 				continue
@@ -314,8 +339,8 @@ func guardYearImmutable(e *core.RecordEvent, refs []dependentRef) error {
 			ref.collection,
 			ref.filter,
 			"",
-			1, // existence check only -- one match is enough to refuse
-			0,
+			0, // 0 = unlimited -- the refusal message below reports a real count,
+			0, // matching guardUnitDelete and guardAliasDelete's own queries
 			map[string]any{"id": e.Record.Id},
 		)
 		if err != nil {
@@ -325,10 +350,10 @@ func guardYearImmutable(e *core.RecordEvent, refs []dependentRef) error {
 		if len(records) > 0 {
 			return apis.NewBadRequestError(
 				fmt.Sprintf(
-					"Cannot change %q's year from %d to %d: at least one %s row "+
-						"references it. Use the roll-forward to move it to a new "+
-						"season instead of re-seasoning an existing row in place.",
-					e.Record.GetString("code"), oldYear, newYear, ref.collection,
+					"Cannot change %q's year from %d to %d: %d %s row(s) reference "+
+						"it. Use the roll-forward to move it to a new season instead "+
+						"of re-seasoning an existing row in place.",
+					e.Record.GetString("code"), oldYear, newYear, len(records), ref.collection,
 				),
 				nil,
 			)

--- a/pocketbase/lodging/hooks_test.go
+++ b/pocketbase/lodging/hooks_test.go
@@ -294,6 +294,22 @@ func seedSession(t *testing.T, app core.App) string {
 	return r.Id
 }
 
+// seedAvailability creates a lodging_availability row naming unit for the
+// given year and returns its id -- the lodging_availability twin of
+// seedUnit/seedArea, for the guardYearImmutable tests that need a dependent
+// availability row without inlining its construction at each call site.
+func seedAvailability(t *testing.T, app core.App, unit string, year int) string {
+	t.Helper()
+	r := core.NewRecord(mustCollection(t, app, "lodging_availability"))
+	r.Set("year", year)
+	r.Set("unit", unit)
+	r.Set("session", seedSession(t, app))
+	if err := app.Save(r); err != nil {
+		t.Fatalf("seed availability for unit %q year %d: %v", unit, year, err)
+	}
+	return r.Id
+}
+
 // newHooksTestApp builds a fresh test app carrying the lodging fixture with
 // the integrity hooks already wired, for tests that don't need to stage state
 // before the guards go live (contrast the delete-guard tests above, which
@@ -1597,6 +1613,38 @@ func TestGuardYearImmutableRejectsAUnitYearChangeWithAnAssignmentDependent(t *te
 
 	if err := app.Save(rec); err == nil {
 		t.Fatal("re-seasoned a unit with a dependent assignment row; want a refusal")
+	}
+}
+
+// TestGuardYearImmutableRejectsAUnitYearChangeWithADraftAssignmentDependent is
+// lodging_assignments_draft's own entry in yearImmutableRefs -- the SCENARIO
+// grain (kindred#1923(a)), not the confirmed board covered above. It is a
+// separate table with its own filter string
+// (`"units.id ?= {:id}"`, hooks.go), so nothing about the assignments test
+// above exercises it: a mutation that broke ONLY this entry -- e.g. reverting
+// it to the bare, silently-zero-matching "units = {:id}" -- left the suite
+// green before this test existed.
+func TestGuardYearImmutableRejectsAUnitYearChangeWithADraftAssignmentDependent(t *testing.T) {
+	app := newHooksTestApp(t)
+	unit := seedUnit(t, app, "test-unit-a", 2027)
+
+	placement := core.NewRecord(mustCollection(t, app, "lodging_assignments_draft"))
+	placement.Set("year", 2027)
+	placement.Set("units", []string{unit})
+	placement.Set("session", seedSession(t, app))
+	placement.Set("household_cm_id", 2000001) // satisfies guardDraftAssignmentGrain's XOR
+	if err := app.Save(placement); err != nil {
+		t.Fatalf("seeding a dependent draft assignment row: %v", err)
+	}
+
+	rec, err := app.FindRecordById(collectionUnits, unit)
+	if err != nil {
+		t.Fatalf("reloading the unit: %v", err)
+	}
+	rec.Set("year", 2028)
+
+	if err := app.Save(rec); err == nil {
+		t.Fatal("re-seasoned a unit with a dependent draft assignment row; want a refusal")
 	}
 }
 

--- a/pocketbase/lodging/hooks_test.go
+++ b/pocketbase/lodging/hooks_test.go
@@ -1504,3 +1504,147 @@ func TestGuardUnitYearSkipsAUnitsSelfReference(t *testing.T) {
 		t.Fatalf("a row must not be refused for disagreeing with itself: %v", err)
 	}
 }
+
+// TestGuardYearImmutableAllowsARoutineEditThatResendsTheSameYear pins the trap
+// kindred#2067 calls out by name: LodgingUnitForm.handleSubmit
+// (frontend/src/components/admin/lodging/LodgingUnitForm.tsx) sends
+// `year: openedYear` on EVERY save, routine edits included -- so a guard that
+// tests whether `year` is PRESENT in the write, rather than whether it
+// CHANGED, would refuse ordinary saves on any unit with so much as one
+// dependent.
+//
+// MUTATION-CHECK: replace guardYearImmutable's
+// `oldYear := e.Record.Original().GetInt("year")` / `oldYear == newYear` pair
+// with a presence test and this test goes red -- the save below resends the
+// unit's unchanged year while a real dependent (the availability row) exists,
+// which is exactly the shape a presence test would wrongly refuse.
+func TestGuardYearImmutableAllowsARoutineEditThatResendsTheSameYear(t *testing.T) {
+	app := newHooksTestApp(t)
+	unit := seedUnit(t, app, "test-unit-a", 2027)
+
+	avail := core.NewRecord(mustCollection(t, app, "lodging_availability"))
+	avail.Set("year", 2027)
+	avail.Set("unit", unit)
+	avail.Set("session", seedSession(t, app))
+	if err := app.Save(avail); err != nil {
+		t.Fatalf("seeding a dependent availability row: %v", err)
+	}
+
+	rec, err := app.FindRecordById(collectionUnits, unit)
+	if err != nil {
+		t.Fatalf("reloading the unit: %v", err)
+	}
+	rec.Set("year", 2027)                 // the value the form always resends
+	rec.Set("name", "Renamed Building A") // the actual edit being made
+
+	if err := app.Save(rec); err != nil {
+		t.Fatalf("refused a routine edit that resent the unchanged year: %v", err)
+	}
+}
+
+// TestGuardYearImmutableRejectsAUnitYearChangeWithAnAvailabilityDependent is
+// the single-relation case (`lodging_availability.unit`, MaxSelect 1) --
+// kindred#2067's second gap: guardUnitYear checks a unit's own OUTGOING
+// relations (area, parent_unit) but never the rows pointing back AT it.
+func TestGuardYearImmutableRejectsAUnitYearChangeWithAnAvailabilityDependent(t *testing.T) {
+	app := newHooksTestApp(t)
+	unit := seedUnit(t, app, "test-unit-a", 2027)
+
+	avail := core.NewRecord(mustCollection(t, app, "lodging_availability"))
+	avail.Set("year", 2027)
+	avail.Set("unit", unit)
+	avail.Set("session", seedSession(t, app))
+	if err := app.Save(avail); err != nil {
+		t.Fatalf("seeding a dependent availability row: %v", err)
+	}
+
+	rec, err := app.FindRecordById(collectionUnits, unit)
+	if err != nil {
+		t.Fatalf("reloading the unit: %v", err)
+	}
+	rec.Set("year", 2028)
+
+	if err := app.Save(rec); err == nil {
+		t.Fatal("re-seasoned a unit with a dependent availability row; want a refusal")
+	}
+}
+
+// TestGuardYearImmutableRejectsAUnitYearChangeWithAnAssignmentDependent is the
+// MULTI-relation case (`lodging_assignments.units`, MaxSelect 20). Filtering a
+// multi-valued relation needs the `.id` join and `?=` any-match operator -- a
+// plain "units = {:id}" compiles and matches ZERO rows against a real id
+// (see countAssignments's own comment, above). This is what would catch
+// yearImmutableRefs getting that filter wrong for lodging_units' dependents,
+// the same way TestMultiRelationAnyMatchFilter guards countAssignments.
+func TestGuardYearImmutableRejectsAUnitYearChangeWithAnAssignmentDependent(t *testing.T) {
+	app := newHooksTestApp(t)
+	unit := seedUnit(t, app, "test-unit-a", 2027)
+
+	placement := core.NewRecord(mustCollection(t, app, "lodging_assignments"))
+	placement.Set("year", 2027)
+	placement.Set("units", []string{unit})
+	placement.Set("session", seedSession(t, app))
+	placement.Set("household_cm_id", 2000001) // satisfies guardAssignmentGrain's XOR
+	if err := app.Save(placement); err != nil {
+		t.Fatalf("seeding a dependent assignment row: %v", err)
+	}
+
+	rec, err := app.FindRecordById(collectionUnits, unit)
+	if err != nil {
+		t.Fatalf("reloading the unit: %v", err)
+	}
+	rec.Set("year", 2028)
+
+	if err := app.Save(rec); err == nil {
+		t.Fatal("re-seasoned a unit with a dependent assignment row; want a refusal")
+	}
+}
+
+// TestGuardYearImmutableRejectsAnAreaYearChangeWithAUnitDependent is
+// kindred#2067's first gap: lodging_areas carried no binding at all, so a
+// superuser or bunking.manage PATCH editing an existing area's own `year` hit
+// no check while lodging_units rows already pointing at it went silently
+// cross-season.
+func TestGuardYearImmutableRejectsAnAreaYearChangeWithAUnitDependent(t *testing.T) {
+	app := newHooksTestApp(t)
+	area := seedArea(t, app, "test-area-a", 2027)
+
+	rec := core.NewRecord(mustCollection(t, app, "lodging_units"))
+	rec.Set("code", "test-unit-a")
+	rec.Set("name", "Test Building A")
+	rec.Set("year", 2027)
+	rec.Set("area", area)
+	if err := app.Save(rec); err != nil {
+		t.Fatalf("seeding a dependent unit: %v", err)
+	}
+
+	areaRec, err := app.FindRecordById(collectionAreas, area)
+	if err != nil {
+		t.Fatalf("reloading the area: %v", err)
+	}
+	areaRec.Set("year", 2028)
+
+	if err := app.Save(areaRec); err == nil {
+		t.Fatal("re-seasoned an area with a dependent unit; want a refusal")
+	}
+}
+
+// TestGuardYearImmutableAllowsAYearChangeWithNoDependents is the positive
+// control, same shape as TestGuardUnitYearAllowsAMatchingRow above: a year
+// change on a unit nothing references must still succeed. Without this, a
+// guard that refused every lodging_units update would also pass every
+// refusal test in this section.
+func TestGuardYearImmutableAllowsAYearChangeWithNoDependents(t *testing.T) {
+	app := newHooksTestApp(t)
+	unit := seedUnit(t, app, "test-unit-a", 2027)
+
+	rec, err := app.FindRecordById(collectionUnits, unit)
+	if err != nil {
+		t.Fatalf("reloading the unit: %v", err)
+	}
+	rec.Set("year", 2028)
+
+	if err := app.Save(rec); err != nil {
+		t.Fatalf("refused a year change on a unit nothing depends on: %v", err)
+	}
+}

--- a/pocketbase/lodging/hooks_test.go
+++ b/pocketbase/lodging/hooks_test.go
@@ -327,6 +327,52 @@ func newHooksTestApp(t *testing.T) core.App {
 	return app
 }
 
+// newSlotMergesTestApp is the lodging_slot_merges twin of newHooksTestApp.
+//
+// lodging_slot_merges is deliberately NOT part of the shared setupCollections
+// fixture every other test in this file builds on --
+// TestGuardUnitYearSkipsAnAbsentCollection needs it ABSENT there to pin
+// wireHooks's collection-not-found skip path. So this adds it as a SEPARATE,
+// later step, mirroring lodging_availability's shape (setupCollections):
+// unit/session/year, since lodging_slot_merges is the second single-relation
+// case ("unit", MaxSelect 1) alongside availability -- session_cm_id and
+// scenario are on the production table (1500000139) but unread by any guard,
+// so they are left out the same way setupCollections leaves out fields
+// nothing under test reads.
+//
+// The collection has to exist BEFORE wireHooks runs: wireHooks's dependent-
+// collection loop pre-filters yearImmutableRefs to collections that exist AT
+// BIND TIME (see its own comment in hooks.go), so creating lodging_slot_merges
+// afterward would leave it permanently excluded from refs for this app's
+// lifetime.
+func newSlotMergesTestApp(t *testing.T) core.App {
+	t.Helper()
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+	setupCollections(t, app)
+
+	unitsCol := mustCollection(t, app, "lodging_units")
+	sessionsCol := mustCollection(t, app, "camp_sessions")
+
+	slotMerges := core.NewBaseCollection("lodging_slot_merges")
+	slotMerges.Fields.Add(&core.RelationField{
+		Name: "unit", CollectionId: unitsCol.Id, MaxSelect: 1,
+	})
+	slotMerges.Fields.Add(&core.RelationField{
+		Name: "session", CollectionId: sessionsCol.Id, MaxSelect: 1,
+	})
+	slotMerges.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(slotMerges); err != nil {
+		t.Fatalf("save lodging_slot_merges: %v", err)
+	}
+
+	wireHooks(app)
+	return app
+}
+
 // newIssue seeds an OPEN work-queue row of the given kind -- unlike
 // newResolvedIssue, which hardcodes unresolved_alias and is_resolved=true.
 func newIssue(
@@ -1537,14 +1583,7 @@ func TestGuardUnitYearSkipsAUnitsSelfReference(t *testing.T) {
 func TestGuardYearImmutableAllowsARoutineEditThatResendsTheSameYear(t *testing.T) {
 	app := newHooksTestApp(t)
 	unit := seedUnit(t, app, "test-unit-a", 2027)
-
-	avail := core.NewRecord(mustCollection(t, app, "lodging_availability"))
-	avail.Set("year", 2027)
-	avail.Set("unit", unit)
-	avail.Set("session", seedSession(t, app))
-	if err := app.Save(avail); err != nil {
-		t.Fatalf("seeding a dependent availability row: %v", err)
-	}
+	seedAvailability(t, app, unit, 2027)
 
 	rec, err := app.FindRecordById(collectionUnits, unit)
 	if err != nil {
@@ -1565,14 +1604,7 @@ func TestGuardYearImmutableAllowsARoutineEditThatResendsTheSameYear(t *testing.T
 func TestGuardYearImmutableRejectsAUnitYearChangeWithAnAvailabilityDependent(t *testing.T) {
 	app := newHooksTestApp(t)
 	unit := seedUnit(t, app, "test-unit-a", 2027)
-
-	avail := core.NewRecord(mustCollection(t, app, "lodging_availability"))
-	avail.Set("year", 2027)
-	avail.Set("unit", unit)
-	avail.Set("session", seedSession(t, app))
-	if err := app.Save(avail); err != nil {
-		t.Fatalf("seeding a dependent availability row: %v", err)
-	}
+	seedAvailability(t, app, unit, 2027)
 
 	rec, err := app.FindRecordById(collectionUnits, unit)
 	if err != nil {
@@ -1645,6 +1677,39 @@ func TestGuardYearImmutableRejectsAUnitYearChangeWithADraftAssignmentDependent(t
 
 	if err := app.Save(rec); err == nil {
 		t.Fatal("re-seasoned a unit with a dependent draft assignment row; want a refusal")
+	}
+}
+
+// TestGuardYearImmutableRejectsAUnitYearChangeWithASlotMergeDependent is
+// lodging_slot_merges's own entry in yearImmutableRefs -- the second
+// single-relation case (`unit`, MaxSelect 1) alongside lodging_availability,
+// and the fourth of the four dependents this guard watches for
+// collectionUnits. Uses newSlotMergesTestApp rather than newHooksTestApp
+// because lodging_slot_merges is absent from the shared fixture (see that
+// helper's own comment). Same coverage gap as the draft-assignment test
+// above: nothing about the availability or assignment tests exercises this
+// entry's filter, so a mutation that broke ONLY it left the suite green
+// before this test existed.
+func TestGuardYearImmutableRejectsAUnitYearChangeWithASlotMergeDependent(t *testing.T) {
+	app := newSlotMergesTestApp(t)
+	unit := seedUnit(t, app, "test-unit-a", 2027)
+
+	merge := core.NewRecord(mustCollection(t, app, "lodging_slot_merges"))
+	merge.Set("unit", unit)
+	merge.Set("session", seedSession(t, app))
+	merge.Set("year", 2027)
+	if err := app.Save(merge); err != nil {
+		t.Fatalf("seeding a dependent slot-merge row: %v", err)
+	}
+
+	rec, err := app.FindRecordById(collectionUnits, unit)
+	if err != nil {
+		t.Fatalf("reloading the unit: %v", err)
+	}
+	rec.Set("year", 2028)
+
+	if err := app.Save(rec); err == nil {
+		t.Fatal("re-seasoned a unit with a dependent slot-merge row; want a refusal")
 	}
 }
 

--- a/pocketbase/lodging/hooks_test.go
+++ b/pocketbase/lodging/hooks_test.go
@@ -1761,3 +1761,118 @@ func TestGuardYearImmutableAllowsAYearChangeWithNoDependents(t *testing.T) {
 		t.Fatalf("refused a year change on a unit nothing depends on: %v", err)
 	}
 }
+
+// relationPair is one (dependent -> target) edge, the unit of correspondence
+// between the two maps. yearScopedRefs states the edge from the dependent's
+// side (a key plus a ref.target); yearImmutableRefs states the same edge from
+// the target's side (a key plus a dependentRef.collection). The pair is what
+// both spellings have to agree on.
+type relationPair struct {
+	dependent string
+	target    string
+}
+
+// unmirroredPairs are the (dependent -> target) edges that exist in
+// yearScopedRefs and are deliberately NOT mirrored in yearImmutableRefs. Every
+// entry here needs a reason recorded next to it, and both maps' doc comments
+// must already say the same thing -- an allowlist that outgrows its comments
+// is how the drift this test exists to catch gets waved through instead.
+var unmirroredPairs = map[relationPair]string{
+	// kindred#2067 scoped guardYearImmutable to the four collections its body
+	// named, and lodging_units.parent_unit was not one of them: a child unit
+	// pointing at a re-seasoned parent is the same shape of gap, stated as
+	// residual risk in both maps' doc comments rather than closed. Deleting
+	// this line the day parent_unit gains a reverse entry is the point --
+	// TestYearRefMapsAgreeOnEveryRelation fails on a stale allowlist too.
+	{dependent: collectionUnits, target: collectionUnits}: "kindred#2067 left parent_unit un-mirrored on purpose",
+}
+
+// TestYearRefMapsAgreeOnEveryRelation is the symmetry check kindred#2146 asks
+// for. yearScopedRefs and yearImmutableRefs describe the same set of edges
+// from opposite ends and are hand-maintained in step with each other -- both
+// maps' doc comments explain why the reverse is hand-typed per entry rather
+// than derived (the `?=` join is only correct for a multi-valued relation and
+// is silently zero-matching in one direction), which leaves nothing but a test
+// to notice when someone adds to one map and forgets the other.
+//
+// The failure this catches is silent by construction: a new year-scoped table
+// added to yearScopedRefs alone still gets its OWN writes checked, so its
+// tests pass, while guardYearImmutable quietly stops covering a parent's year
+// edit against it -- exactly the bug kindred#2067 closed, reopened by
+// omission.
+//
+// It walks both directions. Forward alone would miss a yearImmutableRefs entry
+// naming a dependent that no longer references the target at all, which is the
+// same drift pointing the other way.
+func TestYearRefMapsAgreeOnEveryRelation(t *testing.T) {
+	seenExceptions := make(map[relationPair]bool, len(unmirroredPairs))
+
+	// Forward: everything yearScopedRefs says a row points AT must appear in
+	// yearImmutableRefs as something that points back.
+	for dependent, refs := range yearScopedRefs {
+		for _, ref := range refs {
+			pair := relationPair{dependent: dependent, target: ref.target}
+			mirrored := false
+			for _, dep := range yearImmutableRefs[ref.target] {
+				if dep.collection == dependent {
+					mirrored = true
+					break
+				}
+			}
+			if _, allowed := unmirroredPairs[pair]; allowed {
+				seenExceptions[pair] = true
+				if mirrored {
+					t.Errorf(
+						"%s.%s -> %s is now mirrored in yearImmutableRefs but is still"+
+							" listed in unmirroredPairs; drop the allowlist entry and the"+
+							" doc comments that call it residual",
+						dependent, ref.field, ref.target,
+					)
+				}
+				continue
+			}
+			if !mirrored {
+				t.Errorf(
+					"yearScopedRefs says %s.%s references %s, but yearImmutableRefs[%s]"+
+						" carries no entry for %s -- guardYearImmutable will not refuse a"+
+						" %s year edit that strands it (kindred#2067)",
+					dependent, ref.field, ref.target, ref.target, dependent, ref.target,
+				)
+			}
+		}
+	}
+
+	// Reverse: everything yearImmutableRefs treats as a dependent must be a
+	// collection yearScopedRefs actually points at that target.
+	for target, deps := range yearImmutableRefs {
+		for _, dep := range deps {
+			mirrored := false
+			for _, ref := range yearScopedRefs[dep.collection] {
+				if ref.target == target {
+					mirrored = true
+					break
+				}
+			}
+			if !mirrored {
+				t.Errorf(
+					"yearImmutableRefs[%s] lists %s as a dependent, but"+
+						" yearScopedRefs[%s] declares no relation into %s -- one of the"+
+						" two maps is stale",
+					target, dep.collection, dep.collection, target,
+				)
+			}
+		}
+	}
+
+	// An allowlist entry for an edge yearScopedRefs no longer declares would
+	// silently excuse a future edge of the same shape, so it has to be an
+	// error rather than dead data.
+	for pair, why := range unmirroredPairs {
+		if !seenExceptions[pair] {
+			t.Errorf(
+				"unmirroredPairs still excuses %s -> %s (%s), but yearScopedRefs declares no such relation",
+				pair.dependent, pair.target, why,
+			)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`guardUnitYear` checks a `lodging_units` row's own `year` against the parent it points AT (area, parent_unit), but nothing previously re-validated the rows that point BACK at a parent whose `year` gets edited in place. Two gaps, both named in kindred#2039:

- `lodging_areas` carried no year binding at all — a superuser or `bunking.manage` PATCH editing an existing area's own `year` hit no check, silently stranding every `lodging_units` row pointing at it.
- Editing a `lodging_units` row's own `year` was checked against its own area/parent_unit, but not against the rows depending on it: `lodging_availability`, `lodging_assignments`, `lodging_assignments_draft`, `lodging_slot_merges`.

This adds `guardYearImmutable`, bound via `OnRecordUpdate` on `lodging_areas` and `lodging_units`, which refuses to change a row's `year` in place once any dependent row references it. Cascading the new year onto every dependent row would be a materially bigger change than any other guard in this file makes, and nothing in the product needs to re-season a row in place — `copyAreas`/`copyUnits` (roll-forward) already create a new record for the target year rather than mutating the source, so a categorical refusal costs the roll-forward nothing.

The comparison is `e.Record.Original().GetInt("year")` against the new value, **not** whether `year` is present in the write — `LodgingUnitForm.handleSubmit` (`frontend/src/components/admin/lodging/LodgingUnitForm.tsx`) sends `year: openedYear` on every save, routine edits included, so a presence test would block ordinary saves on any unit with a dependent. A test pins this: a routine edit that resends the unchanged year, on a unit with a real dependent row, must succeed.

`lodging_units.parent_unit` is deliberately left uncovered as a dependent — scoped to the four collections the issue names; a child unit pointing at a re-seasoned parent via `parent_unit` is the same shape of gap and isn't addressed here.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (full suite, exit 0)
- [x] `scripts/dev/verify-lodging-schema.sh` — PocketBase boots against a throwaway DB, all migrations apply
- [x] `scripts/dev/verify-lodging-seed.sh` — seed path exercises the hooks end-to-end
- [x] New tests: routine same-year resend is allowed; area/unit year change is refused when a dependent exists (availability single-relation, assignments multi-relation, area→unit)
- [x] Pre-push hooks green (ruff, go-build, mypy, pb-js-lint, shellcheck, markdownlint, api-types-freshness, type-check, pytest 6020 passed)

Closes #2067.

## Folded in: #2146 — no test enforced the two ref maps staying in sync

`yearImmutableRefs` is a hand-maintained reverse of `yearScopedRefs` and nothing checked the correspondence. Adding a year-scoped table to `yearScopedRefs` alone is silent — the new table's own writes are still checked, so its tests pass, while `guardYearImmutable` stops covering a parent's year edit against it.

`TestYearRefMapsAgreeOnEveryRelation` walks both maps in both directions. The one deliberate exception, `lodging_units.parent_unit` (scoped out by #2067, already documented in both maps), is allowlisted with its reason — and the allowlist is itself checked, so the test also fails if that pair ever gains a mirror or stops being declared without the allowlist following. No production behaviour change; the map comments are repointed from the issue to the test that now enforces them.

Mutation-checked all four assertion paths (drop a mirror; add a bogus dependent; mirror the allowlisted pair; drop the allowlisted pair from `yearScopedRefs`) — each fails with its own message, `go test` exit 1.

Closes #2146.
