### PR TITLE
test(sync): guard against fixture/production schema drift on lodging_assignments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -598,6 +598,20 @@ jobs:
 
         echo "✅ Migration smoke test passed"
 
+    # kindred#1921: the sync package's fixtures build their PocketBase
+    # collections by hand (see newLodgingTestApp in
+    # pocketbase/sync/lodging_testsupport_test.go) rather than replaying
+    # pb_migrations, so a column a migration drops or renames can stay in the
+    # fixture indefinitely -- go test ./... never notices. /tmp/collections.json
+    # above is the real schema those same migrations just produced; this step
+    # diffs the fixture's declared fields against it and fails on a field the
+    # fixture has that production does not (drop/rename direction only).
+    - name: Fixture schema agreement (kindred#1921)
+      working-directory: ./pocketbase
+      env:
+        KINDRED_PROD_SCHEMA_JSON: /tmp/collections.json
+      run: go test ./sync/... -run TestLodgingTestsupportFixtureFieldsExistInProductionSchema -v
+
   # Frontend tests — sharded across 2 matrix jobs to cut wall-clock
   # (vitest --shard splits files; matrix gives each shard its own runner)
   tests-frontend:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -569,18 +569,22 @@ jobs:
           exit 1
         fi
 
-        # Validate schema via API. perPage=200 is required: PocketBase's
-        # default page size is 30, well under the ~69 collections the real
-        # migrations produce, so an unpaginated call here silently truncates
-        # the dump. validate_migrations.py never noticed -- every collection
-        # in its REQUIRED_COLLECTIONS/REQUIRED_FIELDS happens to be an early
-        # one that already fell inside the first 30 -- but kindred#1921's
-        # fixture-schema-agreement step (below) walks all of newLodgingTestApp's
-        # collections and several of those are late enough (lodging_* from
-        # migration 1500000116+) to land past that cutoff, which is exactly
-        # what surfaced this.
+        # Validate schema via API. perPage is required: PocketBase's default
+        # page size is 30, well under the ~69 collections the real migrations
+        # produce, so an unpaginated call here silently truncates the dump.
+        # validate_migrations.py never noticed -- every collection in its
+        # REQUIRED_COLLECTIONS/REQUIRED_FIELDS happens to be an early one that
+        # already fell inside the first 30 -- but kindred#1921's
+        # fixture-schema-agreement step (below) walks every collection
+        # newLodgingTestApp builds, several of them late (lodging_* from
+        # migration 1500000116+), which is what surfaced this. Pinned to
+        # PocketBase's own MaxPerPage (tools/search/provider.go) rather than
+        # some smaller headroom number: a perPage above MaxPerPage is
+        # silently clamped down to it, never rejected, so this asks for
+        # everything the API could ever return in one page and can't
+        # under-ask again as collections keep being added.
         echo "Validating migration schema..."
-        curl -sf "http://127.0.0.1:18999/api/collections?perPage=200" \
+        curl -sf "http://127.0.0.1:18999/api/collections?perPage=1000" \
           -H "Authorization: Bearer $AUTH_TOKEN" \
           > /tmp/collections.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -619,11 +619,23 @@ jobs:
     # above is the real schema those same migrations just produced; this step
     # diffs the fixture's declared fields against it and fails on a field the
     # fixture has that production does not (drop/rename direction only).
+    #
+    # -count=1 disables the test result cache deliberately: Go's cache only
+    # tracks files opened from within the package's own module tree, and
+    # /tmp/collections.json lives outside it, so the cache can't see it
+    # change between runs. KINDRED_PROD_SCHEMA_JSON is the same literal path
+    # every time, and actions/setup-go's cache:true (keyed on
+    # pocketbase/go.sum, which most PRs don't touch) restores GOCACHE across
+    # separate CI runs. Without -count=1, once this test passes once with
+    # unchanged Go source, a later PR that drops/renames a field in
+    # pb_migrations -- without touching this test's .go file -- can get a
+    # cached "ok" and never re-read that run's schema dump at all, silently
+    # defeating the guard.
     - name: Fixture schema agreement (kindred#1921)
       working-directory: ./pocketbase
       env:
         KINDRED_PROD_SCHEMA_JSON: /tmp/collections.json
-      run: go test ./sync/... -run TestLodgingTestsupportFixtureFieldsExistInProductionSchema -v
+      run: go test -count=1 ./sync/... -run TestLodgingTestsupportFixtureFieldsExistInProductionSchema -v
 
   # Frontend tests — sharded across 2 matrix jobs to cut wall-clock
   # (vitest --shard splits files; matrix gives each shard its own runner)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -569,9 +569,18 @@ jobs:
           exit 1
         fi
 
-        # Validate schema via API
+        # Validate schema via API. perPage=200 is required: PocketBase's
+        # default page size is 30, well under the ~69 collections the real
+        # migrations produce, so an unpaginated call here silently truncates
+        # the dump. validate_migrations.py never noticed -- every collection
+        # in its REQUIRED_COLLECTIONS/REQUIRED_FIELDS happens to be an early
+        # one that already fell inside the first 30 -- but kindred#1921's
+        # fixture-schema-agreement step (below) walks all of newLodgingTestApp's
+        # collections and several of those are late enough (lodging_* from
+        # migration 1500000116+) to land past that cutoff, which is exactly
+        # what surfaced this.
         echo "Validating migration schema..."
-        curl -sf http://127.0.0.1:18999/api/collections \
+        curl -sf "http://127.0.0.1:18999/api/collections?perPage=200" \
           -H "Authorization: Bearer $AUTH_TOKEN" \
           > /tmp/collections.json
 

--- a/pocketbase/sync/lodging_testsupport_fixture_test.go
+++ b/pocketbase/sync/lodging_testsupport_fixture_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/pocketbase/pocketbase/core"
@@ -85,39 +86,64 @@ type productionCollection struct {
 	Fields []productionField `json:"fields"`
 }
 
+// productionSchemaEnvelope mirrors the paginated shape PocketBase's
+// /api/collections endpoint actually returns. Confirmed empirically against
+// the pinned v0.39.10 binary (built from this repo's own pb_migrations):
+// it is always this envelope, never a bare array. scripts/ci/validate_migrations.py
+// also tolerates a bare array, but that's a different, Python caller with its
+// own history -- there is no bare-array code path here to keep in sync with.
+type productionSchemaEnvelope struct {
+	Items      []productionCollection `json:"items"`
+	Page       int                    `json:"page"`
+	PerPage    int                    `json:"perPage"`
+	TotalItems int                    `json:"totalItems"`
+	TotalPages int                    `json:"totalPages"`
+}
+
 // loadProductionSchema reads a dump of PocketBase's /api/collections response
 // -- booted from the real pocketbase/pb_migrations, no Go fixtures involved
 // -- and returns collection name -> set of field names actually present in
-// that schema. Tolerates both response shapes load_collections() in
-// scripts/ci/validate_migrations.py already tolerates: a bare array, or the
-// paginated {"items": [...]} envelope.
+// that schema.
 func loadProductionSchema(path string) (map[string]map[string]bool, error) {
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read %s: %w", path, err)
 	}
 
-	var cols []productionCollection
-	if err := json.Unmarshal(raw, &cols); err != nil {
-		var envelope struct {
-			Items []productionCollection `json:"items"`
-		}
-		// envelope.Items stays nil (not just empty) when the JSON has no
-		// "items" key at all -- Go's json package doesn't error on an unknown
-		// shape, it just leaves unmatched fields at their zero value. Without
-		// this check, a genuinely malformed document (e.g. a PocketBase error
-		// body: {"code":400,"message":"..."}) would unmarshal "successfully"
-		// into an empty envelope, and the caller would see a confusing
-		// "no collections" failure instead of the real parse error.
-		if err2 := json.Unmarshal(raw, &envelope); err2 != nil || envelope.Items == nil {
-			return nil, fmt.Errorf("%s is neither a bare collections array (%w) "+
-				"nor a paginated {items:[...]} envelope", path, err)
-		}
-		cols = envelope.Items
+	var envelope productionSchemaEnvelope
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return nil, fmt.Errorf("parse %s as a paginated {items:[...]} envelope: %w", path, err)
+	}
+	// envelope.Items stays nil (not just empty) when the JSON has no "items"
+	// key at all -- Go's json package doesn't error on an unrecognized
+	// shape, it just leaves unmatched fields at their zero value. Without
+	// this check, a genuinely malformed document (e.g. a PocketBase error
+	// body: {"code":400,"message":"..."}) would unmarshal "successfully"
+	// into an empty envelope, and the caller would see a confusing
+	// "no collections" failure instead of the real parse error.
+	if envelope.Items == nil {
+		return nil, fmt.Errorf("%s has no \"items\" key -- not a valid /api/collections "+
+			"response (got a %d-byte body)", path, len(raw))
+	}
+	// The ci.yml curl call that produces this dump has already truncated it
+	// silently once, when the request had no perPage at all and PocketBase's
+	// default page size (30) cut off the real ~69 collections (kindred#1921's
+	// own history). Bumping perPage to a bigger literal only pushes the same
+	// failure mode further out -- it recreates itself the moment collection
+	// count grows past whatever number is hardcoded there. totalItems is
+	// PocketBase's own count of everything that request could have returned,
+	// so comparing it against what was actually read catches truncation
+	// structurally, at any perPage, rather than trusting the literal.
+	if len(envelope.Items) < envelope.TotalItems {
+		return nil, fmt.Errorf("%s is truncated: got %d of %d total collections "+
+			"(page=%d perPage=%d totalPages=%d) -- raise perPage in the curl call "+
+			"that produced this dump (.github/workflows/ci.yml)",
+			path, len(envelope.Items), envelope.TotalItems,
+			envelope.Page, envelope.PerPage, envelope.TotalPages)
 	}
 
-	out := make(map[string]map[string]bool, len(cols))
-	for _, c := range cols {
+	out := make(map[string]map[string]bool, len(envelope.Items))
+	for _, c := range envelope.Items {
 		fields := make(map[string]bool, len(c.Fields))
 		for _, f := range c.Fields {
 			fields[f.Name] = true
@@ -125,6 +151,62 @@ func loadProductionSchema(path string) (map[string]map[string]bool, error) {
 		out[c.Name] = fields
 	}
 	return out, nil
+}
+
+// TestLoadProductionSchema exercises loadProductionSchema directly against
+// small in-memory fixtures rather than a real PocketBase boot, so these run
+// everywhere (no KINDRED_PROD_SCHEMA_JSON skip) and fail fast on the parsing
+// contract itself, separate from TestLodgingTestsupportFixtureFieldsExist...
+// below, which needs the full CI boot to exercise the comparison it guards.
+func TestLoadProductionSchema(t *testing.T) {
+	write := func(t *testing.T, body string) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "collections.json")
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("write fixture: %v", err)
+		}
+		return path
+	}
+
+	t.Run("complete envelope parses", func(t *testing.T) {
+		path := write(t, `{"page":1,"perPage":1000,"totalItems":1,"totalPages":1,"items":[
+			{"name":"lodging_units","fields":[{"name":"code"},{"name":"year"}]}
+		]}`)
+		schema, err := loadProductionSchema(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !schema["lodging_units"]["year"] {
+			t.Fatalf("expected lodging_units.year in the parsed schema, got %v", schema)
+		}
+	})
+
+	// totalItems says 69 collections exist; the dump only carries 1 -- the
+	// exact shape a perPage that's too small produces. This is the class of
+	// bug this repo already hit once for real: the ci.yml curl call had no
+	// perPage at all, silently truncating the dump to PocketBase's default
+	// page size (30) of the real ~69 collections (see this file's git
+	// history and kindred#1921). A hardcoded perPage, however generous,
+	// recreates the same trap the moment collection count grows past it;
+	// this test pins the fix -- checking totalItems against what was
+	// actually returned -- rather than trusting the number in ci.yml.
+	t.Run("truncated envelope is rejected, not silently accepted", func(t *testing.T) {
+		path := write(t, `{"page":1,"perPage":1,"totalItems":69,"totalPages":69,"items":[
+			{"name":"lodging_units","fields":[{"name":"code"}]}
+		]}`)
+		_, err := loadProductionSchema(path)
+		if err == nil {
+			t.Fatal("expected an error for a dump reporting totalItems=69 but carrying only 1 item, got nil")
+		}
+	})
+
+	t.Run("malformed response body is rejected, not read as zero collections", func(t *testing.T) {
+		path := write(t, `{"code":400,"message":"something went wrong"}`)
+		_, err := loadProductionSchema(path)
+		if err == nil {
+			t.Fatal("expected an error for a non-collections response body, got nil")
+		}
+	})
 }
 
 // TestLodgingTestsupportFixtureFieldsExistInProductionSchema is kindred#1921's

--- a/pocketbase/sync/lodging_testsupport_fixture_test.go
+++ b/pocketbase/sync/lodging_testsupport_fixture_test.go
@@ -1,6 +1,8 @@
 package sync
 
 import (
+	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/pocketbase/pocketbase/core"
@@ -63,5 +65,135 @@ func TestLodgingUnitsFixtureRejectsYearOutsideProductionRange(t *testing.T) {
 		if err := app.Save(rec); err == nil {
 			t.Errorf("%s: saved year=%v; want the fixture to refuse it like production does", c.label, c.year)
 		}
+	}
+}
+
+// productionField / productionCollection mirror the shape PocketBase's
+// /api/collections endpoint returns -- the same shape
+// scripts/ci/validate_migrations.py already parses in
+// .github/workflows/ci.yml's "Migration Smoke Test" job. Only the field name
+// is read here; type/options agreement is a different, narrower problem than
+// kindred#1921 (field-name agreement).
+type productionField struct {
+	Name string `json:"name"`
+}
+
+type productionCollection struct {
+	Name   string            `json:"name"`
+	Fields []productionField `json:"fields"`
+}
+
+// loadProductionSchema reads a dump of PocketBase's /api/collections response
+// -- booted from the real pocketbase/pb_migrations, no Go fixtures involved
+// -- and returns collection name -> set of field names actually present in
+// that schema. Tolerates both response shapes load_collections() in
+// scripts/ci/validate_migrations.py already tolerates: a bare array, or the
+// paginated {"items": [...]} envelope.
+func loadProductionSchema(path string) (map[string]map[string]bool, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var cols []productionCollection
+	if err := json.Unmarshal(raw, &cols); err != nil {
+		var envelope struct {
+			Items []productionCollection `json:"items"`
+		}
+		if err2 := json.Unmarshal(raw, &envelope); err2 != nil {
+			return nil, err
+		}
+		cols = envelope.Items
+	}
+
+	out := make(map[string]map[string]bool, len(cols))
+	for _, c := range cols {
+		fields := make(map[string]bool, len(c.Fields))
+		for _, f := range c.Fields {
+			fields[f.Name] = true
+		}
+		out[c.Name] = fields
+	}
+	return out, nil
+}
+
+// TestLodgingTestsupportFixtureFieldsExistInProductionSchema is kindred#1921's
+// guard against the bug class migration 1500000132 hit once already: this
+// package's fixtures (newLodgingTestApp, lodging_testsupport_test.go) build
+// every collection by hand, so a column a migration drops or renames stays
+// present in the fixture -- every filter naming it keeps resolving here while
+// production starts rejecting the write with "unknown field ...". Nothing
+// else notices, because nothing else compares what the fixture declares
+// against the schema the real pb_migrations produce.
+//
+// Drop/rename direction ONLY: this fails on a field the fixture declares that
+// production's real schema does not have. The reverse -- production has a
+// field the fixture lacks -- is deliberately out of scope. newLodgingTestApp's
+// own doc comment says the fixtures are minimal on purpose, carrying only the
+// fields the code under test touches, not a full mirror of every production
+// column.
+//
+// Needs KINDRED_PROD_SCHEMA_JSON: a dump of a real PocketBase's
+// /api/collections, booted from pocketbase/pb_migrations with no Go fixture
+// involved. Only .github/workflows/ci.yml's "Migration Smoke Test" job
+// produces that today, so this test SKIPS everywhere else -- including a
+// plain `go test ./...` -- rather than reimplementing the boot a second time.
+func TestLodgingTestsupportFixtureFieldsExistInProductionSchema(t *testing.T) {
+	schemaPath := os.Getenv("KINDRED_PROD_SCHEMA_JSON")
+	if schemaPath == "" {
+		t.Skip("KINDRED_PROD_SCHEMA_JSON not set -- this check runs in CI's " +
+			"Migration Smoke Test job only (.github/workflows/ci.yml); see kindred#1921")
+	}
+
+	prod, err := loadProductionSchema(schemaPath)
+	if err != nil {
+		t.Fatalf("load production schema from %s: %v", schemaPath, err)
+	}
+	if len(prod) == 0 {
+		t.Fatalf("production schema at %s has no collections -- boot step likely broken", schemaPath)
+	}
+
+	app := newLodgingTestApp(t)
+
+	// The exact set newLodgingTestApp builds -- NOT app.FindAllCollections(),
+	// which also returns tests.NewTestApp()'s own bundled testdata (a demo
+	// "users" collection with username/file/rel, unrelated to production's
+	// staff-auth "users" collection). Iterating everything the test app
+	// happens to contain would flag that coincidental name collision as a
+	// fixture bug it is not.
+	fixtureCollections := []string{
+		"custom_field_defs", "camp_sessions", "households", "persons", "attendees",
+		"family_camp_adults", "household_custom_values", "person_custom_values",
+		"lodging_units", "lodging_unit_aliases", "lodging_assignments",
+		"lodging_assignment_history", "lodging_ingest_issues", "lodging_field_mappings",
+	}
+
+	checked := 0
+	for _, name := range fixtureCollections {
+		col, err := app.FindCollectionByNameOrId(name)
+		if err != nil {
+			t.Errorf("newLodgingTestApp no longer builds collection %q -- update fixtureCollections above", name)
+			continue
+		}
+		prodFields, ok := prod[name]
+		if !ok {
+			t.Errorf("collection %q: fixture builds it, but the production schema has no collection by that name", name)
+			continue
+		}
+		checked++
+		for _, f := range col.Fields {
+			fieldName := f.GetName()
+			if prodFields[fieldName] {
+				continue
+			}
+			t.Errorf("collection %q: fixture declares field %q, which the real "+
+				"pb_migrations schema does not have -- dropped or renamed? "+
+				"update newLodgingTestApp in lodging_testsupport_test.go",
+				name, fieldName)
+		}
+	}
+
+	if checked != len(fixtureCollections) {
+		t.Fatalf("checked %d/%d fixture collections against %s", checked, len(fixtureCollections), schemaPath)
 	}
 }

--- a/pocketbase/sync/lodging_testsupport_fixture_test.go
+++ b/pocketbase/sync/lodging_testsupport_fixture_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 // TestLodgingUnitsFixtureRejectsDuplicateCodeYear guards the sync package's
@@ -101,9 +102,16 @@ func loadProductionSchema(path string) (map[string]map[string]bool, error) {
 		var envelope struct {
 			Items []productionCollection `json:"items"`
 		}
-		if err2 := json.Unmarshal(raw, &envelope); err2 != nil {
+		// envelope.Items stays nil (not just empty) when the JSON has no
+		// "items" key at all -- Go's json package doesn't error on an unknown
+		// shape, it just leaves unmatched fields at their zero value. Without
+		// this check, a genuinely malformed document (e.g. a PocketBase error
+		// body: {"code":400,"message":"..."}) would unmarshal "successfully"
+		// into an empty envelope, and the caller would see a confusing
+		// "no collections" failure instead of the real parse error.
+		if err2 := json.Unmarshal(raw, &envelope); err2 != nil || envelope.Items == nil {
 			return nil, fmt.Errorf("%s is neither a bare collections array (%w) "+
-				"nor a paginated {items:[...]} envelope (%w)", path, err, err2)
+				"nor a paginated {items:[...]} envelope", path, err)
 		}
 		cols = envelope.Items
 	}
@@ -155,31 +163,43 @@ func TestLodgingTestsupportFixtureFieldsExistInProductionSchema(t *testing.T) {
 		t.Fatalf("production schema at %s has no collections -- boot step likely broken", schemaPath)
 	}
 
-	app := newLodgingTestApp(t)
+	// A bare, un-fixtured app carries tests.NewTestApp()'s own bundled
+	// testdata -- e.g. a demo "users" collection with username/file/rel,
+	// unrelated to production's staff-auth "users" collection. Diffing
+	// newLodgingTestApp's collections against THIS baseline -- rather than a
+	// hardcoded list of names newLodgingTestApp happens to build today -- is
+	// what keeps this test honest as that function grows: a collection added
+	// there later is picked up automatically, with no allowlist to remember
+	// to update. Iterating app.FindAllCollections() without this diff would
+	// flag the "users" name collision as fixture drift it is not.
+	baseline, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("new baseline test app: %v", err)
+	}
+	t.Cleanup(baseline.Cleanup)
+	baselineCols, err := baseline.FindAllCollections()
+	if err != nil {
+		t.Fatalf("list baseline collections: %v", err)
+	}
+	baselineNames := make(map[string]bool, len(baselineCols))
+	for _, c := range baselineCols {
+		baselineNames[c.Name] = true
+	}
 
-	// The exact set newLodgingTestApp builds -- NOT app.FindAllCollections(),
-	// which also returns tests.NewTestApp()'s own bundled testdata (a demo
-	// "users" collection with username/file/rel, unrelated to production's
-	// staff-auth "users" collection). Iterating everything the test app
-	// happens to contain would flag that coincidental name collision as a
-	// fixture bug it is not.
-	fixtureCollections := []string{
-		"custom_field_defs", "camp_sessions", "households", "persons", "attendees",
-		"family_camp_adults", "household_custom_values", "person_custom_values",
-		"lodging_units", "lodging_unit_aliases", "lodging_assignments",
-		"lodging_assignment_history", "lodging_ingest_issues", "lodging_field_mappings",
+	app := newLodgingTestApp(t)
+	fixtureCols, err := app.FindAllCollections()
+	if err != nil {
+		t.Fatalf("list fixture collections: %v", err)
 	}
 
 	checked := 0
-	for _, name := range fixtureCollections {
-		col, err := app.FindCollectionByNameOrId(name)
-		if err != nil {
-			t.Errorf("newLodgingTestApp no longer builds collection %q -- update fixtureCollections above", name)
-			continue
+	for _, col := range fixtureCols {
+		if baselineNames[col.Name] {
+			continue // part of tests.NewTestApp()'s own bundled testdata, not something newLodgingTestApp added
 		}
-		prodFields, ok := prod[name]
+		prodFields, ok := prod[col.Name]
 		if !ok {
-			t.Errorf("collection %q: fixture builds it, but the production schema has no collection by that name", name)
+			t.Errorf("collection %q: fixture builds it, but the production schema has no collection by that name", col.Name)
 			continue
 		}
 		checked++
@@ -191,11 +211,12 @@ func TestLodgingTestsupportFixtureFieldsExistInProductionSchema(t *testing.T) {
 			t.Errorf("collection %q: fixture declares field %q, which the real "+
 				"pb_migrations schema does not have -- dropped or renamed? "+
 				"update newLodgingTestApp in lodging_testsupport_test.go",
-				name, fieldName)
+				col.Name, fieldName)
 		}
 	}
 
-	if checked != len(fixtureCollections) {
-		t.Fatalf("checked %d/%d fixture collections against %s", checked, len(fixtureCollections), schemaPath)
+	if checked == 0 {
+		t.Fatalf("compared zero collections against %s -- newLodgingTestApp and the "+
+			"baseline test app collection sets came out identical", schemaPath)
 	}
 }

--- a/pocketbase/sync/lodging_testsupport_fixture_test.go
+++ b/pocketbase/sync/lodging_testsupport_fixture_test.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"testing"
 
@@ -92,7 +93,7 @@ type productionCollection struct {
 func loadProductionSchema(path string) (map[string]map[string]bool, error) {
 	raw, err := os.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read %s: %w", path, err)
 	}
 
 	var cols []productionCollection
@@ -101,7 +102,8 @@ func loadProductionSchema(path string) (map[string]map[string]bool, error) {
 			Items []productionCollection `json:"items"`
 		}
 		if err2 := json.Unmarshal(raw, &envelope); err2 != nil {
-			return nil, err
+			return nil, fmt.Errorf("%s is neither a bare collections array (%w) "+
+				"nor a paginated {items:[...]} envelope (%w)", path, err, err2)
 		}
 		cols = envelope.Items
 	}


### PR DESCRIPTION
## Summary

- Adds `TestLodgingTestsupportFixtureFieldsExistInProductionSchema` (in `pocketbase/sync/lodging_testsupport_fixture_test.go`), which diffs `newLodgingTestApp`'s hand-built fixture fields against a real `/api/collections` dump booted from `pocketbase/pb_migrations`, and fails naming the collection and field when the fixture declares a field production's real schema no longer has.
- Which fixture collections get checked is discovered dynamically (diffed against a bare `tests.NewTestApp()` baseline), not hardcoded, so a collection added to `newLodgingTestApp` later is covered automatically.
- Wires the check into CI by appending a step to the existing `tests-migrations` ("Migration Smoke Test") job in `.github/workflows/ci.yml`, reusing the `/tmp/collections.json` that job already produces for `scripts/ci/validate_migrations.py`.
- Scope is deliberately narrow: drop/rename direction only (a fixture field production lacks), and only the collections `newLodgingTestApp` builds. The reverse direction and the other 13 hand-built fixtures repo-wide (full list in kindred#1921) are out of scope here.

## Why

`pocketbase/sync/lodging_testsupport_test.go`'s fixtures build every PocketBase collection by hand rather than replaying `pb_migrations` (documented in that file's own comment: jsvm can't run inside a Go test). So when migration `1500000132` dropped a dead `scenario` column, the fixture kept it, every existing test kept passing, and the drift only surfaced in production once `findAssignment`'s filter hit `unknown field "scenario"`.

`lodging_testsupport_fixture_test.go` already existed but does **not** cover this: its two tests (`TestLodgingUnitsFixtureRejectsDuplicateCodeYear`, `TestLodgingUnitsFixtureRejectsYearOutsideProductionRange`) pin `lodging_units`' validation *rules* (uniqueness, range) against production, not field-name agreement across collections. Neither would have caught the `1500000132` incident.

## The `ci.yml` change, precisely

One step appended at the end of the existing `tests-migrations` job, after "Migration smoke test (fresh database)":

```yaml
    - name: Fixture schema agreement (kindred#1921)
      working-directory: ./pocketbase
      env:
        KINDRED_PROD_SCHEMA_JSON: /tmp/collections.json
      run: go test -count=1 ./sync/... -run TestLodgingTestsupportFixtureFieldsExistInProductionSchema -v
```

`-count=1` disables Go's test result cache for this run. Without it, `actions/setup-go`'s `cache:true` (keyed on `pocketbase/go.sum`, which most PRs don't touch) restores the Go build cache across separate CI runs — and since `/tmp/collections.json` lives outside the module tree, Go's cache dependency tracking can't see it change between runs. A migration-only PR that drops a column, without touching this test's `.go` file, could otherwise get a stale cached PASS and never re-read that run's schema dump — exactly the scenario kindred#1921's acceptance criteria requires catching.

One existing line in that job's script was also changed: the `curl .../api/collections` call gained `?perPage=1000` (PocketBase's own `MaxPerPage`), because the new step exposed a real, previously-latent bug in it (see below). `actionlint -shellcheck="" -color` passes clean against the modified workflow.

The new Go test reads `KINDRED_PROD_SCHEMA_JSON` and `t.Skip()`s when it's unset, so a plain `go test ./...` (including CI's separate `tests-go` job) is unaffected — the integration test only runs where the real schema dump exists. `TestLoadProductionSchema`, the parser's own unit tests, run unconditionally everywhere.

**When does this run?** The `tests-migrations` job's trigger condition (pre-existing, unchanged) is `detect-changes.outputs.migrations == 'true' || detect-changes.outputs.go == 'true'` — skipped on PRs that touch neither `pocketbase/pb_migrations/**` nor any `pocketbase/**/*.go`. That covers both directions of the bug class this guard exists for: a migration-only PR that drops/renames a column (`migrations=true`), and a Go-only PR that lets a fixture drift (`go=true`). A frontend- or docs-only PR skips this job entirely — correct, since there's no schema-relevant change to check.

## Problems found and fixed along the way

Three real bugs surfaced during this PR, none of them fixture drift:

1. **CI's pre-existing `curl .../api/collections` had no `perPage`.** PocketBase's default page size (30) silently truncated `/tmp/collections.json` to the first 30 of the real ~69 collections. `validate_migrations.py`'s own `REQUIRED_COLLECTIONS`/`REQUIRED_FIELDS` never caught it — every collection it checks happens to be an early one that already fell inside that window. This PR's exhaustive walk over `newLodgingTestApp`'s collections (several late, `lodging_*` from migration `1500000116`+) is what surfaced it: CI reported 9 of 14 as "no collection by that name" in production, though they obviously exist.
2. **A bumped `perPage` alone doesn't fix the class.** `loadProductionSchema` now parses PocketBase's actual `{items, page, perPage, totalItems, totalPages}` envelope and compares `len(items)` against `totalItems`, rejecting the read as truncated (naming exactly how much was missing) whenever they disagree — structurally closing the bug at any future collection count, not just up to whatever number is hardcoded in `ci.yml`.
3. **`golangci-lint`'s `wrapcheck`** flagged unwrapped `os.ReadFile`/`json.Unmarshal` errors (not in pre-push, CI-only). Fixed by wrapping both.

## Mutation-check (TDD evidence)

1. **Baseline**: `PASS` against a real ~69-collection dump from the unmodified tree, zero false positives.
2. **Proved the blind spot**: temporarily dropped `household_cm_id` from `lodging_assignments` in `1500000119_lodging_assignments.js` — PocketBase itself refused to boot (an index names that column), a *louder* failure than the issue describes. Reverted, then dropped `party_size` instead (not referenced by any index). PocketBase booted fine, and the **entire existing `sync` package suite stayed green**, including `TestLodgingAssignmentsSyncUpdatesPartySizeInSameCabin` — a test named after that exact field.
3. **Guard catches the drop**: with `party_size` still dropped, the new test `FAIL`s, naming both:
   ```
   collection "lodging_assignments": fixture declares field "party_size", which the real
   pb_migrations schema does not have -- dropped or renamed? update newLodgingTestApp in
   lodging_testsupport_test.go
   ```
4. **Guard catches truncation directly**: re-fed the original bug's own truncated 30-collection dump (the exact shape the pre-`perPage` `curl` call used to produce) — `FAIL`, naming the truncation itself:
   ```
   .../collections_truncated.json is truncated: got 30 of 69 total collections
   (page=1 perPage=30 totalPages=3) -- raise perPage in the curl call that produced
   this dump (.github/workflows/ci.yml)
   ```
5. Reverted all mutations, re-dumped, confirmed `PASS` again.

Re-measured fixture scope per kindred#1921: **14** hand-built fixtures repo-wide (`grep -rl "core.NewBaseCollection" pocketbase/ --include="*_test.go" | wc -l`), matching the issue body. This PR covers only the `sync` package's lodging fixture, per the files-touched scope for this item.

## Test plan

- [x] `go build ./...`
- [x] `go test -count=1 ./sync/...` (existing suite green)
- [x] `gofmt -l` clean
- [x] `golangci-lint run --config ../.golangci.yml ./...` — `0 issues`
- [x] `lefthook run pre-push` — full suite green (ruff, go-build, shellcheck, pb-js-lint, markdownlint, api-types-freshness, mypy, tsc, 6020 pytest tests)
- [x] `actionlint` clean on the modified `ci.yml`
- [x] Mutation-check transcript above
- [x] CI green end to end: https://github.com/adamflagg/kindred/pull/2147/checks

Closes #1921.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
