### PR TITLE
fix(api): a container's sleeps is a delta over its rooms, not a whole-house total

### DIFF
--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -119,9 +119,11 @@ class LodgingUnitSummary(BaseModel):
     # A building/grouping row. Present in the payload so the map and board
     # can draw the building. Whether it COUNTS is no longer this flag's
     # answer: a container resolved combined (see `is_combined`) is the one
-    # space the board draws, at its own measured `sleeps`, and its rooms
-    # count for nothing. `drawn_units` is the one predicate for that, and
-    # `_build_counts` reads it -- never filter on `is_container` alone.
+    # space the board draws. Its own `sleeps` is a DELTA over its rooms, not
+    # a whole-house total (owner ruling, kindred#2041) -- the drawn total is
+    # its own `sleeps` PLUS every leaf beneath it. `drawn_units` is the one
+    # predicate for which units get a card, and `_build_counts` reads it --
+    # never filter on `is_container` alone.
     is_container: bool = False
     # The parent container's CODE, not its record id — the board keys on code,
     # and code is the cross-year identity thread. "" means no parent.

--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -290,13 +290,20 @@ class RosterParty(BaseModel):
 
 
 class RosterCounts(BaseModel):
-    """Honest counts. Every capacity figure excludes container rows."""
+    """Honest counts, at the level the board DRAWS -- see `drawn_units`. A
+    split container's own row is excluded and its rooms count instead; a
+    combined container's row counts ONCE, for a `sleeps` that now folds in
+    every leaf beneath it (kindred#2041) -- never a container and its own
+    rooms both.
+    """
 
     parties_total: int = 0
     parties_assigned: int = 0
     parties_unassigned: int = 0
-    # Active, non-container units that are PLANNING INVENTORY -- permanent
-    # staff housing is excluded and reported by units_staff_housing.
+    # Units the board draws that are PLANNING INVENTORY -- permanent staff
+    # housing is excluded and reported by units_staff_housing. A combined
+    # container's own drawn row is included here; its rooms, which never
+    # draw their own card, are not counted a second time.
     units_total: int = 0
     units_family_available: int = 0
     # Planning inventory held back from families this session -- a burst pipe,

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -1224,7 +1224,7 @@ class LodgingRosterService:
             leaf_total = sum(
                 leaf.sleeps
                 for code in tree.leaf_codes_under(unit.code)
-                if (leaf := tree.units_by_code.get(code)) is not None and leaf.sleeps is not None
+                if (leaf := tree.units_by_code.get(code)) is not None and leaf.is_active and leaf.sleeps is not None
             )
             return (unit.sleeps or 0) + leaf_total
 

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -1190,25 +1190,46 @@ class LodgingRosterService:
     ) -> RosterCounts:
         # The population the BOARD DRAWS, at each tree's resolved level -- not
         # "every non-container row". A combined container IS one space a
-        # family can hold, at the whole-house `sleeps` somebody measured, and
-        # its rooms are not separately lettable, so counting them instead
-        # reports more spaces than the board draws cards. That is the exact
-        # drift `_is_planning_inventory` exists to prevent, one field over.
+        # family can hold, and its rooms are not separately lettable, so
+        # counting them instead reports more spaces than the board draws
+        # cards. That is the exact drift `_is_planning_inventory` exists to
+        # prevent, one field over.
         #
         # A NON-combined container is still excluded, for the original reason:
         # it carries a whole-building aggregate its rooms already report, and
         # counting both double-counts beds (408 vs a true 389). What changed is
         # that "container" stopped being the same question as "not drawn".
         #
-        # The bed figure can move OPPOSITE the space figure, which is correct:
-        # a container's `sleeps` is independently measured and NOT the sum of
-        # its rooms (one house records 7 against rooms summing to 6). Fewer,
-        # larger spaces.
+        # Owner ruling, kindred#2041: a container's `sleeps` is a DELTA over
+        # its rooms -- the beds in space belonging to no single room, e.g. a
+        # futon on a landing -- never a whole-house total. A drawn combined
+        # container's true capacity is its own `sleeps` PLUS every LEAF
+        # beneath it, walked past any intermediate container the same way
+        # `_BathroomIndex.leaf_codes_under` already walks the same
+        # `parent_code` relation for bathrooms. An unset container reads as a
+        # delta of 0 -- real common space nobody measured, correctly zero and
+        # never "unknown" -- so only a genuinely unmeasured LEAF can still
+        # leave a total unknown.
         drawn = [u for u in drawn_units(units) if u.is_active]
         bookable = [u for u in drawn if _is_planning_inventory(u)]
         staff_housing = [u for u in drawn if not _is_planning_inventory(u)]
         available = [u for u in bookable if u.is_family_available]
         assigned = sum(1 for p in parties if p.unit_code or p.unit_name)
