### PR TITLE
fix(frontend): a lodging hold blocks placement and refuses on occupied units

### DIFF
--- a/docs/architecture/lodging-occupancy.md
+++ b/docs/architecture/lodging-occupancy.md
@@ -139,6 +139,25 @@ rule: it blocks legitimate work and teaches staff to ignore warnings.
   deleted it, because availability is a fact about the weekend rather than
   about the plan — a burst pipe closes a cabin in every scenario for that
   weekend.
+
+  ### What a hold represents (owner ruling, 2026-08-09; kindred#2090, kindred#2087)
+
+  A hold records **who is in a building** — chiefly non-rostered staff, a
+  caretaker, a burst pipe — not a reservation of empty space. It is a fact
+  about the BUILDING for one weekend; a placement is a fact about a PLAN.
+  They used to live on different axes for that reason, but the two questions
+  "is anyone in this building" and "has a family been placed here" answer the
+  same underlying fact from two directions, and the ruling settles them as
+  **mutually exclusive states**: a unit cannot be both held and occupied.
+
+  Concretely: `family_available_override = false` on a unit **blocks
+  placement outright** (`resolveDrop` in `dragPlacement.ts`, plus the
+  matching `useDroppable` `disabled` flag in `LodgingUnitCard.tsx`, refuse a
+  drop onto a held unit rather than merely dimming it), and a unit already
+  holding a placed party offers no "Hold" action (`availabilityAction` in
+  `unitBadges.ts` takes the slot's own occupancy and returns `null` for the
+  `hold` branch). The `clear` action — removing an existing hold — is never
+  blocked by occupancy, since clearing only ever reduces the conflict.
 - The unique indexes on `lodging_assignments` are
   `(session, year, household_cm_id)` and the person-grain equivalent, each
   partial on `> 0` so the two grains do not collide. (Migration `1500000132`

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -285,6 +285,42 @@ describe('LodgingUnitCard', () => {
   })
 })
 
