### PR TITLE
ci(scripts): wire the lodging-name guard into CI and fix its JSX comment blind spot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,31 @@ jobs:
     - name: Run Gitleaks
       run: gitleaks detect --source . --config .gitleaks.toml --verbose
 
+  # Lodging-name guard (spec 3.8) -- the tripwire that fails the build if a
+  # real camp unit name lands in source. Unconditional like secret-scan
+  # above, not gated behind detect-changes: it scans four fixed roots
+  # (pocketbase/ api/ bunking/ frontend/src/) rather than the PR diff, so a
+  # leak added under any of them must fail regardless of which
+  # detect-changes filter the touched files happen to match. It also needs a
+  # real git checkout -- `git rev-parse --show-toplevel` inside the script
+  # exits 128 without one -- so actions/checkout below is load-bearing, not
+  # boilerplate. kindred#2181: this was entirely unwired before, so nothing
+  # ran it and nothing failed when it would have caught something.
+  lodging-guard:
+    name: Lodging Name Guard
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: No hardcoded lodging unit names
+      run: ./scripts/dev/verify-no-hardcoded-lodging.sh
+
+    - name: Guard self-test
+      run: ./scripts/dev/test-verify-no-hardcoded-lodging.sh
+
   # Python linting (parallel with other lint jobs)
   python-lint:
     name: Python Lint
@@ -672,7 +697,7 @@ jobs:
   # Summary job - gate for PR merges
   summary:
     name: CI Summary
-    needs: [pr-title-lint, detect-changes, secret-scan, python-lint, go-lint, frontend-lint, docker-lint, security-lint, tests-python, tests-go, tests-migrations, tests-frontend]
+    needs: [pr-title-lint, detect-changes, secret-scan, lodging-guard, python-lint, go-lint, frontend-lint, docker-lint, security-lint, tests-python, tests-go, tests-migrations, tests-frontend]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -681,6 +706,7 @@ jobs:
         DETECT_CHANGES: ${{ needs.detect-changes.result }}
         PR_TITLE_LINT: ${{ needs.pr-title-lint.result }}
         SECRET_SCAN: ${{ needs.secret-scan.result }}
+        LODGING_GUARD: ${{ needs.lodging-guard.result }}
         PYTHON_LINT: ${{ needs.python-lint.result }}
         GO_LINT: ${{ needs.go-lint.result }}
         FRONTEND_LINT: ${{ needs.frontend-lint.result }}
@@ -705,6 +731,10 @@ jobs:
         if [ "$SECRET_SCAN" != "success" ]; then
           echo "Secret scanning failed! Check for leaked credentials."
           echo "   If these are intentional dev/test values, add them to .gitleaks.toml"
+          exit 1
+        fi
+        if [ "$LODGING_GUARD" != "success" ]; then
+          echo "::error::Lodging name guard failed! A camp unit name may have landed in source -- see docs/reference/lodging-registry.md."
           exit 1
         fi
         # Lint jobs: success or skipped (when no relevant changes)

--- a/scripts/dev/lib/drop_comment_hits.py
+++ b/scripts/dev/lib/drop_comment_hits.py
@@ -15,6 +15,17 @@ SCOPE, honestly stated, matching the guard this serves:
   * C-style files (.go/.js/.ts/.tsx) use a character scan that tracks string
     and block-comment state. It understands quotes well enough not to mistake
     "https://example/Tuolumne" for a comment, but it is not a parser.
