### PR TITLE
fix(config): gate pre-push commands on the actual push range, not a decorative glob

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -88,7 +88,23 @@ commit-msg:
 
 # ─── Pre-push: fast type checks + linters (parallel) ─────────────────
 # Keeps: type checkers (mypy, tsc), compilation (go build), fast linters (<1s each)
-# Moved to CI-only: eslint, golangci-lint, hadolint, caddy-validate, all test suites
+# Moved to CI-only: eslint, golangci-lint, hadolint, caddy-validate
+# (pytest was added back below in #1617 — it is NOT CI-only; it also runs here)
+#
+# kindred#1937: lefthook 2.1.6 never reads the pre-push stdin refs (its only
+# file query at this stage is `git diff --name-only --cached`, which is
+# empty on a normal push). That makes `{files}` empty and `{push_files}`
+# fall back to "every tracked file in the repo", so every `glob:` below
+# always matches and never actually gates — a single-commit, markdown-only
+# branch was measured still running `go-build`. The `glob:` keys are kept
+# only as documentation of each command's intended scope; the real gate is
+# the `skip:` condition on each command, computed over the actual push range
+# (`origin/main...HEAD`, three-dot/merge-base form — two-dot misreports once
+# `main` moves). Each condition best-effort fetches `origin/main` first
+# (mirroring `behind-origin` below) and fails OPEN — i.e. runs the check —
+# if `origin/main` can't be resolved at all, so a missing/unfetchable ref
+# never silently skips every check. This mirrors the in-repo precedent of
+# `shellcheck` guarding itself with a `skip: - run:` condition below.
 pre-push:
   parallel: true
   commands:
@@ -98,6 +114,8 @@ pre-push:
         - "ruff.toml"
         - "pyproject.toml"
       run: uv run ruff check .
+      skip:
+        - run: "git fetch origin main --quiet 2>/dev/null || true; git rev-parse -q --verify origin/main >/dev/null 2>&1 && ! git diff --name-only origin/main...HEAD | grep -qE '\\.py$|(^|/)ruff\\.toml$|(^|/)pyproject\\.toml$'"
 
     # Full mockable Python suite, parallelized (~37s on 12 cores via xdist
     # worksteal). SKIP_POCKETBASE_TESTS gates the server/DB-dependent suites;
@@ -109,12 +127,16 @@ pre-push:
         - "pyproject.toml"
         - "conftest.py"
       run: SKIP_POCKETBASE_TESTS=true uv run pytest tests/ -n auto --dist worksteal -q -p no:cacheprovider
+      skip:
+        - run: "git fetch origin main --quiet 2>/dev/null || true; git rev-parse -q --verify origin/main >/dev/null 2>&1 && ! git diff --name-only origin/main...HEAD | grep -qE '\\.py$|(^|/)pyproject\\.toml$|(^|/)conftest\\.py$'"
 
     mypy:
       glob:
         - "**/*.py"
         - "pyproject.toml"
       run: uv run mypy . --explicit-package-bases
+      skip:
+        - run: "git fetch origin main --quiet 2>/dev/null || true; git rev-parse -q --verify origin/main >/dev/null 2>&1 && ! git diff --name-only origin/main...HEAD | grep -qE '\\.py$|(^|/)pyproject\\.toml$'"
 
     type-check:
       root: "frontend/"
@@ -123,6 +145,8 @@ pre-push:
         - "frontend/tsconfig.json"
         - "frontend/tsconfig.node.json"
       run: npm run type-check
+      skip:
+        - run: "git fetch origin main --quiet 2>/dev/null || true; git rev-parse -q --verify origin/main >/dev/null 2>&1 && ! git diff --name-only origin/main...HEAD | grep -qE '^frontend/.*\\.(ts|tsx)$|^frontend/tsconfig(\\.node)?\\.json$'"
 
     go-build:
       root: "pocketbase/"
@@ -132,12 +156,15 @@ pre-push:
         - "pocketbase/go.mod"
         - "pocketbase/go.sum"
       run: go build .
+      skip:
+        - run: "git fetch origin main --quiet 2>/dev/null || true; git rev-parse -q --verify origin/main >/dev/null 2>&1 && ! git diff --name-only origin/main...HEAD | grep -qE '^pocketbase/.*\\.go$|^pocketbase/go\\.(mod|sum)$'"
 
     shellcheck:
       glob: "**/*.sh"
       run: find scripts/ docker/ frontend/ tests/shell/ -maxdepth 3 -name '*.sh' 2>/dev/null | xargs shellcheck --severity=warning
       skip:
         - run: "! command -v shellcheck >/dev/null 2>&1"
