### PR TITLE
fix(frontend): spare the live parent, not the stored one, in the unit picker

### DIFF
--- a/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
@@ -446,6 +446,66 @@ describe('LodgingUnitForm — the parent picker reflects a live allocation chang
       'staff_building',
     ])
   })
+
+  // #2065: the mirror of the test above. #2051 pinned only the widening
+  // direction (guest → staff, options grow); the narrowing direction — staff
+  // → guest, options shrink — is where the bug actually lived.
+  it('keeps the just-picked parent visible and selected after Allocation flips back to guest, rather than blanking the select while the stale value still saves', async () => {
+    const room: LodgingUnitRecord = {
+      ...UNIT,
+      id: 'room1',
+      name: 'Alpine Room',
+      code: 'alpine-room',
+      parent_unit: '',
+      inventory_class: 'family_pool',
+      is_container: false,
+    }
+    const guestBuilding: LodgingUnitRecord = {
+      ...UNIT,
+      id: 'guest_building',
+      name: 'Guest Lodge',
+      code: 'guest-lodge',
+      is_container: true,
+      inventory_class: 'family_pool',
+    }
+    const staffBuilding: LodgingUnitRecord = {
+      ...UNIT,
+      id: 'staff_building',
+      name: 'Staff Quarters',
+      code: 'staff-quarters',
+      is_container: true,
+      inventory_class: 'staff_default',
+    }
+    const user = userEvent.setup()
+
+    render(
+      <LodgingUnitForm
+        areas={AREAS}
+        units={[room, guestBuilding, staffBuilding]}
+        year={2026}
+        unit={room}
+        onSaved={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+
+    const parentSelect = screen.getByLabelText<HTMLSelectElement>('Parent unit')
+
+    // Flip to staff, pick the staff building as parent, then flip back to
+    // guest — all in the same render, no save, no remount.
+    await user.selectOptions(screen.getByLabelText('Allocation'), 'staff_default')
+    await user.selectOptions(parentSelect, 'staff_building')
+    await user.selectOptions(screen.getByLabelText('Allocation'), 'family_pool')
+
+    // `parentCandidates` used to spare the STORED parent
+    // (`units.find(...)?.parent_unit`, still '' for this room) rather than
+    // the live selection, so the staff building dropped out of the options
+    // while `identity.parent_unit` still held it. A `<select>` whose value
+    // is not among its options renders blank while quietly keeping the
+    // stale value, which is what saved a guest room under a staff building.
+    expect([...parentSelect.options].map((o) => o.value)).toContain('staff_building')
+    expect(parentSelect.value).toBe('staff_building')
+  })
 })
 
 describe('LodgingUnitForm — beds', () => {

--- a/frontend/src/components/admin/lodging/UnitIdentityFields.tsx
+++ b/frontend/src/components/admin/lodging/UnitIdentityFields.tsx
@@ -146,7 +146,9 @@ export function UnitIdentityFields({
 
             Scoped to the Area chosen above, so switching area re-scopes the
             buildings on offer. See ./unitTree for why the unit's existing
-            parent survives that narrowing regardless. */}
+            parent survives that narrowing regardless — and why that has to be
+            `value.parent_unit`, the LIVE selection below, not a lookup of the
+            stored record (#2065). */}
         <select
           className={FIELD}
           value={value.parent_unit}
@@ -155,11 +157,13 @@ export function UnitIdentityFields({
           }}
         >
           <option value="">No parent</option>
-          {parentCandidates(unitId, units, value.area, inventoryClass).map((candidate) => (
-            <option key={candidate.id} value={candidate.id}>
-              {candidate.name}
-            </option>
-          ))}
+          {parentCandidates(unitId, units, value.parent_unit, value.area, inventoryClass).map(
+            (candidate) => (
+              <option key={candidate.id} value={candidate.id}>
+                {candidate.name}
+              </option>
+            )
+          )}
         </select>
       </label>
 

--- a/frontend/src/components/admin/lodging/unitTree.test.ts
+++ b/frontend/src/components/admin/lodging/unitTree.test.ts
@@ -140,14 +140,14 @@ describe('directChildren', () => {
 describe('parentCandidates', () => {
   it('excludes the unit itself', () => {
     const units = [unit({ id: 'a', is_container: true }), unit({ id: 'b', is_container: true })]
-    const ids = parentCandidates('a', units).map((u) => u.id)
+    const ids = parentCandidates('a', units, '').map((u) => u.id)
     expect(ids).not.toContain('a')
     expect(ids).toEqual(['b'])
   })
 
   it('excludes non-container units — a room may not be a parent', () => {
     const units = [unit({ id: 'a', is_container: true }), unit({ id: 'b', is_container: false })]
-    expect(parentCandidates('a', units)).toEqual([])
+    expect(parentCandidates('a', units, '')).toEqual([])
   })
 
   it('excludes a direct child, which would create a cycle', () => {
@@ -155,7 +155,7 @@ describe('parentCandidates', () => {
       unit({ id: 'a', is_container: true }),
       unit({ id: 'b', parent_unit: 'a', is_container: true }),
     ]
-    expect(parentCandidates('a', units).map((u) => u.id)).not.toContain('b')
+    expect(parentCandidates('a', units, '').map((u) => u.id)).not.toContain('b')
   })
 
   it('excludes a grandchild, not just a direct child', () => {
@@ -164,14 +164,14 @@ describe('parentCandidates', () => {
       unit({ id: 'b', parent_unit: 'a', is_container: true }),
       unit({ id: 'c', parent_unit: 'b', is_container: true }),
     ]
-    const ids = parentCandidates('a', units).map((u) => u.id)
+    const ids = parentCandidates('a', units, '').map((u) => u.id)
     expect(ids).not.toContain('b')
     expect(ids).not.toContain('c')
   })
 
   it('offers every container on create, since there is no self or descendant yet', () => {
     const units = [unit({ id: 'a', is_container: true }), unit({ id: 'b', is_container: true })]
-    expect(parentCandidates(undefined, units).map((u) => u.id)).toEqual(['a', 'b'])
+    expect(parentCandidates(undefined, units, '').map((u) => u.id)).toEqual(['a', 'b'])
   })
 })
 
@@ -190,7 +190,7 @@ describe('parentCandidates — scoped to the area', () => {
       unit({ id: 'far', area: SOUTH, is_container: true }),
     ]
 
-    const ids = parentCandidates('child', units, NORTH).map((u) => u.id)
+    const ids = parentCandidates('child', units, '', NORTH).map((u) => u.id)
     expect(ids).toEqual(['near'])
   })
 
@@ -198,13 +198,16 @@ describe('parentCandidates — scoped to the area', () => {
     // Filtering a stored parent out of its own picker would leave the select
     // with no matching option: it would fall to the first entry, and the next
     // save would silently REPARENT the unit the staffer only meant to rename.
+    // The caller passes the CURRENT parent explicitly (#2065) — on initial
+    // load that's the stored value, `unit.parent_unit`, but this function no
+    // longer looks it up itself.
     const units = [
       unit({ id: 'child', area: NORTH, parent_unit: 'far' }),
       unit({ id: 'near', area: NORTH, is_container: true }),
       unit({ id: 'far', area: SOUTH, is_container: true }),
     ]
 
-    const ids = parentCandidates('child', units, NORTH).map((u) => u.id)
+    const ids = parentCandidates('child', units, 'far', NORTH).map((u) => u.id)
     expect(ids).toContain('far')
     expect(ids).toContain('near')
   })
@@ -215,7 +218,7 @@ describe('parentCandidates — scoped to the area', () => {
       unit({ id: 'far', area: SOUTH, is_container: true }),
     ]
 
-    expect(parentCandidates(undefined, units).map((u) => u.id)).toEqual(['near', 'far'])
+    expect(parentCandidates(undefined, units, '').map((u) => u.id)).toEqual(['near', 'far'])
   })
 })
 
@@ -232,7 +235,7 @@ describe('parentCandidates — scoped to how the unit is used', () => {
       unit({ id: 'staff-bldg', area: A, is_container: true, inventory_class: 'staff_default' }),
     ]
 
-    const ids = parentCandidates('guest-room', units, A, 'family_pool').map((u) => u.id)
+    const ids = parentCandidates('guest-room', units, '', A, 'family_pool').map((u) => u.id)
     expect(ids).toEqual(['guest-bldg'])
   })
 
@@ -246,7 +249,7 @@ describe('parentCandidates — scoped to how the unit is used', () => {
       unit({ id: 'staff-bldg', area: A, is_container: true, inventory_class: 'staff_default' }),
     ]
 
-    const ids = parentCandidates('staff-room', units, A, 'staff_default').map((u) => u.id)
+    const ids = parentCandidates('staff-room', units, '', A, 'staff_default').map((u) => u.id)
     expect(ids).toEqual(['guest-bldg', 'staff-bldg'])
   })
 
@@ -263,8 +266,31 @@ describe('parentCandidates — scoped to how the unit is used', () => {
       unit({ id: 'staff-bldg', area: A, is_container: true, inventory_class: 'staff_default' }),
     ]
 
-    expect(parentCandidates('guest-room', units, A, 'family_pool').map((u) => u.id)).toContain(
-      'staff-bldg'
+    expect(
+      parentCandidates('guest-room', units, 'staff-bldg', A, 'family_pool').map((u) => u.id)
+    ).toContain('staff-bldg')
+  })
+
+  // #2065: `parentCandidates` used to spare the STORED parent
+  // (`units.find((u) => u.id === unitId)?.parent_unit`) rather than the LIVE
+  // selection the caller is about to render. This reproduces the narrowing
+  // direction the widening test above's sibling (#2051) never covered: a
+  // guest room picks a staff parent while Allocation is briefly "staff",
+  // then Allocation flips back to "guest" — the stored record was never
+  // saved, so a stored-parent lookup would still return '', but the LIVE,
+  // not-yet-saved selection is the staff building.
+  it('spares the LIVE selection when narrowing, not the stale stored parent', () => {
+    const units = [
+      unit({ id: 'guest-room', area: A, inventory_class: 'family_pool' }), // stored parent_unit: ''
+      unit({ id: 'guest-bldg', area: A, is_container: true, inventory_class: 'family_pool' }),
+      unit({ id: 'staff-bldg', area: A, is_container: true, inventory_class: 'staff_default' }),
+    ]
+
+    // Live selection is staff-bldg even though the stored record's
+    // parent_unit is still ''.
+    const ids = parentCandidates('guest-room', units, 'staff-bldg', A, 'family_pool').map(
+      (u) => u.id
     )
+    expect(ids).toContain('staff-bldg')
   })
 })