+describe('LodgingUnitCard — a held unit refuses the drop outright (#2087)', () => {
+  // The `disabled` half of the fix. `resolveDrop` (dragPlacement.test.ts) is
+  // the load-bearing check — #2080's picker never touches a droppable at
+  // all — but `useDroppable`'s own `disabled` flag is what keeps dnd-kit
+  // from ever reporting `isOver` for a held card in the first place, which
+  // is what this asserts.
+  function card(container: HTMLElement): HTMLElement {
+    const el = container.querySelector('[data-unit-card]')
+    if (!el) throw new Error('no card rendered')
+    return el as HTMLElement
+  }
+
+  const held = unit({ family_available_override: false, is_family_available: false })
+
+  it('keeps the droppable disabled on a held unit even while placement is live', () => {
+    overDroppableId = unitDroppableId('cedar-1')
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: held })}
+        hue="hsl(160 45% 42%)"
+        canPlace
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(card(container)).not.toHaveClass('border-primary')
+  })
+
+  it('keeps an ordinary unheld unit droppable enabled (regression guard)', () => {
+    overDroppableId = unitDroppableId('cedar-1')
+    const { container } = render(
+      <LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" canPlace onOpenParty={vi.fn()} />
+    )
+    expect(card(container)).toHaveClass('border-primary')
+  })
+})
+
 describe('LodgingUnitCard — the split control belongs to containers only', () => {
   it('offers a split control on a combined CONTAINER', () => {
     render(

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -284,9 +284,17 @@ export function LodgingUnitCard({
   // simultaneously-enabled droppables — this one and the merge droppable
   // above — and which one dnd-kit resolves `over` to would be a tie decided
   // by hook registration order, not by which gesture is actually in flight.
+  //
+  // Disabled on a HELD unit (#2087): a hold is global and blocks placement
+  // outright, per the owner ruling on #2090. This is the AFFORDANCE half —
+  // it keeps dnd-kit from ever reporting `isOver` here, so the card cannot
+  // even highlight as a target — while `resolveDrop` (`dragPlacement.ts`) is
+  // the half that actually enforces it, because #2080 adds a placement path
+  // that reaches `resolveDrop` without ever touching this hook.
+  const held = unit.family_available_override === false
   const { setNodeRef: setUnitDropRef, isOver: isUnitOver } = useDroppable({
     id: unitDroppableId(unit.code),
-    disabled: !canPlace || mergeDragActive,
+    disabled: !canPlace || mergeDragActive || held,
   })
 
   const setCardRef = (node: HTMLDivElement | null) => {
@@ -514,6 +522,7 @@ export function LodgingUnitCard({
         <UnitAvailabilityControl
           unit={unit}
           canManage={canSetAvailability && onSetAvailability !== undefined}
+          occupied={parties.length > 0}
           isSaving={savingAvailability}
           onSubmit={(write) => {
             onSetAvailability?.(unit, write)

--- a/frontend/src/components/weekend/UnitAvailabilityControl.test.tsx
+++ b/frontend/src/components/weekend/UnitAvailabilityControl.test.tsx
@@ -62,6 +62,7 @@ function renderControl(props: Partial<React.ComponentProps<typeof UnitAvailabili
     <UnitAvailabilityControl
       unit={unit()}
       canManage
+      occupied={false}
       isSaving={false}
       onSubmit={onSubmit}
       {...props}
@@ -77,6 +78,22 @@ describe('UnitAvailabilityControl', () => {
     renderControl({ canManage: false })
 
     expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('offers nothing to hold an OCCUPIED unit — held and occupied are mutually exclusive (#2090)', () => {
+    // A space that already has a family assigned may not also be marked
+    // held. `occupied` is a fact from the slot's own parties, kept separate
+    // from `canManage`'s permission gate — folding it in there would
+    // resurrect the scenario dimension 1500000135 deleted.
+    renderControl({ occupied: true })
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('still offers to hold an unoccupied unit (regression guard)', () => {
+    renderControl({ occupied: false })
+
+    expect(screen.getByRole('button', { name: /hold/i })).toBeInTheDocument()
   })
 
   it('holds a family cabin back for this weekend, with the reason staff gave', async () => {

--- a/frontend/src/components/weekend/UnitAvailabilityControl.tsx
+++ b/frontend/src/components/weekend/UnitAvailabilityControl.tsx
@@ -41,6 +41,15 @@ export interface UnitAvailabilityControlProps {
    * CampMinder mirror could not close a cabin at all.
    */
   canManage: boolean
+  /**
+   * Whether the slot this unit sits in already holds a party this scenario —
+   * a fact read off the CARD, never off availability itself. Owner ruling on
+   * #2090: held and occupied are mutually exclusive states, so an occupied
+   * unit offers no "Hold" action. Kept separate from `canManage`: folding
+   * occupancy into the permission gate would resurrect the scenario
+   * dimension 1500000135 deleted from availability.
+   */
+  occupied: boolean
   /** True while THIS unit's write is in flight. */
   isSaving: boolean
   onSubmit: (write: { familyAvailable: boolean | null; reason: string }) => void
@@ -49,13 +58,14 @@ export interface UnitAvailabilityControlProps {
 export function UnitAvailabilityControl({
   unit,
   canManage,
+  occupied,
   isSaving,
   onSubmit,
 }: UnitAvailabilityControlProps) {
   const [reason, setReason] = useState('')
   const [isOpen, setIsOpen] = useState(false)
   const [wantsReason, setWantsReason] = useState(false)
-  const action = availabilityAction(unit)
+  const action = availabilityAction(unit, occupied)
 
   const close = () => {
     setIsOpen(false)

--- a/frontend/src/components/weekend/dragPlacement.test.ts
+++ b/frontend/src/components/weekend/dragPlacement.test.ts
@@ -308,6 +308,35 @@ describe('resolveDrop', () => {
     ).toEqual({ kind: 'unplace', party: merged })
   })
 
+  it('refuses a drop onto a held unit (#2087) — a hold blocks placement outright', () => {
+    // Owner ruling on #2090: a hold is global and blocks placement, not merely
+    // dimmed. This is the load-bearing check, since `resolveDrop` is the only
+    // path #2080's picker reaches — a `disabled`-only fix would not cover it.
+    const held = unit({ family_available_override: false, is_family_available: false })
+    const p = party()
+    expect(
+      resolveDrop({
+        activeId: partyKey(p),
+        overId: unitDroppableId('cedar-1'),
+        parties: [p],
+        units: [held],
+      })
+    ).toBeNull()
+  })
+
+  it('still accepts a drop onto an ordinary unheld unit (regression guard)', () => {
+    const unheld = unit({ family_available_override: null, is_family_available: true })
+    const p = party()
+    expect(
+      resolveDrop({
+        activeId: partyKey(p),
+        overId: unitDroppableId('cedar-1'),
+        parties: [p],
+        units: [unheld],
+      })
+    ).toMatchObject({ kind: 'place', unitId: 'u1' })
+  })
+
   it('refuses to move a party carrying neither CampMinder id', () => {
     // The roster service emits household_cm_id = 0 for a household whose
     // record failed to resolve, and `partyKey` falls back to display_name for

--- a/frontend/src/components/weekend/dragPlacement.ts
+++ b/frontend/src/components/weekend/dragPlacement.ts
@@ -211,6 +211,15 @@ export function resolveDrop({
 
   const unit = units.find((candidate) => candidate.code === target.unitCode)
   if (unit === undefined) return null
+  // Owner ruling on #2090: a hold is a GLOBAL fact about the building (who is
+  // in it, chiefly non-rostered staff), not a scenario-scoped reservation of
+  // empty space, and held/occupied are mutually exclusive states. Dragging
+  // onto a held unit is refused outright, not dimmed — see #2087. This is
+  // the load-bearing check: #2080 adds a placement path that never touches a
+  // `useDroppable`, so a refusal only on that hook's `disabled` flag would be
+  // silently bypassed by it. `LodgingUnitCard` also disables its droppable
+  // for the drag affordance, but this is what actually enforces it.
+  if (unit.family_available_override === false) return null
   // A COMBINED container IS a card now — Task 6 draws its own row in place of
   // its rooms (unitLevel.ts, `drawnUnits`) — so it must accept a drop exactly
   // like any other drawn unit. A NON-combined container still carries only

--- a/frontend/src/components/weekend/unitBadges.test.ts
+++ b/frontend/src/components/weekend/unitBadges.test.ts
@@ -221,6 +221,14 @@ describe('availabilityAction', () => {
     ).toBe('clear')
   })
 
+  it('offers nothing to hold an OCCUPIED family cabin — held and occupied are mutually exclusive (#2090)', () => {
+    expect(availabilityAction(unit(), true)).toBeNull()
+  })
+
+  it('still offers to hold an unoccupied family cabin (regression guard)', () => {
+    expect(availabilityAction(unit(), false)?.kind).toBe('hold')
+  })
+
   it('offers nothing on a building row', () => {
     // A container is a whole-building aggregate, not a bookable room. Holding
     // one would write an availability row against a unit no family can be

--- a/frontend/src/components/weekend/unitBadges.ts
+++ b/frontend/src/components/weekend/unitBadges.ts
@@ -119,8 +119,20 @@ export interface AvailabilityAction {
  *
  * Lives beside `reservationBadge` so the two cannot drift. A card badged
  * "Held" that offers to "Hold" it says two things about one cabin.
+ *
+ * `occupied` names a fact from the SLOT (whether any party is placed on this
+ * card this scenario), never folded into `canManage`'s permission gate.
+ * Owner ruling on #2090: held and occupied are mutually exclusive states, so
+ * a space that already holds a family may not also be marked held — but this
+ * must not become a THIRD dimension threaded onto availability itself.
+ * `family_available_override` stays exactly what 1500000135 made it: global,
+ * scenario-less, and reachable only through `clear` for a space that somehow
+ * already carries both facts.
  */
-export function availabilityAction(unit: LodgingUnitRow): AvailabilityAction | null {
+export function availabilityAction(
+  unit: LodgingUnitRow,
+  occupied = false
+): AvailabilityAction | null {
   // A container is a whole-building aggregate, never a bookable room.
   if (unit.is_container === true) return null
   // `!== null` and not truthiness: null (no row for this weekend) and false
@@ -140,5 +152,10 @@ export function availabilityAction(unit: LodgingUnitRow): AvailabilityAction | n
   if (unit.inventory_class === 'staff_default') {
     return { kind: 'release', label: 'Release', familyAvailable: true, needsReason: true }
   }
+  // An already-occupied space offers no "Hold": the fix for #2090. Only
+  // reachable here, past both branches above, so an already-held unit keeps
+  // its `clear` action regardless of occupancy — clearing only ever REDUCES
+  // the conflict, so it is never the state that needs blocking.
+  if (occupied) return null
   return { kind: 'hold', label: 'Hold', familyAvailable: false, needsReason: true }
 }


### PR DESCRIPTION
## Owner ruling (2026-08-09, posted on #2090)

A hold records **who is in a building** (chiefly non-rostered staff), not a reservation of empty space. It is **global** — it applies across every scenario, matching how `lodging_availability` already stores it (no scenario dimension since migration `1500000135`). It **blocks placement**: dragging onto a held space is refused outright, not dimmed. Held and occupied are **mutually exclusive states**.

This PR implements that ruling for both halves of the hold cluster.

## What changed

**#2087 — a held unit refuses the drop outright**
- `resolveDrop` (`frontend/src/components/weekend/dragPlacement.ts`) refuses any placement onto a unit with `family_available_override === false`. This is the load-bearing check: #2080 adds a placement path that never touches a `useDroppable`, so a refusal implemented only at the droppable would be silently bypassed by it.
- `LodgingUnitCard`'s `useDroppable` also disables the unit's droppable when the unit is held, for the drag affordance (dnd-kit never reports `isOver`).
- No new visual channel introduced — the existing "Held" badge (`unitBadges.ts`) already marks the card. This board never validated fit before now; this is the first block, not a strengthening of an existing dim.

**#2090 — an occupied unit can no longer be marked held**
- `availabilityAction` (`frontend/src/components/weekend/unitBadges.ts`) now takes the slot's own occupancy (a fact read off the card's `parties`, not the unit) and returns no `hold` action when the unit already holds a placed party. The `clear` action (removing an existing hold) stays reachable regardless of occupancy, since clearing only ever reduces the conflict.
- Kept deliberately separate from `canManage`'s permission gate — folding occupancy into that gate would resurrect the scenario dimension `1500000135` removed from availability.
- `LodgingUnitCard` passes `occupied={parties.length > 0}` through to `UnitAvailabilityControl`.

**Docs**
- `docs/architecture/lodging-occupancy.md` gets the written definition of what a hold represents, per #2090's own ask.

## Visual scope fence

Per the owner's note (asleep, defer any new-visual-design decision): this PR uses only affordances that already exist — the "Held" badge and the disabled droppable. It does **not** add any new colour, ring, chip, hatch, cursor, or animation. See `notDone` below for the one thing that was tabled.

## Tests (TDD — RED confirmed before implementation)

- `dragPlacement.test.ts`: `resolveDrop` refuses a drop onto a held unit; still accepts a drop onto an ordinary unheld unit (regression guard).
- `LodgingUnitCard.test.tsx`: the unit droppable stays disabled on a held unit even while placement is live; stays enabled on an ordinary unheld unit (regression guard).
- `unitBadges.test.ts`: `availabilityAction` offers nothing to hold an occupied cabin; still offers to hold an unoccupied one (regression guard).
- `UnitAvailabilityControl.test.tsx`: the control renders no button at all for an occupied unit; still offers "Hold" for an unoccupied one (regression guard).

Fictional data throughout (`Johnson`, `Garcia`).

Closes #2090.
Closes #2087.
