### PR TITLE
fix(sync): reserve the run before building a custom-field-values service

### DIFF
--- a/pocketbase/sync/api.go
+++ b/pocketbase/sync/api.go
@@ -1615,8 +1615,8 @@ func handlePersonCustomFieldValuesSync(e *core.RequestEvent, scheduler *Schedule
 	orchestrator := scheduler.GetOrchestrator()
 	syncType := "person_custom_values"
 
-	// Note: "already running" check is handled by MarkSyncRunning below,
-	// which returns an error if the sync is already in progress
+	// Note: "already running" check is handled by RunSingleSyncWithService below,
+	// which reserves the run and returns an error if the sync is already in progress
 
 	// Parse session filter (accepts "all" or a numeric cm_id)
 	session := normalizeSession(e.Request.URL.Query().Get("session"))
@@ -1632,19 +1632,19 @@ func handlePersonCustomFieldValuesSync(e *core.RequestEvent, scheduler *Schedule
 	debugParam := e.Request.URL.Query().Get("debug")
 	debug := debugParam == boolTrueStr || debugParam == "1"
 
-	// Get the service and set options
-	service, ok := orchestrator.GetService(syncType).(*PersonCustomFieldValuesSync)
-	if !ok || service == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]any{
-			"error": "Person custom field values sync service not found",
-		})
-	}
+	// Request-scoped instance — never the shared registered singleton. Mutating the
+	// singleton let a rejected (409) request's SetSession stick before MarkSyncRunning ever
+	// ran, silently narrowing whichever request was actually in flight (#2105).
+	// RunSingleSyncWithService also reserves the run atomically, so the check-then-mutate gap
+	// the old pattern had between GetService and MarkSyncRunning can't reopen.
+	service := NewPersonCustomFieldValuesSync(e.App, orchestrator.BaseClient())
 	service.SetSession(session)
 	service.SetDebug(debug)
 
