### PR TITLE
fix(sync): prefer well-formed email over malformed in adult merge

### DIFF
--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -578,18 +578,28 @@ func (s *FamilyCampDerivedSync) loadPersonCustomValues(
 //     `name`; a "delete the blank rows" cleanup written from that misreading
 //     would have erased every one of them.
 //
-// PENDING, and deliberately not resolved here (owner ruling, kindred#1945):
-// the person-partition loop below merges with "first non-empty wins" over a
+// The person-partition loop below merges with "first non-empty wins" over a
 // slice loadPersonCustomValues returns in record-id order, so when two
 // enrolled siblings carry different answers the winner is whichever row has
 // the lower id -- which correlates with nothing. Measured over the 382
 // rostered 2026 households: 254 (household, field, adult) groups disagree
-// across 113 households, and resolving by CampMinder's own last_updated (the
-// rule spec 4.1 already applies to the REQUEST fields, via
-// CollapseToHouseholdGrain) would pick differently in 130 of them. Which
-// sibling should win is a product decision, coupled to the still-open question
-// of whether gender/date_of_birth/email/pronouns are kept at all, so today's
-// behavior is pinned by test instead of changed on a guess.
+// across 113 households.
+//
+// RESOLVED for email only (owner ruling 2026-08-09, kindred#1945): when the
+// siblings' emails differ and are both non-empty, preferEmail breaks the tie
+// by well-formedness instead of load order -- see its doc comment. Email got
+// a rule because the harm is concrete and the rule is crisp: 5 stored adult
+// emails carry a domain typo in production, 4 of which have a correct
+// version on a sibling form that iteration order was discarding.
+//
+// STILL PENDING for every other merged field (first/last name, pronouns,
+// gender, date_of_birth, relationship): first-non-empty-wins over load order
+// stands, unchanged, because none of them has a validity notion as crisp as
+// "syntactically valid email" -- inventing one to feel consistent would be
+// guessing, not fixing. Which sibling should win there remains a product
+// decision, coupled to the still-open question of whether
+// gender/date_of_birth/pronouns are kept at all, so today's behavior for
+// those fields is pinned by test instead of changed on a guess.
 func (s *FamilyCampDerivedSync) processAdults(
 	householdValues []customValueEntry, personValues []customValueEntry,
 ) []*adultData {
@@ -642,14 +652,17 @@ func (s *FamilyCampDerivedSync) processAdults(
 
 		adult := adultMap[v.householdPBID][adultNum]
 
-		// Only set if empty (first non-empty wins for deduplication)
+		// Only set if empty (first non-empty wins for deduplication), EXCEPT
+		// email: see preferEmail for the kindred#1945 validity-preferring rule.
 		switch {
 		case strings.Contains(v.fieldName, "First Name") && adult.firstName == "":
 			adult.firstName = v.value
 		case strings.Contains(v.fieldName, "Last Name") && adult.lastName == "":
 			adult.lastName = v.value
-		case strings.Contains(v.fieldName, "Email") && adult.email == "":
-			adult.email = v.value
+		case strings.Contains(v.fieldName, "Email"):
+			if preferEmail(adult.email, v.value) {
+				adult.email = v.value
+			}
 		case strings.Contains(v.fieldName, "Pronouns") && adult.pronouns == "":
 			adult.pronouns = v.value
 		case strings.Contains(v.fieldName, "Gender") && adult.gender == "":
@@ -673,6 +686,37 @@ func (s *FamilyCampDerivedSync) processAdults(
 	}
 
 	return result
+}
+
+// emailFormatPattern is a narrow, defensible notion of "well-formed enough
+// to prefer in a merge tie" -- local@domain.tld, no embedded whitespace or
+// commas (the two junk shapes measured in the 2026 snapshot), and at least
+// one dot in the domain. It is NOT full RFC 5322 validation and it is not
+// used to reject input anywhere; it exists solely to break a tie between two
+// sibling forms' answers for the same adult (kindred#1945).
+var emailFormatPattern = regexp.MustCompile(`^[^\s@,]+@[^\s@,]+\.[^\s@,]+$`)
+
+// isWellFormedEmail reports whether value looks like a syntactically valid
+// email address per emailFormatPattern.
+func isWellFormedEmail(value string) bool {
+	return emailFormatPattern.MatchString(value)
+}
+
+// preferEmail decides whether candidate should replace current in the
+// per-adult email merge (kindred#1945). Gap-fill is unchanged: an empty
+// current always loses to any non-empty candidate. When both are non-empty
+// and differ, well-formed beats malformed; when validity does not
+// discriminate between them (both well-formed, or both malformed), the
+// pre-existing first-loaded-sibling tie-break stands -- candidate does not
+// replace current.
+func preferEmail(current, candidate string) bool {
+	if current == "" {
+		return true
+	}
+	if candidate == "" || candidate == current {
+		return false
+	}
+	return isWellFormedEmail(candidate) && !isWellFormedEmail(current)
 }
 
 // processRegistrations extracts registration data from custom values

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -2171,3 +2171,132 @@ func TestProcessAdultsKeepsANameOnlyAdult(t *testing.T) {
 		t.Errorf("nothing may invent split columns: got first=%q last=%q", adults[0].firstName, adults[0].lastName)
 	}
 }
+
+// TestProcessAdultsEmailMergePrefersWellFormedValue pins the kindred#1945
+// fix: when two sibling forms carry DIFFERENT NON-EMPTY emails for the same
+// adult, the well-formed one must win, regardless of which sibling's row
+// processAdults sees first. Both orderings are asserted for every case
+// because the bug being fixed IS the iteration-order tie-break -- a test
+// that only tried the order where the well-formed value happens to load
+// first would pass against the OLD, buggy code too (first-non-empty already
+// gets it right by luck in that order) and would prove nothing.
+func TestProcessAdultsEmailMergePrefersWellFormedValue(t *testing.T) {
+	cases := []struct {
+		name       string
+		malformed  string
+		wellFormed string
+	}{
+		// Missing dot in the domain -- mirrors the "domain typo" harm the
+		// issue measured against production (5 stored emails, 4 with a
+		// correct sibling value discarded by iteration order).
+		{name: "missing dot in domain", malformed: "amy.johnson@examplecom", wellFormed: "amy.johnson@example.com"},
+		// Trailing junk -- the other malformation kindred#1945 calls out
+		// explicitly ("no trailing/leading junk such as a trailing comma").
+		{name: "trailing comma junk", malformed: "ben.garcia@example.com,", wellFormed: "ben.garcia@example.com"},
+	}
+
+	for _, tc := range cases {
+		for _, order := range []string{"malformed-first", "well-formed-first"} {
+			t.Run(tc.name+"/"+order, func(t *testing.T) {
+				s := &FamilyCampDerivedSync{}
+				householdValues := []customValueEntry{
+					{householdPBID: "hh_1", fieldName: "Family Camp Adult 1", value: "Amy Johnson"},
+				}
+				malformedEntry := customValueEntry{
+					householdPBID: "hh_1", fieldName: "Family Camp Adult 1 Email", value: tc.malformed,
+				}
+				wellFormedEntry := customValueEntry{
+					householdPBID: "hh_1", fieldName: "Family Camp Adult 1 Email", value: tc.wellFormed,
+				}
+
+				var personValues []customValueEntry
+				if order == "malformed-first" {
+					personValues = []customValueEntry{malformedEntry, wellFormedEntry}
+				} else {
+					personValues = []customValueEntry{wellFormedEntry, malformedEntry}
+				}
+
+				adults := s.processAdults(householdValues, personValues)
+
+				if len(adults) != 1 {
+					t.Fatalf("expected 1 merged adult, got %d", len(adults))
+				}
+				if adults[0].email != tc.wellFormed {
+					t.Errorf(
+						"order=%s: got email %q, want well-formed %q -- validity must decide, not load order",
+						order, adults[0].email, tc.wellFormed,
+					)
+				}
+			})
+		}
+	}
+}
+
+// TestProcessAdultsEmailBothWellFormedKeepsFirstLoaded guards the OTHER half
+// of the kindred#1945 rule: validity only breaks a tie when it actually
+// discriminates. Two different but BOTH well-formed emails (e.g. two
+// legitimately distinct addresses) must fall back to the pre-existing
+// first-loaded-sibling behavior, not get silently overwritten just because
+// email now has a validity notion.
+func TestProcessAdultsEmailBothWellFormedKeepsFirstLoaded(t *testing.T) {
+	const first = "amy.johnson@example.com"
+	const second = "amy.j.johnson@example.org"
+
+	s := &FamilyCampDerivedSync{}
+	householdValues := []customValueEntry{
+		{householdPBID: "hh_1", fieldName: "Family Camp Adult 1", value: "Amy Johnson"},
+	}
+	personValues := []customValueEntry{
+		{householdPBID: "hh_1", fieldName: "Family Camp Adult 1 Email", value: first},
+		{householdPBID: "hh_1", fieldName: "Family Camp Adult 1 Email", value: second},
+	}
+
+	adults := s.processAdults(householdValues, personValues)
+
+	if len(adults) != 1 {
+		t.Fatalf("expected 1 merged adult, got %d", len(adults))
+	}
+	if adults[0].email != first {
+		t.Errorf("both emails are well-formed: got %q, want first-loaded %q unchanged", adults[0].email, first)
+	}
+}
+
+// TestProcessAdultsEmailGapFillStillWins is the regression guard the issue
+// asks for: gap-fill (one sibling blank, the other filled) must keep
+// producing the filled value, in both iteration orders. This is ~246 of
+// what the merge does across the dataset, and a validity change that broke
+// it would be a regression, not a fix.
+func TestProcessAdultsEmailGapFillStillWins(t *testing.T) {
+	const filled = "amy.johnson@example.com"
+
+	for _, order := range []string{"blank-first", "filled-first"} {
+		t.Run(order, func(t *testing.T) {
+			s := &FamilyCampDerivedSync{}
+			householdValues := []customValueEntry{
+				{householdPBID: "hh_1", fieldName: "Family Camp Adult 1", value: "Amy Johnson"},
+			}
+			blankEntry := customValueEntry{
+				householdPBID: "hh_1", fieldName: "Family Camp Adult 1 Email", value: "",
+			}
+			filledEntry := customValueEntry{
+				householdPBID: "hh_1", fieldName: "Family Camp Adult 1 Email", value: filled,
+			}
+
+			var personValues []customValueEntry
+			if order == "blank-first" {
+				personValues = []customValueEntry{blankEntry, filledEntry}
+			} else {
+				personValues = []customValueEntry{filledEntry, blankEntry}
+			}
+
+			adults := s.processAdults(householdValues, personValues)
+
+			if len(adults) != 1 {
+				t.Fatalf("expected 1 merged adult, got %d", len(adults))
+			}
+			if adults[0].email != filled {
+				t.Errorf("order=%s: got email %q, want %q -- gap-fill must still win", order, adults[0].email, filled)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

`pocketbase/sync/family_camp_derived.go`, `processAdults`' per-person merge: when two sibling
camper records carry **different non-empty** values for the same adult's **email**, the merge now
prefers the **well-formed** value over the malformed one instead of letting load order (the
lowest-record-id sibling) decide.

- Added `isWellFormedEmail` / `emailFormatPattern`: `local@domain.tld`, no embedded whitespace or
  commas, at least one dot in the domain. Not RFC 5322 validation — narrow, just enough to catch
  the two junk shapes measured in production (missing-dot domain typo, trailing comma).
- Added `preferEmail(current, candidate)`: empty `current` always loses (gap-fill unchanged);
  non-empty-and-differ picks the well-formed one; when validity doesn't discriminate (both
  well-formed or both malformed), the pre-existing first-loaded-sibling tie-break stands.
- Updated the `processAdults` doc comment: email is now marked RESOLVED, every other merged field
  (first/last name, pronouns, gender, date_of_birth, relationship) is marked STILL PENDING with the
  reason (no crisp validity notion for those — implementing one would be guessing).

### Fields that got a validity rule vs. fields that didn't

| Field | Validity rule? |
|---|---|
| email | **Yes** — syntactic well-formedness (this PR) |
| first_name, last_name, pronouns, gender, date_of_birth, relationship | **No** — kept exactly as-is (first-non-empty-wins over load order); no crisp, defensible malformed/well-formed distinction exists for these |

## What did NOT change

- No union of adult slots.
- No schema change, no migration.
- No deletion of `gender` / `date_of_birth` / `email` / `pronouns` columns (2026-08-07 hold stands).
- `deleteOrphanedAdults` — untouched (out of scope, belongs to a different concern).
- The admission filter (`adult.name != "" || ... || adult.gender != ""`) — untouched, belongs to #1946.
- Gap-fill behavior (blank + filled → filled) — unchanged, still the majority (~246 cases) of what the merge does.

## TDD evidence

**RED** (test written first, against the OLD code):

```
go test ./sync/... -run 'TestProcessAdultsEmail' -v
[FAIL] TestProcessAdultsEmailMergePrefersWellFormedValue/missing_dot_in_domain/malformed-first
[FAIL] TestProcessAdultsEmailMergePrefersWellFormedValue/trailing_comma_junk/malformed-first
exit=1
```

Only the `malformed-first` orderings failed — the `well-formed-first` orderings already passed
under the old code by accident of load order, which is exactly the bug: whether the merge "looks
right" depended on which sibling's row loaded first.

**GREEN** (after implementing `preferEmail`/`isWellFormedEmail`):

```
go test ./sync/... -run 'TestProcessAdults' -v
--- PASS: TestProcessAdultsPersonFieldsTakeTheFirstLoadedSibling
--- PASS: TestProcessAdultsKeepsANameOnlyAdult
--- PASS: TestProcessAdultsEmailMergePrefersWellFormedValue (both orderings, both cases)
--- PASS: TestProcessAdultsEmailBothWellFormedKeepsFirstLoaded
--- PASS: TestProcessAdultsEmailGapFillStillWins (both orderings)
exit=0
```

The two pre-existing tests (`...TakeTheFirstLoadedSibling`, `...KeepsANameOnlyAdult`) pass unchanged
— the relationship-field tie-break and the name-only-adult admission path are untouched.

**Mutation checks** (tests that passed on first write, verified they actually pin behavior):

1. Changed `preferEmail`'s final line to `return true` (always prefer candidate, ignore validity)
   → `TestProcessAdultsEmailMergePrefersWellFormedValue/.../well-formed-first` and
   `TestProcessAdultsEmailBothWellFormedKeepsFirstLoaded` went RED. Reverted.
2. Changed the gap-fill guard `if current == "" { return true }` to `return false`
   → both `TestProcessAdultsEmailGapFillStillWins` subtests went RED. Reverted.

Full suite: `go build ./...` exit=0, `go test ./...` exit=0 (all packages, including `sync` at
136s), `gofmt -l .` exit=0 with no output, `go vet ./sync/...` exit=0.

## Part A body gap

None found. The 2026-08-09 ruling banner and the numbers underneath (5 typo'd emails, 4 with a
correct sibling version, the field/line references) checked out against the tree as written.

## Not done (deliberately, per scope)

- No validity rule for DOB, gender, pronouns, first/last name, or relationship — the issue asks not
  to invent one where it can't be stated crisply, and none of these has an obviously "malformed"
  shape the way an email does.
- `family_camp_derived.go` is a collision hub with #1946 (admission filter) and #2159 (parked) —
  this PR touches only the merge switch's `Email` case plus the two new helper functions, nothing
  else in the file.

Closes #1945.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
