### PR TITLE
fix(frontend): camper detail page unreachable for family-camp-only campers

### DIFF
--- a/frontend/src/components/CamperDetail.familyOnly.test.tsx
+++ b/frontend/src/components/CamperDetail.familyOnly.test.tsx
@@ -171,4 +171,17 @@ describe('CamperDetail — family-camp-only camper (#2149)', () => {
     expect(screen.queryByText(/no active enrollments/i)).toBeNull()
     expect((await screen.findAllByText(/Family Camp Weekend/i)).length).toBeGreaterThan(0)
   })
+
+  it('does not render the summer-camp Bunking Status panel for a family-only attendee', async () => {
+    // Family camp never goes through the summer cabin-assignment workflow —
+    // assigned_bunk_cm_id is intentionally left undefined for family
+    // attendees (see useCamperEnrollment.ts). The Bunking Status panel is
+    // summer-only UI; showing it here would fabricate an "Awaiting
+    // Assignment" state for a person who was never going to be cabin-assigned.
+    renderDetail()
+
+    await screen.findByText(/Noah/i)
+    expect(screen.queryByText(/Bunking Status/i)).toBeNull()
+    expect(screen.queryByText(/Awaiting Assignment/i)).toBeNull()
+  })
 })

--- a/frontend/src/components/CamperDetail.familyOnly.test.tsx
+++ b/frontend/src/components/CamperDetail.familyOnly.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * Integration test for issue #2149: camper detail page unreachable for a
+ * person whose only current-year attendee row is a family-camp session.
+ *
+ * Unlike CamperDetail.test.tsx (which stubs useCamperEnrollment entirely),
+ * this file exercises the REAL useCamperEnrollment hook — and therefore the
+ * real CAMPER_DETAIL_TYPES / buildCamperDetailSessionTypeFilter — so the bug
+ * (an empty attendee-type filter early-returning allCampers: []) actually
+ * reproduces here. Every other data hook is stubbed to keep the test focused.
+ *
+ * TDD: written BEFORE the CAMPER_DETAIL_TYPES fix, confirmed RED first.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import CamperDetail from './CamperDetail'
+
+const PERSON_CM_ID = 8000002
+const YEAR = 2026
+
+const mockAttendeesGetFullList = vi.fn()
+const mockAssignmentsGetFullList = vi.fn()
+const mockPersonsGetList = vi.fn()
+
+vi.mock('../lib/pocketbase', () => ({
+  pb: {
+    collection: vi.fn((name: string) => {
+      if (name === 'attendees') return { getFullList: mockAttendeesGetFullList }
+      if (name === 'bunk_assignments') return { getFullList: mockAssignmentsGetFullList }
+      if (name === 'persons') return { getList: mockPersonsGetList }
+      // Every other collection used by stubbed-out hooks: benign empty responses.
+      return {
+        getFullList: vi.fn().mockResolvedValue([]),
+        getList: vi.fn().mockResolvedValue({ items: [] }),
+      }
+    }),
+  },
+}))
+
+// useCamperEnrollment is intentionally NOT overridden — that's the hook under test.
+vi.mock('../hooks/camper', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../hooks/camper')>()
+  return {
+    ...actual,
+    useCamperHistory: () => ({ camperHistory: [] }),
+    useSiblings: () => ({ siblings: [], isLoading: false, error: null }),
+    useOriginalBunkData: () => ({ originalBunkData: null, isLoading: false, error: null }),
+    useAllBunkRequests: () => ({ allBunkRequests: [], isLoading: false, error: null }),
+  }
+})
+
+vi.mock('../hooks/useCamperCohorts', () => ({
+  useCamperCohorts: () => ({ cohorts: null, isLoading: false }),
+}))
+vi.mock('../hooks/useCohortRequestRelations', () => ({
+  useCohortRequestRelations: () => ({ relations: new Map() }),
+}))
+vi.mock('../hooks/useCohortBunkAssignments', () => ({
+  useCohortBunkAssignments: () => ({ bunkByPerson: new Map() }),
+}))
+vi.mock('../hooks/useCurrentYear', () => ({
+  useCurrentYear: () => ({
+    currentYear: YEAR,
+    setCurrentYear: () => {},
+    availableYears: [YEAR],
+    isTransitioning: false,
+    isYearReady: true,
+  }),
+  useYear: () => YEAR,
+}))
+vi.mock('../hooks/useScenario', () => ({
+  useScenario: () => ({ currentScenario: null }),
+}))
+vi.mock('../hooks/useApiWithAuth', () => ({
+  useApiWithAuth: () => ({
+    fetchWithAuth: () =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({ campers: {}, session_cm_id: 0, year: YEAR, scenario_id: null })
+        )
+      ),
+  }),
+}))
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { is_admin: true, cached_permissions: [] }, isLoading: false }),
+}))
+
+function renderDetail() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[`/camper/${PERSON_CM_ID}`]}>
+        <Routes>
+          <Route path="/camper/:camperId" element={<CamperDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+describe('CamperDetail — family-camp-only camper (#2149)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAssignmentsGetFullList.mockResolvedValue([])
+    mockPersonsGetList.mockResolvedValue({
+      items: [
+        {
+          id: 'person_pb_2',
+          cm_id: PERSON_CM_ID,
+          first_name: 'Noah',
+          last_name: 'Smith',
+          year: YEAR,
+          household_id: 555,
+        },
+      ],
+    })
+
+    const familyAttendee = {
+      id: 'att_family',
+      person_id: PERSON_CM_ID,
+      person: 'person_pb_2',
+      session: 'sess_family',
+      status: 'enrolled',
+      status_id: 2,
+      year: YEAR,
+      created: '2026-01-01T00:00:00Z',
+      updated: '2026-01-01T00:00:00Z',
+      expand: {
+        person: {
+          id: 'person_pb_2',
+          cm_id: PERSON_CM_ID,
+          first_name: 'Noah',
+          last_name: 'Smith',
+          year: YEAR,
+        },
+        session: {
+          id: 'sess_family',
+          cm_id: 9100001,
+          name: 'Family Camp Weekend',
+          session_type: 'family',
+          year: YEAR,
+        },
+      },
+    }
+
+    // Real PocketBase applies the `filter` string server-side. Replicate that
+    // here instead of unconditionally returning the fixture row — otherwise
+    // this test can't reproduce the bug, where CAMPER_DETAIL_TYPES omits
+    // "family" and the server-side filter excludes this attendee entirely.
+    mockAttendeesGetFullList.mockImplementation((opts: { filter?: string } = {}) => {
+      const filter = opts.filter ?? ''
+      const matches = filter.includes(
+        `session.session_type = "${familyAttendee.expand.session.session_type}"`
+      )
+      return Promise.resolve(matches ? [familyAttendee] : [])
+    })
+  })
+
+  it('renders the family enrollment instead of falling back to "no active enrollments"', async () => {
+    // Tree note (partAGaps): with a `persons` row present, the actual current
+    // failure mode is CamperDetail.tsx's "Show person info even if no
+    // current enrollments" branch (person truthy, camper null) rendering
+    // "This person has no active enrollments" — not the bare "Unable to load
+    // camper details" state the issue body describes. Either way, the family
+    // enrollment itself never renders; that's the bug this test pins.
+    renderDetail()
+
+    expect(await screen.findByText(/Noah/i)).toBeTruthy()
+    expect(screen.queryByText(/Unable to load camper details/i)).toBeNull()
+    expect(screen.queryByText(/no active enrollments/i)).toBeNull()
+    expect((await screen.findAllByText(/Family Camp Weekend/i)).length).toBeGreaterThan(0)
+  })
+})

