### PR TITLE
feat(frontend): mark whole-building holds and count buildings per area

### DIFF
--- a/frontend/src/components/weekend/FamilyCard.test.tsx
+++ b/frontend/src/components/weekend/FamilyCard.test.tsx
@@ -414,6 +414,16 @@ describe('FamilyCard — what it shows', () => {
     )
     expect(screen.getByText('Wants to share')).toBeInTheDocument()
   })
+
+  it('marks a placement that holds a whole building — #2008', () => {
+    render(<FamilyCard party={party()} holdsWholeBuilding={true} onOpen={vi.fn()} />)
+    expect(screen.getByText('Whole building')).toBeInTheDocument()
+  })
+
+  it('says nothing about a placement that does not hold a whole building', () => {
+    render(<FamilyCard party={party()} onOpen={vi.fn()} />)
+    expect(screen.queryByText('Whole building')).not.toBeInTheDocument()
+  })
 })
 
 describe('FamilyCard — spec §3.8, what must stay off it', () => {

--- a/frontend/src/components/weekend/FamilyCard.tsx
+++ b/frontend/src/components/weekend/FamilyCard.tsx
@@ -41,7 +41,7 @@
  * its `display_name` stays.
  */
 import { useDraggable } from '@dnd-kit/core'
-import { Repeat, Star, Users } from 'lucide-react'
+import { Home, Repeat, Star, Users, type LucideIcon } from 'lucide-react'
 import { Fragment } from 'react'
 
 import type { LodgingUnitRow, PartyChildRow, RosterPartyRow } from '../../types/lodging'
@@ -62,6 +62,14 @@ export interface FamilyCardProps {
    */
   sharedSlot?: boolean
   /**
+   * Whether this PLACEMENT — this party's own occupied leaves, not the
+   * card it happens to share — covers an entire building (kindred#2008).
+   * A household holding a whole building is private in a way no
+   * combination of room-level flags conveys; the caller computes this from
+   * `boardLayout.ts`'s `wholeBuildingHolders`, never re-derived here.
+   */
+  holdsWholeBuilding?: boolean
+  /**
    * The card is in the unplaced queue rather than in a slot on the board.
    * Purely a surface choice: the popover's own background is already the
    * page's, so a card inside it needs `bg-card` to read as a card at all,
@@ -80,7 +88,7 @@ export interface FamilyCardProps {
   onOpen: (party: RosterPartyRow) => void
 }
 
-type ChipTone = 'need' | 'warn' | 'share' | 'quiet' | 'muted'
+type ChipTone = 'need' | 'warn' | 'share' | 'quiet' | 'muted' | 'building'
 
 const CHIP_TONE: Record<ChipTone, string> = {
   need: 'bg-amber-100 text-amber-800 dark:bg-amber-950/50 dark:text-amber-300',
@@ -88,13 +96,28 @@ const CHIP_TONE: Record<ChipTone, string> = {
   share: 'bg-forest-100 text-forest-800 dark:bg-forest-950/50 dark:text-forest-300',
   quiet: 'border-border text-muted-foreground border border-dashed',
   muted: 'bg-muted text-muted-foreground',
+  // Distinct from `share` (a REQUEST) and `warn` (a problem) — a whole
+  // building held is neither, it is a privacy fact staff act on. Distinct
+  // from `unitBadges.ts`'s violet "Staff" badge too, so the two never read
+  // as the same signal on adjoining cards.
+  building: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-950/50 dark:text-indigo-300',
 }
 
-function Chip({ label, tone }: { label: string; tone: ChipTone }) {
+function Chip({
+  label,
+  tone,
+  icon: Icon,
+}: {
+  label: string
+  tone: ChipTone
+  /** Optional, e.g. the "Whole building" chip's `Home` — every other chip omits it. */
+  icon?: LucideIcon
+}) {
   return (
     <span
       className={`inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-semibold whitespace-nowrap ${CHIP_TONE[tone]}`}
     >
+      {Icon && <Icon className="mr-0.5 h-3 w-3 flex-shrink-0" aria-hidden="true" />}
       {label}
     </span>
   )
@@ -159,10 +182,12 @@ function FamilyCardBody({
   party,
   unit,
   sharedSlot,
+  holdsWholeBuilding = false,
 }: {
   party: RosterPartyRow
   unit?: LodgingUnitRow | undefined
   sharedSlot: boolean
+  holdsWholeBuilding?: boolean
 }) {
   const flags = party.flags ?? {}
   const children = party.children ?? []
@@ -227,6 +252,11 @@ function FamilyCardBody({
           )}
 
       <span className="flex flex-wrap gap-1">
+        {/* #2008: this PLACEMENT covers every leaf of a building, not merely
+            a card it happens to share — see `holdsWholeBuilding`'s doc.
+            First in the row: it is a fact about the household's privacy, not
+            a need or a warning, and staff scan left-to-right. */}
+        {holdsWholeBuilding && <Chip label="Whole building" tone="building" icon={Home} />}
         {/* The needs a cabin field can actually answer — the same two the fit
             check judges. `needs_accommodation` names no specific amenity, so
             it is carried by the verdict chip below instead of duplicated. */}
@@ -300,6 +330,7 @@ export function FamilyCard({
   party,
   unit,
   sharedSlot = false,
+  holdsWholeBuilding = false,
   inQueue = false,
   isDraggable = false,
   onOpen,
@@ -338,7 +369,12 @@ export function FamilyCard({
         isDragging ? 'opacity-40' : ''
       }`}
     >
-      <FamilyCardBody party={party} unit={unit} sharedSlot={sharedSlot} />
+      <FamilyCardBody
+        party={party}
+        unit={unit}
+        sharedSlot={sharedSlot}
+        holdsWholeBuilding={holdsWholeBuilding}
+      />
     </button>
   )
 }
@@ -363,14 +399,21 @@ export function FamilyCardPreview({
   party,
   unit,
   sharedSlot = false,
+  holdsWholeBuilding = false,
 }: {
   party: RosterPartyRow
   unit?: LodgingUnitRow | undefined
   sharedSlot?: boolean
+  holdsWholeBuilding?: boolean
 }) {
   return (
     <div className={`${CARD_FRAME} bg-card shadow-lodge-lg border-primary/50 rotate-2`}>
-      <FamilyCardBody party={party} unit={unit} sharedSlot={sharedSlot} />
+      <FamilyCardBody
+        party={party}
+        unit={unit}
+        sharedSlot={sharedSlot}
+        holdsWholeBuilding={holdsWholeBuilding}
+      />
     </div>
   )
 }

--- a/frontend/src/components/weekend/LodgingBoard.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.test.tsx
@@ -187,6 +187,21 @@ describe('LodgingBoard — layout', () => {
     expect(screen.getByRole('heading', { name: /North Ridge/ })).toBeInTheDocument()
   })
 
+  it('shows the building count alongside rooms and families in the area header — #2009', () => {
+    // Two halves of one house are DIFFERENT buildings under the
+    // immediate-parent grain ruled on #2008, so three rooms read as two
+    // buildings, not one.
+    const halvedHouseUnits = [
+      unit({ unit_id: 'up', code: 'upstairs', is_container: true }),
+      unit({ unit_id: 'down', code: 'downstairs', is_container: true }),
+      unit({ code: 'up-r1', parent_code: 'upstairs' }),
+      unit({ unit_id: 'u2', code: 'up-r2', parent_code: 'upstairs' }),
+      unit({ unit_id: 'u3', code: 'down-r1', parent_code: 'downstairs' }),
+    ]
+    render(<LodgingBoard parties={[]} units={halvedHouseUnits} year={2026} />, { wrapper })
+    expect(screen.getByText('3 rooms · 0 families · 2 buildings')).toBeInTheDocument()
+  })
+
   it('spaces the card grid on summer’s gap-3', () => {
     /*
      * `BunkingBoardByArea` lays its bunks out at `gap-3` (12px); this board

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -434,7 +434,13 @@ export function LodgingBoard({
                           {area.name}
                         </span>
                         <span className="text-muted-foreground/70 text-[11px] tabular-nums">
-                          {`${String(area.slots.length)} rooms · ${String(area.partyCount)} families`}
+                          {/* Buildings alongside rooms and families (#2009):
+                              how many DISTINCT buildings this area's drawn
+                              rooms belong to, at the immediate-parent grain
+                              #2008 ruled — a two-half house counts as two,
+                              not one. Reads `area.buildingCount`
+                              (`buildBoard`), never re-derived here. */}
+                          {`${String(area.slots.length)} rooms · ${String(area.partyCount)} families · ${String(area.buildingCount)} buildings`}
                         </span>
                         <span className="bg-border/70 ml-1 h-px flex-1" aria-hidden="true" />
                       </button>

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -527,6 +527,89 @@ describe('LodgingUnitCard — the per-party sharing chip follows ROOM overlap, n
   })
 })
 
+describe('LodgingUnitCard — the whole-building mark (#2008)', () => {
+  // A halved house: `upstairs`/`downstairs` are DIFFERENT buildings under
+  // the immediate-parent grain ruled on #2008, even though both share the
+  // `house` root.
+  const halvedHouseUnits = [
+    unit({ unit_id: 'up', code: 'upstairs', is_container: true }),
+    unit({ unit_id: 'down', code: 'downstairs', is_container: true }),
+    unit({ unit_id: 'r1', code: 'up-r1', parent_code: 'upstairs' }),
+    unit({ unit_id: 'r2', code: 'up-r2', parent_code: 'upstairs' }),
+  ]
+  const combinedUpstairs = unit({
+    unit_id: 'up',
+    code: 'upstairs',
+    name: 'Upstairs',
+    is_container: true,
+    is_combined: true,
+  })
+
+  it('marks a party whose own unit_codes cover the whole card it is drawn on', () => {
+    render(
+      <LodgingUnitCard
+        slot={slot({
+          unit: combinedUpstairs,
+          parties: [
+            party({
+              household_cm_id: 101,
+              unit_code: 'upstairs',
+              unit_codes: ['upstairs'],
+            }),
+          ],
+        })}
+        units={halvedHouseUnits}
+        hue="hsl(160 45% 42%)"
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Whole building')).toBeInTheDocument()
+  })
+
+  it('does not mark a party holding only one room of a two-room half', () => {
+    render(
+      <LodgingUnitCard
+        slot={slot({
+          unit: unit({ code: 'up-r1', parent_code: 'upstairs' }),
+          parties: [party({ household_cm_id: 101, unit_code: 'up-r1', unit_codes: ['up-r1'] })],
+        })}
+        units={halvedHouseUnits}
+        hue="hsl(160 45% 42%)"
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.queryByText('Whole building')).not.toBeInTheDocument()
+  })
+
+  it('does not mark either of two households splitting a combined card between disjoint rooms', () => {
+    render(
+      <LodgingUnitCard
+        slot={slot({
+          unit: combinedUpstairs,
+          parties: [
+            party({
+              household_cm_id: 101,
+              display_name: 'Alpha',
+              unit_code: 'up-r1',
+              children: [{ person_cm_id: 9101, display_name: 'Ivy Alpha', age: 7, grade: 1 }],
+            }),
+            party({
+              household_cm_id: 102,
+              display_name: 'Beta',
+              unit_code: 'up-r2',
+              children: [{ person_cm_id: 9102, display_name: 'Leo Beta', age: 9, grade: 3 }],
+            }),
+          ],
+        })}
+        units={halvedHouseUnits}
+        hue="hsl(160 45% 42%)"
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.queryByText('Whole building')).not.toBeInTheDocument()
+  })
+})
+
 describe('LodgingUnitCard — the shared-space mark (#2091)', () => {
   // The master housing sheet's fill for "two families here", adopted as the
   // ring `LodgingMap.tsx`'s `halo` already draws for the identical flag

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -15,7 +15,12 @@ import { useDraggable, useDroppable } from '@dnd-kit/core'
 import { Bath, Merge, Plug, Snowflake, Split, TriangleAlert, Users } from 'lucide-react'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
-import { overlappingPartyKeys, slotOccupancy, type BoardSlot } from './boardLayout'
+import {
+  overlappingPartyKeys,
+  slotOccupancy,
+  wholeBuildingHolders,
+  type BoardSlot,
+} from './boardLayout'
 import { isValidMergeTarget, mergeDragId, unitDroppableId } from './dragPlacement'
 import { FamilyCard } from './FamilyCard'
 import { partyKey } from './partyKey'
@@ -218,6 +223,14 @@ export function LodgingUnitCard({
   // expansion is identical too: the slot flag and the per-card chip can never
   // answer "do these two overlap" two different ways.
   const overlappingKeys = overlappingPartyKeys(parties, units)
+
+  // #2008: read against each party's OWN occupied leaves, not the slot's
+  // combined membership — two households splitting this card between
+  // disjoint rooms neither holds it alone, even when the CARD itself is the
+  // whole building. Computed from THIS slot's own parties, the same way
+  // `overlappingKeys` above is: the answer depends only on a party's own
+  // occupied codes, never on its neighbours in the slot.
+  const wholeBuildingKeys = wholeBuildingHolders(parties, units)
 
   // Merging is promotion to the parent, so a parentless room offers nothing
   // to promote it to — the handle is ABSENT, not merely disabled.
@@ -606,6 +619,7 @@ export function LodgingUnitCard({
               party={party}
               unit={unit}
               sharedSlot={overlappingKeys.has(partyKey(party))}
+              holdsWholeBuilding={wholeBuildingKeys.has(partyKey(party))}
               isDraggable={canPlace}
               onOpen={onOpenParty}
             />

--- a/frontend/src/components/weekend/boardLayout.test.ts
+++ b/frontend/src/components/weekend/boardLayout.test.ts
@@ -13,7 +13,15 @@ import type {
   ShareEligibilityValue,
   SharePreferenceValue,
 } from '../../types/lodging'
-import { AREA_HUES, areaTokens, buildBoard, countBoardSlots, slotOccupancy } from './boardLayout'
+import {
+  AREA_HUES,
+  areaTokens,
+  buildBoard,
+  countBoardSlots,
+  slotOccupancy,
+  wholeBuildingHolders,
+} from './boardLayout'
+import { partyKey } from './partyKey'
 
 function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
   return {
@@ -846,6 +854,24 @@ describe('buildBoard — area grouping and colour', () => {
     )
     expect(board.areas.map((area) => area.partyCount)).toEqual([2, 0])
   })
+
+  it('counts distinct buildings the area draws — #2009', () => {
+    // Two halves of one house share a root but are DIFFERENT buildings under
+    // the immediate-parent grain ruled on #2008; a third, freestanding cabin
+    // in the same area is its own building. The halves themselves are
+    // containers and never drawn, so they add no slots of their own.
+    const units = [
+      unit({ unit_id: 'up', code: 'upstairs', is_container: true }),
+      unit({ unit_id: 'down', code: 'downstairs', is_container: true }),
+      unit({ code: 'up-r1', parent_code: 'upstairs' }),
+      unit({ unit_id: 'u2', code: 'up-r2', parent_code: 'upstairs' }),
+      unit({ unit_id: 'u3', code: 'down-r1', parent_code: 'downstairs' }),
+      unit({ unit_id: 'u4', code: 'cabin-9' }),
+    ]
+    const board = buildBoard([], units)
+    expect(board.areas[0]?.slots).toHaveLength(4)
+    expect(board.areas[0]?.buildingCount).toBe(3)
+  })
 })
 
 describe('buildBoard — drawing at the resolved container level', () => {
@@ -1121,5 +1147,67 @@ describe('buildBoard — consent flag follows leaf overlap, not the card (task-1
     )
     expect(board.areas[0]?.slots[0]?.consent).not.toBeNull()
     expect(board.flaggedCount).toBe(1)
+  })
+})
+
+describe("wholeBuildingHolders — #2008's placement marker, keyed by party", () => {
+  const halvedHouse = [
+    unit({ unit_id: 'up', code: 'upstairs', is_container: true }),
+    unit({ unit_id: 'down', code: 'downstairs', is_container: true }),
+    unit({ code: 'up-r1', parent_code: 'upstairs' }),
+    unit({ unit_id: 'u2', code: 'up-r2', parent_code: 'upstairs' }),
+    unit({ unit_id: 'u3', code: 'down-r1', parent_code: 'downstairs' }),
+    unit({ unit_id: 'u4', code: 'down-r2', parent_code: 'downstairs' }),
+  ]
+
+  it('marks a party whose own unit_codes cover one whole half', () => {
+    const alpha = party({
+      household_cm_id: 500001,
+      unit_code: '',
+      unit_codes: ['up-r1', 'up-r2'],
+      is_merged_slot: true,
+    })
+    expect(wholeBuildingHolders([alpha], halvedHouse)).toEqual(new Set([partyKey(alpha)]))
+  })
+
+  it('does not mark a party holding only part of a half', () => {
+    const alpha = party({ household_cm_id: 500001, unit_code: 'up-r1', unit_codes: ['up-r1'] })
+    expect(wholeBuildingHolders([alpha], halvedHouse).size).toBe(0)
+  })
+
+  it('does not mark either of two households splitting one combined house between them', () => {
+    // The Front/Back case: a combined card holding two DISJOINT households.
+    // The CARD is the whole building, but neither PARTY individually is —
+    // that is the point of the signal being about the placement, not the
+    // slot. Named at a container code that expands to every leaf via the
+    // container row itself, mirroring how a real combined-house drop names
+    // the container's own code.
+    const combinedHouse = [
+      unit({ code: 'house', is_container: true, is_combined: true }),
+      unit({ code: 'r1', parent_code: 'house' }),
+      unit({ code: 'r2', parent_code: 'house' }),
+    ]
+    const alpha = party({ household_cm_id: 500001, unit_code: 'r1', unit_codes: ['r1'] })
+    const beta = party({ household_cm_id: 500002, unit_code: 'r2', unit_codes: ['r2'] })
+    expect(wholeBuildingHolders([alpha, beta], combinedHouse).size).toBe(0)
+  })
+
+  it('marks a single party named at the combined container code covering both its rooms', () => {
+    const combinedHouse = [
+      unit({ code: 'house', is_container: true, is_combined: true }),
+      unit({ code: 'r1', parent_code: 'house' }),
+      unit({ code: 'r2', parent_code: 'house' }),
+    ]
+    const alpha = party({
+      household_cm_id: 500001,
+      unit_code: 'house',
+      unit_codes: ['house'],
+    })
+    expect(wholeBuildingHolders([alpha], combinedHouse)).toEqual(new Set([partyKey(alpha)]))
+  })
+
+  it('never marks a party alone in a freestanding room with no registry parent', () => {
+    const alpha = party({ household_cm_id: 500001, unit_code: 'cedar-1', unit_codes: ['cedar-1'] })
+    expect(wholeBuildingHolders([alpha], [unit()]).size).toBe(0)
   })
 })

--- a/frontend/src/components/weekend/boardLayout.ts
+++ b/frontend/src/components/weekend/boardLayout.ts
@@ -45,7 +45,13 @@
  */
 import type { LodgingUnitRow, RosterPartyRow, ShareEligibilityValue } from '../../types/lodging'
 import { partyKey } from './partyKey'
-import { coveredCodes, drawnUnits, representingCodes } from './unitLevel'
+import {
+  buildingsSpanned,
+  coveredCodes,
+  drawnUnits,
+  representingCodes,
+  wholeBuildingHeld,
+} from './unitLevel'
 
 /**
  * The leaf codes a party currently occupies.
@@ -346,6 +352,17 @@ export interface BoardArea {
   hue: string
   slots: BoardSlot[]
   partyCount: number
+  /**
+   * How many distinct buildings the area's DRAWN slots span — kindred#2009.
+   *
+   * Reads `slots`, the same set `slots.length` (rooms) counts, not just the
+   * occupied ones: a static fact about how this area's inventory is carved
+   * up into buildings, the same way "rooms" is a static fact about its
+   * inventory rather than a count of who is in it. `buildingsSpanned`
+   * (`unitLevel.ts`) is the one definition — the immediate-parent grain
+   * ruled on #2008, so a two-half house counts as two buildings here too.
+   */
+  buildingCount: number
 }
 
 export interface BoardModel {
@@ -428,6 +445,33 @@ export function overlappingPartyKeys(
     for (const owner of owners) overlapping.add(partyKey(owner))
   }
   return overlapping
+}
+
+/**
+ * Which of these parties hold an entire building, keyed by `partyKey` —
+ * kindred#2008's placement marker.
+ *
+ * Read against each party's OWN occupied leaves (`occupiedLeafCodes`), never
+ * the slot's combined membership. Two households splitting one combined
+ * house between disjoint rooms is the Front/Back case `overlappingPartyKeys`
+ * already treats as NOT a share of a room; it is likewise not a whole-
+ * building HOLD for either one of them individually, even though the CARD
+ * they share is structurally the whole building — the marker is about a
+ * placement, not a card. See `unitLevel.ts`'s `wholeBuildingHeld` for the
+ * grain (immediate parent, ruled on #2008) and why a one-room "building" can
+ * never qualify.
+ */
+export function wholeBuildingHolders(
+  parties: RosterPartyRow[],
+  units: LodgingUnitRow[]
+): Set<string> {
+  const unitsByCode = new Map(units.map((unit) => [unit.code, unit]))
+  const holders = new Set<string>()
+  for (const party of parties) {
+    const leaves = occupiedLeafCodes(party, units, unitsByCode)
+    if (wholeBuildingHeld(leaves, units)) holders.add(partyKey(party))
+  }
+  return holders
 }
 
 /**
@@ -623,6 +667,17 @@ function indexPayload(parties: RosterPartyRow[], units: LodgingUnitRow[]) {
     const unit = unitsByCode.get(named)
     if (unit === undefined) return []
     // Roll up: walk to the drawn ancestor.
+    //
+    // REJECTED as the "whole building" grain for #2008/#2009, deliberately.
+    // This walk stops at the nearest DRAWN ancestor, which depends on
+    // `is_combined` — a VIEW-level fact that flips when staff merge or split
+    // a card — not on registry structure. Using it for "whole building"
+    // would make the same placement read as holding a whole building only
+    // while its house happens to be combined, and stop the moment somebody
+    // splits it back to rooms. #2008 ruled a purely structural grain instead
+    // (immediate parent, never walk-to-root either) — see `buildingKey` and
+    // `buildingGroups` in `unitLevel.ts`, which this function does not call
+    // and must not be made to.
     let cursor = unit
     const seen = new Set<string>()
     while ((cursor.parent_code ?? '') !== '' && !seen.has(cursor.code)) {
@@ -716,12 +771,17 @@ export function buildBoard(parties: RosterPartyRow[], units: LodgingUnitRow[]): 
 
   const areas: BoardArea[] = orderedKeys.map((key, index) => {
     const bucket = buckets.get(key)
+    const slots = bucket?.slots ?? []
     return {
       key,
       name: bucket?.name ?? '',
       hue: AREA_HUES[index % AREA_HUES.length] ?? AREA_HUES[0],
-      slots: bucket?.slots ?? [],
+      slots,
       partyCount: bucket?.partyKeys.size ?? 0,
+      buildingCount: buildingsSpanned(
+        slots.map((slot) => slot.unit),
+        units
+      ),
     }
   })
 

--- a/frontend/src/components/weekend/unitLevel.test.ts
+++ b/frontend/src/components/weekend/unitLevel.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
 import type { LodgingUnitRow } from '../../types/lodging'
-import { coveredCodes, drawnUnits } from './unitLevel'
+import {
+  buildingGroups,
+  buildingsSpanned,
+  coveredCodes,
+  drawnUnits,
+  wholeBuildingHeld,
+} from './unitLevel'
 
 function u(over: Partial<LodgingUnitRow> & { code: string }): LodgingUnitRow {
   return {
@@ -158,5 +164,124 @@ describe('coveredCodes', () => {
     // `offBoard` — never `[unit.code]`, which would fabricate a card.
     const lonelyContainer = u({ code: 'lone-container', is_container: true })
     expect(coveredCodes(lonelyContainer, [lonelyContainer])).toEqual([])
+  })
+})
+
+// house -> {upstairs, downstairs} -> two rooms each. Mirrors the real halved
+// buildings (e.g. gt-tioga-upstairs/gt-tioga-downstairs, measured against
+// production) the grain ruling on #2008 is about: each half is independently
+// lettable and carries its own bathroom_group, so it is a DIFFERENT building
+// from its sibling half under the IMMEDIATE-PARENT grain even though both
+// share one root.
+const HALVED_HOUSE = [
+  u({ code: 'house', is_container: true }),
+  u({ code: 'upstairs', is_container: true, parent_code: 'house' }),
+  u({ code: 'downstairs', is_container: true, parent_code: 'house' }),
+  u({ code: 'up-r1', parent_code: 'upstairs' }),
+  u({ code: 'up-r2', parent_code: 'upstairs' }),
+  u({ code: 'down-r1', parent_code: 'downstairs' }),
+  u({ code: 'down-r2', parent_code: 'downstairs' }),
+]
+
+describe('buildingGroups — the immediate-parent grain ruled on #2008', () => {
+  it('groups leaves under their immediate parent, not the root', () => {
+    const groups = buildingGroups(HALVED_HOUSE)
+    expect(groups.get('upstairs')?.toSorted()).toEqual(['up-r1', 'up-r2'])
+    expect(groups.get('downstairs')?.toSorted()).toEqual(['down-r1', 'down-r2'])
+    // 'house' the root is never a group key on its own — the two halves are
+    // different buildings under this grain, not one.
+    expect(groups.has('house')).toBe(false)
+  })
+
+  it('gives a parentless leaf its own one-room group', () => {
+    const solo = u({ code: 'solo' })
+    expect(buildingGroups([solo]).get('solo')).toEqual(['solo'])
+  })
+
+  it('never groups a container as a member of any group', () => {
+    const groups = buildingGroups(HALVED_HOUSE)
+    for (const leaves of groups.values()) {
+      expect(leaves).not.toContain('house')
+      expect(leaves).not.toContain('upstairs')
+      expect(leaves).not.toContain('downstairs')
+    }
+  })
+})
+
+describe("wholeBuildingHeld — #2008's placement marker", () => {
+  it('is true when occupied leaves cover an entire half', () => {
+    expect(wholeBuildingHeld(new Set(['up-r1', 'up-r2']), HALVED_HOUSE)).toBe(true)
+  })
+
+  it('is false when one leaf of the half is missing', () => {
+    expect(wholeBuildingHeld(new Set(['up-r1']), HALVED_HOUSE)).toBe(false)
+  })
+
+  it('is false for a standalone room with no registry parent — a single room is not a "building"', () => {
+    // 71 of the 103 production leaf units have no parent at all (2026
+    // measurement). Without this exclusion, every one of those placements
+    // would trivially "cover" its own one-room group and the marker would
+    // fire on most single-room placements instead of the ~15/year genuine
+    // whole-building holds.
+    const solo = u({ code: 'solo' })
+    expect(wholeBuildingHeld(new Set(['solo']), [solo])).toBe(false)
+  })
+
+  it('is true when the occupied leaves cover BOTH halves under the root', () => {
+    // A party naming the whole house directly (both halves split) still
+    // occupies every leaf of each half individually.
+    const leaves = new Set(['up-r1', 'up-r2', 'down-r1', 'down-r2'])
+    expect(wholeBuildingHeld(leaves, HALVED_HOUSE)).toBe(true)
+  })
+
+  it('is true when a party fully covers one half AND holds a stray room in the other', () => {
+    // The first half is fully covered, which is enough — the marker asks
+    // "does this placement hold at least one whole building", not "does it
+    // hold ONLY whole buildings".
+    const leaves = new Set(['up-r1', 'up-r2', 'down-r1'])
+    expect(wholeBuildingHeld(leaves, HALVED_HOUSE)).toBe(true)
+  })
+
+  it('ignores an occupied code the registry has no unit for', () => {
+    expect(wholeBuildingHeld(new Set(['up-r1', 'up-r2', 'ghost-code']), HALVED_HOUSE)).toBe(true)
+  })
+})
+
+describe("buildingsSpanned — #2009's distinct-building count", () => {
+  it('counts each half as its own building', () => {
+    const drawn = HALVED_HOUSE.filter((x) => ['up-r1', 'up-r2', 'down-r1'].includes(x.code))
+    expect(buildingsSpanned(drawn, HALVED_HOUSE)).toBe(2)
+  })
+
+  it('de-duplicates two rooms of the same half into one building', () => {
+    const drawn = HALVED_HOUSE.filter((x) => ['up-r1', 'up-r2'].includes(x.code))
+    expect(buildingsSpanned(drawn, HALVED_HOUSE)).toBe(1)
+  })
+
+  it('counts a card combined at the immediate-parent grain as ONE building', () => {
+    const combined = HALVED_HOUSE.map((x) =>
+      x.code === 'upstairs' ? { ...x, is_combined: true } : x
+    )
+    const upstairsCard = combined.find((x) => x.code === 'upstairs')!
+    expect(buildingsSpanned([upstairsCard], combined)).toBe(1)
+  })
+
+  it('counts a card combined at the ROOT as spanning every grain-level building beneath it', () => {
+    // Structurally correct even though it draws as ONE card: `drawnUnits`
+    // takes the highest combined node, but the root still structurally
+    // covers both halves' full leaf sets, and each half is its own building
+    // under this grain.
+    const combined = HALVED_HOUSE.map((x) => (x.code === 'house' ? { ...x, is_combined: true } : x))
+    const houseCard = combined.find((x) => x.code === 'house')!
+    expect(buildingsSpanned([houseCard], combined)).toBe(2)
+  })
+
+  it('counts each freestanding leaf as its own building', () => {
+    const solos = [u({ code: 'a' }), u({ code: 'b' }), u({ code: 'c' })]
+    expect(buildingsSpanned(solos, solos)).toBe(3)
+  })
+
+  it('returns 0 for nothing drawn', () => {
+    expect(buildingsSpanned([], HALVED_HOUSE)).toBe(0)
   })
 })

--- a/frontend/src/components/weekend/unitLevel.ts
+++ b/frontend/src/components/weekend/unitLevel.ts
@@ -176,14 +176,14 @@ export function buildingGroups(units: LodgingUnitRow[]): Map<string, string[]> {
  * one card — `slots.length` already counts CARDS; this counts something
  * different on purpose.
  */
-export function buildingsSpanned(drawnUnits: LodgingUnitRow[], units: LodgingUnitRow[]): number {
+export function buildingsSpanned(drawnCards: LodgingUnitRow[], units: LodgingUnitRow[]): number {
   const groups = buildingGroups(units)
   const leafBuilding = new Map<string, string>()
   for (const [key, leaves] of groups) {
     for (const leaf of leaves) leafBuilding.set(leaf, key)
   }
   const touched = new Set<string>()
-  for (const unit of drawnUnits) {
+  for (const unit of drawnCards) {
     for (const leaf of coveredCodes(unit, units)) {
       const key = leafBuilding.get(leaf)
       if (key !== undefined) touched.add(key)

--- a/frontend/src/components/weekend/unitLevel.ts
+++ b/frontend/src/components/weekend/unitLevel.ts
@@ -13,6 +13,12 @@
  * ancestor default already holds — and taking the higher is what keeps a room
  * from being drawn twice. The admin control that prevents the confusing state
  * is a UX guard, not what makes this total.
+ *
+ * A second, related question also lives here: not which units get a card, but
+ * which BUILDING a unit belongs to (`buildingKey`, `buildingGroups`) — the
+ * grain kindred#2008 ruled (immediate parent, not walk-to-root), and what
+ * #2008's placement marker (`wholeBuildingHeld`) and #2009's area header count
+ * (`buildingsSpanned`) both read.
  */
 import type { LodgingUnitRow } from '../../types/lodging'
 
@@ -94,6 +100,131 @@ export function representingCodes(
     else queue.push(...(children.get(next.code) ?? []))
   }
   return out
+}
+
+/**
+ * A leaf unit's "building" — the grain ruled on kindred#2008: the leaf's
+ * IMMEDIATE parent, never walked further toward the root.
+ *
+ * Registry nesting is two levels deep, and a small number of buildings are
+ * modelled as a root with two container HALVES beneath it — an upstairs and
+ * a downstairs, each carrying its own `bathroom_group` — so the halves
+ * behave as independently lettable units under one roof. Walking to the
+ * root would merge two halves staff let separately into one "building"
+ * neither of them is. The evidence for the grain is the placement history,
+ * not the structural argument alone: whole-building holds resolved per
+ * weekend across 2022-2025 are overwhelmingly half-level (13-17/year), not
+ * root-level (see #2008).
+ *
+ * A leaf with no resolvable parent code is its OWN one-room building — a
+ * genuinely freestanding cabin, not a fragment of anything larger. 71 of the
+ * 103 leaf units in the production registry are this way (2026 measurement).
+ *
+ * `boardLayout.ts`'s `cardCodesFor` ALSO rolls a named code up toward an
+ * ancestor, but to the nearest DRAWN one — whichever ancestor the board
+ * happens to be showing a card for right now, which flips with
+ * `is_combined`. That rule is deliberately NOT reused here and is rejected
+ * at its own definition site: "whole building" has to be a fact about the
+ * REGISTRY, not about which card the board is currently drawing, or the same
+ * placement would read as holding a whole building only while its house
+ * happens to be combined and stop being one the moment somebody splits it.
+ */
+export function buildingKey(
+  unit: LodgingUnitRow,
+  unitsByCode: ReadonlyMap<string, LodgingUnitRow>
+): string {
+  const parent = unit.parent_code ?? ''
+  return parent !== '' && unitsByCode.has(parent) ? parent : unit.code
+}
+
+/**
+ * Every LEAF unit, grouped into its building (`buildingKey`).
+ *
+ * Containers are never members of a group — a container's OWN code is what
+ * becomes a group's key when a leaf names it as an immediate parent, and
+ * grouping the container too would double-count it against its own
+ * children.
+ *
+ * ONE per-registry computation, shared by both #2008's and #2009's reads —
+ * `wholeBuildingHeld` below (a placement's marker) and `buildingsSpanned`
+ * below (the area header's distinct count). Two copies of "what building is
+ * this" is exactly how the two numbers would start disagreeing.
+ */
+export function buildingGroups(units: LodgingUnitRow[]): Map<string, string[]> {
+  const unitsByCode = new Map(units.map((unit) => [unit.code, unit]))
+  const groups = new Map<string, string[]>()
+  for (const unit of units) {
+    if (unit.is_container === true) continue
+    const key = buildingKey(unit, unitsByCode)
+    const bucket = groups.get(key)
+    if (bucket) bucket.push(unit.code)
+    else groups.set(key, [unit.code])
+  }
+  return groups
+}
+
+/**
+ * How many distinct buildings a set of drawn units span — #2009's area
+ * header count.
+ *
+ * Reads the RAW LEAVES beneath each drawn unit (`coveredCodes`), never the
+ * drawn unit's own code: a container combined at the ROOT rather than at a
+ * half (rare — the placement history says whole-building holds are nearly
+ * always half-level) still structurally spans however many `buildingKey`
+ * groups its leaves fall into. A card drawn ABOVE the building grain must
+ * not be counted as one building just because the board is drawing it as
+ * one card — `slots.length` already counts CARDS; this counts something
+ * different on purpose.
+ */
+export function buildingsSpanned(drawnUnits: LodgingUnitRow[], units: LodgingUnitRow[]): number {
+  const groups = buildingGroups(units)
+  const leafBuilding = new Map<string, string>()
+  for (const [key, leaves] of groups) {
+    for (const leaf of leaves) leafBuilding.set(leaf, key)
+  }
+  const touched = new Set<string>()
+  for (const unit of drawnUnits) {
+    for (const leaf of coveredCodes(unit, units)) {
+      const key = leafBuilding.get(leaf)
+      if (key !== undefined) touched.add(key)
+    }
+  }
+  return touched.size
+}
+
+/**
+ * Whether a set of occupied LEAF codes covers an entire building —
+ * #2008's placement marker.
+ *
+ * Takes the already-expanded leaf set rather than a party or a named code,
+ * so this module stays pure over `LodgingUnitRow[]` — the party-shaped
+ * wrapper (`occupiedLeafCodes` in `boardLayout.ts`) calls this, not the
+ * reverse, which is what keeps the two files from cycling.
+ *
+ * A group of exactly one is a standalone room, not a building with siblings
+ * to hold ALL of — see `buildingKey`'s doc. Requiring `length > 1` is what
+ * keeps this signal to the genuine whole-building holds in the placement
+ * history rather than firing on most single-room placements: 71 of the 103
+ * production leaf units have no registry parent at all, so without this
+ * exclusion every one of those ordinary single-room placements would
+ * trivially "cover" its own one-room group.
+ */
+export function wholeBuildingHeld(
+  occupiedLeaves: ReadonlySet<string>,
+  units: LodgingUnitRow[]
+): boolean {
+  const unitsByCode = new Map(units.map((unit) => [unit.code, unit]))
+  const groups = buildingGroups(units)
+  const touchedKeys = new Set<string>()
+  for (const leaf of occupiedLeaves) {
+    const unit = unitsByCode.get(leaf)
+    if (unit !== undefined) touchedKeys.add(buildingKey(unit, unitsByCode))
+  }
+  for (const key of touchedKeys) {
+    const group = groups.get(key) ?? []
+    if (group.length > 1 && group.every((code) => occupiedLeaves.has(code))) return true
+  }
+  return false
 }
 
 /** The units that get a card, at the level each tree resolves to. */


### PR DESCRIPTION
## Summary

Item B8 — closes #2008 and #2009 together; they hard-serialise on `boardLayout.ts`/`unitLevel.ts`.

**The grain ruling (already settled on #2008, 2026-08-07):** a "building" is a unit's IMMEDIATE parent, never walk-to-root. A few buildings are modelled as a root with two independently-lettable halves beneath it (an upstairs and a downstairs, each with its own `bathroom_group`), so the halves are DIFFERENT buildings under this grain even though they share one root.

- **`unitLevel.ts`** (new exports, per the campaign's directive — export here, not `boardLayout.ts`, to avoid a cycle):
  - `buildingKey` / `buildingGroups` — the one definition of "what building is this leaf in". A leaf with no resolvable registry parent is its own one-room building.
  - `wholeBuildingHeld(occupiedLeaves, units)` — #2008's placement marker. Requires the covered group to have a real registry parent AND `length > 1` — a standalone room is not a "building with siblings to hold all of". Without this, 71 of the 103 production leaf units (freestanding, no parent) would trivially "hold a whole building" on every single-room placement.
  - `buildingsSpanned(drawnUnits, units)` — #2009's distinct-building count over a set of drawn units, reading raw leaves via `coveredCodes` so a card combined above the grain (rare) still counts correctly.

- **`boardLayout.ts`**:
  - `BoardArea.buildingCount`, computed in `buildBoard` via `buildingsSpanned` over each area's drawn slots.
  - `wholeBuildingHolders(parties, units)` — party-keyed, mirrors `overlappingPartyKeys`'s existing pattern. Two households splitting one combined card between disjoint rooms (the Front/Back case) are NOT marked — the signal is about a *placement*, never a card, so the card being the whole building doesn't make either party's own placement one.
  - Rejects `cardCodesFor`'s nearest-drawn-ancestor roll-up as the whole-building grain, with a comment at the site: that rule tracks `is_combined` (view state), so the same placement would flip between "holds a whole building" and not depending on whether staff happened to have merged the card.

- **`LodgingBoard.tsx`**: area header now reads `N rooms · M families · K buildings`.
- **`LodgingUnitCard.tsx` / `FamilyCard.tsx`**: a "Whole building" chip on the family card of a placement that holds one (computed per-slot from that slot's own parties, same as `overlappingKeys`). Extended beyond the campaign's file hypothesis because #2008 explicitly asks for the mark to render "on the family card" — an unused exported boolean wouldn't close the issue.

## #2009's number, re-derived read-only against `data-prod.db`

Measured independently (not copied from the issue body):

```
total non-container (leaf) units: 103
Immediate-parent grouping (parentless = own building): 83 distinct groups
Walk-to-root grouping: 79 distinct groups
Gap: 4

That gap is 18 leaves under 7 half-containers (e.g. gt-tioga-upstairs),
which collapse into 3 distinct roots under walk-to-root: 7 - 3 = 4.
```

This matches the issue body's corrected figure (gap of FOUR, not two) and independently confirms the specific half-container/root counts cited there.

## Mutation-check transcript

Every new test was written and verified RED before implementation, with one exception class: three tests (`FamilyCard`'s "says nothing…", two of `LodgingUnitCard`'s "does not mark…" tests) pass vacuously before the feature exists (absence of a chip that isn't rendered yet). Mutation-checked those plus the parallel negative tests in `unitLevel.test.ts`/`boardLayout.test.ts`:

1. `wholeBuildingHeld` → forced to `return occupiedLeaves.size > 0`. Result: **7 tests went RED** (2 in `unitLevel.test.ts`, 3 in `boardLayout.test.ts`, 2 in `LodgingUnitCard.test.tsx`) — exactly the negative-path set. Reverted, all green again.
2. `FamilyCard`'s chip gate → forced unconditional render. Result: **"says nothing about a placement that does not hold a whole building" went RED**. Reverted, all green again.

## Verification

- `npx vitest run` (full frontend suite): 423 files, 6061 tests, all green.
- `npx tsc --noEmit` (both configs): clean.
- `npx eslint` on touched files: 0 errors (5 pre-existing warnings, confirmed unchanged via `git stash` diff against baseline).
- `npm run build`: succeeds; confirmed the new `indigo-*` Tailwind classes for the "Whole building" chip actually compile into the output CSS (not dead classes).

## Test plan

- [x] `unitLevel.test.ts` — building grouping, whole-building coverage, buildings-spanned count
- [x] `boardLayout.test.ts` — `BoardArea.buildingCount`, `wholeBuildingHolders` (including the Front/Back disjoint-rooms case)
- [x] `LodgingBoard.test.tsx` — area header shows the buildings count
- [x] `LodgingUnitCard.test.tsx` / `FamilyCard.test.tsx` — the "Whole building" chip appears/doesn't appear correctly, including the disjoint-rooms non-marking case
- [x] Full suite green, tsc clean, build succeeds, new Tailwind classes verified in compiled CSS

Closes #2008.
Closes #2009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)