### PR TITLE
fix(pb): OnServe hook errors never reach os.Exit(1) — boot failures exit 0

### DIFF
--- a/pocketbase/main.go
+++ b/pocketbase/main.go
@@ -93,6 +93,23 @@ func (s *bootFailureSentinel) Reset() {
 
 var bootSentinel bootFailureSentinel
 
+// Seams for the fallible calls inside the boot-stopping OnServe hooks below
+// (lodgingRegistryOnServeHook, syncServiceOnServeHook). Package-level
+// function variables rather than direct calls to sync.ParseSeasonYear,
+// lodging.RegistryHasRows, etc., so tests can substitute a failing
+// implementation and invoke the extracted hook functions directly to verify
+// each call site actually records a boot failure -- see
+// main_boot_failure_sentinel_test.go and issue #2140. Production wiring
+// never reassigns these; only tests do, and always restore the original
+// afterward.
+var (
+	parseSeasonYearFn       = sync.ParseSeasonYear
+	registryHasRowsFn       = lodging.RegistryHasRows
+	registryFilePresentFn   = lodging.RegistryFilePresent
+	seedRegistryFn          = lodging.SeedRegistry
+	initializeSyncServiceFn = sync.InitializeSyncService
+)
+
 // recordBootFailure marks a boot-stopping OnServe hook failure for main()
 // to observe after app.Start() returns nil despite the hook's error. See
 // bootFailureSentinel above.
@@ -250,34 +267,7 @@ func main() {
 	// Skip rather than guess. Seeding ~118 units into a guessed season is
 	// strictly worse than seeding none: the first roll-forward would carry
 	// the phantom season forward as though it were real.
-	app.OnServe().BindFunc(func(e *core.ServeEvent) error {
-		year, err := sync.ParseSeasonYear()
-		if err != nil {
-			hasRows, rowsErr := lodging.RegistryHasRows(e.App)
-			if rowsErr != nil {
-				// Can't determine whether the registry already has rows —
-				// fail open (warn, don't take the boot down) rather than
-				// compound one failure with a second, less legible one.
-				slog.Warn("lodging registry load skipped: season unavailable "+
-					"(row-presence check also failed)", "err", err, "rows_check_err", rowsErr)
-				return e.Next()
-			}
-			if bootErr := lodgingRegistryBootDecision(err, lodging.RegistryFilePresent(), hasRows); bootErr != nil {
-				// Recorded so main() can os.Exit(1) after app.Start()
-				// returns nil regardless -- see bootFailureSentinel (#2140).
-				recordBootFailure(bootErr)
-				return bootErr
-			}
-			return e.Next()
-		}
-		if bootErr := lodgingRegistrySeedBootDecision(lodging.SeedRegistry(e.App, year)); bootErr != nil {
-			// Recorded so main() can os.Exit(1) after app.Start() returns
-			// nil regardless -- see bootFailureSentinel (#2140).
-			recordBootFailure(bootErr)
-			return bootErr
-		}
-		return e.Next()
-	})
+	app.OnServe().BindFunc(lodgingRegistryOnServeHook)
 
 	// Config initialization now handled by migrations
 
@@ -288,17 +278,7 @@ func main() {
 	// Register sync service
 	app.OnServe().Bind(&hook.Handler[*core.ServeEvent]{
 		Func: func(e *core.ServeEvent) error {
-			// Initialize sync service
-			slog.Info("Initializing Kindred sync service")
-			if err := sync.InitializeSyncService(app, e); err != nil {
-				bootErr := fmt.Errorf("initializing sync service: %w", err)
-				// Recorded so main() can os.Exit(1) after app.Start()
-				// returns nil regardless -- see bootFailureSentinel (#2140).
-				recordBootFailure(bootErr)
-				return bootErr
-			}
-
-			return e.Next()
+			return syncServiceOnServeHook(app, e)
 		},
 	})
 
@@ -401,6 +381,58 @@ func runHistorySync(app core.App) error {
 		return fmt.Errorf("history-sync WAL checkpoint failed: %w", err)
 	}
 	return nil
+}
+
+// lodgingRegistryOnServeHook is the OnServe hook body for the lodging
+// registry loader (bound in main() via app.OnServe().BindFunc). Extracted to
+// a named, directly-callable function -- rather than left as an anonymous
+// closure -- so a test can invoke it against a substituted (failing) seam
+// and assert bootFailure() becomes non-nil, pinning that this call site
+// really does call recordBootFailure(bootErr) before returning the error.
+// See main_boot_failure_sentinel_test.go and issue #2140.
+func lodgingRegistryOnServeHook(e *core.ServeEvent) error {
+	year, err := parseSeasonYearFn()
+	if err != nil {
+		hasRows, rowsErr := registryHasRowsFn(e.App)
+		if rowsErr != nil {
+			// Can't determine whether the registry already has rows —
+			// fail open (warn, don't take the boot down) rather than
+			// compound one failure with a second, less legible one.
+			slog.Warn("lodging registry load skipped: season unavailable "+
+				"(row-presence check also failed)", "err", err, "rows_check_err", rowsErr)
+			return e.Next()
+		}
+		if bootErr := lodgingRegistryBootDecision(err, registryFilePresentFn(), hasRows); bootErr != nil {
+			// Recorded so main() can os.Exit(1) after app.Start()
+			// returns nil regardless -- see bootFailureSentinel (#2140).
+			recordBootFailure(bootErr)
+			return bootErr
+		}
+		return e.Next()
+	}
+	if bootErr := lodgingRegistrySeedBootDecision(seedRegistryFn(e.App, year)); bootErr != nil {
+		// Recorded so main() can os.Exit(1) after app.Start() returns
+		// nil regardless -- see bootFailureSentinel (#2140).
+		recordBootFailure(bootErr)
+		return bootErr
+	}
+	return e.Next()
+}
+
+// syncServiceOnServeHook is the OnServe hook body that initializes the
+// Kindred sync service (bound in main() via app.OnServe().Bind). Extracted
+// for the same reason as lodgingRegistryOnServeHook above -- see its doc
+// comment.
+func syncServiceOnServeHook(app *pocketbase.PocketBase, e *core.ServeEvent) error {
+	slog.Info("Initializing Kindred sync service")
+	if err := initializeSyncServiceFn(app, e); err != nil {
+		bootErr := fmt.Errorf("initializing sync service: %w", err)
+		// Recorded so main() can os.Exit(1) after app.Start()
+		// returns nil regardless -- see bootFailureSentinel (#2140).
+		recordBootFailure(bootErr)
+		return bootErr
+	}
+	return e.Next()
 }
 
 // lodgingRegistryBootDecision turns a sync.ParseSeasonYear failure into

--- a/pocketbase/main.go
+++ b/pocketbase/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/pocketbase/pocketbase"
@@ -39,6 +40,76 @@ func init() {
 			return p
 		}
 	}
+}
+
+// bootFailureSentinel records an error from a boot-stopping OnServe hook so
+// main() can observe it after app.Start() returns. It exists because
+// pocketbase.PocketBase.Execute() (pocketbase.go:179-212) runs cobra's
+// RootCmd.Execute() in a goroutine and discards its return value: the
+// serve command's OnServe-hook error does stop apis.Serve and gets printed
+// by cobra, but Execute() itself returns whatever OnTerminate().Trigger(...)
+// produces, which is nil on the normal shutdown path regardless of whether
+// serve actually failed. So app.Start() -- a thin wrapper over Execute() --
+// comes back nil too, and main()'s existing `if err := app.Start(); err !=
+// nil { os.Exit(1) }` block never fires for this class of failure. See
+// issue #2140.
+//
+// A hook that decides the boot must not continue calls Set alongside
+// returning its error (the hook's return value is unchanged -- OnServe
+// still needs it to stop apis.Serve and to have cobra print it). main()
+// then checks Get once app.Start() returns.
+//
+// atomic.Pointer over a mutex-guarded var: Set/Get are single-word CAS/load
+// ops, so there's no lock to forget to take, and a zero-value
+// bootFailureSentinel is immediately safe to use -- no constructor needed
+// for the package-level instance below.
+type bootFailureSentinel struct {
+	err atomic.Pointer[error]
+}
+
+// Set records err as the reason the boot must not continue. A later Set
+// overwrites an earlier one -- main() only needs to know that at least one
+// boot-stopping hook failed and why, not the full history.
+func (s *bootFailureSentinel) Set(err error) {
+	s.err.Store(&err)
+}
+
+// Get returns the most recently recorded boot failure, or nil if no
+// boot-stopping hook has failed.
+func (s *bootFailureSentinel) Get() error {
+	p := s.err.Load()
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+// Reset clears any recorded boot failure. Exists for tests: the sentinel
+// below is a package-level singleton, so a test that records into it must
+// clear it afterward to avoid leaking state into the next test.
+func (s *bootFailureSentinel) Reset() {
+	s.err.Store(nil)
+}
+
+var bootSentinel bootFailureSentinel
+
+// recordBootFailure marks a boot-stopping OnServe hook failure for main()
+// to observe after app.Start() returns nil despite the hook's error. See
+// bootFailureSentinel above.
+func recordBootFailure(err error) {
+	bootSentinel.Set(err)
+}
+
+// bootFailure returns the last error recorded by recordBootFailure, or nil
+// if no boot-stopping hook has failed.
+func bootFailure() error {
+	return bootSentinel.Get()
+}
+
+// resetBootFailure clears the sentinel. Exists for tests -- see
+// bootFailureSentinel.Reset.
+func resetBootFailure() {
+	bootSentinel.Reset()
 }
 
 func main() {
@@ -192,11 +263,17 @@ func main() {
 				return e.Next()
 			}
 			if bootErr := lodgingRegistryBootDecision(err, lodging.RegistryFilePresent(), hasRows); bootErr != nil {
+				// Recorded so main() can os.Exit(1) after app.Start()
+				// returns nil regardless -- see bootFailureSentinel (#2140).
+				recordBootFailure(bootErr)
 				return bootErr
 			}
 			return e.Next()
 		}
 		if bootErr := lodgingRegistrySeedBootDecision(lodging.SeedRegistry(e.App, year)); bootErr != nil {
+			// Recorded so main() can os.Exit(1) after app.Start() returns
+			// nil regardless -- see bootFailureSentinel (#2140).
+			recordBootFailure(bootErr)
 			return bootErr
 		}
 		return e.Next()
@@ -214,7 +291,11 @@ func main() {
 			// Initialize sync service
 			slog.Info("Initializing Kindred sync service")
 			if err := sync.InitializeSyncService(app, e); err != nil {
-				return fmt.Errorf("initializing sync service: %w", err)
+				bootErr := fmt.Errorf("initializing sync service: %w", err)
+				// Recorded so main() can os.Exit(1) after app.Start()
+				// returns nil regardless -- see bootFailureSentinel (#2140).
+				recordBootFailure(bootErr)
+				return bootErr
 			}
 
 			return e.Next()
@@ -288,6 +369,16 @@ func main() {
 
 	if err := app.Start(); err != nil {
 		slog.Error("Failed to start application", "error", err)
+		os.Exit(1)
+	}
+
+	// app.Start() can return nil even though a boot-stopping OnServe hook
+	// failed: pocketbase.PocketBase.Execute() runs cobra's RootCmd in a
+	// goroutine and discards its return value, so the serve command's
+	// error never reaches here. Check the sentinel those hooks record into
+	// instead. See bootFailureSentinel above and issue #2140.
+	if err := bootFailure(); err != nil {
+		slog.Error("Boot aborted by a serve hook", "error", err)
 		os.Exit(1)
 	}
 }

--- a/pocketbase/main_boot_failure_sentinel_test.go
+++ b/pocketbase/main_boot_failure_sentinel_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestBootFailureSentinel pins issue #2140: an OnServe hook error that stops
+// the boot never reaches main()'s os.Exit(1) block, because
+// pocketbase.Execute() runs cobra's RootCmd in a goroutine and discards its
+// return value -- app.Start() comes back nil regardless of whether a
+// boot-stopping hook failed. The sentinel is how main() finds out anyway: a
+// hook that decides to abort the boot also records its error here, and
+// main() checks it after app.Start() returns.
+//
+// This test cannot exercise the real fix end-to-end -- that would require
+// calling os.Exit(1) inside the test process, which is destructive and
+// exactly what the issue says not to do. So it pins the sentinel's
+// record/get/reset contract directly: a fresh process starts with no
+// recorded failure, recording one makes it observable, and resetting clears
+// it back to the starting state (needed so tests don't leak boot-failure
+// state into each other via the shared package-level sentinel).
+func TestBootFailureSentinel(t *testing.T) {
+	t.Cleanup(resetBootFailure)
+
+	t.Run("starts nil", func(t *testing.T) {
+		resetBootFailure()
+		if err := bootFailure(); err != nil {
+			t.Fatalf("expected no boot failure recorded yet, got: %v", err)
+		}
+	})
+
+	t.Run("recording an error makes it observable", func(t *testing.T) {
+		resetBootFailure()
+		want := errors.New("lodging registry file present but no season is resolvable")
+
+		recordBootFailure(want)
+
+		got := bootFailure()
+		if got == nil {
+			t.Fatal("expected bootFailure() to return the recorded error, got nil")
+		}
+		if !errors.Is(got, want) {
+			t.Errorf("expected bootFailure() to return the exact recorded error, got: %v", got)
+		}
+	})
+
+	t.Run("reset clears a previously recorded failure", func(t *testing.T) {
+		resetBootFailure()
+		recordBootFailure(errors.New("initializing sync service: boom"))
+
+		resetBootFailure()
+
+		if err := bootFailure(); err != nil {
+			t.Fatalf("expected bootFailure() to be nil after reset, got: %v", err)
+		}
+	})
+
+	t.Run("a later record overwrites an earlier one", func(t *testing.T) {
+		resetBootFailure()
+		first := errors.New("first hook failure")
+		second := errors.New("second hook failure")
+
+		recordBootFailure(first)
+		recordBootFailure(second)
+
+		got := bootFailure()
+		if !errors.Is(got, second) {
+			t.Errorf("expected the most recent recorded error, got: %v", got)
+		}
+		if errors.Is(got, first) {
+			t.Errorf("did not expect the first error to still be reachable, got: %v", got)
+		}
+	})
+}

--- a/pocketbase/main_boot_failure_wiring_test.go
+++ b/pocketbase/main_boot_failure_wiring_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// TestBootFailureWiring exercises the three OnServe hook bodies that are
+// supposed to call recordBootFailure(bootErr) immediately before returning
+// their error -- lodgingRegistryOnServeHook's two branches and
+// syncServiceOnServeHook. main_boot_failure_sentinel_test.go pins the
+// sentinel's Set/Get/Reset contract in isolation; it never called these hook
+// functions, so a future edit that dropped the recordBootFailure call at any
+// of the three sites (while leaving everything else, including that other
+// test file, untouched) would go undetected. This test closes that gap by
+// calling the extracted hook functions directly, with the fallible call each
+// branch depends on substituted via a package-level seam (see the var block
+// above lodgingRegistryOnServeHook's declaration in main.go), and asserting
+// bootFailure() becomes non-nil afterward. See issue #2140.
+func TestBootFailureWiring(t *testing.T) {
+	t.Cleanup(resetBootFailure)
+
+	t.Run("lodgingRegistryOnServeHook records a failure on the unresolvable-season branch", func(t *testing.T) {
+		resetBootFailure()
+
+		origParseSeasonYear := parseSeasonYearFn
+		origRegistryHasRows := registryHasRowsFn
+		origRegistryFilePresent := registryFilePresentFn
+		t.Cleanup(func() {
+			parseSeasonYearFn = origParseSeasonYear
+			registryHasRowsFn = origRegistryHasRows
+			registryFilePresentFn = origRegistryFilePresent
+		})
+
+		parseSeasonYearFn = func() (int, error) { return 0, errors.New("no season configured") }
+		registryHasRowsFn = func(_ core.App) (bool, error) { return false, nil }
+		registryFilePresentFn = func() bool { return true }
+
+		e := &core.ServeEvent{}
+		err := lodgingRegistryOnServeHook(e)
+		if err == nil {
+			t.Fatal("expected lodgingRegistryOnServeHook to return an error")
+		}
+		if got := bootFailure(); got == nil {
+			t.Fatal("expected bootFailure() to be recorded by lodgingRegistryOnServeHook's " +
+				"unresolvable-season branch, got nil -- recordBootFailure(bootErr) missing at this call site")
+		} else if !errors.Is(got, err) {
+			t.Errorf("expected bootFailure() to be the hook's own returned error, got: %v (hook returned: %v)", got, err)
+		}
+	})
+
+	t.Run("lodgingRegistryOnServeHook records a failure on the unloadable-registry branch", func(t *testing.T) {
+		resetBootFailure()
+
+		origParseSeasonYear := parseSeasonYearFn
+		origSeedRegistry := seedRegistryFn
+		t.Cleanup(func() {
+			parseSeasonYearFn = origParseSeasonYear
+			seedRegistryFn = origSeedRegistry
+		})
+
+		parseSeasonYearFn = func() (int, error) { return 2026, nil }
+		seedRegistryFn = func(_ core.App, _ int) error { return errors.New("duplicate unit code") }
+
+		e := &core.ServeEvent{}
+		err := lodgingRegistryOnServeHook(e)
+		if err == nil {
+			t.Fatal("expected lodgingRegistryOnServeHook to return an error")
+		}
+		if got := bootFailure(); got == nil {
+			t.Fatal("expected bootFailure() to be recorded by lodgingRegistryOnServeHook's " +
+				"unloadable-registry branch, got nil -- recordBootFailure(bootErr) missing at this call site")
+		} else if !errors.Is(got, err) {
+			t.Errorf("expected bootFailure() to be the hook's own returned error, got: %v (hook returned: %v)", got, err)
+		}
+	})
+
+	t.Run("syncServiceOnServeHook records a failure when InitializeSyncService fails", func(t *testing.T) {
+		resetBootFailure()
+
+		origInitializeSyncService := initializeSyncServiceFn
+		t.Cleanup(func() { initializeSyncServiceFn = origInitializeSyncService })
+
+		initializeSyncServiceFn = func(_ *pocketbase.PocketBase, _ *core.ServeEvent) error {
+			return errors.New("sync service init boom")
+		}
+
+		e := &core.ServeEvent{}
+		err := syncServiceOnServeHook(nil, e)
+		if err == nil {
+			t.Fatal("expected syncServiceOnServeHook to return an error")
+		}
+		if got := bootFailure(); got == nil {
+			t.Fatal("expected bootFailure() to be recorded by syncServiceOnServeHook, got nil -- " +
+				"recordBootFailure(bootErr) missing at this call site")
+		} else if !errors.Is(got, err) {
+			t.Errorf("expected bootFailure() to be the hook's own returned error, got: %v (hook returned: %v)", got, err)
+		}
+	})
+}


### PR DESCRIPTION
## What changed

`app.Start()` in `pocketbase/main.go` returns `nil` even when a boot-stopping
`OnServe` hook fails, because `pocketbase.PocketBase.Execute()` runs cobra's
`RootCmd` in a goroutine and discards its return value. The `serve` command's
`OnServe`-hook error stops `apis.Serve` and gets printed by cobra, but
`Execute()` returns whatever `OnTerminate().Trigger(...)` produces, which is
`nil` on the normal path — so the existing `if err := app.Start(); err != nil
{ os.Exit(1) }` block never fires for this class of failure, and a boot
failure exits 0.

Implements the issue's preferred fix — a boot-failure sentinel checked in
`main()` after `app.Start()` returns — and only that fix. `os.Exit` inside the
hooks, patching upstream pocketbase, and documenting-only were explicitly
rejected in the issue and are not implemented here.

Added `bootFailureSentinel`, a package-level `atomic.Pointer[error]`-backed
struct with `Set`/`Get`/`Reset`, and three unexported wrapper functions
(`recordBootFailure`, `bootFailure`, `resetBootFailure`) that `main.go` and
its tests use.

The three boot-stopping sites now call `recordBootFailure(bootErr)`
immediately before `return bootErr` (the hook's own return value is
unchanged):

- the unresolvable-season abort (`lodgingRegistryBootDecision` return path)
- the unloadable-registry abort (`lodgingRegistrySeedBootDecision` return path)
- the `sync.InitializeSyncService` failure path

`main()` checks `bootFailure()` right after the existing `app.Start()` error
check and calls `os.Exit(1)` if a hook recorded a failure, logging
`"Boot aborted by a serve hook"`.

The decision functions (`lodgingRegistryBootDecision`,
`lodgingRegistrySeedBootDecision`) are untouched — no `os.Exit` was added to
them, so they remain unit-testable exactly as before.

## TDD evidence

RED (sentinel functions didn't exist yet — compile failure):

```
./main_boot_failure_sentinel_test.go:37:3: undefined: recordBootFailure
./main_boot_failure_sentinel_test.go:39:10: undefined: bootFailure
./main_boot_failure_sentinel_test.go:49:3: undefined: resetBootFailure
FAIL	github.com/camp/kindred/pocketbase [build failed]
```

GREEN after implementing `bootFailureSentinel`:

```
$ go test . -run TestBootFailureSentinel -v
--- PASS: TestBootFailureSentinel (0.00s)
    --- PASS: TestBootFailureSentinel/starts_nil (0.00s)
    --- PASS: TestBootFailureSentinel/recording_an_error_makes_it_observable (0.00s)
    --- PASS: TestBootFailureSentinel/reset_clears_a_previously_recorded_failure (0.00s)
    --- PASS: TestBootFailureSentinel/a_later_record_overwrites_an_earlier_one (0.00s)
PASS
ok  	github.com/camp/kindred/pocketbase	0.291s
```

Also passes under `-race`. Full package suite (`go test ./...`), `go build
./...`, `go vet ./...`, and `gofmt -l .` all pass.

Per the issue, the sentinel's record/get/reset contract is what's directly
unit-testable — `main()` itself calls `os.Exit(1)` and can't be exercised in
a test process, and the three call sites are one-line `recordBootFailure`
calls glued into already-tested decision functions.

## Deliberately not done

- No change to the three decision functions' logic (`lodgingRegistryBootDecision`,
  `lodgingRegistrySeedBootDecision`) — only the sentinel wiring around their
  return paths.
- No end-to-end test that boots the real binary and checks the process exit
  code — the issue's own reproduction already confirms this at the shell
  level; adding that here would need a subprocess test harness out of scope
  for this fix.
- No pocketbase migration — none needed.

## Part A gap

None. The issue's three site descriptions (unresolvable-season abort,
unloadable-registry abort, `InitializeSyncService` failure) matched the tree;
only the exact line numbers shifted slightly by the time of this PR, which is
expected drift and not a body error.

Closes #2140.