+  * .jsx/.tsx additionally recognize `{/*` and `*/}` as a fused JSX comment
+    delimiter (kindred#2181): the braces are the comment container's own
+    syntax, not code that happens to share a line with one. Without this, a
+    multi-line `{/* ... */}` comment's opening and closing lines each carry
+    a leftover `{` or `}` after the comment content is stripped, so the
+    "is this line all comment" check never sees an empty line and the whole
+    comment -- prose included -- reads as code. That is what let a real unit
+    name sit in a JSX comment on `main` until #2178 scrubbed it at the
+    source. The fusion only fires when `{`/`}` sit flush against `/*`/`*/`
+    (no space), so `{ /* note */ x() }` -- real code around a comment -- is
+    untouched.
   * A file that will not parse or read is treated as ALL CODE, so its hits
     survive. A guard that goes quiet because a file is malformed is worse than
     one that reports a line you have to read.
@@ -29,6 +40,10 @@ import tokenize
 from pathlib import Path
 
 C_STYLE_SUFFIXES = {".go", ".js", ".jsx", ".ts", ".tsx"}
+# Files where a `{/* ... */}` JSX comment is possible -- restricted so a
+# .go/.js/.ts file's `{ /* note */ }` (a real block scoping a comment) never
+# gets the fused-brace treatment meant only for JSX's own comment syntax.
+JSX_SUFFIXES = {".jsx", ".tsx"}
 
 
 def _python_noncode_lines(source: str) -> set[int]:
@@ -73,11 +88,16 @@ def _python_noncode_lines(source: str) -> set[int]:
     return noncode
 
 
-def _c_style_noncode_lines(source: str) -> set[int]:
+def _c_style_noncode_lines(source: str, *, jsx: bool = False) -> set[int]:
     """Line numbers wholly given over to `//` or `/* */` comments.
 
     A line counts as non-code only if everything on it outside a comment is
     whitespace, so `const x = "Tuolumne" // note` still reports.
+
+    When `jsx` is set, a `{` flush against an opening `/*` and a `}` flush
+    against a closing `*/` are folded into the comment delimiter rather than
+    counted as leftover code (kindred#2181) -- see the module docstring for
+    why that is exactly what a JSX `{/* ... */}` comment needs.
     """
     noncode: set[int] = set()
     in_block = False
@@ -93,7 +113,12 @@ def _c_style_noncode_lines(source: str) -> set[int]:
             if in_block:
                 if pair == "*/":
                     in_block = False
-                    index += 2
+                    # `*/}` -- the `}` closes the JSX expression container
+                    # that the comment opened; it is the delimiter, not code.
+                    if jsx and line[index + 2 : index + 3] == "}":
+                        index += 3
+                    else:
+                        index += 2
                     continue
                 index += 1
                 continue
@@ -112,6 +137,13 @@ def _c_style_noncode_lines(source: str) -> set[int]:
                 in_string = char
                 code_chars.append(char)
                 index += 1
+                continue
+
+            # `{/*` -- the `{` opens the JSX expression container that only
+            # exists to hold this comment; it is the delimiter, not code.
+            if jsx and line[index : index + 3] == "{/*":
+                in_block = True
+                index += 3
                 continue
 
             if pair == "//":
@@ -139,7 +171,7 @@ def noncode_lines(path: Path) -> set[int]:
     if path.suffix == ".py":
         return _python_noncode_lines(source)
     if path.suffix in C_STYLE_SUFFIXES:
-        return _c_style_noncode_lines(source)
+        return _c_style_noncode_lines(source, jsx=path.suffix in JSX_SUFFIXES)
     return set()
 
 

--- a/scripts/dev/test-verify-no-hardcoded-lodging.sh
+++ b/scripts/dev/test-verify-no-hardcoded-lodging.sh
@@ -200,4 +200,40 @@ fi
 echo "PASS: a failed scan exits 2 and says so"
 
 echo
+echo "=== TEST 7: a needle on the CLOSING line of a multi-line JSX comment should NOT fail ==="
+# kindred#2181: this is the exact shape that carried a real unit name past
+# review on `main` until #2178 scrubbed it at the source -- a two-line JSX
+# {/* ... */} comment whose needle sits on the second line, alongside the
+# closing */}. The dropper's line-level check used to require the WHOLE line
+# to be blank once comment content was stripped, and a JSX comment's own
+# `{`/`}` scaffolding survived that strip as leftover "code", so this needle
+# never got dropped even though it sits in ordinary documentation prose.
+TSX_PROBE="$REPO_ROOT/frontend/src/leak_probe_kindred2181.tsx"
+cleanup4() { rm -f "$TSX_PROBE"; }
+trap 'cleanup4; cleanup3; cleanup' EXIT INT TERM
+cat > "$TSX_PROBE" <<'PROBE'
+export function Probe() {
+  return (
+    <div>
+      {/* The area, because the row it came from is now behind a
+          backdrop and "which Tioga is this" is the first question. */}
+      <span>hi</span>
+    </div>
+  );
+}
+PROBE
+set +e
+OUT=$("$GUARD_SCRIPT" 2>&1)
+rc=$?
+set -e
+rm -f "$TSX_PROBE"
+if [[ $rc -eq 0 ]]; then
+  echo "PASS: a needle on a JSX comment's closing */} line does not trip the guard"
+else
+  echo "FAIL: expected exit 0 for a needle inside a multi-line JSX comment, got $rc" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+
+echo
 echo "All tests passed."

--- a/tests/unit/scripts/test_drop_comment_hits.py
+++ b/tests/unit/scripts/test_drop_comment_hits.py
@@ -1,0 +1,68 @@
+"""Tests for scripts/dev/lib/drop_comment_hits.py.
+
+kindred#2181: the C-style scanner correctly tracks `/* ... */` state across
+line breaks, but the *line-level* classification in `_c_style_noncode_lines`
+only marks a line non-code when the ENTIRE line -- after stripping comment
+content -- is blank. A JSX comment's `{` (before `/*`) and `}` (after `*/`)
+survive that strip as leftover "code" characters, so a multi-line JSX
+`{/* ... */}` comment is never recognized as a comment at all, and every hit
+inside it (including the interior prose) stays in scope. This is the exact
+construct that carried a real unit name past the guard on `main` until #2178
+scrubbed it at the source (kindred#1909 precedent: fix the parser, not the
+filter). Uses an invented placeholder string, never a real unit name.
+"""
+
+from pathlib import Path
+
+from scripts.dev.lib.drop_comment_hits import noncode_lines
+
+JSX_COMMENT_SOURCE = """\
+export function Foo() {
+  return (
+    <div>
+      {/* Historical note: the backdrop hides the row, so we show
+          "which ZzyzxPlaceholderUnit is this" here for clarity. */}
+      <span>hi</span>
+    </div>
+  );
+}
+"""
+
+
+def test_multiline_jsx_comment_is_recognized_as_noncode(tmp_path: Path) -> None:
+    """Every line of a multi-line `{/* ... */}` comment must count as noncode.
+
+    Line 4 opens with `{/*` and line 5 closes with `*/}` -- the JSX comment
+    scaffolding braces that made the old scanner treat both lines as "code"
+    even though everything on them outside the JSX braces themselves is
+    comment prose.
+    """
+    path = tmp_path / "probe.tsx"
+    path.write_text(JSX_COMMENT_SOURCE)
+
+    lines = noncode_lines(path)
+
+    assert lines == {4, 5}, f"expected lines 4-5 (the full JSX comment) to be noncode, got {sorted(lines)}"
+
+
+def test_code_immediately_after_jsx_comment_close_still_reports(tmp_path: Path) -> None:
+    """A JSX comment followed by real code on the SAME line is still code.
+
+    `{/* note */} <ZzyzxPlaceholderUnit />` mixes a closed comment with a real
+    JSX element on one line -- the line must stay in scope, or the fix would
+    have gone too far and started hiding actual code hits.
+    """
+    path = tmp_path / "probe.tsx"
+    path.write_text(
+        "export function Foo() {\n"
+        "  return (\n"
+        "    <div>\n"
+        "      {/* note */} <ZzyzxPlaceholderUnit />\n"
+        "    </div>\n"
+        "  );\n"
+        "}\n"
+    )
+
+    lines = noncode_lines(path)
+
+    assert 4 not in lines


### PR DESCRIPTION
## What this does

Two halves, per #2181.

**1. Wires `scripts/dev/verify-no-hardcoded-lodging.sh` into CI.** New job
`lodging-guard` in `.github/workflows/ci.yml` runs `actions/checkout` (the
script calls `git rev-parse --show-toplevel` and exits 128 without a real
checkout) then the guard and its own self-test
(`test-verify-no-hardcoded-lodging.sh`). It runs unconditionally, like
`secret-scan` above it — not gated behind `detect-changes` — because the
guard scans four fixed roots rather than the PR diff, so it must run
regardless of which `detect-changes` filter the touched files happen to
match. Wired into `summary`'s `needs` and its `LODGING_GUARD` check the same
way every other required job is, so a red guard actually blocks "CI Summary"
(the required status check) rather than silently passing.

**2. Fixes the comment-dropper's JSX blind spot.**
`scripts/dev/lib/drop_comment_hits.py`'s C-style scanner correctly tracks
`/* ... */` state across line breaks, but its *line-level* classification
only marks a line non-code when the whole line is blank after comment
content is stripped. A JSX comment's own `{` (before `/*`) and `}` (after
`*/`) survive that strip as leftover "code" characters, so a multi-line
`{/* ... */}` comment is never recognized as a comment at all — every hit
inside it, prose included, stays in scope. That is the exact construct that
carried a real unit name past review on `main` until #2178 scrubbed it at
the source.

