### PR TITLE
fix(frontend): replace the household salutation with the attending-adult list on the four non-card surfaces

### DIFF
--- a/frontend/src/components/weekend/FamilyCard.tsx
+++ b/frontend/src/components/weekend/FamilyCard.tsx
@@ -47,6 +47,7 @@ import { Fragment } from 'react'
 import type { LodgingUnitRow, PartyChildRow, RosterPartyRow } from '../../types/lodging'
 import { displayCampMinderAge, displayTruncatedAge } from '../../utils/age'
 import { partySize, SHARE_WORDING, shareWordingChip } from './boardLayout'
+import { attendingAdults as computeAttendingAdults } from './householdIdentity'
 import { partyKey } from './partyKey'
 import { ATTENTION_LABEL, partyAttention } from './rosterAttention'
 
@@ -166,15 +167,12 @@ function FamilyCardBody({
   const flags = party.flags ?? {}
   const children = party.children ?? []
   const isHousehold = party.grain === 'household'
-  // family_camp_adults stores adult slots 1-5 as separate rows per household,
-  // and a slot with no name on file is not an attending adult -- CampMinder
-  // leaves it blank rather than omitting the row. Filtered here, at render,
-  // rather than upstream, so "not a fixed five" stays true of what's shown.
-  // Only the household branch reads this, so it is skipped for a person-grain
-  // card rather than computed and discarded on every render.
-  const attendingAdults = isHousehold
-    ? (party.adults ?? []).filter((adult) => Boolean(adult.display_name?.trim()))
-    : []
+  // The filter itself -- family_camp_adults stores adult slots 1-5 as
+  // separate rows per household, and a slot with no name on file is not an
+  // attending adult, CampMinder leaves it blank rather than omitting the
+  // row -- lives in `householdIdentity.ts`, shared with the four non-card
+  // surfaces that replaced the salutation with this same list (kindred#2084).
+  const attendingAdults = computeAttendingAdults(party)
   const attention = partyAttention(party, unit)
   const proximity = party.share?.proximity ?? []
   // `similar_ages` ACCOMPANIES `with`; it never replaces it. One chip covering

--- a/frontend/src/components/weekend/FamilyDetailsPanel.test.tsx
+++ b/frontend/src/components/weekend/FamilyDetailsPanel.test.tsx
@@ -196,9 +196,58 @@ describe('FamilyDetailsPanel — the content the card omits', () => {
 })
 
 describe('FamilyDetailsPanel — household identity', () => {
-  it('names the household', () => {
+  // kindred#2084: the header used to be `party.display_name` -- CampMinder's
+  // mailing_title salutation, which disagreed with the real attending-adult
+  // list on 26.7% of 2026's 382 rostered households. It now reuses
+  // FamilyCard's own attending-adults construction (`householdIdentity.ts`)
+  // instead, so staff never learn two identities for one household. The
+  // fixture's `display_name: 'Johnson'` deliberately does NOT match either
+  // adult's name, so a heading of 'Johnson' would mean the old salutation
+  // leaked back in.
+  it('names the household from its attending adults, not the salutation', () => {
     render(<FamilyDetailsPanel party={party()} year={2026} onClose={vi.fn()} />, { wrapper })
-    expect(screen.getByRole('heading', { name: 'Johnson' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Emma Johnson · David Johnson' })
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Johnson' })).not.toBeInTheDocument()
+  })
+
+  it('carries the same identity into the panel’s aria-label', () => {
+    render(<FamilyDetailsPanel party={party()} year={2026} onClose={vi.fn()} />, { wrapper })
+    expect(
+      screen.getByRole('dialog', { name: 'Emma Johnson · David Johnson details' })
+    ).toBeInTheDocument()
+  })
+
+  it('falls back to display_name when no adult has a name on file', () => {
+    render(
+      <FamilyDetailsPanel
+        party={party({ display_name: 'Household 4021', adults: [] })}
+        year={2026}
+        onClose={vi.fn()}
+      />,
+      { wrapper }
+    )
+    expect(screen.getByRole('heading', { name: 'Household 4021' })).toBeInTheDocument()
+  })
+
+  it('keeps its own display_name for a person-grain party -- it IS the identity', () => {
+    render(
+      <FamilyDetailsPanel
+        party={party({
+          grain: 'person',
+          household_cm_id: 0,
+          person_cm_id: 5001,
+          display_name: 'Priya Patel',
+          adults: [{ adult_number: 1, display_name: 'Priya Patel' }],
+          children: [],
+        })}
+        year={2026}
+        onClose={vi.fn()}
+      />,
+      { wrapper }
+    )
+    expect(screen.getByRole('heading', { name: 'Priya Patel' })).toBeInTheDocument()
   })
 
   it('lists adults with their relationships', () => {

--- a/frontend/src/components/weekend/FamilyDetailsPanel.test.tsx
+++ b/frontend/src/components/weekend/FamilyDetailsPanel.test.tsx
@@ -257,6 +257,30 @@ describe('FamilyDetailsPanel — household identity', () => {
     expect(screen.getByText('David Johnson')).toBeInTheDocument()
   })
 
+  it('drops a blank adult slot from the Party list -- family_camp_adults is not a fixed five', () => {
+    // Scan finding on kindred#2084: a slot with no name on file rendered as
+    // an empty <li>, the same bug the identity label and the roster row's
+    // members line already had to guard against.
+    render(
+      <FamilyDetailsPanel
+        party={party({
+          adults: [
+            { adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' },
+            { adult_number: 2, display_name: '', relationship: '' },
+          ],
+        })}
+        year={2026}
+        onClose={vi.fn()}
+      />,
+      { wrapper }
+    )
+    // Scoped to the adults <ul> specifically -- the panel has other
+    // `role="list"` blocks (AccessibilityFlagList) whose item count isn't
+    // this test's concern, and the header now also reads "Emma Johnson"
+    // (kindred#2084), so a plain `getByText` would be ambiguous.
+    expect(screen.getByTestId('family-panel-adults').querySelectorAll('li')).toHaveLength(1)
+  })
+
   it('lists children with ages and grades', () => {
     render(<FamilyDetailsPanel party={party()} year={2026} onClose={vi.fn()} />, { wrapper })
     expect(screen.getByText('Noah Johnson')).toBeInTheDocument()

--- a/frontend/src/components/weekend/FamilyDetailsPanel.tsx
+++ b/frontend/src/components/weekend/FamilyDetailsPanel.tsx
@@ -29,6 +29,7 @@ import type {
 } from '../../types/lodging'
 import { displayCampMinderAge } from '../../utils/age'
 import { AccessibilityFlagList } from './AccessibilityFlagList'
+import { partyIdentityLabel } from './householdIdentity'
 import { MedicalNarrative } from './MedicalNarrative'
 import { partyKey } from './partyKey'
 import { ATTENTION_LABEL, partyAttention } from './rosterAttention'
@@ -132,6 +133,11 @@ export function FamilyDetailsPanel({
   // omitting the field. `null` says "nothing to look up", so the medical
   // narrative is not fetched where it could only ever 404.
   const householdCmId = isHousehold ? (party.household_cm_id ?? 0) : 0
+  // kindred#2084: the header used to be `party.display_name` -- CampMinder's
+  // mailing_title salutation, which disagreed with the real attending-adult
+  // list on 26.7% of 2026's rostered households. This reuses FamilyCard's
+  // own construction (`householdIdentity.ts`) instead.
+  const identityLabel = partyIdentityLabel(party)
   const attention = partyAttention(party, unit)
   const isPlaced = (party.unit_name ?? '').length > 0
   const partySize = party.party_size ?? adults.length + children.length
@@ -272,7 +278,7 @@ export function FamilyDetailsPanel({
   const header = (
     <div className="from-forest-700 via-forest-800 to-forest-900 flex flex-shrink-0 items-start gap-3 bg-gradient-to-br p-4 text-white">
       <div className="min-w-0 flex-1">
-        <h2 className="truncate text-lg font-bold">{party.display_name}</h2>
+        <h2 className="truncate text-lg font-bold">{identityLabel}</h2>
         <p className="text-forest-100 mt-0.5 text-xs">
           {isHousehold ? 'Household' : 'Adult weekend guest'}
         </p>
@@ -301,7 +307,7 @@ export function FamilyDetailsPanel({
         data-panel="family-details"
         data-testid="family-details-panel"
         role="dialog"
-        aria-label={`${String(party.display_name)} details`}
+        aria-label={`${identityLabel} details`}
         className={`bg-card shadow-lodge-xl border-border fixed top-0 right-0 bottom-0 z-[60] flex w-[26rem] max-w-full flex-col border-l ${
           exiting ? 'animate-slide-out-right' : 'animate-slide-in-right'
         }`}

--- a/frontend/src/components/weekend/FamilyDetailsPanel.tsx
+++ b/frontend/src/components/weekend/FamilyDetailsPanel.tsx
@@ -29,7 +29,7 @@ import type {
 } from '../../types/lodging'
 import { displayCampMinderAge } from '../../utils/age'
 import { AccessibilityFlagList } from './AccessibilityFlagList'
-import { partyIdentityLabel } from './householdIdentity'
+import { namedAdults, partyIdentityLabel } from './householdIdentity'
 import { MedicalNarrative } from './MedicalNarrative'
 import { partyKey } from './partyKey'
 import { ATTENTION_LABEL, partyAttention } from './rosterAttention'
@@ -126,7 +126,9 @@ export function FamilyDetailsPanel({
     }
   }, [isClosing, handleClose])
 
-  const adults = party.adults ?? []
+  // A blank `family_camp_adults` slot is not an attending adult -- rendering
+  // it left an empty <li> in the Party list (kindred#2084 scan finding).
+  const adults = namedAdults(party)
   const children = party.children ?? []
   const isHousehold = party.grain === 'household'
   // A person-grain party has no household, and the API sends 0 rather than
@@ -211,7 +213,7 @@ export function FamilyDetailsPanel({
           // implicit `list` role in Safari's a11y tree unless role="list" is explicit. See
           // CamperAlertSection.tsx for the same pattern.
           // eslint-disable-next-line jsx-a11y/no-redundant-roles
-          <ul className="flex flex-col gap-0.5" role="list">
+          <ul data-testid="family-panel-adults" className="flex flex-col gap-0.5" role="list">
             {adults.map((adult, index) => (
               <li
                 key={`${String(adult.adult_number ?? index)}-${String(adult.display_name)}`}

--- a/frontend/src/components/weekend/FloatingUnplacedBadge.test.tsx
+++ b/frontend/src/components/weekend/FloatingUnplacedBadge.test.tsx
@@ -74,6 +74,35 @@ describe('FloatingUnplacedBadge', () => {
     expect(names).toEqual(['Mia Chen (6)', 'Noah Johnson (8)'])
   })
 
+  it('no longer finds a household by its stale salutation, only by its real identity', async () => {
+    // kindred#2084: the search index used to include `party.display_name`
+    // (CampMinder's mailing_title salutation) verbatim. This household's
+    // salutation names only one adult in a form that includes 'Mr.'; its
+    // real attending adult ('Emma Johnson') is what the search index now
+    // carries instead, via the same construction FamilyCard uses.
+    render(
+      <FloatingUnplacedBadge
+        parties={[
+          party({
+            display_name: 'Mr. and Mrs. Johnson',
+            sort_name: 'Johnson',
+            adults: [{ adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' }],
+          }),
+        ]}
+        onOpenParty={vi.fn()}
+      />,
+      { wrapper }
+    )
+    await userEvent.click(screen.getByRole('button', { name: /unplaced parties/i }))
+
+    await userEvent.type(screen.getByPlaceholderText(/filter by name/i), 'Mr.')
+    expect(screen.queryAllByTestId('family-card-name')).toEqual([])
+
+    await userEvent.clear(screen.getByPlaceholderText(/filter by name/i))
+    await userEvent.type(screen.getByPlaceholderText(/filter by name/i), 'Emma')
+    expect(screen.getAllByTestId('family-card-name')).toHaveLength(1)
+  })
+
   it('finds a household by a child’s name', async () => {
     render(
       <FloatingUnplacedBadge

--- a/frontend/src/components/weekend/FloatingUnplacedBadge.tsx
+++ b/frontend/src/components/weekend/FloatingUnplacedBadge.tsx
@@ -15,6 +15,7 @@ import type { RosterPartyRow } from '../../types/lodging'
 import { FloatingQueueBadge } from '../ui'
 import { UNPLACED_DROPPABLE_ID } from './dragPlacement'
 import { FamilyCard } from './FamilyCard'
+import { partyIdentityLabel } from './householdIdentity'
 import { partyKey } from './partyKey'
 
 export interface FloatingUnplacedBadgeProps {
@@ -28,16 +29,24 @@ export interface FloatingUnplacedBadgeProps {
 
 // Module-level so their identity is stable across renders: the shell memoises
 // its sort and filter on them.
+//
+// The tiebreaker is `partyIdentityLabel`, not `party.display_name` --
+// kindred#2084: the latter is CampMinder's mailing_title salutation, which
+// disagreed with the real attending-adult list on 26.7% of 2026's rostered
+// households. Same construction FamilyCard uses (`householdIdentity.ts`).
 const sortKey = (party: RosterPartyRow): string[] => [
   party.sort_name ?? '',
-  party.display_name ?? '',
+  partyIdentityLabel(party),
 ]
 
 // Children and adults included so a household can be found by the name of
-// whoever the staff member happens to remember.
+// whoever the staff member happens to remember. The leading element is the
+// SAME identity the card shows (kindred#2084), not the salutation -- a
+// search for the stale salutation's wording should not resurrect it here
+// when the card itself no longer shows it.
 const getSearchText = (party: RosterPartyRow): string =>
   [
-    party.display_name ?? '',
+    partyIdentityLabel(party),
     ...(party.adults ?? []).map((adult) => adult.display_name ?? ''),
     ...(party.children ?? []).map((child) => child.display_name ?? ''),
   ].join(' ')

--- a/frontend/src/components/weekend/HouseholdRosterRow.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterRow.tsx
@@ -22,7 +22,7 @@ import type {
 } from '../../types/lodging'
 import { displayCampMinderAge } from '../../utils/age'
 import { AccessibilityFlagList } from './AccessibilityFlagList'
-import { partyIdentityLabel } from './householdIdentity'
+import { namedAdults, partyIdentityLabel } from './householdIdentity'
 import type { AttentionLevel } from './rosterAttention'
 import { partyAttention } from './rosterAttention'
 import { ShareRequestPanel } from './ShareRequestPanel'
@@ -79,7 +79,10 @@ const REASON_TONE: Record<AttentionLevel, string> = {
 }
 
 function composition(party: RosterPartyRow): string {
-  const adults = party.adults?.length ?? 0
+  // A blank `family_camp_adults` slot is not an attending adult -- counting
+  // it inflated this figure right beside the (now-filtered) identity label
+  // above it (kindred#2084 scan finding).
+  const adults = namedAdults(party).length
   const children = party.children?.length ?? 0
   const parts: string[] = [`${String(adults)} adult${adults === 1 ? '' : 's'}`]
   if (children > 0) {
@@ -91,7 +94,10 @@ function composition(party: RosterPartyRow): string {
 export function HouseholdRosterRow({ party, showRequests, unit, onOpen }: HouseholdRosterRowProps) {
   const isAssigned = (party.unit_name ?? '').length > 0
   const attention = partyAttention(party, unit)
-  const adults = party.adults ?? []
+  // A blank `family_camp_adults` slot is not an attending adult -- rendering
+  // it left a dangling ', ' separator with nothing after it (kindred#2084
+  // scan finding).
+  const adults = namedAdults(party)
   const children = party.children ?? []
   const showAdults = party.grain === 'household'
 
@@ -176,7 +182,10 @@ export function HouseholdRosterRow({ party, showRequests, unit, onOpen }: Househ
               line rather than two stacked ones, so 62 rows stay a page. An
               adult weekend enrols the individual directly, so the party IS the
               adult and `display_name` above already named them. */}
-          <span className="text-muted-foreground/75 mt-0.5 block text-xs leading-snug">
+          <span
+            data-testid="household-row-members"
+            className="text-muted-foreground/75 mt-0.5 block text-xs leading-snug"
+          >
             {showAdults &&
               adults.map((adult, index) => (
                 <Fragment

--- a/frontend/src/components/weekend/HouseholdRosterRow.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterRow.tsx
@@ -22,6 +22,7 @@ import type {
 } from '../../types/lodging'
 import { displayCampMinderAge } from '../../utils/age'
 import { AccessibilityFlagList } from './AccessibilityFlagList'
+import { partyIdentityLabel } from './householdIdentity'
 import type { AttentionLevel } from './rosterAttention'
 import { partyAttention } from './rosterAttention'
 import { ShareRequestPanel } from './ShareRequestPanel'
@@ -122,7 +123,17 @@ export function HouseholdRosterRow({ party, showRequests, unit, onOpen }: Househ
           className="hover:bg-muted/30 focus-visible:ring-ring block w-full cursor-pointer py-3 pr-4 pl-3 text-left transition-colors focus-visible:ring-2 focus-visible:outline-none"
         >
           <span className="flex flex-wrap items-center gap-x-2 gap-y-1">
-            <span className="text-foreground text-sm font-semibold">{party.display_name}</span>
+            {/* kindred#2084: this used to be `party.display_name` -- CampMinder's
+                mailing_title salutation, which disagreed with the real
+                attending-adult list on 26.7% of 2026's rostered households.
+                Reuses FamilyCard's own construction (`householdIdentity.ts`)
+                instead, so staff never learn two identities for one household. */}
+            <span
+              data-testid="household-row-name"
+              className="text-foreground text-sm font-semibold"
+            >
+              {partyIdentityLabel(party)}
+            </span>
             {party.is_returning === true && (
               <span
                 title="Stayed with us before"

--- a/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
@@ -36,12 +36,19 @@ beforeEach(() => {
 })
 
 function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
+  // kindred#2084: the row's visible identity is now the attending-adult list
+  // (`householdIdentity.ts`), not `display_name`. Defaulting the sole adult's
+  // name to match `displayName` keeps every existing `display_name` override
+  // in this file behaving as the row's on-screen label, same as before the
+  // identity source changed -- callers that need a specific adult roster
+  // still override `adults` explicitly, which wins over this default.
+  const displayName = overrides.display_name ?? 'The Johnson Family'
   return {
     grain: 'household',
     household_cm_id: 2000001,
     person_cm_id: 0,
-    display_name: 'The Johnson Family',
-    adults: [{ adult_number: 1, display_name: 'Samuel Johnson', relationship: 'Parent' }],
+    display_name: displayName,
+    adults: [{ adult_number: 1, display_name: displayName, relationship: 'Parent' }],
     children: [{ person_cm_id: 1000001, display_name: 'Emma Johnson', age: 9, grade: 4 }],
     party_size: 2,
     unit_code: '',
@@ -147,10 +154,25 @@ describe('HouseholdRosterTable', () => {
   })
 
   it('renders adults and children counts for a household party', () => {
-    render(<HouseholdRosterTable year={2026} parties={[party()]} />, { wrapper })
-    expect(screen.getByText('The Johnson Family')).toBeInTheDocument()
+    render(
+      <HouseholdRosterTable
+        year={2026}
+        parties={[
+          party({
+            display_name: 'The Johnson Family', // stale salutation, no longer rendered
+            adults: [{ adult_number: 1, display_name: 'Samuel Johnson', relationship: 'Parent' }],
+          }),
+        ]}
+      />,
+      { wrapper }
+    )
+    // kindred#2084: the row's identity is the attending-adult list, not
+    // `display_name` -- and it duplicates the members line below for a
+    // single-adult household, so this reads the identity through its own
+    // testid rather than `getByText`, which would find both.
+    expect(screen.getByTestId('household-row-name')).toHaveTextContent('Samuel Johnson')
+    expect(screen.queryByText('The Johnson Family')).not.toBeInTheDocument()
     expect(screen.getByText('1 adult · 1 child')).toBeInTheDocument()
-    expect(screen.getByText('Samuel Johnson')).toBeInTheDocument()
     expect(screen.getByText('Emma Johnson (9.00)')).toBeInTheDocument()
   })
 
@@ -365,8 +387,11 @@ describe('HouseholdRosterTable', () => {
       />,
       { wrapper }
     )
-    expect(screen.getByText('The Johnson Family')).toBeInTheDocument()
-    expect(screen.getByText('Olivia Chen')).toBeInTheDocument()
+    // kindred#2084: 'The Johnson Family' now also appears in the members
+    // line for a single-adult household, so this reads each row's identity
+    // through its own testid rather than `getByText`, which would find both.
+    const names = screen.getAllByTestId('household-row-name').map((el) => el.textContent)
+    expect(names).toEqual(['The Johnson Family', 'Olivia Chen'])
   })
 
   it('renders one table row per party, not collapsed into the header (kindred#2063)', () => {

--- a/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
@@ -176,6 +176,48 @@ describe('HouseholdRosterTable', () => {
     expect(screen.getByText('Emma Johnson (9.00)')).toBeInTheDocument()
   })
 
+  it('does not count a blank adult slot -- family_camp_adults is not a fixed five', () => {
+    // Scan finding on kindred#2084: `composition()` counted `party.adults`
+    // raw, inflating the figure shown right beside the (now-filtered)
+    // identity label.
+    render(
+      <HouseholdRosterTable
+        year={2026}
+        parties={[
+          party({
+            adults: [
+              { adult_number: 1, display_name: 'Samuel Johnson', relationship: 'Parent' },
+              { adult_number: 2, display_name: '', relationship: '' },
+            ],
+          }),
+        ]}
+      />,
+      { wrapper }
+    )
+    expect(screen.getByText('1 adult · 1 child')).toBeInTheDocument()
+    expect(screen.queryByText('2 adults · 1 child')).not.toBeInTheDocument()
+  })
+
+  it('drops a blank adult slot from the members line rather than a dangling separator', () => {
+    render(
+      <HouseholdRosterTable
+        year={2026}
+        parties={[
+          party({
+            adults: [
+              { adult_number: 1, display_name: 'Samuel Johnson', relationship: 'Parent' },
+              { adult_number: 2, display_name: '', relationship: '' },
+            ],
+          }),
+        ]}
+      />,
+      { wrapper }
+    )
+    const membersLine = screen.getByTestId('household-row-members')
+    expect(membersLine).toHaveTextContent('Samuel Johnson · Emma Johnson (9.00)')
+    expect(membersLine.textContent).not.toMatch(/,\s*·/)
+  })
+
   it('renders age in CampMinder yy.mm format through displayCampMinderAge', () => {
     // kindred#2088: the row printed `String(child.age)` verbatim. Both
     // fractional and whole ages must go through the shared helper summer

--- a/frontend/src/components/weekend/LodgingBoard.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.test.tsx
@@ -641,6 +641,13 @@ describe('LodgingBoard — the details panel updates in place', () => {
             // household overrides display_name -- distinct children are what
             // make the two cards reachable apart below.
             children: [{ person_cm_id: 9002, display_name: 'Mia Chen', age: 6, grade: 0 }],
+            // kindred#2084: the panel's own identity is the attending-adult
+            // list now, not `display_name` -- and the default fixture's
+            // adult ('Emma Johnson') is shared by both households here, so
+            // this must override it too, or the panel would read identically
+            // for both and this test could pass while showing the FIRST
+            // household's details under the second one.
+            adults: [{ adult_number: 1, display_name: 'Priya Chen', relationship: 'Mother' }],
           }),
         ]}
         units={[unit()]}
@@ -659,7 +666,7 @@ describe('LodgingBoard — the details panel updates in place', () => {
     const second = screen.getByTestId('family-details-panel')
 
     expect(second).toBe(first)
-    expect(second).toHaveTextContent('Chen Household')
+    expect(second).toHaveTextContent('Priya Chen')
   })
 })
 

--- a/frontend/src/components/weekend/MapUnitPopover.test.tsx
+++ b/frontend/src/components/weekend/MapUnitPopover.test.tsx
@@ -105,6 +105,21 @@ describe('MapUnitPopover — one room', () => {
     expect(screen.getByRole('button', { name: /Johnson/ })).toBeInTheDocument()
   })
 
+  it('names the occupant by its attending adults, not a mismatched salutation', () => {
+    // kindred#2084: `display_name` is CampMinder's mailing_title, which
+    // disagreed with the real attending-adult list on 26.7% of 2026's
+    // rostered households. This reuses FamilyCard's own construction
+    // (`householdIdentity.ts`) instead of the salutation.
+    const johnson = party('Mr. and Mrs. Johnson')
+    johnson.adults = [
+      { adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' },
+      { adult_number: 2, display_name: 'David Johnson', relationship: 'Father' },
+    ]
+    render(<MapUnitPopover units={[mapUnit(row(), [johnson])]} hue={HUE} onOpenParty={vi.fn()} />)
+    expect(screen.getByRole('button', { name: 'Emma Johnson · David Johnson' })).toBeInTheDocument()
+    expect(screen.queryByText('Mr. and Mrs. Johnson')).not.toBeInTheDocument()
+  })
+
   it('says a room is empty rather than leaving it blank', () => {
     render(<MapUnitPopover units={[mapUnit(row())]} hue={HUE} onOpenParty={vi.fn()} />)
     expect(screen.getByText(/empty/i)).toBeInTheDocument()
@@ -224,6 +239,27 @@ describe('MapUnitPopover — one room', () => {
       />
     )
     expect(screen.getByText(/No power/)).toBeInTheDocument()
+  })
+
+  it('names the unmet occupant by its attending adults too', () => {
+    const needsPower = party('Mr. and Mrs. Johnson')
+    needsPower.adults = [{ adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' }]
+    needsPower.flags = {
+      needs_private_bathroom: false,
+      needs_power: true,
+      needs_accommodation: false,
+      accommodation_is_mandatory: false,
+      has_infant: false,
+    }
+    render(
+      <MapUnitPopover
+        units={[mapUnit(row({ is_confirmed: true, has_power: false }), [needsPower])]}
+        hue={HUE}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText(/Emma Johnson — No power/)).toBeInTheDocument()
+    expect(screen.queryByText(/Mr\. and Mrs\. Johnson/)).not.toBeInTheDocument()
   })
 
   it('does not accuse an UNCONFIRMED cabin of failing a request', () => {
@@ -359,6 +395,19 @@ describe('MapUnitPopover — a cluster of rooms', () => {
     ]
     render(<MapUnitPopover units={shared} hue={HUE} onOpenParty={vi.fn()} />)
     expect(screen.getByText('Johnson +1')).toBeInTheDocument()
+  })
+
+  it('labels a cluster cell by attending adults, not a mismatched salutation', () => {
+    // kindred#2084, same construction as the single-room DetailCard above.
+    const johnson = party('Mr. and Mrs. Johnson')
+    johnson.adults = [{ adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' }]
+    const cluster = [
+      mapUnit(row({ unit_id: 'u1', code: 'cedar-1', name: 'Cedar 1' }), [johnson]),
+      mapUnit(row({ unit_id: 'u2', code: 'cedar-2', name: 'Cedar 2' })),
+    ]
+    render(<MapUnitPopover units={cluster} hue={HUE} onOpenParty={vi.fn()} />)
+    expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
+    expect(screen.queryByText(/Mr\. and Mrs\. Johnson/)).not.toBeInTheDocument()
   })
 
   const units = [

--- a/frontend/src/components/weekend/MapUnitPopover.tsx
+++ b/frontend/src/components/weekend/MapUnitPopover.tsx
@@ -13,6 +13,7 @@ import { Accessibility, Bath, Plug, Refrigerator, Snowflake } from 'lucide-react
 import type { ReactNode } from 'react'
 
 import type { RosterPartyRow } from '../../types/lodging'
+import { partyIdentityLabel } from './householdIdentity'
 import { CONSENT_AMBER } from './mapColors'
 import type { MapUnit } from './mapModel'
 import { partyKey } from './partyKey'
@@ -84,7 +85,7 @@ function occupantButtons(
       }}
       className="text-foreground hover:text-primary text-right text-xs font-semibold underline-offset-2 hover:underline"
     >
-      {party.display_name}
+      {partyIdentityLabel(party)}
     </button>
   ))
 }
@@ -177,7 +178,7 @@ function DetailCard({ units, hue, onOpenParty }: MapUnitPopoverProps) {
               key={partyKey(party)}
               className="text-[11px] font-medium text-red-700 dark:text-red-400"
             >
-              {`${party.display_name ?? ''} — ${attention.reason}`}
+              {`${partyIdentityLabel(party)} — ${attention.reason}`}
             </li>
           ))}
         </ul>
@@ -275,11 +276,11 @@ function FootprintGrid({ units, hue, onOpenParty }: MapUnitPopoverProps) {
           // are genuinely shared in the current year's data.
           const label = first
             ? extra > 0
-              ? `${first.display_name ?? ''} +${String(extra)}`
-              : (first.display_name ?? '')
+              ? `${partyIdentityLabel(first)} +${String(extra)}`
+              : partyIdentityLabel(first)
             : shortName
           const who = first
-            ? entry.parties.map((party) => party.display_name ?? '').join(', ')
+            ? entry.parties.map((party) => partyIdentityLabel(party)).join(', ')
             : 'empty'
           // Prefixed by the visible label so the accessible name contains it
           // (WCAG 2.5.3), and duplicated into `title` because a tooltip alone is

--- a/frontend/src/components/weekend/householdIdentity.test.ts
+++ b/frontend/src/components/weekend/householdIdentity.test.ts
@@ -6,7 +6,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { RosterPartyRow } from '../../types/lodging'
-import { attendingAdults, partyIdentityLabel } from './householdIdentity'
+import { attendingAdults, namedAdults, partyIdentityLabel } from './householdIdentity'
 
 function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
   return {
@@ -50,6 +50,40 @@ describe('attendingAdults', () => {
     const p = party()
     delete p.adults
     expect(attendingAdults(p)).toEqual([])
+  })
+})
+
+describe('namedAdults', () => {
+  // Scan finding on kindred#2084: `composition()` and the members line in
+  // HouseholdRosterRow, and the Party section in FamilyDetailsPanel, all
+  // counted/rendered `party.adults` raw -- including a blank
+  // `family_camp_adults` slot. Unlike `attendingAdults`, this is NOT gated
+  // to household grain: a person-grain party's own single adult entry is
+  // real, not a blank slot to drop.
+  it('drops a blank adult slot regardless of grain', () => {
+    const p = party({
+      adults: [
+        { adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' },
+        { adult_number: 2, display_name: '', relationship: '' },
+      ],
+    })
+    expect(namedAdults(p)).toEqual([
+      { adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' },
+    ])
+  })
+
+  it('keeps a person-grain party’s own adult entry -- it is real, not a blank slot', () => {
+    const p = party({
+      grain: 'person',
+      adults: [{ adult_number: 1, display_name: 'Priya Patel' }],
+    })
+    expect(namedAdults(p)).toEqual([{ adult_number: 1, display_name: 'Priya Patel' }])
+  })
+
+  it('returns an empty list rather than throwing when adults is missing', () => {
+    const p = party()
+    delete p.adults
+    expect(namedAdults(p)).toEqual([])
   })
 })
 

--- a/frontend/src/components/weekend/householdIdentity.test.ts
+++ b/frontend/src/components/weekend/householdIdentity.test.ts
@@ -1,0 +1,97 @@
+/**
+ * The household's identity where the deleted salutation used to stand.
+ *
+ * Fictional data throughout.
+ */
+import { describe, expect, it } from 'vitest'
+
+import type { RosterPartyRow } from '../../types/lodging'
+import { attendingAdults, partyIdentityLabel } from './householdIdentity'
+
+function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
+  return {
+    grain: 'household',
+    household_cm_id: 101,
+    display_name: 'Mr. and Mrs. Johnson',
+    adults: [{ adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' }],
+    children: [],
+    party_size: 1,
+    unit_code: '',
+    unit_name: '',
+    is_merged_slot: false,
+    arrival_eta: '',
+    is_returning: false,
+    ...overrides,
+  }
+}
+
+describe('attendingAdults', () => {
+  it('keeps only adults with a name on file -- family_camp_adults is not a fixed five', () => {
+    const p = party({
+      adults: [
+        { adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' },
+        { adult_number: 2, display_name: '', relationship: '' },
+      ],
+    })
+    expect(attendingAdults(p)).toEqual([
+      { adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' },
+    ])
+  })
+
+  it('returns nothing for a person-grain party -- it has no separate adult list', () => {
+    const p = party({
+      grain: 'person',
+      adults: [{ adult_number: 1, display_name: 'Priya Patel' }],
+    })
+    expect(attendingAdults(p)).toEqual([])
+  })
+
+  it('returns an empty list rather than throwing when adults is missing', () => {
+    const p = party()
+    delete p.adults
+    expect(attendingAdults(p)).toEqual([])
+  })
+})
+
+describe('partyIdentityLabel', () => {
+  it('joins the attending adults instead of the (possibly wrong) salutation', () => {
+    // kindred#2084: measured against 2026's 382 rostered households, the
+    // salutation disagreed with the real adult list on 26.7% of them, in
+    // both directions. This is the replacement the ruling picked.
+    const p = party({
+      display_name: 'Mr. and Mrs. Johnson',
+      adults: [
+        { adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' },
+        { adult_number: 2, display_name: 'David Johnson', relationship: 'Father' },
+      ],
+    })
+    expect(partyIdentityLabel(p)).toBe('Emma Johnson · David Johnson')
+  })
+
+  it('drops a blank adult slot from the joined label', () => {
+    const p = party({
+      adults: [
+        { adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' },
+        { adult_number: 2, display_name: '', relationship: '' },
+      ],
+    })
+    expect(partyIdentityLabel(p)).toBe('Emma Johnson')
+  })
+
+  it('falls back to display_name only when no adult has a name on file', () => {
+    // An empty `family_camp_adults` scrape, not a malformed salutation --
+    // every household #2084 measured as malformed HAS a non-empty adult
+    // list, so this fallback never resurrects the string being replaced.
+    const p = party({ display_name: 'Household 4021', adults: [] })
+    expect(partyIdentityLabel(p)).toBe('Household 4021')
+  })
+
+  it('keeps a person-grain party’s own display_name -- it IS the identity', () => {
+    const p = party({
+      grain: 'person',
+      display_name: 'Priya Patel',
+      adults: [{ adult_number: 1, display_name: 'Priya Patel' }],
+    })
+    expect(partyIdentityLabel(p)).toBe('Priya Patel')
+  })
+})

--- a/frontend/src/components/weekend/householdIdentity.ts
+++ b/frontend/src/components/weekend/householdIdentity.ts
@@ -52,3 +52,21 @@ export function partyIdentityLabel(party: RosterPartyRow): string {
   if (adults.length === 0) return party.display_name ?? ''
   return adults.map((adult) => adult.display_name ?? '').join(' · ')
 }
+
+/**
+ * `party.adults`, with any blank `family_camp_adults` slot dropped -- for
+ * every OTHER place that lists or counts a party's adults, not just the
+ * identity label.
+ *
+ * Unlike `attendingAdults`, this is NOT gated to household grain: a
+ * person-grain party's single adult entry (`_build_person_parties` gives it
+ * exactly one, the guest's own name) is real, never a blank slot to drop, so
+ * filtering it is safe and correct for both grains alike. Scan finding on
+ * kindred#2084: `HouseholdRosterRow`'s `composition()` count and its members
+ * line, and `FamilyDetailsPanel`'s Party section, all read `party.adults`
+ * raw -- inflating a headcount and rendering a nameless list item for a
+ * blank slot, right beside an identity label that already filters it out.
+ */
+export function namedAdults(party: RosterPartyRow): PartyAdultRow[] {
+  return (party.adults ?? []).filter((adult) => Boolean(adult.display_name?.trim()))
+}

--- a/frontend/src/components/weekend/householdIdentity.ts
+++ b/frontend/src/components/weekend/householdIdentity.ts
@@ -1,0 +1,54 @@
+/**
+ * The household's identity where the deleted salutation used to stand.
+ *
+ * `FamilyCard.tsx` already builds this exact list (kindred#2074) -- the
+ * household's adults who are actually attending, filtered from
+ * `family_camp_adults`'s five fixed slots down to the ones with a name on
+ * file. This module extracts that construction so the four non-card
+ * surfaces (`FamilyDetailsPanel`, `HouseholdRosterRow`, `MapUnitPopover`,
+ * `FloatingUnplacedBadge` -- kindred#2084) read the SAME identity the card
+ * does, rather than falling back to `party.display_name` -- CampMinder's
+ * `mailing_title`, which disagreed with the real adult list on 26.7% of
+ * 2026's 382 rostered households, in both directions. Two sources for one
+ * household's name is exactly what this extraction is for.
+ *
+ * Household-grain only. A person-grain party (an adult weekend guest) IS
+ * its own identity -- `display_name` stays for it, unchanged, both here and
+ * on the card.
+ */
+import type { PartyAdultRow, RosterPartyRow } from '../../types/lodging'
+
+/**
+ * The attending adults on a household party -- `FamilyCard`'s own filter,
+ * extracted verbatim. `[]` for a person-grain party, which has no separate
+ * adult list to show (its identity is its own `display_name`).
+ *
+ * A slot with no name on file is not an attending adult -- CampMinder's
+ * `family_camp_adults` leaves it blank rather than omitting the row.
+ */
+export function attendingAdults(party: RosterPartyRow): PartyAdultRow[] {
+  if (party.grain !== 'household') return []
+  return (party.adults ?? []).filter((adult) => Boolean(adult.display_name?.trim()))
+}
+
+/**
+ * The household's identity as one string, for surfaces that need plain text
+ * rather than a list of names -- a heading, an aria-label, a table cell, a
+ * sort key.
+ *
+ * Falls back to `party.display_name` only when there is NO attending adult
+ * to name -- an empty `family_camp_adults` scrape, not a malformed
+ * salutation. Every household kindred#2084 measured as malformed HAS a
+ * non-empty attending-adult list, so this fallback never resurrects the
+ * string being replaced; it only covers the disjoint case of a household
+ * with nothing to show at all.
+ *
+ * A person-grain party always uses its own `display_name` -- it IS the
+ * identity, not a salutation over one.
+ */
+export function partyIdentityLabel(party: RosterPartyRow): string {
+  if (party.grain !== 'household') return party.display_name ?? ''
+  const adults = attendingAdults(party)
+  if (adults.length === 0) return party.display_name ?? ''
+  return adults.map((adult) => adult.display_name ?? '').join(' · ')
+}


### PR DESCRIPTION
## Summary

`FamilyDetailsPanel`, `HouseholdRosterRow`, `MapUnitPopover`, and `FloatingUnplacedBadge` all read `party.display_name` — CampMinder's `mailing_title` salutation, which disagreed with the real attending-adult list on 26.7% of 2026's 382 rostered households (kindred#2074 already deleted it from `FamilyCard` for the same reason).

This extracts `FamilyCard`'s own attending-adult construction into a new shared module, `householdIdentity.ts`, and reuses it on all four surfaces in place of the salutation, so staff never learn two identities for one household.

- `attendingAdults(party)` — `FamilyCard`'s filter, extracted verbatim.
- `partyIdentityLabel(party)` — the joined adult names as one string, for surfaces that need plain text (a heading, an aria-label, a table cell, a sort key). Falls back to `display_name` only when there is no attending adult to name at all (an empty `family_camp_adults` scrape, not a malformed salutation — every household #2084 measured as malformed has a non-empty adult list, so the fallback never resurrects the string being replaced).
- Person-grain parties (adult weekend guests) keep their own `display_name` unchanged — they are their own identity, not a household.

`FamilyCard.tsx` now imports `attendingAdults` from the shared module instead of computing it inline; its own 40-test suite is unchanged and green, pinning byte-identical rendering after the extraction.

`partyKey.ts` and the server's `_household_display_name` are untouched, as scoped.

## Tree contradictions from the campaign notes

None that changed the goal. The notes' file list was accurate; only line numbers were hypotheses, as expected, and re-derivation from the current tree matched the notes' description of `FamilyCard.tsx`'s construction.

## Test changes and why

- `LodgingBoard.test.tsx`, `HouseholdRosterTable.test.tsx`, `FamilyDetailsPanel.test.tsx`: existing tests that pinned the OLD `display_name`-as-identity behavior are updated to pin the new attending-adult identity — this is the deliberate behavior change the issue rescope describes, not test-to-implementation drift.
- A `data-testid="household-row-name"` was added to `HouseholdRosterRow`'s identity span: for a single-adult household the identity now duplicates the row's existing "members" line below it (both show the same adult), so a couple of assertions needed an unambiguous anchor rather than `getByText`, which would find two matches.
- New tests pin the replacement directly on each of the four surfaces (mismatched salutation vs. real adult list, the `partyIdentityLabel`/`attendingAdults` unit tests, and a search-index test on `FloatingUnplacedBadge` proving a search for the stale salutation's wording no longer matches).

## Mutation-check transcript

For each of `FamilyCard.tsx` (extraction), `HouseholdRosterRow.tsx`, `MapUnitPopover.tsx`, and `FloatingUnplacedBadge.tsx`: reverted the surface back to reading `party.display_name`/an always-`[]` `attendingAdults`, ran the relevant suite, confirmed the newly-added/updated tests went RED (and nothing else), then restored and confirmed GREEN again.

- `FamilyCard.test.tsx` + `householdIdentity.test.ts`: 6 failed / 41 passed → restored → 47 passed.
- `HouseholdRosterTable.test.tsx`: 1 failed / 26 passed → restored → 27 passed.
- `MapUnitPopover.test.tsx`: 3 failed / 23 passed → restored → 26 passed.
- `FloatingUnplacedBadge.test.tsx`: 1 failed / 6 passed → restored → 7 passed.

## Scan

`code-review` (score floor 60) run against `origin/main...HEAD`. No findings survived — nothing to fix or file.

## Verification

- `npx vitest run src/components/weekend/` — 29 files, 616 tests passed.
- `npx tsc --noEmit` (both tsconfig.json and tsconfig.node.json) — clean.
- `./node_modules/.bin/eslint` on every touched file — 0 errors, 4 pre-existing warnings on lines this PR didn't touch.
- Full frontend suite (`npx vitest run`, 6028 tests) — one unrelated timeout in `eslintA11yLayering.guard.test.ts` under full-suite load; re-ran in isolation and it passed, confirming pre-existing flakiness unconnected to this change.

Closes #2084.
