### PR TITLE
refactor(frontend): share the ring precedence rule between the lodging card and map

### DIFF
--- a/frontend/src/components/weekend/LodgingMap.tsx
+++ b/frontend/src/components/weekend/LodgingMap.tsx
@@ -58,6 +58,7 @@ import {
   type Viewport,
   zoomAt,
 } from './mapViewport'
+import { resolveRingPrecedence } from './ringPrecedence'
 
 /** Served from the private repo, exactly as the logos are. */
 const MAP_IMAGE_URL = '/local/assets/camp-map.webp'
@@ -568,10 +569,20 @@ export function LodgingMap({ parties, units, year }: LodgingMapProps) {
               if (!many && unmeasured) summary += ' · capacity unknown'
               // Amber SUPERSEDES the shared ring rather than competing with it:
               // a consent flag only ever exists on a shared room, so the two
-              // can never both need the same ring.
+              // can never both need the same ring. The ORDERING is
+              // `resolveRingPrecedence` (kindred#2136), shared with
+              // `LodgingUnitCard.tsx`'s `ringState` — the map has no drag, so
+              // `dropTarget` is always `false` here and this can only ever
+              // land on `consentFlagged`, `shared` or `plain`.
+              const ringState = resolveRingPrecedence({
+                dropTarget: false,
+                consentFlagged: flagged > 0,
+                shared,
+              })
               let halo = '0 0 0 2px rgba(255,255,255,.95)'
-              if (flagged > 0) halo = `0 0 0 2px #fff, 0 0 0 4.5px ${CONSENT_AMBER}`
-              else if (shared) halo = `0 0 0 2px #fff, 0 0 0 4.5px ${hue}`
+              if (ringState === 'consentFlagged')
+                halo = `0 0 0 2px #fff, 0 0 0 4.5px ${CONSENT_AMBER}`
+              else if (ringState === 'shared') halo = `0 0 0 2px #fff, 0 0 0 4.5px ${hue}`
               return (
                 // Deliberately a plain clickable div, not role="button": see the ACCESSIBILITY note
                 // at the top of this file. A role this mark cannot honour with real keyboard/focus

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -23,6 +23,7 @@ import {
 } from './boardLayout'
 import { isValidMergeTarget, mergeDragId, unitDroppableId } from './dragPlacement'
 import { FamilyCard } from './FamilyCard'
+import { resolveRingPrecedence } from './ringPrecedence'
 import { partyKey } from './partyKey'
 import { reservationBadge, shareabilityBadge } from './unitBadges'
 import { UnitAvailabilityControl } from './UnitAvailabilityControl'
@@ -309,14 +310,11 @@ export function LodgingUnitCard({
    *      matching `LodgingMap.tsx`'s `halo` for the identical slot flag.
    *   4. plain — none of the above.
    */
-  let ringState: 'dropTarget' | 'consentFlagged' | 'shared' | 'plain' = 'plain'
-  if (isUnitOver || isMergeOver) {
-    ringState = 'dropTarget'
-  } else if (consent) {
-    ringState = 'consentFlagged'
-  } else if (isShared) {
-    ringState = 'shared'
-  }
+  const ringState = resolveRingPrecedence({
+    dropTarget: isUnitOver || isMergeOver,
+    consentFlagged: consent !== null,
+    shared: isShared,
+  })
 
   /*
    * An invalid merge target mid-drag: dims the card so a doomed drop is not

--- a/frontend/src/components/weekend/ringPrecedence.test.ts
+++ b/frontend/src/components/weekend/ringPrecedence.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveRingPrecedence } from './ringPrecedence'
+
+describe('resolveRingPrecedence', () => {
+  it('is plain when nothing is set', () => {
+    expect(resolveRingPrecedence({ dropTarget: false, consentFlagged: false, shared: false })).toBe(
+      'plain'
+    )
+  })
+
+  it('is shared when only shared is set', () => {
+    expect(resolveRingPrecedence({ dropTarget: false, consentFlagged: false, shared: true })).toBe(
+      'shared'
+    )
+  })
+
+  it('is consentFlagged when only consentFlagged is set', () => {
+    expect(resolveRingPrecedence({ dropTarget: false, consentFlagged: true, shared: false })).toBe(
+      'consentFlagged'
+    )
+  })
+
+  it('is dropTarget when only dropTarget is set', () => {
+    expect(resolveRingPrecedence({ dropTarget: true, consentFlagged: false, shared: false })).toBe(
+      'dropTarget'
+    )
+  })
+
+  it('prefers consentFlagged over shared when both are set', () => {
+    expect(resolveRingPrecedence({ dropTarget: false, consentFlagged: true, shared: true })).toBe(
+      'consentFlagged'
+    )
+  })
+
+  it('prefers dropTarget over consentFlagged when both are set', () => {
+    expect(resolveRingPrecedence({ dropTarget: true, consentFlagged: true, shared: false })).toBe(
+      'dropTarget'
+    )
+  })
+
+  it('prefers dropTarget over shared when both are set', () => {
+    expect(resolveRingPrecedence({ dropTarget: true, consentFlagged: false, shared: true })).toBe(
+      'dropTarget'
+    )
+  })
+
+  it('prefers dropTarget over everything when all three are set', () => {
+    expect(resolveRingPrecedence({ dropTarget: true, consentFlagged: true, shared: true })).toBe(
+      'dropTarget'
+    )
+  })
+})

--- a/frontend/src/components/weekend/ringPrecedence.ts
+++ b/frontend/src/components/weekend/ringPrecedence.ts
@@ -1,0 +1,56 @@
+/**
+ * The "consent supersedes shared" precedence rule, shared between
+ * `LodgingUnitCard.tsx`'s `ringState` and `LodgingMap.tsx`'s `halo`
+ * (kindred#2136) — both sites independently encoded the identical ordering,
+ * and nothing kept them in sync.
+ *
+ * DELIBERATELY its own leaf module — not exported from
+ * `frontend/src/components/weekend/index.ts`. That barrel is claimed by
+ * #2080, #2078 and PR #2169; adding an export there would serialise this
+ * refactor behind all three for no benefit. Nor does it live in
+ * `boardLayout.ts`: `LodgingMap.tsx` does not import that module today, and
+ * routing this helper through it would add a new static import edge. See
+ * `mapColors.ts`'s header for the same shape of constraint — a module the
+ * map imports has to stay light enough that `WeekendLegendButton`'s eager
+ * mount (kindred#2057) never drags the map's lazy chunk into the eager
+ * bundle. `WeekendRosterPage.chunkGraph.test.ts` is the real `vite build`
+ * that catches a regression here.
+ *
+ * ONLY the precedence is shared. The two callers' inputs are deliberately
+ * different — the card's `consent` is one slot's `ConsentFlag | null` and
+ * its `shared` is `parties.length > 1`; the map's `flagged` is a COUNT of
+ * cluster members with `consent !== null` and its `shared` is
+ * `!many && first.parties.length > 1`, so a multi-room cluster is never
+ * "shared". Each caller keeps deriving its own booleans and keeps rendering
+ * its own way (Tailwind classes vs. an inline `boxShadow`) — this function
+ * knows nothing about either.
+ */
+
+export interface RingPrecedenceInputs {
+  dropTarget: boolean
+  consentFlagged: boolean
+  shared: boolean
+}
+
+export type RingState = 'dropTarget' | 'consentFlagged' | 'shared' | 'plain'
+
+/**
+ * Highest wins, and every check assumes every state above it false:
+ *   1. an active drop target — the placement affordance has to read clearly
+ *      even over a flagged or shared room. Always `false` on the map, which
+ *      is read-only and has no drag.
+ *   2. the consent flag (#1926) — a household sharing without having agreed
+ *      to.
+ *   3. two or more families sharing without a flag.
+ *   4. plain — none of the above.
+ */
+export function resolveRingPrecedence({
+  dropTarget,
+  consentFlagged,
+  shared,
+}: RingPrecedenceInputs): RingState {
+  if (dropTarget) return 'dropTarget'
+  if (consentFlagged) return 'consentFlagged'
+  if (shared) return 'shared'
+  return 'plain'
+}


### PR DESCRIPTION
## What changed

`LodgingUnitCard.tsx`'s `ringState` and `LodgingMap.tsx`'s `halo` each independently
encoded the same "drop target > consent flag > shared > plain" precedence, with
nothing keeping them in sync. Extracted the precedence into a new pure function,
`resolveRingPrecedence`, in a dedicated leaf module: `frontend/src/components/weekend/ringPrecedence.ts`.

**Only the precedence moved.** The inputs stay exactly as different as the issue
requires:
- card `consentFlagged` = one slot's `ConsentFlag | null` (`consent !== null`, equivalent to the prior truthy check since `consent: ConsentFlag | null`)
- map `consentFlagged` = `flagged > 0`, a **count** of cluster members with `consent !== null`
- card `shared` = `parties.length > 1`
- map `shared` = `!many && first.parties.length > 1` — a multi-room cluster is never "shared"
- map always passes `dropTarget: false` (read-only, no drag)

Each caller still renders its own way — the card via `RING_CLASSES` Tailwind
classes, the map via an inline `boxShadow` string built from its own `ringState`
value.

**Placement**, per the issue's scheduling note: NOT `weekend/index.ts` (claimed by
#2080, #2078, PR #2169), NOT `boardLayout.ts` (`LodgingMap.tsx` doesn't import it
today, so that would add a new static import edge). `ringPrecedence.ts` follows the
`mapColors.ts` precedent — a light leaf module the map can import without dragging
its lazy chunk into the eager bundle (#2057).

**Left untouched, per the issue:**
- The `OPEN QUESTION` comment on `LodgingUnitCard.tsx`'s `isShared` — not answered, not touched.
- `LodgingMap.tsx`'s selection logic (`panelParty`/`pinnedKey`) — owned by a concurrent sibling PR. The diff there is confined to the `halo` block (17 lines).

## TDD evidence

1. **RED**: wrote `ringPrecedence.test.ts` against the full 3-input truth table (8 cases) before the module existed.
   ```
   Error: Failed to resolve import "./ringPrecedence" ...
   Test Files  1 failed (1)
   exit=1
   ```
2. **GREEN**: added `ringPrecedence.ts`.
   ```
   Test Files  1 passed (1)
        Tests  8 passed (8)
   exit=0
   ```
3. **Mutation-check on the wiring** (the test passed on first write against the new module, and the two call-site edits had no new tests of their own — verified via the pre-existing regression anchors instead): reordered the helper to `return 'plain'` unconditionally before the precedence checks. Result: not just the helper's own 8 tests but the pre-existing regression anchors in both callers went RED too —
   ```
   FAIL LodgingUnitCard.test.tsx (multiple)
   FAIL LodgingMap.test.tsx (multiple)
   Tests  17 failed | 104 passed (121)
   exit=1
   ```
   confirming both `LodgingUnitCard.tsx` and `LodgingMap.tsx` genuinely route through the shared function rather than the wiring being vacuous. Restored, re-verified GREEN: `121/121`, `exit=0`.

## Gates run

- `vitest run src/components/weekend/ringPrecedence.test.ts` — 8/8 pass, exit=0
- `vitest run LodgingUnitCard.test.tsx LodgingMap.test.tsx ringPrecedence.test.ts` — 121/121 pass, exit=0 (regression anchors: the composed `boxShadow` string in `LodgingUnitCard.test.tsx`, and the `CONSENT_AMBER`-containing boxShadow in `LodgingMap.test.tsx`, both pass unchanged)
- `vitest run src/components/weekend/` (full directory) — 696/696 pass, exit=0
- `WeekendRosterPage.chunkGraph.test.ts` (real `vite build`) — 3/3 pass, exit=0
- `tsc --noEmit` — exit=0
- `eslint` on all 4 touched/added files — exit=0 (2 pre-existing `prefer-optional-chain` warnings in `LodgingMap.tsx` at lines untouched by this diff, unrelated to this change)
- `prettier --check` then `--write` (2 files needed reformatting; re-verified tests/types/lint after)
- pre-push hook `type-check` — passed

## What I deliberately did not do

- Did not touch `frontend/src/components/weekend/index.ts`.
- Did not touch `boardLayout.ts`.
- Did not answer the `OPEN QUESTION` comment about `isShared`'s overlap-aware definition.
- Did not touch `LodgingMap.tsx`'s selection derivation (`panelParty`/`pinnedKey`) — a concurrent sibling PR's territory.
- Did not create any PocketBase migration (none was needed).

## Part A gap found

None — the issue's line-number anchors (`LodgingMap.tsx:515` for `shared`, `:545` for `flagged`, `:572-574` for `halo`; `LodgingUnitCard.tsx:183/232/312-318`) all matched the tree exactly as written, including the "verified against main 2026-08-09" note. `LodgingUnitCard.test.tsx`'s boxShadow assertions and `LodgingMap.test.tsx:445`'s `CONSENT_AMBER` assertion also matched.

Closes #2136.
