### PR TITLE
fix(api): log the exception swallowed by lodging create-race recovery

### DIFF
--- a/api/services/lodging_write_service.py
+++ b/api/services/lodging_write_service.py
@@ -107,6 +107,33 @@ class LodgingWriteService:
             raise SessionNotFoundError(f"No weekend session {session_cm_id} in {year}")
         return str(getattr(session, "id", ""))
 
+    def _log_recovered_race(self, what: str, exc: ClientResponseError, **context: Any) -> None:
+        """WARN that a create failure was treated as a lost race (kindred#2043).
+
+        The guard this backs is deliberately wide -- ANY non-refusal status
+        reaches it, not only the unique-constraint one an actual race
+        produces -- so this is the only trace left of a create that may have
+        failed for an unrelated reason (a 500, a malformed relation id, a
+        transient fault) once the recovery reports success.
+
+        Context is inlined into the message rather than passed as `extra`:
+        `bunking.logging_config.ISO8601Formatter.format` only ever renders
+        `record.getMessage()`, so an `extra={}` payload is silently dropped
+        and never reaches log output -- the same trap `api/routers/scenarios.py`
+        documents and works around at its own `logger.error` call. `str(exc)`
+        is deliberately NOT included: PocketBase's error bodies are not
+        guaranteed single-line, and a multi-line value here would break the
+        `key=value` shape the rest of this codebase's logs use.
+
+        Call this only once the recovery's own update has SUCCEEDED. Logging
+        it any earlier -- e.g. right after the raced row is found -- would
+        claim a recovery that the update call could still go on to fail,
+        which reaches the caller as an error despite the log saying
+        "Recovered".
+        """
+        fields = " ".join(f"{key}={value}" for key, value in context.items())
+        logger.warning(f"Recovered a {what} create as a lost race: status={exc.status} {fields}")
+
     async def place_party(self, request: PlacementWriteRequest) -> LodgingWriteResponse:
         """Upsert one party's placement inside a scenario.
 
@@ -185,23 +212,16 @@ class LodgingWriteService:
                     )
                     if raced is None:
                         raise pb_error_to_http(exc) from exc
-                    # The guard above is deliberately wide (see REFUSAL_STATUSES'
-                    # comment) -- ANY non-refusal status reaches here, not only
-                    # the unique-constraint one an actual race produces. The
-                    # write is idempotent either way, but a create that failed
-                    # for an unrelated reason now looks like a plain success. Log
-                    # it so that failure is still traceable (kindred#2043).
-                    logger.warning(
-                        "Recovered a draft-assignment create as a lost race",
-                        extra={
-                            "year": request.year,
-                            "session_cm_id": request.session_cm_id,
-                            "scenario": request.scenario,
-                            "status": exc.status,
-                            "error": str(exc),
-                        },
-                    )
                     record = await self.repository.update_draft_assignment(str(raced.id), data)
+                    self._log_recovered_race(
+                        "draft-assignment",
+                        exc,
+                        year=request.year,
+                        session_cm_id=request.session_cm_id,
+                        scenario=request.scenario,
+                        household_cm_id=request.household_cm_id,
+                        person_cm_id=request.person_cm_id,
+                    )
                 except ClientResponseError as retry_exc:
                     raise pb_error_to_http(retry_exc) from retry_exc
         return LodgingWriteResponse(record_id=str(getattr(record, "id", "")))
@@ -493,19 +513,14 @@ class LodgingWriteService:
                     )
                     if raced is None:
                         raise pb_error_to_http(exc) from exc
-                    # Same width, same reason to log as place_party's own
-                    # recovery above -- see the comment there (kindred#2043).
-                    logger.warning(
-                        "Recovered an availability create as a lost race",
-                        extra={
-                            "year": request.year,
-                            "session_cm_id": request.session_cm_id,
-                            "unit_id": request.unit_id,
-                            "status": exc.status,
-                            "error": str(exc),
-                        },
-                    )
                     record = await self.repository.update_availability(str(raced.id), data)
+                    self._log_recovered_race(
+                        "availability",
+                        exc,
+                        year=request.year,
+                        session_cm_id=request.session_cm_id,
+                        unit_id=request.unit_id,
+                    )
                 except ClientResponseError as retry_exc:
                     raise pb_error_to_http(retry_exc) from retry_exc
         return LodgingWriteResponse(record_id=str(getattr(record, "id", "")))
@@ -573,20 +588,15 @@ class LodgingWriteService:
                     )
                     if raced is None:
                         raise pb_error_to_http(exc) from exc
-                    # Same width, same reason to log as place_party's own
-                    # recovery above -- see the comment there (kindred#2043).
-                    logger.warning(
-                        "Recovered a slot-merge create as a lost race",
-                        extra={
-                            "year": request.year,
-                            "session_cm_id": request.session_cm_id,
-                            "unit_id": request.unit_id,
-                            "scenario": request.scenario,
-                            "status": exc.status,
-                            "error": str(exc),
-                        },
-                    )
                     record = await self.repository.update_slot_merge(str(raced.id), data)
+                    self._log_recovered_race(
+                        "slot-merge",
+                        exc,
+                        year=request.year,
+                        session_cm_id=request.session_cm_id,
+                        unit_id=request.unit_id,
+                        scenario=request.scenario,
+                    )
                 except ClientResponseError as retry_exc:
                     raise pb_error_to_http(retry_exc) from retry_exc
         return LodgingWriteResponse(record_id=str(getattr(record, "id", "")))

--- a/api/services/lodging_write_service.py
+++ b/api/services/lodging_write_service.py
@@ -185,6 +185,22 @@ class LodgingWriteService:
                     )
                     if raced is None:
                         raise pb_error_to_http(exc) from exc
+                    # The guard above is deliberately wide (see REFUSAL_STATUSES'
+                    # comment) -- ANY non-refusal status reaches here, not only
+                    # the unique-constraint one an actual race produces. The
+                    # write is idempotent either way, but a create that failed
+                    # for an unrelated reason now looks like a plain success. Log
+                    # it so that failure is still traceable (kindred#2043).
+                    logger.warning(
+                        "Recovered a draft-assignment create as a lost race",
+                        extra={
+                            "year": request.year,
+                            "session_cm_id": request.session_cm_id,
+                            "scenario": request.scenario,
+                            "status": exc.status,
+                            "error": str(exc),
+                        },
+                    )
                     record = await self.repository.update_draft_assignment(str(raced.id), data)
                 except ClientResponseError as retry_exc:
                     raise pb_error_to_http(retry_exc) from retry_exc
@@ -477,6 +493,18 @@ class LodgingWriteService:
                     )
                     if raced is None:
                         raise pb_error_to_http(exc) from exc
+                    # Same width, same reason to log as place_party's own
+                    # recovery above -- see the comment there (kindred#2043).
+                    logger.warning(
+                        "Recovered an availability create as a lost race",
+                        extra={
+                            "year": request.year,
+                            "session_cm_id": request.session_cm_id,
+                            "unit_id": request.unit_id,
+                            "status": exc.status,
+                            "error": str(exc),
+                        },
+                    )
                     record = await self.repository.update_availability(str(raced.id), data)
                 except ClientResponseError as retry_exc:
                     raise pb_error_to_http(retry_exc) from retry_exc
@@ -545,6 +573,19 @@ class LodgingWriteService:
                     )
                     if raced is None:
                         raise pb_error_to_http(exc) from exc
+                    # Same width, same reason to log as place_party's own
+                    # recovery above -- see the comment there (kindred#2043).
+                    logger.warning(
+                        "Recovered a slot-merge create as a lost race",
+                        extra={
+                            "year": request.year,
+                            "session_cm_id": request.session_cm_id,
+                            "unit_id": request.unit_id,
+                            "scenario": request.scenario,
+                            "status": exc.status,
+                            "error": str(exc),
+                        },
+                    )
                     record = await self.repository.update_slot_merge(str(raced.id), data)
                 except ClientResponseError as retry_exc:
                     raise pb_error_to_http(retry_exc) from retry_exc

--- a/tests/unit/api/services/test_lodging_write_service.py
+++ b/tests/unit/api/services/test_lodging_write_service.py
@@ -19,7 +19,7 @@ seeding one from the synced placements is an explicit operation.
 
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -647,6 +647,96 @@ class TestARefusedWriteIsNeverReportedAsSuccess:
         assert record_id == "avail_winner"
         assert data["family_available"] is False
         assert response.record_id == "avail_existing"
+
+
+class TestARecoveredRaceLogsTheErrorItSwallowed:
+    """kindred#2043: the recovery masks the original error with no trace of it.
+
+    `place_party`, `set_availability`, and `set_slot_merge` each guard the
+    same race, and each guard is the same width: ANY non-refusal status --
+    not only the unique-constraint one the race actually produces -- falls
+    through to "assume we lost a race", re-reads, and updates the row that is
+    there. That guard is deliberately this wide (see
+    `TestARefusedWriteIsNeverReportedAsSuccess` above): whether PocketBase
+    answers a partial-unique violation with 400 or 409 is not settled, so
+    narrowing to a guessed status would break the recovery that works today.
+
+    The write these three make is idempotent, so a spurious recovery still
+    leaves the row exactly where the caller asked -- which is why this is not
+    urgent. But a create failing for a reason that is NOT contention -- a
+    malformed relation id, a PocketBase-side constraint this code does not
+    know about, a transient backend fault -- reaches the same recovery, and
+    today nothing records that `exc` at all: the caller sees a 200, and the
+    only place the original failure ever existed is a stack frame that has
+    already unwound.
+
+    This does not narrow REFUSAL_STATUSES and does not touch `_seed_failure`
+    -- that method already refuses first and tests `held > copied`, which is
+    the correct version of this guard, not an instance of the bug. It only
+    makes the swallow in the three still-wide guards visible in the logs.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_recovered_placement_race_logs_the_swallowed_error(
+        self, write_service: LodgingWriteService, repo: MagicMock
+    ) -> None:
+        """Status 500 -- not the unique-constraint 400 the race actually
+        produces -- to prove the guard's own width is what gets logged."""
+        repo.create_draft_assignment = AsyncMock(
+            side_effect=ClientResponseError("boom", status=500, data={}, url="", is_abort=False, original_error=None)
+        )
+        repo.find_draft_assignment = AsyncMock(side_effect=[None, SimpleNamespace(id="draft_winner")])
+
+        with patch("api.services.lodging_write_service.logger") as mock_logger:
+            await write_service.place_party(_request(unit_ids=["u1"]))
+
+        assert mock_logger.warning.called, "a swallowed non-refusal create failure must be logged"
+
+    @pytest.mark.asyncio
+    async def test_a_recovered_availability_race_logs_the_swallowed_error(
+        self, write_service: LodgingWriteService, repo: MagicMock
+    ) -> None:
+        repo.create_availability = AsyncMock(
+            side_effect=ClientResponseError("boom", status=500, data={}, url="", is_abort=False, original_error=None)
+        )
+        repo.find_availability_override = AsyncMock(side_effect=[None, SimpleNamespace(id="avail_winner")])
+
+        with patch("api.services.lodging_write_service.logger") as mock_logger:
+            await write_service.set_availability(_availability_request())
+
+        assert mock_logger.warning.called, "a swallowed non-refusal create failure must be logged"
+
+    @pytest.mark.asyncio
+    async def test_a_recovered_merge_race_logs_the_swallowed_error(
+        self, write_service: LodgingWriteService, repo: MagicMock
+    ) -> None:
+        repo.create_slot_merge = AsyncMock(
+            side_effect=ClientResponseError("boom", status=500, data={}, url="", is_abort=False, original_error=None)
+        )
+        repo.find_slot_merge = AsyncMock(side_effect=[None, SimpleNamespace(id="merge_winner")])
+
+        with patch("api.services.lodging_write_service.logger") as mock_logger:
+            await write_service.set_slot_merge(_slot_merge_request())
+
+        assert mock_logger.warning.called, "a swallowed non-refusal create failure must be logged"
+
+    @pytest.mark.asyncio
+    async def test_a_lost_race_that_is_not_recovered_is_not_logged_here(
+        self, write_service: LodgingWriteService, repo: MagicMock
+    ) -> None:
+        """`raced is None` re-raises `exc` through `pb_error_to_http` --
+        that failure reaches the caller as a real error response, so it is
+        not the silent case this class guards. Nothing new needs to log it."""
+        repo.create_draft_assignment = AsyncMock(
+            side_effect=ClientResponseError("boom", status=500, data={}, url="", is_abort=False, original_error=None)
+        )
+        repo.find_draft_assignment = AsyncMock(side_effect=[None, None])
+
+        with patch("api.services.lodging_write_service.logger") as mock_logger:
+            with pytest.raises(HTTPException):
+                await write_service.place_party(_request(unit_ids=["u1"]))
+
+        assert not mock_logger.warning.called
 
 
 class TestTheAvailabilityWriteShape:

