### PR TITLE
perf(api): single-flight coalescing for LodgingYearCache misses

### DIFF
--- a/api/services/lodging_cache.py
+++ b/api/services/lodging_cache.py
@@ -49,6 +49,7 @@ per-request patch for exactly that gap: one small live fetch for the
 missing id(s), never a second cache.
 """
 
+import asyncio
 import functools
 import threading
 import time
@@ -78,6 +79,16 @@ class LodgingYearCache:
         self._ttl = ttl_seconds
         self._max_size = max_size
         self._lock = threading.RLock()
+        # Per-key single-flight coalescing (kindred#2144): one asyncio.Lock
+        # per (read_name, year) so concurrent misses on the same key await
+        # the first in-flight fetch instead of each issuing their own. This
+        # dict is itself only ever touched synchronously under `self._lock`
+        # -- never awaited on while holding it -- the same rule that governs
+        # `_cache`/`_cache_times`/`_access_times`. The locks it hands out are
+        # a different story: `cached_by_year`'s wrapper awaits one of THOSE
+        # across the fetch, but that await happens after `_lock_for` has
+        # already released `self._lock`.
+        self._inflight_locks: dict[str, asyncio.Lock] = {}
 
     @staticmethod
     def _make_key(read_name: str, year: int) -> str:
@@ -112,15 +123,42 @@ class LodgingYearCache:
         (kindred#2142), which the frontend fires on CampMinder sync completion --
         see the module docstring for which syncs write the four cached reads and
         for the residual gap the TTL still covers.
+
+        Also drops the in-flight lock map (kindred#2144). `asyncio.Lock` binds
+        to the event loop it is first awaited on, and this cache is a
+        process-wide singleton (`api/dependencies.py`) shared across every
+        pytest-asyncio test, each of which gets its own loop. Leaving a lock
+        from a prior test's loop in the map raises `RuntimeError` the next
+        time a test awaits it -- `_reset_lodging_cache`
+        (`tests/unit/api/services/test_lodging_repository.py`) already calls
+        `invalidate_all()` around every test, which is what keeps that from
+        happening.
         """
         with self._lock:
             count = len(self._cache)
             self._cache.clear()
             self._cache_times.clear()
             self._access_times.clear()
+            self._inflight_locks.clear()
             if count:
                 logger.info(f"Lodging year cache invalidated: cleared {count} entries")
             return count
+
+    def _lock_for(self, read_name: str, year: int) -> asyncio.Lock:
+        """The per-(read_name, year) asyncio.Lock, created on first ask.
+
+        Looking the lock up (or creating it) is a plain dict operation, so it
+        stays under `self._lock` like every other access to this instance's
+        state. The lock this returns is then awaited OUTSIDE that
+        `threading.RLock` -- by `cached_by_year`'s wrapper -- never inside it.
+        """
+        key = self._make_key(read_name, year)
+        with self._lock:
+            lock = self._inflight_locks.get(key)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._inflight_locks[key] = lock
+            return lock
 
     def _evict(self, key: str) -> None:
         self._cache.pop(key, None)