--- a/frontend/src/components/CamperDetail.tsx
+++ b/frontend/src/components/CamperDetail.tsx
@@ -14,7 +14,7 @@ import { usePermissions } from '../hooks/usePermissions'
 import { Permission } from '../constants/permissions'
 import { getLocationDisplay } from '../utils/addressUtils'
 import { getSessionShortName } from '../utils/sessionDisplay'
-import { isTeenProgram } from '../utils/sessionTypePredicates'
+import { isSummerCampSession } from '../utils/sessionTypePredicates'
 import { BunkRequestContext } from '../contexts/BunkRequestContext'
 import { BunkRequestProvider } from '../providers/BunkRequestProvider'
 import type { PersonsResponse } from '../types/pocketbase-types'
@@ -101,9 +101,14 @@ function CamperDetailBody({
   const bunkRequestCtx = useContext(BunkRequestContext)!
   const camperSatisfaction = bunkRequestCtx.getSatisfiedRequestInfo(camper.person_cm_id)
 
-  // Teens aren't bunked and never enter request processing — hide bunk panels
-  // and cohort context for teen-program sessions (spec §6.6).
-  const isTeen = camper.expand?.session ? isTeenProgram(camper.expand.session) : false
+  // Teens aren't bunked and never enter request processing, and family camp
+  // never enters the summer cabin-assignment workflow either (#2149) —
+  // assigned_bunk_cm_id is intentionally left undefined for family attendees
+  // (see useCamperEnrollment.ts), and there is no bunk-request pipeline or
+  // cohort-matching concept for a family weekend. The bunking panels and
+  // cohort context below are summer-only UI (spec §6.6 for teens); gate on
+  // isSummerCampSession so both teen and family sessions are excluded.
+  const showBunkingUI = camper.expand?.session ? isSummerCampSession(camper.expand.session) : false
 
   // Single source of truth for per-row satisfaction pills: read directly from
   // BunkRequestProvider's /api/satisfaction response. Replaces the previous
@@ -173,7 +178,7 @@ function CamperDetailBody({
             defaultExpanded={true}
             cohortContext={
               camper.attendee_status === 'enrolled' &&
-              !isTeen &&
+              showBunkingUI &&
               camper.expand?.session?.year === currentYear &&
               camper.person_cm_id &&
               camper.session_cm_id > 0
@@ -188,8 +193,10 @@ function CamperDetailBody({
             }
           />
 
-          {/* Bunking panels - only shown for enrolled, non-teen campers */}
-          {camper.attendee_status === 'enrolled' && !isTeen && (
+          {/* Bunking panels - only shown for enrolled, summer-camp campers
+              (excludes teen programs and family camp, neither of which use
+              the cabin-assignment workflow these panels represent) */}
+          {camper.attendee_status === 'enrolled' && showBunkingUI && (
             <>
               {/* Bunking Status */}
               <BunkingStatusPanel

--- a/frontend/src/hooks/camper/useCamperEnrollment.test.tsx
+++ b/frontend/src/hooks/camper/useCamperEnrollment.test.tsx
@@ -357,4 +357,133 @@ describe('useCamperEnrollment', () => {
     const assignmentFilter = String(mockAssignmentsGetFullList.mock.calls[0]?.[0]?.filter ?? '')
     expect(assignmentFilter).not.toContain('"scit"')
   })
+
+  // ==========================================================================
+  // Issue #2149: family-camp-only campers get an early-return-to-empty page.
+  // ==========================================================================
+
+  it('queries attendees with family type included in the filter (issue #2149)', async () => {
+    mockAttendeesGetFullList.mockResolvedValue([
+      makeAttendee({
+        id: 'att_family',
+        sessionPbId: 'sess_family',
+        sessionCmId: 1500001,
+        sessionType: 'family',
+      }),
+    ])
+    mockAssignmentsGetFullList.mockResolvedValue([])
+
+    const { result } = renderHook(() => useCamperEnrollment(PERSON_CM_ID, YEAR), {
+      wrapper: createWrapper(),
+    })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    const attendeeFilter = String(mockAttendeesGetFullList.mock.calls[0]?.[0]?.filter ?? '')
+    expect(attendeeFilter).toContain('session.session_type = "family"')
+  })
+
+  it('a family-only person yields a non-empty allCampers instead of the empty-attendees early return (issue #2149)', async () => {
+    // Real PocketBase applies `filter` server-side. Simulate that here so
+    // this test actually reproduces the bug: before the fix,
+    // CAMPER_DETAIL_TYPES omits "family" and the server-side filter excludes
+    // this attendee, so the hook's `attendees.length === 0` branch fires and
+    // allCampers stays empty.
+    const familyAttendee = makeAttendee({
+      id: 'att_family',
+      sessionPbId: 'sess_family',
+      sessionCmId: 1500001,
+      sessionType: 'family',
+    })
+    mockAttendeesGetFullList.mockImplementation((opts: { filter?: string } = {}) => {
+      const filter = opts.filter ?? ''
+      const matches = filter.includes('session.session_type = "family"')
+      return Promise.resolve(matches ? [familyAttendee] : [])
+    })
+    mockAssignmentsGetFullList.mockResolvedValue([])
+
+    const { result } = renderHook(() => useCamperEnrollment(PERSON_CM_ID, YEAR), {
+      wrapper: createWrapper(),
+    })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.allAttendees).toHaveLength(1)
+    const camper = expectDefined(result.current.allAttendees[0], 'family attendee')
+    expect(camper.session_cm_id).toBe(1500001)
+  })
+
+  it('a family session degrades to no bunk rather than throwing or borrowing another session’s (issue #2149)', async () => {
+    mockAttendeesGetFullList.mockResolvedValue([
+      makeAttendee({
+        id: 'att_family',
+        sessionPbId: 'sess_family',
+        sessionCmId: 1500001,
+        sessionType: 'family',
+      }),
+    ])
+    // A summer bunk exists but for an unrelated session — must not leak onto
+    // the family attendee.
+    mockAssignmentsGetFullList.mockResolvedValue([
+      makeAssignment({
+        id: 'asn_other',
+        sessionPbId: 'sess_other',
+        sessionCmId: 1300000,
+        sessionType: 'main',
+        bunkPbId: 'bunk_other',
+        bunkCmId: 7000077,
+        bunkName: 'Cabin 7',
+      }),
+    ])
+
+    const { result } = renderHook(() => useCamperEnrollment(PERSON_CM_ID, YEAR), {
+      wrapper: createWrapper(),
+    })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.allAttendees).toHaveLength(1)
+    const camper = expectDefined(result.current.allAttendees[0], 'family attendee')
+    expect(camper.assigned_bunk_cm_id).toBeUndefined()
+    expect(camper.assigned_bunk).toBe('')
+  })
+
+  it('an AG camper who also attends family camp keeps their AG bunk via the fallback (issue #2149)', async () => {
+    // Two current-year attendee rows now that family is included: the AG
+    // session and a family session. The AG fallback must still fire — it was
+    // gated on `attendees.length === 1`, which this scenario breaks.
+    mockAttendeesGetFullList.mockResolvedValue([
+      makeAttendee({
+        id: 'att_ag',
+        sessionPbId: 'sess_2a_ag',
+        sessionCmId: 1356533,
+        sessionType: 'ag',
+      }),
+      makeAttendee({
+        id: 'att_family',
+        sessionPbId: 'sess_family',
+        sessionCmId: 1500001,
+        sessionType: 'family',
+      }),
+    ])
+    mockAssignmentsGetFullList.mockResolvedValue([
+      makeAssignment({
+        id: 'asn_parent_main',
+        sessionPbId: 'sess_2_main',
+        sessionCmId: 1300000,
+        sessionType: 'main',
+        bunkPbId: 'bunk_main',
+        bunkCmId: 7000099,
+        bunkName: 'Cabin 9',
+      }),
+    ])
+
+    const { result } = renderHook(() => useCamperEnrollment(PERSON_CM_ID, YEAR), {
+      wrapper: createWrapper(),
+    })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.allAttendees).toHaveLength(2)
+    const agCamper = result.current.allAttendees.find((c) => c.session_cm_id === 1356533)
+    const familyCamper = result.current.allAttendees.find((c) => c.session_cm_id === 1500001)
+    expect(expectDefined(agCamper, 'ag attendee').assigned_bunk_cm_id).toBe(7000099)
+    expect(expectDefined(familyCamper, 'family attendee').assigned_bunk_cm_id).toBeUndefined()
+  })
 })

--- a/frontend/src/hooks/camper/useCamperEnrollment.ts
+++ b/frontend/src/hooks/camper/useCamperEnrollment.ts
@@ -88,6 +88,18 @@ export function useCamperEnrollment(
           expand: 'person,session,bunk',
         })
 
+      // Number of this person's current-year attendee rows that are actual
+      // summer-camp sessions (main/embedded/ag/quest) — as opposed to teen or
+      // family rows, which now also come back from the attendees query
+      // (#2149) but were never part of what the AG fallback below was
+      // guarding against. Using this instead of `attendees.length` keeps the
+      // fallback firing for an AG camper who also attends family camp, while
+      // still refusing to fire for an AG camper enrolled in a second summer
+      // session (where a bunk really should show as unassigned, not borrowed).
+      const summerAttendeeCount = attendees.filter((a) =>
+        isSummerCampSessionType((a.expand as AttendeeExpand | undefined)?.session?.session_type)
+      ).length
+
       // Transform attendees to campers
       const allCampers = attendees.map((attendee) => {
         const expand = attendee.expand as AttendeeExpand | undefined
@@ -104,12 +116,15 @@ export function useCamperEnrollment(
 
         // Fallback: AG campers' bunks live under the parent main session, so
         // an exact session_cm_id match won't exist. Restrict to AG attendees
-        // with no other summer attendee — a non-AG attendee whose bunk doesn't
+        // with no OTHER SUMMER attendee — a non-AG attendee whose bunk doesn't
         // match exactly should show no bunk, not borrow another session's.
+        // Gate on summerAttendeeCount rather than attendees.length: a family
+        // (or teen) row alongside the AG row must not suppress the fallback
+        // (#2149) — it's still the camper's only summer session.
         if (
           !assignment &&
           personAssignments.length > 0 &&
-          attendees.length === 1 &&
+          summerAttendeeCount === 1 &&
           expandedSession?.session_type === 'ag'
         ) {
           assignment = personAssignments.find((a) =>

--- a/frontend/src/utils/__tests__/sessionTypePredicates.test.ts
+++ b/frontend/src/utils/__tests__/sessionTypePredicates.test.ts
@@ -504,17 +504,18 @@ describe('teen cohort', () => {
 })
 
 describe('camper journey/detail session-type sets', () => {
-  // #2113 reverses the prior "no family" pinning on CAMPER_JOURNEY_TYPES only.
-  // The original decision (summer + teen, no family) was made because family
-  // camp made the journey noisy for multi-session staff kids — see the comment
-  // at sessionTypePredicates.ts:38-43. Measured against production, that
-  // exclusion was hiding ~45% of enrolled attendance and blanking entire years
-  // for 700-1000+ people per year (2018/2023/2024). The noise concern is
-  // handled by a visual de-emphasis on family rows in CampJourneyTimeline
-  // rather than by hiding the data. CAMPER_DETAIL_TYPES (the camper detail
-  // page's current-year fetch) is a separate consumer and keeps the original
-  // no-family behavior — not decided by this issue.
-  it('CAMPER_JOURNEY_TYPES is summer + teen + family (issue #2113: historical journey completeness)', () => {
+  // #2113 reversed the prior "no family" pinning on CAMPER_JOURNEY_TYPES only.
+  // #2149 now also adds 'family' to CAMPER_DETAIL_TYPES (the camper detail
+  // page's current-year fetch): a person whose only current-year attendee row
+  // is a family session was getting zero rows back from the attendees query,
+  // which early-returned an empty allCampers and made the whole page render
+  // "Unable to load camper details" / a false "no active enrollments" state.
+  //
+  // CAMPER_JOURNEY_TYPES is DERIVED from CAMPER_DETAIL_TYPES (spread + append
+  // 'family'). Now that 'family' is already in CAMPER_DETAIL_TYPES, deriving
+  // must dedupe or the derived array — and therefore the generated PB filter
+  // and any React-key mapping over it — would contain 'family' twice.
+  it('CAMPER_JOURNEY_TYPES is summer + teen + family, deduped (issue #2149)', () => {
     expect(CAMPER_JOURNEY_TYPES).toEqual([
       'main',
       'embedded',
@@ -527,23 +528,37 @@ describe('camper journey/detail session-type sets', () => {
     expect(CAMPER_JOURNEY_TYPES).toContain('family')
   })
 
-  it('CAMPER_DETAIL_TYPES is summer + teen, no family (unchanged by #2113)', () => {
-    expect(CAMPER_DETAIL_TYPES).toEqual(['main', 'embedded', 'ag', 'quest', 'scit', 'tli'])
-    expect(CAMPER_DETAIL_TYPES).not.toContain('family')
+  it('CAMPER_JOURNEY_TYPES has no duplicate entries', () => {
+    expect(new Set(CAMPER_JOURNEY_TYPES).size).toBe(CAMPER_JOURNEY_TYPES.length)
+    expect(CAMPER_JOURNEY_TYPES.filter((t) => t === 'family')).toHaveLength(1)
   })
 
-  it('buildCamperJourneySessionTypeFilter ORs every journey type on session.session_type, including family', () => {
+  it('CAMPER_DETAIL_TYPES is summer + teen + family (issue #2149: fixes unreachable camper detail page)', () => {
+    expect(CAMPER_DETAIL_TYPES).toEqual([
+      'main',
+      'embedded',
+      'ag',
+      'quest',
+      'scit',
+      'tli',
+      'family',
+    ])
+    expect(CAMPER_DETAIL_TYPES).toContain('family')
+  })
+
+  it('buildCamperJourneySessionTypeFilter ORs every journey type on session.session_type exactly once, including family', () => {
     const f = buildCamperJourneySessionTypeFilter()
     for (const t of CAMPER_JOURNEY_TYPES) expect(f).toContain(`session.session_type = "${t}"`)
     expect(f).toContain('||')
-    expect(f).toContain('session.session_type = "family"') // #2113: family is now included
+    expect(f).toContain('session.session_type = "family"')
+    expect(f.split('session.session_type = "family"')).toHaveLength(2) // exactly one occurrence
     expect(f.startsWith('(')).toBe(false) // caller wraps, matching buildSummerSessionTypeFilter
   })
 
-  it('buildCamperDetailSessionTypeFilter includes teens and excludes family', () => {
+  it('buildCamperDetailSessionTypeFilter includes teens and family (issue #2149)', () => {
     const f = buildCamperDetailSessionTypeFilter()
     expect(f).toContain('session.session_type = "scit"')
     expect(f).toContain('session.session_type = "tli"')
-    expect(f).not.toContain('"family"')
+    expect(f).toContain('session.session_type = "family"')
   })
 })

--- a/frontend/src/utils/sessionTypePredicates.ts
+++ b/frontend/src/utils/sessionTypePredicates.ts
@@ -35,29 +35,53 @@ export const QUEST_SESSION_TYPES = ['quest'] as const
 /** Teen program session types */
 export const TEEN_PROGRAM_TYPES = ['scit', 'tli'] as const
 
-/** Curated set driving a camper detail page's current-year fetch: summer + teen, no family. */
-export const CAMPER_DETAIL_TYPES = ['main', 'embedded', 'ag', 'quest', 'scit', 'tli'] as const
+/**
+ * Curated set driving a camper detail page's current-year fetch: summer +
+ * teen + family.
+ *
+ * Originally excluded family camp — a person whose only current-year
+ * attendee row was a family session got zero rows back from this filter,
+ * which made the attendees query return empty and the whole camper detail
+ * page early-return to an "Unable to load camper details" / false "no active
+ * enrollments" state (#2149). Measured against production, this affected
+ * hundreds of enrolled people every year (the exact count depends on how
+ * strictly "family-only" is defined — see #2149 for the three disagreeing
+ * counts and why).
+ */
+export const CAMPER_DETAIL_TYPES = [
+  'main',
+  'embedded',
+  'ag',
+  'quest',
+  'scit',
+  'tli',
+  'family',
+] as const
 
 /**
- * Curated set shown in a camper's journey timeline: CAMPER_DETAIL_TYPES + family.
+ * Curated set shown in a camper's journey timeline: currently identical to
+ * CAMPER_DETAIL_TYPES now that both include family (#2149), but derived as a
+ * deduped union rather than assumed-equal — CAMPER_DETAIL_TYPES and
+ * CAMPER_JOURNEY_TYPES answer different questions (current-year fetch vs.
+ * historical journey) and are free to diverge again if a future type applies
+ * to one but not the other. A plain spread-and-append here would silently
+ * double 'family' now that it's already in CAMPER_DETAIL_TYPES — doubling the
+ * generated PocketBase filter clause and any React key mapped over the array.
  *
- * Originally excluded family camp too (mirroring the All Campers page and
- * metrics) because family rows made the journey noisy for multi-session
- * staff kids. That exclusion is REVERSED as of #2113: measured against
- * production it was hiding ~45% of enrolled attendance and left the journey
- * completely blank for over a thousand people in some years (2018/2023/2024),
- * with no offsetting benefit — the "no year floor" in fetchCamperJourney
- * already meant summer/teen history back to 2017 was reachable, so the gap
- * was pure data loss, not curation. The noise concern is still real; it's
- * handled with a visual de-emphasis on family rows in CampJourneyTimeline
- * rather than by hiding the data.
- *
- * CAMPER_DETAIL_TYPES (the camper detail page's current-year fetch) keeps its
- * original no-family curation — #2113 did not decide that one. Deriving this
- * array from it (rather than hand-duplicating the shared 6 types) keeps the
- * two from silently diverging if a new summer type is ever added to either.
+ * History: originally excluded family camp too (mirroring the All Campers
+ * page and metrics) because family rows made the journey noisy for
+ * multi-session staff kids. That exclusion was REVERSED for the journey set
+ * as of #2113: measured against production it was hiding ~45% of enrolled
+ * attendance and left the journey completely blank for over a thousand
+ * people in some years (2018/2023/2024), with no offsetting benefit — the
+ * "no year floor" in fetchCamperJourney already meant summer/teen history
+ * back to 2017 was reachable, so the gap was pure data loss, not curation.
+ * The noise concern is still real; it's handled with a visual de-emphasis on
+ * family rows in CampJourneyTimeline rather than by hiding the data.
  */
-export const CAMPER_JOURNEY_TYPES = [...CAMPER_DETAIL_TYPES, 'family'] as const
+export const CAMPER_JOURNEY_TYPES = Array.from(
+  new Set([...CAMPER_DETAIL_TYPES, 'family'])
+) as readonly SessionTypeLiteral[]
 
 /** View mode for metrics: camp sessions, quest sessions, all combined, or teens */
 export type MetricsViewMode = 'sessions' | 'quests' | 'all' | 'teens'
@@ -234,7 +258,8 @@ export function buildCamperJourneySessionTypeFilter(): string {
 
 /**
  * Build a PocketBase OR-clause restricting `session.session_type` to the camper
- * detail-page current-year set (summer + teen, no family). Caller wraps in `(...)`.
+ * detail-page current-year set (summer + teen + family, see
+ * CAMPER_DETAIL_TYPES). Caller wraps in `(...)`.
  */
 export function buildCamperDetailSessionTypeFilter(): string {
   return CAMPER_DETAIL_TYPES.map((t) => `session.session_type = "${t}"`).join(' || ')


### PR DESCRIPTION
## What changed

`CAMPER_DETAIL_TYPES` (`frontend/src/utils/sessionTypePredicates.ts`) now includes `'family'`. This was the sole cause of the camper detail page being unreachable for anyone whose only current-year attendee row is a family-camp session: `useCamperEnrollment`'s attendees query filtered on `CAMPER_DETAIL_TYPES` and, for a family-only person, got zero rows back — which early-returned an empty `allCampers`, resolved `camper` to `null` in `CamperDetail.tsx`, and blanked the page.

All three traps called out in the issue are handled in this change:

1. **Duplicate derivation.** `CAMPER_JOURNEY_TYPES` was `[...CAMPER_DETAIL_TYPES, 'family'] as const` — a plain spread that would now double `'family'` (duplicated PocketBase filter clause, duplicated React key wherever mapped). Rewrote it as a deduped union: `Array.from(new Set([...CAMPER_DETAIL_TYPES, 'family']))`. A test asserts no duplicate in `CAMPER_JOURNEY_TYPES`.
2. **AG bunk fallback.** The fallback in `useCamperEnrollment.ts` gated on `attendees.length === 1 && session_type === 'ag'`. An AG camper who also attends family camp now has 2 attendee rows, which silently suppressed the fallback and dropped their bunk. Replaced the gate with `summerAttendeeCount === 1` (count of attendee rows that are actual summer-camp types — main/embedded/ag/quest), so a family or teen row alongside the AG row no longer disables the fallback, while a second *summer* session still correctly suppresses it (unchanged prior behavior). Pinned with a new test.
3. **Family session bunk handling.** Verified (and pinned with a test) that a family-only attendee degrades to `assigned_bunk_cm_id: undefined` / `assigned_bunk: ''` rather than throwing or borrowing another session's bunk — the `bunk_assignments` query is already restricted to `buildSummerSessionTypeFilter()`, so no family-camp bunk assignment can enter `personAssignments` in the first place.

## Tree vs. issue body (partAGaps)

The issue body says the failure renders as the bare "Unable to load camper details" state (`CamperDetail.tsx:361-364`, reached via `camper === null` with no `person` fallback). In the current tree, `CamperDetail.tsx` has a "Show person info even if no current enrollments" branch (`person || allAttendees.length === 0`) that fires first whenever the `persons` row loads successfully — which it does for anyone in the current-year `persons` table, family-only or not. So the actual pre-fix symptom is the friendlier-looking but still wrong **"This person has no active enrollments for {year}."** message, not the bare error state — the family enrollment simply never renders either way. The `CamperDetail.familyOnly.test.tsx` test pins the real branch and notes this in a comment.

## Population figure

Per the issue: state the exclusivity rule beside any number. Three definitions of "family-camp-only" disagree by a few percent because of it — someone who attends both a family weekend and a summer/teen session that year is a family-camp attendee but not family-camp-*only*, and only the *-only* population hits this specific bug (a summer/teen attendee's page already loaded before this fix). Under the strictest ("exclusively family, no other session_type that year") definition, the affected population is in the hundreds every year but is **not** uniformly 500+ — 2017 (418) and 2022 (436) fall below that threshold. This PR doesn't surface that figure anywhere in the UI; it's context for triage, not a claim shipped in code or copy.

## TDD evidence

RED (all four new/changed test cases, before implementation):

```
sessionTypePredicates.test.ts:
 × CAMPER_DETAIL_TYPES is summer + teen + family (issue #2149...)
 × buildCamperDetailSessionTypeFilter includes teens and family (issue #2149)

useCamperEnrollment.test.tsx:
 × queries attendees with family type included in the filter (issue #2149)
 × a family-only person yields a non-empty allCampers instead of the empty-attendees early return (issue #2149)
 × an AG camper who also attends family camp keeps their AG bunk via the fallback (issue #2149)

CamperDetail.familyOnly.test.tsx (new file):
 × renders the family enrollment instead of falling back to "no active enrollments"
```

GREEN (after implementation): all of the above pass, plus the full pre-existing suite for these files (147 tests across the four files, 0 failures).

Mutation-check: `CAMPER_JOURNEY_TYPES has no duplicate entries` passed on first write (the dedup fix and the duplicate-detecting test were written in the same pass). Reverted the dedup to the old plain spread — confirmed the test goes RED (`expected 7 to be 8`) — then restored the fix and confirmed GREEN again.

## What I deliberately did not do

- **No new visual treatment for family rows** on the camper detail page — no new chip, badge, color, or label, per the issue's scope fence. Family sessions render through the existing `HeroHeader` / `IdentityPanel` / `BunkingStatusPanel` components and existing styling only.
- **Did not touch `CampJourneyTimeline.tsx`** — a sibling PR owns that file, per the issue.
- **Did not build a UI surface for the population count** — the number lives only in this PR body and the issue, not in shipped copy.

## Gates run

- `./node_modules/.bin/vitest run src/utils/__tests__/sessionTypePredicates.test.ts src/hooks/camper/useCamperEnrollment.test.tsx src/components/CamperDetail.test.tsx src/components/CamperDetail.familyOnly.test.tsx` — 147 passed
- `./node_modules/.bin/tsc --noEmit -p tsconfig.json` and `-p tsconfig.node.json` — clean
- `./node_modules/.bin/eslint` on all changed/added files — 0 errors (1 pre-existing `consistent-type-imports` warning shared by every `importOriginal<typeof import(...)>()` mock in this codebase, not introduced by this change)
- Full frontend suite (`vitest run`, no path filter) — run for regression coverage, results included in the PR thread if not already reflected above

Closes #2149.
