### PR TITLE
fix(pb): roll-forward plan returns null for empty unit_codes/skipped_codes

### DIFF
--- a/frontend/src/components/admin/lodging/SeasonRollForwardPanel.test.tsx
+++ b/frontend/src/components/admin/lodging/SeasonRollForwardPanel.test.tsx
@@ -44,8 +44,14 @@ interface RollForwardPlanFixture {
   units_to_create: number
   areas_present: number
   units_present: number
-  unit_codes: string[]
-  skipped_codes: string[]
+  // Widened to allow `null`: a source year with no registry at all never runs
+  // either `append` on the Go side, so an uninitialized `[]string` field stays
+  // nil and marshals as `null`, not `[]` (pocketbase/lodging/rollforward.go).
+  // The fixture type used to make that shape unrepresentable, which is why
+  // the suite stayed green through the outage -- widening it is part of the
+  // regression test, not just a type fix.
+  unit_codes: string[] | null
+  skipped_codes: string[] | null
 }
 
 const DEFAULT_PLAN: RollForwardPlanFixture = {
@@ -161,6 +167,26 @@ describe('SeasonRollForwardPanel', () => {
       },
     })
     expect(await screen.findByText(/test-unit-a/)).toBeInTheDocument()
+  })
+
+  it('renders instead of throwing when the endpoint returns null arrays', async () => {
+    // Reproduces #2182: a source year with no registry leaves both slices nil
+    // on the Go side, which encoding/json marshals as `null`. Before the fix,
+    // `plan.skipped_codes.length` throws `Cannot read properties of null
+    // (reading 'length')` during render -- the Season tab crashes outright,
+    // not through an error handler QueryGuard could catch.
+    renderWithProviders(<SeasonRollForwardPanel />, {
+      preview: {
+        units_to_create: 0,
+        areas_to_create: 0,
+        units_present: 0,
+        areas_present: 0,
+        unit_codes: null,
+        skipped_codes: null,
+      },
+    })
+    const applyButton = await screen.findByRole('button', { name: /forward/i })
+    expect(applyButton).toHaveTextContent(/nothing to carry forward/i)
   })
 
   it('does not fetch the preview before the season resolves', () => {

--- a/frontend/src/components/admin/lodging/SeasonRollForwardPanel.tsx
+++ b/frontend/src/components/admin/lodging/SeasonRollForwardPanel.tsx
@@ -33,7 +33,18 @@ const BASE = '/api/custom/lodging/roll-forward'
 /** Ties the Details disclosure to the list it expands, for assistive tech. */
 const UNIT_CODES_ID = 'roll-forward-unit-codes'
 
-/** What both the preview and apply endpoints return — a dry run and a real one render identically. */
+/**
+ * What both the preview and apply endpoints return — a dry run and a real one
+ * render identically.
+ *
+ * `unit_codes` / `skipped_codes` are typed nullable because the Go side only
+ * ever grows them with `append` (pocketbase/lodging/rollforward.go); a source
+ * year that copies and skips nothing never runs either append, and an
+ * uninitialized `[]string` field marshals as `null`, not `[]` (#2182). The Go
+ * fix initializes both to `[]string{}`, but this type stays nullable and the
+ * two call sites below keep their `?? []` guard as insurance against the same
+ * class from any other nil slice on this endpoint — not the fix itself.
+ */
 export interface RollForwardPlan {
   from_year: number
   to_year: number
@@ -41,8 +52,8 @@ export interface RollForwardPlan {
   units_to_create: number
   areas_present: number
   units_present: number
-  unit_codes: string[]
-  skipped_codes: string[]
+  unit_codes: string[] | null
+  skipped_codes: string[] | null
 }
 
 /** This is a PocketBase custom route, not FastAPI — errors carry `error`, not `detail`. */
@@ -191,18 +202,18 @@ export function SeasonRollForwardPanel() {
               </button>
             </div>
 
-            {plan.skipped_codes.length > 0 && (
+            {(plan.skipped_codes ?? []).length > 0 && (
               <p className="text-muted-foreground text-xs">
-                Left as-is, already present in {toYear}: {plan.skipped_codes.join(', ')}
+                Left as-is, already present in {toYear}: {(plan.skipped_codes ?? []).join(', ')}
               </p>
             )}
 
-            {expanded && plan.unit_codes.length > 0 && (
+            {expanded && (plan.unit_codes ?? []).length > 0 && (
               <ul
                 id={UNIT_CODES_ID}
                 className="text-muted-foreground grid grid-cols-2 gap-x-4 gap-y-1 text-xs sm:grid-cols-3"
               >
-                {plan.unit_codes.map((code) => (
+                {(plan.unit_codes ?? []).map((code) => (
                   <li key={code} className="font-mono">
                     {code}
                   </li>

--- a/pocketbase/lodging/rollforward.go
+++ b/pocketbase/lodging/rollforward.go
@@ -58,6 +58,23 @@ type RollForwardPlan struct {
 	SkippedCodes  []string `json:"skipped_codes"`
 }
 
+// newRollForwardPlan initializes both slice fields to empty (non-nil) slices,
+// not just FromYear/ToYear. UnitCodes and SkippedCodes are only ever grown by
+// append, so a source year that copies or skips nothing never runs either
+// append, and a zero-value `[]string` field stays nil. encoding/json marshals
+// a nil slice as `null`, not `[]`, which crashes the frontend's RollForwardPlan
+// type -- it declares both fields as non-nullable string[]. Every construction
+// site must go through here, including the early error returns, so nothing on
+// this type can ever reach json.Marshal holding a nil slice.
+func newRollForwardPlan(from, to int) RollForwardPlan {
+	return RollForwardPlan{
+		FromYear:     from,
+		ToYear:       to,
+		UnitCodes:    []string{},
+		SkippedCodes: []string{},
+	}
+}
+
 // PreviewRollForward reports what ApplyRollForward would do, without writing.
 func PreviewRollForward(app core.App, from, to int) (RollForwardPlan, error) {
 	return rollForward(app, from, to, false)
@@ -101,7 +118,7 @@ func ApplyRollForward(app core.App, from, to int) (RollForwardPlan, error) {
 // a rolled-back attempt cannot return counts for rows that no longer exist.
 func rollForward(app core.App, from, to int, write bool) (RollForwardPlan, error) {
 	if from == to {
-		return RollForwardPlan{FromYear: from, ToYear: to},
+		return newRollForwardPlan(from, to),
 			fmt.Errorf("cannot roll year %d onto itself", from)
 	}
 
@@ -109,21 +126,21 @@ func rollForward(app core.App, from, to int, write bool) (RollForwardPlan, error
 	// `plan` through the pointer, so the call is sequenced before the return
 	// rather than sharing a return statement with the value it mutates.
 	if !write {
-		plan := RollForwardPlan{FromYear: from, ToYear: to}
+		plan := newRollForwardPlan(from, to)
 		err := rollForwardPasses(app, from, to, false, &plan)
 		return plan, err
 	}
 
 	var committed RollForwardPlan
 	if err := app.RunInTransaction(func(txApp core.App) error {
-		plan := RollForwardPlan{FromYear: from, ToYear: to}
+		plan := newRollForwardPlan(from, to)
 		if err := rollForwardPasses(txApp, from, to, true, &plan); err != nil {
 			return err
 		}
 		committed = plan
 		return nil
 	}); err != nil {
-		return RollForwardPlan{FromYear: from, ToYear: to},
+		return newRollForwardPlan(from, to),
 			fmt.Errorf("rolling %d forward to %d: %w", from, to, err)
 	}
 	return committed, nil

--- a/pocketbase/lodging/rollforward_test.go
+++ b/pocketbase/lodging/rollforward_test.go
@@ -1,7 +1,9 @@
 package lodging
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/pocketbase/pocketbase/core"
@@ -244,6 +246,38 @@ func TestPreviewRollForwardWritesNothing(t *testing.T) {
 	rec, _ := findByCodeAndYear(app, "lodging_units", "test-unit-a", 2027)
 	if rec != nil {
 		t.Error("preview created a row")
+	}
+}
+
+// TestPreviewRollForwardEmptySourceMarshalsEmptyArraysNotNull pins the wire
+// format, not the struct: a source year with no registry at all leaves
+// UnitCodes and SkippedCodes never appended to, so an unintialized `[]string`
+// field stays nil and encoding/json marshals a nil slice as `null`, not `[]`.
+// The frontend's RollForwardPlan type declares both fields as non-nullable
+// string[], so a `null` on the wire crashes the Season tab's render. Asserting
+// on the struct fields would NOT catch this -- nil and []string{} are both
+// falsy-empty and indistinguishable there. Only json.Marshal exposes the bug.
+func TestPreviewRollForwardEmptySourceMarshalsEmptyArraysNotNull(t *testing.T) {
+	app := newRollForwardTestApp(t)
+	// Deliberately no seedYear call: 2030 has no registry at all, so both
+	// passes iterate zero source rows and neither append ever runs.
+
+	plan, err := PreviewRollForward(app, 2030, 2031)
+	if err != nil {
+		t.Fatalf("PreviewRollForward: %v", err)
+	}
+
+	raw, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	body := string(raw)
+	if !strings.Contains(body, `"unit_codes":[]`) {
+		t.Errorf("expected unit_codes to marshal as [], got: %s", body)
+	}
+	if !strings.Contains(body, `"skipped_codes":[]`) {
+		t.Errorf("expected skipped_codes to marshal as [], got: %s", body)
 	}
 }
 


### PR DESCRIPTION
## What changed

`RollForwardPlan.UnitCodes` and `.SkippedCodes` are only ever grown by `append`. A source year with no registry at all (the first roll-forward of a new season, or every January once only one year is seeded) never runs either append, so the zero-value `[]string` field stays `nil`. `encoding/json` marshals a nil slice as `null`, not `[]`. The frontend's `RollForwardPlan` type declared both fields as non-nullable `string[]`, so the Season tab crashed on render: `Cannot read properties of null (reading 'length')`.

**Fix (Go-side, per the issue):** a `newRollForwardPlan(from, to)` constructor initializes both slices to `[]string{}` and replaces every `RollForwardPlan{}` literal in `rollforward.go`, including the two early error returns, so nothing on this type can ever reach `json.Marshal` holding a nil slice.

**Belt-and-braces (insurance, not the fix):** widened the frontend `RollForwardPlan` type to `string[] | null` and added a `?? []` guard at both call sites in `SeasonRollForwardPanel.tsx`. This guards the same class from any other nil slice on this endpoint, but the actual bug is fixed entirely Go-side, as the issue asked.

## TDD evidence

Both tests written first and confirmed RED before the fix.

**Go** — `TestPreviewRollForwardEmptySourceMarshalsEmptyArraysNotNull` (`pocketbase/lodging/rollforward_test.go`): previews a roll-forward from a source year with no registry and asserts the **marshaled JSON body**, not the struct — nil and `[]string{}` are both falsy-empty on the struct and indistinguishable there.

RED:
```
rollforward_test.go:277: expected unit_codes to marshal as [], got: {...,"unit_codes":null,"skipped_codes":null}
rollforward_test.go:280: expected skipped_codes to marshal as [], got: {...,"unit_codes":null,"skipped_codes":null}
--- FAIL: TestPreviewRollForwardEmptySourceMarshalsEmptyArraysNotNull (0.30s)
```
GREEN:
```
--- PASS: TestPreviewRollForwardEmptySourceMarshalsEmptyArraysNotNull (0.29s)
ok  	github.com/camp/kindred/pocketbase/lodging	0.300s
```

**Frontend** — `SeasonRollForwardPanel.test.tsx` gains a fixture returning `unit_codes: null, skipped_codes: null` and asserts the panel renders. The test's local fixture type was widened from `string[]` to `string[] | null`, which was itself part of the bug: the old type made the null shape unrepresentable, which is why the suite stayed green through the outage.

RED:
```
TypeError: Cannot read properties of null (reading 'length')
 ❯ children src/components/admin/lodging/SeasonRollForwardPanel.tsx:194:33
Tests  1 failed | 11 skipped (12)
```
GREEN:
```
Test Files  1 passed (1)
     Tests  12 passed (12)
```

## Gates run

- `go build ./...` — pass
- `gofmt -l .` — clean
- `go test ./...` (pocketbase) — pass, all packages
- `./node_modules/.bin/vitest run src/components/admin/lodging/SeasonRollForwardPanel.test.tsx` — 12/12 pass
- `./node_modules/.bin/tsc --noEmit` — clean
- `./node_modules/.bin/eslint` on both changed frontend files — clean
- pre-push hook (go-build, tsc type-check) — pass

## Not done / scope

Nothing scoped out — the fix matches the issue exactly: Go-side initialization as the real fix, `?? []` as explicitly-labeled insurance.

## Part A gap

None found — the issue body's file/line references (`rollforward.go:50-59`, `:214`, `:218`; `SeasonRollForwardPanel.tsx:37-46`, `:194`, `:200`) matched the tree as found.

Closes #2182.