@@ -146,6 +184,13 @@ def cached_by_year(cache: LodgingYearCache) -> Callable[[_YearRead[T]], _YearRea
     literal, which a rename or a copy-paste could silently desync from the
     method it was supposed to key. Tying the key to `__name__` makes that
     class of bug impossible instead of just avoided.
+
+    Single-flight coalesced (kindred#2144): a miss acquires the per-key
+    `asyncio.Lock` from `cache._lock_for` and re-checks the cache once inside
+    it, so a caller that lost the race to another concurrent miss on the same
+    key finds the winner's result already written and never calls `fn` at
+    all. The fast-path check above stays lock-free -- only a miss pays for
+    the lock.
     """
 
     def decorator(fn: _YearRead[T]) -> _YearRead[T]:
@@ -154,9 +199,15 @@ def cached_by_year(cache: LodgingYearCache) -> Callable[[_YearRead[T]], _YearRea
             cached = cache.get(fn.__name__, year)
             if cached is not None:
                 return cached  # type: ignore[no-any-return]
-            result = await fn(self, year)
-            cache.set(fn.__name__, year, result)
-            return result
+            async with cache._lock_for(fn.__name__, year):
+                # Re-check: another coroutine may have already populated this
+                # key while we were waiting for the lock.
+                cached = cache.get(fn.__name__, year)
+                if cached is not None:
+                    return cached  # type: ignore[no-any-return]
+                result = await fn(self, year)
+                cache.set(fn.__name__, year, result)
+                return result
 
         return wrapper
 

--- a/tests/unit/api/services/test_lodging_repository.py
+++ b/tests/unit/api/services/test_lodging_repository.py
@@ -899,10 +899,11 @@ class TestCachedByYearSingleFlight:
                 both_entered.set()
             return await fake.fetch_households(2026)
 
-        results = await asyncio.gather(caller(), caller())
+        first, second = await asyncio.gather(caller(), caller())
 
         assert call_count == 1, "single-flight must coalesce concurrent misses into one fetch"
-        assert results == ["value", "value"]
+        assert first == "value"
+        assert second == "value"
 
     def test_invalidate_all_clears_stale_inflight_locks(self) -> None:
         """`asyncio.Lock` binds to the event loop it is first awaited on, and

--- a/tests/unit/api/services/test_lodging_repository.py
+++ b/tests/unit/api/services/test_lodging_repository.py
@@ -856,6 +856,74 @@ class TestLodgingYearCache:
         assert cache.get("fetch_households", 2026) is not None
 
 
+class TestCachedByYearSingleFlight:
+    """Concurrent misses on the same key must coalesce onto one fetch (kindred#2144).
+
+    A test that merely calls the wrapper twice in sequence passes against the
+    *unfixed* code -- the second call would just see the first call's already-
+    written cache entry. This races two coroutines through a shared
+    `asyncio.Event` so both have genuinely entered the wrapper concurrently,
+    before either one has written the cache, and asserts the wrapped
+    function only ran once.
+    """
+
+    @pytest.mark.asyncio
+    async def test_concurrent_misses_on_the_same_key_coalesce_to_one_fetch(self) -> None:
+        import asyncio
+
+        from api.services.lodging_cache import LodgingYearCache, cached_by_year
+
+        cache = LodgingYearCache(ttl_seconds=300, max_size=10)
+        call_count = 0
+        callers_entered = 0
+        both_entered = asyncio.Event()
+
+        class Fake:
+            @cached_by_year(cache)
+            async def fetch_households(self, year: int) -> str:
+                nonlocal call_count
+                call_count += 1
+                # Blocks until the test confirms BOTH callers have already
+                # entered the wrapper -- proving the second caller observed
+                # the first one's in-flight fetch rather than running after
+                # it had already finished and written the cache.
+                await both_entered.wait()
+                return "value"
+
+        fake = Fake()
+
+        async def caller() -> str:
+            nonlocal callers_entered
+            callers_entered += 1
+            if callers_entered == 2:
+                both_entered.set()
+            return await fake.fetch_households(2026)
+
+        results = await asyncio.gather(caller(), caller())
+
+        assert call_count == 1, "single-flight must coalesce concurrent misses into one fetch"
+        assert results == ["value", "value"]
+
+    def test_invalidate_all_clears_stale_inflight_locks(self) -> None:
+        """`asyncio.Lock` binds to the event loop it is first awaited on, and
+        pytest-asyncio hands every test its own loop -- a lock left behind by
+        a prior test's loop raises RuntimeError when a later test awaits it.
+        `invalidate_all()` must drop the in-flight lock map, not just the
+        cached values, so the existing `_reset_lodging_cache` autouse fixture
+        (which already calls `invalidate_all()` around every test) keeps the
+        suite green.
+        """
+        from api.services.lodging_cache import LodgingYearCache
+
+        cache = LodgingYearCache(ttl_seconds=300, max_size=10)
+        lock_before = cache._lock_for("fetch_households", 2026)
+
+        cache.invalidate_all()
+
+        lock_after = cache._lock_for("fetch_households", 2026)
+        assert lock_before is not lock_after, "invalidate_all must drop stale per-key locks"
+
+
 class TestFetchSessionStatuses:
     """The staff-owned cancelled flag (kindred#2092).
 


### PR DESCRIPTION
## What changed

`LodgingYearCache`'s `threading.RLock` (`api/services/lodging_cache.py`) guarded the dict read/write but not the `await` between a miss and the matching `set()` in `cached_by_year`'s wrapper, so concurrent misses on the same `(read_name, year)` key each issued their own PocketBase fetch instead of coalescing.

Added a per-key `asyncio.Lock` (`LodgingYearCache._lock_for`), acquired only on a miss and held across the fetch-and-set gap. A caller that loses the race re-checks the cache once inside the lock and finds the winner's result already written, so it returns that instead of calling the underlying `fn` again. The fast path (a hit) stays lock-free.

`invalidate_all()` now also clears the in-flight lock map. `asyncio.Lock` binds to the event loop it is first awaited on; the cache is a process-wide singleton and pytest-asyncio hands every test its own loop, so a lock left behind by a prior test's loop would raise `RuntimeError` in a later one. The existing `_reset_lodging_cache` autouse fixture already calls `invalidate_all()` before and after every test, which is what keeps that from happening.

The two layers stay separate per the issue's constraint: `self._lock` (the `threading.RLock`) is only ever held synchronously around plain dict operations — including handing out an `asyncio.Lock` from `_lock_for` — and is released before that lock is ever awaited.

## TDD evidence

**RED** — `TestCachedByYearSingleFlight::test_concurrent_misses_on_the_same_key_coalesce_to_one_fetch` races two coroutines through a shared `asyncio.Event` so both have genuinely entered the wrapper before either has written the cache (a test that just calls the wrapper twice in sequence would pass against the unfixed code, per the issue). Against the unfixed wrapper:

```
AssertionError: single-flight must coalesce concurrent misses into one fetch
assert 2 == 1
```

`test_invalidate_all_clears_stale_inflight_locks` also started RED:

```
AttributeError: 'LodgingYearCache' object has no attribute '_lock_for'
```

**GREEN** — after adding the per-key lock and clearing it in `invalidate_all()`, both new tests pass, and the full existing file (75 tests, including all of `TestYearScopedCaching` and `TestLodgingYearCache`) still passes with no changes to `if cached is not None`.

```
75 passed in 3.20s
```

Full suite: `uv run pytest tests/ -q` → 6169 passed, 23 skipped, exit 0.
`uv run ruff check .` → clean.
`uv run mypy api bunking` → clean (a follow-up commit fixed a `mypy --strict` finding in the test itself: `asyncio.gather`'s two-arg overload types to `tuple[T1, T2]` in typeshed even though the runtime value is a list, so comparing it to a list literal is a non-overlapping-equality error — fixed by unpacking into two names instead).

## Deliberately not done

- **`api/services/metrics_cache.py`** has the identical `threading.RLock`-only shape with no coalescing. The issue calls this out explicitly as a reasonable future widening but out of scope for #2144 — left untouched.
- **The latent invalidate-ordering race** between `invalidateSyncData`'s fire-and-forget `fetch` and the synchronous `invalidateQueries` call right after it (frontend) is also explicitly out of scope per the issue body — not touched.
- Left `if cached is not None` exactly as it was, per constraint #3 in the issue.

## Issue body

No gaps found — the corrected issue body (the 2026-08-08 correction block at the top) matched the tree: `lodging_cache.py`'s decorator body, the `threading.RLock`, and the `_reset_lodging_cache` fixture all matched the cited line ranges and behavior.

Closes #2144.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
