### PR TITLE
feat(frontend): show a container's derived whole-house capacity beside its delta field

### DIFF
--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -1352,14 +1352,28 @@ class LodgingRosterService:
         assigned = sum(1 for p in parties if p.unit_code or p.unit_name)
 
         def _effective_sleeps(unit: LodgingUnitSummary) -> int | None:
-            # MIRRORED by `effectiveSleeps` in
-            # `frontend/src/components/weekend/rosterAttention.ts`, which
-            # `countUnmeasuredSpaces` reads to answer the same "has anyone
-            # measured this?" question for the chip `WeekendStatsBar` prints
-            # beside `beds_family_available`. Named in BOTH directions on
-            # purpose: the pairing being undocumented is what let the two drift
-            # apart unnoticed until kindred#1945's PR, and a change here that
-            # is not made there puts two disagreeing numbers on one line.
+            # MIRRORED IN TWO PLACES, and both are named here on purpose --
+            # the pairing being undocumented is what let the first two drift
+            # apart unnoticed, and a change here that is not made there puts
+            # disagreeing numbers on one screen:
+            #
+            #   1. `effectiveSleeps` in
+            #      `frontend/src/components/weekend/rosterAttention.ts`, which
+            #      `countUnmeasuredSpaces` reads to answer the same "has anyone
+            #      measured this?" question for the chip `WeekendStatsBar`
+            #      prints beside `beds_family_available`.
+            #   2. `derivedWholeHouseSleeps` in
+            #      `frontend/src/components/admin/lodging/derivedCapacity.ts`
+            #      (kindred#2079), the read-only whole-house figure shown beside
+            #      the container's delta field on the units admin form.
+            #
+            # THREE copies is one too many. (2) could not import (1): it is an
+            # unexported helper, and routing admin code through a `weekend/**`
+            # module adds a static import edge across two lazily-chunked route
+            # trees -- see `WeekendRosterPage.chunkGraph.test.ts`, the real
+            # `vite build` that guards it. The fix is a neutral leaf module both
+            # frontends import, not a cross-tree import. Until then: change one,
+            # change all three.
             if not unit.is_container:
                 return unit.sleeps
             leaf_sleeps = [

--- a/frontend/src/components/admin/lodging/LodgingUnitForm.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitForm.tsx
@@ -234,6 +234,8 @@ export function LodgingUnitForm({
         onChange={setCapacity}
         isConfirmed={amenities.is_confirmed}
         isContainer={isContainer}
+        unit={unit}
+        units={units}
       />
 
       <UnitAmenityFieldset

--- a/frontend/src/components/admin/lodging/UnitCapacityFields.test.tsx
+++ b/frontend/src/components/admin/lodging/UnitCapacityFields.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * The read-only whole-house figure this file's header now promises: shown
+ * beside the delta field for a container, never written anywhere (kindred#2079,
+ * owner ruling: offer, never write — see derivedCapacity.ts for the
+ * arithmetic this renders).
+ */
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { LodgingUnitRecord } from '../../../types/lodging'
+import { UnitCapacityFields, type UnitCapacityFieldsProps } from './UnitCapacityFields'
+
+function unit(over: Partial<LodgingUnitRecord> & { id: string }): LodgingUnitRecord {
+  return {
+    area: 'area_1',
+    name: over.id,
+    code: over.id,
+    parent_unit: '',
+    map_x: 0,
+    map_y: 0,
+    sleeps: 0,
+    beds: null,
+    bathroom: 'none',
+    bathroom_group: '',
+    near_bathhouse: false,
+    has_power: false,
+    has_ac: false,
+    has_fridge: false,
+    is_accessible: false,
+    has_tub: false,
+    has_kitchenette: false,
+    has_crib: false,
+    has_changing_table: false,
+    has_shared_fridge: false,
+    inventory_class: 'family_pool',
+    shareability: '',
+    is_confirmed: false,
+    is_active: true,
+    is_container: false,
+    default_combined: false,
+    notes: '',
+    ...over,
+  }
+}
+
+const HOUSE = unit({ id: 'house', is_container: true })
+const ROOM_1 = unit({ id: 'room-1', parent_unit: 'house', sleeps: 4 })
+const ROOM_2 = unit({ id: 'room-2', parent_unit: 'house', sleeps: 5 })
+
+function renderFields(over: Partial<UnitCapacityFieldsProps> = {}) {
+  const onChange = vi.fn()
+  render(
+    <UnitCapacityFields
+      value={{ sleeps: '', beds: [] }}
+      onChange={onChange}
+      isConfirmed={false}
+      isContainer={false}
+      unit={undefined}
+      units={[]}
+      {...over}
+    />
+  )
+  return { onChange }
+}
+
+describe('UnitCapacityFields — derived whole-house figure', () => {
+  it('shows the derived total for a container whose rooms are all measured', () => {
+    renderFields({ isContainer: true, unit: HOUSE, units: [HOUSE, ROOM_1, ROOM_2] })
+
+    expect(screen.getByText(/9/)).toBeInTheDocument()
+  })
+
+  it('adds the typed delta rather than replacing the room sum with it', () => {
+    renderFields({
+      value: { sleeps: '1', beds: [] },
+      isContainer: true,
+      unit: HOUSE,
+      units: [HOUSE, ROOM_1, ROOM_2],
+    })
+
+    expect(screen.getByText(/10/)).toBeInTheDocument()
+  })
+
+  it('reacts live as the delta field is edited', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    const { rerender } = render(
+      <UnitCapacityFields
+        value={{ sleeps: '', beds: [] }}
+        onChange={onChange}
+        isConfirmed={false}
+        isContainer={true}
+        unit={HOUSE}
+        units={[HOUSE, ROOM_1, ROOM_2]}
+      />
+    )
+    expect(screen.getByText(/9/)).toBeInTheDocument()
+
+    await user.type(screen.getByLabelText('Sleeps'), '2')
+    // The component itself is controlled — re-render with the value its own
+    // onChange would have produced, same as the real form does.
+    rerender(
+      <UnitCapacityFields
+        value={{ sleeps: '2', beds: [] }}
+        onChange={onChange}
+        isConfirmed={false}
+        isContainer={true}
+        unit={HOUSE}
+        units={[HOUSE, ROOM_1, ROOM_2]}
+      />
+    )
+    expect(screen.getByText(/11/)).toBeInTheDocument()
+  })
+
+  it('shows nothing when a leaf under the container is unmeasured', () => {
+    renderFields({
+      isContainer: true,
+      unit: HOUSE,
+      units: [HOUSE, ROOM_1, unit({ id: 'room-2', parent_unit: 'house', sleeps: 0 })],
+    })
+
+    expect(screen.queryByText(/9/)).not.toBeInTheDocument()
+  })
+
+  it('shows nothing for a childless container — nothing but its own delta to report', () => {
+    renderFields({
+      value: { sleeps: '1', beds: [] },
+      isContainer: true,
+      unit: HOUSE,
+      units: [HOUSE],
+    })
+
+    // The delta field itself already shows "1" — a second "derived" copy of
+    // the same number would be noise, not information.
+    expect(screen.queryByText(/derived/i)).not.toBeInTheDocument()
+  })
+
+  it('shows nothing for a leaf (non-container) unit', () => {
+    renderFields({
+      isContainer: false,
+      unit: ROOM_1,
+      units: [HOUSE, ROOM_1, ROOM_2],
+    })
+
+    expect(screen.queryByText(/derived/i)).not.toBeInTheDocument()
+  })
+
+  it('shows nothing on create, before the unit has an id to look up children by', () => {
+    renderFields({ isContainer: true, unit: undefined, units: [HOUSE, ROOM_1, ROOM_2] })
+
+    expect(screen.queryByText(/derived/i)).not.toBeInTheDocument()
+  })
+
+  it('renders as plain text, not as a control — no button offers to write it', () => {
+    renderFields({ isContainer: true, unit: HOUSE, units: [HOUSE, ROOM_1, ROOM_2] })
+
+    expect(screen.getByText(/9/).closest('button')).toBeNull()
+    expect(
+      screen.queryByRole('button', { name: /derived|use derived|whole house/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('never calls onChange merely by rendering the derived figure', () => {
+    const { onChange } = renderFields({
+      isContainer: true,
+      unit: HOUSE,
+      units: [HOUSE, ROOM_1, ROOM_2],
+    })
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/admin/lodging/UnitCapacityFields.tsx
+++ b/frontend/src/components/admin/lodging/UnitCapacityFields.tsx
@@ -12,11 +12,21 @@
  * WHICH of the two advisory states shows, and the far larger set of rows where
  * neither does, is `capacityFlag` — read its header before changing anything
  * here. This file only renders what that decides.
+ *
+ * A CONTAINER's Sleeps field carries a second, unrelated bit of help text:
+ * the whole-house figure derived from its rooms (kindred#2079). It is not
+ * part of the capacity flag above — that rule is silent on every container,
+ * deliberately (its own beds are not the building's) — and it never writes
+ * anything. See derivedCapacity.ts for the arithmetic and the owner ruling
+ * it implements: offer the number, never populate the field with it.
  */
 import { type BedInventory } from '../../../types/beds'
+import type { LodgingUnitRecord } from '../../../types/lodging'
 import { BedInventoryEditor } from './BedInventoryEditor'
 import { capacityFlag } from './capacityFlag'
+import { activeLeavesUnder, derivedWholeHouseSleeps } from './derivedCapacity'
 import { FIELD, LABEL } from './lodgingStyles'
+import { parseSleeps } from './sleepsValue'
 
 export interface UnitCapacity {
   /** A string because blank is a real value: UNKNOWN. */
@@ -34,6 +44,14 @@ export interface UnitCapacityFieldsProps {
    */
   isConfirmed: boolean
   isContainer: boolean
+  /**
+   * The unit being edited, and every unit in the registry — together they
+   * let this derive the whole-house figure from stored rooms. `unit` is
+   * `undefined` on CREATE, where there is no id yet to look up children by,
+   * so nothing derives.
+   */
+  unit: LodgingUnitRecord | undefined
+  units: LodgingUnitRecord[]
 }
 
 export function UnitCapacityFields({
@@ -41,24 +59,52 @@ export function UnitCapacityFields({
   onChange,
   isConfirmed,
   isContainer,
+  unit,
+  units,
 }: UnitCapacityFieldsProps) {
   const flag = capacityFlag({ beds: value.beds, sleeps: value.sleeps, isConfirmed, isContainer })
 
+  // Gated on having at least one room to sum, not just on `derivedSleeps`
+  // being non-null: a childless container's total IS its own delta, and
+  // printing that delta a second time under a "derived from rooms" label
+  // would be noise — no room contributed anything to it.
+  const derivedSleeps =
+    isContainer && unit && activeLeavesUnder(unit.id, units).length > 0
+      ? derivedWholeHouseSleeps(unit.id, parseSleeps(value.sleeps) ?? 0, units)
+      : null
+
   return (
     <>
-      <label className="text-sm">
-        <span className={LABEL}>Sleeps</span>
-        <input
-          className={FIELD}
-          type="number"
-          min={1}
-          value={value.sleeps}
-          placeholder="Unknown"
-          onChange={(e) => {
-            onChange({ ...value, sleeps: e.target.value })
-          }}
-        />
-      </label>
+      <div className="text-sm">
+        <label>
+          <span className={LABEL}>Sleeps</span>
+          <input
+            className={FIELD}
+            type="number"
+            min={1}
+            value={value.sleeps}
+            placeholder="Unknown"
+            onChange={(e) => {
+              onChange({ ...value, sleeps: e.target.value })
+            }}
+          />
+        </label>
+        {/* A SIBLING of the label, not a child of it — nesting it inside
+            would fold this text into the label's accessible name and break
+            every `getByLabelText('Sleeps')` lookup, this file's own tests
+            included.
+
+            READ-ONLY. Plain helper text, same treatment as the suggestion
+            copy below — no new colour, chip or control. Reacts live to the
+            field above because it reads the value being TYPED
+            (`value.sleeps`), not the last-saved one — the same choice
+            `capacityFlag` already makes for its conflict/suggestion text. */}
+        {derivedSleeps !== null && (
+          <p className="text-muted-foreground mt-1.5 text-xs">
+            Derived from rooms: sleeps {derivedSleeps}
+          </p>
+        )}
+      </div>
 
       <div className="text-sm">
         <span className={LABEL}>Beds</span>

--- a/frontend/src/components/admin/lodging/derivedCapacity.test.ts
+++ b/frontend/src/components/admin/lodging/derivedCapacity.test.ts
@@ -1,0 +1,151 @@
+/**
+ * `_effective_sleeps`'s arithmetic, mirrored for the admin form.
+ *
+ * Every case here is measured against the production shapes in kindred#2079:
+ * a two-level container over plain rooms, and the three-level grandparent
+ * whose intermediate children are themselves containers with `sleeps = 0`
+ * (`gt-tioga`, `gt-tenaya`, `hc-health-center`) — summing immediate children
+ * gets that second shape wrong, refusing on exactly the whole-building
+ * rollups most worth showing.
+ */
+import { describe, expect, it } from 'vitest'
+
+import type { LodgingUnitRecord } from '../../../types/lodging'
+import { activeLeavesUnder, derivedWholeHouseSleeps } from './derivedCapacity'
+
+function unit(over: Partial<LodgingUnitRecord> & { id: string }): LodgingUnitRecord {
+  return {
+    area: 'area_1',
+    name: over.id,
+    code: over.id,
+    parent_unit: '',
+    map_x: 0,
+    map_y: 0,
+    sleeps: 0,
+    beds: null,
+    bathroom: 'none',
+    bathroom_group: '',
+    near_bathhouse: false,
+    has_power: false,
+    has_ac: false,
+    has_fridge: false,
+    is_accessible: false,
+    has_tub: false,
+    has_kitchenette: false,
+    has_crib: false,
+    has_changing_table: false,
+    has_shared_fridge: false,
+    inventory_class: 'family_pool',
+    shareability: '',
+    is_confirmed: false,
+    is_active: true,
+    is_container: false,
+    default_combined: false,
+    notes: '',
+    ...over,
+  }
+}
+
+describe('derivedWholeHouseSleeps', () => {
+  it('derives delta + Σ(leaves) for a two-level container, not Σ(immediate children)', () => {
+    const units = [
+      unit({ id: 'house', is_container: true }),
+      unit({ id: 'room-1', parent_unit: 'house', sleeps: 4 }),
+      unit({ id: 'room-2', parent_unit: 'house', sleeps: 5 }),
+    ]
+    expect(derivedWholeHouseSleeps('house', 0, units)).toBe(9)
+  })
+
+  it('derives the full leaf total through a three-level grandparent whose intermediate children are unmeasured containers', () => {
+    // Mirrors gt-tioga: two container halves, each sleeps=0, each holding two
+    // measured leaves. Summing immediate children would see two zeros and
+    // refuse; the leaf walk must not.
+    const units = [
+      unit({ id: 'gt-tioga', is_container: true }),
+      unit({ id: 'gt-tioga-upstairs', parent_unit: 'gt-tioga', is_container: true, sleeps: 0 }),
+      unit({ id: 'gt-tioga-1', parent_unit: 'gt-tioga-upstairs', sleeps: 4 }),
+      unit({ id: 'gt-tioga-2', parent_unit: 'gt-tioga-upstairs', sleeps: 4 }),
+      unit({ id: 'gt-tioga-downstairs', parent_unit: 'gt-tioga', is_container: true, sleeps: 0 }),
+      unit({ id: 'gt-tioga-3', parent_unit: 'gt-tioga-downstairs', sleeps: 4 }),
+      unit({ id: 'gt-tioga-4', parent_unit: 'gt-tioga-downstairs', sleeps: 5 }),
+    ]
+    expect(derivedWholeHouseSleeps('gt-tioga', 0, units)).toBe(17)
+  })
+
+  it('adds a non-zero own delta to Σ(leaves) rather than replacing it (the double-count guard)', () => {
+    // gt-clouds-rest: the one production container with a real own delta — a
+    // landing futon nothing else in the registry records.
+    const units = [
+      unit({ id: 'house', is_container: true }),
+      unit({ id: 'room-1', parent_unit: 'house', sleeps: 4 }),
+      unit({ id: 'room-2', parent_unit: 'house', sleeps: 5 }),
+    ]
+    // Writing Σ(rooms) = 9 into the delta field would make this 18, not 10.
+    expect(derivedWholeHouseSleeps('house', 1, units)).toBe(10)
+  })
+
+  it('refuses when any leaf beneath the container is unmeasured', () => {
+    const units = [
+      unit({ id: 'house', is_container: true }),
+      unit({ id: 'room-1', parent_unit: 'house', sleeps: 4 }),
+      unit({ id: 'room-2', parent_unit: 'house', sleeps: 0 }), // unmeasured
+    ]
+    expect(derivedWholeHouseSleeps('house', 0, units)).toBeNull()
+  })
+
+  it('refuses when any leaf is unmeasured even under an intermediate container', () => {
+    const units = [
+      unit({ id: 'house', is_container: true }),
+      unit({ id: 'wing', parent_unit: 'house', is_container: true }),
+      unit({ id: 'room-1', parent_unit: 'wing', sleeps: 4 }),
+      unit({ id: 'room-2', parent_unit: 'wing', sleeps: 0 }), // unmeasured
+    ]
+    expect(derivedWholeHouseSleeps('house', 0, units)).toBeNull()
+  })
+
+  it('skips a retired leaf entirely — neither counted nor blocking the total', () => {
+    const units = [
+      unit({ id: 'house', is_container: true }),
+      unit({ id: 'room-1', parent_unit: 'house', sleeps: 4 }),
+      unit({ id: 'room-2', parent_unit: 'house', sleeps: 0, is_active: false }),
+    ]
+    expect(derivedWholeHouseSleeps('house', 0, units)).toBe(4)
+  })
+
+  it('returns null for the degenerate case: no own delta and no rooms', () => {
+    // Summing an absent delta over an empty room list would otherwise yield
+    // 0 — the confident claim "this house sleeps nobody" rather than "nobody
+    // has measured this house".
+    const units = [unit({ id: 'house', is_container: true })]
+    expect(derivedWholeHouseSleeps('house', 0, units)).toBeNull()
+  })
+
+  it('a childless container with a real own delta still derives that delta', () => {
+    const units = [unit({ id: 'house', is_container: true })]
+    expect(derivedWholeHouseSleeps('house', 1, units)).toBe(1)
+  })
+})
+
+describe('activeLeavesUnder', () => {
+  it('returns leaves through an intermediate container, excluding the containers themselves', () => {
+    const units = [
+      unit({ id: 'house', is_container: true }),
+      unit({ id: 'wing', parent_unit: 'house', is_container: true }),
+      unit({ id: 'room-1', parent_unit: 'wing', sleeps: 4 }),
+    ]
+    expect(activeLeavesUnder('house', units).map((leaf) => leaf.id)).toEqual(['room-1'])
+  })
+
+  it('excludes a retired leaf', () => {
+    const units = [
+      unit({ id: 'house', is_container: true }),
+      unit({ id: 'room-1', parent_unit: 'house', sleeps: 4, is_active: false }),
+    ]
+    expect(activeLeavesUnder('house', units)).toEqual([])
+  })
+
+  it('returns nothing for a childless container', () => {
+    const units = [unit({ id: 'house', is_container: true })]
+    expect(activeLeavesUnder('house', units)).toEqual([])
+  })
+})

--- a/frontend/src/components/admin/lodging/derivedCapacity.ts
+++ b/frontend/src/components/admin/lodging/derivedCapacity.ts
@@ -1,0 +1,80 @@
+/**
+ * A container unit's whole-house capacity, derived from its rooms — READ-ONLY.
+ *
+ * MIRRORS `_effective_sleeps` in `api/services/lodging_roster_service.py`
+ * (owner ruling, kindred#2041; the admin affordance, kindred#2079). A third
+ * mirror, `effectiveSleeps` in `frontend/src/components/weekend/rosterAttention.ts`,
+ * implements the same arithmetic for the weekend roster's "unmeasured" chip
+ * — this file could not import it directly: it is an unexported helper
+ * inside a file this campaign was fenced off from touching (concurrent
+ * sibling PRs owned `frontend/src/components/weekend/**` the night this
+ * landed), so this is a THIRD copy by necessity, not by choice. If the
+ * arithmetic changes in one place, change it in all three.
+ *
+ * NEVER WRITES `sleeps`. A container's own stored value is a DELTA — real
+ * common-area furniture (a landing futon, in the one measured production
+ * case) that no room row records — ADDED to the room sum, never replaced by
+ * it. Writing Σ(rooms) into that field would make every consumer report
+ * 2 × Σ(rooms). `ownDelta` is a parameter rather than a read off `units` so
+ * a caller can feed the value staff are actively typing: the figure reacts
+ * as they edit the field it sits beside, without this module reaching into
+ * form state to do it.
+ */
+import type { LodgingUnitRecord } from '../../../types/lodging'
+import { descendantIds } from './unitTree'
+
+/**
+ * Every ACTIVE leaf unit under `containerId`, walked past any intermediate
+ * container — never just its immediate children. `descendantIds` already
+ * recurses past every intermediate container; filtering its result down to
+ * non-container, active rows is the leaf walk `leaf_codes_under` performs
+ * server-side. A retired leaf is excluded outright: it adds no beds and
+ * must not block a total either, in `derivedWholeHouseSleeps` below.
+ *
+ * Exported (not folded into `derivedWholeHouseSleeps`) so a caller can tell
+ * "no rooms recorded yet" apart from "a room is unmeasured" — the admin form
+ * uses that to decide whether showing a derived figure says anything a
+ * childless container's own delta doesn't already say.
+ */
+export function activeLeavesUnder(
+  containerId: string,
+  units: LodgingUnitRecord[]
+): LodgingUnitRecord[] {
+  const byId = new Map(units.map((unit) => [unit.id, unit]))
+  return [...descendantIds(containerId, units)]
+    .map((id) => byId.get(id))
+    .filter(
+      (candidate): candidate is LodgingUnitRecord =>
+        candidate !== undefined && !candidate.is_container && candidate.is_active
+    )
+}
+
+/**
+ * `ownDelta + Σ(active leaves under containerId)`. The registry is three
+ * levels deep in production and every "derives to nothing" case under the
+ * old immediate-children logic was a grandparent whose own children are
+ * containers with `sleeps = 0`; the leaf walk in `activeLeavesUnder`
+ * resolves those, which is the whole reason it recurses.
+ *
+ * Returns `null` — refuses to show a figure — when any active leaf beneath
+ * the container has an unmeasured `sleeps` (PocketBase's only spelling of
+ * "unmeasured" is `0`; it cannot store `NULL` in a number column). A
+ * partial sum would understate capacity silently, which is worse than
+ * showing nothing.
+ *
+ * Also returns `null` for the degenerate case — no own delta and no rooms —
+ * where summing would otherwise produce 0, i.e. the confident claim "this
+ * house sleeps nobody" rather than "nobody has measured this house yet".
+ */
+export function derivedWholeHouseSleeps(
+  containerId: string,
+  ownDelta: number,
+  units: LodgingUnitRecord[]
+): number | null {
+  const leaves = activeLeavesUnder(containerId, units)
+
+  if (leaves.some((leaf) => leaf.sleeps === 0)) return null
+  if (ownDelta === 0 && leaves.length === 0) return null
+
+  return ownDelta + leaves.reduce((total, leaf) => total + leaf.sleeps, 0)
+}


### PR DESCRIPTION
## Summary

- Adds a read-only derived whole-house capacity figure beside a container unit's Sleeps (delta) field in the lodging admin form.
- The figure is `stored delta + Σ(active leaves)`, walked past any intermediate container to the leaves themselves (mirrors `_effective_sleeps` in `api/services/lodging_roster_service.py`). Summing only immediate children was ruled out — three production containers are grandparents whose own children are containers with `sleeps = 0`, and only the leaf walk resolves them.
- Nothing is written. The container's own `sleeps` continues to mean "beds in space belonging to no single room" (a real common-area futon in the one measured production case) and is never overwritten or populated by this feature.
- Refuses to show a figure if any active leaf beneath the container is unmeasured (`sleeps = 0`, PocketBase's only spelling of "unknown"), since a partial sum would understate capacity silently.
- Skips the figure entirely for a childless container — its total is just its own delta, and repeating that number under a "derived from rooms" label would be noise.

## Why a third copy of the arithmetic

`frontend/src/components/weekend/rosterAttention.ts` already has an `effectiveSleeps` mirror of the same formula, but it is an unexported, private helper, and that directory was explicitly off-limits during this work (concurrent sibling PRs owned it). Rather than touch a file out of scope, `frontend/src/components/admin/lodging/derivedCapacity.ts` reimplements the same rule as a third mirror, documented as such at the point of drift risk in all three locations. Flagging this rather than silently duplicating: if this or `#2175`'s `effectiveSleeps` changes, the other two need to change too.

## Visual treatment

Plain helper text under the Sleeps field (`text-muted-foreground text-xs`), the same typographic treatment `UnitCapacityFields` already uses for its "Suggested: sleeps N" copy — no new colour, chip, badge, or panel. No button is attached to it (unlike the suggestion text), since there is nothing to click: the figure is informational only.

## Test plan

- [x] `derivedCapacity.test.ts` — pure arithmetic: two-level container, three-level grandparent with unmeasured-delta intermediate containers, double-count guard (non-zero own delta added not replaced), unmeasured-leaf refusal (direct and through an intermediate container), retired-leaf skip, degenerate zero/zero case, childless-container-with-delta case, plus `activeLeavesUnder` coverage.
- [x] `UnitCapacityFields.test.tsx` — component wiring: renders for a fully-measured container, adds the typed delta live as it's edited, hides for an unmeasured leaf, hides for a childless container, hides for a non-container, hides on create (no unit id yet), renders as plain text with no button, and asserts `onChange` is never called merely by rendering the figure.
- [x] Both files RED before implementation, then GREEN. The three most load-bearing assertions (leaf-walk-not-immediate-children, double-count guard, degenerate-zero guard, plus the component's childless-container gate) were mutation-checked: each mutation reproduced the exact bug it exists to catch, confirmed RED, then reverted.
- [x] `./node_modules/.bin/vitest run src/components/admin/lodging` — 283/283 passed, no regressions to the existing capacity-flag suite.
- [x] `./node_modules/.bin/tsc --noEmit` — clean.
- [x] `./node_modules/.bin/eslint <changed files>` — 0 errors (2 pre-existing warnings in an untouched function).
- [x] `./scripts/dev/verify-no-hardcoded-lodging.sh` — OK (no camp-identifying display names introduced; fixtures use unit codes/ids only).

Closes #2079.