-	// Mark as running BEFORE starting goroutine to prevent race condition
-	// This ensures the first frontend poll sees the sync as active
-	if err := orchestrator.MarkSyncRunning(syncType); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Minute)
+	defer cancel()
+
+	if err := orchestrator.RunSingleSyncWithService(ctx, syncType, service); err != nil {
 		return e.JSON(http.StatusConflict, map[string]any{
 			"error":    err.Error(),
 			"status":   "running",
@@ -1652,27 +1652,10 @@ func handlePersonCustomFieldValuesSync(e *core.RequestEvent, scheduler *Schedule
 		})
 	}
 
-	// Run in background
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Minute)
-		defer cancel()
-
-		slog.Info("Starting person_custom_values sync",
-			"session", session,
-			"debug", debug,
-		)
-		if err := orchestrator.RunSingleSync(ctx, syncType); err != nil {
-			slog.Error("Person custom field values sync failed", "error", err)
-		} else {
-			stats := service.GetStats()
-			slog.Info("Person custom field values sync completed",
-				"created", stats.Created,
-				"updated", stats.Updated,
-				"skipped", stats.Skipped,
-				"errors", stats.Errors,
-			)
-		}
-	}()
+	slog.Info("Starting person_custom_values sync",
+		"session", session,
+		"debug", debug,
+	)
 
 	return e.JSON(http.StatusOK, map[string]any{
 		"message":  fmt.Sprintf("%s sync started", syncType),
@@ -1691,8 +1674,8 @@ func handleHouseholdCustomFieldValuesSync(e *core.RequestEvent, scheduler *Sched
 	orchestrator := scheduler.GetOrchestrator()
 	syncType := "household_custom_values"
 
-	// Note: "already running" check is handled by MarkSyncRunning below,
-	// which returns an error if the sync is already in progress
+	// Note: "already running" check is handled by RunSingleSyncWithService below,
+	// which reserves the run and returns an error if the sync is already in progress
 
 	// Parse session filter (accepts "all" or a numeric cm_id)
 	session := normalizeSession(e.Request.URL.Query().Get("session"))
@@ -1708,19 +1691,19 @@ func handleHouseholdCustomFieldValuesSync(e *core.RequestEvent, scheduler *Sched
 	debugParam := e.Request.URL.Query().Get("debug")
 	debug := debugParam == boolTrueStr || debugParam == "1"
 
-	// Get the service and set options
-	service, ok := orchestrator.GetService(syncType).(*HouseholdCustomFieldValuesSync)
-	if !ok || service == nil {
-		return e.JSON(http.StatusInternalServerError, map[string]any{
-			"error": "Household custom field values sync service not found",
-		})
-	}
+	// Request-scoped instance — never the shared registered singleton. Mutating the
+	// singleton let a rejected (409) request's SetSession stick before MarkSyncRunning ever
+	// ran, silently narrowing whichever request was actually in flight (#2105).
+	// RunSingleSyncWithService also reserves the run atomically, so the check-then-mutate gap
+	// the old pattern had between GetService and MarkSyncRunning can't reopen.
+	service := NewHouseholdCustomFieldValuesSync(e.App, orchestrator.BaseClient())
 	service.SetSession(session)
 	service.SetDebug(debug)
 
-	// Mark as running BEFORE starting goroutine to prevent race condition
-	// This ensures the first frontend poll sees the sync as active
-	if err := orchestrator.MarkSyncRunning(syncType); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Minute)
+	defer cancel()
+
+	if err := orchestrator.RunSingleSyncWithService(ctx, syncType, service); err != nil {
 		return e.JSON(http.StatusConflict, map[string]any{
 			"error":    err.Error(),
 			"status":   "running",
@@ -1728,27 +1711,10 @@ func handleHouseholdCustomFieldValuesSync(e *core.RequestEvent, scheduler *Sched
 		})
 	}
 
-	// Run in background
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Minute)
-		defer cancel()
-
-		slog.Info("Starting household_custom_values sync",
-			"session", session,
-			"debug", debug,
-		)
-		if err := orchestrator.RunSingleSync(ctx, syncType); err != nil {
-			slog.Error("Household custom field values sync failed", "error", err)
-		} else {
-			stats := service.GetStats()
-			slog.Info("Household custom field values sync completed",
-				"created", stats.Created,
-				"updated", stats.Updated,
-				"skipped", stats.Skipped,
-				"errors", stats.Errors,
-			)
-		}
-	}()
+	slog.Info("Starting household_custom_values sync",
+		"session", session,
+		"debug", debug,
+	)
 
 	return e.JSON(http.StatusOK, map[string]any{
 		"message":  fmt.Sprintf("%s sync started", syncType),

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -307,6 +307,19 @@ func (o *Orchestrator) GetService(name string) Service {
 	return o.services[name]
 }
 
+// BaseClient returns the orchestrator's base CampMinder client (set by InitializeSyncServices).
+//
+// This exists so on-demand handlers can build a private, request-scoped service instance
+// (e.g. NewPersonCustomFieldValuesSync(e.App, orchestrator.BaseClient())) instead of fetching
+// and mutating the registered singleton returned by GetService (#2105). baseClient itself
+// stays unexported to keep year-override cloning (CloneWithYear) as the orchestrator's own
+// concern.
+func (o *Orchestrator) BaseClient() *campminder.Client {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	return o.baseClient
+}
+
 // IsRunning checks if a sync type is currently running
 func (o *Orchestrator) IsRunning(syncType string) bool {
 	o.mu.RLock()

--- a/pocketbase/sync/orchestrator_test.go
+++ b/pocketbase/sync/orchestrator_test.go
@@ -3,12 +3,16 @@ package sync
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
+
+	"github.com/pocketbase/pocketbase/core"
 )
 
 // MockService implements Service interface for testing
@@ -3544,5 +3548,108 @@ func TestRunSingleSyncWithServiceConcurrentCallsExactlyOneWins(t *testing.T) {
 	}
 	if ranCount != 1 {
 		t.Errorf("expected exactly 1 service instance to have run, got %d", ranCount)
+	}
+}
+
+// TestCustomFieldValuesHandlersReserveBeforeMutatingSharedState pins the fix for #2105.
+//
+// Both on-demand custom-field-values handlers (person and household) used to fetch the
+// orchestrator's registered singleton and call SetSession/SetDebug on it *before* calling
+// MarkSyncRunning to reserve the run. A second request that lost the reservation race still
+// got to mutate the singleton on its way to a 409 response. That mutation is not cosmetic:
+// person_custom_field_values.go:225 (and the household twin) read Session mid-run to decide
+// which persons/households to sync, so a rejected request could silently narrow whatever
+// session a still-running request had asked for.
+//
+// The fix builds a private, request-scoped service instance per request and hands it to
+// RunSingleSyncWithService instead of writing onto the shared registered singleton. This test
+// simulates "request A is already running an all-sessions sync" by reserving directly via
+// MarkSyncRunning (mirroring exactly what a real in-flight run leaves behind), then drives
+// the real handler for "request B" (a single-session request that must lose the race) and
+// asserts the registered singleton's Session field is untouched by B, no matter how B is
+// rejected.
+func TestCustomFieldValuesHandlersReserveBeforeMutatingSharedState(t *testing.T) {
+	cases := []struct {
+		name     string
+		syncType string
+		register func(o *Orchestrator)
+		handler  func(e *core.RequestEvent, scheduler *Scheduler) error
+		session  func(svc Service) (session string, ok bool)
+	}{
+		{
+			name:     "person",
+			syncType: "person_custom_values",
+			register: func(o *Orchestrator) {
+				o.RegisterService("person_custom_values", NewPersonCustomFieldValuesSync(nil, nil))
+			},
+			handler: handlePersonCustomFieldValuesSync,
+			session: func(svc Service) (string, bool) {
+				s, ok := svc.(*PersonCustomFieldValuesSync)
+				if !ok {
+					return "", false
+				}
+				return s.Session, true
+			},
+		},
+		{
+			name:     "household",
+			syncType: "household_custom_values",
+			register: func(o *Orchestrator) {
+				o.RegisterService("household_custom_values", NewHouseholdCustomFieldValuesSync(nil, nil))
+			},
+			handler: handleHouseholdCustomFieldValuesSync,
+			session: func(svc Service) (string, bool) {
+				s, ok := svc.(*HouseholdCustomFieldValuesSync)
+				if !ok {
+					return "", false
+				}
+				return s.Session, true
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scheduler := NewScheduler(nil)
+			orchestrator := scheduler.GetOrchestrator()
+			tc.register(orchestrator)
+
+			// Simulate request A: an all-sessions sync already reserved and running. We don't
+			// need its goroutine to actually execute a real Sync() -- only that
+			// runningJobs[syncType] is occupied, exactly as it would be while a real request-A
+			// sync is in flight.
+			if err := orchestrator.MarkSyncRunning(tc.syncType); err != nil {
+				t.Fatalf("MarkSyncRunning: %v", err)
+			}
+
+			singleton := orchestrator.GetService(tc.syncType)
+			sessionBefore, ok := tc.session(singleton)
+			if !ok {
+				t.Fatalf("registered singleton has unexpected type %T", singleton)
+			}
+			if sessionBefore != DefaultSession {
+				t.Fatalf("test setup: expected registered singleton Session=%q, got %q", DefaultSession, sessionBefore)
+			}
+
+			// Request B: a single-session request that must lose the reservation race and be
+			// rejected with 409, since request A already occupies syncType.
+			re := &core.RequestEvent{}
+			re.Request = httptest.NewRequest(http.MethodPost, "/?session=1", http.NoBody)
+			rec := httptest.NewRecorder()
+			re.Response = rec
+
+			if err := tc.handler(re, scheduler); err != nil {
+				t.Fatalf("handler returned error: %v", err)
+			}
+			if rec.Code != http.StatusConflict {
+				t.Errorf("expected %d (already running), got %d: %s", http.StatusConflict, rec.Code, rec.Body.String())
+			}
+
+			sessionAfter, _ := tc.session(orchestrator.GetService(tc.syncType))
+			if sessionAfter != sessionBefore {
+				t.Errorf("rejected request B mutated the shared singleton's Session from %q to %q -- "+
+					"request A's in-flight run would silently narrow to it", sessionBefore, sessionAfter)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Problem

Both custom-field-values handlers fetched the registered singleton via `GetService` and called `SetSession`/`SetDebug` on it **before** `MarkSyncRunning` decided whether the request was allowed to run at all.

So a request that then got a **409** had already mutated shared state — silently narrowing whichever sync was actually in flight to the rejected request's session filter.

## Fix

Each handler now builds a **private, request-scoped instance** from `orchestrator.BaseClient()` and hands it to `RunSingleSyncWithService`, which reserves the run atomically under the orchestrator lock. That also closes the check-then-mutate gap the old `GetService` → `MarkSyncRunning` pair left open.

Adds `Orchestrator.BaseClient()` so on-demand handlers can construct their own service. `baseClient` itself stays unexported, keeping year-override cloning (`CloneWithYear`) the orchestrator's own concern.

**Fixed in BOTH handlers** — the household twin carried the identical hazard, and fixing only the person handler is the failure mode this issue exists to prevent.

## Not a blocking change

`RunSingleSyncWithService` reserves under lock and then spawns its own goroutine with a timeout deliberately **not** derived from the handler's context, so the handler still responds immediately. The endpoint stays fire-and-forget.

## Verification

- `go build ./...` — exit 0
- `go test -race -count=1 ./sync/...` — **ok**, exit 0 (439s, uncached). The race detector is the gate that matters for this defect.
- pre-push (forced): `pytest` ✔

## Minor note for the reviewer

Each handler still constructs a 60-minute `context.WithTimeout` and passes it as `parentCtx`. `RunSingleSyncWithService` deliberately does not derive from it, so it is inert. Left as-is to keep this diff to the defect; happy to drop it if you'd rather it went now.

Closes #2105.