### PR TITLE
perf(frontend): gate LodgingAliasesPanel's unit fetch on the editor being open

### DIFF
--- a/frontend/src/components/admin/lodging/LodgingAliasesPanel.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingAliasesPanel.test.tsx
@@ -124,19 +124,41 @@ function zeroYearWrapper({ children }: { children: ReactNode }) {
 }
 
 describe('LodgingAliasesPanel', () => {
-  it('asks the units picker for the current season only', async () => {
+  it('does not fetch the units picker while the editor is closed', async () => {
+    // kindred#2154: the aliases table's own content comes from a separate
+    // query (listLodgingAliases); the unit list is only needed by the
+    // member-unit picker inside the editor, which is not rendered here.
     render(<LodgingAliasesPanel />, { wrapper })
     await waitFor(() => {
       expect(screen.getByText('North Lodge - Whole')).toBeInTheDocument()
     })
-    expect(listLodgingUnits).toHaveBeenCalledWith(2026)
+    expect(listLodgingUnits).not.toHaveBeenCalled()
   })
 
-  it('does not fetch the units picker until the year resolves', async () => {
+  it('asks the units picker for the current season once the editor opens', async () => {
+    const user = userEvent.setup()
+    render(<LodgingAliasesPanel />, { wrapper })
+    await waitFor(() => {
+      expect(screen.getByText('North Lodge - Whole')).toBeInTheDocument()
+    })
+    expect(listLodgingUnits).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole('button', { name: 'New alias' }))
+    await waitFor(() => {
+      expect(listLodgingUnits).toHaveBeenCalledWith(2026)
+    })
+  })
+
+  it('does not fetch the units picker until the year resolves, even with the editor open', async () => {
+    // With the editor closed alone sufficient to gate the fetch, this test
+    // must open the editor to still exercise the YEAR gate specifically.
+    const user = userEvent.setup()
     render(<LodgingAliasesPanel />, { wrapper: zeroYearWrapper })
     await waitFor(() => {
       expect(screen.getByText('North Lodge - Whole')).toBeInTheDocument()
     })
+
+    await user.click(await screen.findByRole('button', { name: /new alias/i }))
     expect(listLodgingUnits).not.toHaveBeenCalled()
   })
 

--- a/frontend/src/components/admin/lodging/LodgingAliasesPanel.tsx
+++ b/frontend/src/components/admin/lodging/LodgingAliasesPanel.tsx
@@ -65,7 +65,13 @@ export function LodgingAliasesPanel() {
   // every consumer below, so the render guard still needs this separately.
   const yearReady = currentYear > 0
 
-  const unitsQuery = useLodgingUnits()
+  // The aliases table's own content comes from a separate query above; the
+  // unit list is only read inside the editor (the member-unit picker, and
+  // the isSuccess-driven focus effect below), so it is only worth fetching
+  // while that editor is open (kindred#2154). UnresolvedAliasQueue and
+  // LodgingUnitsPanel read the unit list unconditionally and keep the
+  // hook's always-on default.
+  const unitsQuery = useLodgingUnits({ enabled: editing !== null })
 
   /**
    * Move attention to the editor whenever it opens — including switching

--- a/frontend/src/hooks/useLodgingUnits.test.tsx
+++ b/frontend/src/hooks/useLodgingUnits.test.tsx
@@ -116,6 +116,23 @@ describe('useLodgingUnits', () => {
     expect(listLodgingUnits).not.toHaveBeenCalled()
   })
 
+  it('does not fetch when the caller disables it, even with a ready year', () => {
+    // kindred#2154: LodgingAliasesPanel only needs the unit list while its
+    // editor is open, so the hook needs a real `enabled` escape hatch.
+    renderHook(() => useLodgingUnits({ enabled: false }), { wrapper: wrapper(YEAR_CONTEXT) })
+    expect(listLodgingUnits).not.toHaveBeenCalled()
+  })
+
+  it('ANDs a caller-supplied enabled with the year gate, rather than replacing it', () => {
+    // enabled: true from the caller must not override an unresolved year —
+    // otherwise a cold load with the editor open would reintroduce the
+    // false-empty-state bug the year gate exists to prevent.
+    renderHook(() => useLodgingUnits({ enabled: true }), {
+      wrapper: wrapper({ ...YEAR_CONTEXT, currentYear: 0, isYearReady: false }),
+    })
+    expect(listLodgingUnits).not.toHaveBeenCalled()
+  })
+
   describe('.items', () => {
     it('coerces to an empty array before the query settles, so callers need no `?? []`', () => {
       const { result } = renderHook(() => useLodgingUnits(), {

--- a/frontend/src/hooks/useLodgingUnits.ts
+++ b/frontend/src/hooks/useLodgingUnits.ts
@@ -29,7 +29,19 @@ export interface UseLodgingUnitsResult {
   error: Error | null
 }
 
-export function useLodgingUnits(): UseLodgingUnitsResult {
+export interface UseLodgingUnitsOptions {
+  /**
+   * ANDed with the year-readiness gate below, never a replacement for it —
+   * see the comment on that gate. Defaults to `true` (always-on), which is
+   * what `LodgingUnitsPanel` and `UnresolvedAliasQueue` want: they read the
+   * unit list unconditionally. `LodgingAliasesPanel` is the one consumer
+   * that only needs it while its own editor is open (kindred#2154).
+   */
+  enabled?: boolean
+}
+
+export function useLodgingUnits(options: UseLodgingUnitsOptions = {}): UseLodgingUnitsResult {
+  const { enabled = true } = options
   const currentYear = useYear()
 
   const query = useQuery({
@@ -39,8 +51,9 @@ export function useLodgingUnits(): UseLodgingUnitsResult {
     // CurrentYearContext returns the literal 0 until the backend supplies the
     // configured year, and PocketBase answers `year = 0` with a successful
     // `200 []` rather than an error — without this gate a cold load renders a
-    // false empty state.
-    enabled: currentYear > 0,
+    // false empty state. The caller-supplied `enabled` is ANDed on top, never
+    // in place of it.
+    enabled: enabled && currentYear > 0,
   })
 
   return {


### PR DESCRIPTION
## What changed

`useLodgingUnits` gains a real `enabled` option, **ANDed with** the existing
year-readiness gate (`enabled: enabled && currentYear > 0`) — not replacing
it. The year gate exists because PocketBase answers `year = 0` with a
successful `200 []`; dropping it would reintroduce a false empty state.

`LodgingAliasesPanel` now passes `enabled: editing !== null`, so the unit
list is fetched — and refetched on window focus — only while its own editor
is open. `UnresolvedAliasQueue` and `LodgingUnitsPanel` are unchanged and
keep the always-on default, since they read the unit list unconditionally.

`useLodgingAreas` is untouched — its `enabled` option was removed in #2132
because it was inert at its only call site, and it still would be. This PR
does not re-add it.

## TDD evidence

RED (before implementation):
```
useLodgingUnits.test.tsx > does not fetch when the caller disables it, even with a ready year — FAIL (called with [2026])
LodgingAliasesPanel.test.tsx > does not fetch the units picker while the editor is closed — FAIL (called with [2026])
LodgingAliasesPanel.test.tsx > asks the units picker for the current season once the editor opens — FAIL (called with [2026])
```

GREEN (after implementation): all 28 tests across both files pass.

Mutation check on the year-gate ANDing: temporarily changed
`enabled: enabled && currentYear > 0` to `enabled: enabled` (dropping the
year gate). This turned 3 tests RED — `does not fetch until the year
resolves` (hook), `ANDs a caller-supplied enabled with the year gate,
rather than replacing it` (hook), and `does not fetch the units picker
until the year resolves, even with the editor open` (panel) — each now
calling `listLodgingUnits` with `[0]`. Reverted; all 28 pass again.

Verified without changes: `still moves focus into the form when the units
resolve after the editor opened` — this test's `unitsQuery.isSuccess`
dependency now genuinely toggles false → true only after the editor opens
under the new gate, and it still passes.

## Test changes (per the issue's guidance)

- `asks the units picker for the current season only` → split into "does
  not fetch while closed" + "asks... once the editor opens".
- `does not fetch the units picker until the year resolves` → now opens the
  editor first, so the YEAR gate (not the closed-editor gate) is what's
  under test. Mutation-checked above.
- New: mount with `editing === null`, assert `listLodgingUnits` is not
  called.
- Added two hook-level tests for the new `enabled` option and its ANDing
  with the year gate.

## What I deliberately did not do

- Did not touch `useLodgingAreas` — the issue explicitly says not to
  re-add `enabled` there for symmetry.
- Did not change `UnresolvedAliasQueue` or `LodgingUnitsPanel` — both keep
  the hook's always-on default.

## Part A gap

The issue body's line-number anchors were all stale against `main` (as the
issue itself warns); I re-derived every location from the current tree
rather than trusting them. No behavioral or scope disagreement with the
issue — everything else in the body matched what I found.

Closes #2154.
