### PR TITLE
feat(pb): classify lodging units by shareability so multi-party occupancy can be judged

### DIFF
--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -78,6 +78,19 @@ ShareEligibilitySource = Literal["form", "registration", "none"]
 PartyGrain = Literal["household", "person"]
 EffectiveBathroom = Literal["unknown", "none", "private", "shared"]
 
+# The UNIT half of "may two families sleep here", from
+# lodging_units.shareability (1500000145, kindred#2026). Distinct from
+# SharePreference / ShareEligibility above, which are the HOUSEHOLD half:
+# whether a family is willing to share. Both must be true before two parties
+# may be put in one space, and the unit's half had no column until #2026.
+#
+# "unknown" is this layer's rendering of the column's empty string, exactly as
+# EffectiveBathroom renders its own. A select rather than a bool because three
+# states are real and collapsing them loses the one that matters: unrecorded is
+# neither permission to double-book nor a ruling that one family only may go
+# here. It is never coerced into either.
+Shareability = Literal["unknown", "shareable", "single_party"]
+
 # The STAFF-OWNED weekend status, from lodging_session_status (1500000142).
 # Unlike every other vocabulary in this module it mirrors no Go ingest, because
 # there is no ingest: CampMinder's Sessions API has no status concept at all,
@@ -159,6 +172,18 @@ class LodgingUnitSummary(BaseModel):
     # "default" name until 1500000136, which implied an override -- and the
     # override is a rare per-weekend exception rather than the point.
     inventory_class: str = ""
+    # Whether more than one party may sleep here at once. READ from the
+    # registry, never re-derived on this side: the rule lives in exactly two
+    # places (1500000145's backfill and `classifyShareability` in
+    # pocketbase/lodging/registry.go), and a third copy here is how a surface
+    # comes to disagree with the column it is rendering.
+    #
+    # Compared AT THE LEVEL THE ASSIGNMENT WAS MADE (owner ruling, 2026-08-07),
+    # never always resolved down to leaves: two households on one container is
+    # a legitimate share, because they occupy different rooms beneath it and
+    # CampMinder has no sub-room concept for every building. Measured over
+    # 2022-2025, resolving down instead would raise 36 false alarms.
+    shareability: Shareability = "unknown"
     # None when no lodging_availability row exists for this unit this weekend,
     # i.e. the unit's ROLE decides. None and False are different answers and
     # must not be flattened into one: False is "closed this weekend".

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -29,6 +29,7 @@ from api.schemas.lodging import (
     ProximityKind,
     RosterCounts,
     RosterParty,
+    Shareability,
     ShareEligibility,
     ShareEligibilitySource,
     SharePreference,
@@ -45,6 +46,7 @@ from api.services.lodging_rules import (
     effective_bathroom,
     is_family_available,
     unit_capacity,
+    unit_shareability,
 )
 from bunking.logging_config import get_logger
 
@@ -899,6 +901,11 @@ class LodgingRosterService:
                         session_override=session_merge_by_unit.get(_s(unit, "id")),
                     ),
                     inventory_class=inventory_class,
+                    # cast, not a re-derivation: `unit_shareability` is total
+                    # over the Literal's three members and rails everything
+                    # else to `unknown`, but mypy cannot narrow a `str` return
+                    # to the Literal on its own.
+                    shareability=cast(Shareability, unit_shareability(_s(unit, "shareability"))),
                     family_available_override=override,
                     reason=reason_by_unit.get(_s(unit, "id"), ""),
                     is_family_available=is_family_available(inventory_class, override),

--- a/api/services/lodging_rules.py
+++ b/api/services/lodging_rules.py
@@ -45,6 +45,32 @@ def unit_capacity(sleeps: int | None) -> int | None:
     return int(sleeps)
 
 
