### PR TITLE
fix(frontend): camp journey header labels count as summers, not years

### DIFF
--- a/frontend/src/components/camper/CampJourneyTimeline.test.tsx
+++ b/frontend/src/components/camper/CampJourneyTimeline.test.tsx
@@ -42,14 +42,17 @@ describe('CampJourneyTimeline program-agnostic strings (#2113)', () => {
     expect(screen.getByText(/first year at camp/i)).toBeInTheDocument()
   })
 
-  it('renders the header year count without a summer-flavored tagline', () => {
+  it('renders the header count as summers, not program-agnostic years (#2123)', () => {
+    // years_at_camp counts SUMMER attendance only (#2123 ruling), so the
+    // label must say so, or a family-camp row below a 0 reads as a
+    // contradiction.
     render(<CampJourneyTimeline history={[]} yearsAtCamp={3} currentYear={2026} />)
-    expect(screen.getByText('3 years at camp')).toBeInTheDocument()
+    expect(screen.getByText('3 summers at camp')).toBeInTheDocument()
   })
 
-  it('singularizes the header count for one year', () => {
+  it('singularizes the header count for one summer (#2123)', () => {
     render(<CampJourneyTimeline history={[]} yearsAtCamp={1} currentYear={2026} />)
-    expect(screen.getByText('1 year at camp')).toBeInTheDocument()
+    expect(screen.getByText('1 summer at camp')).toBeInTheDocument()
   })
 
   it('tags a family-camp row with a de-emphasis label', () => {

--- a/frontend/src/components/camper/CampJourneyTimeline.tsx
+++ b/frontend/src/components/camper/CampJourneyTimeline.tsx
@@ -27,11 +27,14 @@ export function CampJourneyTimeline({
           <TreePine className="h-5 w-5" />
           Camp Journey
         </h2>
-        {/* Program-agnostic count (#2113): the branding tagline reads as
-            summer-only ("summers at camp") and the journey now includes
-            family camp and teen years, so it's no longer paired here. */}
+        {/* Summer-flavored count (#2123, reverses #2113): years_at_camp is
+            CampMinder's calculated field and counts SUMMER attendance only —
+            it is not a program-agnostic total. The journey below can include
+            family camp and teen years, so leaving this program-agnostic
+            reads as a contradiction on a family-camp row under a 0. Say what
+            the number actually measures. */}
         <p className="text-forest-200 mt-1 text-sm">
-          {yearsAtCamp} {yearsAtCamp === 1 ? 'year' : 'years'} at camp
+          {yearsAtCamp} {yearsAtCamp === 1 ? 'summer' : 'summers'} at camp
         </p>
       </div>
 


### PR DESCRIPTION
## What changed

`years_at_camp` is CampMinder's calculated field and counts **summer** attendance only (verified against production, see #2123). #2113 had made the camp-journey header wording program-agnostic ("years at camp") on the theory that the journey timeline now spans family camp and teen years too — but that leaves the header contradicting a family-camp row rendered below a `0`. #2123 reverses that call.

- `frontend/src/components/camper/CampJourneyTimeline.tsx`: header now renders `{n} summer(s) at camp` instead of `{n} year(s) at camp`.
- Comment above the line rewritten: it used to argue *for* the program-agnostic wording (#2113's reasoning); it now explains why that reasoning is overruled (#2123) and what the number actually measures.
- `CampJourneyTimeline.test.tsx`: the two header-count assertions now pin `'3 summers at camp'` / `'1 summer at camp'` instead of the old `'years'` wording.

## TDD evidence

RED (test file edited first, wording changed to `summer`/`summers`, source untouched):
```
✗ renders the header count as summers, not program-agnostic years (#2123)
  Unable to find an element with the text: 3 summers at camp
✗ singularizes the header count for one summer (#2123)
  Unable to find an element with the text: 1 summer at camp
Test Files  1 failed (1)
     Tests  2 failed | 5 passed (7)
```

GREEN (after editing `CampJourneyTimeline.tsx`):
```
Test Files  1 passed (1)
     Tests  7 passed (7)
```

## Deliberately not done (scope fence per issue)

- Did not touch `sessionTypePredicates.ts`, `useCamperEnrollment.ts`, or `CamperDetail.tsx` — owned by a sibling PR.
- Did not touch `HeroHeader.tsx:111` (also renders `years at camp`) — issue explicitly rules the consumer audit moot; out of scope here.
- Did not chase the "609 people with summer attendance still show `years_at_camp = 0`" CampMinder data defect — issue says file separately if it becomes operationally visible.
- Left the unrelated `First year at camp!` empty-state string alone — different string, not covered by this issue.

## Part A gaps found

None — the issue body's file path, line numbers (30-34), and the current comment text matched the tree exactly.

Closes #2123.
