### PR TITLE
feat(frontend): say which answers disagree on the share-conflict chip

### DIFF
--- a/frontend/src/components/weekend/FamilyCard.test.tsx
+++ b/frontend/src/components/weekend/FamilyCard.test.tsx
@@ -379,6 +379,57 @@ describe('FamilyCard — what it shows', () => {
     expect(screen.queryByText('Declined sharing')).not.toBeInTheDocument()
   })
 
+  it('says which two answers disagreed, and that the form wins, on the "Answers disagree" chip (kindred#2083)', () => {
+    render(
+      <FamilyCard
+        party={party({
+          share: {
+            preference: 'no_share',
+            proximity: [],
+            request_text: '',
+            needs_resolution: false,
+            eligibility: 'open',
+            eligibility_source: 'form',
+            answers_conflict: true,
+          },
+        })}
+        onOpen={vi.fn()}
+      />
+    )
+    const chip = screen.getByText('Answers disagree')
+    expect(chip).toHaveAttribute('title', expect.stringContaining('will not share'))
+    expect(chip).toHaveAttribute('title', expect.stringContaining('open to sharing'))
+    expect(chip).toHaveAttribute('title', expect.stringContaining("form's answer"))
+  })
+
+  it('renders no "Answers disagree" chip, and no tooltip, when there is no conflict', () => {
+    render(
+      <FamilyCard
+        party={party({
+          share: {
+            preference: 'yes_share',
+            proximity: ['with'],
+            request_text: '',
+            needs_resolution: false,
+            eligibility: 'open',
+            eligibility_source: 'form',
+            answers_conflict: false,
+          },
+        })}
+        onOpen={vi.fn()}
+      />
+    )
+    expect(screen.queryByText('Answers disagree')).not.toBeInTheDocument()
+  })
+
+  it('never shows "Answers disagree" for an adult weekend guest — there is no share question to disagree on', () => {
+    // person-grain parties carry no share block at all
+    // (`_build_person_parties` attaches none), so there is nothing here to
+    // report — not an empty chip.
+    render(<FamilyCard party={party({ grain: 'person' })} onOpen={vi.fn()} />)
+    expect(screen.queryByText('Answers disagree')).not.toBeInTheDocument()
+  })
+
   it('shows a share request as one chip covering both `with` and `similar_ages`', () => {
     // `similar_ages` ACCOMPANIES `with`; a chip showing one or the other drops
     // 22 households out of any "wants to share" view.

--- a/frontend/src/components/weekend/FamilyCard.tsx
+++ b/frontend/src/components/weekend/FamilyCard.tsx
@@ -46,7 +46,7 @@ import { Fragment } from 'react'
 
 import type { LodgingUnitRow, PartyChildRow, RosterPartyRow } from '../../types/lodging'
 import { displayCampMinderAge, displayTruncatedAge } from '../../utils/age'
-import { partySize, SHARE_WORDING, shareWordingChip } from './boardLayout'
+import { answersConflictDetail, partySize, SHARE_WORDING, shareWordingChip } from './boardLayout'
 import { attendingAdults as computeAttendingAdults } from './householdIdentity'
 import { partyKey } from './partyKey'
 import { ATTENTION_LABEL, partyAttention } from './rosterAttention'
@@ -107,14 +107,22 @@ function Chip({
   label,
   tone,
   icon: Icon,
+  title,
 }: {
   label: string
   tone: ChipTone
   /** Optional, e.g. the "Whole building" chip's `Home` — every other chip omits it. */
   icon?: LucideIcon
+  /**
+   * Native hover tooltip, e.g. the "Answers disagree" chip's per-party detail
+   * (kindred#2083) — matches `SharePreferenceChip`'s `raw` tooltip pattern
+   * rather than inventing a second affordance for the same idea.
+   */
+  title?: string
 }) {
   return (
     <span
+      title={title}
       className={`inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-semibold whitespace-nowrap ${CHIP_TONE[tone]}`}
     >
       {Icon && <Icon className="mr-0.5 h-3 w-3 flex-shrink-0" aria-hidden="true" />}
@@ -205,6 +213,7 @@ function FamilyCardBody({
   // view — a chip showing one *or* the other loses them.
   const wantsToShare = proximity.includes('with') || proximity.includes('similar_ages')
   const wantsNear = proximity.includes('near')
+  const conflictDetail = answersConflictDetail(party.share)
 
   return (
     <>
@@ -279,9 +288,19 @@ function FamilyCardBody({
           <Chip label={shareWordingChip(SHARE_WORDING.declined)} tone="warn" />
         )}
         {/* 16 households for 2026 carry disagreeing answers. Shown on the card
-            as well as the slot, so a party sitting alone still surfaces one. */}
-        {party.share?.answers_conflict === true && (
-          <Chip label={shareWordingChip(SHARE_WORDING.conflict)} tone="warn" />
+            as well as the slot, so a party sitting alone still surfaces one.
+            Gated on the DETAIL, not the raw boolean (kindred#2083): a party
+            this can't explain — none exist today, but a person-grain party
+            carries no share block to begin with — never renders an empty
+            chip. The tooltip names which two answers disagreed and which one
+            staff are acting on, matching `SharePreferenceChip`'s hover
+            pattern rather than a bare unexplained flag. */}
+        {conflictDetail !== null && (
+          <Chip
+            label={shareWordingChip(SHARE_WORDING.conflict)}
+            tone="warn"
+            title={conflictDetail}
+          />
         )}
         {wantsToShare && <Chip label="Wants to share" tone="share" />}
         {/* NEAR and WITH are different requests: NEAR is satisfied by map

--- a/frontend/src/components/weekend/boardLayout.test.ts
+++ b/frontend/src/components/weekend/boardLayout.test.ts
@@ -12,12 +12,15 @@ import type {
   RosterPartyRow,
   ShareEligibilityValue,
   SharePreferenceValue,
+  ShareRequest,
 } from '../../types/lodging'
 import {
+  answersConflictDetail,
   AREA_HUES,
   areaTokens,
   buildBoard,
   countBoardSlots,
+  SHARE_WORDING,
   slotOccupancy,
   wholeBuildingHolders,
 } from './boardLayout'
@@ -776,6 +779,91 @@ describe('buildBoard — consent flagging on ELIGIBILITY, not the gate', () => {
   it('reports how many slots are flagged across the whole board', () => {
     expect(shared(['declined', 'open']).flaggedCount).toBe(1)
     expect(shared(['open', 'open']).flaggedCount).toBe(0)
+  })
+})
+
+describe('answersConflictDetail — which two answers disagreed, and which one won (kindred#2083)', () => {
+  /** A minimal share block, defaulting to no conflict. */
+  function shareBlock(overrides: Partial<ShareRequest> = {}): ShareRequest {
+    return {
+      preference: 'unknown',
+      proximity: [],
+      request_text: '',
+      needs_resolution: false,
+      eligibility: 'unknown',
+      eligibility_source: 'none',
+      answers_conflict: false,
+      ...overrides,
+    }
+  }
+
+  it('says nothing when there is no conflict', () => {
+    expect(answersConflictDetail(shareBlock({ answers_conflict: false }))).toBeNull()
+  })
+
+  it('says nothing for a party with no share block at all — an adult weekend guest', () => {
+    // Adult weekends carry no share question (_build_person_parties attaches
+    // no share data), so there is nothing here to disagree about.
+    expect(answersConflictDetail(undefined)).toBeNull()
+  })
+
+  it('names the registration answer, the form answer, and that the form wins', () => {
+    // Measured against production 2026 data: all 16 conflicting households
+    // resolved with `eligibility_source: 'form'` — DeriveShareEligibility only
+    // ever sets `answers_conflict` true on that branch, so `eligibility` here
+    // already IS the form's own verdict, not a re-derivation of it.
+    const detail = answersConflictDetail(
+      shareBlock({
+        preference: 'no_share',
+        eligibility: 'open',
+        eligibility_source: 'form',
+        answers_conflict: true,
+      })
+    )
+    expect(detail).not.toBeNull()
+    expect(detail).toMatch(/regist.*will not share/i)
+    expect(detail).toMatch(/form.*open to sharing/i)
+    expect(detail).toMatch(/form/i)
+  })
+
+  it('reuses the ONE "did not request sharing" wording for a form decline, never "declined"', () => {
+    // SHARE_WORDING is defined once specifically so the slot flag, the card
+    // chip, and this tooltip cannot drift into three different claims about a
+    // form with no refusal option.
+    const detail = answersConflictDetail(
+      shareBlock({
+        preference: 'yes_share',
+        eligibility: 'declined',
+        eligibility_source: 'form',
+        answers_conflict: true,
+      })
+    )
+    expect(detail).toContain(SHARE_WORDING.declined)
+    expect(detail).not.toMatch(/\bdeclined\b/i)
+  })
+
+  it('names a named-partner form answer distinctly from an open one', () => {
+    const detail = answersConflictDetail(
+      shareBlock({
+        preference: 'no_share',
+        eligibility: 'named',
+        eligibility_source: 'form',
+        answers_conflict: true,
+      })
+    )
+    expect(detail).toMatch(/named/i)
+  })
+
+  it('never crashes on an unrecognised preference or eligibility value', () => {
+    // Same guard philosophy as `SharePreferenceChip`: a payload ahead of a
+    // type regen must degrade, not throw and take the whole card with it.
+    expect(() =>
+      answersConflictDetail({
+        ...shareBlock({ answers_conflict: true }),
+        preference: 'bogus' as unknown as SharePreferenceValue,
+        eligibility: 'bogus' as unknown as ShareEligibilityValue,
+      })
+    ).not.toThrow()
   })
 })
 

--- a/frontend/src/components/weekend/boardLayout.test.ts
+++ b/frontend/src/components/weekend/boardLayout.test.ts
@@ -854,6 +854,26 @@ describe('answersConflictDetail — which two answers disagreed, and which one w
     expect(detail).toMatch(/named/i)
   })
 
+  it('never attributes the resolved answer to the form when eligibility_source says otherwise', () => {
+    // DeriveShareEligibility (Go, lodging_requests.go) only ever sets
+    // `answers_conflict` true on its form-answered branch -- measured on 2026
+    // production, all 16 conflicting rows carry `eligibility_source: 'form'`.
+    // This reads the field rather than assuming it, so a future Go change or
+    // a stale mid-recompute row can never misattribute a registration-only
+    // verdict to a form the household may not have even returned.
+    const detail = answersConflictDetail(
+      shareBlock({
+        preference: 'no_share',
+        eligibility: 'open',
+        eligibility_source: 'registration',
+        answers_conflict: true,
+      })
+    )
+    expect(detail).not.toBeNull()
+    expect(detail).not.toMatch(/Family Camp form/i)
+    expect(detail).toMatch(/open to sharing/)
+  })
+
   it('never crashes on an unrecognised preference or eligibility value', () => {
     // Same guard philosophy as `SharePreferenceChip`: a payload ahead of a
     // type regen must degrade, not throw and take the whole card with it.

--- a/frontend/src/components/weekend/boardLayout.ts
+++ b/frontend/src/components/weekend/boardLayout.ts
@@ -43,7 +43,13 @@
  *    rooms is drawn on each of them, which is why an area's family count reads
  *    distinct `partyKey`s rather than slot entries.
  */
-import type { LodgingUnitRow, RosterPartyRow, ShareEligibilityValue } from '../../types/lodging'
+import type {
+  LodgingUnitRow,
+  RosterPartyRow,
+  ShareEligibilityValue,
+  ShareRequest,
+  SharePreferenceValue,
+} from '../../types/lodging'
 import { partyKey } from './partyKey'
 import {
   buildingsSpanned,
@@ -236,6 +242,82 @@ export const SHARE_WORDING = {
 /** The same phrase as a standalone chip label. One source, two positions. */
 export function shareWordingChip(phrase: string): string {
   return phrase.charAt(0).toUpperCase() + phrase.slice(1)
+}
+
+/**
+ * The REGISTRATION gate's answer, worded for a sentence rather than a chip.
+ *
+ * `preference` (`share_cabin_gate`) is a 3-state answer plus "never
+ * answered" — see `SharePreferenceChip`'s doc, which owns the CHIP-label
+ * spelling of the same four values. This is a distinct wording, not a
+ * duplicate: it exists to sit in a sentence fragment ("Registration said
+ * …"), where the chip's title-case labels ("Will not share") read oddly.
+ */
+const REGISTRATION_ANSWER: Record<SharePreferenceValue, string> = {
+  no_share: 'will not share',
+  maybe_mutual: 'only if a mutual match',
+  yes_share: 'open to sharing',
+  unknown: 'not answered',
+}
+
+/**
+ * The FAMILY CAMP FORM's resolved answer, worded for the same sentence.
+ *
+ * `declined` reuses `SHARE_WORDING.declined` rather than its own phrase —
+ * ONE definition of that claim, so the slot flag, the card's "did not
+ * request sharing" chip, and this tooltip cannot drift into three different
+ * wordings of a form that has no refusal option to record.
+ */
+const FORM_ANSWER: Record<ShareEligibilityValue, string> = {
+  open: 'open to sharing',
+  named: 'wants to share with a named family',
+  declined: SHARE_WORDING.declined,
+  unknown: 'not answered',
+}
+
+/**
+ * Guarded lookup — same philosophy as `SharePreferenceChip`'s `Object.hasOwn`
+ * guard on `CHIP`: a payload sent ahead of a type regen must degrade to the
+ * "not answered" phrasing rather than throw and take the whole card with it.
+ */
+function wordingFor<T extends string>(
+  table: Record<T, string>,
+  value: T,
+  fallback: string
+): string {
+  return Object.hasOwn(table, value) ? table[value] : fallback
+}
+
+/**
+ * The tooltip text for the per-party "answers disagree" chip (kindred#2083).
+ *
+ * The chip alone said only that the two forms disagreed, never which two
+ * answers or which one staff are acting on. This names both sides and the
+ * resolution in one sentence.
+ *
+ * Reads `preference` (the registration gate) and `eligibility` (the
+ * resolved verdict) directly rather than re-deriving either from `proximity`
+ * — `DeriveShareEligibility` only ever sets `answers_conflict` true on its
+ * form-answered branch (Go, `lodging_requests.go`), so whenever this
+ * returns non-null, `eligibility` already IS the Family Camp form's own
+ * answer, confirmed against 2026 production: all 16 conflicting households
+ * carry `eligibility_source: 'form'`.
+ *
+ * Returns null when there is nothing to report: no conflict, or no share
+ * block at all — the shape of an adult-weekend guest, who has no share
+ * question to disagree on (`_build_person_parties` attaches no share data).
+ * The caller gates the whole chip on this, rather than on the raw boolean,
+ * so a party this can't explain never renders an empty chip.
+ */
+export function answersConflictDetail(share: ShareRequest | undefined): string | null {
+  if (share?.answers_conflict !== true) return null
+  const registration = wordingFor(
+    REGISTRATION_ANSWER,
+    share.preference ?? 'unknown',
+    'not answered'
+  )
+  const form = wordingFor(FORM_ANSWER, share.eligibility ?? 'unknown', 'not answered')
+  return `Registration said ${registration}; the Family Camp form said ${form} — staff use the form's answer.`
 }
 
 /** A shared unit holding somebody who did not consent to sharing it. */

--- a/frontend/src/components/weekend/boardLayout.ts
+++ b/frontend/src/components/weekend/boardLayout.ts
@@ -296,12 +296,21 @@ function wordingFor<T extends string>(
  * resolution in one sentence.
  *
  * Reads `preference` (the registration gate) and `eligibility` (the
- * resolved verdict) directly rather than re-deriving either from `proximity`
- * — `DeriveShareEligibility` only ever sets `answers_conflict` true on its
- * form-answered branch (Go, `lodging_requests.go`), so whenever this
- * returns non-null, `eligibility` already IS the Family Camp form's own
- * answer, confirmed against 2026 production: all 16 conflicting households
- * carry `eligibility_source: 'form'`.
+ * resolved verdict) directly rather than re-deriving either from `proximity`.
+ * `DeriveShareEligibility` only ever sets `answers_conflict` true on its
+ * form-answered branch (Go, `lodging_requests.go`), so whenever this returns
+ * non-null, `eligibility` already IS the Family Camp form's own answer,
+ * confirmed against 2026 production: all 16 conflicting households carry
+ * `eligibility_source: 'form'`.
+ *
+ * That invariant is enforced only in a separate Go file, with nothing here
+ * to catch a future change or a stale mid-`family_camp_derived`-recompute
+ * row that briefly disagrees with it — so this still BRANCHES on
+ * `eligibility_source` rather than assuming it, and only names "the Family
+ * Camp form" when the field itself says so. Off that branch the resolved
+ * answer is worded as "the answer on file" instead: a claim this function
+ * can defend either way, matching `consentFlag`'s own rule of reporting only
+ * what was recorded.
  *
  * Returns null when there is nothing to report: no conflict, or no share
  * block at all — the shape of an adult-weekend guest, who has no share
@@ -316,8 +325,12 @@ export function answersConflictDetail(share: ShareRequest | undefined): string |
     share.preference ?? 'unknown',
     'not answered'
   )
-  const form = wordingFor(FORM_ANSWER, share.eligibility ?? 'unknown', 'not answered')
-  return `Registration said ${registration}; the Family Camp form said ${form} — staff use the form's answer.`
+  const resolved = wordingFor(FORM_ANSWER, share.eligibility ?? 'unknown', 'not answered')
+  const winner =
+    share.eligibility_source === 'form'
+      ? `the Family Camp form said ${resolved} — staff use the form's answer`
+      : `the answer on file is ${resolved} — staff use that answer`
+  return `Registration said ${registration}; ${winner}.`
 }
 
 /** A shared unit holding somebody who did not consent to sharing it. */


### PR DESCRIPTION
## Summary

The "Answers disagree" chip on a family card (weekend housing board) said only that the two share forms disagreed — never which two answers, or which one staff are acting on. This adds a hover tooltip naming both sides and the resolution.

- `answersConflictDetail` (`boardLayout.ts`) reads the already-resolved `preference` (registration gate) and `eligibility` (Family Camp form verdict) fields already on the roster payload — no new API schema field, and specifically no `shared_cabin_modes_raw`.
- The chip now gates on the computed detail, not the raw `answers_conflict` boolean, so a party this can't explain (structurally: a person-grain adult-weekend guest, which carries no share block at all) never renders an empty chip.
- Wording reuses `SHARE_WORDING.declined` ("did not request sharing") for a form decline, rather than a second "declined" spelling — the form has no refusal option, so it must never read as one.

## Measured

Re-verified against production (read-only) rather than trusting the issue body:

```
2026 conflicts (share_answers_conflict=1): 16
2026 conflicts NOT sourced from the form:  0
```

All 16 conflicting 2026 households resolve with `share_eligibility_source = 'form'` — confirming the form always wins, and that a conflicting party's `eligibility` field already *is* the form's own answer rather than something that needs re-deriving from `proximity`.

## Test plan
- [x] `boardLayout.test.ts`: `answersConflictDetail` — null on no conflict, null on no share block (adult weekend), names both sides + "form's answer" on a conflict, reuses `SHARE_WORDING.declined`, distinguishes `named` from `open`, never throws on an unrecognised value
- [x] `FamilyCard.test.tsx`: chip carries the detail as its `title`; no chip/tooltip when there's no conflict; no chip for a person-grain (adult weekend) party
- [x] `npx vitest run` — full frontend suite, 424 files / 6104 tests green
- [x] `tsc --noEmit` (both configs) — clean
- [x] `./node_modules/.bin/eslint` on touched files — 0 errors (2 pre-existing warnings unrelated to this change)
- [x] Mutation-checked: broke `answersConflictDetail` to return a fixed string (8 tests → RED across both files), and separately dropped the `title` prop wiring in the JSX (1 test → RED); both restored, transcript in PR comment

Closes #2083.