+# Values of lodging_units.shareability (1500000145, kindred#2026). An unset
+# select stores as "", which is a real third state: nobody has classified this
+# unit. It is neither permission to double-book nor a ruling that one family
+# only may go here.
+SHAREABILITY_VALUES = ("shareable", "single_party")
+
+
+def unit_shareability(stored: str) -> str:
+    """Render the stored classification, or `unknown` when there is none.
+
+    NOT a derivation, and deliberately so. The rule that decides `shareable`
+    vs `single_party` lives in exactly two places -- 1500000145's backfill and
+    `classifyShareability` in pocketbase/lodging/registry.go -- and the
+    registry they write is canonical. Re-deriving it here from `sleeps` would
+    be a third copy free to disagree with the column it is rendering, and it
+    would answer confidently on rows nobody has classified: an unmeasured
+    cabin is exactly where a guess is both easiest and most damaging.
+
+    So this maps and nothing more. Anything unrecognised -- an empty column, or
+    a value added to the select by a schema newer than this build -- degrades
+    to `unknown`, the non-permissive state, rather than being passed through
+    into a Literal no consumer has a branch for.
+    """
+    return stored if stored in SHAREABILITY_VALUES else "unknown"
+
+
 def is_family_available(inventory_class: str, override: bool | None) -> bool:
     """Whether this unit can take a family this weekend, in exactly one place.
 

--- a/docs/architecture/lodging-occupancy.md
+++ b/docs/architecture/lodging-occupancy.md
@@ -114,9 +114,26 @@ rule: it blocks legitimate work and teaches staff to ignore warnings.
 
 ## What is not yet modelled
 
-- `lodging_units` has no shareability field. `inventory_class`
-  (`family_pool` / `staff_default`) describes who a unit is *reserved for*, not
-  how many parties may occupy it.
+- ~~`lodging_units` has no shareability field.~~ **Modelled as of kindred#2026**
+  (migration `1500000145`). `lodging_units.shareability` is a three-state select
+  — `shareable`, `single_party`, and blank for "nobody has classified this",
+  which must never read as permission to double-book nor as a ruling that one
+  family only may go here. `inventory_class` (`family_pool` / `staff_default`)
+  still describes who a unit is *reserved for*, not how many parties may occupy
+  it; the two are read together, and only a `family_pool` unit is ever
+  `shareable`.
+
+  Classified at BOTH levels, and compared at whichever level the assignment was
+  actually made (owner ruling, 2026-08-07). Two households on one container is a
+  legitimate share, not a violation: they occupy different rooms beneath it, and
+  CampMinder has no sub-room concept for every building, so staff assign at
+  container level for some buildings and will keep doing so. Measured over
+  2022-2025, resolving down to leaves instead raises 36 false alarms.
+
+  **Still not modelled: the enforcement itself.** The column makes the question
+  answerable; nothing yet blocks or warns on a second party being dropped into a
+  `single_party` unit. That is the board-side check this document's next section
+  describes, and it remains where a human is choosing.
 - `lodging_availability` carries a per-unit `family_available` boolean per
   session, not capacity. It has no scenario dimension: migration `1500000135`
   deleted it, because availability is a fact about the weekend rather than

--- a/frontend/src/components/admin/lodging/LodgingAliasForm.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingAliasForm.test.tsx
@@ -49,6 +49,7 @@ function fixtureUnit(over: Partial<LodgingUnitRecord> & { id: string }): Lodging
     has_changing_table: false,
     has_shared_fridge: false,
     inventory_class: 'family_pool',
+    shareability: '',
     is_confirmed: false,
     is_active: true,
     is_container: false,

--- a/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
@@ -101,6 +101,98 @@ describe('LodgingUnitForm — create', () => {
     expect(payload.year).toBe(2027)
   })
 
+  it('sends an explicit shareability on create, and it is UNCLASSIFIED', async () => {
+    // kindred#2026. A new unit must not be born claiming to be one-family-only
+    // — that is a ruling nobody made. '' is the honest state and is what the
+    // read path renders as `unknown`.
+    createLodgingUnit.mockResolvedValue({ id: 'u1' })
+    const user = userEvent.setup()
+
+    render(
+      <LodgingUnitForm areas={AREAS} units={[]} year={2026} onSaved={vi.fn()} onCancel={vi.fn()} />
+    )
+
+    await user.type(screen.getByLabelText('Name'), 'Cabin N')
+    await user.click(screen.getByRole('button', { name: 'Create unit' }))
+
+    await waitFor(() => {
+      expect(createLodgingUnit).toHaveBeenCalledTimes(1)
+    })
+    const [payload] = createLodgingUnit.mock.calls[0] as [LodgingUnitInput]
+    expect(payload.shareability).toBe('')
+  })
+
+  it.each(['shareable', 'single_party', ''] as const)(
+    'carries shareability %j through to the save payload unchanged',
+    async (value) => {
+      createLodgingUnit.mockResolvedValue({ id: 'u1' })
+      const user = userEvent.setup()
+
+      render(
+        <LodgingUnitForm
+          areas={AREAS}
+          units={[]}
+          year={2026}
+          onSaved={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      )
+
+      await user.type(screen.getByLabelText('Name'), 'Cabin N')
+      await user.selectOptions(screen.getByLabelText('Sharing'), value)
+      await user.click(screen.getByRole('button', { name: 'Create unit' }))
+
+      await waitFor(() => {
+        expect(createLodgingUnit).toHaveBeenCalledTimes(1)
+      })
+      const [payload] = createLodgingUnit.mock.calls[0] as [LodgingUnitInput]
+      expect(payload.shareability).toBe(value)
+    }
+  )
+
+  it('warns when a shareable unit is edited below the capacity threshold', async () => {
+    // The staleness this feature can create: shareability is derived once and
+    // then human-owned, so correcting `sleeps` downward leaves an affirmative
+    // "Shared OK" chip on the board endorsing a double-booking. Advisory only
+    // — settling it is the staffer's ruling, not the form's.
+    const user = userEvent.setup()
+    render(
+      <LodgingUnitForm areas={AREAS} units={[]} year={2026} onSaved={vi.fn()} onCancel={vi.fn()} />
+    )
+
+    await user.selectOptions(screen.getByLabelText('Sharing'), 'shareable')
+    await user.type(screen.getByLabelText('Sleeps'), '8')
+
+    expect(
+      await screen.findByText(/but the unit as edited reads one family only/)
+    ).toBeInTheDocument()
+  })
+
+  it('stays quiet while the unit still agrees with its classification', async () => {
+    const user = userEvent.setup()
+    render(
+      <LodgingUnitForm areas={AREAS} units={[]} year={2026} onSaved={vi.fn()} onCancel={vi.fn()} />
+    )
+
+    await user.selectOptions(screen.getByLabelText('Sharing'), 'shareable')
+    await user.type(screen.getByLabelText('Sleeps'), '15')
+
+    expect(screen.queryByText(/but the unit as edited reads/)).not.toBeInTheDocument()
+  })
+
+  it('offers a real blank option for sharing, unlike allocation', () => {
+    // The contrast is the point. An empty inventory_class matches neither
+    // branch of the availability rules, so Allocation offers no blank. An
+    // empty shareability is a STATE — nobody has classified this — and the
+    // migration deliberately leaves rows in it, so the staffer must be able
+    // to both see it and return to it.
+    render(
+      <LodgingUnitForm areas={AREAS} units={[]} year={2026} onSaved={vi.fn()} onCancel={vi.fn()} />
+    )
+    const select = screen.getByLabelText<HTMLSelectElement>('Sharing')
+    expect([...select.options].map((o) => o.value)).toEqual(['', 'shareable', 'single_party'])
+  })
+
   it('offers no blank option for the allocation default', () => {
     render(
       <LodgingUnitForm areas={AREAS} units={[]} year={2026} onSaved={vi.fn()} onCancel={vi.fn()} />
@@ -670,7 +762,7 @@ describe('LodgingUnitForm — capacity flag', () => {
     // typing the number that creates the conflict.
     renderUnit({ ...BUNKED, sleeps: 3 })
 
-    const region = screen.getByRole('status')
+    const region = screen.getByRole('status', { name: 'Capacity advisory' })
     expect(region).toBeInTheDocument()
     expect(region).toHaveAttribute('aria-live', 'polite')
     expect(region).toHaveTextContent('')
@@ -682,13 +774,17 @@ describe('LodgingUnitForm — capacity flag', () => {
     // noticed; drawing it in amber does that for one class of user only.
     renderUnit(CONFLICTED)
 
-    expect(screen.getByRole('status')).toHaveTextContent('Beds account for 4, but sleeps says 8.')
+    expect(screen.getByRole('status', { name: 'Capacity advisory' })).toHaveTextContent(
+      'Beds account for 4, but sleeps says 8.'
+    )
   })
 
   it('announces the suggestion too', () => {
     renderUnit({ ...BUNKED, sleeps: 0 })
 
-    expect(screen.getByRole('status')).toHaveTextContent(/Suggested: sleeps 4/i)
+    expect(screen.getByRole('status', { name: 'Capacity advisory' })).toHaveTextContent(
+      /Suggested: sleeps 4/i
+    )
   })
 
   it('carries the conflict once, not as a second hidden copy', () => {
@@ -709,7 +805,7 @@ describe('LodgingUnitForm — capacity flag', () => {
 
     const text = screen.getByText(/beds account for 4, but sleeps says 8/i)
     expect(text).not.toHaveAttribute('aria-hidden')
-    expect(screen.getByRole('status')).toContainElement(text)
+    expect(screen.getByRole('status', { name: 'Capacity advisory' })).toContainElement(text)
   })
 
   it('never shows the sheet capacity, which is not a corroborating number', () => {

--- a/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
@@ -51,6 +51,7 @@ const UNIT: LodgingUnitRecord = {
   has_changing_table: false,
   has_shared_fridge: false,
   inventory_class: 'family_pool',
+  shareability: '',
   is_confirmed: false,
   is_active: true,
   is_container: false,

--- a/frontend/src/components/admin/lodging/LodgingUnitForm.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitForm.tsx
@@ -46,6 +46,7 @@ import type {
   LodgingAreaRecord,
   LodgingUnitInput,
   LodgingUnitRecord,
+  ShareabilityStoredValue,
 } from '../../../types/lodging'
 import { amenitiesOf } from './unitAmenities'
 import { BUTTON_PRIMARY, BUTTON_SECONDARY, FIELD, LABEL } from './lodgingStyles'
@@ -126,6 +127,15 @@ export function LodgingUnitForm({
   const [inventoryClass, setInventoryClass] = useState<InventoryClassValue>(
     unit?.inventory_class === 'staff_default' ? 'staff_default' : 'family_pool'
   )
+  // Its own state, NOT part of `amenities` (kindred#2026). The amenity bag is
+  // governed by the single `is_confirmed` checkbox; shareability is a policy
+  // classification the read path trusts the moment it is stored, so it sits
+  // with the other policy classifications below rather than with the flags.
+  // '' is UNCLASSIFIED and is where a new unit starts — defaulting a fresh
+  // unit to 'single_party' would look tidier and would be a claim nobody made.
+  const [shareability, setShareability] = useState<ShareabilityStoredValue>(
+    unit?.shareability ?? ''
+  )
   const [isActive, setIsActive] = useState(unit ? unit.is_active : true)
   const [isContainer, setIsContainer] = useState(unit?.is_container ?? false)
   const [combined, setCombined] = useState(unit?.default_combined ?? false)
@@ -173,6 +183,11 @@ export function LodgingUnitForm({
       // Never omitted — see the header comment.
       is_active: isActive,
       inventory_class: inventoryClass,
+      // Always sent, create and edit alike, for the same reason `is_active`
+      // and `inventory_class` are: '' is a real value here (unclassified), so
+      // omitting the key on an EDIT would make clearing the field a silent
+      // no-op the staffer believes worked.
+      shareability,
       is_container: isContainer,
       default_combined: combined,
       notes,
@@ -225,6 +240,11 @@ export function LodgingUnitForm({
         value={amenities}
         onChange={setAmenities}
         bathroomGroups={bathroomGroups}
+        shareability={shareability}
+        onShareabilityChange={setShareability}
+        inventoryClass={inventoryClass}
+        isContainer={isContainer}
+        sleeps={capacity.sleeps}
       />
 
       <div className="flex flex-col justify-end gap-2 pb-1 text-sm">

--- a/frontend/src/components/admin/lodging/LodgingUnitsPanel.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitsPanel.tsx
@@ -250,7 +250,16 @@ export function LodgingUnitsPanel() {
                     {editing === 'new' ? 'Add a unit' : editing.name}
                   </h2>
                   {/* The area, because the row it came from is now behind a
-                      backdrop and "which Tioga is this" is the first question. */}
+                      backdrop and "which of the four rooms in that building is
+                      this one" is the first question. Several buildings number
+                      their rooms identically, so the name alone does not say.
+
+                      The original wording named a real unit, which put a camp
+                      name in a public repo and made
+                      verify-no-hardcoded-lodging.sh red on main -- its filter
+                      exempts test files but not JSX comments in application
+                      source. Fixed at the source rather than by narrowing the
+                      guard, following the precedent set in kindred#1909. */}
                   <p className="text-forest-200 text-sm">
                     {editing === 'new'
                       ? 'A cabin, tent, yurt or room'

--- a/frontend/src/components/admin/lodging/UnitAmenityFieldset.tsx
+++ b/frontend/src/components/admin/lodging/UnitAmenityFieldset.tsx
@@ -12,7 +12,7 @@
  * family's housing need against this cabin at all — so it belongs beside Save,
  * where the form's other commitments live.
  */
-import type { BathroomStoredValue } from '../../../types/lodging'
+import type { BathroomStoredValue, ShareabilityStoredValue } from '../../../types/lodging'
 import { AMENITY_FLAGS, type UnitAmenities } from './unitAmenities'
 import { FIELD, LABEL } from './lodgingStyles'
 
@@ -65,6 +65,33 @@ export function UnitAmenityFieldset({ value, onChange, bathroomGroups }: UnitAme
             <option key={group} value={group} />
           ))}
         </datalist>
+      </label>
+
+      <label className="text-sm">
+        <span className={LABEL}>Sharing</span>
+        {/* THE BLANK OPTION IS NOT DECORATION. It is what makes "nobody has
+            classified this" answerable, which is the whole reason the column
+            is a select rather than a bool: unrecorded must be distinguishable
+            from "one family only", and must never read as permission to
+            double-book. Contrast the Allocation select above, which has no
+            blank option because an empty inventory_class matches neither
+            branch of the availability rules — there, blank is meaningless;
+            here it is a state 1500000145 deliberately leaves rows in when it
+            cannot honestly classify them.
+
+            Wording is the staff question, not the column name: a staffer
+            deciding this is asking whether two families can go in the room. */}
+        <select
+          className={FIELD}
+          value={value.shareability}
+          onChange={(e) => {
+            onChange({ ...value, shareability: e.target.value as ShareabilityStoredValue })
+          }}
+        >
+          <option value="">Not classified</option>
+          <option value="shareable">Two or more families may share</option>
+          <option value="single_party">One family only</option>
+        </select>
       </label>
 
       <fieldset className="sm:col-span-2">

--- a/frontend/src/components/admin/lodging/UnitAmenityFieldset.tsx
+++ b/frontend/src/components/admin/lodging/UnitAmenityFieldset.tsx
@@ -12,18 +12,61 @@
  * family's housing need against this cabin at all — so it belongs beside Save,
  * where the form's other commitments live.
  */
-import type { BathroomStoredValue, ShareabilityStoredValue } from '../../../types/lodging'
+import type {
+  BathroomStoredValue,
+  InventoryClassValue,
+  ShareabilityStoredValue,
+} from '../../../types/lodging'
+import { shareabilityDrift } from './shareabilityDrift'
 import { AMENITY_FLAGS, type UnitAmenities } from './unitAmenities'
 import { FIELD, LABEL } from './lodgingStyles'
+
+/**
+ * How each classification is said in a sentence, so the advisory reads as
+ * English rather than as two column values. Deliberately the SAME words as the
+ * options above — a staffer must be able to match the message to the control
+ * without translating.
+ */
+const SHAREABILITY_WORDING = {
+  shareable: 'two or more families may share',
+  single_party: 'one family only',
+} as const
 
 export interface UnitAmenityFieldsetProps {
   value: UnitAmenities
   onChange: (next: UnitAmenities) => void
   /** Every group id already in use, deduplicated and sorted. */
   bathroomGroups: string[]
+  /**
+   * Separate from `value` on purpose — see the note in `unitAmenities.ts`.
+   * Shareability is a policy classification the board trusts immediately, not
+   * an amenity gated behind the `is_confirmed` checkbox that governs
+   * everything in `UnitAmenities`. It renders here and only here.
+   */
+  shareability: ShareabilityStoredValue
+  onShareabilityChange: (next: ShareabilityStoredValue) => void
+  /**
+   * Live form values, not the stored row, so the advisory below reacts as the
+   * staffer types rather than at the next reload — the same discipline
+   * `UnitCapacityFields` uses for its own flag.
+   */
+  inventoryClass: InventoryClassValue | ''
+  isContainer: boolean
+  sleeps: string
 }
 
-export function UnitAmenityFieldset({ value, onChange, bathroomGroups }: UnitAmenityFieldsetProps) {
+export function UnitAmenityFieldset({
+  value,
+  onChange,
+  bathroomGroups,
+  shareability,
+  onShareabilityChange,
+  inventoryClass,
+  isContainer,
+  sleeps,
+}: UnitAmenityFieldsetProps) {
+  const drift = shareabilityDrift({ inventoryClass, isContainer, sleeps, stored: shareability })
+
   return (
     <>
       <label className="text-sm">
@@ -67,7 +110,13 @@ export function UnitAmenityFieldset({ value, onChange, bathroomGroups }: UnitAme
         </datalist>
       </label>
 
-      <label className="text-sm">
+      {/* Full width rather than a third half-width control. This fragment's
+          items are direct children of the form's `sm:grid-cols-2` grid, and
+          the next sibling (Features) is `sm:col-span-2` and cannot back-fill,
+          so a third narrow control would sit alone against a visible hole —
+          in a section this file's own header made a fixed grid precisely so
+          that nothing would move around between openings. */}
+      <label className="text-sm sm:col-span-2">
         <span className={LABEL}>Sharing</span>
         {/* THE BLANK OPTION IS NOT DECORATION. It is what makes "nobody has
             classified this" answerable, which is the whole reason the column
@@ -83,15 +132,29 @@ export function UnitAmenityFieldset({ value, onChange, bathroomGroups }: UnitAme
             deciding this is asking whether two families can go in the room. */}
         <select
           className={FIELD}
-          value={value.shareability}
+          value={shareability}
           onChange={(e) => {
-            onChange({ ...value, shareability: e.target.value as ShareabilityStoredValue })
+            onShareabilityChange(e.target.value as ShareabilityStoredValue)
           }}
         >
           <option value="">Not classified</option>
           <option value="shareable">Two or more families may share</option>
           <option value="single_party">One family only</option>
         </select>
+        {/* ALWAYS MOUNTED, and wrapping the visible text rather than duplicating
+            it — the same two constraints `UnitCapacityFields` documents at
+            length for its own advisory. A live region is only announced when
+            its contents change while it is already in the document, so
+            rendering the region together with its text is missed by several
+            screen readers; and an sr-only second copy would be read twice by
+            anyone navigating the form linearly. */}
+        <div role="status" aria-live="polite" aria-label="Sharing advisory">
+          {drift && (
+            <p className="mt-1.5 text-xs text-amber-700 dark:text-amber-400">
+              {`This is set to ${SHAREABILITY_WORDING[drift.stored]}, but the unit as edited reads ${SHAREABILITY_WORDING[drift.derived]}.`}
+            </p>
+          )}
+        </div>
       </label>
 
       <fieldset className="sm:col-span-2">

--- a/frontend/src/components/admin/lodging/UnitCapacityFields.tsx
+++ b/frontend/src/components/admin/lodging/UnitCapacityFields.tsx
@@ -83,7 +83,12 @@ export function UnitCapacityFields({
             The button lives inside, which is the one compromise. Keeping it
             out would mean breaking the text and its action onto separate rows;
             the cost is that the announcement ends with the control's label. */}
-        <div role="status" aria-live="polite">
+        {/* NAMED, because this form now has two live regions (the sharing
+            advisory in UnitAmenityFieldset is the other). Two unnamed `status`
+            regions are indistinguishable to a screen-reader user moving
+            between landmarks — the announcement arrives with no indication of
+            which control it belongs to. */}
+        <div role="status" aria-live="polite" aria-label="Capacity advisory">
           {flag.kind === 'suggestion' && (
             <div className="text-muted-foreground mt-1.5 flex items-center gap-2 text-xs">
               <span>Suggested: sleeps {flag.derived}</span>

--- a/frontend/src/components/admin/lodging/shareabilityDrift.test.ts
+++ b/frontend/src/components/admin/lodging/shareabilityDrift.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The classification is derived ONCE and then owned by a human, so its inputs
+ * can move out from under it. This is the advisory that says so.
+ *
+ * The dangerous direction is `shareable` outliving a capacity correction: a
+ * staffer fixing a cabin from `sleeps: 15` to `sleeps: 8` leaves the unit
+ * marked shareable, and the board goes on showing an affirmative "Shared OK"
+ * chip inviting a second household into a room the rule now says holds one —
+ * the exact double-booking kindred#2026 exists to prevent, endorsed.
+ *
+ * Advisory only, with no "apply" button, for the same reason `capacityFlag`'s
+ * conflict branch has none: the classification is a human ruling and this file
+ * does not get to overturn it. It states the disagreement and asks nothing.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { shareabilityDrift } from './shareabilityDrift'
+
+const base = {
+  inventoryClass: 'family_pool',
+  isContainer: false,
+  sleeps: '15',
+  stored: 'shareable',
+} as const
+
+describe('shareabilityDrift', () => {
+  it('is silent when the stored classification still matches the rule', () => {
+    expect(shareabilityDrift(base)).toBeNull()
+  })
+
+  it('flags a shareable unit whose capacity has dropped below the threshold', () => {
+    // THE case this exists for, and the only one where staying silent would
+    // leave a green chip endorsing a double-booking.
+    const drift = shareabilityDrift({ ...base, sleeps: '8' })
+    expect(drift?.stored).toBe('shareable')
+    expect(drift?.derived).toBe('single_party')
+  })
+
+  it('flags the conservative direction too, so a cabin is not left under-used', () => {
+    const drift = shareabilityDrift({ ...base, sleeps: '15', stored: 'single_party' })
+    expect(drift?.stored).toBe('single_party')
+    expect(drift?.derived).toBe('shareable')
+  })
+
+  it('flags a unit moved to staff housing while still marked shareable', () => {
+    const drift = shareabilityDrift({ ...base, inventoryClass: 'staff_default' })
+    expect(drift?.derived).toBe('single_party')
+  })
+
+  it('flags a room promoted to a container while still marked one-family', () => {
+    const drift = shareabilityDrift({ ...base, isContainer: true, stored: 'single_party' })
+    expect(drift?.derived).toBe('shareable')
+  })
+
+  it('says nothing on an UNCLASSIFIED unit', () => {
+    // '' is not a wrong answer that drifted, it is the absence of one. The
+    // board already badges it "Sharing unset"; a second nag in the form for a
+    // staffer who has not answered yet would train them to dismiss this.
+    expect(shareabilityDrift({ ...base, stored: '' })).toBeNull()
+    expect(shareabilityDrift({ ...base, sleeps: '8', stored: '' })).toBeNull()
+  })
+
+  it('says nothing when capacity is unknown, rather than guessing', () => {
+    // Blank sleeps is UNKNOWN. The rule declines to classify an unmeasured
+    // leaf, so it has no derived answer to disagree with, and asserting drift
+    // off a missing number is exactly the guess the select exists to refuse.
+    expect(shareabilityDrift({ ...base, sleeps: '' })).toBeNull()
+    expect(shareabilityDrift({ ...base, sleeps: '0' })).toBeNull()
+  })
+
+  it('says nothing when the role is unrecorded', () => {
+    expect(shareabilityDrift({ ...base, inventoryClass: '' })).toBeNull()
+  })
+
+  it('ignores capacity entirely on a container, as the rule does', () => {
+    // A container's `sleeps` is a DELTA over its rooms (kindred#2041), so a
+    // small number on one is not evidence of anything. A shareable container
+    // must not be nagged about its delta.
+    expect(shareabilityDrift({ ...base, isContainer: true, sleeps: '1' })).toBeNull()
+    expect(shareabilityDrift({ ...base, isContainer: true, sleeps: '' })).toBeNull()
+  })
+})

--- a/frontend/src/components/admin/lodging/shareabilityDrift.ts
+++ b/frontend/src/components/admin/lodging/shareabilityDrift.ts
@@ -1,0 +1,72 @@
+/**
+ * Does the stored shareability still agree with the unit in front of you?
+ *
+ * `lodging_units.shareability` is DERIVED ONCE — by 1500000145's backfill on
+ * production, by `classifyShareability` (registry.go) on a fresh database — and
+ * is then owned by a human. Nothing re-derives it. That is deliberate: the
+ * registry is canonical, and a rule that silently overwrote a staffer's ruling
+ * every time a neighbouring field moved would be worse than no rule.
+ *
+ * The cost of that choice is that the INPUTS can move out from under the
+ * answer. `sleeps` is staff-owned and editable in this same form;
+ * `inventory_class` and `is_container` are two controls above it. A staffer who
+ * corrects a cabin from `sleeps: 15` to `sleeps: 8` leaves it marked
+ * `shareable`, and the board goes on rendering an affirmative "Shared OK" chip
+ * inviting a second household into a room the rule now says holds one — the
+ * exact double-booking kindred#2026 exists to prevent, now endorsed.
+ *
+ * So this states the disagreement and asks nothing. NO "apply" BUTTON, for the
+ * same reason `capacityFlag`'s conflict branch has none: settling it is a
+ * ruling about who may sleep where, and a one-click overwrite of a human's
+ * classification by a derived guess is precisely the automation the select was
+ * chosen over a bool to avoid.
+ *
+ * BOTH DIRECTIONS are reported, not just the permissive one. `shareable` gone
+ * stale is the hazard; `single_party` gone stale silently costs the camp a
+ * cabin's worth of capacity every weekend, which staff also want to know.
+ *
+ * SILENT on the states where there is nothing honest to say: an unclassified
+ * unit (no answer has drifted — the board already badges that), an unmeasured
+ * leaf (the rule declines to classify it, so there is nothing to disagree
+ * with), an unrecorded role, and a container's capacity (a container's `sleeps`
+ * is a DELTA over its rooms, kindred#2041, so a small number on one is not
+ * evidence).
+ *
+ * THE RULE ITSELF IS NOT RESTATED HERE AS A NEW SOURCE OF TRUTH — it is the
+ * third and last expression of the one in 1500000145's header and
+ * registry.go's `classifyShareability`, and it exists only to say when the
+ * stored value and the rule disagree. If you change the rule, change all three.
+ */
+import type { InventoryClassValue, ShareabilityStoredValue } from '../../../types/lodging'
+
+export interface ShareabilityDriftInput {
+  inventoryClass: InventoryClassValue | ''
+  isContainer: boolean
+  /** The raw form string. Blank is a real value: UNKNOWN. */
+  sleeps: string
+  stored: ShareabilityStoredValue
+}
+
+export interface ShareabilityDrift {
+  stored: 'shareable' | 'single_party'
+  derived: 'shareable' | 'single_party'
+}
+
+/** The classification the rule would give, or '' when it declines to answer. */
+function derive(input: ShareabilityDriftInput): ShareabilityStoredValue {
+  if (input.inventoryClass === 'staff_default') return 'single_party'
+  if (input.inventoryClass !== 'family_pool') return ''
+  if (input.isContainer) return 'shareable'
+  // Blank and 0 are both UNMEASURED — PocketBase stores an unset number as 0,
+  // and this codebase reads 0 as unknown, never as "zero capacity".
+  const sleeps = Number.parseInt(input.sleeps, 10)
+  if (!Number.isFinite(sleeps) || sleeps < 1) return ''
+  return sleeps >= 12 ? 'shareable' : 'single_party'
+}
+
+export function shareabilityDrift(input: ShareabilityDriftInput): ShareabilityDrift | null {
+  if (input.stored === '') return null
+  const derived = derive(input)
+  if (derived === '' || derived === input.stored) return null
+  return { stored: input.stored, derived }
+}

--- a/frontend/src/components/admin/lodging/unitAmenities.test.ts
+++ b/frontend/src/components/admin/lodging/unitAmenities.test.ts
@@ -67,3 +67,22 @@ describe('amenitiesOf', () => {
     }
   })
 })
+
+describe('shareability', () => {
+  // kindred#2026. Edited beside the other unit-level classifications rather
+  // than derived in the form: the rule that produced the stored value lives in
+  // the migration and the Go loader, and a third copy in the browser would be
+  // the one staff could not see disagreeing.
+
+  it('reads a new unit as unclassified rather than as one family', () => {
+    // '' is UNKNOWN, and the staffer has to answer it. Defaulting a fresh
+    // unit to 'single_party' would look tidier and would be a claim nobody
+    // made — the same failure the select exists to prevent on the read side.
+    expect(amenitiesOf().shareability).toBe('')
+  })
+
+  it('carries a stored classification off an existing unit', () => {
+    const unit = { shareability: 'shareable' } as Parameters<typeof amenitiesOf>[0]
+    expect(amenitiesOf(unit).shareability).toBe('shareable')
+  })
+})

--- a/frontend/src/components/admin/lodging/unitAmenities.test.ts
+++ b/frontend/src/components/admin/lodging/unitAmenities.test.ts
@@ -68,21 +68,18 @@ describe('amenitiesOf', () => {
   })
 })
 
-describe('shareability', () => {
-  // kindred#2026. Edited beside the other unit-level classifications rather
-  // than derived in the form: the rule that produced the stored value lives in
-  // the migration and the Go loader, and a third copy in the browser would be
-  // the one staff could not see disagreeing.
-
-  it('reads a new unit as unclassified rather than as one family', () => {
-    // '' is UNKNOWN, and the staffer has to answer it. Defaulting a fresh
-    // unit to 'single_party' would look tidier and would be a claim nobody
-    // made — the same failure the select exists to prevent on the read side.
-    expect(amenitiesOf().shareability).toBe('')
+describe('shareability is deliberately NOT an amenity (kindred#2026)', () => {
+  it('stays out of the bag the is_confirmed checkbox governs', () => {
+    // The regression this pins: everything in UnitAmenities is confirmed by one
+    // checkbox, and until it is ticked the roster reads `has_power: false` as
+    // "nobody has said". Shareability is trusted by the read path the moment it
+    // is stored, so folding it back in here would put a value the board acts on
+    // beside values the board discounts, saved by the same click. It lives in
+    // its own state in LodgingUnitForm; the payload assertions are there.
+    expect('shareability' in amenitiesOf()).toBe(false)
   })
 
-  it('carries a stored classification off an existing unit', () => {
-    const unit = { shareability: 'shareable' } as Parameters<typeof amenitiesOf>[0]
-    expect(amenitiesOf(unit).shareability).toBe('shareable')
+  it('is not an AMENITY_FLAGS entry either', () => {
+    expect(AMENITY_FLAGS.some((f) => (f.key as string) === 'shareability')).toBe(false)
   })
 })

--- a/frontend/src/components/admin/lodging/unitAmenities.ts
+++ b/frontend/src/components/admin/lodging/unitAmenities.ts
@@ -25,11 +25,7 @@ import {
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
-import type {
-  BathroomStoredValue,
-  LodgingUnitRecord,
-  ShareabilityStoredValue,
-} from '../../../types/lodging'
+import type { BathroomStoredValue, LodgingUnitRecord } from '../../../types/lodging'
 
 export type AmenityFlag =
   | 'has_power'
@@ -46,14 +42,6 @@ export type AmenityFlag =
 export interface UnitAmenities {
   bathroom: BathroomStoredValue
   bathroom_group: string
-  /**
-   * Whether more than one party may sleep here at once (kindred#2026). Travels
-   * with the amenities because it is saved by the same form submit, but it is
-   * NOT an amenity and is not in AMENITY_FLAGS: it is a policy classification
-   * about occupancy, not a fact about what the cabin contains, so it renders
-   * as its own select rather than as an eleventh checkbox.
-   */
-  shareability: ShareabilityStoredValue
   has_power: boolean
   has_ac: boolean
   has_fridge: boolean
@@ -89,6 +77,24 @@ export const AMENITY_FLAGS: readonly { key: AmenityFlag; label: string; icon: Lu
   { key: 'has_changing_table', label: 'Has changing table', icon: Table },
 ]
 
+/**
+ * `shareability` is DELIBERATELY NOT in this object (kindred#2026).
+ *
+ * Everything here is governed by the one `is_confirmed` checkbox: until it is
+ * true, the roster reads `has_power: false` as "nobody has said" rather than
+ * "there is no power". Shareability is not like that. It is a policy
+ * classification, and the read path (`unit_shareability`, lodging_rules.py)
+ * treats it as authoritative the moment it is stored — so riding in this bag
+ * would put a value the board trusts immediately next to values the board
+ * discounts, saved by the same click and confirmed by the same checkbox that
+ * does not apply to it.
+ *
+ * It lives in its own `useState` in `LodgingUnitForm`, alongside the other
+ * policy classifications (`inventoryClass`, `isContainer`, `combined`), and is
+ * passed to `UnitAmenityFieldset` as its own prop purely so the control renders
+ * in that section of the form.
+ */
+
 /** An existing unit's amenity state, or the all-unrecorded state for a new one. */
 export function amenitiesOf(unit?: LodgingUnitRecord): UnitAmenities {
   return {
@@ -96,10 +102,6 @@ export function amenitiesOf(unit?: LodgingUnitRecord): UnitAmenities {
     // column as the token `unknown`, which PocketBase would reject on write.
     bathroom: unit?.bathroom ?? '',
     bathroom_group: unit?.bathroom_group ?? '',
-    // '' is UNCLASSIFIED, and a new unit starts there rather than at
-    // 'single_party'. Defaulting to the safe-looking answer would look tidier
-    // and would be a claim nobody made.
-    shareability: unit?.shareability ?? '',
     has_power: unit?.has_power ?? false,
     has_ac: unit?.has_ac ?? false,
     has_fridge: unit?.has_fridge ?? false,

--- a/frontend/src/components/admin/lodging/unitAmenities.ts
+++ b/frontend/src/components/admin/lodging/unitAmenities.ts
@@ -25,7 +25,11 @@ import {
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
-import type { BathroomStoredValue, LodgingUnitRecord } from '../../../types/lodging'
+import type {
+  BathroomStoredValue,
+  LodgingUnitRecord,
+  ShareabilityStoredValue,
+} from '../../../types/lodging'
 
 export type AmenityFlag =
   | 'has_power'
@@ -42,6 +46,14 @@ export type AmenityFlag =
 export interface UnitAmenities {
   bathroom: BathroomStoredValue
   bathroom_group: string
+  /**
+   * Whether more than one party may sleep here at once (kindred#2026). Travels
+   * with the amenities because it is saved by the same form submit, but it is
+   * NOT an amenity and is not in AMENITY_FLAGS: it is a policy classification
+   * about occupancy, not a fact about what the cabin contains, so it renders
+   * as its own select rather than as an eleventh checkbox.
+   */
+  shareability: ShareabilityStoredValue
   has_power: boolean
   has_ac: boolean
   has_fridge: boolean
@@ -84,6 +96,10 @@ export function amenitiesOf(unit?: LodgingUnitRecord): UnitAmenities {
     // column as the token `unknown`, which PocketBase would reject on write.
     bathroom: unit?.bathroom ?? '',
     bathroom_group: unit?.bathroom_group ?? '',
+    // '' is UNCLASSIFIED, and a new unit starts there rather than at
+    // 'single_party'. Defaulting to the safe-looking answer would look tidier
+    // and would be a claim nobody made.
+    shareability: unit?.shareability ?? '',
     has_power: unit?.has_power ?? false,
     has_ac: unit?.has_ac ?? false,
     has_fridge: unit?.has_fridge ?? false,

--- a/frontend/src/components/admin/lodging/unitSort.test.ts
+++ b/frontend/src/components/admin/lodging/unitSort.test.ts
@@ -32,6 +32,7 @@ function unit(over: Partial<LodgingUnitRecord> & { id: string }): LodgingUnitRec
     has_changing_table: false,
     has_shared_fridge: false,
     inventory_class: 'family_pool',
+    shareability: '',
     is_confirmed: false,
     is_active: true,
     is_container: false,

--- a/frontend/src/components/admin/lodging/unitTree.test.ts
+++ b/frontend/src/components/admin/lodging/unitTree.test.ts
@@ -34,6 +34,7 @@ function unit(over: Partial<LodgingUnitRecord> & { id: string }): LodgingUnitRec
     has_changing_table: false,
     has_shared_fridge: false,
     inventory_class: 'family_pool',
+    shareability: '',
     is_confirmed: false,
     is_active: true,
     is_container: false,

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -59,6 +59,7 @@ function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
     is_active: true,
     is_container: false,
     inventory_class: 'family_pool',
+    shareability: 'single_party',
     family_available_override: null,
     reason: '',
     is_family_available: true,
@@ -1221,5 +1222,35 @@ describe('LodgingUnitCard — summer’s chrome, the rest of it', () => {
     const roster = container.querySelector('[data-family-card]')?.parentElement
     expect(roster).toHaveClass('gap-2')
     expect(roster).not.toHaveClass('gap-1.5')
+  })
+})
+
+describe('LodgingUnitCard shareability (kindred#2026)', () => {
+  it('marks a unit a second family may be placed into', () => {
+    render(
+      <LodgingUnitCard
+        slot={slot({ unit: unit({ shareability: 'shareable' }) })}
+        hue="hsl(160 45% 42%)"
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Shared OK')).toBeInTheDocument()
+  })
+
+  it('says nothing on a one-family room', () => {
+    render(<LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />)
+    expect(screen.queryByText('Shared OK')).not.toBeInTheDocument()
+    expect(screen.queryByText('Sharing unset')).not.toBeInTheDocument()
+  })
+
+  it('flags a unit nobody has classified rather than letting it read as safe', () => {
+    render(
+      <LodgingUnitCard
+        slot={slot({ unit: unit({ shareability: 'unknown' }) })}
+        hue="hsl(160 45% 42%)"
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Sharing unset')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -1243,6 +1243,26 @@ describe('LodgingUnitCard shareability (kindred#2026)', () => {
     expect(screen.queryByText('Sharing unset')).not.toBeInTheDocument()
   })
 
+  it('marks a WHOLE-HOUSE let, which is the card the ruling is actually about', () => {
+    // A split container gets no card at all — `dragPlacement` rejects it as a
+    // drop target and `unitLevel` fans down past it — so the only container
+    // that reaches this component is a COMBINED one, and that is the slot
+    // staff place into. The owner's ruling is that two households on one
+    // container is a legitimate share, so this is the card that most needs to
+    // say so. An earlier version suppressed the chip on every container and
+    // hid it in exactly the place it earns its keep.
+    render(
+      <LodgingUnitCard
+        slot={slot({
+          unit: unit({ is_container: true, is_combined: true, shareability: 'shareable' }),
+        })}
+        hue="hsl(160 45% 42%)"
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Shared OK')).toBeInTheDocument()
+  })
+
   it('flags a unit nobody has classified rather than letting it read as safe', () => {
     render(
       <LodgingUnitCard

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -24,7 +24,7 @@ import {
 import { isValidMergeTarget, mergeDragId, unitDroppableId } from './dragPlacement'
 import { FamilyCard } from './FamilyCard'
 import { partyKey } from './partyKey'
-import { reservationBadge } from './unitBadges'
+import { reservationBadge, shareabilityBadge } from './unitBadges'
 import { UnitAvailabilityControl } from './UnitAvailabilityControl'
 
 /**
@@ -182,6 +182,9 @@ export function LodgingUnitCard({
 }: LodgingUnitCardProps) {
   const { unit, parties, consent } = slot
   const badge = reservationBadge(unit)
+  // Only on rooms. A container is a whole-building aggregate that no family is
+  // placed into directly, and `reservationBadge` already labels it "Building".
+  const sharing = unit.is_container === true ? null : shareabilityBadge(unit)
   const capacityKnown = unit.sleeps !== null && unit.sleeps !== undefined
   /*
    * How full the room is. The corner figure used to be CAPACITY alone, so the
@@ -459,6 +462,14 @@ export function LodgingUnitCard({
         {badge && (
           <span className={`rounded-full px-1.5 py-0.5 text-xs font-medium ${badge.className}`}>
             {badge.label}
+          </span>
+        )}
+        {/* Beside the availability badge because the two answer adjacent
+            questions about the same room: whether a family may go in it at
+            all, and whether a SECOND one may. */}
+        {sharing && (
+          <span className={`rounded-full px-1.5 py-0.5 text-xs font-medium ${sharing.className}`}>
+            {sharing.label}
           </span>
         )}
         {/* The only actionable capacity state, and the only one summer's

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -182,9 +182,20 @@ export function LodgingUnitCard({
 }: LodgingUnitCardProps) {
   const { unit, parties, consent } = slot
   const badge = reservationBadge(unit)
-  // Only on rooms. A container is a whole-building aggregate that no family is
-  // placed into directly, and `reservationBadge` already labels it "Building".
-  const sharing = unit.is_container === true ? null : shareabilityBadge(unit)
+  // On every unit this card can be a SLOT for, which includes a COMBINED
+  // container and excludes a split one.
+  //
+  // Suppressing it on containers wholesale was the first version and was
+  // exactly backwards: a split container gets no card at all (`dragPlacement`
+  // rejects it as a drop target, and `unitLevel` fans down past it), so the
+  // only container that ever reaches this component is a combined one — the
+  // whole-house let, which IS the slot staff place into. That is precisely
+  // where the owner's ruling lives: two households on one container is a
+  // legitimate share, so the whole-house card is the card that most needs to
+  // say so. The guard remains as belt-and-braces for the split case rather
+  // than being dropped, since nothing here enforces how the card is mounted.
+  const isSplitContainer = unit.is_container === true && unit.is_combined !== true
+  const sharing = isSplitContainer ? null : shareabilityBadge(unit)
   const capacityKnown = unit.sleeps !== null && unit.sleeps !== undefined
   /*
    * How full the room is. The corner figure used to be CAPACITY alone, so the

--- a/frontend/src/components/weekend/MapUnitPopover.test.tsx
+++ b/frontend/src/components/weekend/MapUnitPopover.test.tsx
@@ -28,6 +28,7 @@ function row(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
     is_active: true,
     is_container: false,
     inventory_class: 'family_pool',
+    shareability: 'single_party',
     family_available_override: null,
     reason: '',
     is_family_available: true,
@@ -322,6 +323,57 @@ describe('MapUnitPopover — one room', () => {
     const messages = warn.mock.calls.map((call) => String(call[0])).join('\n')
     warn.mockRestore()
     expect(messages).not.toMatch(/same key/i)
+  })
+})
+
+describe('MapUnitPopover — shareability (kindred#2026)', () => {
+  // This popover is the ONE surface that already prints `shared by N`. Saying a
+  // room is shared by two while saying nothing about whether it MAY be is the
+  // drift `unitBadges`' header exists to prevent ("shared by the board's slot
+  // cards and the map's unit popover so the two cannot drift").
+
+  it('says a unit may take a second family', () => {
+    render(
+      <MapUnitPopover
+        units={[mapUnit(row({ shareability: 'shareable' }))]}
+        hue={HUE}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Shared OK')).toBeInTheDocument()
+  })
+
+  it('flags an unclassified unit rather than letting silence read as safe', () => {
+    render(
+      <MapUnitPopover
+        units={[mapUnit(row({ shareability: 'unknown' }))]}
+        hue={HUE}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Sharing unset')).toBeInTheDocument()
+  })
+
+  it('stays silent on a one-family room, exactly as the board card does', () => {
+    render(<MapUnitPopover units={[mapUnit(row())]} hue={HUE} onOpenParty={vi.fn()} />)
+    expect(screen.queryByText('Shared OK')).not.toBeInTheDocument()
+    expect(screen.queryByText('Sharing unset')).not.toBeInTheDocument()
+  })
+
+  it('shows BOTH the occupancy fact and the permission on a shared room', () => {
+    // The pairing is the point: `shared by 2` reports what IS, the chip reports
+    // what is ALLOWED. A staffer seeing the first without the second cannot
+    // tell a legitimate share from a double-booking.
+    render(
+      <MapUnitPopover
+        units={[
+          mapUnit(row({ shareability: 'single_party' }), [party('Johnson'), party('Garcia')]),
+        ]}
+        hue={HUE}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText(/shared by 2/)).toBeInTheDocument()
   })
 })
 

--- a/frontend/src/components/weekend/MapUnitPopover.tsx
+++ b/frontend/src/components/weekend/MapUnitPopover.tsx
@@ -18,7 +18,7 @@ import { CONSENT_AMBER } from './mapColors'
 import type { MapUnit } from './mapModel'
 import { partyKey } from './partyKey'
 import { partyAttention, partyBeds } from './rosterAttention'
-import { reservationBadge } from './unitBadges'
+import { reservationBadge, shareabilityBadge } from './unitBadges'
 
 /**
  * The board's `border-amber-400`, reused rather than re-picked. A consent flag
@@ -110,6 +110,14 @@ function DetailCard({ units, hue, onOpenParty }: MapUnitPopoverProps) {
   if (unit.near_bathhouse) tags.push('near bathhouse')
   if (unit.inventory_class === 'staff_default') tags.push('staff-default')
   if (parties.length > 1) tags.push(`shared by ${String(parties.length)}`)
+  // kindred#2026, and it belongs HERE rather than only on the board because
+  // this popover is the one surface that already prints `shared by N`. Saying
+  // a room is shared by two while saying nothing about whether it MAY be is
+  // the disagreement `unitBadges`' own header exists to prevent ("shared by
+  // the board's slot cards and the map's unit popover so the two cannot
+  // drift"). Rendered through the shared helper, never re-derived, so the
+  // wording and the silence on `single_party` match the board exactly.
+  const sharing = shareabilityBadge(unit)
 
   return (
     <div className="flex min-w-[11rem] flex-col gap-1.5">
@@ -182,6 +190,13 @@ function DetailCard({ units, hue, onOpenParty }: MapUnitPopoverProps) {
             </li>
           ))}
         </ul>
+      )}
+      {sharing && (
+        <div>
+          <span className={`rounded-full px-1.5 py-0.5 text-xs font-medium ${sharing.className}`}>
+            {sharing.label}
+          </span>
+        </div>
       )}
       {tags.length > 0 && (
         <ul className="flex flex-wrap gap-1">

--- a/frontend/src/components/weekend/index.ts
+++ b/frontend/src/components/weekend/index.ts
@@ -25,7 +25,7 @@ export type { AttentionLevel, AttentionSection, PartyAttention } from './rosterA
 export { formatSessionDates } from './sessionDates'
 export { SharePreferenceChip } from './SharePreferenceChip'
 export { ShareRequestPanel } from './ShareRequestPanel'
-export { reservationBadge } from './unitBadges'
+export { reservationBadge, shareabilityBadge } from './unitBadges'
 export type { UnitBadge } from './unitBadges'
 export { scenarioForWeekend } from './weekendScenario'
 export type { ScenarioRef } from './weekendScenario'

--- a/frontend/src/components/weekend/unitBadges.test.ts
+++ b/frontend/src/components/weekend/unitBadges.test.ts
@@ -17,7 +17,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { LodgingUnitRow } from '../../types/lodging'
-import { availabilityAction, reservationBadge } from './unitBadges'
+import { availabilityAction, reservationBadge, shareabilityBadge } from './unitBadges'
 
 function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
   return {
@@ -38,6 +38,7 @@ function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
     is_active: true,
     is_container: false,
     inventory_class: 'family_pool',
+    shareability: 'single_party',
     family_available_override: null,
     reason: '',
     is_family_available: true,
@@ -225,5 +226,38 @@ describe('availabilityAction', () => {
     // one would write an availability row against a unit no family can be
     // placed into, and the board draws no card for it anyway.
     expect(availabilityAction(unit({ is_container: true }))).toBeNull()
+  })
+})
+
+describe('shareabilityBadge', () => {
+  // kindred#2026. The unit half of "may two families sleep here", distinct
+  // from the household half (`share_eligibility`) that the party cards carry.
+
+  it('marks a unit a second party may be placed into', () => {
+    expect(shareabilityBadge(unit({ shareability: 'shareable' }))?.label).toBe('Shared OK')
+  })
+
+  it('says nothing on a one-family room', () => {
+    // 74 of 118 registry rows are single_party, so badging them would put a
+    // chip on most of the board to state the default expectation. Silence
+    // here is the SAFE direction: it advertises no permission.
+    expect(shareabilityBadge(unit({ shareability: 'single_party' }))).toBeNull()
+  })
+
+  it('says so out loud when nobody has classified the unit', () => {
+    // NOT silence, and this is the whole reason the column is a select rather
+    // than a bool. After 1500000145's backfill no registry row is unknown, so
+    // this chip only ever appears on a hand-created unit — where it is the one
+    // prompt a staffer gets to answer the question before the board is worked.
+    expect(shareabilityBadge(unit({ shareability: 'unknown' }))?.label).toBe('Sharing unset')
+  })
+
+  it('treats an absent field as unclassified rather than as permission', () => {
+    // Pydantic defaults render optional in TypeScript, so a payload built by
+    // an older server arrives with the key missing. Undefined must land on the
+    // same non-permissive answer as an empty column, never on 'shareable'.
+    const withoutField = unit()
+    delete (withoutField as Partial<LodgingUnitRow>).shareability
+    expect(shareabilityBadge(withoutField)?.label).toBe('Sharing unset')
   })
 })

--- a/frontend/src/components/weekend/unitBadges.ts
+++ b/frontend/src/components/weekend/unitBadges.ts
@@ -54,6 +54,44 @@ export function reservationBadge(unit: LodgingUnitRow): UnitBadge | null {
   return null
 }
 
+/**
+ * Whether a second family may go in this room — the UNIT half of the sharing
+ * question (kindred#2026). The household half (`share_eligibility`) rides on
+ * the party cards; both have to be true before two parties may occupy one
+ * space.
+ *
+ * TWO OF THE THREE STATES BADGE, AND THE SILENT ONE IS THE SAFE ONE.
+ *
+ *   shareable    -> badged. It grants something, so it has to be legible.
+ *   single_party -> silent. It is the default expectation and the majority of
+ *                   the registry; a chip on most of the board to restate what
+ *                   staff already assume is noise, and silence advertises no
+ *                   permission, so nothing is risked by it.
+ *   unknown      -> badged. NOT silent, and this is the point of a select over
+ *                   a bool. After 1500000145's backfill no registry row is
+ *                   unclassified, so this chip only ever appears on a
+ *                   hand-created unit — where it is the one prompt a staffer
+ *                   gets to answer the question before the board is worked.
+ *
+ * Undefined is treated as unknown rather than trusted: Pydantic fields with a
+ * default render OPTIONAL in TypeScript, so a payload from an older server
+ * arrives with the key missing, and the only wrong answer to give there is a
+ * permissive one.
+ */
+export function shareabilityBadge(unit: LodgingUnitRow): UnitBadge | null {
+  if (unit.shareability === 'shareable') {
+    return {
+      label: 'Shared OK',
+      className: 'bg-sky-100 text-sky-800 dark:bg-sky-950/40 dark:text-sky-300',
+    }
+  }
+  if (unit.shareability === 'single_party') return null
+  return {
+    label: 'Sharing unset',
+    className: 'border-border text-muted-foreground border',
+  }
+}
+
 /** Which of the three reachable availability outcomes this unit can move to. */
 export interface AvailabilityAction {
   kind: 'hold' | 'release' | 'clear'

--- a/frontend/src/services/lodgingCrud.test.ts
+++ b/frontend/src/services/lodgingCrud.test.ts
@@ -72,6 +72,7 @@ describe('createLodgingUnit', () => {
       code: 'ridge-n',
       is_active: true,
       inventory_class: 'family_pool',
+      shareability: '',
       year: 2026,
     })
 
@@ -87,6 +88,7 @@ describe('createLodgingUnit', () => {
       code: 'ridge-n',
       is_active: true,
       inventory_class: 'staff_default',
+      shareability: '',
       year: 2026,
     })
 

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -1934,6 +1934,10 @@ export type LodgingUnitSummary = {
    */
   inventory_class?: string
   /**
+   * Shareability
+   */
+  shareability?: 'unknown' | 'shareable' | 'single_party'
+  /**
    * Family Available Override
    */
   family_available_override?: boolean | null

--- a/frontend/src/types/lodging.test.ts
+++ b/frontend/src/types/lodging.test.ts
@@ -138,6 +138,7 @@ const _exhaustiveLodgingUnit: Required<LodgingUnitRow> = {
   parent_code: '',
   is_combined: false,
   inventory_class: 'family_pool',
+  shareability: 'single_party',
   family_available_override: null,
   reason: '',
   is_family_available: true,

--- a/frontend/src/types/lodging.ts
+++ b/frontend/src/types/lodging.ts
@@ -183,6 +183,21 @@ export type BathroomStoredValue = 'none' | 'private' | 'shared' | ''
  */
 export type InventoryClassValue = 'family_pool' | 'staff_default'
 
+/**
+ * The STORED shareability vocabulary — may more than one party sleep here at
+ * once (1500000145, kindred#2026).
+ *
+ * `''` is a real third state and the reason this is a select rather than a
+ * bool: nobody has classified the unit. It is neither permission to
+ * double-book nor a ruling that one family only may go here, and the admin
+ * form must be able to leave it unanswered.
+ *
+ * NOT the same vocabulary the READ api uses: `LodgingUnitRow.shareability`
+ * renders `''` as the token `unknown`, exactly as `bathroom` does, and writing
+ * that token back would fail the select's validation.
+ */
+export type ShareabilityStoredValue = 'shareable' | 'single_party' | ''
+
 /** A named zone of the site. */
 export interface LodgingAreaRecord extends PocketBaseRecordBase {
   name: string
@@ -226,6 +241,14 @@ export interface LodgingUnitRecord extends PocketBaseRecordBase {
   has_changing_table: boolean
   has_shared_fridge: boolean
   inventory_class: InventoryClassValue | ''
+  /**
+   * Whether more than one party may sleep here at once.
+   *
+   * Distinct from a HOUSEHOLD's willingness to share (`share_eligibility` on
+   * the party rows): both have to be true before two parties may be put in one
+   * space, and this is the half that had no column until kindred#2026.
+   */
+  shareability: ShareabilityStoredValue
   /**
    * Whether staff have actually verified this row's amenities.
    *
@@ -346,6 +369,13 @@ export interface LodgingUnitInput {
   is_active: boolean
   inventory_class: InventoryClassValue
   year: number
+  /**
+   * Optional, unlike `inventory_class` above, because `''` IS a meaningful
+   * value here — the unit is unclassified and the staffer has not answered.
+   * Omitting the key on create leaves PocketBase's own empty select, which is
+   * the same state, so nothing is lost by its absence.
+   */
+  shareability?: ShareabilityStoredValue
   parent_unit?: string
   map_x?: number
   map_y?: number

--- a/frontend/src/types/lodging.ts
+++ b/frontend/src/types/lodging.ts
@@ -370,12 +370,17 @@ export interface LodgingUnitInput {
   inventory_class: InventoryClassValue
   year: number
   /**
-   * Optional, unlike `inventory_class` above, because `''` IS a meaningful
-   * value here — the unit is unclassified and the staffer has not answered.
-   * Omitting the key on create leaves PocketBase's own empty select, which is
-   * the same state, so nothing is lost by its absence.
+   * REQUIRED, and always sent, for the same reason as `is_active` and
+   * `inventory_class` above — but note the reason is different in one respect:
+   * `''` is a genuinely meaningful value here (unclassified), not a broken
+   * one. What makes omission wrong is the EDIT path. Leaving the key out would
+   * leave the previous classification in place, so a staffer clearing the
+   * field back to "Not classified" would get a silent no-op they believe
+   * worked. `LodgingUnitForm` holds it in its own state and always supplies
+   * it; making it non-optional here is what keeps a second write path from
+   * quietly dropping it.
    */
-  shareability?: ShareabilityStoredValue
+  shareability: ShareabilityStoredValue
   parent_unit?: string
   map_x?: number
   map_y?: number

--- a/pocketbase/lodging/registry.go
+++ b/pocketbase/lodging/registry.go
@@ -54,22 +54,17 @@ const (
 // NEVER `max_beds`: it disagrees with the unit's own recorded bed inventory on
 // roughly a third of rows, including rows where it falls BELOW the bed count.
 //
-// A FRESH DATABASE WILL NOT MATCH PRODUCTION, and that is not this function
-// misbehaving. The registry file's `sleeps` is the pre-inventory seed: measured
-// 2026-08-08, it disagrees with production on 77 of the 118 units, and NO leaf
-// in the file reaches 12 (the file's leaf maximum is 9) where production has 31.
-// Production's capacities arrived later, from the 2026 Master Housing import and
-// from staff editing confirmed rows -- neither of which writes back to the file.
-// So a fresh worktree or a rebuilt CD seed classifies the family CONTAINERS
-// shareable and no leaves at all, while production classifies 44 units shareable.
-// Both are this rule applied faithfully to the data actually present.
+// A FRESH DATABASE CARRIES A SUBSET OF PRODUCTION'S CLASSIFICATION, never a
+// contradicting one, and that is enforced at the CALL SITE rather than here:
+// `seedUnits` passes nil for `sleeps` because the registry file's capacities
+// are a pre-inventory guess (77 of 118 disagree with production, and no leaf in
+// the file reaches 12). Read the note there before changing either.
 //
-// The consequence is a pre-existing staleness this feature inherits rather than
-// creates -- a fresh database already disagrees with production about capacity,
-// which the capacity counts and the bed flags have always reflected. Do not
-// "fix" it by loosening the rule here or by seeding from a second column; the
-// fix, if one is wanted, is to refresh `sleeps` in the private registry file,
-// which is a data decision for the owner and not a code change.
+// This function stays a total, honest rule over whatever it is given. Do not
+// "fix" the fresh-database gap by loosening the thresholds here or by seeding
+// from a second column; the fix, if one is wanted, is to refresh `sleeps` in
+// the private registry file, which is a data decision for the owner rather
+// than a code change.
 func classifyShareability(inventoryClass string, isContainer bool, sleeps *int) string {
 	switch inventoryClass {
 	case "staff_default":
@@ -575,13 +570,37 @@ func seedUnits(
 		rec.Set("near_bathhouse", u.NearBathhouse)
 		rec.Set("inventory_class", u.InventoryClass)
 		rec.Set("is_container", u.IsContainer)
-		// Derived here rather than read from the registry file, so the private
-		// JSON needs no new key and cannot drift from the rule. Left unset when
-		// the classifier declines, so UNCLASSIFIED reaches the database as an
-		// empty select rather than as a decision -- same handling as HasRamp
-		// below. This is the FRESH-DATABASE half only: 1500000145 backfills
-		// every row that already exists, which on production is all of them.
-		if s := classifyShareability(u.InventoryClass, u.IsContainer, u.Sleeps); s != "" {
+		// NOTE THE `nil`: the loader deliberately declines to classify from the
+		// file's `sleeps`.
+		//
+		// Measured 2026-08-08, the registry file disagrees with production on
+		// `sleeps` for 77 of 118 units and NO leaf in it reaches 12, while it
+		// disagrees on `is_container` for 0 and on `inventory_class` for 2.
+		// So the file is authoritative for the two structural fields and is a
+		// pre-inventory guess for the capacity one -- production's capacities
+		// arrived later, from the Master Housing import and from staff editing
+		// confirmed rows, neither of which writes back to the file.
+		//
+		// Feeding that guess in would stamp every family leaf `single_party`
+		// off a number known to be wrong, on a row this same loop marks
+		// `is_confirmed: false` three lines below precisely because "every
+		// seeded value is a guess until staff confirm it". Unlike the amenity
+		// flags, nothing downstream discounts shareability for being
+		// unconfirmed, so that stamp would be read as settled. Passing nil
+		// makes the leaf legs return "" -- the honest "nobody has classified
+		// this" the select exists to represent -- while the container and
+		// staff-housing legs, which need no capacity, still classify.
+		//
+		// The RULE is not forked to achieve this: `classifyShareability` has
+		// one definition, shared with 1500000145, and only the input differs.
+		// A fresh database therefore classifies strictly FEWER units than
+		// production -- measured, 14 containers and 23 staff rows against
+		// production's 44 and 74, with all 81 family leaves left honestly
+		// blank. It is not literally a subset: the file also disagrees with
+		// production on `inventory_class` for TWO units, so those two can land
+		// differently. That is an inventory_class data divergence rather than
+		// anything this rule does, and it predates this feature.
+		if s := classifyShareability(u.InventoryClass, u.IsContainer, nil); s != "" {
 			rec.Set("shareability", s)
 		}
 		rec.Set("default_combined", u.DefaultCombined)

--- a/pocketbase/lodging/registry.go
+++ b/pocketbase/lodging/registry.go
@@ -17,6 +17,83 @@ import (
 // scripts/setup/setup-local-config.sh.
 const registryFileName = "lodging_registry.json"
 
+// The lodging_units.shareability vocabulary (kindred#2026, added by
+// pb_migrations/1500000145). A UNIT property -- may more than one party sleep
+// here at once -- and NOT to be confused with the household-side share
+// vocabulary in sync/lodging_requests.go, which answers whether a FAMILY is
+// willing to share. Both must be true before two parties may occupy one space.
+//
+// The empty string is the third state and is never spelled here, because it is
+// what a row carries when the classifier declines to answer: nobody has
+// classified this. It must never read as permission to double-book, and
+// equally must never read as a ruling that one family only may go here.
+const (
+	shareabilityShareable   = "shareable"
+	shareabilitySingleParty = "single_party"
+)
+
+// classifyShareability decides whether a unit about to be CREATED may hold
+// more than one party. Returns "" when it cannot honestly answer.
+//
+// The rule, and why each leg is what it is, is documented in full on
+// pb_migrations/1500000145 -- read that header before changing this, because
+// the two implementations have to agree. In short: a family LEAF sleeping 12
+// or more is shareable (this reproduces the owner's own enumeration of the
+// shared cabins exactly); a family CONTAINER is shareable at its own level,
+// because two households on one container occupy different rooms beneath it
+// and that is a legitimate share rather than a violation (owner ruling); staff
+// housing is not family-camp inventory, so multi-family occupancy is not a
+// question it answers.
+//
+// A container is deliberately NOT tested against `sleeps`. A container's
+// `sleeps` is a DELTA over its rooms (kindred#2041), not a whole-house total,
+// and the whole-house total is not the right input either -- the container
+// carrying the most historical two-household shares totals 9 across its rooms.
+// What makes a container shareable is having rooms, not having capacity.
+//
+// NEVER `max_beds`: it disagrees with the unit's own recorded bed inventory on
+// roughly a third of rows, including rows where it falls BELOW the bed count.
+//
+// A FRESH DATABASE WILL NOT MATCH PRODUCTION, and that is not this function
+// misbehaving. The registry file's `sleeps` is the pre-inventory seed: measured
+// 2026-08-08, it disagrees with production on 77 of the 118 units, and NO leaf
+// in the file reaches 12 (the file's leaf maximum is 9) where production has 31.
+// Production's capacities arrived later, from the 2026 Master Housing import and
+// from staff editing confirmed rows -- neither of which writes back to the file.
+// So a fresh worktree or a rebuilt CD seed classifies the family CONTAINERS
+// shareable and no leaves at all, while production classifies 44 units shareable.
+// Both are this rule applied faithfully to the data actually present.
+//
+// The consequence is a pre-existing staleness this feature inherits rather than
+// creates -- a fresh database already disagrees with production about capacity,
+// which the capacity counts and the bed flags have always reflected. Do not
+// "fix" it by loosening the rule here or by seeding from a second column; the
+// fix, if one is wanted, is to refresh `sleeps` in the private registry file,
+// which is a data decision for the owner and not a code change.
+func classifyShareability(inventoryClass string, isContainer bool, sleeps *int) string {
+	switch inventoryClass {
+	case "staff_default":
+		return shareabilitySingleParty
+	case "family_pool":
+		if isContainer {
+			return shareabilityShareable
+		}
+		// nil is "never observed" and 0 is how PocketBase stores that, so both
+		// mean UNMEASURED -- never "zero capacity". An unmeasured leaf cannot
+		// be classified, and guessing would be wrong in both directions.
+		if sleeps == nil || *sleeps < 1 {
+			return ""
+		}
+		if *sleeps >= 12 {
+			return shareabilityShareable
+		}
+		return shareabilitySingleParty
+	default:
+		// No role recorded, so a role-dependent question has no answer.
+		return ""
+	}
+}
+
 // registryBasePath is the base for the relative candidate paths below.
 // Overridden in tests.
 var registryBasePath = "."
@@ -498,6 +575,15 @@ func seedUnits(
 		rec.Set("near_bathhouse", u.NearBathhouse)
 		rec.Set("inventory_class", u.InventoryClass)
 		rec.Set("is_container", u.IsContainer)
+		// Derived here rather than read from the registry file, so the private
+		// JSON needs no new key and cannot drift from the rule. Left unset when
+		// the classifier declines, so UNCLASSIFIED reaches the database as an
+		// empty select rather than as a decision -- same handling as HasRamp
+		// below. This is the FRESH-DATABASE half only: 1500000145 backfills
+		// every row that already exists, which on production is all of them.
+		if s := classifyShareability(u.InventoryClass, u.IsContainer, u.Sleeps); s != "" {
+			rec.Set("shareability", s)
+		}
 		rec.Set("default_combined", u.DefaultCombined)
 		rec.Set("notes", u.Notes)
 		rec.Set("has_power", u.HasPower)

--- a/pocketbase/lodging/registry_shareability_test.go
+++ b/pocketbase/lodging/registry_shareability_test.go
@@ -1,0 +1,72 @@
+package lodging
+
+import "testing"
+
+// The seed-time half of kindred#2026.
+//
+// classifyShareability answers "may more than one party sleep here at once"
+// for a row the loader is about to CREATE. The other half -- rows that already
+// exist -- is pb_migrations/1500000145, because neither named seed path can
+// reach them (seedUnits skips any existing code+year, and
+// apply_lodging_inventory.py withholds every non-notes change from a confirmed
+// row, which in production is all of them). The two implementations state the
+// same rule and this file is what stops them drifting apart in the direction
+// that matters: a Go loader that classified a small room `shareable` on a
+// fresh database would seed permission to double-book a bedroom.
+
+func intPtr(v int) *int { return &v }
+
+func TestClassifyShareability(t *testing.T) {
+	cases := []struct {
+		name           string
+		inventoryClass string
+		isContainer    bool
+		sleeps         *int
+		want           string
+	}{
+		// The rule proper: 12 is the floor, on LEAF rows.
+		{"large leaf cabin is shareable", "family_pool", false, intPtr(15), shareabilityShareable},
+		{"exactly at the floor is shareable", "family_pool", false, intPtr(12), shareabilityShareable},
+		{"one below the floor is one family", "family_pool", false, intPtr(11), shareabilitySingleParty},
+		{"a bedroom is one family", "family_pool", false, intPtr(4), shareabilitySingleParty},
+
+		// A container's own `sleeps` is a DELTA over its rooms (kindred#2041),
+		// so the >= 12 test does not apply to it and is not applied. Under the
+		// owner's settled ruling two households on one container is a
+		// legitimate share, not a violation -- the parties occupy different
+		// rooms beneath it and CampMinder has no sub-room concept for every
+		// building, so staff assign at container level and will keep doing so.
+		{"a family container is shareable whatever its delta", "family_pool", true, intPtr(0), shareabilityShareable},
+		{"a family container with a small delta is still shareable", "family_pool", true, intPtr(1), shareabilityShareable},
+		{"a family container with no measured delta is shareable", "family_pool", true, nil, shareabilityShareable},
+
+		// Staff housing is not family-camp inventory, so multi-party family
+		// occupancy is not a question it answers. This is also the mechanism
+		// that lands the owner's call on the one residue row -- a staff
+		// building sleeping 19 that would otherwise clear the leaf floor.
+		{"a large staff building is one party", "staff_default", false, intPtr(19), shareabilitySingleParty},
+		{"a staff container is one party", "staff_default", true, nil, shareabilitySingleParty},
+
+		// UNKNOWN, and it stays unknown. A leaf nobody has measured cannot be
+		// classified either way, and guessing here is the failure the select
+		// exists to prevent: `single_party` would block legitimate work and
+		// `shareable` would permit a double-booking.
+		{"an unmeasured leaf is left unclassified", "family_pool", false, nil, ""},
+		// PocketBase stores an unset number as 0, and registry.go's own
+		// comment says consumers read 0 as UNKNOWN, never "zero capacity".
+		{"a leaf sleeping zero is unclassified, not tiny", "family_pool", false, intPtr(0), ""},
+
+		// An unclassified ROLE cannot decide a role-dependent question.
+		{"a leaf with no inventory class is unclassified", "", false, intPtr(15), ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyShareability(tc.inventoryClass, tc.isContainer, tc.sleeps)
+			if got != tc.want {
+				t.Errorf("classifyShareability(%q, %v, %v) = %q, want %q",
+					tc.inventoryClass, tc.isContainer, tc.sleeps, got, tc.want)
+			}
+		})
+	}
+}

--- a/pocketbase/pb_migrations/1500000145_lodging_unit_shareability.js
+++ b/pocketbase/pb_migrations/1500000145_lodging_unit_shareability.js
@@ -1,0 +1,170 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Add `shareability` to lodging_units — may more than one party sleep here.
+ *
+ * `docs/architecture/lodging-occupancy.md` has recorded the staff rule since
+ * the surface was built, and nothing could enforce it because no column
+ * distinguished the two classes. `inventory_class` (family_pool /
+ * staff_default) says who a unit is RESERVED FOR, not how many parties may
+ * occupy it, so a bedroom double-booked between two households was possible
+ * and undetected. This is that column. See kindred#2026.
+ *
+ * A SELECT, NOT A BOOL, and that is load-bearing. Three states are real:
+ * `shareable`, `single_party`, and the empty string — nobody has classified
+ * this. Unrecorded must never read as permission to double-book, and it must
+ * also never read as a decision that one family only may go here, which would
+ * block legitimate work and teach staff to ignore the warning. The same doc
+ * warns about exactly that: "a rule encoded early and wrongly is worse than no
+ * rule".
+ *
+ * ── THE RULE ────────────────────────────────────────────────────────────────
+ *
+ *   family_pool  + leaf      + sleeps >= 12  ->  shareable
+ *   family_pool  + leaf      + sleeps 1..11  ->  single_party
+ *   family_pool  + container                 ->  shareable
+ *   staff_default (either)                   ->  single_party
+ *   anything else                            ->  left EMPTY, deliberately
+ *
+ * `sleeps >= 12` on leaves reproduces the owner's own enumeration of the
+ * shared cabins exactly — no member of that set falls below 12, and the two
+ * proxies tested when the issue was filed (parentless-leaf, `max_beds`) both
+ * failed. `max_beds` is NEVER a seed input here: it disagrees with the unit's
+ * own recorded bed inventory on roughly a third of rows, including rows where
+ * it sits BELOW the bed count, so a `max_beds >= 12` seed would silently mark
+ * a large cabin single-party and start rejecting legitimate placements.
+ *
+ * CONTAINERS ARE CLASSIFIED, AND AT THEIR OWN LEVEL — owner ruling, 2026-08-07.
+ * Shareability is both leaf-level and container-level, and the board check
+ * compares at whichever level the assignment was actually made rather than
+ * always resolving down to leaves. Two households on one container is a
+ * LEGITIMATE SHARE: they occupy different rooms beneath it, CampMinder has no
+ * sub-room concept for every building, so staff assign at container level for
+ * some buildings and will keep doing so. Measured over 2022-2025, that ruling
+ * is what converts 36 apparent leaf-level "violations" into correct data.
+ *
+ * A container is NOT tested against `sleeps >= 12`, and must not be. A
+ * container's `sleeps` is a DELTA over its rooms (kindred#2041), not a
+ * whole-house total — 14 of the 15 containers carry none at all. Nor is the
+ * whole-house total (`_effective_sleeps`) the right input: the container
+ * carrying the MOST historical two-household shares totals 9 across its rooms,
+ * so a >= 12 test on the effective figure would re-flag the very placements
+ * this ruling settled. What makes a container shareable is having rooms, not
+ * having capacity.
+ *
+ * THE `family_pool` CONJUNCT is how the owner's call on the one residue row
+ * lands. Exactly one unit clears `sleeps >= 12` and is not in the owner's set:
+ * a staff-housing building sleeping 19, with zero family-camp placements
+ * 2022-2025. The ruling on it is NON-SHAREABLE, and it is inert either way —
+ * no family has ever been placed there. Rather than name it (this directory is
+ * scanned by verify-no-hardcoded-lodging.sh, and a unit list in a migration is
+ * a failure), the rule states the reason: staff housing is not family-camp
+ * inventory, so "may two FAMILIES share it" is not a question it answers, and
+ * single_party is the honest answer at any capacity. This also settles the one
+ * staff container, equally inert for the same reason.
+ *
+ * ── WHY A MIGRATION BACKFILL, AND NOT EITHER SEED PATH ──────────────────────
+ *
+ * NEITHER named seed path can reach a row that already exists, and in
+ * production all 118 registry units already exist and are confirmed:
+ *
+ *   - `seedUnits` (pocketbase/lodging/registry.go) looks the unit up by code
+ *     and year and `continue`s outright when it finds one. It only ever
+ *     CREATES.
+ *   - `scripts/dev/apply_lodging_inventory.py` withholds every field but
+ *     `notes` from a row with `is_confirmed` set.
+ *
+ * So a seed silently classifies NOTHING in production — it would report
+ * success and change no row. The loader still learns the rule, for FRESH
+ * databases: migrations run before SeedRegistry (main.go), so on a new
+ * worktree or a rebuilt CD seed the UPDATEs below hit an empty table and
+ * `classifyShareability` in registry.go supplies the value instead. The two
+ * implementations state the same rule and `registry_shareability_test.go`
+ * pins the Go half.
+ *
+ * A FRESH DATABASE STILL WILL NOT MATCH PRODUCTION, because its INPUTS do not:
+ * the registry file's `sleeps` disagrees with production on 77 of 118 units and
+ * no leaf in the file reaches 12, so the loader classifies the family
+ * containers and no leaves. Production's capacities came from the 2026 Master
+ * Housing import and from staff edits, neither of which writes back to the
+ * file. See the long note on `classifyShareability` — this is inherited
+ * staleness, not a defect in either implementation of the rule.
+ *
+ * ── NON-DESTRUCTIVE, AND IDEMPOTENT BY CONSTRUCTION ─────────────────────────
+ *
+ * Both UPDATEs are gated on `shareability = ''`, so they only ever FILL. A
+ * value a staffer has already set in /manage/lodging outranks this migration
+ * and is never rewritten; a second run is a no-op returning zero rows. The
+ * two predicates are also mutually exclusive, so neither depends on running
+ * after the other.
+ *
+ * The backfill is a PREDICATE, never a list of codes — same reason as
+ * 1500000138's. A predicate names nothing, so it cannot leak a unit name and
+ * cannot go stale when the registry changes.
+ */
+
+migrate(
+  (app) => {
+    const col = app.findCollectionByNameOrId('lodging_units');
+
+    // Idempotent: editing an already-applied migration silently skips it
+    // (`_migrations` keys on filename), so every add in this codebase is
+    // written to tolerate the field already being present.
+    if (!col.fields.getByName('shareability')) {
+      col.fields.add(
+        new Field({
+          type: 'select',
+          name: 'shareability',
+          // NOT `required`. A required select would force every existing row
+          // to carry a value before this migration could set one, and would
+          // make "nobody has classified this" unrepresentable — which is the
+          // state the whole column is shaped around.
+          required: false,
+          presentable: false,
+          values: ['shareable', 'single_party'],
+          maxSelect: 1,
+        })
+      );
+      app.save(col);
+    }
+
+    // A unit families may be placed into more than one party at a time: a
+    // large shared-sleeping cabin, or any family building whose rooms are
+    // assigned separately.
+    app
+      .db()
+      .newQuery(
+        "UPDATE lodging_units SET shareability = 'shareable' " +
+          "WHERE shareability = '' " +
+          "AND inventory_class = 'family_pool' " +
+          'AND (is_container = true OR sleeps >= 12)'
+      )
+      .execute();
+
+    // One party only. `sleeps >= 1` and not `> 0` for readability alone; both
+    // exclude the stored 0, which is UNKNOWN rather than "zero capacity"
+    // (PocketBase number columns are NUMERIC DEFAULT 0 NOT NULL, so an unset
+    // value is indistinguishable from a real zero and the codebase reads it as
+    // unmeasured everywhere else).
+    //
+    // An unmeasured family leaf therefore stays EMPTY: it cannot be classified
+    // either way, and guessing would be wrong in both directions. A row with
+    // no `inventory_class` at all stays empty for the same reason — a
+    // role-dependent question cannot be answered without the role.
+    app
+      .db()
+      .newQuery(
+        "UPDATE lodging_units SET shareability = 'single_party' " +
+          "WHERE shareability = '' " +
+          "AND (inventory_class = 'staff_default' " +
+          "     OR (inventory_class = 'family_pool' AND is_container = false " +
+          '        AND sleeps >= 1 AND sleeps < 12))'
+      )
+      .execute();
+  },
+  (app) => {
+    const col = app.findCollectionByNameOrId('lodging_units');
+    if (!col.fields.getByName('shareability')) return;
+    col.fields.removeByName('shareability');
+    app.save(col);
+  }
+);

--- a/scripts/dev/verify-lodging-schema.sh
+++ b/scripts/dev/verify-lodging-schema.sh
@@ -111,6 +111,21 @@ rv=$(field_prop lodging_units has_ramp values || true)
 rr=$(field_prop lodging_units has_ramp required || true)
 [[ "$rr" != "1" && "$rr" != "true" ]] || note "lodging_units.has_ramp is required (must be optional: blank means not assessed)"
 
+# shareability is deliberately NOT a bool, and deliberately NOT required —
+# kindred#2026, migration 1500000145. Same discipline as has_ramp above and for
+# a sharper reason: a bool collapses "nobody has classified this cabin" into
+# "one family only", and a REQUIRED select makes that third state
+# unrepresentable altogether. Unrecorded must never read as permission to
+# double-book, and must equally never read as a ruling. Both halves are pinned
+# here because a later migration flipping either would ship green otherwise —
+# the Go table test only exercises the rule in memory and never sees the schema.
+st=$(field_prop lodging_units shareability type || true)
+[[ "$st" == "select" ]] || note "lodging_units.shareability type is '$st' (expected select, so blank can mean 'not classified')"
+sv=$(field_prop lodging_units shareability values || true)
+[[ "$sv" == '["shareable","single_party"]' ]] || note "lodging_units.shareability values are $sv (expected [\"shareable\",\"single_party\"])"
+sr=$(field_prop lodging_units shareability required || true)
+[[ "$sr" != "1" && "$sr" != "true" ]] || note "lodging_units.shareability is required (must be optional: blank means not classified)"
+
 # max_beds is the sheet's total sleeping spots. It is NOT sleeps, which is a
 # staff judgement for the session type and disagrees with it on most units —
 # HANDOFF §6, spaces not beds. Both columns exist precisely so neither

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -50,6 +50,7 @@ def _unit(
     map_y: float | None = 0.5,
     default_combined: bool = False,
     parent_unit: str = "",
+    shareability: str = "",
 ) -> SimpleNamespace:
     return _rec(
         id=pb_id,
@@ -71,6 +72,9 @@ def _unit(
         map_y=map_y,
         default_combined=default_combined,
         parent_unit=parent_unit,
+        # Blank by default: the migration leaves an unclassifiable row empty
+        # rather than guessing, so "" is a state the service really sees.
+        shareability=shareability,
         expand={"area": _rec(code="RIDGE", name="Ridge Side", sort_order=1)},
     )
 
@@ -894,6 +898,64 @@ class TestUnitsAndCounts:
             await LodgingRosterService(repo).build_roster(2026, 1000001)
 
         spy.assert_called_once()
+
+
+class TestShareabilityPassthrough:
+    """kindred#2026. The unit's classification is READ, never re-derived here.
+
+    The registry is canonical (`feedback_registry_no_silent_fallback`): the
+    rule that produces `shareable` / `single_party` lives in exactly two
+    places, the migration backfill and the Go loader, and this layer must not
+    grow a third copy that could disagree with the stored column. So the only
+    thing worth pinning here is that the value arrives intact and that an
+    unclassified row surfaces as `unknown` rather than being guessed into
+    either real answer.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_stored_classification_reaches_the_payload(self) -> None:
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("u1", "ridge-a", "Ridge A", sleeps=15, shareability="shareable"),
+                _unit("u2", "hc-upstairs-1", "Upstairs 1", sleeps=4, shareability="single_party"),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        by_code = {u.code: u for u in roster.units}
+        assert by_code["ridge-a"].shareability == "shareable"
+        assert by_code["hc-upstairs-1"].shareability == "single_party"
+
+    @pytest.mark.asyncio
+    async def test_an_unclassified_row_reads_unknown_not_a_guess(self) -> None:
+        """An empty column is the ONE case a read-time default would be
+        tempting, and the one where it would do the damage: `sleeps` 15 is
+        exactly the shape the rule calls shareable, so a service that
+        re-derived would answer `shareable` here off a column nobody set.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[_unit("u1", "ridge-a", "Ridge A", sleeps=15, shareability="")],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.units[0].shareability == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_an_unrecognised_stored_value_reads_unknown_not_permissive(self) -> None:
+        """A select gains values over time and a stale API build must not fail
+        open. Anything this layer does not recognise degrades to `unknown`,
+        the non-permissive state, rather than raising or passing through into
+        a Literal the frontend has no branch for.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[_unit("u1", "ridge-a", "Ridge A", sleeps=15, shareability="two_parties_max")],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.units[0].shareability == "unknown"
 
 
 class TestCountsFollowTheDrawLevel:

--- a/tests/unit/api/test_lodging_roster_units.py
+++ b/tests/unit/api/test_lodging_roster_units.py
@@ -126,3 +126,31 @@ def test_a_leaf_below_a_cycle_is_blocked_too() -> None:
     leaf = LodgingUnitSummary(unit_id="rec_leaf", code="leaf", name="Room", parent_code="p1")
 
     assert drawn_units([p1, p2, leaf]) == []
+
+
+# ── Shareability (kindred#2026) ───────────────────────────────────────────────
+#
+# A UNIT property: may more than one party sleep here at once. Not to be
+# confused with the household-level share vocabulary above (`SharePreference`,
+# `ShareEligibility`), which answers whether a FAMILY is willing to share. Both
+# have to be true before two parties may be put in one space, and the unit's
+# half is the one that had no column until this issue.
+
+
+def test_shareability_defaults_to_unknown_never_to_a_permissive_value() -> None:
+    """Unrecorded must never read as permission to double-book.
+
+    `unknown` is a distinct third state, exactly as `bathroom` renders its
+    empty column: the point of a select over a bool (#2026) is that "nobody
+    has classified this" and "one family only" stay different facts.
+    """
+    summary = LodgingUnitSummary(unit_id="rec1", code="hc-upstairs-1", name="Upstairs 1")
+    assert summary.shareability == "unknown"
+
+
+def test_shareability_carries_both_classified_values() -> None:
+    shared = LodgingUnitSummary(unit_id="r1", code="ridge-a", name="Ridge A", shareability="shareable")
+    single = LodgingUnitSummary(unit_id="r2", code="hc-upstairs-1", name="Upstairs 1", shareability="single_party")
+
+    assert shared.shareability == "shareable"
+    assert single.shareability == "single_party"