--- a/frontend/src/components/admin/lodging/unitTree.ts
+++ b/frontend/src/components/admin/lodging/unitTree.ts
@@ -99,25 +99,38 @@ export function combinedAncestor(
  * room, so hiding guest buildings from staff units would deny a new staff room
  * there its real parent. Buildings are mixed; staff housing is not.
  *
- * Both narrowings spare the unit's CURRENT parent whatever it is. Filtering a
- * stored parent out of its own picker would leave the select with no matching
- * option, so it would fall to the first entry and the next save would silently
- * reparent a unit the staffer only meant to rename — the exact accident these
- * filters exist to prevent, arriving through them.
+ * Both narrowings spare the CURRENT parent whatever it is — the caller's
+ * `currentParentId`, not something this function looks up. Filtering a
+ * current parent out of its own picker would leave the select with no
+ * matching option, so it would fall to the first entry and the next save
+ * would silently reparent a unit the staffer only meant to rename — the
+ * exact accident these filters exist to prevent, arriving through them.
+ *
+ * `currentParentId` MUST be the LIVE, not-yet-saved selection — the same
+ * value `LodgingUnitForm`'s `blockingAncestor` reads off `identity.parent_unit`
+ * — not a lookup of the STORED record (`units.find((u) => u.id ===
+ * unitId)?.parent_unit`, #2065). A staffer can pick a parent, then change
+ * Area or Allocation before saving; if the narrowing looks up the stored
+ * value it still finds the OLD parent (or none, on a unit being created),
+ * so the just-picked selection silently drops out of the options while
+ * remaining the form's value. A `<select>` whose value isn't among its
+ * options renders blank while the stale value rides through to the next
+ * save. On mount the caller's live value equals the stored one, so the
+ * grandfather-clause behavior below is unchanged for that case.
  */
 export function parentCandidates(
   unitId: string | undefined,
   units: LodgingUnitRecord[],
+  currentParentId: string,
   areaId?: string,
   inventoryClass?: string
 ): LodgingUnitRecord[] {
   const excluded = unitId === undefined ? new Set<string>() : descendantIds(unitId, units)
-  const currentParent = units.find((u) => u.id === unitId)?.parent_unit ?? ''
   return units.filter((candidate) => {
     if (!candidate.is_container || candidate.id === unitId || excluded.has(candidate.id)) {
       return false
     }
-    if (candidate.id === currentParent) return true
+    if (candidate.id === currentParentId) return true
     if (areaId !== undefined && candidate.area !== areaId) return false
     // One direction only — see the header. Guest rooms are kept out of staff
     // housing; staff rooms are NOT kept out of guest buildings, because more


### PR DESCRIPTION
## Problem

`parentCandidates` looked up the current parent from the **stored** record — `units.find((u) => u.id === unitId)?.parent_unit` — rather than taking the caller's **live** selection.

A staffer can pick a parent, then change Area or Allocation before saving. The narrowing then still finds the OLD parent (or none, on a unit being created), so the just-picked selection silently drops out of the options while remaining the form's value. A `<select>` whose value is not among its options **renders blank while the stale value rides through to the next save** — which is how a guest room gets saved under staff housing.

## Fix

`currentParentId` is now a required argument, supplied by the picker from the live identity state — the same value `LodgingUnitForm`'s `blockingAncestor` already reads off `identity.parent_unit`.

On mount the live value equals the stored one, so the grandfather clause (sparing a unit's current parent from its own filters) is unchanged for that case.

**Client-side only** — no PocketBase hooks. This is a picker-filtering defect, not a server validation gap.

## Verification

- `vitest run src/components/admin/lodging` — **13 files / 226 tests passed**, exit 0
- `tsc --noEmit` — exit 0
- pre-push (forced): `type-check` ✔ · `pytest` ✔

Closes #2065.