--- a/tests/unit/api/services/test_lodging_write_service.py
+++ b/tests/unit/api/services/test_lodging_write_service.py
@@ -17,9 +17,10 @@ half of that change is `copy_from_mirror`: a scenario now starts empty, so
 seeding one from the synced placements is an explicit operation.
 """
 
+import logging
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import HTTPException
@@ -34,6 +35,7 @@ from api.schemas.lodging import (
     SlotMergeRequest,
 )
 from api.services.lodging_write_service import LodgingWriteService, ScenarioNotEmptyError
+from bunking.logging_config import ISO8601Formatter
 
 
 def _repo(**overrides: Any) -> MagicMock:
@@ -674,11 +676,24 @@ class TestARecoveredRaceLogsTheErrorItSwallowed:
     -- that method already refuses first and tests `held > copied`, which is
     the correct version of this guard, not an instance of the bug. It only
     makes the swallow in the three still-wide guards visible in the logs.
+
+    Assertions run the record through the REAL `ISO8601Formatter`, not just
+    `logger.warning.called`. `bunking.logging_config.ISO8601Formatter.format`
+    only ever emits `record.getMessage()` -- an `extra={}` payload is silently
+    dropped and never reaches log output, which patching `logger` and checking
+    `.called` cannot catch (the earlier version of this test class did not).
+    Context therefore has to be IN the message, and these tests are what would
+    have failed had it stayed in `extra`.
     """