+
+        tree = _BathroomIndex.build(units)
+
+        def _effective_sleeps(unit: LodgingUnitSummary) -> int | None:
+            if not unit.is_container:
+                return unit.sleeps
+            leaf_total = sum(
+                leaf.sleeps
+                for code in tree.leaf_codes_under(unit.code)
+                if (leaf := tree.units_by_code.get(code)) is not None and leaf.sleeps is not None
+            )
+            return (unit.sleeps or 0) + leaf_total
+
+        effective_sleeps = {u.unit_id: _effective_sleeps(u) for u in bookable}
+
         return RosterCounts(
             parties_total=len(parties),
             parties_assigned=assigned,
@@ -1217,8 +1238,8 @@ class LodgingRosterService:
             units_family_available=len(available),
             units_reserved=len(bookable) - len(available),
             units_staff_housing=len(staff_housing),
-            beds_family_available=sum(u.sleeps for u in available if u.sleeps is not None),
-            units_capacity_unknown=sum(1 for u in bookable if u.sleeps is None),
+            beds_family_available=sum(s for u in available if (s := effective_sleeps[u.unit_id]) is not None),
+            units_capacity_unknown=sum(1 for u in bookable if effective_sleeps[u.unit_id] is None),
             # Over `bookable`, NOT a separate PocketBase count. The old query
             # filtered is_confirmed/is_container/is_active with no inventory
             # predicate, so once units_total dropped staff housing the two

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -367,10 +367,19 @@ def drawn_units(units: list[LodgingUnitSummary]) -> list[LodgingUnitSummary]:
 
 
 class _BathroomIndex(NamedTuple):
-    """Lookups `_resolve_party_bathroom` needs, built ONCE per roster/summary
-    call from the unit registry rather than once per party -- the same
-    "compute across all units, read per party" split `_build_units` already
-    uses for `group_members`.
+    """The unit tree, built ONCE per roster/summary call from the unit
+    registry and threaded through to every consumer, rather than rebuilt per
+    consumer -- the same "compute across all units, read per party" split
+    `_build_units` already uses for `group_members`.
+
+    Two consumers share it: `_resolve_party_bathroom` (via `_build_parties`)
+    and, since kindred#2041, `_build_counts`'s `_effective_sleeps`, which
+    walks `leaf_codes_under` to total a combined container's rooms. Both
+    orchestrators (`build_roster`, `build_summary`'s per-weekend `_entry`)
+    build ONE instance right after `_build_units` and pass it to both --
+    building a second one from the same `units` list was caught in review on
+    kindred#2041's PR and is exactly the duplicate work this docstring
+    already warned against.
     """
 
     units_by_code: dict[str, LodgingUnitSummary]
@@ -578,6 +587,11 @@ class LodgingRosterService:
             availability_task.result(),
             merges_task.result(),
         )
+        # ONE index, threaded to both consumers below -- see `_BathroomIndex`'s
+        # own "built ONCE per call" docstring. Rebuilding a second one from the
+        # same `unit_summaries` for `_build_counts` was caught in review on
+        # kindred#2041's PR.
+        unit_index = _BathroomIndex.build(unit_summaries)
         parties = self._build_parties(
             session_type=session_type,
             attendees=attendees_task.result(),
@@ -586,9 +600,9 @@ class LodgingRosterService:
             adults_by_household=adults_task.result(),
             registrations=registrations_task.result(),
             assignments=placements_task.result(),
-            units=unit_summaries,
+            unit_index=unit_index,
         )
-        counts = self._build_counts(unit_summaries, parties, aliases_task.result())
+        counts = self._build_counts(unit_summaries, parties, aliases_task.result(), unit_index)
 
         return WeekendRosterResponse(
             year=year,
@@ -686,6 +700,9 @@ class LodgingRosterService:
                 availability_task.result(),
                 merges_task.result(),
             )
+            # Same one-index-per-call rule `build_roster` follows -- see the
+            # comment there and `_BathroomIndex`'s own docstring.
+            unit_index = _BathroomIndex.build(unit_summaries)
             parties = self._build_parties(
                 session_type=_s(session, "session_type"),
                 attendees=attendees_task.result(),
@@ -694,11 +711,11 @@ class LodgingRosterService:
                 adults_by_household=adults_by_household,
                 registrations=registrations,
                 assignments=placements_task.result(),
-                units=unit_summaries,
+                unit_index=unit_index,
             )
             return WeekendSummaryEntry(
                 session=self._session_summary(session),
-                counts=self._build_counts(unit_summaries, parties, unresolved_aliases),
+                counts=self._build_counts(unit_summaries, parties, unresolved_aliases, unit_index),
             )
 
         async with asyncio.TaskGroup() as tg:
@@ -881,13 +898,12 @@ class LodgingRosterService:
         adults_by_household: dict[str, list[Any]],
         registrations: dict[str, Any],
         assignments: list[Any],
-        units: list[LodgingUnitSummary],
+        unit_index: _BathroomIndex,
     ) -> list[RosterParty]:
         placement_by_household, placement_by_person = self._index_assignments(assignments)
-        bathroom_index = _BathroomIndex.build(units)
 
         if session_type == "adult":
-            return self._build_person_parties(attendees, placement_by_person, bathroom_index)
+            return self._build_person_parties(attendees, placement_by_person, unit_index)
 
         return self._build_household_parties(
             attendees=attendees,
@@ -896,7 +912,7 @@ class LodgingRosterService:
             adults_by_household=adults_by_household,
             registrations=registrations,
             placement_by_household=placement_by_household,
-            bathroom_index=bathroom_index,
+            bathroom_index=unit_index,
         )
 
     @staticmethod
@@ -1187,6 +1203,7 @@ class LodgingRosterService:
         units: list[LodgingUnitSummary],
         parties: list[RosterParty],
         unresolved_aliases: int,
+        unit_index: _BathroomIndex,
     ) -> RosterCounts:
         # The population the BOARD DRAWS, at each tree's resolved level -- not
         # "every non-container row". A combined container IS one space a
@@ -1204,27 +1221,28 @@ class LodgingRosterService:
         # its rooms -- the beds in space belonging to no single room, e.g. a
         # futon on a landing -- never a whole-house total. A drawn combined
         # container's true capacity is its own `sleeps` PLUS every LEAF
-        # beneath it, walked past any intermediate container the same way
-        # `_BathroomIndex.leaf_codes_under` already walks the same
-        # `parent_code` relation for bathrooms. An unset container reads as a
-        # delta of 0 -- real common space nobody measured, correctly zero and
-        # never "unknown" -- so only a genuinely unmeasured LEAF can still
-        # leave a total unknown.
+        # beneath it, walked past any intermediate container via
+        # `unit_index.leaf_codes_under` -- the SAME index `_build_parties`
+        # already built for bathroom resolution, passed in rather than
+        # rebuilt here (see `_BathroomIndex`'s own "built ONCE" docstring).
+        # An unset container reads as a delta of 0 -- real common space
+        # nobody measured, correctly zero and never "unknown" -- so only a
+        # genuinely unmeasured LEAF can still leave a total unknown.
         drawn = [u for u in drawn_units(units) if u.is_active]
         bookable = [u for u in drawn if _is_planning_inventory(u)]
         staff_housing = [u for u in drawn if not _is_planning_inventory(u)]
         available = [u for u in bookable if u.is_family_available]
         assigned = sum(1 for p in parties if p.unit_code or p.unit_name)
 
-        tree = _BathroomIndex.build(units)
-
         def _effective_sleeps(unit: LodgingUnitSummary) -> int | None:
             if not unit.is_container:
                 return unit.sleeps
             leaf_total = sum(
                 leaf.sleeps
-                for code in tree.leaf_codes_under(unit.code)
-                if (leaf := tree.units_by_code.get(code)) is not None and leaf.is_active and leaf.sleeps is not None
+                for code in unit_index.leaf_codes_under(unit.code)
+                if (leaf := unit_index.units_by_code.get(code)) is not None
+                and leaf.is_active
+                and leaf.sleeps is not None
             )
             return (unit.sleeps or 0) + leaf_total
 

--- a/frontend/src/components/weekend/rosterAttention.ts
+++ b/frontend/src/components/weekend/rosterAttention.ts
@@ -181,12 +181,15 @@ export function indexUnitsByCode(units: LodgingUnitRow[]): Map<string, LodgingUn
  * matches its neighbour.
  */
 export function countUnmeasuredSpaces(units: LodgingUnitRow[]): number {
-  // Over the DRAWN units, not "every non-container row". A combined house is
-  // the space, at the whole-house capacity somebody measured; its rooms draw
-  // no card and their own missing `sleeps` describes nothing a family could
-  // be put in. `drawnUnits` resolves that top-down and is the one definition
-  // of which units get a card — deriving it here a second way is how this
-  // starts disagreeing with the board it sits above.
+  // Over the DRAWN units, not "every non-container row". A combined house
+  // draws one card, at its own registry row; its rooms draw no card. That
+  // row's `sleeps` is now read as a DELTA over its rooms, not a whole-house
+  // total (kindred#2041) — but a container with no `sleeps` of its own is
+  // still nothing this walk can call measured, since its rooms never get a
+  // card here to speak for themselves. `drawnUnits` resolves the draw level
+  // top-down and is the one definition of which units get a card — deriving
+  // it here a second way is how this starts disagreeing with the board it
+  // sits above.
   return drawnUnits(units).filter(
     (unit) =>
       unit.is_family_available === true && (unit.sleeps === null || unit.sleeps === undefined)

--- a/frontend/src/components/weekend/unitLevel.ts
+++ b/frontend/src/components/weekend/unitLevel.ts
@@ -2,9 +2,11 @@
  * Which units the board draws, given each container's resolved draw level.
  *
  * A merge is a PROMOTION TO THE PARENT: the card drawn for a combined house is
- * the house's own registry row, never a synthetic one, so it carries the
- * measured whole-house `sleeps` — which is NOT the sum of its rooms. One house
- * records 7 against rooms summing to 6. Never re-derive it.
+ * the house's own registry row, never a synthetic one. That row's `sleeps` is
+ * a DELTA over its rooms, not a whole-house total (owner ruling, kindred#2041)
+ * — the beds in space belonging to no single room, e.g. a futon on a landing.
+ * Whole-house capacity is `sleeps` plus every leaf beneath it; this module
+ * only decides which card is drawn, so it never computes that total itself.
  *
  * Top-down, stopping at the first combined node. Two nodes on one root-to-leaf
  * path can both resolve combined — a scenario override can set one where an

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -4781,7 +4781,11 @@ export type RetentionTrendsResponse = {
 /**
  * RosterCounts
  *
- * Honest counts. Every capacity figure excludes container rows.
+ * Honest counts, at the level the board DRAWS -- see `drawn_units`. A
+ * split container's own row is excluded and its rooms count instead; a
+ * combined container's row counts ONCE, for a `sleeps` that now folds in
+ * every leaf beneath it (kindred#2041) -- never a container and its own
+ * rooms both.
  */
 export type RosterCounts = {
   /**

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -23,11 +23,11 @@ same AttributeError a real record would, so getattr defaults are exercised.
 
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from api.services.lodging_roster_service import LodgingRosterService, SessionNotFoundError
+from api.services.lodging_roster_service import LodgingRosterService, SessionNotFoundError, _BathroomIndex
 
 
 def _rec(**kwargs: Any) -> SimpleNamespace:
@@ -751,6 +751,25 @@ class TestUnitsAndCounts:
         roster = await LodgingRosterService(repo).build_roster(2026, 1000001, scenario="scn_1")
 
         assert roster.units[0].is_combined is True
+
+    @pytest.mark.asyncio
+    async def test_the_unit_index_is_built_once_per_roster_call(self) -> None:
+        """`_BathroomIndex`'s own docstring says built ONCE per roster/summary
+        call, not once per consumer. kindred#2041 added a second consumer
+        (`_build_counts`'s `_effective_sleeps`) and an early draft rebuilt the
+        index there instead of reusing `_build_parties`'s -- caught in
+        review, not by a test. This pins the invariant down so a future
+        consumer cannot reintroduce the same duplicate walk.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[_unit("u1", "ridge-a", "Ridge A", sleeps=5)],
+        )
+
+        with patch.object(_BathroomIndex, "build", wraps=_BathroomIndex.build) as spy:
+            await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        spy.assert_called_once()
 
 
 class TestCountsFollowTheDrawLevel:

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -930,6 +930,27 @@ class TestCountsFollowTheDrawLevel:
         assert roster.counts.units_total == 1
         assert roster.counts.beds_family_available == 13
 
+    @pytest.mark.asyncio
+    async def test_an_inactive_room_does_not_swell_a_combined_containers_total(self) -> None:
+        """A decommissioned room stays in the registry (kindred#1899-adjacent
+        history), but never contributes beds -- the same guard `drawn` already
+        applies to a container's OWN row. The inactive room here carries a
+        deliberately large `sleeps` (10) so the assertion fails loudly if the
+        leaf walk ever stops filtering it out.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("u1", "house", "The House", sleeps=5, is_container=True, default_combined=True),
+                _unit("u2", "r1", "Room 1", sleeps=3, parent_unit="u1"),
+                _unit("u3", "r2", "Room 2 (decommissioned)", sleeps=10, parent_unit="u1", is_active=False),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.counts.units_total == 1
+        assert roster.counts.beds_family_available == 8
+
 
 class TestSlotMergeTiers:
     """resolve_combined's three tiers, exercised through the roster assembly.

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -4,8 +4,13 @@ Domain facts these tests pin down:
   * Family camp enrols only CHILDREN, so a party is a household and its
     adults come from family_camp_adults.
   * Adult weekends enrol individuals, so a party is a person.
-  * Container units are in the payload but never in a capacity count.
-  * sleeps = 0 is UNKNOWN, so it is neither summed nor rendered.
+  * Container units are in the payload; a SPLIT one never counts on its own
+    row. A COMBINED one counts at its own `sleeps` PLUS every leaf beneath
+    it -- `sleeps` on a container is a DELTA over its rooms, never a
+    whole-house total (owner ruling, kindred#2041).
+  * sleeps = 0 is UNKNOWN on a leaf, so it is neither summed nor rendered.
+    On a container it is a legitimate zero delta (no measured common space)
+    and does not block totalling its rooms.
   * Staff-reserved units stay visible but are excluded from availability.
   * The share layer is READ from ingest-derived columns, never re-parsed.
 
@@ -755,24 +760,25 @@ class TestCountsFollowTheDrawLevel:
     two drift, the Housing tab and the stats bar describe different weekends
     -- the board drawing 81 cards beside a bar reporting 102 units is exactly
     the disagreement this shape exists to prevent." A combined container is
-    ONE space a family can hold, at the whole-house `sleeps` somebody
-    measured; its rooms are not separately lettable and must not be counted
-    as though they were.
+    ONE space a family can hold; its rooms are not separately lettable and
+    never draw their own card.
 
-    The bed figure moves in the OPPOSITE direction from the space figure on
-    real data, which looks wrong until you see why: a container's `sleeps` is
-    an independently measured whole-house number and NOT the sum of its rooms
-    (one house records 7 against rooms summing to 6, and one records 6
-    against two rooms nobody has measured at all). Fewer, larger spaces.
+    Owner ruling, kindred#2041: a container's `sleeps` is a DELTA over its
+    rooms -- the beds in space belonging to no single room, e.g. a futon on a
+    landing -- never a whole-house total. A combined container's true
+    capacity is therefore its own `sleeps` PLUS every LEAF beneath it, walked
+    past any intermediate container rather than stopping at its immediate
+    children. An unset container reads as a delta of zero (real, not
+    "unknown") and still totals its measured rooms.
     """
 
     @pytest.mark.asyncio
-    async def test_a_combined_container_counts_once_at_its_own_sleeps(self) -> None:
-        """The whole-house figure, never the sum of the rooms it replaces.
+    async def test_a_combined_container_counts_its_own_delta_plus_every_leaf_beneath_it(self) -> None:
+        """7 (the container's own delta) + 3 + 3 (its rooms) = 13, not 7.
 
-        7 vs 3+3 is the real shape: the measured whole is one bed larger than
-        its parts, because a house let whole sleeps somebody on a landing
-        that belongs to no single room. Summing would report 6.
+        Summing ONLY the rooms would report 6 and silently drop the space the
+        container's own row measures; reading the container's row ALONE (the
+        pre-#2041 behaviour) would report 7 and silently drop the rooms.
         """
         repo = _repo(
             fetch_session=FAMILY_SESSION,
@@ -786,7 +792,30 @@ class TestCountsFollowTheDrawLevel:
 
         assert roster.counts.units_total == 1
         assert roster.counts.units_family_available == 1
-        assert roster.counts.beds_family_available == 7
+        assert roster.counts.beds_family_available == 13
+
+    @pytest.mark.asyncio
+    async def test_a_combined_containers_sleeps_is_a_delta_not_a_whole_house_total(self) -> None:
+        """The real shape kindred#2041 measured against production: a
+        whole-let building's own `sleeps` records ONE piece of shared
+        furniture (a futon on a landing), not the building's capacity. Its
+        four rooms sleep 8 between them. The whole-house total is 9 -- the
+        live defect was reporting 1.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("u1", "wl-lodge", "Lodge", sleeps=1, is_container=True, default_combined=True),
+                _unit("u2", "wl-lodge-1", "Lodge Room 1", sleeps=2, parent_unit="u1"),
+                _unit("u3", "wl-lodge-2", "Lodge Room 2", sleeps=2, parent_unit="u1"),
+                _unit("u4", "wl-lodge-3", "Lodge Room 3", sleeps=2, parent_unit="u1"),
+                _unit("u5", "wl-lodge-4", "Lodge Room 4", sleeps=2, parent_unit="u1"),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.counts.units_total == 1
+        assert roster.counts.beds_family_available == 9
 
     @pytest.mark.asyncio
     async def test_a_split_container_still_counts_its_rooms_and_not_itself(self) -> None:
@@ -811,8 +840,14 @@ class TestCountsFollowTheDrawLevel:
     async def test_a_combined_ancestor_swallows_an_intermediate_container(self) -> None:
         """Top-down, first-true -- the same rule `drawnUnits` applies. Two
         nodes on one root-to-leaf path can both resolve combined; the higher
-        one draws and nothing beneath it counts, or the block's rooms would
-        be counted under a card that does not exist.
+        one draws and nothing beneath it gets its OWN card, or the block's
+        rooms would be counted under a card that does not exist.
+
+        The total still walks THROUGH the intermediate container to the real
+        LEAVES beneath it (10 + room1 3 + room2 3 = 16). The intermediate
+        container's own `sleeps` (7) is not itself a leaf, so it is not
+        added a second time -- only the outermost drawn container's own
+        delta and the actual rooms count.
         """
         repo = _repo(
             fetch_session=FAMILY_SESSION,
@@ -826,17 +861,18 @@ class TestCountsFollowTheDrawLevel:
         roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
 
         assert roster.counts.units_total == 1
-        assert roster.counts.beds_family_available == 10
+        assert roster.counts.beds_family_available == 16
 
     @pytest.mark.asyncio
     async def test_a_combined_container_reports_its_own_measured_beds_over_unmeasured_rooms(self) -> None:
-        """The real Doctor's House shape, and the sharpest case for this rule.
+        """The real Doctor's House shape.
 
         Its two rooms were split out of the container with `sleeps`
         deliberately left unset -- the bed lists carry their capacity, the
-        number does not. Counting the rooms reports a house that sleeps
-        NOBODY and two spaces of unknown capacity; counting the drawn card
-        reports the 6 somebody measured.
+        number does not. An unmeasured room contributes nothing to the total
+        (same silent-skip treatment an unmeasured LEAF gets everywhere else),
+        so the total is the container's own measured 6 plus two zeros: 6, not
+        "unknown".
         """
         repo = _repo(
             fetch_session=FAMILY_SESSION,
@@ -853,10 +889,12 @@ class TestCountsFollowTheDrawLevel:
         assert roster.counts.units_capacity_unknown == 0
 
     @pytest.mark.asyncio
-    async def test_a_combined_container_nobody_has_measured_is_the_unknown_one(self) -> None:
-        """The inverse: the card drawn is the one whose capacity is unknown,
-        not the rooms it replaced. `sleeps` maps 0 -> None here, so an
-        unmeasured house is an unmeasured SPACE.
+    async def test_a_combined_container_with_no_own_figure_still_totals_its_measured_rooms(self) -> None:
+        """The inverse of the Doctor's House case: no common-space furniture
+        was ever recorded for this house, and that is a real zero, not a
+        missing measurement (kindred#2041) -- 14 of 15 production containers
+        are in exactly this state. The card drawn still totals what its
+        rooms report: 0 + 2 + 2 = 4, and the total is KNOWN.
         """
         repo = _repo(
             fetch_session=FAMILY_SESSION,
@@ -869,8 +907,8 @@ class TestCountsFollowTheDrawLevel:
         roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
 
         assert roster.counts.units_total == 1
-        assert roster.counts.units_capacity_unknown == 1
-        assert roster.counts.beds_family_available == 0
+        assert roster.counts.units_capacity_unknown == 0
+        assert roster.counts.beds_family_available == 4
 
     @pytest.mark.asyncio
     async def test_a_scenario_merge_moves_the_counts_the_same_way_the_default_does(self) -> None:
@@ -890,7 +928,7 @@ class TestCountsFollowTheDrawLevel:
         roster = await LodgingRosterService(repo).build_roster(2026, 1000001, scenario="scn_1")
 
         assert roster.counts.units_total == 1
-        assert roster.counts.beds_family_available == 7
+        assert roster.counts.beds_family_available == 13
 
 
 class TestSlotMergeTiers:


### PR DESCRIPTION
## What this fixes

Owner ruling (#2041): a container's `sleeps` records the beds in space belonging to no single room (a futon on a landing), not the whole-house capacity. `_build_counts` was reading it as the latter, so a combined container's card contributed only its own figure and its rooms' beds vanished entirely.

**Verified against production (read-only), before and after** — unit CODES only, no display names:

| container | own `sleeps` | leaf rooms sum to | OLD contribution | NEW contribution |
|---|---:|---:|---:|---:|
| `gt-clouds-rest` | 1 | 8 | 1 | 9 |
| `gt-wawona` | 0 (unset) | 7 | 0 | 7 |
| `hc-downstairs` | 0 (unset) | 5 | 0 | 5 |
| `hc-doctors-house` | 0 (unset) | 5 | 0 | 5 |
| **total** | | | **1** | **26** |

Matches the issue's "roughly 25" estimate.

## What changed

- `api/services/lodging_roster_service.py` — `_build_counts` now computes each drawn combined container's total as its own `sleeps` (defaulted to 0 if unset — a real zero-delta, not "unknown") **plus** every LEAF beneath it, reusing the existing `_BathroomIndex.leaf_codes_under` tree walk rather than re-implementing it. Both `beds_family_available` and `units_capacity_unknown` read this derived total now. No registry data changes — only the interpretation.
- Three in-tree comments that asserted the now-overturned "whole-house total" premise are corrected: `lodging_roster_service.py`, `frontend/src/components/weekend/unitLevel.ts` (the two the campaign named), plus `api/schemas/lodging.py`'s `is_container` field doc, found via grep for the same stale phrasing.
- `frontend/src/components/weekend/rosterAttention.ts`'s `countUnmeasuredSpaces` doc is corrected too, but **its check is unchanged** — the three genuinely-unset whole-let containers on production have no measured rooms to total either, so it still correctly flags them.

## Tree contradictions vs. the campaign notes

- The stale anchor `lodging_roster_service.py:1018-1036` didn't match current line numbers; the real code was at `_build_counts` around line 1185-1232 (`beds_family_available`/`units_capacity_unknown`), matching the notes' own re-derived pointer to ~1193-1221.
- `rosterAttention.ts` did carry the same false premise in `countUnmeasuredSpaces`'s doc comment (confirmed via grep, not assumed) — fixed, logic untouched, exactly as the notes anticipated as the "still correct" branch.

## Tests (TDD)

`tests/unit/api/services/test_lodging_roster_service.py`:
- New test pinning the exact production shape (1 futon-container + 4 leaf rooms summing to 8 → 9).
- Updated 4 pre-existing tests whose assertions encoded the now-overturned total-reading premise (renamed two to describe the new behavior); one test's numbers were unaffected by coincidence (unmeasured leaves contribute 0 either way) and only its docstring changed.
- All 5 changed assertions were run RED against the old code first (confirmed failing), then GREEN after the fix. 107/107 pass in the file; 5914+/6113+ pass across the full unit suite.

**Mutation check**: reverted `_effective_sleeps` to `return unit.sleeps` (the old whole-house-total reading) — the same 5 tests failed (exit 1), confirming they pin real behavior and aren't vacuous. Restored, re-ran green (exit 0).

## Scan

Ran `scan-it` at floor 60. No findings — see PR comment for the full record (what was fixed, what was refuted, mutation-check transcript).

Closes #2041.