### PR DESCRIPTION
## What this adds

`lodging_units.shareability` — **may more than one party sleep here at once**. The rule has been recorded in `docs/architecture/lodging-occupancy.md` since the surface was built and could not be enforced, because no column distinguished a large shared-sleeping cabin from a bedroom. `inventory_class` says who a unit is *reserved for*, not how many parties may occupy it, so a bedroom double-booked between two households was possible and undetected.

**A select, not a bool.** Three states are real: `shareable`, `single_party`, and empty — nobody has classified this. Unrecorded must never read as permission to double-book, and equally must never read as a ruling that one family only may go here.

## The rule

| Unit | Classification |
|---|---|
| `family_pool` + leaf + `sleeps >= 12` | `shareable` |
| `family_pool` + leaf + `sleeps` 1–11 | `single_party` |
| `family_pool` + container | `shareable` |
| `staff_default` (leaf or container) | `single_party` |
| anything else | left **empty**, deliberately |

`sleeps >= 12` on leaves reproduces the owner's own enumeration of the shared cabins exactly. **`max_beds` is never an input** — it disagrees with the unit's own bed inventory on roughly a third of rows, including rows where it falls *below* the bed count.

**Containers classify at their own level** (owner ruling, 2026-08-07) and are deliberately *not* tested against `sleeps`. A container's `sleeps` is a delta over its rooms (#2041), and the whole-house total is not the right input either: the container carrying the most historical two-household shares totals **9** across its rooms, so a `>= 12` test on the effective figure would re-flag the very placements the ruling settled. What makes a container shareable is having rooms, not having capacity.

