### PR TITLE
feat(frontend): indent lodging rooms under their building in tree order

### DIFF
--- a/frontend/src/components/admin/lodging/LodgingUnitRow.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitRow.tsx
@@ -14,6 +14,12 @@
  * Every action is labelled with the unit name (`Confirm Cabin A`, not
  * `Confirm`) so a screen reader — and a test — can tell 93 identical buttons
  * apart.
+ *
+ * `depth` indents the name cell under its parent's row (#2082) — the caller
+ * (`UnitAreaGroup`, via `flattenUnitTree`) has already put this row in tree
+ * order, so this component only draws what depth it landed at. It is not a
+ * new visual channel: the existing name cell just gains left padding, same
+ * spacing primitive already used everywhere else on this surface.
  */
 import { Bath } from 'lucide-react'
 
@@ -22,8 +28,13 @@ import { normaliseBeds, totalBedCount } from '../../../types/beds'
 import { ACTION_LINK, MUTED_PILL, PILL } from './lodgingStyles'
 import { AMENITY_FLAGS } from './unitAmenities'
 
+/** Indent per tree depth, in pixels. Inline, not a Tailwind class — depth is unbounded, so no fixed set of classes covers it. */
+const INDENT_STEP_PX = 20
+
 export interface LodgingUnitRowProps {
   unit: LodgingUnitRecord
+  /** How deep `flattenUnitTree` placed this row under its parent. 0 = a root row, no indent. */
+  depth: number
   isSelected: boolean
   onToggleSelect: () => void
   onEdit: () => void
@@ -33,6 +44,7 @@ export interface LodgingUnitRowProps {
 
 export function LodgingUnitRow({
   unit,
+  depth,
   isSelected,
   onToggleSelect,
   onEdit,
@@ -58,7 +70,11 @@ export function LodgingUnitRow({
           onChange={onToggleSelect}
         />
       </td>
-      <td className="py-1.5 font-medium" data-testid="unit-name">
+      <td
+        className="py-1.5 font-medium"
+        data-testid="unit-name"
+        style={depth > 0 ? { paddingLeft: `${depth * INDENT_STEP_PX}px` } : undefined}
+      >
         {unit.name}
       </td>
       <td className="py-1.5 tabular-nums">

--- a/frontend/src/components/admin/lodging/LodgingUnitsPanel.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitsPanel.test.tsx
@@ -202,18 +202,53 @@ describe('LodgingUnitsPanel', () => {
     expect(screen.getAllByText('Unconfirmed')).toHaveLength(2)
   })
 
-  it('sorts within an area when a column header is activated', async () => {
+  // This used to pin a flat, whole-area sort. #2082 replaced that with
+  // TREE order: rows render under their parent regardless of which column
+  // is active, and the chosen column only ranks a sibling set — a building's
+  // own rooms among themselves, and the area's roots among themselves.
+  // Shipping indent-plus-unchanged-flat-sort was ruled out because it is the
+  // one option that can display a FALSE PARENT: a child whose own sort key
+  // outranks another root's row would read as indented under that root.
+  it('sorts a sibling set by the chosen column, indented under its own parent — not the whole area flat', async () => {
+    // Cabin B Loft is a CHILD of Cabin B (parent_unit: 'u3'), not a sibling
+    // of Cabin A/Cabin B at the area's root. Its sleeps value (2) is lower
+    // than both roots', so a flat area-wide sort by Sleeps would rank it
+    // FIRST — exactly the false-parent-producing case #2082 rules out.
+    listLodgingUnits.mockResolvedValueOnce([
+      fixtureUnit({ id: 'u1', name: 'Cabin A', code: 'cabin-a', area: 'area_1', sleeps: 0 }),
+      fixtureUnit({
+        id: 'u3',
+        name: 'Cabin B',
+        code: 'cabin-b',
+        area: 'area_1',
+        sleeps: 4,
+        is_container: true,
+      }),
+      fixtureUnit({
+        id: 'u4',
+        name: 'Cabin B Loft',
+        code: 'cabin-b-loft',
+        area: 'area_1',
+        parent_unit: 'u3',
+        sleeps: 2,
+      }),
+    ])
     const user = userEvent.setup()
     await renderPanel()
 
     await user.click(screen.getByRole('button', { name: 'Sleeps' }))
 
     const north = screen.getByTestId('area-group-area_1')
-    const names = within(north)
-      .getAllByTestId('unit-name')
-      .map((el) => el.textContent)
-    // Cabin B sleeps 4; Cabin A is unknown and must sort last, not first.
-    expect(names).toEqual(['Cabin B', 'Cabin A'])
+    const rows = within(north).getAllByTestId('unit-name')
+    // Cabin B (4) ranks ahead of Cabin A (unknown, always last regardless of
+    // direction) at the root. Cabin B Loft (2) stays directly under Cabin B
+    // — it never jumps ahead of Cabin B, and it is never compared against
+    // Cabin A at all, despite having the lowest sleeps value of the three.
+    expect(rows.map((el) => el.textContent)).toEqual(['Cabin B', 'Cabin B Loft', 'Cabin A'])
+    // The indent itself: Cabin B Loft is the only row under a parent.
+    expect(rows[0]).not.toHaveStyle({ paddingLeft: '20px' })
+    expect(rows[1]).toHaveStyle({ paddingLeft: '20px' })
+    expect(rows[2]).not.toHaveStyle({ paddingLeft: '20px' })
   })
 
   it('marks the active column with aria-sort', async () => {

--- a/frontend/src/components/admin/lodging/UnitAreaGroup.tsx
+++ b/frontend/src/components/admin/lodging/UnitAreaGroup.tsx
@@ -3,14 +3,26 @@
  *
  * A `tbody` per area rather than a table per area: staff reason about the site
  * by zone and a flat 93-row list loses that, but the sort control has to stay
- * singular (see `UnitsTableHeader`). The chosen column sorts WITHIN the zone.
+ * singular (see `UnitsTableHeader`).
+ *
+ * Within the zone, rows render in TREE order (#2082): a parent's row is
+ * immediately followed by its own subtree, indented by its computed
+ * `parent_unit` depth, and the chosen column sorts only WITHIN each sibling
+ * set — a building's own rooms among themselves, and the zone's root-level
+ * buildings among themselves — never as one flat ranking across the whole
+ * zone. That is deliberate, not a simplification: sorting the zone flat and
+ * indenting whatever came out could draw a room under a building's row that
+ * does not actually contain it (a FALSE PARENT) the moment the chosen column
+ * scattered a subtree apart. See `flattenUnitTree` in `./unitTree` for the
+ * walk that produces this order.
  */
 import { ChevronDown, ChevronRight } from 'lucide-react'
 
 import type { LodgingUnitRecord } from '../../../types/lodging'
 import { GROUP_HEADING, MUTED_PILL } from './lodgingStyles'
 import { LodgingUnitRow } from './LodgingUnitRow'
-import { sortUnits, UNIT_SORT_COLUMNS, type AreaGroup, type UnitSort } from './unitSort'
+import { UNIT_SORT_COLUMNS, type AreaGroup, type UnitSort } from './unitSort'
+import { flattenUnitTree } from './unitTree'
 
 export interface UnitAreaGroupProps {
   group: AreaGroup
@@ -35,7 +47,7 @@ export function UnitAreaGroup({
   onConfirm,
   onDeactivate,
 }: UnitAreaGroupProps) {
-  const rows = sortUnits(group.units, sort)
+  const rows = flattenUnitTree(group.units, sort)
   const Chevron = isCollapsed ? ChevronRight : ChevronDown
 
   return (
@@ -67,10 +79,11 @@ export function UnitAreaGroup({
         </td>
       </tr>
       {!isCollapsed &&
-        rows.map((unit) => (
+        rows.map(({ unit, depth }) => (
           <LodgingUnitRow
             key={unit.id}
             unit={unit}
+            depth={depth}
             isSelected={selected.has(unit.id)}
             onToggleSelect={() => {
               onToggleSelect(unit.id)

--- a/frontend/src/components/admin/lodging/unitSort.ts
+++ b/frontend/src/components/admin/lodging/unitSort.ts
@@ -2,7 +2,14 @@
  * Unit table ordering.
  *
  * Area is the OUTER ordering — staff think about the site by zone, and a flat
- * 93-row list loses that. The chosen column then sorts within each zone.
+ * 93-row list loses that. `sortUnits` below is the comparator for one SIBLING
+ * SET — this file no longer flattens a whole zone with it. Since #2082 the
+ * zone itself renders in TREE order (`flattenUnitTree` in `./unitTree`): a
+ * parent's row immediately followed by its own subtree, and this comparator
+ * only orders a building's own rooms among themselves, or a zone's root-level
+ * buildings among themselves. Sorting a whole zone flat and indenting
+ * whatever came out was ruled out — it is the one way to draw a room
+ * indented under a building's row that does not actually contain it.
  *
  * `sleeps === 0` means UNKNOWN (PocketBase stores an unset number as 0), so it
  * sorts last in BOTH directions. Treating it as the smallest number would put

--- a/frontend/src/components/admin/lodging/unitTree.test.ts
+++ b/frontend/src/components/admin/lodging/unitTree.test.ts
@@ -9,7 +9,13 @@
 import { describe, expect, it } from 'vitest'
 
 import type { LodgingUnitRecord } from '../../../types/lodging'
-import { combinedAncestor, descendantIds, directChildren, parentCandidates } from './unitTree'
+import {
+  combinedAncestor,
+  descendantIds,
+  directChildren,
+  flattenUnitTree,
+  parentCandidates,
+} from './unitTree'
 
 function unit(over: Partial<LodgingUnitRecord> & { id: string }): LodgingUnitRecord {
   return {
@@ -220,6 +226,87 @@ describe('parentCandidates — scoped to the area', () => {
     ]
 
     expect(parentCandidates(undefined, units, '').map((u) => u.id)).toEqual(['near', 'far'])
+  })
+})
+
+describe('flattenUnitTree', () => {
+  // #2082: the lodging table renders in TREE order — a parent's row
+  // immediately followed by its own subtree — so the depth used for the
+  // indent has to come from walking `parent_unit`, not from `!== ''`.
+  // Measured on production: 79 roots / 21 at depth 1 / 18 at depth 2, and
+  // three containers hold container children, so a one-level model would
+  // put 18 of 118 rows at the wrong depth.
+  it('computes depth from a parent_unit walk, not from merely having a parent', () => {
+    const units = [
+      unit({ id: 'building', is_container: true }),
+      unit({ id: 'room', parent_unit: 'building', is_container: true }),
+      unit({ id: 'bunk', parent_unit: 'room' }),
+    ]
+    const rows = flattenUnitTree(units, { field: 'name', desc: false })
+    expect(rows.map((r) => [r.unit.id, r.depth])).toEqual([
+      ['building', 0],
+      ['room', 1],
+      ['bunk', 2],
+    ])
+  })
+
+  it('sorts a sibling set by the chosen column while it stays under its parent', () => {
+    const units = [
+      unit({ id: 'building', is_container: true }),
+      unit({ id: 'room-b', parent_unit: 'building', sleeps: 2 }),
+      unit({ id: 'room-a', parent_unit: 'building', sleeps: 4 }),
+    ]
+    // Ascending by sleeps: room-b (2) before room-a (4) — the reverse of
+    // name order — proving the column, not the name tiebreak, drove this.
+    const rows = flattenUnitTree(units, { field: 'sleeps', desc: false })
+    expect(rows.map((r) => r.unit.id)).toEqual(['building', 'room-b', 'room-a'])
+  })
+
+  // This is the case #2082 rules out shipping without: "indent-plus-
+  // unchanged-flat-sort" would let a child whose own sort key ranks ahead of
+  // ANOTHER root's row read as indented under that other root — a FALSE
+  // PARENT. Tree-order-always means the column only ranks siblings; a root
+  // and its whole subtree move together.
+  it('keeps a root and its subtree together even when a child would outrank another root by the sorted column', () => {
+    const units = [
+      unit({ id: 'big-building', is_container: true, sleeps: 20 }),
+      unit({ id: 'big-building-room', parent_unit: 'big-building', sleeps: 1 }),
+      unit({ id: 'small-building', is_container: true, sleeps: 2 }),
+    ]
+    const rows = flattenUnitTree(units, { field: 'sleeps', desc: false })
+    expect(rows.map((r) => r.unit.id)).toEqual([
+      'small-building',
+      'big-building',
+      'big-building-room',
+    ])
+  })
+
+  // A unit whose area was deleted lands in `groupUnitsByArea`'s trailing
+  // `__unassigned__` bucket (see unitSort.test.ts) alongside units it has no
+  // real relationship to — its actual parent, if it has one, is not
+  // guaranteed to be in that same bucket. This must render rather than
+  // crash the walk on a parent lookup that can't find its target.
+  it('renders a unit whose parent is outside this group flat, at depth 0, instead of crashing the walk', () => {
+    const units = [unit({ id: 'orphan', parent_unit: 'not-in-this-group' })]
+    const rows = flattenUnitTree(units, { field: 'name', desc: false })
+    expect(rows).toEqual([{ unit: units[0], depth: 0 }])
+  })
+
+  // Same rationale as descendantIds' and combinedAncestor's matching tests
+  // above: guardUnitParentCycle (#1899) cannot un-write a cycle already
+  // sitting in the database from before it existed, and this walk has no
+  // way to know whether the hook ran on any given row. Unlike those two
+  // walks, this one starts from ROOTS rather than from a known id — a pure
+  // cycle with no unit reachable from an actual root would never be found by
+  // a top-down walk at all, so every member has to be picked up afterward
+  // rather than silently dropped from the roster.
+  it('terminates on already-cyclic stored data and renders every member once, rather than dropping it', () => {
+    const units = [
+      unit({ id: 'a', parent_unit: 'b', is_container: true }),
+      unit({ id: 'b', parent_unit: 'a', is_container: true }),
+    ]
+    const rows = flattenUnitTree(units, { field: 'name', desc: false })
+    expect(rows.map((r) => r.unit.id).sort()).toEqual(['a', 'b'])
   })
 })
 

--- a/frontend/src/components/admin/lodging/unitTree.ts
+++ b/frontend/src/components/admin/lodging/unitTree.ts
@@ -6,14 +6,17 @@
  * cycle `descendantIds`' own walk below and the Go-side `HasParentCycle`
  * would otherwise have to guard against every time they run — and a
  * non-container parent, which `scripts/dev/verify-lodging-seed.sh` treats as
- * a seed failure. Nothing else walks parent links: `descendantIds` below and
- * the Go-side `HasParentCycle` are the only two, and both carry visited
- * guards. The cycle case now has a server-side backstop too
- * (`guardUnitParentCycle`, #1899), for the direct write this picker can't
- * filter; the non-container case still has no PocketBase rule or Go hook at
- * all. This filters both before either ever reaches a write.
+ * a seed failure. Nothing else walks parent links DOWNWARD: `descendantIds`
+ * below, `flattenUnitTree` below (the lodging table's tree-order render,
+ * #2082), and the Go-side `HasParentCycle` are the only three, and all carry
+ * visited guards. `combinedAncestor` below walks the other direction, up
+ * toward the root, and carries its own visited guard for the same reason —
+ * a data-only cycle predates `guardUnitParentCycle` (#1899) and that hook
+ * cannot un-write one already sitting in the database. This filters both
+ * things the picker rejects before either ever reaches a write.
  */
 import type { LodgingUnitRecord } from '../../../types/lodging'
+import { sortUnits, type UnitSort } from './unitSort'
 
 /** Every id descending from `unitId` via `parent_unit` — its children, grandchildren, and so on. */
 export function descendantIds(unitId: string, units: LodgingUnitRecord[]): Set<string> {
@@ -140,4 +143,82 @@ export function parentCandidates(
     }
     return true
   })
+}
+
+/** One row of a tree-ordered unit table: the unit, and how deep its `parent_unit` chain put it. */
+export interface UnitTreeRow {
+  unit: LodgingUnitRecord
+  depth: number
+}
+
+/**
+ * `units` — one area group's worth — in TREE order: a parent's row
+ * immediately followed by its own subtree, at whatever depth the
+ * `parent_unit` chain actually puts it. NEVER one level — three containers
+ * on site hold container children too (#2082), so `parent_unit !== ''` alone
+ * would misplace those rows.
+ *
+ * `sort` orders each SIBLING SET only — a building's own rooms among
+ * themselves, and the group's roots among themselves — never the group as
+ * one flat ranking. That is the load-bearing decision behind this function:
+ * "indent-plus-unchanged-flat-sort" (sorting the whole group, then indenting
+ * whatever came out) is the one option #2082 rules out shipping, because it
+ * is the only one that can display a FALSE PARENT — a child whose own sort
+ * key outranks another root's row would read as indented under that root.
+ * Tree-order-always means a root and its whole subtree move together
+ * regardless of which column is active.
+ *
+ * A unit whose `parent_unit` does not resolve to another unit IN THIS GROUP
+ * — unset, or naming a unit outside it — renders as its own root at depth 0
+ * rather than being dropped. That is what keeps `groupUnitsByArea`'s
+ * trailing `__unassigned__` bucket (`unitSort.ts`) safe to walk: those units
+ * have no guaranteed parent in the same bucket, so this never crashes on a
+ * lookup that can't find its target.
+ *
+ * Visited guard to match this file's other walks. Unlike `descendantIds` and
+ * `combinedAncestor`, which start from one known id, this one starts from
+ * every ROOT in the group — so a pure cycle with no unit reachable from an
+ * actual root (every member's `parent_unit` also resolves inside the cycle)
+ * would never be found by the top-down pass at all. Rather than let those
+ * rows silently vanish from the roster, anything still unvisited afterward
+ * is walked again as an extra root: each member still renders exactly once,
+ * and the recursion still stops the instant it loops back to an id already
+ * drawn.
+ */
+export function flattenUnitTree(units: LodgingUnitRecord[], sort: UnitSort): UnitTreeRow[] {
+  const byId = new Map(units.map((unit) => [unit.id, unit]))
+  const childrenOf = new Map<string, LodgingUnitRecord[]>()
+  const roots: LodgingUnitRecord[] = []
+
+  for (const unit of units) {
+    const parent = unit.parent_unit !== '' ? byId.get(unit.parent_unit) : undefined
+    if (parent === undefined) {
+      roots.push(unit)
+      continue
+    }
+    const siblings = childrenOf.get(parent.id)
+    if (siblings) siblings.push(unit)
+    else childrenOf.set(parent.id, [unit])
+  }
+
+  const rows: UnitTreeRow[] = []
+  const visited = new Set<string>()
+
+  const walk = (level: LodgingUnitRecord[], depth: number) => {
+    for (const unit of sortUnits(level, sort)) {
+      if (visited.has(unit.id)) continue
+      visited.add(unit.id)
+      rows.push({ unit, depth })
+      const children = childrenOf.get(unit.id)
+      if (children) walk(children, depth + 1)
+    }
+  }
+
+  walk(roots, 0)
+  // Cycle members with no external entry point: never reached from a real
+  // root, so pick them up here instead of losing them from the render.
+  const stranded = units.filter((unit) => !visited.has(unit.id))
+  if (stranded.length > 0) walk(stranded, 0)
+
+  return rows
 }


### PR DESCRIPTION
## Summary

- Indent lodging room rows under their parent building in the lodging management screen, using a computed `parent_unit` depth rather than `parent_unit !== ''` — the hierarchy is two levels deep (79 roots / 21 depth-1 / 18 depth-2), and three containers hold container children.
- Rows now render in **tree order always**: a parent's row is immediately followed by its own subtree, and the active sort column ranks only within a sibling set (a building's own rooms, or an area's root-level buildings) — never as one flat ranking across the whole area. This was the ruled-out alternative to avoid: sorting an area flat and indenting the result can draw a room under a building's row that does not actually contain it (a false parent).
- New `flattenUnitTree` helper in `unitTree.ts`, alongside the file's existing `descendantIds`/`combinedAncestor` parent-link walks, with the same visited guard so a cycle already sitting in stored data renders instead of hanging the table.
- Updated the prose contracts in `UnitAreaGroup.tsx` and `unitSort.ts` that described the old flat area-outer/column-inner ordering.

## Test plan

- [x] `unitTree.test.ts`: depth from a two-level `parent_unit` walk, sibling-set-only sort (including the "child would outrank another root" false-parent case), an orphaned/cross-group parent renders flat, a stored cycle terminates and every member still renders once.
- [x] `LodgingUnitsPanel.test.tsx`: rewrote the test that pinned the old flat-sort behavior to assert tree order + the actual `paddingLeft` indent, preserving its original point (unknown capacity still sorts last).
- [x] `./node_modules/.bin/vitest run src/components/admin/lodging src/components/weekend` — 951/951 passing
- [x] `./node_modules/.bin/tsc --noEmit` — clean
- [x] `./node_modules/.bin/eslint <changed files>` — clean
- [x] Mutation-checked the rewritten panel test: reverting to flat sort, and separately forcing depth to 0, both turned it RED; restoring returned it to GREEN.

Closes #2082.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
