### PR TITLE
perf(api): bound the lodging summary fan-out with a semaphore

### DIFF
--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -65,6 +65,14 @@ _GATE_VALUES: frozenset[str] = frozenset({"no_share", "maybe_mutual", "yes_share
 _ELIGIBILITY_VALUES: frozenset[str] = frozenset({"open", "named", "declined"})
 _ELIGIBILITY_SOURCE_VALUES: frozenset[str] = frozenset({"form", "registration"})
 
+# kindred#1920: `build_summary` opens a `TaskGroup` per weekend and each one
+# opens four `to_thread` reads of its own, so an uncapped year is 4x its
+# weekend count in concurrent reads against one executor -- 48 for 2026's 12
+# weekends, 72 for 2024's 18. The default `to_thread` pool is
+# `min(32, cpu+4)`, so 8 concurrent weekends (32 reads) keeps the fan-out
+# from ever queuing behind itself.
+SUMMARY_ENTRY_CONCURRENCY = 8
+
 
 class SessionNotFoundError(LookupError):
     """No family/adult session matches the requested (year, cm_id)."""
@@ -699,12 +707,12 @@ class LodgingRosterService:
         lander cannot drift from the page it links to, and it resolves a
         scenario the same way: replace, never fall through.
 
-        THREE session-scoped reads per weekend, with or without a scenario.
-        Naming one used to cost a fourth -- the scenario's own availability
-        overrides -- and 1500000135 deleted that dimension outright rather than
-        making the extra read cheaper. Nothing caps the resulting fan-out;
-        that is deliberate for now, since no lander calls this with a scenario
-        yet, and kindred#1920 records the two ways to bound it when one does.
+        FOUR session-scoped reads per weekend, with or without a scenario:
+        availability, attendees, one placement source, and slot merges (the
+        last of these unconditional since 1500000140). A `Semaphore` below
+        bounds how many weekends' worth of those run at once -- kindred#1920,
+        which also records why a per-weekend cap was chosen over collapsing
+        the placement read to one call for the whole year.
         """
         sessions = await self.repository.fetch_weekend_sessions(year)
         if not sessions:
@@ -737,9 +745,14 @@ class LodgingRosterService:
         unresolved_aliases = aliases_task.result()
         statuses = statuses_task.result()
 
+        # Bounds how many weekends' four-read TaskGroups run at once. Per-year
+        # (one instance per `build_summary` call), not module-level -- see
+        # SUMMARY_ENTRY_CONCURRENCY.
+        entry_gate = asyncio.Semaphore(SUMMARY_ENTRY_CONCURRENCY)
+
         async def _entry(session: Any) -> WeekendSummaryEntry:
             session_pb_id = _s(session, "id")
-            async with asyncio.TaskGroup() as inner:
+            async with entry_gate, asyncio.TaskGroup() as inner:
                 availability_task = inner.create_task(self.repository.fetch_availability(year, session_pb_id))
                 attendees_task = inner.create_task(self.repository.fetch_attendees_for_session(year, session_pb_id))
                 # One placement source, exactly as build_roster chooses it.

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -21,13 +21,19 @@ below would pass without the service doing anything. A namespace raises the
 same AttributeError a real record would, so getattr defaults are exercised.
 """
 
+import asyncio
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from api.services.lodging_roster_service import LodgingRosterService, SessionNotFoundError, _BathroomIndex
+from api.services.lodging_roster_service import (
+    SUMMARY_ENTRY_CONCURRENCY,
+    LodgingRosterService,
+    SessionNotFoundError,
+    _BathroomIndex,
+)
 
 
 def _rec(**kwargs: Any) -> SimpleNamespace:
@@ -2553,7 +2559,56 @@ class TestBuildSummary:
         await LodgingRosterService(repo).build_summary(2026, scenario="scn123")
 
         assert repo.fetch_availability.await_count == 2
-        assert repo.fetch_scenario_availability.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_per_weekend_fan_out_is_bounded_by_a_semaphore(self) -> None:
+        """kindred#1920: `_entry` must not run unboundedly for every weekend at once.
+
+        12 weekends (2026's real count) each open a `TaskGroup` of four
+        concurrent reads inside `_entry`. Uncapped, that is 48 simultaneous
+        `asyncio.to_thread` calls sharing one executor. This pins the ACTUAL
+        bound -- peak concurrent `_entry` bodies in flight -- rather than
+        merely asserting a `Semaphore` object exists, which would pin nothing
+        (a `Semaphore(9999)` would satisfy that check and cap nothing real).
+        """
+        sessions = [
+            _rec(
+                id=f"sess_{i}",
+                cm_id=1000000 + i,
+                name=f"Weekend {i}",
+                session_type="family",
+                year=2026,
+                start_date="2026-09-04",
+                end_date="2026-09-07",
+                sort_order=i,
+            )
+            for i in range(12)
+        ]
+        repo = _repo(fetch_weekend_sessions=sessions)
+
+        concurrency = {"current": 0, "peak": 0}
+
+        async def _tracked_fetch_availability(*_args: Any, **_kwargs: Any) -> list[Any]:
+            concurrency["current"] += 1
+            concurrency["peak"] = max(concurrency["peak"], concurrency["current"])
+            # Cede control so overlapping `_entry` calls actually interleave --
+            # without a yield point, cooperative scheduling would never let a
+            # second `_entry` start before the first one finishes.
+            await asyncio.sleep(0.01)
+            concurrency["current"] -= 1
+            return []
+
+        repo.fetch_availability = AsyncMock(side_effect=_tracked_fetch_availability)
+
+        await LodgingRosterService(repo).build_summary(2026)
+
+        assert concurrency["peak"] <= SUMMARY_ENTRY_CONCURRENCY, (
+            f"peak concurrent weekend entries ({concurrency['peak']}) exceeded the bound ({SUMMARY_ENTRY_CONCURRENCY})"
+        )
+        # Not a tautology: with 12 weekends and a bound below 12, the fan-out
+        # must actually have been throttled at some point, not merely never
+        # have reached the cap by coincidence.
+        assert concurrency["peak"] == SUMMARY_ENTRY_CONCURRENCY
 
     @pytest.mark.asyncio
     async def test_returns_one_entry_per_weekend_carrying_its_identity(self) -> None:


### PR DESCRIPTION
## What changed

`LodgingRosterService.build_summary` spawned one `_entry` task per weekend in
an uncapped outer `TaskGroup`, and each `_entry` opened four concurrent
`asyncio.to_thread` reads of its own (`fetch_availability`,
`fetch_attendees_for_session`, one placement read, `fetch_slot_merges`). 12
weekends in 2026 is 48 concurrent reads against one PocketBase instance; 18
weekends in 2024 is 72.

Implements **Option 1** from kindred#1920 (owner-confirmed 2026-08-09): an
`asyncio.Semaphore` bounding per-year concurrency, guarding only `_entry`'s
inner `TaskGroup` (the four reads). The outer per-weekend fan-out shape is
unchanged. `SUMMARY_ENTRY_CONCURRENCY = 8` — with 4 reads per weekend, 8
concurrent weekends is 32 concurrent reads, matching the default
`asyncio.to_thread` executor size (`min(32, cpu+4)`), so the fan-out no
longer queues behind itself.

Did **not** implement Option 2 (the year-wide placement read) — it requires
rewriting the three guard tests below, which is explicitly out of scope per
the owner ruling.

### Ride-alongs the issue asked for, same method

1. `build_summary`'s docstring said "THREE session-scoped reads per weekend."
   There are four (availability, attendees, one placement source, slot
   merges — the last unconditional since 1500000140). Corrected the count
   and updated the paragraph to describe the new semaphore instead of the
   old "nothing caps this" note, which is no longer true.
2. `tests/unit/api/services/test_lodging_roster_service.py`'s
   `test_the_summary_reads_no_second_availability_layer` carried
   `assert repo.fetch_scenario_availability.await_count == 0`. That
   repository method does not exist (`api/services/lodging_repository.py:237`
   notes there is no companion `fetch_scenario_availability`) — it only
   exists as a leftover mock attribute, so the assertion could never
   meaningfully fail. **Removed it** rather than making it "real," since
   there is nothing on the real repository interface for `build_summary` to
   call. (Two other tests — `test_no_scenario_never_reads_the_draft` and
   `test_a_scenario_never_reads_the_campminder_mirror`, both in
   `TestScenarioResolution`, testing `build_roster` rather than
   `build_summary` — carry the identical pattern; left those untouched as
   out of scope for this issue, which is specific to `build_summary`.)

## TDD evidence

**RED** — new test `test_per_weekend_fan_out_is_bounded_by_a_semaphore`
added first, importing a not-yet-existing `SUMMARY_ENTRY_CONCURRENCY`:

```
ImportError: cannot import name 'SUMMARY_ENTRY_CONCURRENCY' from
'api.services.lodging_roster_service'
exit=2
```

**GREEN** — after adding the semaphore and the constant, all 124 tests in
the file pass, including the three guard tests the issue named
(`test_session_scoped_reads_happen_once_per_weekend`,
`test_a_scenario_reads_the_draft_per_weekend_and_the_mirror_never`,
`test_the_summary_reads_no_second_availability_layer`) — untouched, as
Option 1 requires.

**Mutation check** (the new test passed test-worthy scrutiny rather than
merely asserting a `Semaphore` object exists): temporarily set
`SUMMARY_ENTRY_CONCURRENCY = 9999` and reran the new test alone —

```
assert 12 == 9999
FAILED ... test_per_weekend_fan_out_is_bounded_by_a_semaphore
```

confirming it actually measures peak concurrent `_entry` bodies (via a
tracked `fetch_availability` side effect counting concurrent in-flight
calls), not a tautology. Restored to `8` and reran — GREEN again.

## Verify gates

- `uv run pytest tests/unit/api/services/test_lodging_roster_service.py -q` → 124 passed
- `uv run pytest tests/ -q` → full suite, see below
- `uv run ruff check api/services/lodging_roster_service.py tests/unit/api/services/test_lodging_roster_service.py` → all checks passed
- `uv run mypy api bunking` → Success: no issues found in 268 source files

## Not done (deliberately)

- Option 2 (year-wide placement read) — explicitly gated on a fresh owner
  ask per the issue.
- The two `TestScenarioResolution` tests with the same vacuous
  `fetch_scenario_availability` assertion pattern — those test
  `build_roster`, not `build_summary`, and are out of this issue's scope.

Closes #1920.
