### PR TITLE
fix(frontend): close the party panel on a weekend switch, not just a party drop

### DIFF
--- a/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
@@ -574,3 +574,45 @@ describe('HouseholdRosterTable — clears a stale selection (kindred#2062)', () 
     expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
   })
 })
+
+describe('HouseholdRosterTable — clears the selection on a SESSION change (kindred#2138)', () => {
+  // #2062's guard only clears `selected` when the household stops matching
+  // `partyKey` — and `partyKey` carries no session dimension (partyKey.ts).
+  // A household enrolled in BOTH weekends still matches after the switch, so
+  // the #2062 tests above (which use a party that disappears) pass without
+  // ever exercising this path. This one keeps the same household in
+  // `parties` across the rerender and changes only `sessionCmId`.
+  it('closes the panel on a session change even though the same household is still in parties', async () => {
+    const johnsonInBothWeekends = () => [
+      party({ display_name: 'Johnson Family', household_cm_id: 2000001 }),
+    ]
+    const { rerender } = render(
+      <HouseholdRosterTable year={2026} sessionCmId={101} parties={johnsonInBothWeekends()} />,
+      { wrapper }
+    )
+    await userEvent.click(screen.getByRole('button', { name: /Johnson Family/ }))
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+
+    // Same household, same partyKey — a different weekend's roster.
+    rerender(
+      <HouseholdRosterTable year={2026} sessionCmId={202} parties={johnsonInBothWeekends()} />
+    )
+    expect(screen.queryByTestId('family-details-panel')).not.toBeInTheDocument()
+  })
+
+  // The companion trap to #2062's own: a rerender that keeps the SAME
+  // session must not close a panel out from under whoever has it open, even
+  // when `parties` is a fresh array identity from a refetch.
+  it('keeps the panel open when the session is unchanged, even across a parties refetch', async () => {
+    const makeParties = () => [party({ display_name: 'Johnson Family', household_cm_id: 2000001 })]
+    const { rerender } = render(
+      <HouseholdRosterTable year={2026} sessionCmId={101} parties={makeParties()} />,
+      { wrapper }
+    )
+    await userEvent.click(screen.getByRole('button', { name: /Johnson Family/ }))
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+
+    rerender(<HouseholdRosterTable year={2026} sessionCmId={101} parties={makeParties()} />)
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/weekend/HouseholdRosterTable.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.tsx
@@ -27,6 +27,14 @@ export interface HouseholdRosterTableProps {
   units?: LodgingUnitRow[]
   /** Threads through to `FamilyDetailsPanel`'s medical-narrative fetch (kindred#1996). */
   year: number
+  /**
+   * The weekend this roster belongs to, so a household enrolled in TWO
+   * weekends (kindred#2138) can be told apart from one that merely refetched.
+   * Optional and defaulting to 0 for the same reason `LodgingBoard`'s prop
+   * of the same name does: most tests render one weekend's roster and never
+   * exercise a session change.
+   */
+  sessionCmId?: number
 }
 
 const HEAD_CELL = 'text-muted-foreground pb-2 text-xs font-bold tracking-wider uppercase'
@@ -43,7 +51,12 @@ function hasAnyRequest(parties: RosterPartyRow[]): boolean {
   })
 }
 
-export function HouseholdRosterTable({ parties, units = [], year }: HouseholdRosterTableProps) {
+export function HouseholdRosterTable({
+  parties,
+  units = [],
+  year,
+  sessionCmId = 0,
+}: HouseholdRosterTableProps) {
   // A third `FamilyDetailsPanel` callsite (kindred#1996), wired exactly as
   // `LodgingBoard` and `LodgingMap` wire the other two — same `selected` /
   // `requestClose` pair, same `useDismissOnDeadSpace` hookup. The row itself
@@ -61,6 +74,28 @@ export function HouseholdRosterTable({ parties, units = [], year }: HouseholdRos
     setSelected(null)
     setRequestClose(false)
   }, [])
+
+  // RESET, not filtered (kindred#2138) — the owner's ruling was explicit: a
+  // session change closes the panel outright, it does not merely stop
+  // rendering it while `selected` quietly survives underneath. #2062's
+  // `panelParty` guard below only catches a household that drops OUT of
+  // `parties`; a household enrolled in two weekends never does that, since
+  // `partyKey` (deliberately — see partyKey.ts) carries no session
+  // dimension, so the same key still matches after the switch and the panel
+  // would keep rendering the PREVIOUS weekend's placement data.
+  //
+  // This is React's own "storing information from previous renders"
+  // pattern: compare this render's prop against the last one seen, and if
+  // it moved, correct the state right here in the render body rather than
+  // in an Effect. Calling `setSelected` conditionally during render does not
+  // add a paint the way an Effect would — React discards this render's
+  // output and re-renders synchronously with the corrected state before
+  // anything commits, so nobody ever sees the stale mid-render frame.
+  const [lastSessionCmId, setLastSessionCmId] = useState(sessionCmId)
+  if (sessionCmId !== lastSessionCmId) {
+    setLastSessionCmId(sessionCmId)
+    setSelected(null)
+  }
 
   // DERIVED, not effect-cleared (kindred#2062). A weekend switch re-renders
   // this table with a different `parties` prop but never unmounts it, so a

--- a/frontend/src/components/weekend/LodgingBoard.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.test.tsx
@@ -734,3 +734,56 @@ describe('LodgingBoard — clears a stale selection (kindred#2062)', () => {
     expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
   })
 })
+
+describe('LodgingBoard — clears the selection on a SESSION change (kindred#2138)', () => {
+  // #2062's guard above only clears `selected` when the household stops
+  // matching `partyKey` — and `partyKey` carries no session dimension
+  // (partyKey.ts). A household enrolled in BOTH weekends still matches
+  // after the switch, so the #2062 tests (which use a party that
+  // disappears) pass without ever exercising this path. This one keeps the
+  // same household in `parties` across the rerender and changes only
+  // `sessionCmId`.
+  it('closes the panel on a session change even though the same household is still in parties', async () => {
+    const johnsonInBothWeekends = () => [party({ unit_code: 'cedar-1', unit_name: 'Cedar 1' })]
+    const { rerender } = render(
+      <LodgingBoard
+        parties={johnsonInBothWeekends()}
+        units={[unit()]}
+        year={2026}
+        sessionCmId={101}
+      />,
+      { wrapper }
+    )
+    await userEvent.click(screen.getByRole('button', { name: /Johnson/ }))
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+
+    // Same household, same partyKey — a different weekend's roster.
+    rerender(
+      <LodgingBoard
+        parties={johnsonInBothWeekends()}
+        units={[unit()]}
+        year={2026}
+        sessionCmId={202}
+      />
+    )
+    expect(screen.queryByTestId('family-details-panel')).not.toBeInTheDocument()
+  })
+
+  // The companion trap to #2062's own: a rerender that keeps the SAME
+  // session must not close a panel out from under whoever has it open, even
+  // when `parties` is a fresh array identity from a refetch.
+  it('keeps the panel open when the session is unchanged, even across a parties refetch', async () => {
+    const makeParties = () => [party({ unit_code: 'cedar-1', unit_name: 'Cedar 1' })]
+    const { rerender } = render(
+      <LodgingBoard parties={makeParties()} units={[unit()]} year={2026} sessionCmId={101} />,
+      { wrapper }
+    )
+    await userEvent.click(screen.getByRole('button', { name: /Johnson/ }))
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+
+    rerender(
+      <LodgingBoard parties={makeParties()} units={[unit()]} year={2026} sessionCmId={101} />
+    )
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -156,6 +156,28 @@ export function LodgingBoard({
   // to avoid. Do not "fix" this back to `canPlace`.
   const canMergeUnits = canManage && sessionCmId > 0
 
+  // RESET, not filtered (kindred#2138) — the owner's ruling was explicit: a
+  // session change closes the panel outright, it does not merely stop
+  // rendering it while `selected` quietly survives underneath. The
+  // `panelParty` guard further down only catches a household that drops OUT
+  // of `parties`; a household enrolled in two weekends never does that,
+  // since `partyKey` (deliberately — see partyKey.ts) carries no session
+  // dimension, so the same key still matches after the switch and the panel
+  // would keep rendering the PREVIOUS weekend's placement data.
+  //
+  // This is React's own "storing information from previous renders"
+  // pattern: compare this render's prop against the last one seen, and if
+  // it moved, correct the state right here in the render body rather than
+  // in an Effect. Calling `setSelected` conditionally during render does not
+  // add a paint the way an Effect would — React discards this render's
+  // output and re-renders synchronously with the corrected state before
+  // anything commits, so nobody ever sees the stale mid-render frame.
+  const [lastSessionCmId, setLastSessionCmId] = useState(sessionCmId)
+  if (sessionCmId !== lastSessionCmId) {
+    setLastSessionCmId(sessionCmId)
+    setSelected(null)
+  }
+
   const { move } = useLodgingPlacement({ year, sessionCmId, scenario })
   const { setAvailability, pendingUnitId } = useUnitAvailability({ year, sessionCmId })
   // `scenario` here is the same prop `useLodgingPlacement` gets — on the

--- a/frontend/src/components/weekend/LodgingMap.test.tsx
+++ b/frontend/src/components/weekend/LodgingMap.test.tsx
@@ -859,3 +859,47 @@ describe('LodgingMap — clears a stale selection (kindred#2062)', () => {
     expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
   })
 })
+
+describe('LodgingMap — clears the selection on a SESSION change (kindred#2138)', () => {
+  // #2062's guard only clears `selected` when the household stops matching
+  // `partyKey` — and `partyKey` carries no session dimension (partyKey.ts).
+  // A household enrolled in BOTH weekends still matches after the switch,
+  // so the #2062 tests above (which use a party that disappears) pass
+  // without ever exercising this path. This one keeps the same household in
+  // `parties` across the rerender and changes only `sessionCmId`.
+  it('closes the panel on a session change even though the same household is still in parties', async () => {
+    const johnsonInBothWeekends = () => [PLACED]
+    const { rerender } = render(
+      <LodgingMap parties={johnsonInBothWeekends()} units={UNITS} year={2026} sessionCmId={101} />,
+      { wrapper }
+    )
+    await userEvent.click(screen.getAllByTestId('map-mark')[0] as HTMLElement)
+    await userEvent.click(screen.getByRole('button', { name: /Johnson/ }))
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+
+    // Same household, same partyKey — a different weekend's roster.
+    rerender(
+      <LodgingMap parties={johnsonInBothWeekends()} units={UNITS} year={2026} sessionCmId={202} />
+    )
+    expect(screen.queryByTestId('family-details-panel')).not.toBeInTheDocument()
+  })
+
+  // The companion trap to #2062's own: a rerender that keeps the SAME
+  // session must not close a panel out from under whoever has it open, even
+  // when `parties` is a fresh array identity from a refetch.
+  it('keeps the panel open when the session is unchanged, even across a parties refetch', async () => {
+    const makeParties = () => [
+      party({ display_name: 'Johnson', unit_code: 'cedar-1', unit_name: 'Cedar 1' }),
+    ]
+    const { rerender } = render(
+      <LodgingMap parties={makeParties()} units={UNITS} year={2026} sessionCmId={101} />,
+      { wrapper }
+    )
+    await userEvent.click(screen.getAllByTestId('map-mark')[0] as HTMLElement)
+    await userEvent.click(screen.getByRole('button', { name: /Johnson/ }))
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+
+    rerender(<LodgingMap parties={makeParties()} units={UNITS} year={2026} sessionCmId={101} />)
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/weekend/LodgingMap.tsx
+++ b/frontend/src/components/weekend/LodgingMap.tsx
@@ -93,9 +93,17 @@ export interface LodgingMapProps {
   parties: RosterPartyRow[]
   units: LodgingUnitRow[]
   year: number
+  /**
+   * The weekend this map belongs to, so a household enrolled in TWO
+   * weekends (kindred#2138) can be told apart from one that merely
+   * refetched. Optional and defaulting to 0 for the same reason
+   * `LodgingBoard`'s prop of the same name does: most tests render one
+   * weekend's map and never exercise a session change.
+   */
+  sessionCmId?: number
 }
 
-export function LodgingMap({ parties, units, year }: LodgingMapProps) {
+export function LodgingMap({ parties, units, year, sessionCmId = 0 }: LodgingMapProps) {
   // MEMOISED, and not as a micro-optimisation: panning updates `view` on every
   // pointermove, and an unmemoised call would re-run buildBoard — area bucketing,
   // sorting, hue assignment, the lot — on every frame of a drag.
@@ -191,6 +199,28 @@ export function LodgingMap({ parties, units, year }: LodgingMapProps) {
     setSelected(null)
     setRequestClose(false)
   }, [])
+
+  // RESET, not filtered (kindred#2138) — the owner's ruling was explicit: a
+  // session change closes the panel outright, it does not merely stop
+  // rendering it while `selected` quietly survives underneath. The
+  // `panelParty` guard below only catches a household that drops OUT of
+  // `parties`; a household enrolled in two weekends never does that, since
+  // `partyKey` (deliberately — see partyKey.ts) carries no session
+  // dimension, so the same key still matches after the switch and the panel
+  // would keep rendering the PREVIOUS weekend's placement data.
+  //
+  // This is React's own "storing information from previous renders"
+  // pattern: compare this render's prop against the last one seen, and if
+  // it moved, correct the state right here in the render body rather than
+  // in an Effect. Calling `setSelected` conditionally during render does not
+  // add a paint the way an Effect would — React discards this render's
+  // output and re-renders synchronously with the corrected state before
+  // anything commits, so nobody ever sees the stale mid-render frame.
+  const [lastSessionCmId, setLastSessionCmId] = useState(sessionCmId)
+  if (sessionCmId !== lastSessionCmId) {
+    setLastSessionCmId(sessionCmId)
+    setSelected(null)
+  }
 
   // DERIVED, not effect-cleared (kindred#2062). A weekend switch re-renders
   // the map with a different `parties` prop but never unmounts it, so a

--- a/frontend/src/pages/WeekendRosterPage.tsx
+++ b/frontend/src/pages/WeekendRosterPage.tsx
@@ -394,10 +394,15 @@ export default function WeekendRosterPage() {
                 aria-labelledby="weekend-tab-housing"
                 hidden={view !== 'housing'}
               >
-                {/* The board takes the scenario, the weekend and the manage
-                    permission because it WRITES now (#1989) — main's note that
-                    drag placement "is what earns plumbing it back down" is
-                    this. The map still takes only what it renders.
+                {/* The board takes the scenario AND the manage permission
+                    because it WRITES now (#1989) — main's note that drag
+                    placement "is what earns plumbing it back down" is this.
+                    The map and roster table still take neither; they only
+                    read. All three take `sessionCmId` regardless (#2138) —
+                    every surface needs to know which weekend it is showing
+                    so a party panel left open across a weekend switch can
+                    be told apart from one that merely refetched the same
+                    household.
 
                     Each is its own Suspense boundary, not one wrapping the
                     whole panel: `Activity` keeps a previously-opened tab
@@ -432,7 +437,12 @@ export default function WeekendRosterPage() {
                 {openedViews.has('roster') && (
                   <Activity mode={view === 'roster' ? 'visible' : 'hidden'}>
                     <ErrorBoundary>
-                      <HouseholdRosterTable parties={parties} units={units} year={currentYear} />
+                      <HouseholdRosterTable
+                        parties={parties}
+                        units={units}
+                        year={currentYear}
+                        sessionCmId={selectedCmId ?? 0}
+                      />
                     </ErrorBoundary>
                   </Activity>
                 )}
@@ -448,7 +458,12 @@ export default function WeekendRosterPage() {
                   <Activity mode={view === 'map' ? 'visible' : 'hidden'}>
                     <ErrorBoundary>
                       <Suspense fallback={<TabLoadingFallback />}>
-                        <LodgingMap parties={parties} units={units} year={currentYear} />
+                        <LodgingMap
+                          parties={parties}
+                          units={units}
+                          year={currentYear}
+                          sessionCmId={selectedCmId ?? 0}
+                        />
                       </Suspense>
                     </ErrorBoundary>
                   </Activity>


### PR DESCRIPTION
## What changed

kindred#2062 clears the selected party (`selected`) when the household stops matching `partyKey` in the current `parties` list. `partyKey` deliberately carries no session dimension (`partyKey.ts` is a fence — untouched here), so a household enrolled in TWO weekends still matches after a session switch, and the `FamilyDetailsPanel` kept rendering the PREVIOUS weekend's placement data over the new roster.

Owner ruling on the issue: the panel closes outright on a weekend switch — it does not merely stop rendering while `selected` quietly survives underneath.

Fix: reset `selected` when the SESSION changes, not when the party key stops matching. Uses the same render-time-adjustment style #2121 established (React's "storing information from previous renders" pattern — compare this render's prop to the last one seen, correct state in the render body) rather than a `useEffect`, so no extra commit/paint is added.

Applied to all three surfaces #2121 touched:
- `HouseholdRosterTable.tsx`
- `LodgingBoard.tsx`
- `LodgingMap.tsx`

`HouseholdRosterTable` and `LodgingMap` did not previously take a `sessionCmId` prop at all (only `LodgingBoard` did, for its write gates). Added it to both — optional, default `0`, same shape as `LodgingBoard`'s existing prop — and wired it through from `WeekendRosterPage`.

All three components already funnel `panelParty`, `isPanelOpen`, and `useDismissOnDeadSpace`'s open flag through the same derived `panelParty` value, so resetting the underlying `selected` state is consistent across all three reads per surface without touching each read site separately.

## TDD evidence

For each surface, added a test that keeps the SAME household (by content, same `partyKey`) in `parties` across a rerender, changing only `sessionCmId`:

```
RED  (before fix): "closes the panel on a session change..." failed —
     panel stayed open, rendering the previous weekend's household.
GREEN (after fix):  same test passes; the existing #2062 tests
     (party disappears from `parties`) continue to pass unchanged.
```

Confirmed RED on all three components individually before implementing (HouseholdRosterTable, LodgingBoard, LodgingMap), then GREEN after.

**Mutation check** on the paired "keeps panel open when session is unchanged, even across a parties refetch" tests (these passed on first write, since they don't require the fix to already pass): re-keyed the reset off `parties` array identity instead of `sessionCmId` — a plausible wrong implementation, and exactly the trap the comment in the code calls out. This broke precisely those tests (both the new #2138 ones and the pre-existing #2062 "refetch with same content" ones) — 7 failures, 106 still green — confirming the guard is load-bearing and keyed on the right dimension. Restored and reran full suite: 113/113 green again.

Full frontend suite: `425 files / 6144 tests passed`. `tsc --noEmit` clean on both configs. `eslint` on touched files: 0 errors (3 pre-existing warnings, all outside the diff).

## Deliberately not done (scope fence)

- No `usePanelParty` hook extraction — owned by #2137/#2139.
- No fix to the stale-object `.some()`-vs-`.find()` bug — owned by #2137/#2139.
- No fix to the `pinnedKey`/`dwellKey` latch — owned by #2137/#2139.
- `partyKey.ts` untouched, and `_household_display_name`'s output unchanged.
- `LodgingMap.tsx`'s `halo`/ring-precedence region (owned by a concurrent sibling PR) not touched — diff is confined to the props interface (~line 95) and the `selected`/session-reset block (~line 195-225).

## Part A gap found

None — the issue body's proposed fix direction ("reset on session change, at render time, not `partyKey`") matched the tree exactly. The one thing the body didn't spell out is that `HouseholdRosterTable` and `LodgingMap` had no session identifier prop at all before this PR (only `LodgingBoard` did, for its write gates) — threading `sessionCmId` through from `WeekendRosterPage` to all three was necessary to have anything to key the reset on.

Closes #2138.