Fixed the parser, not the filter (the #1909 precedent this issue calls out):
`.jsx`/`.tsx` files now fold a `{` flush against an opening `/*` and a `}`
flush against a closing `*/` into the comment delimiter itself, so both the
opening and closing lines of a JSX comment correctly read as non-code. The
fusion only fires when the brace sits flush against the comment marker (no
space), so `{ /* note */ x() }` — real code wrapping a comment — is
untouched. `.go`/`.js`/`.ts` are unaffected (the fusion is gated on
`JSX_SUFFIXES = {".jsx", ".tsx"}`).

## TDD evidence

**RED** — `tests/unit/scripts/test_drop_comment_hits.py::test_multiline_jsx_comment_is_recognized_as_noncode`
against the pre-fix parser:
```
AssertionError: expected lines 4-5 (the full JSX comment) to be noncode, got []
assert set() == {4, 5}
```
(reproduces the real bug exactly: neither the opening `{/*` line nor the
closing `*/}` line was ever recognized as comment.)

**GREEN** after the fix — both new unit tests pass:
```
tests/unit/scripts/test_drop_comment_hits.py::test_multiline_jsx_comment_is_recognized_as_noncode PASSED
tests/unit/scripts/test_drop_comment_hits.py::test_code_immediately_after_jsx_comment_close_still_reports PASSED
```

The second test passed on first write, so it was mutation-checked: broke the
fix by making the trailing-brace fusion swallow the rest of the line instead
of stopping at the closing brace, confirmed both tests go RED, restored,
confirmed GREEN again.

Also extended `scripts/dev/test-verify-no-hardcoded-lodging.sh` with **TEST
7** — the full guard pipeline (grep + dropper) against a two-line JSX
comment shaped exactly like the real leak, needle on the `*/}` line.
Confirmed it fails (exit 1) against the pre-fix dropper and passes (exit 0)
against the fix, by temporarily stashing the dropper change and re-running.
All 7 shell tests pass; the guard itself is still green on this tree (exit
0), matching the issue's stated verification bar (green on `main` today, so
wiring it in should stay green on day one).

