### PR TITLE
fix(frontend): credit a confirmed whole-house merge on the roster row, card, and panel

### DIFF
--- a/frontend/src/components/weekend/HouseholdRosterTable.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.tsx
@@ -15,7 +15,7 @@ import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
 import { FamilyDetailsPanel } from './FamilyDetailsPanel'
 import { HouseholdRosterRow } from './HouseholdRosterRow'
 import { partyKey } from './partyKey'
-import { attentionSections, indexUnitsByCode } from './rosterAttention'
+import { attentionSections, indexUnitsByCode, resolvePartyUnit } from './rosterAttention'
 
 export interface HouseholdRosterTableProps {
   parties: RosterPartyRow[]
@@ -134,7 +134,7 @@ export function HouseholdRosterTable({ parties, units = [], year }: HouseholdRos
                   key={`${party.grain}-${String(party.household_cm_id ?? 0)}-${String(party.person_cm_id ?? 0)}`}
                   party={party}
                   showRequests={showRequests}
-                  unit={unitsByCode.get(party.unit_code ?? '')}
+                  unit={resolvePartyUnit(party, unitsByCode)}
                   onOpen={openParty}
                 />
               ))}
@@ -146,7 +146,7 @@ export function HouseholdRosterTable({ parties, units = [], year }: HouseholdRos
       {panelParty !== null && (
         <FamilyDetailsPanel
           party={panelParty}
-          unit={unitsByCode.get(panelParty.unit_code ?? '')}
+          unit={resolvePartyUnit(panelParty, unitsByCode)}
           year={year}
           requestClose={requestClose}
           onClose={closePanel}

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -56,6 +56,7 @@ import { FamilyDetailsPanel } from './FamilyDetailsPanel'
 import { FloatingUnplacedBadge } from './FloatingUnplacedBadge'
 import { LodgingUnitCard } from './LodgingUnitCard'
 import { partyKey } from './partyKey'
+import { resolvePartyUnit } from './rosterAttention'
 
 export interface LodgingBoardProps {
   parties: RosterPartyRow[]
@@ -532,7 +533,7 @@ export function LodgingBoard({
         {panelParty !== null && (
           <FamilyDetailsPanel
             party={panelParty}
-            unit={unitsByCode.get(panelParty.unit_code ?? '')}
+            unit={resolvePartyUnit(panelParty, unitsByCode)}
             year={year}
             requestClose={requestClose}
             onClose={closePanel}

--- a/frontend/src/components/weekend/LodgingMap.tsx
+++ b/frontend/src/components/weekend/LodgingMap.tsx
@@ -43,7 +43,7 @@ import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
 import { FamilyCard } from './FamilyCard'
 import { FamilyDetailsPanel } from './FamilyDetailsPanel'
 import { FloatingUnplacedBadge } from './FloatingUnplacedBadge'
-import { indexUnitsByCode } from './rosterAttention'
+import { indexUnitsByCode, resolvePartyUnit } from './rosterAttention'
 import { clusterByProximity, type Cluster } from './mapClustering'
 import { BATHHOUSE_BLUE } from './mapColors'
 import { buildMapModel, type MapUnit } from './mapModel'
@@ -808,7 +808,7 @@ export function LodgingMap({ parties, units, year }: LodgingMapProps) {
       {panelParty !== null && (
         <FamilyDetailsPanel
           party={panelParty}
-          unit={unitsByCode.get(panelParty.unit_code ?? '')}
+          unit={resolvePartyUnit(panelParty, unitsByCode)}
           year={year}
           requestClose={requestClose}
           onClose={closePanel}

--- a/frontend/src/components/weekend/rosterAttention.test.ts
+++ b/frontend/src/components/weekend/rosterAttention.test.ts
@@ -22,6 +22,7 @@ import {
   countUnmeasuredSpaces,
   partyAttention,
   partyBeds,
+  resolvePartyUnit,
 } from './rosterAttention'
 
 function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
@@ -256,6 +257,108 @@ describe('partyAttention — does the cabin provide what was asked for', () => {
       unit()
     )
     expect(a.level).toBe('settled')
+  })
+})
+
+describe('resolvePartyUnit', () => {
+  // `unit_code` is "" on a merged slot by design (kindred#1982), so
+  // `unitsByCode.get(party.unit_code ?? '')` — the resolution every caller
+  // used — always returns undefined for a genuine multi-leaf merge, and
+  // `partyAttention`'s `is_confirmed` gate never gets evidence to check.
+  // `resolvePartyUnit` is the caller-side fix: it falls back to
+  // `unit_codes` and only trusts the merge as evidence once EVERY member
+  // resolves and is confirmed — one unconfirmed room is still an absence
+  // of data, same principle as the single-unit gate, not a looser one for
+  // having more rooms.
+
+  it('resolves an ordinary placement off unit_code, unchanged', () => {
+    const u = unit({ code: 'ridge-a' })
+    const resolved = resolvePartyUnit(party({ unit_code: 'ridge-a' }), new Map([['ridge-a', u]]))
+    expect(resolved).toBe(u)
+  })
+
+  it('resolves a whole-house merge once every member is confirmed', () => {
+    const a = unit({ code: 'tioga-1', is_confirmed: true })
+    const b = unit({ code: 'tioga-2', is_confirmed: true })
+    const resolved = resolvePartyUnit(
+      party({ unit_code: '', unit_codes: ['tioga-1', 'tioga-2'], is_merged_slot: true }),
+      new Map([
+        ['tioga-1', a],
+        ['tioga-2', b],
+      ])
+    )
+    expect(resolved).toBeDefined()
+    expect(resolved?.is_confirmed).toBe(true)
+  })
+
+  it('refuses to treat a merge as evidence while ANY member is unconfirmed', () => {
+    const a = unit({ code: 'tioga-1', is_confirmed: true })
+    const b = unit({ code: 'tioga-2', is_confirmed: false })
+    const resolved = resolvePartyUnit(
+      party({ unit_code: '', unit_codes: ['tioga-1', 'tioga-2'], is_merged_slot: true }),
+      new Map([
+        ['tioga-1', a],
+        ['tioga-2', b],
+      ])
+    )
+    expect(resolved).toBeUndefined()
+  })
+
+  it('refuses to treat a merge as evidence when a member code cannot be found', () => {
+    const a = unit({ code: 'tioga-1', is_confirmed: true })
+    const resolved = resolvePartyUnit(
+      party({ unit_code: '', unit_codes: ['tioga-1', 'ghost'], is_merged_slot: true }),
+      new Map([['tioga-1', a]])
+    )
+    expect(resolved).toBeUndefined()
+  })
+
+  it('returns undefined for an unplaced party (neither field set)', () => {
+    expect(resolvePartyUnit(party({ unit_code: '', unit_codes: [] }), new Map())).toBeUndefined()
+  })
+})
+
+describe('partyAttention + resolvePartyUnit — the roster row / card / panel pipeline', () => {
+  // The pipeline every caller actually runs: resolve a unit, then feed it to
+  // `partyAttention`. `settled` here proves the fix reaches the surfaces
+  // that resolve off `unit_code`/`unit_codes` — the roster row, family
+  // card, and detail panel — not just a hand-picked `unit` fixture.
+  it('credits a confirmed whole-house merge as settled end to end', () => {
+    const a = unit({ code: 'tioga-1', bathroom: 'shared', is_confirmed: true })
+    const b = unit({ code: 'tioga-2', bathroom: 'shared', is_confirmed: true })
+    const mergedParty = party({
+      flags: { needs_private_bathroom: true },
+      is_merged_slot: true,
+      unit_code: '',
+      unit_name: 'Tioga 1 + Tioga 2',
+      unit_codes: ['tioga-1', 'tioga-2'],
+      effective_bathroom: 'private',
+    })
+    const unitsByCode = new Map([
+      ['tioga-1', a],
+      ['tioga-2', b],
+    ])
+    const attention = partyAttention(mergedParty, resolvePartyUnit(mergedParty, unitsByCode))
+    expect(attention.level).toBe('settled')
+  })
+
+  it('mutation guard: one unconfirmed member of the merge keeps it unverified', () => {
+    const a = unit({ code: 'tioga-1', bathroom: 'shared', is_confirmed: true })
+    const b = unit({ code: 'tioga-2', bathroom: 'shared', is_confirmed: false })
+    const mergedParty = party({
+      flags: { needs_private_bathroom: true },
+      is_merged_slot: true,
+      unit_code: '',
+      unit_name: 'Tioga 1 + Tioga 2',
+      unit_codes: ['tioga-1', 'tioga-2'],
+      effective_bathroom: 'private',
+    })
+    const unitsByCode = new Map([
+      ['tioga-1', a],
+      ['tioga-2', b],
+    ])
+    const attention = partyAttention(mergedParty, resolvePartyUnit(mergedParty, unitsByCode))
+    expect(attention.level).toBe('unverified')
   })
 })
 

--- a/frontend/src/components/weekend/rosterAttention.ts
+++ b/frontend/src/components/weekend/rosterAttention.ts
@@ -84,15 +84,52 @@ export function partyBeds(party: RosterPartyRow): number {
 }
 
 /**
- * @param unit The cabin the party is assigned to, when it can be resolved.
- *   A merged slot is named for the merge rather than a unit code, so this is
- *   undefined for a caller keyed off `unit_code` alone — and with no unit to
- *   confirm, the fit reports as unverified regardless of what
- *   `party.effective_bathroom` says (kindred#1982's `is_confirmed` gate: an
- *   unconfirmed cabin is an absence of data, not evidence). A caller that
- *   resolves `unit` per occupied leaf instead (the map draws a merged party
- *   once per unit it spans) can still credit the merge once that leaf is
- *   confirmed — see `VERIFIABLE_NEEDS`.
+ * The unit whose confirmed data backs this party's fit check, or undefined
+ * when there is no confirmed evidence to read.
+ *
+ * An ordinary placement resolves off `unit_code`, same as always. A merged
+ * slot's `unit_code` is "" BY DESIGN (kindred#1982) — `unitsByCode.get('')`
+ * finds nothing, which is exactly how the roster row, family card, and
+ * detail panel each lost every genuine multi-leaf merge to `unverified`
+ * even after `party.effective_bathroom` started reporting `private` for
+ * them. `unit_codes` (kindred#1940) carries every leaf the placement
+ * covers, and each leaf's OWN `is_confirmed` is real staff signal. Trusting
+ * the merge as evidence requires EVERY member to resolve AND be confirmed —
+ * one unconfirmed room is still an absence of data, the same principle the
+ * single-unit gate already enforces, not a looser one for having more
+ * rooms.
+ *
+ * The first resolved member stands in as the representative for a
+ * `VERIFIABLE_NEEDS` check that reads a raw unit field (`needs_power`).
+ * `needs_private_bathroom` never looks at it — it reads
+ * `party.effective_bathroom` — so which member gets picked never changes
+ * that verdict; `is_confirmed` is what has to hold for every one of them.
+ *
+ * The map surface (`MapUnitPopover`) does not call this: it already resolves
+ * a real, defined per-leaf unit for a merged party (drawing it once per
+ * room it occupies), so it never hit this gap.
+ */
+export function resolvePartyUnit(
+  party: RosterPartyRow,
+  unitsByCode: Map<string, LodgingUnitRow>
+): LodgingUnitRow | undefined {
+  const singleCode = party.unit_code ?? ''
+  if (singleCode.length > 0) return unitsByCode.get(singleCode)
+
+  const codes = party.unit_codes ?? []
+  if (codes.length === 0) return undefined
+  const members = codes.map((code) => unitsByCode.get(code))
+  const allConfirmed = members.every((member) => member?.is_confirmed === true)
+  return allConfirmed ? members[0] : undefined
+}
+
+/**
+ * @param unit The cabin the party is assigned to, when it can be resolved —
+ *   ordinarily via `unit_code`, or via `resolvePartyUnit` for a merge.
+ *   Undefined means no confirmed evidence, and the fit reports as
+ *   unverified regardless of what `party.effective_bathroom` says
+ *   (kindred#1982's `is_confirmed` gate: an unconfirmed cabin is an absence
+ *   of data, not evidence).
  */
 export function partyAttention(
   party: RosterPartyRow,
@@ -159,7 +196,7 @@ export function attentionSections(
 ): AttentionSection[] {
   const buckets = new Map<AttentionLevel, RosterPartyRow[]>()
   for (const party of parties) {
-    const { level } = partyAttention(party, unitsByCode.get(party.unit_code ?? ''))
+    const { level } = partyAttention(party, resolvePartyUnit(party, unitsByCode))
     const bucket = buckets.get(level)
     if (bucket) bucket.push(party)
     else buckets.set(level, [party])


### PR DESCRIPTION
## Incident context

This is a follow-up to #2170, which was merged without authorization mid-review by a rogue subagent (full incident report on that PR and on kindred#1982, which I reopened). #2170 shipped a real, tested, correct fix — `needs_private_bathroom` reads `RosterParty.effective_bathroom` instead of `unit.bathroom` — but it merged before the actual gap in #1982 was closed. This PR closes it.

## The gap

`rosterAttention.ts`'s `is_confirmed` gate is keyed off a single resolved `unit`. Every `unitsByCode`-based caller resolved that unit via `unitsByCode.get(party.unit_code ?? '')`. A merged slot's `unit_code` is `""` by design, so on the **roster row, family card, and detail panel** — every surface that resolves this way — `unit` was `undefined` for a genuine multi-leaf merge, the gate never passed, and the party kept reading `"Fit not verified: Private bathroom"` even after the server resolved `effective_bathroom: "private"`. The map surface was unaffected: it already resolves a real, defined per-leaf unit for a merged party (drawing it once per room occupied).

## The fix

`resolvePartyUnit(party, unitsByCode)`: resolves off `unit_code` unchanged for an ordinary placement. For a merge (`unit_code` empty, `unit_codes` non-empty), it trusts the placement as evidence **only once every member of `unit_codes` resolves in the registry and is confirmed** — one unconfirmed room is still an absence of data, the same principle the single-unit gate already enforces, not a looser one for having more rooms. The first resolved member stands in as the representative for `needs_power`'s unit-level check; `needs_private_bathroom` never looks at `unit` at all (it reads `party.effective_bathroom`), so which member is picked never changes that verdict.

Wired into every caller that previously did `unitsByCode.get(party.unit_code ?? '')`:
- `rosterAttention.ts`'s own `attentionSections`
- `HouseholdRosterTable.tsx` — the row's `unit` prop and the detail-panel `unit` prop
- `LodgingBoard.tsx` — the detail-panel `unit` prop
- `LodgingMap.tsx` — the detail-panel `unit` prop

`MapUnitPopover.tsx` is untouched — it already resolves a real per-leaf unit and never had this gap. `LodgingUnitCard.tsx`'s `FamilyCard` usage is untouched for the same reason (per-slot card resolution). `partyAttention`'s own signature and internal logic are unchanged — only how callers compute the `unit` argument changed.

## Testing

TDD, all failing-first:
- `resolvePartyUnit`: 5 new tests (ordinary placement unchanged, whole-house merge resolves once every member confirms, refuses when any member is unconfirmed, refuses when a member code doesn't resolve, undefined for an unplaced party).
- End-to-end pipeline tests (`resolvePartyUnit` piped into `partyAttention`): a confirmed whole-house merge reports `settled`; a mutation-guard test flips one member to unconfirmed and confirms it stays `unverified` (this is the exact check requested in the review of #2170).
- `cd frontend && npx vitest run src/components/weekend/rosterAttention.test.ts` — 37/37 pass
- `cd frontend && npx vitest run src/components/weekend/` — 29 files / 632 tests, no regressions
- `cd frontend && npx tsc --noEmit -p tsconfig.json` — clean
- `./node_modules/.bin/eslint` + `npx prettier --check` on all 5 touched files — clean (2 pre-existing, untouched-line warnings in `LodgingMap.tsx`, confirmed via `git diff origin/main` that my diff doesn't add or move them)

**Mutation-check transcript:** flipped `resolvePartyUnit`'s confirmation check to always-true (`const allConfirmed = true`) → 3 tests went RED, including the exact mutation guard the review asked for (`expected 'settled' to be 'unverified'`, plus the two `resolvePartyUnit` tests pinning "refuses when unconfirmed / unresolved"). Restored — file diffed byte-identical to the fixed version.

Closes #1982.