### PR TITLE
fix(api): retire the dead family_camp_adults.last_name sort rung

### DIFF
--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -205,37 +205,35 @@ def _household_display_name(household: Any, fallback_cm_id: int) -> str:
 
 def _last_token(value: str) -> str:
     """Last whitespace-delimited token. The one heuristic in the chain, reached
-    only when no last_name column is populated anywhere on the party."""
+    only when no enrolled child on the party carries a last_name."""
     parts = value.split()
     return parts[-1] if parts else ""
 
 
-def _adult_last_name(adults: list[Any]) -> str:
-    """Adult 1's surname, else the lowest-numbered adult that has one.
-
-    Reads the `last_name` COLUMN, never the combined `name` column:
-    family_camp_adults populates first_name/last_name only for adults 1-2, and
-    that is exactly the range this walk reaches before giving up.
-    """
-    # A missing adult_number reads as 0 through _i, which would sort AHEAD of
-    # adult 1. Push it to the back instead -- an unnumbered row is the least
-    # trustworthy source of the household's surname, not the most.
-    for adult in sorted(adults, key=lambda a: _i(a, "adult_number") or 999):
-        last = _s(adult, "last_name")
-        if last:
-            return last
-    return ""
-
-
-def _household_sort_name(adults: list[Any], children: list[Any], display_name: str) -> str:
-    """Surname for a household party. First non-empty rung wins.
+def _household_sort_name(children: list[Any], display_name: str) -> str:
+    """Surname for a household party, from the ELDEST enrolled child's column.
 
     `children` arrives oldest-first, so the child rung prefers the eldest
     enrolled camper.
+
+    THERE IS DELIBERATELY NO ADULT RUNG (kindred#1945). This used to read
+    `family_camp_adults.last_name` first, on the reasoning that a household's
+    surname is its adults'. That column is DEAD UPSTREAM: its two CampMinder
+    sources (`Family Camp-P1/P2 Last Name`, cm_id 216785/216786) stopped being
+    populated after 2022, so measured against the production snapshot the
+    column holds 0 of 834 rows in 2026 and 2 rows a year in 2023-2025. The rung
+    could not fire on any current weekend -- retiring it moved the sort key for
+    ZERO of the 382 rostered 2026 households -- while its docstring described a
+    walk over "adults 1-2" that in fact reached nothing.
+
+    Do NOT reinstate it by deriving a surname from the combined `name` column
+    instead. `name` is a whole name typed into a field CampMinder labels "First
+    Name" (773 of 788 2026 values contain a space), so a last-token split is a
+    heuristic, and the rung it would shadow -- the child's `last_name` -- is a
+    real column that is actually populated. Never persist such a derivation
+    back to the database either; a split that works on ~95% mishandles the rest
+    permanently.
     """
-    adult_last = _adult_last_name(adults)
-    if adult_last:
-        return adult_last
     for child in children:
         child_last = _s(child, "last_name")
         if child_last:
@@ -1099,11 +1097,27 @@ class LodgingRosterService:
                     household_cm_id=household_cm_id,
                     display_name=_household_display_name(household, household_cm_id),
                     sort_name=_household_sort_name(
-                        adults, children_oldest_first, _household_display_name(household, household_cm_id)
+                        children_oldest_first, _household_display_name(household, household_cm_id)
                     ),
                     adults=[
                         PartyAdult(
                             adult_number=_i(adult, "adult_number"),
+                            # `name` is the COLUMN OF RECORD for an attending
+                            # adult, and the split columns are a best-effort
+                            # Adult-1/2-only extra: first_name/last_name are
+                            # empty for 100% of adult_number 3-5 rows in every
+                            # measured year, and last_name is empty for all of
+                            # 2026 (kindred#1945).
+                            #
+                            # THE FALLBACK IS LOAD-BEARING -- do not "simplify"
+                            # it away on the grounds that `name` is
+                            # authoritative. 377 of 382 rostered 2026
+                            # households have a non-blank `name`; for several
+                            # of the rest this is the only thing that renders
+                            # an adult at all. Equally, never conclude a row is
+                            # empty from the split columns alone: 136 real
+                            # adults across 2022-2026 are blank in
+                            # first_name/last_name and populated in `name`.
                             display_name=_s(adult, "name")
                             or f"{_s(adult, 'first_name')} {_s(adult, 'last_name')}".strip(),
                             relationship=_s(adult, "relationship_to_camper"),

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -1306,6 +1306,16 @@ class LodgingRosterService:
         # An unset container reads as a delta of 0 -- real common space
         # nobody measured, correctly zero and never "unknown" -- so only a
         # genuinely unmeasured LEAF can still leave a total unknown.
+        #
+        # And it DOES leave it unknown, including a leaf beneath a drawn
+        # container. That sentence used to be aspirational: the container
+        # branch dropped unmeasured leaves from its sum, so it could never
+        # return None, which structurally excluded every container from
+        # `units_capacity_unknown` and let a half-measured house report a
+        # confident undercount. Latent when fixed -- 0 of 15 active production
+        # containers had an unmeasured active leaf, so no reported number moved
+        # -- and live the moment staff add a room with no bed count under a
+        # combined house.
         drawn = [u for u in drawn_units(units) if u.is_active]
         bookable = [u for u in drawn if _is_planning_inventory(u)]
         staff_housing = [u for u in drawn if not _is_planning_inventory(u)]
@@ -1315,14 +1325,22 @@ class LodgingRosterService:
         def _effective_sleeps(unit: LodgingUnitSummary) -> int | None:
             if not unit.is_container:
                 return unit.sleeps
-            leaf_total = sum(
+            leaf_sleeps = [
                 leaf.sleeps
                 for code in unit_index.leaf_codes_under(unit.code)
-                if (leaf := unit_index.units_by_code.get(code)) is not None
-                and leaf.is_active
-                and leaf.sleeps is not None
-            )
-            return (unit.sleeps or 0) + leaf_total
+                if (leaf := unit_index.units_by_code.get(code)) is not None and leaf.is_active
+            ]
+            # ACTIVE leaves only, in both directions: a retired room adds no
+            # beds, and equally must not drag its whole house into "unknown".
+            if any(s is None for s in leaf_sleeps):
+                return None
+            # The degenerate case. "Unset container reads as a delta of 0"
+            # holds only because its rooms supply the rest of the answer --
+            # with no rooms to supply it, 0 is not a delta over anything, it
+            # is the claim "this house sleeps nobody".
+            if unit.sleeps is None and not leaf_sleeps:
+                return None
+            return (unit.sleeps or 0) + sum(s for s in leaf_sleeps if s is not None)
 
         effective_sleeps = {u.unit_id: _effective_sleeps(u) for u in bookable}
 

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -1341,6 +1341,16 @@ class LodgingRosterService:
             ]
             # ACTIVE leaves only, in both directions: a retired room adds no
             # beds, and equally must not drag its whole house into "unknown".
+            #
+            # NOT additionally filtered by `_is_planning_inventory`, and that
+            # is deliberate rather than an oversight. Six active
+            # `staff_default` leaves sit under active containers in production
+            # (44 family_pool + 6 staff_default under 15 containers), and the
+            # SUM below has counted their beds since kindred#2041 -- a family
+            # holding the whole house holds that room too, which is what
+            # "combined" means. Gating the unknown on a narrower leaf set than
+            # the sum reads from would let a room's beds count while its
+            # missing measurement did not.
             if any(s is None for s in leaf_sleeps):
                 return None
             # The degenerate case. "Unset container reads as a delta of 0"

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -1332,6 +1332,14 @@ class LodgingRosterService:
         assigned = sum(1 for p in parties if p.unit_code or p.unit_name)
 
         def _effective_sleeps(unit: LodgingUnitSummary) -> int | None:
+            # MIRRORED by `effectiveSleeps` in
+            # `frontend/src/components/weekend/rosterAttention.ts`, which
+            # `countUnmeasuredSpaces` reads to answer the same "has anyone
+            # measured this?" question for the chip `WeekendStatsBar` prints
+            # beside `beds_family_available`. Named in BOTH directions on
+            # purpose: the pairing being undocumented is what let the two drift
+            # apart unnoticed until kindred#1945's PR, and a change here that
+            # is not made there puts two disagreeing numbers on one line.
             if not unit.is_container:
                 return unit.sleeps
             leaf_sleeps = [

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -205,7 +205,16 @@ def _household_display_name(household: Any, fallback_cm_id: int) -> str:
 
 def _last_token(value: str) -> str:
     """Last whitespace-delimited token. The one heuristic in the chain, reached
-    only when no enrolled child on the party carries a last_name."""
+    only when no enrolled child on the party carries a last_name.
+
+    For a household its input is the MAILING TITLE, not a name, so its answer
+    is wrong whenever the title does not end in the surname -- "The Chen
+    Family" files under F. Pinned rather than fixed
+    (`test_last_resort_yields_family_for_a_real_mailing_title`), and safe to
+    leave that way: every household party has an enrolled child by
+    construction, and measured against production ZERO rostered households in
+    any year 2022-2026 lack a child `last_name`, so nothing reaches this rung.
+    """
     parts = value.split()
     return parts[-1] if parts else ""
 

--- a/frontend/src/components/weekend/rosterAttention.test.ts
+++ b/frontend/src/components/weekend/rosterAttention.test.ts
@@ -319,17 +319,65 @@ describe('countUnmeasuredSpaces', () => {
     ).toBe(1)
   })
 
-  it('drops the unmeasured rooms of a MEASURED combined house', () => {
-    // The real Doctor's House shape: the container carries the only recorded
-    // capacity and its two rooms carry none. Once it draws as one card there
-    // is nothing unmeasured on the board at all.
+  it('counts a combined house whose ROOMS are unmeasured, even when the house is not', () => {
+    // This asserted 0 until kindred#1945's PR, on the reading that the
+    // container's own 6 was the house's capacity. It is not: kindred#2041
+    // ruled a container's `sleeps` is a DELTA over its rooms — the futon on
+    // the landing — so 6 plus two unmeasured rooms is an unmeasured house.
+    //
+    // THE MIRROR of `_effective_sleeps` in
+    // `api/services/lodging_roster_service.py`, which returns None for exactly
+    // this shape. `WeekendStatsBar` prints the backend's
+    // `beds_family_available` on the same line as this count, so if the two
+    // disagree the bar reports beds for a house it simultaneously calls
+    // measured.
     expect(
       countUnmeasuredSpaces([
         unit({ code: 'house', is_container: true, is_combined: true, sleeps: 6 }),
         unit({ code: 'r1', parent_code: 'house', sleeps: null }),
         unit({ code: 'r2', parent_code: 'house', sleeps: null }),
       ])
+    ).toBe(1)
+  })
+
+  it('does NOT count a combined house whose rooms all carry numbers', () => {
+    // The regression guard for the case above: walking to the leaves must not
+    // start calling every combined house unmeasured. Also the 14-of-15
+    // production shape — no common-space furniture recorded on the house
+    // itself, which the delta rule reads as a real zero.
+    expect(
+      countUnmeasuredSpaces([
+        unit({ code: 'house', is_container: true, is_combined: true, sleeps: null }),
+        unit({ code: 'r1', parent_code: 'house', sleeps: 2 }),
+        unit({ code: 'r2', parent_code: 'house', sleeps: 2 }),
+      ])
     ).toBe(0)
+  })
+
+  it('ignores an INACTIVE room when judging its house', () => {
+    // Active leaves only, the same qualifier `_effective_sleeps` applies. A
+    // retired room nobody will ever measure must not park its whole house in
+    // the unmeasured list permanently.
+    expect(
+      countUnmeasuredSpaces([
+        unit({ code: 'house', is_container: true, is_combined: true, sleeps: 6 }),
+        unit({ code: 'r1', parent_code: 'house', sleeps: 4 }),
+        unit({ code: 'r2', parent_code: 'house', sleeps: null, is_active: false }),
+      ])
+    ).toBe(0)
+  })
+
+  it('counts a combined house with no figure of its own and no rooms beneath it', () => {
+    // The degenerate case, and the one worth writing a test for because the
+    // obvious implementation gets it wrong: summing an absent delta over an
+    // empty room list yields 0, i.e. the confident claim "this house sleeps
+    // nobody". "Unset container reads as a delta of zero" holds only because
+    // its rooms supply the rest of the answer.
+    expect(
+      countUnmeasuredSpaces([
+        unit({ code: 'house', is_container: true, is_combined: true, sleeps: null }),
+      ])
+    ).toBe(1)
   })
 
   it('still counts the rooms of a SPLIT house, and never the house', () => {

--- a/frontend/src/components/weekend/rosterAttention.ts
+++ b/frontend/src/components/weekend/rosterAttention.ts
@@ -20,7 +20,7 @@
  * every constrained family on the strength of unset defaults.
  */
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
-import { drawnUnits } from './unitLevel'
+import { coveredCodes, drawnUnits } from './unitLevel'
 
 /** Ordered most urgent first. The order of this array IS the section order. */
 export const ATTENTION_ORDER = ['required', 'unmet', 'unplaced', 'unverified', 'settled'] as const
@@ -200,16 +200,59 @@ export function indexUnitsByCode(units: LodgingUnitRow[]): Map<string, LodgingUn
  */
 export function countUnmeasuredSpaces(units: LodgingUnitRow[]): number {
   // Over the DRAWN units, not "every non-container row". A combined house
-  // draws one card, at its own registry row; its rooms draw no card. That
-  // row's `sleeps` is now read as a DELTA over its rooms, not a whole-house
-  // total (kindred#2041) — but a container with no `sleeps` of its own is
-  // still nothing this walk can call measured, since its rooms never get a
-  // card here to speak for themselves. `drawnUnits` resolves the draw level
-  // top-down and is the one definition of which units get a card — deriving
-  // it here a second way is how this starts disagreeing with the board it
-  // sits above.
+  // draws one card, at its own registry row; its rooms draw no card.
+  // `drawnUnits` resolves the draw level top-down and is the one definition of
+  // which units get a card — deriving it here a second way is how this starts
+  // disagreeing with the board it sits above.
+  //
+  // What "measured" MEANS is `effectiveSleeps` below, and it has to stay the
+  // mirror of the backend's (kindred#1945's PR). This used to read only the
+  // drawn row's own `sleeps`, which got both container cases wrong in opposite
+  // directions: a house whose rooms all carry numbers read as unmeasured
+  // because the house row was blank, and a house with a recorded delta read as
+  // measured even though no room beneath it had ever been counted. The backend
+  // made the second mistake too, and the two were fixed together — they cannot
+  // be allowed to disagree, because `WeekendStatsBar` prints this number on
+  // the same line as the backend's `beds_family_available`.
   return drawnUnits(units).filter(
-    (unit) =>
-      unit.is_family_available === true && (unit.sleeps === null || unit.sleeps === undefined)
+    (unit) => unit.is_family_available === true && effectiveSleeps(unit, units) === null
   ).length
+}
+
+/**
+ * A drawn unit's capacity, or `null` when nobody has measured it.
+ *
+ * THE MIRROR of `_effective_sleeps` in `api/services/lodging_roster_service.py`
+ * — that one returns the total, this returns only whether there is one, which
+ * is all this file needs. Keep the two in step.
+ *
+ * Under the kindred#2041 delta ruling a container's own `sleeps` is the beds in
+ * space belonging to no single room, so a combined house's capacity is that
+ * delta PLUS its rooms, and one unmeasured ACTIVE room leaves the whole total
+ * unknown. Inactive leaves are skipped in both directions: a retired room adds
+ * no beds and must not park its house in the unmeasured list forever.
+ *
+ * Leaves are NOT additionally filtered by inventory class, deliberately. Six
+ * active `staff_default` leaves sit under active containers in production and
+ * the backend's sum has counted their beds since kindred#2041 — a family
+ * holding the whole house holds that room too, which is what "combined" means.
+ * Gating the unknown on a narrower set than the sum reads from would let a
+ * room's beds count while its missing measurement did not.
+ */
+function effectiveSleeps(unit: LodgingUnitRow, units: LodgingUnitRow[]): number | null {
+  const own = unit.sleeps ?? null
+  if (unit.is_container !== true) return own
+
+  const byCode = new Map(units.map((row) => [row.code, row]))
+  const leaves = coveredCodes(unit, units)
+    .map((code) => byCode.get(code))
+    .filter((leaf): leaf is LodgingUnitRow => leaf !== undefined && leaf.is_active !== false)
+
+  if (leaves.some((leaf) => (leaf.sleeps ?? null) === null)) return null
+  // The degenerate case, and the one an obvious implementation gets wrong:
+  // summing an absent delta over an empty room list yields 0, i.e. the
+  // confident claim "this house sleeps nobody". "Unset container reads as a
+  // delta of zero" holds only because its rooms supply the rest of the answer.
+  if (own === null && leaves.length === 0) return null
+  return (own ?? 0) + leaves.reduce((total, leaf) => total + (leaf.sleeps ?? 0), 0)
 }

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -589,7 +589,7 @@ func (s *FamilyCampDerivedSync) loadPersonCustomValues(
 // CollapseToHouseholdGrain) would pick differently in 130 of them. Which
 // sibling should win is a product decision, coupled to the still-open question
 // of whether gender/date_of_birth/email/pronouns are kept at all, so today's
-// behaviour is pinned by test instead of changed on a guess.
+// behavior is pinned by test instead of changed on a guess.
 func (s *FamilyCampDerivedSync) processAdults(
 	householdValues []customValueEntry, personValues []customValueEntry,
 ) []*adultData {

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -556,7 +556,40 @@ func (s *FamilyCampDerivedSync) loadPersonCustomValues(
 	return result, nil
 }
 
-// processAdults extracts adult data from custom values
+// processAdults extracts adult data from custom values.
+//
+// `name`, from the household-partition `Family Camp Adult 1-5`, is the COLUMN
+// OF RECORD for who is attending. Staff transpose the person-level FC-P1/P2
+// fields into Adults 1-2 and `Family Camp-Additional Adults` into Adults 3-5,
+// splitting the names themselves, so it is a curated list rather than a
+// household contact roster. The split columns below are a best-effort extra
+// that only ever populates for adults 1-2: first_name/last_name are empty for
+// 100% of adult_number 3-5 rows in every measured year, and CampMinder itself
+// stopped filling `Family Camp-P1/P2 Last Name` (cm_id 216785/216786) after
+// 2022, so `last_name` holds 0 of 834 rows in 2026.
+//
+// TWO CONSEQUENCES, both of which have already caught someone (kindred#1945):
+//
+//   - `first_name` is a MISLABELED FULL NAME. 773 of 788 2026 values contain a
+//     space -- parents type their whole name into a field CampMinder labels
+//     "First Name". Nothing may treat it as a given name.
+//   - NEVER conclude a row is empty from the split columns. 136 real adults
+//     across 2022-2026 are blank in first_name/last_name and populated in
+//     `name`; a "delete the blank rows" cleanup written from that misreading
+//     would have erased every one of them.
+//
+// PENDING, and deliberately not resolved here (owner ruling, kindred#1945):
+// the person-partition loop below merges with "first non-empty wins" over a
+// slice loadPersonCustomValues returns in record-id order, so when two
+// enrolled siblings carry different answers the winner is whichever row has
+// the lower id -- which correlates with nothing. Measured over the 382
+// rostered 2026 households: 254 (household, field, adult) groups disagree
+// across 113 households, and resolving by CampMinder's own last_updated (the
+// rule spec 4.1 already applies to the REQUEST fields, via
+// CollapseToHouseholdGrain) would pick differently in 130 of them. Which
+// sibling should win is a product decision, coupled to the still-open question
+// of whether gender/date_of_birth/email/pronouns are kept at all, so today's
+// behaviour is pinned by test instead of changed on a guess.
 func (s *FamilyCampDerivedSync) processAdults(
 	householdValues []customValueEntry, personValues []customValueEntry,
 ) []*adultData {

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -2071,3 +2071,95 @@ func TestRegistrationNeedsUpdateIgnoresTheUnknownSpelling(t *testing.T) {
 		t.Error("a real verdict change must still be detected")
 	}
 }
+
+// TestProcessAdultsPersonFieldsTakeTheFirstLoadedSibling pins the CURRENT,
+// arbitrary tie-break in processAdults' per-person merge, so that changing it
+// is a deliberate, visible break rather than a silent drift.
+//
+// The person-partition fields (FC-P1/P2 First/Last Name, Email, Pronouns,
+// Gender, DOB, Relationship) describe the household's ADULTS, but CampMinder
+// stores them on every enrolled child's record. A household with two children
+// therefore supplies two copies, and when a form was filled twice they can
+// disagree. processAdults resolves that with "first non-empty wins" over a
+// slice that loadPersonCustomValues returns in person_custom_values record-id
+// order -- so the winner is whichever sibling's row happens to carry the lower
+// record id, which correlates with nothing about the answer.
+//
+// Measured against the production snapshot for 2026, over the 382 rostered
+// family-camp households: 254 (household, field, adult) groups have siblings
+// that disagree, spread across 113 households, and resolving by CampMinder's
+// own last_updated instead would pick a different value in 130 of them. So
+// this is a live arbitrary choice, not a theoretical one -- but it is also a
+// small one, because only two of the merged columns reach the UI at all.
+//
+// PENDING, deliberately (owner ruling on kindred#1945): which sibling should
+// win is a product decision, and it is coupled to the still-open question of
+// whether gender/date_of_birth/email/pronouns are kept. Do not "fix" this test
+// by changing the merge until that ruling lands.
+func TestProcessAdultsPersonFieldsTakeTheFirstLoadedSibling(t *testing.T) {
+	s := &FamilyCampDerivedSync{}
+
+	householdValues := []customValueEntry{
+		{householdPBID: "hh_1", fieldName: "Family Camp Adult 1", value: "Emma Johnson"},
+	}
+	// Both entries come from the same household via two different children.
+	// Order here is the order loadPersonCustomValues yields: ascending record
+	// id. The SECOND one is the more recently edited, which is exactly why the
+	// choice matters.
+	personValues := []customValueEntry{
+		{
+			householdPBID: "hh_1",
+			fieldName:     "Family Camp-Relationship to 1",
+			value:         "Mother",
+			lastUpdated:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			householdPBID: "hh_1",
+			fieldName:     "Family Camp-Relationship to 1",
+			value:         "Stepmother",
+			lastUpdated:   time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	adults := s.processAdults(householdValues, personValues)
+
+	if len(adults) != 1 {
+		t.Fatalf("expected 1 merged adult, got %d", len(adults))
+	}
+	if adults[0].name != "Emma Johnson" {
+		t.Errorf("household `name` is the column of record: got %q", adults[0].name)
+	}
+	if adults[0].relationship != "Mother" {
+		t.Errorf(
+			"first-loaded sibling wins today: got %q, want %q (if you changed the merge on purpose, "+
+				"update this test and kindred#1945 together)",
+			adults[0].relationship, "Mother",
+		)
+	}
+}
+
+// TestProcessAdultsKeepsANameOnlyAdult guards the shape that makes the
+// household `name` column authoritative: adults 3-5 arrive with ONLY `name`,
+// and first_name/last_name empty for 100% of those rows in every measured
+// year. An admission filter that reads the split columns to decide whether a
+// row is real would drop them -- 136 real adults across 2022-2026 are blank in
+// first_name/last_name and populated in `name` (kindred#1945).
+func TestProcessAdultsKeepsANameOnlyAdult(t *testing.T) {
+	s := &FamilyCampDerivedSync{}
+
+	householdValues := []customValueEntry{
+		{householdPBID: "hh_1", fieldName: "Family Camp Adult 3", value: "Mateo Rivera"},
+	}
+
+	adults := s.processAdults(householdValues, nil)
+
+	if len(adults) != 1 {
+		t.Fatalf("a name-only adult must survive the merge, got %d adults", len(adults))
+	}
+	if adults[0].adultNumber != 3 || adults[0].name != "Mateo Rivera" {
+		t.Errorf("got adult %d %q, want 3 %q", adults[0].adultNumber, adults[0].name, "Mateo Rivera")
+	}
+	if adults[0].firstName != "" || adults[0].lastName != "" {
+		t.Errorf("nothing may invent split columns: got first=%q last=%q", adults[0].firstName, adults[0].lastName)
+	}
+}

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -2090,7 +2090,10 @@ func TestRegistrationNeedsUpdateIgnoresTheUnknownSpelling(t *testing.T) {
 // that disagree, spread across 113 households, and resolving by CampMinder's
 // own last_updated instead would pick a different value in 130 of them. So
 // this is a live arbitrary choice, not a theoretical one -- but it is also a
-// small one, because only two of the merged columns reach the UI at all.
+// small one: of the columns merged here, only relationship and the split name
+// pair reach the UI (the latter solely through the roster's `name or
+// first+last` coalesce, which fires for 5 of 382 households). gender,
+// date_of_birth, email and pronouns have zero readers anywhere.
 //
 // PENDING, deliberately (owner ruling on kindred#1945): which sibling should
 // win is a product decision, and it is coupled to the still-open question of

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -2099,8 +2099,13 @@ func TestRegistrationNeedsUpdateIgnoresTheUnknownSpelling(t *testing.T) {
 func TestProcessAdultsPersonFieldsTakeTheFirstLoadedSibling(t *testing.T) {
 	s := &FamilyCampDerivedSync{}
 
+	// A local constant rather than the literal twice: goconst counts repeated
+	// string literals across the package and this name is already used in
+	// three other sync tests.
+	const wantName = "Emma Johnson"
+
 	householdValues := []customValueEntry{
-		{householdPBID: "hh_1", fieldName: "Family Camp Adult 1", value: "Emma Johnson"},
+		{householdPBID: "hh_1", fieldName: "Family Camp Adult 1", value: wantName},
 	}
 	// Both entries come from the same household via two different children.
 	// Order here is the order loadPersonCustomValues yields: ascending record
@@ -2126,7 +2131,7 @@ func TestProcessAdultsPersonFieldsTakeTheFirstLoadedSibling(t *testing.T) {
 	if len(adults) != 1 {
 		t.Fatalf("expected 1 merged adult, got %d", len(adults))
 	}
-	if adults[0].name != "Emma Johnson" {
+	if adults[0].name != wantName {
 		t.Errorf("household `name` is the column of record: got %q", adults[0].name)
 	}
 	if adults[0].relationship != "Mother" {

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -358,6 +358,38 @@ class TestFamilyCampParties:
         assert party.party_size == 3
 
     @pytest.mark.asyncio
+    async def test_a_blank_name_column_falls_back_to_first_plus_last(self) -> None:
+        """THE LOAD-BEARING COALESCE (kindred#1945). Do not remove it.
+
+        `family_camp_adults.name` is the column of record, but it is blank on a
+        small tail of rows. Measured against 2026: of the 382 rostered family
+        households, 377 have at least one non-blank `name` and 5 do not -- and
+        this fallback is the only thing that renders any adult at all for
+        several of those. Deleting it in the name of "name is authoritative"
+        would blank real adults off the board.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_households={"hh_1": _household()},
+            fetch_attendees_for_session=[_child()],
+            fetch_family_camp_adults={
+                "hh_1": [
+                    _rec(
+                        adult_number=1,
+                        name="",
+                        first_name="Olivia",
+                        last_name="Johnson",
+                        relationship_to_camper="Parent",
+                    ),
+                ]
+            },
+        )
+
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert [a.display_name for a in roster.parties[0].adults] == ["Olivia Johnson"]
+
+    @pytest.mark.asyncio
     async def test_fractional_age_survives_as_the_raw_float(self) -> None:
         """kindred#2088: persons.age is CampMinder's yy.mm as a REAL --
 
@@ -2616,17 +2648,25 @@ class TestPartySortName:
     """A household's display_name is a mailing title, so it cannot be the sort key.
 
     "The Johnson Family" would file under T. sort_name carries the surname the
-    list actually needs, read from last_name COLUMNS -- family_camp_adults
-    populates first/last only for adults 1-2, which is exactly the range the
-    adult rungs look at.
+    list actually needs, read from the ENROLLED CHILD's `last_name` column.
+
+    There used to be a rung above it reading `family_camp_adults.last_name`.
+    kindred#1945 retired it: that column is dead upstream. Its two CampMinder
+    source fields (`Family Camp-P1/P2 Last Name`) have carried nothing since
+    2022, so the column holds 0 of 834 rows in 2026 and 2 rows a year in
+    2023-2025. The rung could not fire, and the child rung it shadowed reads a
+    column that is actually populated.
     """
 
     @pytest.mark.asyncio
-    async def test_household_sorts_under_adult_ones_surname(self) -> None:
+    async def test_household_sorts_under_the_enrolled_childs_surname(self) -> None:
+        # The adults carry a `last_name` that DISAGREES with the child, so the
+        # two rungs give different answers and the test pins which one wins.
+        # A fixture where they agreed would pass against either implementation.
         repo = _repo(
             fetch_session=FAMILY_SESSION,
             fetch_households={"hh_1": _household(title="The Johnson Family")},
-            fetch_attendees_for_session=[_child()],
+            fetch_attendees_for_session=[_child(first="Emma", last="Johnson")],
             fetch_family_camp_adults={
                 "hh_1": [
                     _rec(
@@ -2638,9 +2678,9 @@ class TestPartySortName:
                     ),
                     _rec(
                         adult_number=1,
-                        name="Emma Johnson",
-                        first_name="Emma",
-                        last_name="Johnson",
+                        name="Liam Silva",
+                        first_name="Liam",
+                        last_name="Silva",
                         relationship_to_camper="Parent",
                     ),
                 ]
@@ -2650,30 +2690,36 @@ class TestPartySortName:
 
         roster = await service.build_roster(2026, 1000001)
 
-        # Adult 1 wins even though adult 2 is listed first in the payload.
+        # NOT "Silva" (adult 1's dead column) and NOT "Garcia" (adult 2's).
         assert roster.parties[0].sort_name == "Johnson"
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_a_later_adult_when_adult_one_has_no_surname(self) -> None:
+    async def test_the_adults_are_name_only_which_is_productions_actual_shape(self) -> None:
+        """Adults 3-5 carry ONLY the combined `name`; 1-2 usually do too.
+
+        first_name/last_name are empty for 100% of adult_number 3-5 rows in
+        every measured year, so this fixture is the common case, not an edge.
+        The sort key still has to come out right.
+        """
         repo = _repo(
             fetch_session=FAMILY_SESSION,
             fetch_households={"hh_1": _household(title="The Chen Family")},
-            fetch_attendees_for_session=[_child()],
+            fetch_attendees_for_session=[_child(first="Olivia", last="Chen")],
             fetch_family_camp_adults={
                 "hh_1": [
                     _rec(
                         adult_number=1,
-                        name="Olivia",
-                        first_name="Olivia",
+                        name="Sofia Chen",
+                        first_name="",
                         last_name="",
                         relationship_to_camper="Parent",
                     ),
                     _rec(
-                        adult_number=2,
-                        name="Liam Chen",
-                        first_name="Liam",
-                        last_name="Chen",
-                        relationship_to_camper="Parent",
+                        adult_number=3,
+                        name="Mateo Rivera",
+                        first_name="",
+                        last_name="",
+                        relationship_to_camper="Grandparent",
                     ),
                 ]
             },
@@ -2683,6 +2729,7 @@ class TestPartySortName:
         roster = await service.build_roster(2026, 1000001)
 
         assert roster.parties[0].sort_name == "Chen"
+        assert [a.display_name for a in roster.parties[0].adults] == ["Sofia Chen", "Mateo Rivera"]
 
     @pytest.mark.asyncio
     async def test_falls_back_to_the_enrolled_child_when_no_adult_has_a_surname(self) -> None:
@@ -2782,3 +2829,58 @@ class TestPartySortName:
         roster = await service.build_roster(2026, 1000001)
 
         assert [p.sort_name for p in roster.parties] == ["Chen", "Johnson"]
+
+    @pytest.mark.asyncio
+    async def test_board_order_across_the_three_adult_shapes(self) -> None:
+        """BOARD SORT ORDER IS VISIBLE OUTPUT -- pin it across every adult shape.
+
+        The three households cover what `family_camp_adults` actually contains:
+        name-only rows (all of adults 3-5, and most of 1-2), first+last rows
+        (the adults 1-2 tail), and no adult row at all. Retiring the dead
+        `last_name` rung changes the answer for exactly the middle one, so the
+        surnames are chosen to make that a REORDER rather than a relabel: under
+        the old chain hh_2 filed under "Rivera" and the order was
+        Adams/Johnson/Rivera.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_households={
+                "hh_1": _household(pb_id="hh_1", cm_id=2000001, title="The Johnson Family"),
+                "hh_2": _household(pb_id="hh_2", cm_id=2000002, title="The Chen Family"),
+                "hh_3": _household(pb_id="hh_3", cm_id=2000003, title="The Adams Family"),
+            },
+            fetch_attendees_for_session=[
+                _child(cm_id=1000001, first="Emma", last="Johnson", household_pb_id="hh_1"),
+                _child(cm_id=1000002, first="Olivia", last="Chen", household_pb_id="hh_2"),
+                _child(cm_id=1000003, first="Noah", last="Adams", household_pb_id="hh_3"),
+            ],
+            fetch_family_camp_adults={
+                # Name-only: the shape 100% of adults 3-5 arrive in.
+                "hh_1": [
+                    _rec(
+                        adult_number=1,
+                        name="Sofia Silva",
+                        first_name="",
+                        last_name="",
+                        relationship_to_camper="Parent",
+                    ),
+                ],
+                # first + last populated, and DISAGREEING with the child.
+                "hh_2": [
+                    _rec(
+                        adult_number=1,
+                        name="Mateo Rivera",
+                        first_name="Mateo",
+                        last_name="Rivera",
+                        relationship_to_camper="Parent",
+                    ),
+                ],
+                # hh_3 has no adult row at all.
+            },
+        )
+        service = LodgingRosterService(repo)
+
+        roster = await service.build_roster(2026, 1000001)
+
+        assert [p.sort_name for p in roster.parties] == ["Adams", "Chen", "Johnson"]
+        assert [p.household_cm_id for p in roster.parties] == [2000003, 2000002, 2000001]

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -2833,11 +2833,15 @@ class TestPartySortName:
         # token is "Family". So the last resort files every household that
         # reaches it under F, not under its surname.
         #
-        # Pinned rather than fixed. This rung is reached only when NO adult and
-        # NO child on the party carries a last_name, and family_camp_adults
-        # populates those columns for adults 1-2 — so it is the rare tail, and
-        # the pair still tie-break on display_name. Recorded here so the rung's
-        # real output is on the page instead of implied by a kinder fixture.
+        # Pinned rather than fixed. Since kindred#1945 retired the dead adult
+        # rung this is the ONLY rung below the child's `last_name`, so it is
+        # worth saying how rare it is rather than leaving that implied: every
+        # household party has an enrolled child by construction
+        # (`_build_household_parties` iterates them), and measured against
+        # production ZERO rostered households in any year 2022-2026 lack a
+        # child surname. Nothing reaches this rung today, and the pair still
+        # tie-break on display_name. Recorded here so the rung's real output is
+        # on the page instead of implied by a kinder fixture.
         repo = _repo(
             fetch_session=FAMILY_SESSION,
             fetch_households={"hh_1": _household(title="The Chen Family")},

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -1039,29 +1039,88 @@ class TestCountsFollowTheDrawLevel:
         assert roster.counts.beds_family_available == 16
 
     @pytest.mark.asyncio
-    async def test_a_combined_container_reports_its_own_measured_beds_over_unmeasured_rooms(self) -> None:
-        """The real Doctor's House shape.
+    async def test_a_container_with_an_unmeasured_room_is_unknown_not_a_confident_undercount(self) -> None:
+        """An unmeasured ACTIVE room leaves its container's total UNKNOWN.
 
-        Its two rooms were split out of the container with `sleeps`
-        deliberately left unset -- the bed lists carry their capacity, the
-        number does not. An unmeasured room contributes nothing to the total
-        (same silent-skip treatment an unmeasured LEAF gets everywhere else),
-        so the total is the container's own measured 6 plus two zeros: 6, not
-        "unknown".
+        This reverses what this test asserted before. It used to pin "6, not
+        unknown", on the reasoning that an unmeasured room gets "the same
+        silent-skip treatment an unmeasured LEAF gets everywhere else". That
+        reasoning does not hold: a STANDALONE unmeasured leaf is not skipped at
+        all -- it returns None and lands in `units_capacity_unknown`. Only a
+        leaf that happened to sit under a container was silently read as zero.
+
+        It also contradicted the kindred#2041 delta ruling the container branch
+        is built on. If the container's own `sleeps` is a DELTA over its rooms
+        -- the futon on the landing, not the house -- then 6 plus two unknowns
+        is unknown, and reporting 6 is a confident undercount of a house nobody
+        has measured. `_build_counts`' own comment already said so ("only a
+        genuinely unmeasured LEAF can still leave a total unknown"); the code
+        was what disagreed.
+
+        Latent, not live, when this changed: measured against the production
+        snapshot, 0 of 15 active containers had an unmeasured active leaf, so
+        no reported number moved. It goes live the moment staff add a room with
+        no bed count under a combined house.
         """
         repo = _repo(
             fetch_session=FAMILY_SESSION,
             fetch_units=[
-                _unit("u1", "hc-dh", "Doctor's House", sleeps=6, is_container=True, default_combined=True),
-                _unit("u2", "hc-dh-a", "Doctor's House A", sleeps=0, parent_unit="u1"),
-                _unit("u3", "hc-dh-b", "Doctor's House B", sleeps=0, parent_unit="u1"),
+                _unit("u1", "hc-house", "Combined House", sleeps=6, is_container=True, default_combined=True),
+                _unit("u2", "hc-house-a", "Combined House A", sleeps=4, parent_unit="u1"),
+                _unit("u3", "hc-house-b", "Combined House B", sleeps=0, parent_unit="u1"),
             ],
         )
         roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
 
         assert roster.counts.units_total == 1
-        assert roster.counts.beds_family_available == 6
+        # NOT 10. The house is not measured, so it contributes no bed count
+        # and is flagged for measurement instead.
+        assert roster.counts.beds_family_available == 0
+        assert roster.counts.units_capacity_unknown == 1
+
+    @pytest.mark.asyncio
+    async def test_an_inactive_room_does_not_make_its_container_unknown(self) -> None:
+        """Only an ACTIVE leaf counts, in both directions.
+
+        A retired room contributes no beds to the total (the behaviour that
+        was already there) and equally must not drag the whole house into
+        `units_capacity_unknown` because nobody bothered to measure a room
+        that is out of service.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("u1", "hc-house", "Combined House", sleeps=6, is_container=True, default_combined=True),
+                _unit("u2", "hc-house-a", "Combined House A", sleeps=4, parent_unit="u1"),
+                _unit("u3", "hc-house-b", "Combined House B", sleeps=0, parent_unit="u1", is_active=False),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.counts.units_total == 1
+        assert roster.counts.beds_family_available == 10
         assert roster.counts.units_capacity_unknown == 0
+
+    @pytest.mark.asyncio
+    async def test_an_unset_container_with_nothing_measured_beneath_it_is_unknown(self) -> None:
+        """The degenerate case: no figure of its own, and no leaf to total.
+
+        "Unset container" reads as a delta of ZERO only because its rooms
+        supply the rest of the answer. With no rooms to supply it, zero is not
+        a delta over anything -- it is the claim "this house sleeps nobody",
+        which is never a measurement anyone took.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("u1", "hc-house", "Combined House", sleeps=0, is_container=True, default_combined=True),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.counts.units_total == 1
+        assert roster.counts.beds_family_available == 0
+        assert roster.counts.units_capacity_unknown == 1
 
     @pytest.mark.asyncio
     async def test_a_combined_container_with_no_own_figure_still_totals_its_measured_rooms(self) -> None:

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -945,6 +945,12 @@ class TestCountsFollowTheDrawLevel:
     past any intermediate container rather than stopping at its immediate
     children. An unset container reads as a delta of zero (real, not
     "unknown") and still totals its measured rooms.
+
+    "Measured" is load-bearing in that last sentence (kindred#1945's PR): a
+    delta of zero over rooms that HAVE numbers is a real total, but a delta of
+    zero over a room nobody counted -- or over no rooms at all -- is not. Any
+    active leaf with `sleeps` unset makes its container UNKNOWN, so it counts
+    in `units_capacity_unknown` and contributes no beds.
     """
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What this does

Two independent changes in one file's neighbourhood, plus the frontend half of the second one that the
scan turned up.

> **Do not auto-merge.** A second agent wrote into this worktree and pushed commit `f56f6dfb` while I was
> mid-edit, believing this PR's build agent had been lost. The content it committed is byte-identical to
> the version I had written and mutation-checked (verified with `diff`), so nothing is lost — but the
> branch was writable by another process, so please eyeball the diff before it lands. Full account in the
> report comment.

**1. `fix(api): retire the dead family_camp_adults.last_name sort rung`** — the #1945 half that is decidable.

`_household_sort_name` read `family_camp_adults.last_name` ahead of the enrolled child's `last_name`. That column is dead upstream — CampMinder stopped populating its two sources (`Family Camp-P1/P2 Last Name`, cm_id 216785/216786) after 2022 — so the rung could not fire, while its docstring described a walk over "adults 1-2" that in fact reached nothing.

It is **not** replaced with a last-token split of the combined `name` column. That would be a heuristic shadowing a real, populated column, and `name` is a *whole* name typed into a field CampMinder labels "First Name". Nothing derived is persisted anywhere.

Also documents, at both write sites, what these columns actually are — most importantly that the `name or first+last` coalesce in the roster is **load-bearing** and that no cleanup may read the split columns to decide a row is empty.

**2. `fix(api): propagate an unmeasured room's unknown up to its container`** (+ `fix(frontend): mirror the container capacity rule in countUnmeasuredSpaces`) — a separate latent defect the orchestrator found in the same file, and its frontend mirror, which the scan caught. **Issue 1945 stays open regardless of these commits.** `_effective_sleeps` filtered `sleeps is None` leaves out of a container's sum, so the container branch could never return `None`: an unmeasured room was silently counted as 0 (confident undercount) and `units_capacity_unknown` structurally excluded every container. Details in the commit message.

## Measurements (production snapshot, read-only)

| | |
|---|---|
| `family_camp_adults.last_name` populated, 2026 | **0 / 834** |
| …2023 / 2024 / 2025 | 2 / 2 / 2 per year (628 of the all-time 634 are 2022) |
| Rostered 2026 family households | **382** (`attendees.status_id = 2`, `attendees.session` → `camp_sessions.id`) |
| …with ≥1 non-blank `family_camp_adults.name` | **377 (98.7%)** |
| Households whose sort key CHANGES by retiring the rung, 2026 | **0** |
| …2022 (the only year with data) | 122 of 353 |
| `first_name` values containing a space, 2026 | 773 / 788 (98%) |
| `first_name`/`last_name` empty for `adult_number` 3-5 | 100%, every year |
| Active containers / with an unmeasured active leaf / with no active leaves | **15 / 0 / 0** |
| Active leaves under active containers | 50 = 44 `family_pool` + **6 `staff_default`** |
| Rostered households in ANY year 2022-2026 lacking a child `last_name` | **0** |
| Active containers with their own `sleeps` unset | 14 of 15 |
| `lodging_units` parent/child pairs via `parent_unit` | 39 (join proven non-empty first; there is no `parent_code` column) |

## What the tree contradicted

1. **Every line anchor in the notes was stale.** `_adult_last_name` was at `:213`, not `:211`; the load-bearing coalesce at `:1107`, not `:845`; `_effective_sleeps` at `:1301`, not `:1237`. Re-derived, not trusted.
2. **The issue body's "373 rostered households" does not reproduce; 382 does** — as the 2026-08-08 comment already recorded. Coverage restated on that denominator throughout.
3. **A live test explicitly pinned the OPPOSITE of fold-in 2.** `test_a_combined_container_reports_its_own_measured_beds_over_unmeasured_rooms` asserted "6, not unknown" on the reasoning that an unmeasured room gets "the same silent-skip treatment an unmeasured LEAF gets everywhere else". **That reasoning is false**: a *standalone* unmeasured leaf is not skipped at all — `_effective_sleeps` returns its `None` and it lands in `units_capacity_unknown`. Only a leaf that happened to sit under a container was read as zero. The test's stated rationale also contradicted the #2041 delta ruling it cited: if the container's `sleeps` is a delta over its rooms, a measured delta plus an unmeasured room is unknown. I rewrote the test to state the new spec, with the whole argument in its docstring rather than a silent flip. **Flagging it explicitly because rewriting a deliberate test is exactly the move CLAUDE.md forbids doing casually** — and because it changes visible stats-bar output, even though today it moves nothing (0 of 15 containers are in the shape).

## What I did NOT build, and exactly what it needs

**This PR deliberately carries NO closing keyword for issue 1945 — it must stay open.** The `processAdults` per-person merge half (owner ruling R8: inside #1945, not a separate issue) **needs a product judgement these notes do not answer**, and the issue body itself marks it PENDING.

The defect is real and measured. The person-partition fields (FC-P1/P2 First/Last Name, Email, Pronouns, Gender, DOB, Relationship) describe the household's *adults*, but CampMinder stores a copy on every enrolled child's record. `processAdults` merges with "first non-empty wins" over a slice `loadPersonCustomValues` returns in record-id order — so the winner is whichever sibling's row has the lower id, which correlates with nothing.

Over the 382 rostered 2026 households:

- **254** (household, field, adult) groups have siblings that disagree, across **113** households
- **0** of those groups have all siblings sharing one `last_updated` — so recency *is* available as a discriminator
- resolving by `last_updated` instead would pick a **different value in 130 of the 254**

So it is not a no-op rule change; it moves real rendered output. **The ruling needed is: when two enrolled siblings' forms disagree about an adult, which wins?** Recency (the rule spec 4.1 already applies to the *request* fields via `CollapseToHouseholdGrain`) is the obvious candidate, but it is a choice, not a derivation — and the owner explicitly coupled it to the still-open question of whether `gender`/`date_of_birth`/`email`/`pronouns` are kept at all.

Instead of guessing, I **pinned today's behaviour with a characterization test** (`TestProcessAdultsPersonFieldsTakeTheFirstLoadedSibling`) and wrote the measurement into the `processAdults` doc comment, so the rewrite is a deliberate, visible break rather than a silent drift — and so nobody has to re-derive the numbers. Added `TestProcessAdultsKeepsANameOnlyAdult` alongside it to guard the 136-real-adults deletion trap at the merge itself.

Refs #1945.
