### PR TITLE
fix(sync): stop admitting nameless family_camp_adults rows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ When weekend genuinely must differ, say why at the divergence. `useHouseholdMedi
 
 **When you find an issue body that is wrong — a renamed symbol, a moved line number, a stale count, a proposed fix that would not compile or would cause harm — edit the issue body. Do not merely note it in a PR, a comment, or a triage doc.**
 
-The body is what the next reader implements from. A correction that lives anywhere else does not travel: the next agent opens the issue, follows it, and reproduces the mistake. Two concrete cases from this repo: a proposed fix on #1889 would have re-introduced the class #1875 had just fixed, and a #1925-derived "delete blank rows" would have erased 136 real adults.
+The body is what the next reader implements from. A correction that lives anywhere else does not travel: the next agent opens the issue, follows it, and reproduces the mistake. Two concrete cases from this repo: a proposed fix on #1889 would have re-introduced the class #1875 had just fixed, and a #1925-derived "delete blank rows" would have erased 196 real adults.
 
 The failure mode is systemic, not occasional. A 2026-08-06 sweep of all 70 open issues found **40 of 69 bodies stale** — overwhelmingly not wrong *premises* but wrong *identifiers*, because issues filed from inside a PR are written against a tree a sibling PR has already moved.
 

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -1144,7 +1144,7 @@ class LodgingRosterService:
                             # households have a non-blank `name`; for several
                             # of the rest this is the only thing that renders
                             # an adult at all. Equally, never conclude a row is
-                            # empty from the split columns alone: 136 real
+                            # empty from the split columns alone: 196 real
                             # adults across 2022-2026 are blank in
                             # first_name/last_name and populated in `name`.
                             display_name=_s(adult, "name")

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -573,7 +573,7 @@ func (s *FamilyCampDerivedSync) loadPersonCustomValues(
 //   - `first_name` is a MISLABELED FULL NAME. 773 of 788 2026 values contain a
 //     space -- parents type their whole name into a field CampMinder labels
 //     "First Name". Nothing may treat it as a given name.
-//   - NEVER conclude a row is empty from the split columns. 136 real adults
+//   - NEVER conclude a row is empty from the split columns. 196 real adults
 //     across 2022-2026 are blank in first_name/last_name and populated in
 //     `name`; a "delete the blank rows" cleanup written from that misreading
 //     would have erased every one of them.
@@ -674,12 +674,16 @@ func (s *FamilyCampDerivedSync) processAdults(
 		}
 	}
 
-	// Convert map to slice, only include adults with data
+	// Convert map to slice, only include adults with a real name somewhere.
+	// kindred#1946: the email/gender arms this filter used to carry let 194
+	// wholly nameless rows into production -- an adult with only a gender
+	// value (including a placeholder like "NA") or only an email is not a
+	// person on its own. A `name` with blank first_name/last_name is the
+	// opposite case and must still be admitted; see the doc comment above.
 	var result []*adultData
 	for _, adults := range adultMap {
 		for _, adult := range adults {
-			if adult.name != "" || adult.firstName != "" || adult.lastName != "" ||
-				adult.email != "" || adult.gender != "" {
+			if adult.name != "" || adult.firstName != "" || adult.lastName != "" {
 				result = append(result, adult)
 			}
 		}

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -2150,7 +2150,7 @@ func TestProcessAdultsPersonFieldsTakeTheFirstLoadedSibling(t *testing.T) {
 // household `name` column authoritative: adults 3-5 arrive with ONLY `name`,
 // and first_name/last_name empty for 100% of those rows in every measured
 // year. An admission filter that reads the split columns to decide whether a
-// row is real would drop them -- 136 real adults across 2022-2026 are blank in
+// row is real would drop them -- 196 real adults across 2022-2026 are blank in
 // first_name/last_name and populated in `name` (kindred#1945).
 func TestProcessAdultsKeepsANameOnlyAdult(t *testing.T) {
 	s := &FamilyCampDerivedSync{}
@@ -2169,6 +2169,64 @@ func TestProcessAdultsKeepsANameOnlyAdult(t *testing.T) {
 	}
 	if adults[0].firstName != "" || adults[0].lastName != "" {
 		t.Errorf("nothing may invent split columns: got first=%q last=%q", adults[0].firstName, adults[0].lastName)
+	}
+}
+
+// TestProcessAdultsDropsNamelessRows pins kindred#1946: an adult with no
+// name in ANY field (name/first_name/last_name) must not be admitted, even
+// if email or gender data exists for it -- those two arms of the old
+// admission OR-chain let 194 wholly nameless rows into production. A real
+// `name` with blank split columns is the OPPOSITE case (kindred#1945/#1946
+// safety point, ~196 real adults across 2022-2026) and must still survive.
+func TestProcessAdultsDropsNamelessRows(t *testing.T) {
+	cases := []struct {
+		name            string
+		householdValues []customValueEntry
+		personValues    []customValueEntry
+		wantAdmitted    bool
+	}{
+		{
+			name: "gender only, no name anywhere -- NOT admitted",
+			personValues: []customValueEntry{
+				{householdPBID: "hh_1", fieldName: "Family Camp Gender 1", value: "Female"},
+			},
+			wantAdmitted: false,
+		},
+		{
+			name: "email only, no name anywhere -- NOT admitted",
+			personValues: []customValueEntry{
+				{householdPBID: "hh_1", fieldName: "Family Camp Adult 1 Email", value: "parent@example.com"},
+			},
+			wantAdmitted: false,
+		},
+		{
+			name: "gender placeholder NA does not rescue a nameless row",
+			personValues: []customValueEntry{
+				{householdPBID: "hh_1", fieldName: "Family Camp Gender 1", value: "NA"},
+			},
+			wantAdmitted: false,
+		},
+		{
+			name: "real name, blank first/last name -- IS admitted (196-row safety case)",
+			householdValues: []customValueEntry{
+				{householdPBID: "hh_1", fieldName: "Family Camp Adult 1", value: "Noah Smith"},
+			},
+			wantAdmitted: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &FamilyCampDerivedSync{}
+			adults := s.processAdults(tc.householdValues, tc.personValues)
+			gotAdmitted := len(adults) == 1
+			if len(adults) > 1 {
+				t.Fatalf("expected at most 1 adult, got %d", len(adults))
+			}
+			if gotAdmitted != tc.wantAdmitted {
+				t.Errorf("admitted = %v, want %v (adults: %+v)", gotAdmitted, tc.wantAdmitted, adults)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What

`family_camp_adults` was emitting rows with no name in any field. `processAdults`'s admission
OR-chain let an adult through if it had a `gender` value (including a placeholder like `NA`) or
an `email`, even with `name`/`first_name`/`last_name` all empty. Per the owner ruling on #1946,
this is a hard-delete-and-block-future-import fix: tighten the admission filter to only a real
name, and let the existing `deleteOrphanedAdults` sweep remove the historical nameless rows on
the next successful sync for each affected household/year. No suppression, no migration, no
separate cleanup step.

`deleteOrphanedAdults` itself is untouched — this PR only changes what gets *admitted*.

## Fix

Dropped the `email` and `gender` arms from the OR-chain in
`pocketbase/sync/family_camp_derived.go`'s `processAdults`:

```go
if adult.name != "" || adult.firstName != "" || adult.lastName != "" {
    result = append(result, adult)
}
```

A `name`-populated adult with blank `first_name`/`last_name` is the opposite case (the normal
shape for Adults 3-5, and most of Adults 1-2) and still passes.

## Also in this PR: a stale figure correction

A "136 real adults" figure — committed via #2175 into doc comments in
`family_camp_derived.go`/`family_camp_derived_test.go`/`lodging_roster_service.py`, and repeated
in the #1946 issue body — was never a fresh measurement. Re-measured against production: **196**
for 2022-2026 (198 all years; per year 2021=2, 2022=21, 2023=50, 2024=38, 2025=47, 2026=40).
Corrected the number in all four places it appeared (the fourth being `CLAUDE.md`, since it loads
into every future agent's context). The safety point those comments make — a nameless row is not
the same as a blank *split column*, and ~196 real adults must not be swept up by a
name-predicate delete — is unchanged; only the number moved.

## Tests

`TestProcessAdultsDropsNamelessRows` (table-driven, `pocketbase/sync/family_camp_derived_test.go`):

- an adult with only a `gender` value and no name anywhere → **not** admitted
- an adult with only an `email` and no name anywhere → **not** admitted
- a `gender` placeholder (`NA`) does not rescue a nameless row → **not** admitted
- a real `name` with blank `first_name`/`last_name` → **is** admitted (the ~196-row safety case)

Confirmed RED against the pre-fix filter (3 of 4 subtests failed for the right reason), then GREEN
after dropping the two arms. The safety-case subtest passed on first write; mutation-checked by
temporarily removing `adult.name != ""` from the filter, confirming it fails, then restoring.

`deleteOrphanedAdults` was intentionally left untouched — the existing sweep mechanism (already
covered by `TestUpsertAdultsOrphanDeletion`) does the rest once nameless rows stop being admitted.

Closes #1946

## Verification

- `go build ./...`, `go test ./...`, `gofmt -l .` — all clean
- `uv run ruff check`, `uv run mypy` on the touched Python file — clean
- Full pre-push suite (ruff, go build, markdownlint, api-types-freshness, mypy, pytest 6146
  passed/41 skipped) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