+        - run: "git fetch origin main --quiet 2>/dev/null || true; git rev-parse -q --verify origin/main >/dev/null 2>&1 && ! git diff --name-only origin/main...HEAD | grep -qE '\\.sh$'"
 
     pb-js-lint:
       root: "pocketbase/"
@@ -146,10 +173,14 @@ pre-push:
         - "pocketbase/pb_hooks/*.js"
         - "pocketbase/package.json"
       run: npm run lint
+      skip:
+        - run: "git fetch origin main --quiet 2>/dev/null || true; git rev-parse -q --verify origin/main >/dev/null 2>&1 && ! git diff --name-only origin/main...HEAD | grep -qE '^pocketbase/pb_(migrations|hooks)/.*\\.js$|^pocketbase/package\\.json$'"
 
     markdownlint:
       glob: "**/*.md"
       run: npx markdownlint-cli2 "**/*.md"
+      skip:
+        - run: "git fetch origin main --quiet 2>/dev/null || true; git rev-parse -q --verify origin/main >/dev/null 2>&1 && ! git diff --name-only origin/main...HEAD | grep -qE '\\.md$'"
 
     # Verify generated API types match the current Python schema.
     # Regenerates to a temp directory (no on-disk mutation) so this can run
@@ -159,6 +190,8 @@ pre-push:
       glob:
         - "api/**/*.py"
         - "bunking/**/*.py"
+      skip:
+        - run: "git fetch origin main --quiet 2>/dev/null || true; git rev-parse -q --verify origin/main >/dev/null 2>&1 && ! git diff --name-only origin/main...HEAD | grep -qE '^(api|bunking)/.*\\.py$'"
       run: |
         REGEN_LOG=$(mktemp)
         REGEN_DIR=$(mktemp -d)

