### PR TITLE
chore(security): scrub post-audit camp-name literals from two lodging test files

### DIFF
--- a/frontend/src/components/weekend/boardLayout.test.ts
+++ b/frontend/src/components/weekend/boardLayout.test.ts
@@ -236,7 +236,7 @@ describe('areaTokens — the URL shorthand for each area', () => {
       'Ridge Side',
       'Ridge Yurts',
       'River Side',
-      'Tawonga Village',
+      'Forest Village',
       'Tuolumne Heights',
     ]
     const tokens = areaTokens(areasNamed(...names))

--- a/pocketbase/lodging/registry_alias_target_test.go
+++ b/pocketbase/lodging/registry_alias_target_test.go
@@ -34,14 +34,14 @@ import (
 // it is only wrong when the named unit is absent from its own alias.
 //
 // Nor is a container resolving to its own rooms. "Health Center Downstairs" and
-// "Tawonga Village 5" both name a container and resolve to its children, which
+// "Forest Village 5" both name a container and resolve to its children, which
 // is what booking a whole building HAS to mean: the container is not bookable
 // itself, so the alias has to name the rooms it is made of. That is the same
 // whole-versus-split distinction Clouds Rest turns on. Requiring the container
 // to appear in its own member list would flag both of these real rows.
 //
 // Deliberately NOT a fuzzy check. It fires only on an exact name collision, so
-// a genuine synonym ("Teen Village 1" for tawonga-village-1, whose name is
+// a genuine synonym ("Teen Village 1" for forest-village-1, whose name is
 // different) is untouched. The alternative -- scoring how well an alias
 // resembles its target -- would re-derive its answers on data nobody is
 // looking at, which is what put the wrong code in the file to begin with.
@@ -147,11 +147,11 @@ func TestFindMisdirectedAliasesAllowsACorrectlyTargetedAlias(t *testing.T) {
 }
 
 func TestFindMisdirectedAliasesAllowsASynonymThatNamesNoUnit(t *testing.T) {
-	// "Teen Village 1" is the CampMinder spelling; the unit is "Tawonga Village
+	// "Teen Village 1" is the CampMinder spelling; the unit is "Forest Village
 	// 1". The string matches no unit name, so the check must stay silent.
-	units := []registryUnit{{Code: "tawonga-village-1", Name: "Tawonga Village 1"}}
+	units := []registryUnit{{Code: "forest-village-1", Name: "Forest Village 1"}}
 	aliases := []registryAlias{
-		{AliasString: "Teen Village 1", MemberUnits: []string{"tawonga-village-1"}},
+		{AliasString: "Teen Village 1", MemberUnits: []string{"forest-village-1"}},
 	}
 
 	if got := findMisdirectedAliases(units, aliases); len(got) != 0 {

--- a/scripts/dev/verify-no-hardcoded-lodging.sh
+++ b/scripts/dev/verify-no-hardcoded-lodging.sh
@@ -62,6 +62,19 @@ if [[ "$grep_status" -ge 2 ]]; then
   exit 2
 fi
 
+# The _test./.test. exemption below is a known blind spot, not an oversight:
+# kindred#1909 found that two NEEDLES-matching literals landed in test files
+# (via PR #2006 and #2037) and sailed through, because this filter drops
+# every hit in a test file -- comment prose and fixture code alike -- with no
+# distinction between them. The fix applied there was to scrub those two
+# literals at the source, not narrow this filter: a narrower filter (still
+# failing on fixture literals, only dropping prose) would also fail on the
+# many OTHER lodging test files that legitimately hardcode real unit names as
+# fixture data (lodging_alias_resolver_test.go, LodgingUnitForm.test.tsx, and
+# others) -- the exact case this exemption exists for. A green run on a test
+# file only ever proved "no unit name outside a test file", never "no unit
+# name in test fixtures either" -- treat a future NEEDLES hit inside one as
+# worth a look, not an automatic pass.
 HITS=""
 if [[ -n "$RAW" ]]; then
   HITS=$(printf '%s\n' "$RAW" \


### PR DESCRIPTION
## Summary

Partial follow-up to #1909. Two lodging test files landed after the issue's
2026-08-04 audit baseline (via #2006 and #2037) carrying the camp's literal
name as fixture/comment data. The `verify-no-hardcoded-lodging.sh` guard's
own `NEEDLES` list already covers this string, but the `_test.`/`.test.`
exemption at the line the guard drops hits from test files unconditionally,
comment prose and fixture literals alike — so the guard stayed green through
both landings.

- Re-measured before touching anything: `git grep -ic` over tracked files
  confirms the issue's corrected count of **52**, split exactly as the issue
  describes; the six post-audit literals are `pocketbase/lodging/registry_alias_target_test.go`
  (5) and `frontend/src/components/weekend/boardLayout.test.ts` (1).
- Scrubbed those six occurrences, swapping the literal for a fictional
  stand-in of the same shape. Test *behavior* is unchanged — same pass/fail
  outcomes, same collision-detection shape in the frontend test, same
  domain-quirk narrative in the Go test (CampMinder's field spelling
  differing from the registry's canonical unit name).
- Documented the guard's exemption blind spot in `verify-no-hardcoded-lodging.sh`
  rather than narrowing the exemption itself: a real narrowing (still failing
  on fixture literals, only dropping prose) would false-positive on several
  *other* lodging test files that legitimately hardcode real unit names as
  fixture data — exactly the case the exemption exists for.

Post-fix count: **46** (52 − 6).

## What remains (NOT addressed here)

This PR does **not** close #1909. The issue's larger open item — the
28-hit CampMinder field-vocabulary cluster (`staff_applications.go`,
`quest_registrations.go`, their tests, a seed migration, and the generated
frontend types) — needs a separate alias-vs-accept ruling from the repo
owner before any code changes there. Out of scope for this PR by design; the
issue stays open for that decision. I did not bundle it in per the explicit
instruction not to.

I did not retitle the issue: the vocabulary cluster is real but it is not
literally the *only* unchecked box left (the "accept as-is" de-branding and
guard-needle rows are unchecked too, even though the issue's own prose
already treats them as settled), so a retitle would overstate how narrowed
the remaining scope is. Leaving that call to the owner.

## Pre-existing, unrelated red (not touched)

`scripts/dev/verify-no-hardcoded-lodging.sh` is red on `main` independent of
this PR, on a JSX `{/* */}` comment at
`frontend/src/components/admin/lodging/LodgingUnitsPanel.tsx:259` that the
guard's comment-stripper doesn't parse. Confirmed via `git stash` that the
failure is identical before and after this change. Not in this PR's
`files_touched`; leaving it for whoever picks that up.

## Test plan

- [x] `cd pocketbase && go test ./lodging/...` — green
- [x] `cd frontend && ./node_modules/.bin/vitest run src/components/weekend/boardLayout.test.ts` — 69/69 passed
- [x] `shellcheck scripts/dev/verify-no-hardcoded-lodging.sh` — clean
- [x] `LODGING_SCAN_ROOTS="pocketbase/lodging/ frontend/src/components/weekend/" ./scripts/dev/verify-no-hardcoded-lodging.sh` — OK (scoped to the two touched files, avoiding the unrelated pre-existing red above)
- [x] Full pre-push suite (ruff, go build, mypy, pb-js-lint, shellcheck, markdownlint, api-types-freshness, tsc, full pytest 6020 passed) — green
- [x] `git grep -ic "tawonga"` recount: 52 → 46