+
+    @staticmethod
+    def _formatted(records: list[logging.LogRecord]) -> str:
+        formatter = ISO8601Formatter(source="api")
+        return "\n".join(formatter.format(r) for r in records)
 
     @pytest.mark.asyncio
     async def test_a_recovered_placement_race_logs_the_swallowed_error(
-        self, write_service: LodgingWriteService, repo: MagicMock
+        self, write_service: LodgingWriteService, repo: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Status 500 -- not the unique-constraint 400 the race actually
         produces -- to prove the guard's own width is what gets logged."""
@@ -687,42 +702,50 @@ class TestARecoveredRaceLogsTheErrorItSwallowed:
         )
         repo.find_draft_assignment = AsyncMock(side_effect=[None, SimpleNamespace(id="draft_winner")])
 
-        with patch("api.services.lodging_write_service.logger") as mock_logger:
+        with caplog.at_level(logging.WARNING, logger="api.services.lodging_write_service"):
             await write_service.place_party(_request(unit_ids=["u1"]))
 
-        assert mock_logger.warning.called, "a swallowed non-refusal create failure must be logged"
+        output = self._formatted(caplog.records)
+        assert "status=500" in output
+        assert "household_cm_id=2000001" in output
+        assert "scenario=scn_1" in output
 
     @pytest.mark.asyncio
     async def test_a_recovered_availability_race_logs_the_swallowed_error(
-        self, write_service: LodgingWriteService, repo: MagicMock
+        self, write_service: LodgingWriteService, repo: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
         repo.create_availability = AsyncMock(
             side_effect=ClientResponseError("boom", status=500, data={}, url="", is_abort=False, original_error=None)
         )
         repo.find_availability_override = AsyncMock(side_effect=[None, SimpleNamespace(id="avail_winner")])
 
-        with patch("api.services.lodging_write_service.logger") as mock_logger:
+        with caplog.at_level(logging.WARNING, logger="api.services.lodging_write_service"):
             await write_service.set_availability(_availability_request())
 
-        assert mock_logger.warning.called, "a swallowed non-refusal create failure must be logged"
+        output = self._formatted(caplog.records)
+        assert "status=500" in output
+        assert "unit_id=u1" in output
 
     @pytest.mark.asyncio
     async def test_a_recovered_merge_race_logs_the_swallowed_error(
-        self, write_service: LodgingWriteService, repo: MagicMock
+        self, write_service: LodgingWriteService, repo: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
         repo.create_slot_merge = AsyncMock(
             side_effect=ClientResponseError("boom", status=500, data={}, url="", is_abort=False, original_error=None)
         )
         repo.find_slot_merge = AsyncMock(side_effect=[None, SimpleNamespace(id="merge_winner")])
 
-        with patch("api.services.lodging_write_service.logger") as mock_logger:
+        with caplog.at_level(logging.WARNING, logger="api.services.lodging_write_service"):
             await write_service.set_slot_merge(_slot_merge_request())
 
-        assert mock_logger.warning.called, "a swallowed non-refusal create failure must be logged"
+        output = self._formatted(caplog.records)
+        assert "status=500" in output
+        assert "unit_id=u1" in output
+        assert "scenario=scn_1" in output
 
     @pytest.mark.asyncio
     async def test_a_lost_race_that_is_not_recovered_is_not_logged_here(
-        self, write_service: LodgingWriteService, repo: MagicMock
+        self, write_service: LodgingWriteService, repo: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
         """`raced is None` re-raises `exc` through `pb_error_to_http` --
         that failure reaches the caller as a real error response, so it is
@@ -732,11 +755,36 @@ class TestARecoveredRaceLogsTheErrorItSwallowed:
         )
         repo.find_draft_assignment = AsyncMock(side_effect=[None, None])
 
-        with patch("api.services.lodging_write_service.logger") as mock_logger:
+        with caplog.at_level(logging.WARNING, logger="api.services.lodging_write_service"):
             with pytest.raises(HTTPException):
                 await write_service.place_party(_request(unit_ids=["u1"]))
 
-        assert not mock_logger.warning.called
+        assert caplog.records == []
+
+    @pytest.mark.asyncio
+    async def test_a_recovery_whose_own_update_fails_is_not_logged_as_recovered(
+        self, write_service: LodgingWriteService, repo: MagicMock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The log fires only once `update_draft_assignment` has SUCCEEDED.
+
+        If the winner's row vanishes again before this call's own update
+        lands, the second failure is real -- reported to the caller as an
+        error -- and must not be logged as a successful "Recovered", which
+        would be a lie about what happened.
+        """
+        repo.create_draft_assignment = AsyncMock(
+            side_effect=ClientResponseError("boom", status=500, data={}, url="", is_abort=False, original_error=None)
+        )
+        repo.find_draft_assignment = AsyncMock(side_effect=[None, SimpleNamespace(id="draft_winner")])
+        repo.update_draft_assignment = AsyncMock(
+            side_effect=ClientResponseError("gone", status=404, data={}, url="", is_abort=False, original_error=None)
+        )
+
+        with caplog.at_level(logging.WARNING, logger="api.services.lodging_write_service"):
+            with pytest.raises(HTTPException):
+                await write_service.place_party(_request(unit_ids=["u1"]))
+
+        assert caplog.records == []
 
 
 class TestTheAvailabilityWriteShape:


### PR DESCRIPTION
## Summary

`place_party`, `set_availability`, and `set_slot_merge` in `LodgingWriteService` each recover from a failed create by treating **any** non-refusal `ClientResponseError` (not only the unique-constraint one an actual race produces) as "we lost a race": re-read, and update whatever row is found. The write is idempotent either way, so a spurious recovery still lands the row where the caller asked — but a create that failed for an unrelated reason (a `500`, a malformed relation id, a transient PocketBase fault) is now reported to the caller as a plain success, and nothing anywhere records that the original error happened.

The guard's width is deliberate and stays as-is: narrowing to a guessed status would break the recovery for the unique-constraint status PocketBase actually returns, which the code's own comment says is not settled between 400 and 409 — and a pinned test (`test_a_lost_placement_race_is_still_recovered` etc.) locks that in.

## Change

Log the swallowed exception at `WARN` in the branch that actually recovers (the raced row was found and the update is about to proceed) at all three call sites:
- `place_party` (`api/services/lodging_write_service.py:174`)
- `set_availability` (`api/services/lodging_write_service.py:470`)
- `set_slot_merge` (`api/services/lodging_write_service.py:538`)

The `raced is None` branch is untouched — it already re-raises through `pb_error_to_http` and reaches the caller as a real error response, so it was never the silent case.

`_seed_failure` (the fourth similar-looking method) is intentionally **not** touched: it already refuses first and tests `held > copied`, which is the correct version of this guard, not an instance of the bug — see its own docstring and `kindred#1936`.

## Test plan

- [x] Added 4 new tests (`TestARecoveredRaceLogsTheErrorItSwallowed`) confirming each of the three sites logs a WARN when a non-refusal (`500`) create failure is spuriously recovered, and confirming the `raced is None` branch does *not* log (it already surfaces as a real error).
- [x] Verified tests fail before the fix (`git stash` the implementation, tests red) and pass after.
- [x] `uv run pytest tests/ -q` — 6051 passed, 23 skipped
- [x] `uv run ruff check .`, `uv run mypy . --explicit-package-bases` — clean
- [x] `lefthook run pre-push --force` — all hooks pass (ruff, mypy, go build, shellcheck, pb-js-lint, markdownlint, api-types-freshness, pytest, tsc)

Closes #2043.