--- a/tests/unit/config/test_lefthook_prepush_gating.py
+++ b/tests/unit/config/test_lefthook_prepush_gating.py
@@ -1,0 +1,160 @@
+"""Guard test for kindred#1937: pre-push `glob:` keys never gate.
+
+lefthook 2.1.6's pre-push commands never observe what is actually being
+*pushed* — the only file query lefthook issues in a pre-push run is
+`git diff --name-only --cached`, which is empty on a normal push (nothing is
+staged at push time). That makes `{files}` empty and `{push_files}` fall
+back to "every tracked file in the repo", so every `glob:` pattern matches
+and every command runs regardless of what the branch actually touched.
+Measured directly against lefthook 2.1.6 in kindred#1937: a single-commit,
+markdown-only branch still ran `go-build`.
+
+The fix is `skip: - run: "..."` conditions computed over the actual push
+range (`origin/main...HEAD`, three-dot/merge-base form — two-dot misreports
+once `main` moves), matching the in-repo precedent (`shellcheck` already
+guards itself with a `skip: - run:` condition for a missing binary). This
+test pins that every pre-push command scoped to a language/file-type by a
+`glob:` key also carries a skip condition computed over the three-dot push
+range, so a branch that never touched Python doesn't pay for `pytest`/`mypy`,
+a branch that never touched Go doesn't pay for `go-build`, etc.
+
+`behind-origin` is legitimately exempt: it isn't gated by file type at all
+(gated by `only: - ref: main`) and its entire job *is* to inspect the
+relationship to `origin/main`, so requiring it to skip based on that same
+relationship would be circular.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+LEFTHOOK_CONFIG = REPO_ROOT / ".lefthook.yml"
+
+# Commands whose job is inherently "compare against origin/main" — requiring
+# a skip condition over that same range would be circular, not a gating bug.
+EXEMPT_FROM_GATING = {"behind-origin"}
+
+
+def _load_prepush_commands() -> dict[str, Any]:
+    config = yaml.safe_load(LEFTHOOK_CONFIG.read_text())
+    return dict(config["pre-push"]["commands"])
+
+
+def _skip_run_strings(command: dict[str, Any]) -> list[str]:
+    skip = command.get("skip") or []
+    return [entry["run"] for entry in skip if "run" in entry]
+
+
+def test_every_language_scoped_prepush_command_has_a_skip_condition():
+    """Every `glob:`-scoped pre-push command must also carry a `skip:` list.
+
+    Without this, the glob is decorative: lefthook's push_files fallback
+    (every tracked file) satisfies any glob, so the command always runs.
+    """
+    commands = _load_prepush_commands()
+    scoped = {name: cmd for name, cmd in commands.items() if "glob" in cmd and name not in EXEMPT_FROM_GATING}
+    # Sanity: this is meant to cover the commands #1937 measured (9 of 10).
+    assert len(scoped) >= 9, f"expected >=9 glob-scoped commands, found {sorted(scoped)}"
+
+    missing_skip = [name for name, cmd in scoped.items() if not cmd.get("skip")]
+    assert not missing_skip, (
+        f"pre-push commands with a `glob:` but no `skip:` gate never actually gate (kindred#1937): {missing_skip}"
+    )
+
+
+def test_every_gating_skip_condition_uses_the_three_dot_push_range():
+    """Each skip condition that computes a diff range must use `origin/main...HEAD`.
+
+    Three-dot (merge-base) form is required — two-dot (`origin/main..HEAD`)
+    misreports the push range once `main` has moved ahead independently.
+    A skip condition unrelated to the push range (e.g. shellcheck's
+    "is the binary installed?" check) is fine alongside it; what matters is
+    that *at least one* skip entry gates on the correct diff range.
+    """
+    commands = _load_prepush_commands()
+    scoped = {name: cmd for name, cmd in commands.items() if "glob" in cmd and name not in EXEMPT_FROM_GATING}
+
+    bad = {}
+    for name, cmd in scoped.items():
+        runs = _skip_run_strings(cmd)
+        three_dot = [r for r in runs if "origin/main...HEAD" in r]
+        # Flag any run condition that uses the two-dot form as a diff range
+        # (a common typo'd downgrade of the three-dot form) without also
+        # having a correct three-dot entry present.
+        two_dot_only = [r for r in runs if "origin/main..HEAD" in r and "origin/main...HEAD" not in r]
+        if not three_dot or two_dot_only:
+            bad[name] = runs
+    assert not bad, (
+        "pre-push commands must gate on the three-dot merge-base range "
+        f"'origin/main...HEAD', not omit it or use the two-dot form: {bad}"
+    )
+
+
+def test_gating_skip_conditions_are_inverted_greps_over_the_diff():
+    """Skip conditions must be `... && ! git diff ... | grep -qE '<pattern>'`.
+
+    This is the shape lefthook needs: `skip:` runs the command when the
+    condition is FALSE, so "skip unless the diff matches" is spelled with a
+    leading `!` on the diff/grep pipeline.
+    """
+    commands = _load_prepush_commands()
+    scoped = {name: cmd for name, cmd in commands.items() if "glob" in cmd and name not in EXEMPT_FROM_GATING}
+
+    malformed = {}
+    for name, cmd in scoped.items():
+        runs = _skip_run_strings(cmd)
+        gating_runs = [r for r in runs if "origin/main...HEAD" in r]
+        for r in gating_runs:
+            if "! git diff --name-only origin/main...HEAD" not in r:
+                malformed[name] = r
+            if "grep -qE" not in r:
+                malformed[name] = r
+    assert not malformed, f"malformed gating skip conditions: {malformed}"
+
+
+def test_gating_skip_conditions_fail_open_when_origin_main_is_unresolvable():
+    """Each gating skip condition must fetch + verify `origin/main` exists
+    before trusting a diff against it, and must NOT skip (i.e. must run the
+    check) if that verification fails.
+
+    Without this, a missing/unfetched `origin/main` makes
+    `git diff --name-only origin/main...HEAD` fail with no stdout, which
+    `grep -qE` then reports as "no match" — silently SKIPPING every
+    language-scoped check instead of running them. That is the same
+    false-green failure family already flagged in this repo (rtk's "ok" on
+    a rejected push, `lefthook run pre-push` exiting 0 with nothing to
+    push): failing to determine an answer must never look like "no work to
+    do".
+    """
+    commands = _load_prepush_commands()
+    scoped = {name: cmd for name, cmd in commands.items() if "glob" in cmd and name not in EXEMPT_FROM_GATING}
+
+    unsafe = {}
+    for name, cmd in scoped.items():
+        runs = _skip_run_strings(cmd)
+        gating_runs = [r for r in runs if "origin/main...HEAD" in r]
+        for r in gating_runs:
+            has_fetch = "git fetch origin main" in r
+            has_existence_guard = "git rev-parse -q --verify origin/main" in r
+            # The existence guard must gate (via &&) the diff/grep pipeline,
+            # so a failed guard short-circuits to a non-zero (run) result
+            # rather than falling through to a diff that would fail closed.
+            guards_the_pipeline = bool(has_existence_guard and "&& ! git diff --name-only origin/main...HEAD" in r)
+            if not (has_fetch and has_existence_guard and guards_the_pipeline):
+                unsafe[name] = r
+    assert not unsafe, (
+        f"gating skip conditions must fetch+verify origin/main and fail "
+        f"open (run, not skip) when it can't be resolved: {unsafe}"
+    )
+
+
+def test_behind_origin_is_not_incorrectly_exempted():
+    """Guard the exemption list itself: `behind-origin` must still exist and
+    still be the *only* glob-less pre-push command, so the exemption isn't
+    silently covering up a future gating bug on a different command.
+    """
+    commands = _load_prepush_commands()
+    glob_less = [name for name, cmd in commands.items() if "glob" not in cmd]
+    assert glob_less == ["behind-origin"], f"expected only 'behind-origin' to lack a glob; found: {glob_less}"


### PR DESCRIPTION
## What

lefthook 2.1.6 never reads the pre-push stdin refs — its only file query at this stage is `git diff --name-only --cached`, which is empty on a normal push. That leaves `{push_files}` falling back to every tracked file in the repo, so every `glob:` pattern on a pre-push command always matches, and none of them actually gate. Measured directly: a single-commit, markdown-only branch still ran `go-build`.

This replaces the decorative `glob:` gating with `skip: - run:` conditions computed over the real push range (`origin/main...HEAD`, three-dot/merge-base form — two-dot misreports once `main` moves), matching the in-repo `shellcheck` precedent (`skip: - run: "! command -v shellcheck >/dev/null 2>&1"`).

Each new skip condition:
- best-effort fetches `origin/main` first (mirroring `behind-origin`'s own `git fetch origin main --quiet 2>/dev/null || ...`)
- verifies `origin/main` actually resolves before trusting the diff
- **fails OPEN** (runs the check) if `origin/main` can't be resolved at all — a missing/unfetchable ref must never look like "nothing changed" and silently skip everything

Also corrects a stale pre-push header comment claiming "all test suites" moved to CI-only. `pytest` was added back to pre-push in #1617 and the comment was never updated to reflect it — a second, smaller instance of the same "the file no longer says what it does" problem this PR is about.

## Why (payoff)

A frontend-only branch stops paying `pytest`/`mypy`/`go-build`/`ruff-check`/`pb-js-lint` — the measured 56–134s that ran regardless of what the branch touched.

## Verification

**TDD:** `tests/unit/config/test_lefthook_prepush_gating.py` parses `.lefthook.yml` and asserts every `glob:`-scoped pre-push command also carries a three-dot gating `skip:` condition, in the correct inverted-grep shape, with fail-open behavior on an unresolvable `origin/main`. Confirmed RED against the pre-fix config (2 of 5 assertions failed, listing all 8 ungated commands), then GREEN after the fix.

**Mutation-checked** (see PR comment for full transcript): removed `go-build`'s `skip:` block entirely → RED; restored → GREEN. Separately stripped just the fail-open existence guard from `go-build`'s condition (leaving a diff that would silently skip if `origin/main` were unresolvable) → RED; restored → GREEN.

**Real behavior, both directions**, via `lefthook run pre-push --force` on scratch commits (reset afterward, not part of this PR's history):
- docs-only commit (`docs/reference/git-workflow.md`) → `go-build`/`pytest`/`mypy`/`type-check`/`ruff-check`/`pb-js-lint`/`shellcheck`/`api-types-freshness` all `(skip) by condition`; `markdownlint` ran.
- go-only commit (`pocketbase/main.go`) → `go-build` ran; every other language-scoped command skipped.

**Live confirmation on this PR's own push:** this commit touches `.lefthook.yml` + one new `.py` test file. The real pre-push hook ran `ruff-check`/`mypy`/`pytest` and skipped `type-check`/`shellcheck`/`markdownlint`/`go-build`/`api-types-freshness`/`pb-js-lint` by condition — exactly the intended behavior, on a real push, not a simulation.

Full pytest suite: `6117 passed, 41 skipped` (unrelated pre-existing DB-coupled skips). `go build ./...` clean.

Closes #1937.