### PR TITLE
fix(frontend): surface lodging_prod_audit_warnings on the admin Sync tab

### DIFF
--- a/frontend/src/components/admin/SyncTab.test.tsx
+++ b/frontend/src/components/admin/SyncTab.test.tsx
@@ -8,7 +8,7 @@
  * cards could submit a second request before status polling flipped the card to "running".
  */
 import { render, screen, within } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { SyncTab } from './SyncTab'
 
@@ -17,6 +17,11 @@ vi.mock('../../hooks/useCurrentYear', () => ({
 }))
 
 const idleStatus = { status: 'idle' } as const
+
+// Mutable per-test override for the stranded_assignment_cleanup status, read at call time so a
+// single test (#2161's lodging⚠ badge) can inject a status without re-declaring the whole mock.
+// Reset in `beforeEach` so tests stay isolated.
+let strandedAssignmentCleanupStatus: unknown = idleStatus
 
 vi.mock('../../hooks/useSyncCompletionToasts', () => ({
   useSyncCompletionToasts: () => ({
@@ -31,6 +36,9 @@ vi.mock('../../hooks/useSyncCompletionToasts', () => ({
     quest_registrations: idleStatus,
     staff_applications: idleStatus,
     staff_vehicle_info: idleStatus,
+    get stranded_assignment_cleanup() {
+      return strandedAssignmentCleanupStatus
+    },
   }),
 }))
 
@@ -105,5 +113,36 @@ describe('SyncTab generic card pending guard (#1881)', () => {
 
     expect(getCardRunButton('Camper History')).not.toBeDisabled()
     expect(getCardRunButton('Staff Skills')).not.toBeDisabled()
+  })
+})
+
+// Regression test for #2161: Stats.LodgingProdAuditWarnings (pocketbase/sync/orchestrator.go)
+// had zero frontend consumers. The bunk-side prod_audit_warnings already renders an amber
+// "prod⚠" badge on the Stranded Assignment Cleanup card; the parallel lodging count must render
+// its own distinguishable "lodging⚠" badge on the same card.
+describe('SyncTab lodging prod audit warnings badge (#2161)', () => {
+  afterEach(() => {
+    strandedAssignmentCleanupStatus = idleStatus
+  })
+
+  it('renders a lodging⚠ badge when lodging_prod_audit_warnings is positive', () => {
+    strandedAssignmentCleanupStatus = {
+      status: 'success',
+      summary: {
+        created: 0,
+        updated: 0,
+        skipped: 0,
+        errors: 0,
+        lodging_prod_audit_warnings: 3,
+      },
+    }
+
+    renderSyncTab()
+
+    const heading = screen.getByText('Stranded Assignment Cleanup', { selector: 'div' })
+    const card = heading.closest('.flex.flex-col')
+    if (!card) throw new Error('could not find Stranded Assignment Cleanup card')
+
+    expect(within(card as HTMLElement).getByText('3 lodging⚠')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/admin/SyncTab.tsx
+++ b/frontend/src/components/admin/SyncTab.tsx
@@ -298,6 +298,11 @@ export function SyncTab() {
                     {status.summary.prod_audit_warnings} prod⚠
                   </span>
                 )}
+                {(status.summary.lodging_prod_audit_warnings ?? 0) > 0 && (
+                  <span className="font-medium text-amber-600 dark:text-amber-400">
+                    {status.summary.lodging_prod_audit_warnings} lodging⚠
+                  </span>
+                )}
               </div>
               <div className="text-muted-foreground truncate text-xs sm:text-sm">
                 {status.summary.duration !== undefined && formatDuration(status.summary.duration)}

--- a/frontend/src/hooks/useSyncStatusAPI.ts
+++ b/frontend/src/hooks/useSyncStatusAPI.ts
@@ -43,6 +43,7 @@ export interface SyncStatus {
     errors: number
     already_processed?: number // For process_requests: records already processed
     prod_audit_warnings?: number // For stranded_assignment_cleanup: stranded prod assignments (observe-only)
+    lodging_prod_audit_warnings?: number // For stranded_assignment_cleanup: stranded lodging prod assignments (observe-only)
     duration?: number
     sub_stats?: Record<string, SubStats> // For combined syncs (e.g., persons includes households)
   }

--- a/pocketbase/sync/stranded_assignment_cleanup.go
+++ b/pocketbase/sync/stranded_assignment_cleanup.go
@@ -490,7 +490,7 @@ func reconcileLodgingOrphans(app core.App, year int, stats *Stats) error {
 		"year", year,
 		"orphaned_drafts", len(orphanDrafts),
 		"drafts_swept", writes,
-		"prod_audit_warnings", stats.LodgingProdAuditWarnings,
+		"lodging_prod_audit_warnings", stats.LodgingProdAuditWarnings,
 		"errors", stats.Errors,
 	)
 	return nil


### PR DESCRIPTION
## What changed

Three near-mechanical changes mirroring the existing `prod_audit_warnings` pattern:

1. `frontend/src/hooks/useSyncStatusAPI.ts` — added `lodging_prod_audit_warnings?: number` to `SyncStatus['summary']`, alongside the existing `prod_audit_warnings?: number`.
2. `frontend/src/components/admin/SyncTab.tsx` — added a second amber badge block on the Stranded Assignment Cleanup card, keying off `status.summary.lodging_prod_audit_warnings`, labelled `lodging⚠` to stay distinguishable from the sibling `prod⚠` badge. Same `?? 0` guard, same amber classes (`text-amber-600 dark:text-amber-400`), no new colour/tone.
3. `pocketbase/sync/stranded_assignment_cleanup.go` — renamed the log key from `"prod_audit_warnings"` to `"lodging_prod_audit_warnings"` at the site that logs `stats.LodgingProdAuditWarnings`, so log greps for `prod_audit_warnings` no longer pull in the lodging stat.

The badge renders only when the count is `> 0`, so it stays invisible until the counter goes positive — no live production reading was needed to build or test this, per the issue's note.

## TDD evidence

RED — added `SyncTab.test.tsx` test "renders a lodging⚠ badge when lodging_prod_audit_warnings is positive" (mutable per-test override for the `stranded_assignment_cleanup` status object read from the existing `useSyncCompletionToasts` mock). Before the implementation change:

```
❯ Object.getElementError node_modules/@testing-library/dom/dist/config.js:37:19
 ❯ src/components/admin/SyncTab.test.tsx:146:40
    expect(within(card as HTMLElement).getByText('3 lodging⚠')).toBeInTheDocument()
 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
```

GREEN — after adding the type field and the badge block:

```
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

## Gates run

- `./node_modules/.bin/vitest run src/components/admin/SyncTab.test.tsx` — 3 passed, exit=0
- `./node_modules/.bin/tsc --noEmit` — exit=0
- `./node_modules/.bin/eslint src/components/admin/SyncTab.tsx src/components/admin/SyncTab.test.tsx src/hooks/useSyncStatusAPI.ts` — exit=0
- `go build ./...` — exit=0
- `go test ./sync/...` — ok, exit=0
- `gofmt -l .` — no output, exit=0
- pre-push hook (go-build, type-check) — passed

## Deliberately not done

- No live production reading of the counter (per the issue, not required to build/test this).
- No changes to the bunk-side `prod_audit_warnings` badge — untouched, only copied.

## Part A gaps

None. The issue body's re-verified line numbers and field/hook names matched the tree exactly at the time of this PR.

Closes #2161.