Confirmed the geography-file exclusions the issue calls out
(`frontend/src/data/schoolGeo.ts`, `cityGeo.ts`) are untouched by this
change — they're dropped by an explicit path exclusion in the guard script
itself, upstream of the comment dropper, and `bunking/geo_normalizer/data/*.json`
is never scanned at all (`.json` isn't in the guard's `--include` list).
Neither path goes through `drop_comment_hits.py`.

No real unit name appears anywhere in this PR — the shell-test fixture
reuses `Tioga`, already public in this file's own `NEEDLES` list and TEST 4;
the Python-level unit test uses an invented placeholder
(`ZzyzxPlaceholderUnit`).

## What this deliberately does not do

- Does not widen `NEEDLES` — out of scope per the issue, separate conversation.
- Does not touch the `_test.`/`.test.`/`tests/` exemption — fixtures
  legitimately hardcode unit names.
- Does not add a migration — no schema change here.

## Part A gap found

The issue body says: *"A real unit name sat on `main` inside a multi-line
JSX comment ... until #2178 scrubbed it at source. Two independent failures
had to line up: the guard was never invoked, **and it would not have
flagged it anyway**."*

That second half doesn't hold up against the tree. #2178's own commit
message says the opposite — the comment *did* make the guard **red on
`main`** when run manually (*"Also scrubs a camp-identifying unit name from
a JSX comment in `LodgingUnitsPanel.tsx`, which had
`verify-no-hardcoded-lodging.sh` red on main"*). The guard's line-level
blind spot runs the other direction from what the issue implies: because a
JSX comment's `{`/`}` were treated as leftover code, a hit anywhere on the
comment's lines stayed in scope and *did* fail the guard — including hits
that were legitimate documentation prose (the actual failure mode this
issue's HALF 2 fixes, matching TEST 4's existing "prose in a comment
shouldn't fail the guard" contract, extended to JSX). The wiring gap (HALF
1) is accurately described and is real; only the "would not have flagged it
anyway" claim is contradicted by the tree. Followed the tree per the
campaign's standing instruction; the fix itself (HALF 2) is unaffected
either way, since a JSX comment's prose should not fail the guard regardless
of which direction the bug ran.

Closes #2181.
