### PR TITLE
refactor(frontend): extract lodging areas/units queries into shared hooks

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -20,7 +20,7 @@ React + TypeScript + Vite. Dev server on `:3000` (HMR); prod served via Caddy at
 ## Component patterns
 
 - **Modular extraction** — large components (e.g. `SocialNetworkGraph.tsx`) decompose into utility modules
-- **Custom hooks** — data fetching extracted (`useSocialGraphData`, `useBunkNames`, `useSessionHierarchy`)
+- **Custom hooks** — extract data fetching once a query has **2+ consumers** (`useSocialGraphData`, `useBunkNames`, `useSessionHierarchy`, `useLodgingAreas`, `useLodgingUnits`). A query with a single consumer is fine inline — don't extract pre-emptively.
 - **Barrel exports** — directories use `index.ts` for clean imports
 
 ## Error handling — non-negotiable

--- a/frontend/src/components/admin/lodging/LodgingAliasesPanel.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingAliasesPanel.test.tsx
@@ -313,6 +313,38 @@ describe('LodgingAliasesPanel — units query state', () => {
   // The editor's member checkboxes come from a SECOND query. Coerced to [],
   // a failed units fetch opens an editor with nothing to pick, and saving
   // then strips the alias of its members.
+  it('still moves focus into the form when the units resolve after the editor opened', async () => {
+    // The editor body is gated on the units query, so a staffer who clicks
+    // "New alias" during a slow fetch gets the "Loading units…" placeholder
+    // and nothing focusable. The focus effect fires once against that
+    // placeholder and, keyed on `[editing]` alone, never re-runs when the
+    // real form mounts — focus is left on the button, and the member-unit
+    // fieldset that IS this form's payload is never reached by keyboard.
+    let resolveUnits: (units: unknown[]) => void = () => undefined
+    listLodgingUnits.mockReturnValue(
+      new Promise<unknown[]>((resolve) => {
+        resolveUnits = resolve
+      })
+    )
+    const user = userEvent.setup()
+    render(<LodgingAliasesPanel />, { wrapper })
+    await waitFor(() => {
+      expect(screen.getByText('North Lodge - Whole')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: 'New alias' }))
+    // The editor is open but the form has not mounted yet — this is the
+    // window the bug lives in, so assert it rather than assuming it.
+    expect(screen.getByText(/Loading units/i)).toBeInTheDocument()
+    expect(screen.queryByLabelText('Cabin string')).not.toBeInTheDocument()
+
+    resolveUnits([{ id: 'u1', name: 'North Lodge Front', code: 'north-lodge-front' }])
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Cabin string')).toHaveFocus()
+    })
+  })
+
   it('says so rather than opening an editor with no units to choose', async () => {
     listLodgingUnits.mockRejectedValue(new Error('network'))
     const user = userEvent.setup()

--- a/frontend/src/components/admin/lodging/LodgingAliasesPanel.tsx
+++ b/frontend/src/components/admin/lodging/LodgingAliasesPanel.tsx
@@ -44,20 +44,6 @@ export function LodgingAliasesPanel() {
   const [editing, setEditing] = useState<LodgingAliasRecord | 'new' | null>(null)
   const formRef = useRef<HTMLDivElement>(null)
 
-  /**
-   * Move attention to the editor whenever it opens — including switching
-   * straight from editing one alias to another, since the form never
-   * unmounts in between (see the `key` below). Without this, opening the
-   * form on a 90-row table produces no visible change below the fold, and
-   * the natural response — clicking Edit again, or on a different row — is
-   * exactly how a stale-record write would go unnoticed.
-   */
-  useEffect(() => {
-    if (editing === null) return
-    formRef.current?.scrollIntoView({ block: 'nearest' })
-    formRef.current?.querySelector<HTMLElement>('input, select, textarea')?.focus()
-  }, [editing])
-
   const aliasesQuery = useQuery({
     queryKey: queryKeys.lodgingAliases(),
     ...userDataOptions,
@@ -80,6 +66,32 @@ export function LodgingAliasesPanel() {
   const yearReady = currentYear > 0
 
   const unitsQuery = useLodgingUnits()
+
+  /**
+   * Move attention to the editor whenever it opens — including switching
+   * straight from editing one alias to another, since the form never
+   * unmounts in between (see the `key` below). Without this, opening the
+   * form on a 90-row table produces no visible change below the fold, and
+   * the natural response — clicking Edit again, or on a different row — is
+   * exactly how a stale-record write would go unnoticed.
+   *
+   * `unitsQuery.isSuccess` IS A DEPENDENCY, not a stray one — and it is why
+   * this effect sits BELOW the query rather than up with the other state. The
+   * form is gated on the units having loaded (the branch below), so opening
+   * the editor during a slow fetch runs this effect against the "Loading
+   * units…" placeholder, where there is nothing to scroll to or focus. Keyed
+   * on `[editing]` alone it would never re-run once the real form mounts,
+   * leaving focus on the button and the member-unit fieldset — this form's
+   * whole payload — unreachable by keyboard. `isSuccess` is the right flag
+   * rather than the raw `isLoading`: a units query disabled on an unresolved
+   * year reports `isLoading === false` while still having no data, and only
+   * the loaded case renders anything focusable.
+   */
+  useEffect(() => {
+    if (editing === null) return
+    formRef.current?.scrollIntoView({ block: 'nearest' })
+    formRef.current?.querySelector<HTMLElement>('input, select, textarea')?.focus()
+  }, [editing, unitsQuery.isSuccess])
 
   const refresh = () => {
     setEditing(null)

--- a/frontend/src/components/admin/lodging/LodgingAliasesPanel.tsx
+++ b/frontend/src/components/admin/lodging/LodgingAliasesPanel.tsx
@@ -16,11 +16,8 @@ import { useEffect, useRef, useState } from 'react'
 import toast from 'react-hot-toast'
 
 import { useCurrentYear } from '../../../hooks/useCurrentYear'
-import {
-  deleteLodgingAlias,
-  listLodgingAliases,
-  listLodgingUnits,
-} from '../../../services/lodgingCrud'
+import { useLodgingUnits } from '../../../hooks/useLodgingUnits'
+import { deleteLodgingAlias, listLodgingAliases } from '../../../services/lodgingCrud'
 import type { LodgingAliasRecord } from '../../../types/lodging'
 import {
   invalidateLodgingRegistryQueries,
@@ -75,19 +72,14 @@ export function LodgingAliasesPanel() {
   // configured year. PocketBase answers `year = 0` with a successful `200
   // []` rather than an error, so without this gate the picker would render
   // as if there were genuinely no units to map an alias to.
-  // ONE constant for the fetch gate and the render guard, because gating only
-  // the fetch does not fix what the gate is for. A disabled TanStack query is
-  // `isLoading === false` (pending but idle -- nothing is fetching) with `data
-  // === undefined`, which is indistinguishable from a settled empty result to
-  // every consumer below. Derive both from this and they cannot drift apart.
+  // ONE constant for the render guard below. useLodgingUnits gates its own
+  // fetch on year-readiness; a disabled TanStack query is `isLoading ===
+  // false` (pending but idle -- nothing is fetching) with `data ===
+  // undefined`, which is indistinguishable from a settled empty result to
+  // every consumer below, so the render guard still needs this separately.
   const yearReady = currentYear > 0
 
-  const unitsQuery = useQuery({
-    queryKey: queryKeys.lodgingUnits(currentYear),
-    ...userDataOptions,
-    queryFn: () => listLodgingUnits(currentYear),
-    enabled: yearReady,
-  })
+  const unitsQuery = useLodgingUnits()
 
   const refresh = () => {
     setEditing(null)

--- a/frontend/src/components/admin/lodging/LodgingAliasesPanel.tsx
+++ b/frontend/src/components/admin/lodging/LodgingAliasesPanel.tsx
@@ -149,7 +149,7 @@ export function LodgingAliasesPanel() {
                records writes the PREVIOUS alias's fields to the new one. */
             <LodgingAliasForm
               key={editing === 'new' ? 'new' : editing.id}
-              units={unitsQuery.data ?? []}
+              units={unitsQuery.items}
               alias={editing === 'new' ? undefined : editing}
               onSaved={refresh}
               onCancel={() => {

--- a/frontend/src/components/admin/lodging/LodgingAreasDrawer.tsx
+++ b/frontend/src/components/admin/lodging/LodgingAreasDrawer.tsx
@@ -45,17 +45,23 @@ export function LodgingAreasDrawer({ open, onClose }: LodgingAreasDrawerProps) {
   const { currentYear } = useCurrentYear()
   const [draftName, setDraftName] = useState('')
 
-  // Gated on the drawer being open — useLodgingAreas ANDs that with the year
-  // having resolved. CurrentYearContext returns the literal 0 until the
-  // backend supplies the configured year, and PocketBase answers `year = 0`
-  // with a successful `200 []` rather than an error — see LodgingUnitsPanel.
-  const areasQuery = useLodgingAreas({ enabled: open })
+  // Not gated on `open`: LodgingUnitsPanel — this drawer's only mount point —
+  // already calls useLodgingAreas() unconditionally to feed the units table's
+  // grouping and the unit edit form's area picker, under this identical query
+  // key. That call has already warmed the cache by the time a staffer opens
+  // this drawer, so a per-drawer "while open" gate would never observably
+  // defer a fetch; an earlier version of this hook carried one and it was
+  // dead weight (kindred#2132). useLodgingAreas still gates on the year
+  // itself: CurrentYearContext returns the literal 0 until the backend
+  // supplies the configured year, and PocketBase answers `year = 0` with a
+  // successful `200 []` rather than an error.
+  const areasQuery = useLodgingAreas()
 
   const refresh = () => {
     invalidateLodgingRegistryQueries(queryClient)
   }
 
-  const areas = areasQuery.data ?? []
+  const areas = areasQuery.items
 
   /**
    * Runs a write and reports whether it landed.

--- a/frontend/src/components/admin/lodging/LodgingAreasDrawer.tsx
+++ b/frontend/src/components/admin/lodging/LodgingAreasDrawer.tsx
@@ -11,25 +11,21 @@
  * bathhouse" gets answered (spec §7.2b).
  */
 import { Dialog, DialogPanel, DialogTitle } from '@headlessui/react'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQueryClient } from '@tanstack/react-query'
 import { ChevronDown, ChevronUp, Plus, X } from 'lucide-react'
 import { useState } from 'react'
 import toast from 'react-hot-toast'
 
 import { useCurrentYear } from '../../../hooks/useCurrentYear'
+import { useLodgingAreas } from '../../../hooks/useLodgingAreas'
 import {
   createLodgingArea,
   deleteLodgingArea,
-  listLodgingAreas,
   reorderLodgingAreas,
   updateLodgingArea,
 } from '../../../services/lodgingCrud'
 import type { LodgingAreaRecord } from '../../../types/lodging'
-import {
-  invalidateLodgingRegistryQueries,
-  queryKeys,
-  userDataOptions,
-} from '../../../utils/queryKeys'
+import { invalidateLodgingRegistryQueries } from '../../../utils/queryKeys'
 import { ACTION_LINK, BUTTON_PRIMARY, FIELD_INLINE as FIELD, LABEL } from './lodgingStyles'
 
 function slugify(name: string): string {
@@ -49,16 +45,11 @@ export function LodgingAreasDrawer({ open, onClose }: LodgingAreasDrawerProps) {
   const { currentYear } = useCurrentYear()
   const [draftName, setDraftName] = useState('')
 
-  const areasQuery = useQuery({
-    queryKey: queryKeys.lodgingAreas(currentYear),
-    ...userDataOptions,
-    queryFn: () => listLodgingAreas(currentYear),
-    // Gated on the drawer being open AND the year having resolved.
-    // CurrentYearContext returns the literal 0 until the backend supplies
-    // the configured year, and PocketBase answers `year = 0` with a
-    // successful `200 []` rather than an error — see LodgingUnitsPanel.
-    enabled: open && currentYear > 0,
-  })
+  // Gated on the drawer being open — useLodgingAreas ANDs that with the year
+  // having resolved. CurrentYearContext returns the literal 0 until the
+  // backend supplies the configured year, and PocketBase answers `year = 0`
+  // with a successful `200 []` rather than an error — see LodgingUnitsPanel.
+  const areasQuery = useLodgingAreas({ enabled: open })
 
   const refresh = () => {
     invalidateLodgingRegistryQueries(queryClient)

--- a/frontend/src/components/admin/lodging/LodgingUnitsPanel.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitsPanel.test.tsx
@@ -398,6 +398,39 @@ describe('LodgingUnitsPanel — areas query state', () => {
     expect(screen.getByText('Cabin A')).toBeInTheDocument()
   })
 
+  it('still moves focus into the form when the areas resolve after the editor opened', async () => {
+    // The form is gated on `areasQuery.isSuccess`, so a staffer who clicks
+    // "New unit" during a slow areas fetch opens a dialog whose only content
+    // is the "Loading areas…" placeholder — nothing focusable. The focus
+    // effect fires once on that empty dialog and, keyed on `[editing]` alone,
+    // never re-runs when the real form finally mounts: focus is left on the
+    // trigger behind the backdrop, and a keyboard user is stranded outside an
+    // open aria-modal dialog.
+    let resolveAreas: (areas: typeof AREAS) => void = () => undefined
+    listLodgingAreas.mockReturnValue(
+      new Promise<typeof AREAS>((resolve) => {
+        resolveAreas = resolve
+      })
+    )
+    const user = userEvent.setup()
+    render(<LodgingUnitsPanel />, { wrapper })
+    await waitFor(() => {
+      expect(screen.getByText('Cabin A')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: 'New unit' }))
+    // The dialog is open but the form has not mounted yet — this is the
+    // window the bug lives in, so assert it rather than assuming it.
+    expect(screen.getByText(/Loading areas/i)).toBeInTheDocument()
+    expect(screen.queryByLabelText('Name')).not.toBeInTheDocument()
+
+    resolveAreas(AREAS)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Name')).toHaveFocus()
+    })
+  })
+
   it('does not open the editor when there are no areas to assign a unit to', async () => {
     // The Area select is a required relation with no blank option. Opening the
     // form against an empty list offers a create whose only outcome is a

--- a/frontend/src/components/admin/lodging/LodgingUnitsPanel.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitsPanel.tsx
@@ -67,18 +67,18 @@ export function LodgingUnitsPanel() {
     formRef.current?.querySelector<HTMLElement>('input, select, textarea')?.focus()
   }, [editing])
 
-  // ONE constant for the fetch gate and the render guard, because gating only
-  // the fetch does not fix what the gate is for. A disabled TanStack query is
-  // `isLoading === false` (pending but idle -- nothing is fetching) with `data
-  // === undefined`, which is indistinguishable from a settled empty result to
-  // every consumer below. Derive both from this and they cannot drift apart.
+  // RENDER guard only, not a fetch gate. useLodgingUnits / useLodgingAreas
+  // each gate their own fetch on year-readiness internally — currentYear > 0
+  // is not passed to either call below — so this constant does not control
+  // when they fetch, only when they render. It is still needed for that: a
+  // disabled TanStack query is `isLoading === false` (pending but idle --
+  // nothing is fetching) with `data === undefined`, which is indistinguishable
+  // from a settled empty result to every consumer below. CurrentYearContext
+  // returns the literal 0 until the backend supplies the configured year, and
+  // PocketBase answers `year = 0` with a successful `200 []` rather than an
+  // error — this guard is what keeps that from rendering as genuinely empty.
   const yearReady = currentYear > 0
 
-  // useLodgingUnits / useLodgingAreas each gate on year-readiness themselves
-  // (CurrentYearContext returns the literal 0 until the backend supplies the
-  // configured year, and PocketBase answers `year = 0` with a successful
-  // `200 []` rather than an error). `yearReady` above is still needed here as
-  // the RENDER guard, not the fetch gate — see the ONE constant comment.
   const unitsQuery = useLodgingUnits()
   const areasQuery = useLodgingAreas()
 
@@ -243,7 +243,7 @@ export function LodgingUnitsPanel() {
                   <p className="text-forest-200 text-sm">
                     {editing === 'new'
                       ? 'A cabin, tent, yurt or room'
-                      : (areasQuery.data?.find((a) => a.id === editing.area)?.name ?? 'No area')}
+                      : (areasQuery.items.find((a) => a.id === editing.area)?.name ?? 'No area')}
                   </p>
                 </div>
               </div>
@@ -266,8 +266,8 @@ export function LodgingUnitsPanel() {
                  records writes the PREVIOUS unit's fields to the new one. */
               <LodgingUnitForm
                 key={editing === 'new' ? 'new' : editing.id}
-                areas={areasQuery.data}
-                units={unitsQuery.data ?? []}
+                areas={areasQuery.items}
+                units={unitsQuery.items}
                 unit={editing === 'new' ? undefined : editing}
                 year={currentYear}
                 onSaved={refresh}
@@ -317,7 +317,7 @@ export function LodgingUnitsPanel() {
             <div className="card-lodge overflow-x-auto p-4">
               <table className="w-full text-left text-sm">
                 <UnitsTableHeader sort={sort} onToggleSort={toggleSort} />
-                {groupUnitsByArea(units, areasQuery.data ?? []).map((group) => (
+                {groupUnitsByArea(units, areasQuery.items).map((group) => (
                   <UnitAreaGroup
                     key={group.areaId}
                     group={group}

--- a/frontend/src/components/admin/lodging/LodgingUnitsPanel.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitsPanel.tsx
@@ -17,25 +17,18 @@
  * Deactivate, never delete (spec §3.8). The Go guard in pocketbase/lodging
  * blocks deleting a referenced unit anyway, but the UI should not offer it.
  */
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQueryClient } from '@tanstack/react-query'
 import { Home, Map, Plus } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import toast from 'react-hot-toast'
 import { Link } from 'react-router'
 
 import { useCurrentYear } from '../../../hooks/useCurrentYear'
-import {
-  confirmLodgingUnits,
-  deactivateLodgingUnit,
-  listLodgingAreas,
-  listLodgingUnits,
-} from '../../../services/lodgingCrud'
+import { useLodgingAreas } from '../../../hooks/useLodgingAreas'
+import { useLodgingUnits } from '../../../hooks/useLodgingUnits'
+import { confirmLodgingUnits, deactivateLodgingUnit } from '../../../services/lodgingCrud'
 import type { LodgingUnitRecord } from '../../../types/lodging'
-import {
-  invalidateLodgingRegistryQueries,
-  queryKeys,
-  userDataOptions,
-} from '../../../utils/queryKeys'
+import { invalidateLodgingRegistryQueries } from '../../../utils/queryKeys'
 import { QueryGuard } from '../../QueryGuard'
 import { Modal } from '../../ui/Modal'
 import { BUTTON_PRIMARY, BUTTON_SECONDARY } from './lodgingStyles'
@@ -81,23 +74,13 @@ export function LodgingUnitsPanel() {
   // every consumer below. Derive both from this and they cannot drift apart.
   const yearReady = currentYear > 0
 
-  const unitsQuery = useQuery({
-    queryKey: queryKeys.lodgingUnits(currentYear),
-    ...userDataOptions,
-    queryFn: () => listLodgingUnits(currentYear),
-    // CurrentYearContext returns the literal 0 until the backend supplies the
-    // configured year. Unlike the FastAPI routers (`ge=2000` -> a loud 422),
-    // PocketBase answers `year = 0` with a successful `200 []`, so without
-    // this gate a cold load would render "no lodging units" as if it were
-    // true. Convention: `useWeekendRoster.ts:30-37`.
-    enabled: yearReady,
-  })
-  const areasQuery = useQuery({
-    queryKey: queryKeys.lodgingAreas(currentYear),
-    ...userDataOptions,
-    queryFn: () => listLodgingAreas(currentYear),
-    enabled: yearReady,
-  })
+  // useLodgingUnits / useLodgingAreas each gate on year-readiness themselves
+  // (CurrentYearContext returns the literal 0 until the backend supplies the
+  // configured year, and PocketBase answers `year = 0` with a successful
+  // `200 []` rather than an error). `yearReady` above is still needed here as
+  // the RENDER guard, not the fetch gate — see the ONE constant comment.
+  const unitsQuery = useLodgingUnits()
+  const areasQuery = useLodgingAreas()
 
   const refresh = () => {
     setEditing(null)

--- a/frontend/src/components/admin/lodging/LodgingUnitsPanel.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitsPanel.tsx
@@ -296,6 +296,11 @@ export function LodgingUnitsPanel() {
       <QueryGuard
         isLoading={unitsQuery.isLoading || !yearReady}
         error={unitsQuery.error}
+        // Deliberately `.data`, not `.items` — QueryGuard's empty-vs-loading
+        // branch below keys on `!data`. `.items` coerces to `[]` while
+        // pending, which reads to QueryGuard as a settled empty result and
+        // would swap "still loading" for "No lodging units yet." See the
+        // warning on `UseLodgingUnitsResult.data` in useLodgingUnits.ts.
         data={unitsQuery.data}
         label="lodging units"
         emptyMessage="No lodging units yet."

--- a/frontend/src/components/admin/lodging/LodgingUnitsPanel.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitsPanel.tsx
@@ -49,24 +49,6 @@ export function LodgingUnitsPanel() {
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set())
   const formRef = useRef<HTMLDivElement>(null)
 
-  /**
-   * Move FOCUS to the editor whenever it opens — including switching straight
-   * from editing one unit to another, since the form never unmounts in between
-   * (see the `key` below).
-   *
-   * This used to scroll as well, because the editor mounted above a 93-row
-   * table and opening it otherwise produced no visible change below the fold —
-   * and the natural response, clicking Edit again or on a different row, is
-   * exactly how a stale-record write went unnoticed. The dialog solves that
-   * outright: it is unmissable without moving anything, so the staffer keeps
-   * their place in the list. Only the focus half is still needed, and the
-   * shared Modal does not set initial focus itself.
-   */
-  useEffect(() => {
-    if (editing === null) return
-    formRef.current?.querySelector<HTMLElement>('input, select, textarea')?.focus()
-  }, [editing])
-
   // RENDER guard only, not a fetch gate. useLodgingUnits / useLodgingAreas
   // each gate their own fetch on year-readiness internally — currentYear > 0
   // is not passed to either call below — so this constant does not control
@@ -81,6 +63,35 @@ export function LodgingUnitsPanel() {
 
   const unitsQuery = useLodgingUnits()
   const areasQuery = useLodgingAreas()
+
+  /**
+   * Move FOCUS to the editor whenever it opens — including switching straight
+   * from editing one unit to another, since the form never unmounts in between
+   * (see the `key` below).
+   *
+   * This used to scroll as well, because the editor mounted above a 93-row
+   * table and opening it otherwise produced no visible change below the fold —
+   * and the natural response, clicking Edit again or on a different row, is
+   * exactly how a stale-record write went unnoticed. The dialog solves that
+   * outright: it is unmissable without moving anything, so the staffer keeps
+   * their place in the list. Only the focus half is still needed, and the
+   * shared Modal does not set initial focus itself.
+   *
+   * `areasQuery.isSuccess` IS A DEPENDENCY, not a stray one — and it is why
+   * this effect sits BELOW the query rather than up with the other state. The
+   * form is gated on that flag: until the areas resolve, the dialog holds the
+   * "Loading areas…" paragraph and there is nothing to focus. Opening the
+   * editor during a slow areas fetch therefore runs this effect against an
+   * empty dialog, and keyed on `[editing]` alone it would never re-run once
+   * the real form mounts — leaving focus on the trigger behind the backdrop,
+   * which for an aria-modal dialog strands a keyboard or screen-reader user
+   * outside it entirely. Only the success branch renders anything focusable
+   * (the error branch is a message paragraph), so this one flag covers it.
+   */
+  useEffect(() => {
+    if (editing === null) return
+    formRef.current?.querySelector<HTMLElement>('input, select, textarea')?.focus()
+  }, [editing, areasQuery.isSuccess])
 
   const refresh = () => {
     setEditing(null)

--- a/frontend/src/components/admin/lodging/UnresolvedAliasQueue.tsx
+++ b/frontend/src/components/admin/lodging/UnresolvedAliasQueue.tsx
@@ -19,9 +19,9 @@ import { useState } from 'react'
 import toast from 'react-hot-toast'
 
 import { useCurrentYear } from '../../../hooks/useCurrentYear'
+import { useLodgingUnits } from '../../../hooks/useLodgingUnits'
 import {
   ignoreIngestIssue,
-  listLodgingUnits,
   listUnresolvedAliasIssues,
   mapUnresolvedAlias,
 } from '../../../services/lodgingCrud'
@@ -60,12 +60,7 @@ export function UnresolvedAliasQueue() {
     queryFn: () => listUnresolvedAliasIssues(currentYear),
     enabled: yearReady,
   })
-  const unitsQuery = useQuery({
-    queryKey: queryKeys.lodgingUnits(currentYear),
-    ...userDataOptions,
-    queryFn: () => listLodgingUnits(currentYear),
-    enabled: yearReady,
-  })
+  const unitsQuery = useLodgingUnits()
 
   const refresh = () => {
     invalidateLodgingRegistryQueries(queryClient)

--- a/frontend/src/components/admin/lodging/UnresolvedAliasQueue.tsx
+++ b/frontend/src/components/admin/lodging/UnresolvedAliasQueue.tsx
@@ -47,11 +47,14 @@ export function UnresolvedAliasQueue() {
   // configured year. PocketBase answers `year = 0` with a successful `200
   // []` rather than an error, so without this gate a cold load would render
   // an empty queue as if there were genuinely nothing to resolve.
-  // ONE constant for the fetch gate and the render guard, because gating only
-  // the fetch does not fix what the gate is for. A disabled TanStack query is
-  // `isLoading === false` (pending but idle -- nothing is fetching) with `data
-  // === undefined`, which is indistinguishable from a settled empty result to
-  // every consumer below. Derive both from this and they cannot drift apart.
+  // FETCH gate for queueQuery below (`enabled: yearReady`), and RENDER guard
+  // for both queries — including unitsQuery, which gates its own fetch on
+  // year-readiness internally (see useLodgingUnits.ts) and does not take
+  // yearReady as an argument. A disabled TanStack query is `isLoading ===
+  // false` (pending but idle -- nothing is fetching) with `data === undefined`,
+  // which is indistinguishable from a settled empty result to every consumer
+  // below, so the render guard is still needed here separately from the fetch
+  // gate.
   const yearReady = currentYear > 0
 
   const queueQuery = useQuery({
@@ -152,7 +155,7 @@ export function UnresolvedAliasQueue() {
                   ) : (
                     <fieldset className="flex flex-wrap gap-3">
                       <legend className={LABEL}>Maps to (pick two or more for a merge)</legend>
-                      {eligibleAliasMembers(unitsQuery.data ?? [], chosen).map((unit) => (
+                      {eligibleAliasMembers(unitsQuery.items, chosen).map((unit) => (
                         <label key={unit.id} className="inline-flex items-center gap-1.5 text-sm">
                           <input
                             type="checkbox"

--- a/frontend/src/hooks/useLodgingAreas.test.tsx
+++ b/frontend/src/hooks/useLodgingAreas.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * The Areas query, centralised out of LodgingAreasDrawer and LodgingUnitsPanel
+ * (kindred#1896), which each declared it separately with their own `?? []`
+ * coercion.
+ *
+ * Fictional data throughout.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { queryKeys } from '../utils/queryKeys'
+import { CurrentYearContext, type CurrentYearContextType } from './useCurrentYear'
+import { useLodgingAreas } from './useLodgingAreas'
+
+const listLodgingAreas = vi.fn()
+
+vi.mock('../services/lodgingCrud', () => ({
+  listLodgingAreas: (...args: unknown[]) => listLodgingAreas(...args),
+}))
+
+const AREAS = [
+  { id: 'a1', name: 'North Zone', code: 'NORTH', map_x: 0.2, map_y: 0.3, sort_order: 1 },
+]
+
+let client: QueryClient
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  listLodgingAreas.mockResolvedValue(AREAS)
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+})
+
+const YEAR_CONTEXT: CurrentYearContextType = {
+  currentYear: 2026,
+  setCurrentYear: vi.fn(),
+  availableYears: [2026],
+  isTransitioning: false,
+  isYearReady: true,
+}
+
+function wrapper(context: CurrentYearContextType) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <CurrentYearContext.Provider value={context}>{children}</CurrentYearContext.Provider>
+      </QueryClientProvider>
+    )
+  }
+}
+
+describe('useLodgingAreas', () => {
+  it('fetches the current season by default', async () => {
+    const { result } = renderHook(() => useLodgingAreas(), { wrapper: wrapper(YEAR_CONTEXT) })
+    await waitFor(() => {
+      expect(result.current.data).toEqual(AREAS)
+    })
+    expect(listLodgingAreas).toHaveBeenCalledWith(2026)
+  })
+
+  it('shares a cache entry across consumers under the centralised query key', async () => {
+    // The two duplicated inline declarations this hook replaces each had
+    // their own `?? []` coercion — the point of centralising is that both
+    // consumers now read the SAME cache entry rather than issuing their own
+    // fetch under a key they happened to spell identically.
+    const { result } = renderHook(() => useLodgingAreas(), { wrapper: wrapper(YEAR_CONTEXT) })
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+    expect(client.getQueryData(queryKeys.lodgingAreas(2026))).toEqual(AREAS)
+  })
+
+  it('does not fetch until the year resolves', () => {
+    // CurrentYearContext returns the literal 0 until the backend supplies the
+    // configured year, and PocketBase answers `year = 0` with a successful
+    // `200 []` rather than an error — an ungated query would render a false
+    // empty state.
+    renderHook(() => useLodgingAreas(), {
+      wrapper: wrapper({ ...YEAR_CONTEXT, currentYear: 0, isYearReady: false }),
+    })
+    expect(listLodgingAreas).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch when the caller passes enabled: false, even with a resolved year', () => {
+    // The drawer only wants this while open. The extra gate must AND with
+    // year-readiness, not replace it — see the next test.
+    renderHook(() => useLodgingAreas({ enabled: false }), { wrapper: wrapper(YEAR_CONTEXT) })
+    expect(listLodgingAreas).not.toHaveBeenCalled()
+  })
+
+  it('still withholds the fetch when enabled is true but the year has not resolved', () => {
+    renderHook(() => useLodgingAreas({ enabled: true }), {
+      wrapper: wrapper({ ...YEAR_CONTEXT, currentYear: 0, isYearReady: false }),
+    })
+    expect(listLodgingAreas).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/hooks/useLodgingAreas.test.tsx
+++ b/frontend/src/hooks/useLodgingAreas.test.tsx
@@ -89,6 +89,25 @@ describe('useLodgingAreas', () => {
     expect(client.getQueryData(queryKeys.lodgingAreas(2026))).toEqual(AREAS)
   })
 
+  it('fetches once for two concurrent consumers under one QueryClient', async () => {
+    // A genuine regression guard for the caching behaviour, not proof that
+    // extraction is what CAUSES it — see the NOTE above: two independent
+    // inline `useQuery({ queryKey: queryKeys.lodgingAreas(currentYear) })`
+    // calls (the actual pre-#1896 shape) also single-fetch here, since
+    // TanStack Query dedupes by serialized queryKey regardless of which
+    // function issued the call. This still earns its keep: it would catch a
+    // future regression where the hook stopped resolving to one shared key
+    // (e.g. a per-call cache-buster) even though it wouldn't distinguish
+    // "hook" from "two inline copies of the same key".
+    const consumerA = renderHook(() => useLodgingAreas(), { wrapper: wrapper(YEAR_CONTEXT) })
+    const consumerB = renderHook(() => useLodgingAreas(), { wrapper: wrapper(YEAR_CONTEXT) })
+    await waitFor(() => {
+      expect(consumerA.result.current.isSuccess).toBe(true)
+      expect(consumerB.result.current.isSuccess).toBe(true)
+    })
+    expect(listLodgingAreas).toHaveBeenCalledTimes(1)
+  })
+
   it('does not fetch until the year resolves', () => {
     // CurrentYearContext returns the literal 0 until the backend supplies the
     // configured year, and PocketBase answers `year = 0` with a successful

--- a/frontend/src/hooks/useLodgingAreas.test.tsx
+++ b/frontend/src/hooks/useLodgingAreas.test.tsx
@@ -5,12 +5,13 @@
  *
  * Fictional data throughout.
  */
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { type QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderHook, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { queryKeys } from '../utils/queryKeys'
+import { createTestQueryClient } from '../test/test-helpers'
+import { queryKeys, userDataOptions } from '../utils/queryKeys'
 import { CurrentYearContext, type CurrentYearContextType } from './useCurrentYear'
 import { useLodgingAreas } from './useLodgingAreas'
 
@@ -29,8 +30,21 @@ let client: QueryClient
 beforeEach(() => {
   vi.clearAllMocks()
   listLodgingAreas.mockResolvedValue(AREAS)
-  client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  client = createTestQueryClient()
 })
+
+/**
+ * The options React Query actually resolved for a mounted query, client
+ * defaults merged in. Read from the OBSERVER, not the query — see
+ * `useWeekendRoster.test.tsx`, which this mirrors.
+ */
+function resolvedOptions(queryKey: readonly unknown[]) {
+  const query = client.getQueryCache().find({ queryKey })
+  if (!query) throw new Error(`no query cached for ${JSON.stringify(queryKey)}`)
+  const observer = query.observers[0]
+  if (!observer) throw new Error(`query ${JSON.stringify(queryKey)} has no mounted observer`)
+  return observer.options
+}
 
 const YEAR_CONTEXT: CurrentYearContextType = {
   currentYear: 2026,
@@ -59,11 +73,15 @@ describe('useLodgingAreas', () => {
     expect(listLodgingAreas).toHaveBeenCalledWith(2026)
   })
 
-  it('shares a cache entry across consumers under the centralised query key', async () => {
-    // The two duplicated inline declarations this hook replaces each had
-    // their own `?? []` coercion — the point of centralising is that both
-    // consumers now read the SAME cache entry rather than issuing their own
-    // fetch under a key they happened to spell identically.
+  it('resolves fetched data under the centralised `queryKeys.lodgingAreas` key', async () => {
+    // NOTE on what this does and does not prove: the drawer and the units
+    // table both called `queryKeys.lodgingAreas(currentYear)` even before this
+    // hook existed (they already shared the factory), so a single cache entry
+    // for two consumers is not new behaviour this hook introduces — reverting
+    // to two independent inline `useQuery` calls that each spell the key via
+    // the same factory still shares one entry. What centralising buys is that
+    // there is now exactly ONE place that could get the key, the options, or
+    // the `?? []` coercion (see `.items` below) wrong instead of several.
     const { result } = renderHook(() => useLodgingAreas(), { wrapper: wrapper(YEAR_CONTEXT) })
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true)
@@ -82,17 +100,32 @@ describe('useLodgingAreas', () => {
     expect(listLodgingAreas).not.toHaveBeenCalled()
   })
 
-  it('does not fetch when the caller passes enabled: false, even with a resolved year', () => {
-    // The drawer only wants this while open. The extra gate must AND with
-    // year-readiness, not replace it — see the next test.
-    renderHook(() => useLodgingAreas({ enabled: false }), { wrapper: wrapper(YEAR_CONTEXT) })
-    expect(listLodgingAreas).not.toHaveBeenCalled()
+  describe('.items', () => {
+    it('coerces to an empty array before the query settles, so callers need no `?? []`', () => {
+      const { result } = renderHook(() => useLodgingAreas(), {
+        wrapper: wrapper({ ...YEAR_CONTEXT, currentYear: 0, isYearReady: false }),
+      })
+      expect(result.current.data).toBeUndefined()
+      expect(result.current.items).toEqual([])
+    })
+
+    it('mirrors `.data` once the query resolves', async () => {
+      const { result } = renderHook(() => useLodgingAreas(), { wrapper: wrapper(YEAR_CONTEXT) })
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true)
+      })
+      expect(result.current.items).toEqual(AREAS)
+    })
   })
 
-  it('still withholds the fetch when enabled is true but the year has not resolved', () => {
-    renderHook(() => useLodgingAreas({ enabled: true }), {
-      wrapper: wrapper({ ...YEAR_CONTEXT, currentYear: 0, isYearReady: false }),
+  it('pins the cache options to userDataOptions, so opting down needs a stated reason', async () => {
+    const { result } = renderHook(() => useLodgingAreas(), { wrapper: wrapper(YEAR_CONTEXT) })
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
     })
-    expect(listLodgingAreas).not.toHaveBeenCalled()
+    const options = resolvedOptions(queryKeys.lodgingAreas(2026))
+    expect(options.staleTime).toBe(userDataOptions.staleTime)
+    expect(options.gcTime).toBe(userDataOptions.gcTime)
+    expect(options.refetchOnWindowFocus).toBe(userDataOptions.refetchOnWindowFocus)
   })
 })

--- a/frontend/src/hooks/useLodgingAreas.ts
+++ b/frontend/src/hooks/useLodgingAreas.ts
@@ -12,6 +12,14 @@ import { queryKeys, userDataOptions } from '../utils/queryKeys'
 import { useYear } from './useCurrentYear'
 
 export interface UseLodgingAreasResult {
+  /**
+   * `undefined` until the query settles, exactly like the raw TanStack
+   * result — deliberately NOT coerced. If a future caller passes this to
+   * `QueryGuard` (see `useLodgingUnits.ts`'s twin warning — its `data` feeds
+   * `LodgingUnitsPanel.tsx`'s `QueryGuard` today), that component's
+   * empty-vs-loading branch keys on `!data`; coercing it here would make
+   * that check always false. Use `.items` below at render sites, never here.
+   */
   data: LodgingAreaRecord[] | undefined
   /** `.data ?? []` — the coercion every call site used to do for itself. */
   items: LodgingAreaRecord[]

--- a/frontend/src/hooks/useLodgingAreas.ts
+++ b/frontend/src/hooks/useLodgingAreas.ts
@@ -1,34 +1,46 @@
 /**
  * The Areas query, shared by the areas drawer (the editor itself) and the
  * units table (which groups by area). Before kindred#1896 each declared this
- * inline, with its own `?? []` coercion.
+ * inline, with its own `?? []` coercion — callers now read `.items` instead
+ * of `.data ?? []`, so that coercion lives here once.
  */
 import { useQuery } from '@tanstack/react-query'
 
 import { listLodgingAreas } from '../services/lodgingCrud'
+import type { LodgingAreaRecord } from '../types/lodging'
 import { queryKeys, userDataOptions } from '../utils/queryKeys'
-import { useCurrentYear } from './useCurrentYear'
+import { useYear } from './useCurrentYear'
 
-export interface UseLodgingAreasOptions {
-  /**
-   * ANDed with year-readiness, not a replacement for it. Defaults to true —
-   * most consumers always want the query; the areas drawer passes `open` so
-   * it does not fetch while closed.
-   */
-  enabled?: boolean
+export interface UseLodgingAreasResult {
+  data: LodgingAreaRecord[] | undefined
+  /** `.data ?? []` — the coercion every call site used to do for itself. */
+  items: LodgingAreaRecord[]
+  isLoading: boolean
+  isSuccess: boolean
+  isError: boolean
+  error: Error | null
 }
 
-export function useLodgingAreas({ enabled = true }: UseLodgingAreasOptions = {}) {
-  const { currentYear } = useCurrentYear()
+export function useLodgingAreas(): UseLodgingAreasResult {
+  const currentYear = useYear()
 
-  return useQuery({
+  const query = useQuery({
     queryKey: queryKeys.lodgingAreas(currentYear),
     ...userDataOptions,
     queryFn: () => listLodgingAreas(currentYear),
     // CurrentYearContext returns the literal 0 until the backend supplies the
     // configured year, and PocketBase answers `year = 0` with a successful
-    // `200 []` rather than an error — so `currentYear > 0` gates the fetch
-    // regardless of what the caller passes for `enabled`.
-    enabled: enabled && currentYear > 0,
+    // `200 []` rather than an error — so this gates the fetch regardless of
+    // whether a consumer is currently visible.
+    enabled: currentYear > 0,
   })
+
+  return {
+    data: query.data,
+    items: query.data ?? [],
+    isLoading: query.isLoading,
+    isSuccess: query.isSuccess,
+    isError: query.isError,
+    error: query.error,
+  }
 }

--- a/frontend/src/hooks/useLodgingAreas.ts
+++ b/frontend/src/hooks/useLodgingAreas.ts
@@ -1,0 +1,34 @@
+/**
+ * The Areas query, shared by the areas drawer (the editor itself) and the
+ * units table (which groups by area). Before kindred#1896 each declared this
+ * inline, with its own `?? []` coercion.
+ */
+import { useQuery } from '@tanstack/react-query'
+
+import { listLodgingAreas } from '../services/lodgingCrud'
+import { queryKeys, userDataOptions } from '../utils/queryKeys'
+import { useCurrentYear } from './useCurrentYear'
+
+export interface UseLodgingAreasOptions {
+  /**
+   * ANDed with year-readiness, not a replacement for it. Defaults to true —
+   * most consumers always want the query; the areas drawer passes `open` so
+   * it does not fetch while closed.
+   */
+  enabled?: boolean
+}
+
+export function useLodgingAreas({ enabled = true }: UseLodgingAreasOptions = {}) {
+  const { currentYear } = useCurrentYear()
+
+  return useQuery({
+    queryKey: queryKeys.lodgingAreas(currentYear),
+    ...userDataOptions,
+    queryFn: () => listLodgingAreas(currentYear),
+    // CurrentYearContext returns the literal 0 until the backend supplies the
+    // configured year, and PocketBase answers `year = 0` with a successful
+    // `200 []` rather than an error — so `currentYear > 0` gates the fetch
+    // regardless of what the caller passes for `enabled`.
+    enabled: enabled && currentYear > 0,
+  })
+}

--- a/frontend/src/hooks/useLodgingUnits.test.tsx
+++ b/frontend/src/hooks/useLodgingUnits.test.tsx
@@ -4,12 +4,13 @@
  *
  * Fictional data throughout.
  */
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { type QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderHook, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { queryKeys } from '../utils/queryKeys'
+import { createTestQueryClient } from '../test/test-helpers'
+import { queryKeys, userDataOptions } from '../utils/queryKeys'
 import { CurrentYearContext, type CurrentYearContextType } from './useCurrentYear'
 import { useLodgingUnits } from './useLodgingUnits'
 
@@ -26,8 +27,21 @@ let client: QueryClient
 beforeEach(() => {
   vi.clearAllMocks()
   listLodgingUnits.mockResolvedValue(UNITS)
-  client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  client = createTestQueryClient()
 })
+
+/**
+ * The options React Query actually resolved for a mounted query, client
+ * defaults merged in. Read from the OBSERVER, not the query — see
+ * `useWeekendRoster.test.tsx`, which this mirrors.
+ */
+function resolvedOptions(queryKey: readonly unknown[]) {
+  const query = client.getQueryCache().find({ queryKey })
+  if (!query) throw new Error(`no query cached for ${JSON.stringify(queryKey)}`)
+  const observer = query.observers[0]
+  if (!observer) throw new Error(`query ${JSON.stringify(queryKey)} has no mounted observer`)
+  return observer.options
+}
 
 const YEAR_CONTEXT: CurrentYearContextType = {
   currentYear: 2026,
@@ -56,10 +70,15 @@ describe('useLodgingUnits', () => {
     expect(listLodgingUnits).toHaveBeenCalledWith(2026)
   })
 
-  it('shares a cache entry under the centralised query key', async () => {
-    // Three components each declared this query separately before #1896;
-    // centralising means they now read one cache entry rather than each
-    // trusting its own copy of the key and the `?? []` fallback to agree.
+  it('resolves fetched data under the centralised `queryKeys.lodgingUnits` key', async () => {
+    // NOTE on what this does and does not prove: all three consumers already
+    // called `queryKeys.lodgingUnits(currentYear)` before this hook existed
+    // (they already shared the factory), so a single cache entry across
+    // consumers is not new behaviour this hook introduces — reverting to
+    // three independent inline `useQuery` calls that each spell the key via
+    // the same factory still shares one entry. What centralising buys is that
+    // there is now exactly ONE place that could get the key, the options, or
+    // the `?? []` coercion (see `.items` below) wrong instead of several.
     const { result } = renderHook(() => useLodgingUnits(), { wrapper: wrapper(YEAR_CONTEXT) })
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true)
@@ -76,5 +95,34 @@ describe('useLodgingUnits', () => {
       wrapper: wrapper({ ...YEAR_CONTEXT, currentYear: 0, isYearReady: false }),
     })
     expect(listLodgingUnits).not.toHaveBeenCalled()
+  })
+
+  describe('.items', () => {
+    it('coerces to an empty array before the query settles, so callers need no `?? []`', () => {
+      const { result } = renderHook(() => useLodgingUnits(), {
+        wrapper: wrapper({ ...YEAR_CONTEXT, currentYear: 0, isYearReady: false }),
+      })
+      expect(result.current.data).toBeUndefined()
+      expect(result.current.items).toEqual([])
+    })
+
+    it('mirrors `.data` once the query resolves', async () => {
+      const { result } = renderHook(() => useLodgingUnits(), { wrapper: wrapper(YEAR_CONTEXT) })
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true)
+      })
+      expect(result.current.items).toEqual(UNITS)
+    })
+  })
+
+  it('pins the cache options to userDataOptions, so opting down needs a stated reason', async () => {
+    const { result } = renderHook(() => useLodgingUnits(), { wrapper: wrapper(YEAR_CONTEXT) })
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+    const options = resolvedOptions(queryKeys.lodgingUnits(2026))
+    expect(options.staleTime).toBe(userDataOptions.staleTime)
+    expect(options.gcTime).toBe(userDataOptions.gcTime)
+    expect(options.refetchOnWindowFocus).toBe(userDataOptions.refetchOnWindowFocus)
   })
 })

--- a/frontend/src/hooks/useLodgingUnits.test.tsx
+++ b/frontend/src/hooks/useLodgingUnits.test.tsx
@@ -86,6 +86,25 @@ describe('useLodgingUnits', () => {
     expect(client.getQueryData(queryKeys.lodgingUnits(2026))).toEqual(UNITS)
   })
 
+  it('fetches once for two concurrent consumers under one QueryClient', async () => {
+    // A genuine regression guard for the caching behaviour, not proof that
+    // extraction is what CAUSES it — see the NOTE above: three independent
+    // inline `useQuery({ queryKey: queryKeys.lodgingUnits(currentYear) })`
+    // calls (the actual pre-#1896 shape) also single-fetch here, since
+    // TanStack Query dedupes by serialized queryKey regardless of which
+    // function issued the call. This still earns its keep: it would catch a
+    // future regression where the hook stopped resolving to one shared key
+    // (e.g. a per-call cache-buster) even though it wouldn't distinguish
+    // "hook" from "N inline copies of the same key".
+    const consumerA = renderHook(() => useLodgingUnits(), { wrapper: wrapper(YEAR_CONTEXT) })
+    const consumerB = renderHook(() => useLodgingUnits(), { wrapper: wrapper(YEAR_CONTEXT) })
+    await waitFor(() => {
+      expect(consumerA.result.current.isSuccess).toBe(true)
+      expect(consumerB.result.current.isSuccess).toBe(true)
+    })
+    expect(listLodgingUnits).toHaveBeenCalledTimes(1)
+  })
+
   it('does not fetch until the year resolves', () => {
     // CurrentYearContext returns the literal 0 until the backend supplies the
     // configured year, and PocketBase answers `year = 0` with a successful

--- a/frontend/src/hooks/useLodgingUnits.test.tsx
+++ b/frontend/src/hooks/useLodgingUnits.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * The Units query, centralised out of LodgingUnitsPanel, LodgingAliasesPanel
+ * and UnresolvedAliasQueue (kindred#1896), which each declared it separately.
+ *
+ * Fictional data throughout.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { queryKeys } from '../utils/queryKeys'
+import { CurrentYearContext, type CurrentYearContextType } from './useCurrentYear'
+import { useLodgingUnits } from './useLodgingUnits'
+
+const listLodgingUnits = vi.fn()
+
+vi.mock('../services/lodgingCrud', () => ({
+  listLodgingUnits: (...args: unknown[]) => listLodgingUnits(...args),
+}))
+
+const UNITS = [{ id: 'u1', name: 'Cedar 1', code: 'cedar-1' }]
+
+let client: QueryClient
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  listLodgingUnits.mockResolvedValue(UNITS)
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+})
+
+const YEAR_CONTEXT: CurrentYearContextType = {
+  currentYear: 2026,
+  setCurrentYear: vi.fn(),
+  availableYears: [2026],
+  isTransitioning: false,
+  isYearReady: true,
+}
+
+function wrapper(context: CurrentYearContextType) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <CurrentYearContext.Provider value={context}>{children}</CurrentYearContext.Provider>
+      </QueryClientProvider>
+    )
+  }
+}
+
+describe('useLodgingUnits', () => {
+  it('fetches the current season', async () => {
+    const { result } = renderHook(() => useLodgingUnits(), { wrapper: wrapper(YEAR_CONTEXT) })
+    await waitFor(() => {
+      expect(result.current.data).toEqual(UNITS)
+    })
+    expect(listLodgingUnits).toHaveBeenCalledWith(2026)
+  })
+
+  it('shares a cache entry under the centralised query key', async () => {
+    // Three components each declared this query separately before #1896;
+    // centralising means they now read one cache entry rather than each
+    // trusting its own copy of the key and the `?? []` fallback to agree.
+    const { result } = renderHook(() => useLodgingUnits(), { wrapper: wrapper(YEAR_CONTEXT) })
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+    expect(client.getQueryData(queryKeys.lodgingUnits(2026))).toEqual(UNITS)
+  })
+
+  it('does not fetch until the year resolves', () => {
+    // CurrentYearContext returns the literal 0 until the backend supplies the
+    // configured year, and PocketBase answers `year = 0` with a successful
+    // `200 []` rather than an error — an ungated query would render a false
+    // empty state.
+    renderHook(() => useLodgingUnits(), {
+      wrapper: wrapper({ ...YEAR_CONTEXT, currentYear: 0, isYearReady: false }),
+    })
+    expect(listLodgingUnits).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/hooks/useLodgingUnits.ts
+++ b/frontend/src/hooks/useLodgingUnits.ts
@@ -1,18 +1,31 @@
 /**
  * The Units query, shared by the units table, the aliases panel's unit
  * picker, and the unresolved-alias queue's mapping picker. Before
- * kindred#1896 each declared this inline, three times over.
+ * kindred#1896 each declared this inline, three times over, each with its
+ * own `?? []` coercion — callers now read `.items` instead of `.data ?? []`,
+ * so that coercion lives here once.
  */
 import { useQuery } from '@tanstack/react-query'
 
 import { listLodgingUnits } from '../services/lodgingCrud'
+import type { LodgingUnitRecord } from '../types/lodging'
 import { queryKeys, userDataOptions } from '../utils/queryKeys'
-import { useCurrentYear } from './useCurrentYear'
+import { useYear } from './useCurrentYear'
 
-export function useLodgingUnits() {
-  const { currentYear } = useCurrentYear()
+export interface UseLodgingUnitsResult {
+  data: LodgingUnitRecord[] | undefined
+  /** `.data ?? []` — the coercion every call site used to do for itself. */
+  items: LodgingUnitRecord[]
+  isLoading: boolean
+  isSuccess: boolean
+  isError: boolean
+  error: Error | null
+}
 
-  return useQuery({
+export function useLodgingUnits(): UseLodgingUnitsResult {
+  const currentYear = useYear()
+
+  const query = useQuery({
     queryKey: queryKeys.lodgingUnits(currentYear),
     ...userDataOptions,
     queryFn: () => listLodgingUnits(currentYear),
@@ -22,4 +35,13 @@ export function useLodgingUnits() {
     // false empty state.
     enabled: currentYear > 0,
   })
+
+  return {
+    data: query.data,
+    items: query.data ?? [],
+    isLoading: query.isLoading,
+    isSuccess: query.isSuccess,
+    isError: query.isError,
+    error: query.error,
+  }
 }

--- a/frontend/src/hooks/useLodgingUnits.ts
+++ b/frontend/src/hooks/useLodgingUnits.ts
@@ -13,6 +13,13 @@ import { queryKeys, userDataOptions } from '../utils/queryKeys'
 import { useYear } from './useCurrentYear'
 
 export interface UseLodgingUnitsResult {
+  /**
+   * `undefined` until the query settles, exactly like the raw TanStack
+   * result — deliberately NOT coerced. `LodgingUnitsPanel.tsx` passes this
+   * straight to `QueryGuard`, whose empty-vs-loading branch keys on `!data`;
+   * coercing it here would make that check always false and silently kill
+   * the loading state. Use `.items` below at render sites, never here.
+   */
   data: LodgingUnitRecord[] | undefined
   /** `.data ?? []` — the coercion every call site used to do for itself. */
   items: LodgingUnitRecord[]

--- a/frontend/src/hooks/useLodgingUnits.ts
+++ b/frontend/src/hooks/useLodgingUnits.ts
@@ -1,0 +1,25 @@
+/**
+ * The Units query, shared by the units table, the aliases panel's unit
+ * picker, and the unresolved-alias queue's mapping picker. Before
+ * kindred#1896 each declared this inline, three times over.
+ */
+import { useQuery } from '@tanstack/react-query'
+
+import { listLodgingUnits } from '../services/lodgingCrud'
+import { queryKeys, userDataOptions } from '../utils/queryKeys'
+import { useCurrentYear } from './useCurrentYear'
+
+export function useLodgingUnits() {
+  const { currentYear } = useCurrentYear()
+
+  return useQuery({
+    queryKey: queryKeys.lodgingUnits(currentYear),
+    ...userDataOptions,
+    queryFn: () => listLodgingUnits(currentYear),
+    // CurrentYearContext returns the literal 0 until the backend supplies the
+    // configured year, and PocketBase answers `year = 0` with a successful
+    // `200 []` rather than an error — without this gate a cold load renders a
+    // false empty state.
+    enabled: currentYear > 0,
+  })
+}


### PR DESCRIPTION
## Summary

- `queryKeys.lodgingAreas()` was declared inline twice (`LodgingAreasDrawer`, `LodgingUnitsPanel`) and `queryKeys.lodgingUnits()` three times (`LodgingUnitsPanel`, `LodgingAliasesPanel`, `UnresolvedAliasQueue`), each with its own options and `?? []` fallback handling.
- Adds `useLodgingAreas` (`frontend/src/hooks/useLodgingAreas.ts`) and `useLodgingUnits` (`frontend/src/hooks/useLodgingUnits.ts`), both built on the existing `queryKeys` / `userDataOptions` conventions, and switches all four lodging admin components over. Callers read `.items` (`.data ?? []`) instead of coercing for themselves, so that fallback also lives in one place now.
- Softens the `frontend/CLAUDE.md` "Custom hooks" bullet (line 23) to a **2+-consumer threshold**: the prior wording implied every data fetch should be extracted, which the dozen single-consumer inline `useQuery` calls surfaced in #1896 contradicted. This PR takes the middle path from that issue — soften the doc AND extract the one pair with genuine duplication — rather than sweeping all twelve call sites.

*Updated after review — see the review-response comment below for the `enabled`-gate decision and everything else that changed. `useLodgingAreas` no longer takes an `enabled` option; it turned out to be inert at its only call site.*

## Folded in: #2155 (pre-existing a11y gap in the same two effects)

Both lodging editors focus their first field from an effect keyed on `[editing]` alone, while each form is gated on a *second* query — areas for the units editor, units for the aliases editor. Open the editor during a slow fetch and the effect runs against a loading placeholder with nothing focusable, then never re-runs when the real form mounts. For `LodgingUnitsPanel` that strands a keyboard or screen-reader user with no focus inside an open `aria-modal` dialog.

Folded in rather than left standalone because the objects the dependency arrays must gain are exactly the ones this PR replaced (`const areasQuery = useQuery({...})` -> `useLodgingAreas()`, same for units), and the lines sit inside effects a reviewer of this PR is already reading.

- Adds the readiness flag to each dependency array — `isSuccess` rather than the raw `isLoading`, since a query disabled on an unresolved year reports `isLoading === false` while still having no data, and only the success branch renders anything focusable.
- Each effect also **moves below its query**: the dependency array is evaluated during render, so referencing `areasQuery` / `unitsQuery` from an effect declared above them is a temporal-dead-zone `ReferenceError`, not merely a style point.
- Corrected the issue body in place (CLAUDE.md §4) — it claimed both editors mount into `ui/Modal.tsx`; only the units panel does, so the "trapped in a modal" framing applies there alone. The bug is real in both files.

TDD: one test per panel, opening the editor while the secondary query is still pending, resolving it, then asserting focus lands inside the form. Both confirmed failing first, and **mutation-checked** — reverting only the two dependency arrays (keeping the code motion) fails exactly those two tests and nothing else, which is what proves the deps and not the move are doing the work.

## Test plan

- [x] TDD: `useLodgingAreas.test.tsx` / `useLodgingUnits.test.tsx` written first, confirmed failing (missing module) before the hooks existed
- [x] `npx vitest run` — full suite, 420 files / 5951 tests passed (behavior-preservation is the point of a refactor, so the full suite was run rather than just the touched files)
- [x] `npx tsc --noEmit` (both configs) — clean
- [x] `./node_modules/.bin/eslint` on touched files — clean
- [x] `lefthook run pre-push` (forced, full suite) — ruff, go build, shellcheck, pb-js-lint, markdownlint, api-types-freshness, mypy, type-check, pytest all green
- [x] Push verified via `git fetch` + `git rev-list --count origin/...HEAD` = 0
- [x] Fold-in round (#2155): full suite re-run — 420 files / 5959 tests passed; `npx tsc --noEmit` (both configs) clean; `./node_modules/.bin/eslint` on the four touched files clean
- [x] Review-response round: TDD for `.items`, mutation-checked the "shares a cache" claim, full suite re-run — see PR comment

Closes #1896.
Closes #2155.