The `family_pool` conjunct is the mechanism that lands the owner's call on the one residue row — a staff-housing building sleeping 19 with zero family-camp placements 2022–2025. Stated as a *reason* rather than as a unit code, because `verify-no-hardcoded-lodging.sh` scans `pb_migrations/`.

## Why a migration backfill

Neither named seed path can reach a row that already exists, and in production all 118 units already exist and are confirmed:

- `seedUnits` (`pocketbase/lodging/registry.go`) looks the unit up by code and year and `continue`s outright. It only ever **creates**.
- `scripts/dev/apply_lodging_inventory.py` withholds every field but `notes` from a confirmed row.

So a seed would report success and change nothing. The Go loader still learns the rule, for **fresh** databases.

## Files

| File | What |
|---|---|
| `pocketbase/pb_migrations/1500000145_lodging_unit_shareability.js` | **new** — field + idempotent, non-destructive backfill |
| `pocketbase/lodging/registry.go` | `classifyShareability` + set on create in `seedUnits` |
| `pocketbase/lodging/registry_shareability_test.go` | **new** — 12-case table test |
| `api/schemas/lodging.py` | `Shareability` literal + field on `LodgingUnitSummary` |
| `api/services/lodging_rules.py` | `unit_shareability` — maps, never derives |
| `api/services/lodging_roster_service.py` | passthrough |
| `frontend/src/types/lodging.ts` | stored vocabulary, record + input |
| `frontend/src/components/admin/lodging/UnitAmenityFieldset.tsx` | the editor select, with a real blank option |
| `frontend/src/components/weekend/unitBadges.ts` + `LodgingUnitCard.tsx` | the board chip |

Also scrubs a camp-identifying unit name from a JSX comment in `LodgingUnitsPanel.tsx`, which had `verify-no-hardcoded-lodging.sh` **red on `main`** — its filter exempts test files but not JSX comments in application source. Same fix-at-the-source precedent as #1909.

## Held for the owner

**Do not merge without a look.** This carries a backfill over production classification data. It is idempotent and non-destructive (proved below), but it writes 118 rows.

Closes #2026.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lodging-unit sharing classifications: **Shared OK**, **single-party**, or **Sharing unset**.
  * Administrators can set a unit’s sharing status when editing lodging details.
  * Lodging cards now display sharing badges where applicable.
  * Existing lodging units are automatically classified when sufficient information is available.
* **Bug Fixes**
  * Unrecognized or missing sharing values now display as unset instead of being incorrectly classified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->