### PR TITLE
feat(frontend): family card leads with the campers; the adults take the grey line and the salutation goes

### DIFF
--- a/frontend/src/components/weekend/FamilyCard.test.tsx
+++ b/frontend/src/components/weekend/FamilyCard.test.tsx
@@ -74,9 +74,8 @@ function confirmedUnit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow 
 const REQUEST_TEXT = 'Please put us near the Garcia family, and we need a ground-floor room.'
 
 describe('FamilyCard — what it shows', () => {
-  it('names the household and its size', () => {
+  it('shows the party size', () => {
     render(<FamilyCard party={party()} onOpen={vi.fn()} />)
-    expect(screen.getByText('Johnson')).toBeInTheDocument()
     expect(screen.getByText('4')).toBeInTheDocument()
   })
 
@@ -88,23 +87,82 @@ describe('FamilyCard — what it shows', () => {
     expect(screen.getByText(/5/)).toBeInTheDocument()
   })
 
-  it('renders age in CampMinder yy.mm format through displayCampMinderAge', () => {
-    // kindred#2088: `String(child.age)` printed a raw float verbatim (or
-    // truncated one on the backend). Both sites must go through the shared
-    // helper summer already uses -- two-digit months, no leading-zero years.
+  it('truncates the child’s age to whole years, never rounding up', () => {
+    // kindred#2074: `persons.age` is CampMinder's yy.mm; months never exceed
+    // .11, so a child of 6.11 -- six years, eleven months -- is six, not
+    // seven. The card truncates; only the detail panel keeps `(Y)Y.MM`.
     render(
       <FamilyCard
         party={party({
           children: [
-            { person_cm_id: 9001, display_name: 'Noah', age: 1.5, grade: 0 },
+            { person_cm_id: 9001, display_name: 'Noah', age: 6.11, grade: 0 },
             { person_cm_id: 9002, display_name: 'Ava', age: 0.06, grade: 0 },
           ],
         })}
         onOpen={vi.fn()}
       />
     )
-    expect(screen.getByText('Noah (1.50)')).toBeInTheDocument()
-    expect(screen.getByText('Ava (0.06)')).toBeInTheDocument()
+    expect(screen.getByText('Noah (6)')).toBeInTheDocument()
+    expect(screen.getByText('Ava (0)')).toBeInTheDocument()
+    expect(screen.queryByText(/Noah \(7\)/)).not.toBeInTheDocument()
+  })
+
+  it('shows the attending adults on the grey line beneath the children', () => {
+    render(
+      <FamilyCard
+        party={party({
+          adults: [
+            { adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' },
+            { adult_number: 2, display_name: 'Liam Johnson', relationship: 'Father' },
+          ],
+        })}
+        onOpen={vi.fn()}
+      />
+    )
+    expect(screen.getByText(/Emma Johnson/)).toBeInTheDocument()
+    expect(screen.getByText(/Liam Johnson/)).toBeInTheDocument()
+  })
+
+  it('drops blank adult slots -- family_camp_adults is not a fixed five', () => {
+    render(
+      <FamilyCard
+        party={party({
+          adults: [
+            { adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' },
+            { adult_number: 2, display_name: '', relationship: '' },
+          ],
+        })}
+        onOpen={vi.fn()}
+      />
+    )
+    const adultsLine = screen.getByText(/Emma Johnson/).parentElement
+    expect(adultsLine).toHaveTextContent('Emma Johnson')
+    expect(adultsLine).not.toHaveTextContent('·')
+  })
+
+  it('removes the household salutation from the card entirely', () => {
+    // kindred#2074: display_name is CampMinder's mailing_title, which
+    // disagrees with the actual adult list on 26.7% of 2026 households.
+    // Deletion, not a demotion to the grey line -- the grey line is adults.
+    render(<FamilyCard party={party({ display_name: 'Mr. and Mrs. Johnson' })} onOpen={vi.fn()} />)
+    expect(screen.queryByText('Mr. and Mrs. Johnson')).not.toBeInTheDocument()
+  })
+
+  it('keeps the guest’s own name for an adult weekend party (person grain)', () => {
+    // Person-grain parties are one guest, not a household -- there is no
+    // untrustworthy salutation to remove, so the identity line is unchanged.
+    render(
+      <FamilyCard
+        party={party({
+          grain: 'person',
+          display_name: 'Priya Patel',
+          children: [],
+          adults: [{ adult_number: 1, display_name: 'Priya Patel' }],
+        })}
+        onOpen={vi.fn()}
+      />
+    )
+    expect(screen.getByTestId('family-card-name')).toHaveTextContent('Priya Patel')
   })
 
   it('omits an age it does not have rather than inventing one', () => {
@@ -358,11 +416,11 @@ describe('FamilyCardPreview — the drag overlay', () => {
     expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 
-  it('shows the same children and ages the real card does', () => {
+  it('shows the same children and truncated ages the real card does', () => {
     // It is the card being dragged, so it has to LOOK like the card. Sharing
     // the body is what keeps that true without a second copy to maintain.
     render(<FamilyCardPreview party={party()} />)
-    expect(screen.getByText(/Noah Johnson \(8\.00\)/)).toBeInTheDocument()
+    expect(screen.getByText(/Noah Johnson \(8\)/)).toBeInTheDocument()
   })
 })
 
@@ -447,18 +505,28 @@ describe('FamilyCard — summer’s type scale', () => {
     expect(arbitraryTextSizes(container)).toEqual([])
   })
 
-  it('names the household at summer’s CamperCard name size', () => {
+  it('sets the card’s bold identity line at summer’s CamperCard name size', () => {
     render(<FamilyCard party={party()} onOpen={vi.fn()} />)
     expect(screen.getByTestId('family-card-name')).toHaveClass('text-sm')
   })
 
-  it('sets the children line one step below the name, as summer does', () => {
-    render(<FamilyCard party={party()} onOpen={vi.fn()} />)
-    // Each child gets its own `<span>`, so walk up one to the line that holds
+  it('sets the adults line one step below the children, as summer steps its secondary line', () => {
+    render(
+      <FamilyCard
+        party={party({
+          adults: [
+            { adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' },
+            { adult_number: 2, display_name: 'Liam Johnson', relationship: 'Father' },
+          ],
+        })}
+        onOpen={vi.fn()}
+      />
+    )
+    // Each adult gets its own `<span>`, so walk up one to the line that holds
     // them all — asserting on the inner span would pin nothing, since the size
     // is set on the line.
-    const line = screen.getByText(/Noah Johnson \(8\.00\)/).parentElement
-    expect(line).toHaveTextContent('Ava Johnson (5.00)')
+    const line = screen.getByText(/Emma Johnson/).parentElement
+    expect(line).toHaveTextContent('Liam Johnson')
     expect(line).toHaveClass('text-xs')
   })
 

--- a/frontend/src/components/weekend/FamilyCard.test.tsx
+++ b/frontend/src/components/weekend/FamilyCard.test.tsx
@@ -165,6 +165,45 @@ describe('FamilyCard — what it shows', () => {
     expect(screen.getByTestId('family-card-name')).toHaveTextContent('Priya Patel')
   })
 
+  it('falls back rather than leaving a blank identity line for a nameless child', () => {
+    // `_person_display_name` (unlike `_household_display_name`) has no
+    // fallback and returns '' when a synced person has no preferred_name,
+    // first_name, or last_name on file. Before the salutation was removed
+    // this was invisible -- the bold line came from `display_name`, never
+    // from a child's own name. Now it is the ONLY source for a household
+    // card, so a blank name must not leave the button with no accessible
+    // text at all.
+    render(
+      <FamilyCard
+        party={party({
+          children: [{ person_cm_id: 9001, display_name: '', age: 6, grade: 1 }],
+        })}
+        onOpen={vi.fn()}
+      />
+    )
+    expect(screen.getByTestId('family-card-name')).toHaveTextContent('Unnamed camper (6)')
+  })
+
+  it('renders a person-grain party’s own children, with CampMinder precision, not truncated', () => {
+    // Person-grain (adult weekend) parties don't carry children under
+    // today's sync (`_build_person_parties` never sets the field), but the
+    // grey line's fallback for the rare case it does is real code, not dead
+    // weight -- it should render, and keep the full (Y)Y.MM the household
+    // branch above deliberately does NOT use.
+    render(
+      <FamilyCard
+        party={party({
+          grain: 'person',
+          display_name: 'Priya Patel',
+          adults: [{ adult_number: 1, display_name: 'Priya Patel' }],
+          children: [{ person_cm_id: 9001, display_name: 'Kai Patel', age: 6.11, grade: 1 }],
+        })}
+        onOpen={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Kai Patel (6.11)')).toBeInTheDocument()
+  })
+
   it('omits an age it does not have rather than inventing one', () => {
     render(
       <FamilyCard

--- a/frontend/src/components/weekend/FamilyCard.test.tsx
+++ b/frontend/src/components/weekend/FamilyCard.test.tsx
@@ -204,6 +204,53 @@ describe('FamilyCard — what it shows', () => {
     expect(screen.getByText('Kai Patel (6.11)')).toBeInTheDocument()
   })
 
+  it('falls back for a nameless child on the person-grain grey line too', () => {
+    // The two child lists share one renderer (kindred#2153), so the blank-name
+    // fallback pinned above for the household bold line must hold here as
+    // well. Pinned separately because a shared renderer is exactly the thing a
+    // later session could re-split, and this branch would go quiet first.
+    render(
+      <FamilyCard
+        party={party({
+          grain: 'person',
+          display_name: 'Priya Patel',
+          adults: [{ adult_number: 1, display_name: 'Priya Patel' }],
+          children: [{ person_cm_id: 9001, display_name: '', age: 6.11, grade: 1 }],
+        })}
+        onOpen={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Unnamed camper (6.11)')).toBeInTheDocument()
+  })
+
+  it('separates multiple children with a middot on both child lines', () => {
+    // The separator is the one piece of the child list with no other test
+    // holding it, and it is shared by both lines.
+    const { unmount } = render(<FamilyCard party={party()} onOpen={vi.fn()} />)
+    expect(screen.getByTestId('family-card-name')).toHaveTextContent(
+      'Noah Johnson (8) · Ava Johnson (5)'
+    )
+    unmount()
+
+    render(
+      <FamilyCard
+        party={party({
+          grain: 'person',
+          display_name: 'Priya Patel',
+          adults: [{ adult_number: 1, display_name: 'Priya Patel' }],
+          children: [
+            { person_cm_id: 9001, display_name: 'Kai Patel', age: 6.11, grade: 1 },
+            { person_cm_id: 9002, display_name: 'Mia Patel', age: 4.02, grade: 0 },
+          ],
+        })}
+        onOpen={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Kai Patel (6.11)').parentElement).toHaveTextContent(
+      'Kai Patel (6.11) · Mia Patel (4.02)'
+    )
+  })
+
   it('omits an age it does not have rather than inventing one', () => {
     render(
       <FamilyCard

--- a/frontend/src/components/weekend/FamilyCard.tsx
+++ b/frontend/src/components/weekend/FamilyCard.tsx
@@ -44,7 +44,7 @@ import { useDraggable } from '@dnd-kit/core'
 import { Repeat, Star, Users } from 'lucide-react'
 import { Fragment } from 'react'
 
-import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+import type { LodgingUnitRow, PartyChildRow, RosterPartyRow } from '../../types/lodging'
 import { displayCampMinderAge, displayTruncatedAge } from '../../utils/age'
 import { partySize, SHARE_WORDING, shareWordingChip } from './boardLayout'
 import { partyKey } from './partyKey'
@@ -100,6 +100,54 @@ function Chip({ label, tone }: { label: string; tone: ChipTone }) {
 }
 
 /**
+ * A party's children as one `Name (age) · Name (age)` run.
+ *
+ * `FamilyCardBody` renders a child list TWICE — the household bold identity
+ * line and the person-grain grey secondary line — and the two differ only in
+ * which age formatter they call and what wraps them. Everything else (the key
+ * strategy, the separator, the missing-age omission, the blank-name fallback)
+ * is one decision each, and each was drifting toward being made in two places:
+ * the blank-name fallback had to be hand-applied to both copies in kindred#2074.
+ * Shared for the same reason `FamilyCardPreview` shares `FamilyCardBody` —
+ * so the copies cannot drift apart (kindred#2153).
+ *
+ * The caller supplies the wrapper, because the two sites want different ones:
+ * the bold line's span is also the non-household branch's, and the grey line's
+ * exists only when there are children to put in it.
+ *
+ * @param formatAge - `displayTruncatedAge` on the bold line (whole years are
+ *   the point of a similar-ages match), `displayCampMinderAge` on the grey one.
+ */
+function ChildList({
+  children,
+  formatAge,
+}: {
+  children: PartyChildRow[]
+  formatAge: (age: number) => string
+}) {
+  return (
+    <>
+      {children.map((child, index) => (
+        <Fragment key={String(child.person_cm_id ?? index)}>
+          {index > 0 && ' · '}
+          {/* An age we do not have is omitted, never rendered as 0.
+              A blank name (no first/preferred/last name on file --
+              `_person_display_name` has no fallback the way
+              `_household_display_name` does) falls back rather than
+              leaving this segment, or the whole card when it's the
+              only child, with no accessible text at all. */}
+          <span>
+            {child.age === null || child.age === undefined
+              ? child.display_name || 'Unnamed camper'
+              : `${child.display_name || 'Unnamed camper'} (${formatAge(child.age)})`}
+          </span>
+        </Fragment>
+      ))}
+    </>
+  )
+}
+
+/**
  * Everything the card SHOWS, with nothing about how it is picked up.
  *
  * Split out so the drag overlay can render the card without dnd-kit — see
@@ -147,24 +195,11 @@ function FamilyCardBody({
           // squeeze it rather than wrap or clip.
           className="text-foreground min-w-0 flex-1 truncate text-sm leading-tight font-semibold"
         >
-          {isHousehold
-            ? children.map((child, index) => (
-                <Fragment key={String(child.person_cm_id ?? index)}>
-                  {index > 0 && ' · '}
-                  {/* An age we do not have is omitted, never rendered as 0.
-                      A blank name (no first/preferred/last name on file --
-                      `_person_display_name` has no fallback the way
-                      `_household_display_name` does) falls back rather than
-                      leaving this segment, or the whole card when it's the
-                      only child, with no accessible text at all. */}
-                  <span>
-                    {child.age === null || child.age === undefined
-                      ? child.display_name || 'Unnamed camper'
-                      : `${child.display_name || 'Unnamed camper'} (${displayTruncatedAge(child.age)})`}
-                  </span>
-                </Fragment>
-              ))
-            : party.display_name}
+          {isHousehold ? (
+            <ChildList children={children} formatAge={displayTruncatedAge} />
+          ) : (
+            party.display_name
+          )}
         </span>
         <span className="text-muted-foreground ml-auto inline-flex items-center gap-0.5 text-xs tabular-nums">
           <Users className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
@@ -189,18 +224,7 @@ function FamilyCardBody({
           // rare person-grain party that carries children of its own.
           children.length > 0 && (
             <span className="text-muted-foreground text-xs leading-snug">
-              {children.map((child, index) => (
-                <Fragment key={String(child.person_cm_id ?? index)}>
-                  {index > 0 && ' · '}
-                  {/* An age we do not have is omitted, never rendered as 0.
-                      Same blank-name fallback as the household branch above. */}
-                  <span>
-                    {child.age === null || child.age === undefined
-                      ? child.display_name || 'Unnamed camper'
-                      : `${child.display_name || 'Unnamed camper'} (${displayCampMinderAge(child.age)})`}
-                  </span>
-                </Fragment>
-              ))}
+              <ChildList children={children} formatAge={displayCampMinderAge} />
             </span>
           )}
 

--- a/frontend/src/components/weekend/FamilyCard.tsx
+++ b/frontend/src/components/weekend/FamilyCard.tsx
@@ -23,16 +23,29 @@
  * `FamilyCard.test.tsx` pins all three as ABSENCES, because each is exactly
  * the kind of thing a later session adds back helpfully.
  *
- * What IS here: the household name, the party size, the children with their
- * ages — ages are the entire point of a "similar ages" match — and the housing
- * chips the fit check actually judges.
+ * What IS here: the children lead, bold, with truncated whole-year ages —
+ * ages are the entire point of a "similar ages" match — the party size, the
+ * attending adults one line down in grey, and the housing chips the fit
+ * check actually judges.
+ *
+ * ## The household salutation is gone, not demoted (kindred#2074)
+ *
+ * The bold line used to be `party.display_name`, which is CampMinder's
+ * `mailing_title` -- a postal salutation, not a party manifest. Measured
+ * against 2026's 382 rostered households, it disagreed with the actual adult
+ * list on 26.7%, in both directions: naming an adult who wasn't attending,
+ * and naming only one adult when two were. A two-directional failure can't
+ * be repaired inside the string, so it was deleted rather than sanitised —
+ * see the issue for the full accounting. This only applies to household-grain
+ * parties: a person-grain party (an adult weekend guest) IS the identity, so
+ * its `display_name` stays.
  */
 import { useDraggable } from '@dnd-kit/core'
 import { Repeat, Star, Users } from 'lucide-react'
 import { Fragment } from 'react'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
-import { displayCampMinderAge } from '../../utils/age'
+import { displayCampMinderAge, displayTruncatedAge } from '../../utils/age'
 import { partySize, SHARE_WORDING, shareWordingChip } from './boardLayout'
 import { partyKey } from './partyKey'
 import { ATTENTION_LABEL, partyAttention } from './rosterAttention'
@@ -104,6 +117,14 @@ function FamilyCardBody({
 }) {
   const flags = party.flags ?? {}
   const children = party.children ?? []
+  // family_camp_adults stores adult slots 1-5 as separate rows per household,
+  // and a slot with no name on file is not an attending adult -- CampMinder
+  // leaves it blank rather than omitting the row. Filtered here, at render,
+  // rather than upstream, so "not a fixed five" stays true of what's shown.
+  const attendingAdults = (party.adults ?? []).filter((adult) =>
+    Boolean(adult.display_name?.trim())
+  )
+  const isHousehold = party.grain === 'household'
   const attention = partyAttention(party, unit)
   const proximity = party.share?.proximity ?? []
   // `similar_ages` ACCOMPANIES `with`; it never replaces it. One chip covering
@@ -119,7 +140,19 @@ function FamilyCardBody({
           data-testid="family-card-name"
           className="text-foreground text-sm leading-tight font-semibold"
         >
-          {party.display_name}
+          {isHousehold
+            ? children.map((child, index) => (
+                <Fragment key={String(child.person_cm_id ?? index)}>
+                  {index > 0 && ' · '}
+                  {/* An age we do not have is omitted, never rendered as 0. */}
+                  <span>
+                    {child.age === null || child.age === undefined
+                      ? child.display_name
+                      : `${String(child.display_name)} (${displayTruncatedAge(child.age)})`}
+                  </span>
+                </Fragment>
+              ))
+            : party.display_name}
         </span>
         <span className="text-muted-foreground ml-auto inline-flex items-center gap-0.5 text-xs tabular-nums">
           <Users className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
@@ -127,21 +160,36 @@ function FamilyCardBody({
         </span>
       </span>
 
-      {children.length > 0 && (
-        <span className="text-muted-foreground text-xs leading-snug">
-          {children.map((child, index) => (
-            <Fragment key={String(child.person_cm_id ?? index)}>
-              {index > 0 && ' · '}
-              {/* An age we do not have is omitted, never rendered as 0. */}
-              <span>
-                {child.age === null || child.age === undefined
-                  ? child.display_name
-                  : `${String(child.display_name)} (${displayCampMinderAge(child.age)})`}
-              </span>
-            </Fragment>
-          ))}
-        </span>
-      )}
+      {isHousehold
+        ? attendingAdults.length > 0 && (
+            <span className="text-muted-foreground text-xs leading-snug">
+              {attendingAdults.map((adult, index) => (
+                <Fragment key={String(adult.adult_number ?? index)}>
+                  {index > 0 && ' · '}
+                  <span>{adult.display_name}</span>
+                </Fragment>
+              ))}
+            </span>
+          )
+        : // Person-grain (adult weekend) parties are a single guest identified
+          // by the bold line above, not a household -- so there is no separate
+          // adult list. The old children-with-CampMinder-age line stays for the
+          // rare person-grain party that carries children of its own.
+          children.length > 0 && (
+            <span className="text-muted-foreground text-xs leading-snug">
+              {children.map((child, index) => (
+                <Fragment key={String(child.person_cm_id ?? index)}>
+                  {index > 0 && ' · '}
+                  {/* An age we do not have is omitted, never rendered as 0. */}
+                  <span>
+                    {child.age === null || child.age === undefined
+                      ? child.display_name
+                      : `${String(child.display_name)} (${displayCampMinderAge(child.age)})`}
+                  </span>
+                </Fragment>
+              ))}
+            </span>
+          )}
 
       <span className="flex flex-wrap gap-1">
         {/* The needs a cabin field can actually answer — the same two the fit

--- a/frontend/src/components/weekend/FamilyCard.tsx
+++ b/frontend/src/components/weekend/FamilyCard.tsx
@@ -117,14 +117,16 @@ function FamilyCardBody({
 }) {
   const flags = party.flags ?? {}
   const children = party.children ?? []
+  const isHousehold = party.grain === 'household'
   // family_camp_adults stores adult slots 1-5 as separate rows per household,
   // and a slot with no name on file is not an attending adult -- CampMinder
   // leaves it blank rather than omitting the row. Filtered here, at render,
   // rather than upstream, so "not a fixed five" stays true of what's shown.
-  const attendingAdults = (party.adults ?? []).filter((adult) =>
-    Boolean(adult.display_name?.trim())
-  )
-  const isHousehold = party.grain === 'household'
+  // Only the household branch reads this, so it is skipped for a person-grain
+  // card rather than computed and discarded on every render.
+  const attendingAdults = isHousehold
+    ? (party.adults ?? []).filter((adult) => Boolean(adult.display_name?.trim()))
+    : []
   const attention = partyAttention(party, unit)
   const proximity = party.share?.proximity ?? []
   // `similar_ages` ACCOMPANIES `with`; it never replaces it. One chip covering
@@ -138,17 +140,27 @@ function FamilyCardBody({
       <span className="flex items-baseline gap-1.5">
         <span
           data-testid="family-card-name"
-          className="text-foreground text-sm leading-tight font-semibold"
+          // `min-w-0 flex-1 truncate` matches summer's CamperCard.tsx, whose
+          // equivalent identity line needs it for the same reason: an
+          // unbounded name (here, a multi-child concatenation) sits in a flex
+          // row against the party-size badge at the end and would otherwise
+          // squeeze it rather than wrap or clip.
+          className="text-foreground min-w-0 flex-1 truncate text-sm leading-tight font-semibold"
         >
           {isHousehold
             ? children.map((child, index) => (
                 <Fragment key={String(child.person_cm_id ?? index)}>
                   {index > 0 && ' · '}
-                  {/* An age we do not have is omitted, never rendered as 0. */}
+                  {/* An age we do not have is omitted, never rendered as 0.
+                      A blank name (no first/preferred/last name on file --
+                      `_person_display_name` has no fallback the way
+                      `_household_display_name` does) falls back rather than
+                      leaving this segment, or the whole card when it's the
+                      only child, with no accessible text at all. */}
                   <span>
                     {child.age === null || child.age === undefined
-                      ? child.display_name
-                      : `${String(child.display_name)} (${displayTruncatedAge(child.age)})`}
+                      ? child.display_name || 'Unnamed camper'
+                      : `${child.display_name || 'Unnamed camper'} (${displayTruncatedAge(child.age)})`}
                   </span>
                 </Fragment>
               ))
@@ -180,11 +192,12 @@ function FamilyCardBody({
               {children.map((child, index) => (
                 <Fragment key={String(child.person_cm_id ?? index)}>
                   {index > 0 && ' · '}
-                  {/* An age we do not have is omitted, never rendered as 0. */}
+                  {/* An age we do not have is omitted, never rendered as 0.
+                      Same blank-name fallback as the household branch above. */}
                   <span>
                     {child.age === null || child.age === undefined
-                      ? child.display_name
-                      : `${String(child.display_name)} (${displayCampMinderAge(child.age)})`}
+                      ? child.display_name || 'Unnamed camper'
+                      : `${child.display_name || 'Unnamed camper'} (${displayCampMinderAge(child.age)})`}
                   </span>
                 </Fragment>
               ))}
@@ -235,7 +248,7 @@ function FamilyCardBody({
             never set and arrives as the Pydantic default `false` -- untracked,
             not "no". Gating on grain keeps this badge from calling every
             adult weekend regular a first-timer. */}
-        {party.grain === 'household' && party.is_returning !== true && (
+        {isHousehold && party.is_returning !== true && (
           <span className="inline-flex items-center gap-0.5 text-xs font-semibold text-amber-700 dark:text-amber-300">
             <Star className="h-2.5 w-2.5 flex-shrink-0" aria-hidden="true" />
             First-time

--- a/frontend/src/components/weekend/FloatingUnplacedBadge.test.tsx
+++ b/frontend/src/components/weekend/FloatingUnplacedBadge.test.tsx
@@ -49,14 +49,21 @@ describe('FloatingUnplacedBadge', () => {
   })
 
   it('files a household under its surname, not its mailing title', async () => {
-    // The two names are chosen so the orderings DISAGREE: by surname it is
-    // Chen then Johnson, by mailing title it is "Johnson Household" then "The
-    // Chen Family". A pair that sorted the same either way would pin nothing.
+    // The queue orders by `sort_name` (surname), registration order
+    // notwithstanding: Chen before Johnson below. kindred#2074 removed the
+    // mailing-title salutation from the card entirely, so this reads the
+    // order off each party's own (distinct) child rather than off
+    // `display_name` text that no longer renders.
     render(
       <FloatingUnplacedBadge
         parties={[
           party({ display_name: 'Johnson Household', sort_name: 'Johnson', household_cm_id: 101 }),
-          party({ display_name: 'The Chen Family', sort_name: 'Chen', household_cm_id: 102 }),
+          party({
+            display_name: 'The Chen Family',
+            sort_name: 'Chen',
+            household_cm_id: 102,
+            children: [{ person_cm_id: 9002, display_name: 'Mia Chen', age: 6, grade: 0 }],
+          }),
         ]}
         onOpenParty={vi.fn()}
       />,
@@ -64,7 +71,7 @@ describe('FloatingUnplacedBadge', () => {
     )
     await userEvent.click(screen.getByRole('button', { name: /unplaced parties/i }))
     const names = screen.getAllByTestId('family-card-name').map((el) => el.textContent)
-    expect(names).toEqual(['The Chen Family', 'Johnson Household'])
+    expect(names).toEqual(['Mia Chen (6)', 'Noah Johnson (8)'])
   })
 
   it('finds a household by a child’s name', async () => {
@@ -85,8 +92,10 @@ describe('FloatingUnplacedBadge', () => {
     )
     await userEvent.click(screen.getByRole('button', { name: /unplaced parties/i }))
     await userEvent.type(screen.getByPlaceholderText(/filter by name/i), 'Olivia')
+    // kindred#2074: the surviving card shows the child's name, not the
+    // household's removed salutation.
     expect(screen.getAllByTestId('family-card-name').map((el) => el.textContent)).toEqual([
-      'Garcia Household',
+      'Olivia Garcia (7)',
     ])
   })
 
@@ -148,7 +157,9 @@ describe('FloatingUnplacedBadge', () => {
     const onOpenParty = vi.fn()
     render(<FloatingUnplacedBadge parties={[party()]} onOpenParty={onOpenParty} />, { wrapper })
     await userEvent.click(screen.getByRole('button', { name: /unplaced parties/i }))
-    await userEvent.click(screen.getByRole('button', { name: /The Johnson Family/ }))
+    // kindred#2074: the card is reached by its child's name now -- the
+    // household salutation ('The Johnson Family') no longer renders.
+    await userEvent.click(screen.getByRole('button', { name: /Noah Johnson/ }))
     expect(onOpenParty).toHaveBeenCalledWith(expect.objectContaining({ household_cm_id: 101 }))
   })
 })

--- a/frontend/src/components/weekend/LodgingBoard.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.test.tsx
@@ -534,7 +534,9 @@ describe('LodgingBoard — nobody disappears', () => {
       { wrapper }
     )
     expect(screen.getByText(/Placed outside the board/i)).toBeInTheDocument()
-    expect(screen.getByText('Johnson')).toBeInTheDocument()
+    // kindred#2074 removed the household salutation from the card -- it
+    // leads with the children instead, so the identity check moves there.
+    expect(screen.getByText(/Noah Johnson/)).toBeInTheDocument()
   })
 
   it('does not draw that section when everything fits on the board', () => {
@@ -630,7 +632,16 @@ describe('LodgingBoard — the details panel updates in place', () => {
       <LodgingBoard
         parties={[
           party({ display_name: 'Johnson Household', sort_name: 'Johnson', household_cm_id: 101 }),
-          party({ display_name: 'Chen Household', sort_name: 'Chen', household_cm_id: 102 }),
+          party({
+            display_name: 'Chen Household',
+            sort_name: 'Chen',
+            household_cm_id: 102,
+            // kindred#2074: the card leads with the children now, and the
+            // default fixture's child is 'Noah Johnson' regardless of which
+            // household overrides display_name -- distinct children are what
+            // make the two cards reachable apart below.
+            children: [{ person_cm_id: 9002, display_name: 'Mia Chen', age: 6, grade: 0 }],
+          }),
         ]}
         units={[unit()]}
         year={2026}
@@ -641,10 +652,10 @@ describe('LodgingBoard — the details panel updates in place', () => {
     // both cards are reachable from the corner queue and the panel can be
     // switched between them without touching the board itself.
     await userEvent.click(screen.getByRole('button', { name: /2 unplaced parties/i }))
-    await userEvent.click(screen.getByRole('button', { name: /Johnson Household/ }))
+    await userEvent.click(screen.getByRole('button', { name: /Noah Johnson/ }))
     const first = screen.getByTestId('family-details-panel')
 
-    await userEvent.click(screen.getByRole('button', { name: /Chen Household/ }))
+    await userEvent.click(screen.getByRole('button', { name: /Mia Chen/ }))
     const second = screen.getByTestId('family-details-panel')
 
     expect(second).toBe(first)

--- a/frontend/src/components/weekend/LodgingMap.test.tsx
+++ b/frontend/src/components/weekend/LodgingMap.test.tsx
@@ -175,13 +175,23 @@ describe('LodgingMap', () => {
   it('puts an unplaced party in the corner queue', async () => {
     render(
       <LodgingMap
-        parties={[party({ display_name: 'Silva', sort_name: 'Silva' })]}
+        parties={[
+          party({
+            display_name: 'Silva',
+            sort_name: 'Silva',
+            // kindred#2074: the card leads with the children now, and the
+            // fixture's default `children: []` renders no accessible name at
+            // all for a household party -- a real one always has at least
+            // one child (see `_build_household_parties`), so give it one.
+            children: [{ person_cm_id: 9101, display_name: 'Mia Silva', age: 7, grade: 1 }],
+          }),
+        ]}
         units={UNITS}
         year={2026}
       />
     )
     await userEvent.click(screen.getByRole('button', { name: /1 unplaced parties/i }))
-    expect(screen.getByTestId('family-card-name')).toHaveTextContent('Silva')
+    expect(screen.getByTestId('family-card-name')).toHaveTextContent('Mia Silva')
   })
 
   it('lists a merged party below the map, never as unplaced', async () => {
@@ -191,6 +201,9 @@ describe('LodgingMap', () => {
       unit_code: '',
       unit_name: 'Cedar 1 + Cedar 2',
       is_merged_slot: true,
+      // kindred#2074: same reason as 'Silva' above -- a household party
+      // needs a child to have any accessible name on the card.
+      children: [{ person_cm_id: 9102, display_name: 'Leo Nguyen', age: 9, grade: 3 }],
     })
     render(<LodgingMap parties={[merged]} units={UNITS} year={2026} />)
 
@@ -272,7 +285,15 @@ describe('LodgingMap', () => {
       // click twice.
       render(
         <LodgingMap
-          parties={[party({ display_name: 'Garcia', sort_name: 'Garcia' })]}
+          parties={[
+            party({
+              display_name: 'Garcia',
+              sort_name: 'Garcia',
+              // kindred#2074: same reason as 'Silva' above -- a household
+              // party needs a child to have any accessible name on the card.
+              children: [{ person_cm_id: 9103, display_name: 'Ivy Garcia', age: 5, grade: 0 }],
+            }),
+          ]}
           units={UNITS}
           year={2026}
         />,

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -118,15 +118,28 @@ describe('LodgingUnitCard', () => {
   })
 
   it('renders the families it holds', () => {
+    // kindred#2074 removed the household salutation from the card -- it
+    // leads with the children instead, so two parties need DISTINCT
+    // children to stay distinguishable here (the default fixture's child
+    // is 'Noah Johnson' regardless of which household overrides display_name).
     render(
       <LodgingUnitCard
-        slot={slot({ parties: [party(), party({ household_cm_id: 102, display_name: 'Garcia' })] })}
+        slot={slot({
+          parties: [
+            party(),
+            party({
+              household_cm_id: 102,
+              display_name: 'Garcia',
+              children: [{ person_cm_id: 9002, display_name: 'Liam Garcia', age: 6, grade: 0 }],
+            }),
+          ],
+        })}
         hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
-    expect(screen.getByText('Johnson')).toBeInTheDocument()
-    expect(screen.getByText('Garcia')).toBeInTheDocument()
+    expect(screen.getByText(/Noah Johnson/)).toBeInTheDocument()
+    expect(screen.getByText(/Liam Garcia/)).toBeInTheDocument()
   })
 
   it('says two parties are sharing', () => {
@@ -327,16 +340,30 @@ describe('LodgingUnitCard — the per-party sharing chip follows ROOM overlap, n
         slot={slot({
           unit: mergedHouse,
           parties: [
-            declinedParty({ household_cm_id: 101, display_name: 'Alpha', unit_code: 'r1' }),
-            declinedParty({ household_cm_id: 102, display_name: 'Beta', unit_code: 'r2' }),
+            declinedParty({
+              household_cm_id: 101,
+              display_name: 'Alpha',
+              unit_code: 'r1',
+              // kindred#2074: the card leads with the children now, and
+              // `declinedParty`/`party()`'s default child is 'Noah Johnson'
+              // regardless of display_name -- distinct children are what
+              // make Alpha and Beta distinguishable below.
+              children: [{ person_cm_id: 9101, display_name: 'Ivy Alpha', age: 7, grade: 1 }],
+            }),
+            declinedParty({
+              household_cm_id: 102,
+              display_name: 'Beta',
+              unit_code: 'r2',
+              children: [{ person_cm_id: 9102, display_name: 'Leo Beta', age: 9, grade: 3 }],
+            }),
           ],
         })}
         hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
-    expect(screen.getByText('Alpha')).toBeInTheDocument()
-    expect(screen.getByText('Beta')).toBeInTheDocument()
+    expect(screen.getByText(/Ivy Alpha/)).toBeInTheDocument()
+    expect(screen.getByText(/Leo Beta/)).toBeInTheDocument()
     expect(screen.queryByText('Did not request sharing')).not.toBeInTheDocument()
   })
 
@@ -371,7 +398,14 @@ describe('LodgingUnitCard — the per-party sharing chip follows ROOM overlap, n
               is_merged_slot: true,
             }),
             declinedParty({ household_cm_id: 102, display_name: 'Beta', unit_code: 'r1' }),
-            declinedParty({ household_cm_id: 103, display_name: 'Gamma', unit_code: 'r3' }),
+            declinedParty({
+              household_cm_id: 103,
+              display_name: 'Gamma',
+              unit_code: 'r3',
+              // kindred#2074: located by child name below, since the card no
+              // longer renders the household salutation.
+              children: [{ person_cm_id: 9103, display_name: 'Mia Gamma', age: 5, grade: 0 }],
+            }),
           ],
         })}
         hue="hsl(160 45% 42%)"
@@ -379,7 +413,7 @@ describe('LodgingUnitCard — the per-party sharing chip follows ROOM overlap, n
       />
     )
     expect(screen.getAllByText('Did not request sharing')).toHaveLength(2)
-    const gammaCard = screen.getByText('Gamma').closest('button')
+    const gammaCard = screen.getByText(/Mia Gamma/).closest('button')
     expect(gammaCard?.textContent).not.toContain('Did not request sharing')
   })
 

--- a/frontend/src/utils/age.test.ts
+++ b/frontend/src/utils/age.test.ts
@@ -2,7 +2,7 @@
  * Tests for age utility functions
  */
 import { describe, it, expect } from 'vitest'
-import { formatAge, displayCampMinderAge } from './age'
+import { formatAge, displayCampMinderAge, displayTruncatedAge } from './age'
 
 describe('formatAge', () => {
   it('should format age with years and months', () => {
@@ -39,5 +39,36 @@ describe('displayCampMinderAge', () => {
   it('should handle edge cases', () => {
     expect(displayCampMinderAge(0)).toBe('0.00')
     expect(displayCampMinderAge(15.11)).toBe('15.11')
+  })
+})
+
+describe('displayTruncatedAge', () => {
+  // kindred#2074: the family card leads with the campers' whole-year ages.
+  // `persons.age` is CampMinder's yy.mm, encoded so months never exceed .11
+  // -- a fraction that itself always rounds DOWN (0.11 < 0.5), so `Math.round`
+  // happens to agree with `Math.trunc` on every value this format can produce.
+  // `Math.trunc` is still required: it matches the "completed years" semantics
+  // the format intends, rather than "nearest year", which coincides today only
+  // because no valid month fraction reaches .5. The out-of-range case below is
+  // what actually goes red under `Math.round` -- see its comment.
+  it('truncates 6 years 11 months to 6, never rounds up to 7', () => {
+    expect(displayTruncatedAge(6.11)).toBe('6')
+  })
+
+  it('truncates a sub-1 age to 0, not 1', () => {
+    // A real 6-month-old (0.06), not the "unknown age" sentinel -- the
+    // caller is responsible for that distinction, this just truncates.
+    expect(displayTruncatedAge(0.06)).toBe('0')
+  })
+
+  it('leaves a whole-year age unchanged', () => {
+    expect(displayTruncatedAge(15)).toBe('15')
+  })
+
+  it('does not round the fractional part under any circumstance', () => {
+    // Not a realistic CampMinder value (months cap at .11) -- deliberately
+    // out of range to prove the implementation truncates unconditionally
+    // rather than happening to work only inside the CampMinder envelope.
+    expect(displayTruncatedAge(11.99)).toBe('11')
   })
 })

--- a/frontend/src/utils/age.ts
+++ b/frontend/src/utils/age.ts
@@ -24,3 +24,21 @@ export function displayCampMinderAge(age: number): string {
   // Ensure we always show 2 decimal places and avoid floating point issues
   return age.toFixed(2)
 }
+
+/**
+ * Whole-year age, TRUNCATED not rounded — for the board's compact family
+ * card (kindred#2074), which leads with the campers' ages at a glance.
+ *
+ * `persons.age` is CampMinder's yy.mm as a raw float, and months never
+ * exceed `.11`. That means `Math.round` (or `toFixed(0)`) tips a child of
+ * `6.11` — six years, eleven months — up to `7`, which is simply wrong: they
+ * are not seven until the month field rolls to `.12`/`1.00`. `Math.trunc` is
+ * required here, not a style choice.
+ *
+ * This is deliberately a SECOND renderer beside `displayCampMinderAge`, not
+ * a shared one. The detail panel still needs the full `(Y)Y.MM` precision;
+ * only the card's compact line truncates. Do not unify them.
+ */
+export function displayTruncatedAge(age: number): string {
+  return String(Math.trunc(age))
+}

--- a/frontend/src/utils/age.ts
+++ b/frontend/src/utils/age.ts
@@ -29,15 +29,24 @@ export function displayCampMinderAge(age: number): string {
  * Whole-year age, TRUNCATED not rounded — for the board's compact family
  * card (kindred#2074), which leads with the campers' ages at a glance.
  *
- * `persons.age` is CampMinder's yy.mm as a raw float, and months never
- * exceed `.11`. That means `Math.round` (or `toFixed(0)`) tips a child of
- * `6.11` — six years, eleven months — up to `7`, which is simply wrong: they
- * are not seven until the month field rolls to `.12`/`1.00`. `Math.trunc` is
- * required here, not a style choice.
+ * `persons.age` is CampMinder's yy.mm as a raw float, encoded so months never
+ * exceed `.11` — a fraction that, taken on its own, always rounds DOWN
+ * (`Math.round(6.11)` is `6`, same as `Math.trunc`). `Math.trunc` is still
+ * required, not a style choice: it matches "completed years", the semantics
+ * the yy.mm format intends, rather than "nearest year" — a distinction this
+ * format's current range happens to hide, but a genuinely different
+ * computation (e.g. converting months to a true year-fraction, `6 + 11/12`,
+ * before rounding) would not. Trust the intent, not the coincidence.
  *
  * This is deliberately a SECOND renderer beside `displayCampMinderAge`, not
  * a shared one. The detail panel still needs the full `(Y)Y.MM` precision;
- * only the card's compact line truncates. Do not unify them.
+ * only the card's compact line truncates — CLAUDE.md §4's "model summer's
+ * primitives" rule is why that divergence needs saying: summer's equivalent
+ * compact card (`CamperCard.tsx`) shows the full `.toFixed(2)` precision.
+ * Here the card is deliberately terser because age is the entire point of a
+ * "similar ages" match at a glance across up to 62 simultaneous cards, where
+ * the extra digits of `(Y)Y.MM` cost more legibility than they buy —
+ * precision that stays one click away, unchanged, on the detail panel.
  */
 export function displayTruncatedAge(age: number): string {
   return String(Math.trunc(age))


### PR DESCRIPTION
## Summary

Inverts the family card's identity line per the owner-settled design in #2074:

- **Bold top line = the child attendees**, with **whole-year ages truncated via `Math.trunc`** (a new `displayTruncatedAge` in `frontend/src/utils/age.ts`, kept deliberately separate from `displayCampMinderAge` — the detail panel still needs the full `(Y)Y.MM` form).
- **Grey line = the attending adults** (`party.adults[]`, non-blank slots only — `family_camp_adults` is not a fixed five).
- **The household salutation (`party.display_name`, CampMinder's `mailing_title`) is removed from the card entirely**, not demoted — it disagreed with the actual adult list on 26.7% of 2026's 382 rostered households, in both directions, which can't be repaired inside the string.
- Gated on `party.grain === 'household'`; a person-grain party (adult weekend guest) keeps its own name as the identity line, since it isn't a household salutation to begin with.

## Scope beyond the two authorized sibling files

Removing the salutation broke test fixtures in **four** files, not the two originally scoped — `LodgingUnitCard.test.tsx` and `LodgingBoard.test.tsx` were pre-identified; `LodgingMap.test.tsx` (3 tests) and `FloatingUnplacedBadge.test.tsx` (3 tests) surfaced during the full-suite gate and share the identical root cause, so they're fixed here too rather than left red:

- **`LodgingUnitCard.test.tsx`** (3 failures) and **`LodgingBoard.test.tsx`** (2 failures): default fixture factories gave every party the same default child (`Noah Johnson`) and varied only `display_name`; fixed by giving each party in the affected tests a distinct child.
- **`LodgingMap.test.tsx`** (3 failures): its `party()` fixture defaults to `children: []`. A household-grain party always has ≥1 child in production (`_build_household_parties` only creates a household party from a household with a child attendee), so this was a stale fixture, not a real gap — fixed by giving the three affected call sites a distinct child.
- **`FloatingUnplacedBadge.test.tsx`** (3 failures): renders `<FamilyCard>` directly, so it inherited the same break. Two of its three assertions checked for the now-removed `display_name` text outright (not just a fixture collision) and needed updating to check the child's rendered name instead — this is a test tracking a settled, owner-ruled behavior change, not the implementation dictating the test.

**Concurrent editors**: `LodgingBoard.test.tsx` is also being edited on #2091, and `LodgingUnitCard.test.tsx` on #2062. A merge conflict on either is expected and is not this PR's to resolve.

Not in scope here (tracked separately in #2084): the salutation also reaches `FamilyDetailsPanel`, `HouseholdRosterRow`, `MapUnitPopover`, and `FloatingUnplacedBadge`'s own search/sort keys — those are untouched.

## Test plan
- [x] `npx vitest run` — full suite, exit 0 (see below)
- [x] `npx tsc --noEmit` — exit 0
- [x] `./node_modules/.bin/eslint` on all changed files — exit 0
- [x] Mutation-checked `displayTruncatedAge`: swapping `Math.trunc` → `Math.round` does NOT fail the in-file "6.11 → 6" test (0.11 < 0.5 rounds down regardless), but does fail the deliberately out-of-range "11.99 → 11" test — the comment in `age.test.ts` was corrected to say so precisely rather than overclaim

Closes #2074.

## Folded in: #2153 — the duplicated child-list renderer

`FamilyCardBody` rendered a child list **twice** — the household bold identity line and the person-grain grey secondary line — differing only in which age formatter they called (`displayTruncatedAge` vs `displayCampMinderAge`) and what wrapped them. The `person_cm_id ?? index` key, the ` · ` separator, the missing-age omission, and the blank-name fallback were each one decision made in two places.

This PR is what created that duplication (it added the blank-name fallback to both copies by hand), so the de-duplication lands here rather than trailing behind as backlog.

- Extracted `ChildList({ children, formatAge })`, parameterized by the age formatter. The wrapper stays with the caller, because the two sites want different ones: the bold line's span is also the non-household branch's, and the grey line's exists only when there are children to put in it.
- **Behaviour-preserving, no product decision taken.** Two characterization tests were written FIRST and confirmed **passing against the pre-refactor code** (they capture existing behaviour rather than change it): the blank-name fallback on the person-grain line, and the ` · ` separator on both lines — the only pieces of the child list nothing else pinned.
- **Mutation-checked both ways.** Pre-refactor, each new test fails (exit 1) when its behaviour is broken. Post-refactor, deleting the shared `|| 'Unnamed camper'` fails **both** the household and the person-grain tests — which is what proves the two call sites genuinely route through one renderer, rather than a second copy quietly surviving.
- Side effect: this file's `prefer-nullish-coalescing` warnings drop 4 → 2, purely from removing the duplicate pair. The `||` is correct and stays — a blank string must fall back, which `??` would not do.

**Deliberately left alone**, per the issue's own caveats: `HouseholdRosterRow.tsx` (the third near-copy, unowned by any open PR) is untouched, and whether the person-grain branch is reachable under today's backend (`_build_person_parties` never populates `children`) is left exactly as it was — extraction is orthogonal to that question.

Closes #2153.
