### PR TITLE
fix(frontend): stop the weekend party panel from resurrecting with stale/wrong PHI

### DIFF
--- a/frontend/src/components/weekend/FamilyDetailsPanel.tsx
+++ b/frontend/src/components/weekend/FamilyDetailsPanel.tsx
@@ -90,7 +90,13 @@ export function FamilyDetailsPanel({
   //
   // Adjusted during render, not in an effect: an effect commits one frame with
   // the exit class still on, which is the flicker this exists to prevent.
-  // `requestClose` needs no equivalent — the parent's `openParty` sets it false.
+  // `requestClose` needs no equivalent HERE for a same-click family switch —
+  // the parent's `openParty` already sets it false. A party that DEPARTS the
+  // roster instead of being switched away from is a different path
+  // (kindred#2137 bug 2): this panel can unmount mid-exit-animation before
+  // `onClose` ever fires, so nothing here would clear a latched
+  // `requestClose` for it. `usePanelParty`'s own render-time correction is
+  // what clears it in that case, not this component.
   const identity = partyKey(party)
   const [shownIdentity, setShownIdentity] = useState(identity)
   if (identity !== shownIdentity) {

--- a/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
@@ -4,10 +4,10 @@
  * weekends, where individuals enrol directly).
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { RosterPartyRow } from '../../types/lodging'
 import { HouseholdRosterTable } from './HouseholdRosterTable'
@@ -21,8 +21,44 @@ vi.mock('../../hooks/usePermissions', () => ({
   }),
 }))
 
-vi.mock('../../hooks/useWeekendRoster', () => ({
-  useHouseholdMedical: () => ({ data: undefined, isLoading: false, error: null }),
+// `medicalFetchMode.real` toggles this file's ONE `useHouseholdMedical` mock
+// between the fast canned value every other suite in this file wants and the
+// REAL hook, wired through the mocked `fetchHouseholdMedical` service call
+// below -- so "the actual PHI fetch" describe block near the bottom of this
+// file can drive the genuine fetch path without touching the rest of this
+// file's tests, which never flip it. `vi.hoisted` is required: `vi.mock`
+// factories run before any other module-level code, so a plain `const`
+// referenced inside one would be a use-before-initialization error.
+const { medicalFetchMode, mockFetchHouseholdMedical } = vi.hoisted(() => ({
+  medicalFetchMode: { real: false },
+  mockFetchHouseholdMedical: vi.fn(),
+}))
+
+vi.mock('../../services/lodgingApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../services/lodgingApi')>()
+  return {
+    ...actual,
+    fetchHouseholdMedical: (...args: unknown[]) =>
+      (mockFetchHouseholdMedical as (...a: unknown[]) => unknown)(...args),
+  }
+})
+
+vi.mock('../../hooks/useWeekendRoster', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../hooks/useWeekendRoster')>()
+  return {
+    ...actual,
+    useHouseholdMedical: (year: number, householdCmId: number | null, enabled: boolean) =>
+      medicalFetchMode.real
+        ? actual.useHouseholdMedical(year, householdCmId, enabled)
+        : { data: undefined, isLoading: false, error: null },
+  }
+})
+
+// Only reached when `medicalFetchMode.real` is true — `useHouseholdMedical`
+// itself is mocked away for every other test in this file, so it never
+// invokes `useApiWithAuth` for them.
+vi.mock('../../hooks/useApiWithAuth', () => ({
+  useApiWithAuth: () => ({ fetchWithAuth: vi.fn(), isAuthenticated: true, isAuthLoading: false }),
 }))
 
 let client: QueryClient
@@ -575,6 +611,59 @@ describe('HouseholdRosterTable — clears a stale selection (kindred#2062)', () 
   })
 })
 
+describe('HouseholdRosterTable — closes the panel all the way to the ORIGINAL parties (kindred#2137 bug 1)', () => {
+  // The #2062 tests above stop at ONE rerender: B replaces A and the panel
+  // closes. That passes against the broken implementation just as well as
+  // the fixed one. The actual bug only shows up on a THIRD rerender that
+  // returns to the roster the panel was originally opened against: without
+  // clearing the stored selection, `partyKey` matches again and the panel
+  // silently reopens with no click, re-issuing a real PHI fetch for a
+  // household nobody asked to see.
+  it('does not resurrect the panel when the party reappears (A -> B -> A)', async () => {
+    const johnson = party({ display_name: 'Johnson Family', household_cm_id: 2000001 })
+    const chen = party({ display_name: 'Chen Family', household_cm_id: 2000002 })
+    const { rerender } = render(<HouseholdRosterTable year={2026} parties={[johnson]} />, {
+      wrapper,
+    })
+    await userEvent.click(screen.getByRole('button', { name: /Johnson Family/ }))
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+
+    // B: Johnson drops out of the roster (a weekend switch).
+    rerender(<HouseholdRosterTable year={2026} parties={[chen]} />)
+    expect(screen.queryByTestId('family-details-panel')).not.toBeInTheDocument()
+
+    // A: back to a roster that once again contains Johnson (switching back
+    // to the first weekend, already cached this session). This is the bug.
+    rerender(<HouseholdRosterTable year={2026} parties={[johnson]} />)
+    expect(screen.queryByTestId('family-details-panel')).not.toBeInTheDocument()
+  })
+})
+
+describe('HouseholdRosterTable — reflects the live party, not the one captured at click time (kindred#2137 bug 3)', () => {
+  it('shows the freshly assigned cabin after an optimistic placement', async () => {
+    const johnson = party({
+      display_name: 'Johnson Family',
+      household_cm_id: 2000001,
+      unit_code: 'cedar-1',
+      unit_name: 'Cedar 1',
+    })
+    const { rerender } = render(<HouseholdRosterTable year={2026} parties={[johnson]} />, {
+      wrapper,
+    })
+    await userEvent.click(screen.getByRole('button', { name: /Johnson Family/ }))
+    expect(screen.getByTestId('family-details-panel')).toHaveTextContent('Cedar 1')
+
+    // A drag placement elsewhere (`dragPlacement.ts`'s `applyPlacement`)
+    // returns a NEW party object with a changed `unit_code`/`unit_name`, kept
+    // at the same `partyKey`. The panel must show the new cabin, not the
+    // object captured when the row was clicked.
+    const movedJohnson = { ...johnson, unit_code: 'ridge-a', unit_name: 'Ridge A' }
+    rerender(<HouseholdRosterTable year={2026} parties={[movedJohnson]} />)
+    expect(screen.getByTestId('family-details-panel')).toHaveTextContent('Ridge A')
+    expect(screen.getByTestId('family-details-panel')).not.toHaveTextContent('No cabin yet')
+  })
+})
+
 describe('HouseholdRosterTable — clears the selection on a SESSION change (kindred#2138)', () => {
   // #2062's guard only clears `selected` when the household stops matching
   // `partyKey` — and `partyKey` carries no session dimension (partyKey.ts).
@@ -614,5 +703,65 @@ describe('HouseholdRosterTable — clears the selection on a SESSION change (kin
 
     rerender(<HouseholdRosterTable year={2026} sessionCmId={101} parties={makeParties()} />)
     expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+  })
+})
+
+describe('HouseholdRosterTable — the actual PHI fetch (kindred#2139)', () => {
+  // Every other test in this file mocks `useHouseholdMedical` to a constant,
+  // so `MedicalNarrative`'s fetch -- the exact harm #2062 named -- is never
+  // exercised by any assertion in the whole suite. This block flips
+  // `medicalFetchMode.real` to drive the GENUINE `useHouseholdMedical` hook,
+  // through the same mocked-service-plus-`useApiWithAuth` harness
+  // `useWeekendRoster.test.tsx` already uses to drive its own hooks for
+  // real.
+  beforeEach(() => {
+    medicalFetchMode.real = true
+    mockFetchHouseholdMedical.mockReset().mockResolvedValue({
+      household_cm_id: 2000001,
+      year: 2026,
+      allergy_info: 'Peanuts',
+    })
+  })
+
+  afterEach(() => {
+    medicalFetchMode.real = false
+  })
+
+  it('fetches the real medical narrative when the panel opens', async () => {
+    render(
+      <HouseholdRosterTable
+        year={2026}
+        parties={[party({ display_name: 'Johnson Family', household_cm_id: 2000001 })]}
+      />,
+      { wrapper }
+    )
+    expect(mockFetchHouseholdMedical).not.toHaveBeenCalled()
+
+    await userEvent.click(screen.getByRole('button', { name: /Johnson Family/ }))
+
+    await waitFor(() => {
+      expect(mockFetchHouseholdMedical).toHaveBeenCalledWith(expect.anything(), 2026, 2000001)
+    })
+    expect(await screen.findByText('Peanuts')).toBeInTheDocument()
+  })
+
+  it('never fetches for a party with no household to look up', async () => {
+    render(
+      <HouseholdRosterTable
+        year={2026}
+        parties={[
+          party({
+            grain: 'person',
+            household_cm_id: 0,
+            person_cm_id: 1000004,
+            display_name: 'Olivia Chen',
+          }),
+        ]}
+      />,
+      { wrapper }
+    )
+    await userEvent.click(screen.getByRole('button', { name: /Olivia Chen/ }))
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+    expect(mockFetchHouseholdMedical).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/weekend/HouseholdRosterTable.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.tsx
@@ -8,9 +8,10 @@
  *
  * Read-only in this slice.
  */
-import { useCallback, useState } from 'react'
+import { useState } from 'react'
 
 import { useDismissOnDeadSpace } from '../../hooks/useDismissOnDeadSpace'
+import { usePanelParty } from '../../hooks/usePanelParty'
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
 import { FamilyDetailsPanel } from './FamilyDetailsPanel'
 import { HouseholdRosterRow } from './HouseholdRosterRow'
@@ -58,27 +59,20 @@ export function HouseholdRosterTable({
   sessionCmId = 0,
 }: HouseholdRosterTableProps) {
   // A third `FamilyDetailsPanel` callsite (kindred#1996), wired exactly as
-  // `LodgingBoard` and `LodgingMap` wire the other two — same `selected` /
-  // `requestClose` pair, same `useDismissOnDeadSpace` hookup. The row itself
-  // stays chips-only per kindred#1889; this only gives it somewhere to send
-  // a click.
-  const [selected, setSelected] = useState<RosterPartyRow | null>(null)
-  const [requestClose, setRequestClose] = useState(false)
-
-  const openParty = useCallback((party: RosterPartyRow) => {
-    setRequestClose(false)
-    setSelected(party)
-  }, [])
-
-  const closePanel = useCallback(() => {
-    setSelected(null)
-    setRequestClose(false)
-  }, [])
+  // `LodgingBoard` and `LodgingMap` wire the other two — same `usePanelParty`
+  // hook, same `useDismissOnDeadSpace` hookup. The row itself stays
+  // chips-only per kindred#1889; this only gives it somewhere to send a
+  // click. `panelParty`/`requestClose`/`openParty`/`closePanel` used to be
+  // four lines of hand-rolled state and an 11-line comment per surface
+  // (kindred#2139) — see `usePanelParty`'s own docstring for the derivation
+  // this now shares with `LodgingBoard` and `LodgingMap`.
+  const { panelParty, requestClose, openParty, closePanel, requestPanelClose } =
+    usePanelParty(parties)
 
   // RESET, not filtered (kindred#2138) — the owner's ruling was explicit: a
   // session change closes the panel outright, it does not merely stop
-  // rendering it while `selected` quietly survives underneath. #2062's
-  // `panelParty` guard below only catches a household that drops OUT of
+  // rendering it while the selection quietly survives underneath.
+  // `usePanelParty`'s own guard only catches a household that drops OUT of
   // `parties`; a household enrolled in two weekends never does that, since
   // `partyKey` (deliberately — see partyKey.ts) carries no session
   // dimension, so the same key still matches after the switch and the panel
@@ -87,32 +81,17 @@ export function HouseholdRosterTable({
   // This is React's own "storing information from previous renders"
   // pattern: compare this render's prop against the last one seen, and if
   // it moved, correct the state right here in the render body rather than
-  // in an Effect. Calling `setSelected` conditionally during render does not
+  // in an Effect. Calling `closePanel` conditionally during render does not
   // add a paint the way an Effect would — React discards this render's
   // output and re-renders synchronously with the corrected state before
   // anything commits, so nobody ever sees the stale mid-render frame.
   const [lastSessionCmId, setLastSessionCmId] = useState(sessionCmId)
   if (sessionCmId !== lastSessionCmId) {
     setLastSessionCmId(sessionCmId)
-    setSelected(null)
+    closePanel()
   }
 
-  // DERIVED, not effect-cleared (kindred#2062). A weekend switch re-renders
-  // this table with a different `parties` prop but never unmounts it, so a
-  // `selected` that outlived its own row's departure kept the panel — and
-  // its medical narrative — open over the new weekend's roster. Computing
-  // this at render time, rather than in a useEffect that calls setState,
-  // avoids the extra render pass React's docs warn an Effect would add here
-  // (`selected` itself is untouched; only what gets rendered changes). A
-  // refetch that returns the SAME parties (new array identity, same
-  // content) still resolves to present, because `partyKey` compares
-  // content, not identity — see partyKey.ts's own docstring.
-  const panelParty =
-    selected !== null && parties.some((p) => partyKey(p) === partyKey(selected)) ? selected : null
-
-  useDismissOnDeadSpace(panelParty !== null, () => {
-    setRequestClose(true)
-  })
+  useDismissOnDeadSpace(panelParty !== null, requestPanelClose)
 
   if (parties.length === 0) {
     return (
@@ -163,10 +142,16 @@ export function HouseholdRosterTable({
                 </tr>
               )}
               {section.parties.map((party) => (
-                // Both grains number independently, so a household cm_id can
-                // equal a person cm_id — the key carries the grain and both ids.
+                // `partyKey`, not a hand-rolled string (kindred#2139): the two
+                // used to disagree on an unresolved household (both ids 0),
+                // where this file's own inline key collapsed two different
+                // households into one React key and `partyKey` did not, by
+                // falling through to `display_name`. No live incidence — see
+                // `partyKey.ts`'s own docstring — but importing `partyKey`
+                // into this file and then hand-rolling a second, weaker
+                // definition beside it was the inconsistency worth fixing.
                 <HouseholdRosterRow
-                  key={`${party.grain}-${String(party.household_cm_id ?? 0)}-${String(party.person_cm_id ?? 0)}`}
+                  key={partyKey(party)}
                   party={party}
                   showRequests={showRequests}
                   unit={resolvePartyUnit(party, unitsByCode)}

--- a/frontend/src/components/weekend/LodgingBoard.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.test.tsx
@@ -9,11 +9,11 @@
  * Fictional data throughout.
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
 import { MemoryRouter, useLocation } from 'react-router'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
 import { LodgingBoard } from './LodgingBoard'
@@ -27,9 +27,38 @@ vi.mock('../../hooks/usePermissions', () => ({
   }),
 }))
 
-vi.mock('../../hooks/useWeekendRoster', () => ({
-  useHouseholdMedical: () => ({ data: undefined, isLoading: false, error: null }),
+// `medicalFetchMode.real` toggles this file's ONE `useHouseholdMedical` mock
+// between the fast canned value every other suite in this file wants and the
+// REAL hook, wired through the mocked `fetchHouseholdMedical` service call
+// below -- so "the actual PHI fetch" describe block near the bottom of this
+// file can drive the genuine fetch path without touching the ~30 other
+// tests here, which never flip it. `vi.hoisted` is required: `vi.mock`
+// factories run before any other module-level code, so a plain `const`
+// referenced inside one would be a use-before-initialization error.
+const { medicalFetchMode, mockFetchHouseholdMedical } = vi.hoisted(() => ({
+  medicalFetchMode: { real: false },
+  mockFetchHouseholdMedical: vi.fn(),
 }))
+
+vi.mock('../../services/lodgingApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../services/lodgingApi')>()
+  return {
+    ...actual,
+    fetchHouseholdMedical: (...args: unknown[]) =>
+      (mockFetchHouseholdMedical as (...a: unknown[]) => unknown)(...args),
+  }
+})
+
+vi.mock('../../hooks/useWeekendRoster', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../hooks/useWeekendRoster')>()
+  return {
+    ...actual,
+    useHouseholdMedical: (year: number, householdCmId: number | null, enabled: boolean) =>
+      medicalFetchMode.real
+        ? actual.useHouseholdMedical(year, householdCmId, enabled)
+        : { data: undefined, isLoading: false, error: null },
+  }
+})
 
 // The board reaches auth through `useLodgingPlacement` now. It renders inside
 // AuthProvider in the app; here the provider would be pure ceremony, and these
@@ -735,6 +764,100 @@ describe('LodgingBoard — clears a stale selection (kindred#2062)', () => {
   })
 })
 
+describe('LodgingBoard — closes the panel all the way to the ORIGINAL parties (kindred#2137 bug 1)', () => {
+  // The #2062 tests above stop at ONE rerender: B replaces A and the panel
+  // closes. That passes against the broken implementation just as well as
+  // the fixed one. The actual bug only shows up on a THIRD rerender that
+  // returns to the roster the panel was originally opened against: without
+  // clearing the stored selection, `partyKey` matches again and the panel
+  // silently reopens with no click, re-issuing a real PHI fetch for a
+  // household nobody asked to see.
+  it('does not resurrect the panel when the party reappears (A -> B -> A)', async () => {
+    const johnson = party({ unit_code: 'cedar-1', unit_name: 'Cedar 1' })
+    const chen = party({
+      household_cm_id: 102,
+      display_name: 'Chen',
+      sort_name: 'Chen',
+      unit_code: 'cedar-1',
+      unit_name: 'Cedar 1',
+    })
+    const { rerender } = render(<LodgingBoard parties={[johnson]} units={[unit()]} year={2026} />, {
+      wrapper,
+    })
+    await userEvent.click(screen.getByRole('button', { name: /Johnson/ }))
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+
+    // B: Johnson drops out of the roster (a weekend switch).
+    rerender(<LodgingBoard parties={[chen]} units={[unit()]} year={2026} />)
+    expect(screen.queryByTestId('family-details-panel')).not.toBeInTheDocument()
+
+    // A: back to a roster that once again contains Johnson (switching back
+    // to the first weekend, already cached this session). This is the bug.
+    rerender(<LodgingBoard parties={[johnson]} units={[unit()]} year={2026} />)
+    expect(screen.queryByTestId('family-details-panel')).not.toBeInTheDocument()
+  })
+})
+
+describe('LodgingBoard — reflects the live party, not the one captured at click time (kindred#2137 bug 3)', () => {
+  it('shows the post-drag cabin after the selected party is placed elsewhere', async () => {
+    const johnson = party({ unit_code: 'cedar-1', unit_name: 'Cedar 1' })
+    const { rerender } = render(
+      <LodgingBoard
+        parties={[johnson]}
+        units={[unit(), unit({ unit_id: 'u2', code: 'ridge-a', name: 'Ridge A' })]}
+        year={2026}
+      />,
+      { wrapper }
+    )
+    await userEvent.click(screen.getByRole('button', { name: /Johnson/ }))
+    expect(screen.getByTestId('family-details-panel')).toHaveTextContent('Cedar 1')
+
+    // An optimistic drag placement (`dragPlacement.ts`'s `applyPlacement`)
+    // returns a NEW party object with a changed `unit_code`/`unit_name`, kept
+    // at the same `partyKey`. The panel must show the post-drag cabin, not
+    // the object captured when the card was clicked.
+    const draggedJohnson = { ...johnson, unit_code: 'ridge-a', unit_name: 'Ridge A' }
+    rerender(
+      <LodgingBoard
+        parties={[draggedJohnson]}
+        units={[unit(), unit({ unit_id: 'u2', code: 'ridge-a', name: 'Ridge A' })]}
+        year={2026}
+      />
+    )
+    expect(screen.getByTestId('family-details-panel')).toHaveTextContent('Ridge A')
+    expect(screen.getByTestId('family-details-panel')).not.toHaveTextContent('No cabin yet')
+  })
+})
+
+describe('LodgingBoard — isPanelOpen and useDismissOnDeadSpace track panelParty, not raw selection (kindred#2137)', () => {
+  // Nothing in this file asserted on either prop before -- reverting them to
+  // `selected !== null` would still pass the whole suite. The floating badge
+  // shifts left (`translateX(-28.5rem)`) only while `isPanelOpen` is true,
+  // which is what makes it an observable proxy for the prop.
+  function badgeTransform(container: HTMLElement): string | undefined {
+    const badge = container.querySelector('[data-floating-badge]')
+    return badge instanceof HTMLElement ? badge.style.transform : undefined
+  }
+
+  it('shifts the unplaced badge while the panel is open and un-shifts once the party departs', async () => {
+    const johnson = party({ unit_code: 'cedar-1', unit_name: 'Cedar 1' })
+    const { container, rerender } = render(
+      <LodgingBoard parties={[johnson]} units={[unit()]} year={2026} />,
+      { wrapper }
+    )
+    expect(badgeTransform(container)).toBe('none')
+
+    await userEvent.click(screen.getByRole('button', { name: /Johnson/ }))
+    expect(badgeTransform(container)).toBe('translateX(-28.5rem)')
+
+    // Johnson drops out of the roster -- `panelParty` resolves null, and
+    // `isPanelOpen` must follow it back to false rather than staying pinned
+    // on a `selected` that never got cleared.
+    rerender(<LodgingBoard parties={[]} units={[unit()]} year={2026} />)
+    expect(badgeTransform(container)).toBe('none')
+  })
+})
+
 describe('LodgingBoard — clears the selection on a SESSION change (kindred#2138)', () => {
   // #2062's guard above only clears `selected` when the household stops
   // matching `partyKey` — and `partyKey` carries no session dimension
@@ -785,5 +908,78 @@ describe('LodgingBoard — clears the selection on a SESSION change (kindred#213
       <LodgingBoard parties={makeParties()} units={[unit()]} year={2026} sessionCmId={101} />
     )
     expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+  })
+})
+
+describe('LodgingBoard — the actual PHI fetch (kindred#2139)', () => {
+  // Every other test in this file mocks `useHouseholdMedical` to a constant,
+  // so `MedicalNarrative`'s fetch -- the exact harm #2062 named -- is never
+  // exercised by any assertion in the whole suite. This block flips
+  // `medicalFetchMode.real` to drive the GENUINE `useHouseholdMedical` hook,
+  // through the same mocked-service-plus-`useApiWithAuth` harness
+  // `useWeekendRoster.test.tsx` already uses to drive its own hooks for
+  // real.
+  beforeEach(() => {
+    medicalFetchMode.real = true
+    mockFetchHouseholdMedical.mockReset().mockResolvedValue({
+      household_cm_id: 2000001,
+      year: 2026,
+      allergy_info: 'Peanuts',
+    })
+  })
+
+  afterEach(() => {
+    medicalFetchMode.real = false
+  })
+
+  it('fetches the real medical narrative when the panel opens', async () => {
+    render(
+      <LodgingBoard
+        parties={[
+          party({
+            household_cm_id: 2000001,
+            unit_code: 'cedar-1',
+            unit_name: 'Cedar 1',
+          }),
+        ]}
+        units={[unit()]}
+        year={2026}
+      />,
+      { wrapper }
+    )
+    expect(mockFetchHouseholdMedical).not.toHaveBeenCalled()
+
+    await userEvent.click(screen.getByRole('button', { name: /Johnson/ }))
+
+    await waitFor(() => {
+      expect(mockFetchHouseholdMedical).toHaveBeenCalledWith(expect.anything(), 2026, 2000001)
+    })
+    expect(await screen.findByText('Peanuts')).toBeInTheDocument()
+  })
+
+  it('never fetches for a party with no household to look up', async () => {
+    render(
+      <LodgingBoard
+        parties={[
+          party({
+            grain: 'person',
+            household_cm_id: 0,
+            person_cm_id: 5001,
+            display_name: 'Priya Patel',
+            sort_name: 'Priya Patel',
+            adults: [],
+            children: [],
+            unit_code: 'cedar-1',
+            unit_name: 'Cedar 1',
+          }),
+        ]}
+        units={[unit()]}
+        year={2026}
+      />,
+      { wrapper }
+    )
+    await userEvent.click(screen.getByRole('button', { name: /Priya Patel/ }))
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+    expect(mockFetchHouseholdMedical).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -46,6 +46,7 @@ import { useSearchParams } from 'react-router'
 
 import { useDismissOnDeadSpace } from '../../hooks/useDismissOnDeadSpace'
 import { useLodgingPlacement } from '../../hooks/useLodgingPlacement'
+import { usePanelParty } from '../../hooks/usePanelParty'
 import { useUnitAvailability } from '../../hooks/useUnitAvailability'
 import { useUnitMerge } from '../../hooks/useUnitMerge'
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
@@ -125,8 +126,8 @@ export function LodgingBoard({
     () => new Set(searchParams.getAll(CLOSED_PARAM)),
     [searchParams]
   )
-  const [selected, setSelected] = useState<RosterPartyRow | null>(null)
-  const [requestClose, setRequestClose] = useState(false)
+  const { panelParty, requestClose, openParty, closePanel, requestPanelClose } =
+    usePanelParty(parties)
   const [dragging, setDragging] = useState<RosterPartyRow | null>(null)
   /** The card currently being dragged BY ITS MERGE HANDLE, for grey-out. */
   const [draggingMergeUnit, setDraggingMergeUnit] = useState<LodgingUnitRow | null>(null)
@@ -158,24 +159,24 @@ export function LodgingBoard({
 
   // RESET, not filtered (kindred#2138) — the owner's ruling was explicit: a
   // session change closes the panel outright, it does not merely stop
-  // rendering it while `selected` quietly survives underneath. The
-  // `panelParty` guard further down only catches a household that drops OUT
-  // of `parties`; a household enrolled in two weekends never does that,
-  // since `partyKey` (deliberately — see partyKey.ts) carries no session
+  // rendering it while the selection quietly survives underneath.
+  // `usePanelParty`'s own guard only catches a household that drops OUT of
+  // `parties`; a household enrolled in two weekends never does that, since
+  // `partyKey` (deliberately — see partyKey.ts) carries no session
   // dimension, so the same key still matches after the switch and the panel
   // would keep rendering the PREVIOUS weekend's placement data.
   //
   // This is React's own "storing information from previous renders"
   // pattern: compare this render's prop against the last one seen, and if
   // it moved, correct the state right here in the render body rather than
-  // in an Effect. Calling `setSelected` conditionally during render does not
+  // in an Effect. Calling `closePanel` conditionally during render does not
   // add a paint the way an Effect would — React discards this render's
   // output and re-renders synchronously with the corrected state before
   // anything commits, so nobody ever sees the stale mid-render frame.
   const [lastSessionCmId, setLastSessionCmId] = useState(sessionCmId)
   if (sessionCmId !== lastSessionCmId) {
     setLastSessionCmId(sessionCmId)
-    setSelected(null)
+    closePanel()
   }
 
   const { move } = useLodgingPlacement({ year, sessionCmId, scenario })
@@ -319,33 +320,13 @@ export function LodgingBoard({
     [setAvailability]
   )
 
-  const openParty = useCallback((party: RosterPartyRow) => {
-    setRequestClose(false)
-    setSelected(party)
-  }, [])
-
-  const closePanel = useCallback(() => {
-    setSelected(null)
-    setRequestClose(false)
-  }, [])
-
-  // DERIVED, not effect-cleared (kindred#2062). A weekend switch re-renders
-  // the board with a different `parties` prop but never unmounts it, so a
-  // `selected` that outlived its own card's departure kept the panel — and
-  // its medical narrative — open over the new weekend's roster. Computing
-  // this at render time, rather than in a useEffect that calls setState,
-  // avoids the extra render pass React's docs warn an Effect would add here
-  // (`selected` itself is untouched; only what gets rendered changes). A
-  // refetch that returns the SAME parties (new array identity, same
-  // content) still resolves to present, because `partyKey` compares
-  // content, not identity — see partyKey.ts's own docstring.
-  const panelParty =
-    selected !== null && parties.some((p) => partyKey(p) === partyKey(selected)) ? selected : null
+  // `openParty`/`closePanel`/`panelParty` come from `usePanelParty` above —
+  // shared with `LodgingMap` and `HouseholdRosterTable` (kindred#2139). See
+  // its own docstring for the derivation and why it stores `selectedKey`
+  // rather than the party object.
 
   // Same dead-space dismissal the summer board uses, through the same hook.
-  useDismissOnDeadSpace(panelParty !== null, () => {
-    setRequestClose(true)
-  })
+  useDismissOnDeadSpace(panelParty !== null, requestPanelClose)
 
   const toggleArea = (token: string) => {
     setSearchParams(

--- a/frontend/src/components/weekend/LodgingMap.test.tsx
+++ b/frontend/src/components/weekend/LodgingMap.test.tsx
@@ -2,7 +2,7 @@
  * The map surface. Fictional data throughout.
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { act, fireEvent, render, screen, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -26,8 +26,44 @@ vi.mock('../../hooks/usePermissions', () => ({
   }),
 }))
 
-vi.mock('../../hooks/useWeekendRoster', () => ({
-  useHouseholdMedical: () => ({ data: undefined, isLoading: false, error: null }),
+// `medicalFetchMode.real` toggles this file's ONE `useHouseholdMedical` mock
+// between the fast canned value every other suite in this file wants and the
+// REAL hook, wired through the mocked `fetchHouseholdMedical` service call
+// below -- so "the actual PHI fetch" describe block near the bottom of this
+// file can drive the genuine fetch path without touching the rest of this
+// file's tests, which never flip it. `vi.hoisted` is required: `vi.mock`
+// factories run before any other module-level code, so a plain `const`
+// referenced inside one would be a use-before-initialization error.
+const { medicalFetchMode, mockFetchHouseholdMedical } = vi.hoisted(() => ({
+  medicalFetchMode: { real: false },
+  mockFetchHouseholdMedical: vi.fn(),
+}))
+
+vi.mock('../../services/lodgingApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../services/lodgingApi')>()
+  return {
+    ...actual,
+    fetchHouseholdMedical: (...args: unknown[]) =>
+      (mockFetchHouseholdMedical as (...a: unknown[]) => unknown)(...args),
+  }
+})
+
+vi.mock('../../hooks/useWeekendRoster', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../hooks/useWeekendRoster')>()
+  return {
+    ...actual,
+    useHouseholdMedical: (year: number, householdCmId: number | null, enabled: boolean) =>
+      medicalFetchMode.real
+        ? actual.useHouseholdMedical(year, householdCmId, enabled)
+        : { data: undefined, isLoading: false, error: null },
+  }
+})
+
+// Only reached when `medicalFetchMode.real` is true — `useHouseholdMedical`
+// itself is mocked away for every other test in this file, so it never
+// invokes `useApiWithAuth` for them.
+vi.mock('../../hooks/useApiWithAuth', () => ({
+  useApiWithAuth: () => ({ fetchWithAuth: vi.fn(), isAuthenticated: true, isAuthLoading: false }),
 }))
 
 // One client per TEST, built outside the render path. Constructing it inside the
@@ -819,11 +855,15 @@ describe('LodgingMap — clears a stale selection (kindred#2062)', () => {
   })
 })
 
-describe('LodgingMap — clears a stale selection (kindred#2062)', () => {
-  // A weekend switch re-renders the map with a different `parties` prop
-  // without unmounting it, so the previously-open family's panel — including
-  // its medical narrative — stayed open over the new weekend's roster.
-  it('closes the panel when the selected party is no longer in parties', async () => {
+describe('LodgingMap — closes the panel all the way to the ORIGINAL parties (kindred#2137 bug 1)', () => {
+  // Every #2062-era test above stops at ONE rerender — B replaces A and the
+  // panel closes, full stop. That passes against the broken implementation
+  // just as well as the fixed one. The actual #2137 bug only shows up on a
+  // THIRD rerender that returns to the roster the panel was originally
+  // opened against: without clearing the stored selection, `partyKey`
+  // matches again and the panel silently reopens with no click, re-issuing
+  // a real PHI fetch for a household nobody asked to see.
+  it('does not resurrect the panel when the party reappears (A -> B -> A)', async () => {
     const { rerender } = render(<LodgingMap parties={[PLACED]} units={UNITS} year={2026} />, {
       wrapper,
     })
@@ -838,25 +878,91 @@ describe('LodgingMap — clears a stale selection (kindred#2062)', () => {
       unit_code: 'cedar-1',
       unit_name: 'Cedar 1',
     })
+    // B: Johnson drops out of the roster (a weekend switch).
     rerender(<LodgingMap parties={[other]} units={UNITS} year={2026} />)
     expect(screen.queryByTestId('family-details-panel')).not.toBeInTheDocument()
-  })
 
-  // The trap: a refetch that returns the SAME parties (new array identity,
-  // same content) must not close a panel out from under whoever has it open.
-  it('keeps the panel open when parties refetches with the same content', async () => {
-    const makeParties = () => [
-      party({ display_name: 'Johnson', unit_code: 'cedar-1', unit_name: 'Cedar 1' }),
-    ]
-    const { rerender } = render(<LodgingMap parties={makeParties()} units={UNITS} year={2026} />, {
+    // A: back to a roster that once again contains Johnson (switching back
+    // to the first weekend, already cached this session). This is the bug.
+    rerender(<LodgingMap parties={[PLACED]} units={UNITS} year={2026} />)
+    expect(screen.queryByTestId('family-details-panel')).not.toBeInTheDocument()
+  })
+})
+
+describe('LodgingMap — reflects the live party, not the one captured at click time (kindred#2137 bug 3)', () => {
+  it('shows the post-drag cabin after the selected party is placed elsewhere', async () => {
+    const { rerender } = render(<LodgingMap parties={[PLACED]} units={UNITS} year={2026} />, {
       wrapper,
     })
     await userEvent.click(screen.getAllByTestId('map-mark')[0] as HTMLElement)
     await userEvent.click(screen.getByRole('button', { name: /Johnson/ }))
-    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+    // Scoped to the panel: the mark's own popover is still pinned open behind
+    // it and repeats "Cedar 1" as its own heading.
+    const panel = screen.getByTestId('family-details-panel')
+    expect(within(panel).getByText('Cedar 1')).toBeInTheDocument()
 
-    rerender(<LodgingMap parties={makeParties()} units={UNITS} year={2026} />)
-    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+    // An optimistic drag placement (`dragPlacement.ts`'s `applyPlacement`)
+    // returns a NEW party object with a changed `unit_code`/`unit_name`, kept
+    // at the same `partyKey`. The panel must show the post-drag cabin, not
+    // the object captured when the row was clicked.
+    const draggedJohnson = { ...PLACED, unit_code: 'cedar-2', unit_name: 'Cedar 2' }
+    rerender(<LodgingMap parties={[draggedJohnson]} units={UNITS} year={2026} />)
+
+    expect(within(panel).getByText('Cedar 2')).toBeInTheDocument()
+    expect(within(panel).queryByText('No cabin yet')).not.toBeInTheDocument()
+  })
+})
+
+describe('LodgingMap — isPanelOpen and useDismissOnDeadSpace track panelParty, not raw selection (kindred#2137)', () => {
+  // Nothing in this file asserted on either prop before — reverting them to
+  // `selected !== null` would still pass the whole suite. The floating badge
+  // shifts left (`translateX(-28.5rem)`) only while `isPanelOpen` is true,
+  // which is what makes it an observable proxy for the prop.
+  function badgeTransform(container: HTMLElement): string | undefined {
+    const badge = container.querySelector('[data-floating-badge]')
+    return badge instanceof HTMLElement ? badge.style.transform : undefined
+  }
+
+  it('shifts the unplaced badge while the panel is open and un-shifts once the party departs', async () => {
+    const { container, rerender } = render(
+      <LodgingMap parties={[PLACED]} units={UNITS} year={2026} />,
+      { wrapper }
+    )
+    expect(badgeTransform(container)).toBe('none')
+
+    await userEvent.click(screen.getAllByTestId('map-mark')[0] as HTMLElement)
+    await userEvent.click(screen.getByRole('button', { name: /Johnson/ }))
+    expect(badgeTransform(container)).toBe('translateX(-28.5rem)')
+
+    // Johnson drops out of the roster -- `panelParty` resolves null, and
+    // `isPanelOpen` must follow it back to false rather than staying pinned
+    // on a `selected` that never got cleared.
+    rerender(<LodgingMap parties={[]} units={UNITS} year={2026} />)
+    expect(badgeTransform(container)).toBe('none')
+  })
+})
+
+describe('LodgingMap — clears a stale pin/dwell when its cluster dissolves (kindred#2137 bug 4)', () => {
+  // `openCluster` itself already derives correctly (a fresh `.find` against
+  // the current `clusters` every render) -- what was missing is resetting
+  // `pinnedKey`/`dwellKey` when their cluster stops existing. A `units` prop
+  // change that drops the pinned mark's unit dissolves the cluster; a LATER
+  // prop change that re-adds the identical unit re-mints the same
+  // `clusterKey` (sorted unit ids) and, without a fix, reopens the popover
+  // with no click.
+  it('does not reopen a pinned popover when its unit reappears', async () => {
+    const { rerender } = render(<LodgingMap parties={[]} units={UNITS} year={2026} />, {
+      wrapper,
+    })
+    await userEvent.click(screen.getAllByTestId('map-mark')[0] as HTMLElement)
+    expect(screen.getByText('Cedar 1')).toBeInTheDocument()
+
+    const withoutCedar1 = UNITS.filter((u) => u.unit_id !== 'u1')
+    rerender(<LodgingMap parties={[]} units={withoutCedar1} year={2026} />)
+    expect(screen.queryByText('Cedar 1')).not.toBeInTheDocument()
+
+    rerender(<LodgingMap parties={[]} units={UNITS} year={2026} />)
+    expect(screen.queryByText('Cedar 1')).not.toBeInTheDocument()
   })
 })
 
@@ -901,5 +1007,59 @@ describe('LodgingMap — clears the selection on a SESSION change (kindred#2138)
 
     rerender(<LodgingMap parties={makeParties()} units={UNITS} year={2026} sessionCmId={101} />)
     expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+  })
+})
+
+describe('LodgingMap — the actual PHI fetch (kindred#2139)', () => {
+  // Every other test in this file mocks `useHouseholdMedical` to a constant,
+  // so `MedicalNarrative`'s fetch -- the exact harm #2062 named -- is never
+  // exercised by any assertion in the whole suite. This block flips
+  // `medicalFetchMode.real` to drive the GENUINE `useHouseholdMedical` hook,
+  // through the same mocked-service-plus-`useApiWithAuth` harness
+  // `useWeekendRoster.test.tsx` already uses to drive its own hooks for
+  // real.
+  beforeEach(() => {
+    medicalFetchMode.real = true
+    mockFetchHouseholdMedical.mockReset().mockResolvedValue({
+      household_cm_id: 9001,
+      year: 2026,
+      allergy_info: 'Peanuts',
+    })
+  })
+
+  afterEach(() => {
+    medicalFetchMode.real = false
+  })
+
+  it('fetches the real medical narrative when the panel opens', async () => {
+    render(<LodgingMap parties={[PLACED]} units={UNITS} year={2026} />, { wrapper })
+    expect(mockFetchHouseholdMedical).not.toHaveBeenCalled()
+
+    await userEvent.click(screen.getAllByTestId('map-mark')[0] as HTMLElement)
+    await userEvent.click(screen.getByRole('button', { name: /Johnson/ }))
+
+    await waitFor(() => {
+      expect(mockFetchHouseholdMedical).toHaveBeenCalledWith(expect.anything(), 2026, 9001)
+    })
+    expect(await screen.findByText('Peanuts')).toBeInTheDocument()
+  })
+
+  it('never fetches for a party with no household to look up', async () => {
+    const adultGuest = party({
+      grain: 'person',
+      household_cm_id: 0,
+      person_cm_id: 5001,
+      display_name: 'Priya Patel',
+      sort_name: 'Priya Patel',
+      adults: [],
+      children: [],
+      unit_code: 'cedar-1',
+      unit_name: 'Cedar 1',
+    })
+    render(<LodgingMap parties={[adultGuest]} units={UNITS} year={2026} />, { wrapper })
+    await userEvent.click(screen.getAllByTestId('map-mark')[0] as HTMLElement)
+    await userEvent.click(screen.getByRole('button', { name: /Priya Patel/ }))
+    expect(screen.getByTestId('family-details-panel')).toBeInTheDocument()
+    expect(mockFetchHouseholdMedical).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/weekend/LodgingMap.tsx
+++ b/frontend/src/components/weekend/LodgingMap.tsx
@@ -39,6 +39,7 @@ import { Info } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { useDismissOnDeadSpace } from '../../hooks/useDismissOnDeadSpace'
+import { usePanelParty } from '../../hooks/usePanelParty'
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
 import { FamilyCard } from './FamilyCard'
 import { FamilyDetailsPanel } from './FamilyDetailsPanel'
@@ -145,8 +146,8 @@ export function LodgingMap({ parties, units, year, sessionCmId = 0 }: LodgingMap
   const [pinnedKey, setPinnedKey] = useState<string | null>(null)
   const [dwellKey, setDwellKey] = useState<string | null>(null)
   const dwellTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const [selected, setSelected] = useState<RosterPartyRow | null>(null)
-  const [requestClose, setRequestClose] = useState(false)
+  const { panelParty, requestClose, openParty, closePanel, requestPanelClose } =
+    usePanelParty(parties)
   const unitsByCode = useMemo(() => indexUnitsByCode(units), [units])
 
   const openKey = pinnedKey ?? dwellKey
@@ -191,20 +192,15 @@ export function LodgingMap({ parties, units, year, sessionCmId = 0 }: LodgingMap
     }
   }, [])
 
-  const openParty = useCallback((party: RosterPartyRow) => {
-    setRequestClose(false)
-    setSelected(party)
-  }, [])
-
-  const closePanel = useCallback(() => {
-    setSelected(null)
-    setRequestClose(false)
-  }, [])
+  // `openParty`/`closePanel`/`panelParty` come from `usePanelParty` above —
+  // shared with `LodgingBoard` and `HouseholdRosterTable` (kindred#2139). See
+  // its own docstring for the derivation and why it stores `selectedKey`
+  // rather than the party object.
 
   // RESET, not filtered (kindred#2138) — the owner's ruling was explicit: a
   // session change closes the panel outright, it does not merely stop
-  // rendering it while `selected` quietly survives underneath. The
-  // `panelParty` guard below only catches a household that drops OUT of
+  // rendering it while the selection quietly survives underneath.
+  // `usePanelParty`'s own guard only catches a household that drops OUT of
   // `parties`; a household enrolled in two weekends never does that, since
   // `partyKey` (deliberately — see partyKey.ts) carries no session
   // dimension, so the same key still matches after the switch and the panel
@@ -213,28 +209,15 @@ export function LodgingMap({ parties, units, year, sessionCmId = 0 }: LodgingMap
   // This is React's own "storing information from previous renders"
   // pattern: compare this render's prop against the last one seen, and if
   // it moved, correct the state right here in the render body rather than
-  // in an Effect. Calling `setSelected` conditionally during render does not
+  // in an Effect. Calling `closePanel` conditionally during render does not
   // add a paint the way an Effect would — React discards this render's
   // output and re-renders synchronously with the corrected state before
   // anything commits, so nobody ever sees the stale mid-render frame.
   const [lastSessionCmId, setLastSessionCmId] = useState(sessionCmId)
   if (sessionCmId !== lastSessionCmId) {
     setLastSessionCmId(sessionCmId)
-    setSelected(null)
+    closePanel()
   }
-
-  // DERIVED, not effect-cleared (kindred#2062). A weekend switch re-renders
-  // the map with a different `parties` prop but never unmounts it, so a
-  // `selected` that outlived its own mark's departure kept the panel — and
-  // its medical narrative — open over the new weekend's roster. Computing
-  // this at render time, rather than in a useEffect that calls setState,
-  // avoids the extra render pass React's docs warn an Effect would add here
-  // (`selected` itself is untouched; only what gets rendered changes). A
-  // refetch that returns the SAME parties (new array identity, same
-  // content) still resolves to present, because `partyKey` compares
-  // content, not identity — see partyKey.ts's own docstring.
-  const panelParty =
-    selected !== null && parties.some((p) => partyKey(p) === partyKey(selected)) ? selected : null
 
   // Same dead-space dismissal the summer board and the weekend board use, and
   // deliberately the same one line they use. The canvas is a bare div that a
@@ -246,9 +229,7 @@ export function LodgingMap({ parties, units, year, sessionCmId = 0 }: LodgingMap
   // rather than by teaching this callback to second-guess the clicks it does
   // get. A callback that remembers things about earlier gestures is a callback
   // that can be wrong about the current one.
-  useDismissOnDeadSpace(panelParty !== null, () => {
-    setRequestClose(true)
-  })
+  useDismissOnDeadSpace(panelParty !== null, requestPanelClose)
 
   // jsdom performs no layout, so clientWidth/clientHeight are 0 there (verified).
   // Without this fallback every mark computes position (0,0), the clusterer
@@ -348,6 +329,22 @@ export function LodgingMap({ parties, units, year, sessionCmId = 0 }: LodgingMap
   // null and the ternary short-circuits — only once a mark has been clicked.
   const openCluster =
     openKey === null ? undefined : clusters.find((cluster) => clusterKey(cluster) === openKey)
+
+  // Same latch as `usePanelParty`'s `selectedKey` above, applied to
+  // `pinnedKey`/`dwellKey` (kindred#2137 bug 4). `openCluster` already
+  // derives correctly — a fresh `.find` against the CURRENT `clusters` every
+  // render — but nothing reset `pinnedKey`/`dwellKey` when their cluster
+  // stopped existing. A `parties`/`units` prop change (a roster refetch or a
+  // weekend switch) can dissolve a cluster and a LATER prop change can
+  // re-mint the identical `clusterKey` (sorted unit ids), reopening a
+  // popover with no click. `MapUnitPopover` renders no `MedicalNarrative`,
+  // so this is a correctness/UX defect, not a PHI exposure — but the fix
+  // shape is identical: clear the stored key(s) right here, during render,
+  // rather than in an Effect.
+  if (openKey !== null && openCluster === undefined) {
+    if (pinnedKey !== null) setPinnedKey(null)
+    if (dwellKey !== null) setDwellKey(null)
+  }
 
   // The only way left to reset the view — the control bar's `Fit all` button
   // is gone. Called from the canvas's own `onDoubleClick` below; a bare

--- a/frontend/src/hooks/usePanelParty.test.tsx
+++ b/frontend/src/hooks/usePanelParty.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * `usePanelParty` is the extraction of the triplicated `panelParty`
+ * derivation from `HouseholdRosterTable`, `LodgingBoard` and `LodgingMap`
+ * (kindred#2139), storing `selectedKey` rather than the full party object so
+ * the presence check and "get fresh data" collapse into one operation
+ * (kindred#2137's recommended fix).
+ */
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import type { RosterPartyRow } from '../types/lodging'
+import { usePanelParty } from './usePanelParty'
+
+function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
+  return {
+    grain: 'household',
+    household_cm_id: 2000001,
+    person_cm_id: 0,
+    display_name: 'Johnson Family',
+    unit_code: '',
+    unit_name: '',
+    ...overrides,
+  }
+}
+
+describe('usePanelParty — basic open/close', () => {
+  it('starts with no panel open', () => {
+    const { result } = renderHook(() => usePanelParty([party()]))
+    expect(result.current.panelParty).toBeNull()
+    expect(result.current.requestClose).toBe(false)
+  })
+
+  it('opens the panel for the clicked party', () => {
+    const johnson = party()
+    const { result } = renderHook(() => usePanelParty([johnson]))
+    act(() => {
+      result.current.openParty(johnson)
+    })
+    expect(result.current.panelParty).toBe(johnson)
+  })
+
+  it('closePanel clears both the selection and any pending close', () => {
+    const johnson = party()
+    const { result } = renderHook(() => usePanelParty([johnson]))
+    act(() => {
+      result.current.openParty(johnson)
+    })
+    act(() => {
+      result.current.requestPanelClose()
+    })
+    expect(result.current.requestClose).toBe(true)
+
+    act(() => {
+      result.current.closePanel()
+    })
+    expect(result.current.panelParty).toBeNull()
+    expect(result.current.requestClose).toBe(false)
+  })
+
+  it('opening a new party clears a pending close from the previous one', () => {
+    const johnson = party({ household_cm_id: 2000001, display_name: 'Johnson' })
+    const garcia = party({ household_cm_id: 2000002, display_name: 'Garcia' })
+    const { result } = renderHook(() => usePanelParty([johnson, garcia]))
+    act(() => {
+      result.current.openParty(johnson)
+    })
+    act(() => {
+      result.current.requestPanelClose()
+    })
+    expect(result.current.requestClose).toBe(true)
+
+    act(() => {
+      result.current.openParty(garcia)
+    })
+    expect(result.current.panelParty).toBe(garcia)
+    expect(result.current.requestClose).toBe(false)
+  })
+})
+
+describe('usePanelParty — kindred#2137 bug 1: silent reopen (A -> B -> A)', () => {
+  it('does not resurrect the panel when the party returns on a later rerender', () => {
+    const johnson = party({ household_cm_id: 2000001 })
+    const garcia = party({ household_cm_id: 2000002 })
+
+    const { result, rerender } = renderHook(({ parties }) => usePanelParty(parties), {
+      initialProps: { parties: [johnson, garcia] },
+    })
+
+    act(() => {
+      result.current.openParty(johnson)
+    })
+    expect(result.current.panelParty).toBe(johnson)
+
+    // B: johnson drops out of the roster (weekend switch) -- the panel must
+    // close, exactly as #2062 already required.
+    rerender({ parties: [garcia] })
+    expect(result.current.panelParty).toBeNull()
+
+    // A: back to a roster that once again contains johnson (switching back
+    // to the first weekend, already cached). Without clearing the stored
+    // selection, `partyKey` would match again and the panel would reopen
+    // with no click -- re-issuing a PHI fetch for a household nobody asked
+    // to see. This is the bug.
+    rerender({ parties: [johnson, garcia] })
+    expect(result.current.panelParty).toBeNull()
+  })
+})
+
+describe('usePanelParty — kindred#2137 bug 2: requestClose latches across the same path', () => {
+  it('clears a pending close when the party departs, not just when closePanel runs', () => {
+    const johnson = party({ household_cm_id: 2000001 })
+    const garcia = party({ household_cm_id: 2000002 })
+
+    const { result, rerender } = renderHook(({ parties }) => usePanelParty(parties), {
+      initialProps: { parties: [johnson, garcia] },
+    })
+
+    act(() => {
+      result.current.openParty(johnson)
+    })
+    act(() => {
+      result.current.requestPanelClose()
+    })
+    expect(result.current.requestClose).toBe(true)
+
+    // johnson departs before the 300ms exit animation finishes -- the
+    // element unmounts, so `onClose` (which is what normally clears
+    // `requestClose`) never runs. Without a fix, `requestClose` stays latched
+    // true.
+    rerender({ parties: [garcia] })
+    expect(result.current.panelParty).toBeNull()
+    expect(result.current.requestClose).toBe(false)
+
+    // If johnson reappears now, the panel must mount fresh -- not already
+    // mid-exit.
+    rerender({ parties: [johnson, garcia] })
+    expect(result.current.panelParty).toBeNull()
+    expect(result.current.requestClose).toBe(false)
+  })
+})
+
+describe('usePanelParty — kindred#2137 bug 3: stale captured object vs. live row', () => {
+  it('reflects the LIVE matching party, not the object captured at click time', () => {
+    const johnson = party({ household_cm_id: 2000001, unit_code: 'cedar-1', unit_name: 'Cedar 1' })
+
+    const { result, rerender } = renderHook(({ parties }) => usePanelParty(parties), {
+      initialProps: { parties: [johnson] },
+    })
+
+    act(() => {
+      result.current.openParty(johnson)
+    })
+    expect(result.current.panelParty?.unit_name).toBe('Cedar 1')
+
+    // An optimistic drag placement (`dragPlacement.ts`'s `applyPlacement`)
+    // returns a NEW party object with a changed `unit_code`/`unit_name`, kept
+    // at the same `partyKey`. The panel must show the post-drag cabin, not
+    // the object it captured when the row was clicked.
+    const draggedJohnson = { ...johnson, unit_code: 'ridge-a', unit_name: 'Ridge A' }
+    rerender({ parties: [draggedJohnson] })
+
+    expect(result.current.panelParty).toBe(draggedJohnson)
+    expect(result.current.panelParty?.unit_name).toBe('Ridge A')
+  })
+})
+
+describe('usePanelParty — memoization on the pan hot path (kindred#2139)', () => {
+  it('does not re-scan parties on an unrelated rerender with unchanged inputs', () => {
+    const johnson = party({ household_cm_id: 2000001 })
+    let findCalls = 0
+    const parties = Object.assign([johnson], {
+      find(callback: (p: RosterPartyRow) => boolean) {
+        findCalls += 1
+        return Array.prototype.find.call(this, callback) as RosterPartyRow | undefined
+      },
+    })
+
+    const { result, rerender } = renderHook(({ parties }) => usePanelParty(parties), {
+      initialProps: { parties },
+    })
+
+    act(() => {
+      result.current.openParty(johnson)
+    })
+    expect(findCalls).toBe(1)
+
+    // LodgingMap's `setView` fires on every `pointermove` while panning, which
+    // re-renders the whole component tree with the SAME `parties` reference
+    // and the SAME selection. That must not re-walk the roster.
+    rerender({ parties })
+    rerender({ parties })
+    expect(findCalls).toBe(1)
+  })
+})

--- a/frontend/src/hooks/usePanelParty.ts
+++ b/frontend/src/hooks/usePanelParty.ts
@@ -1,0 +1,109 @@
+import { useCallback, useMemo, useState } from 'react'
+
+import { partyKey } from '../components/weekend/partyKey'
+import type { RosterPartyRow } from '../types/lodging'
+
+export interface UsePanelPartyResult {
+  /**
+   * The party `FamilyDetailsPanel` should render for, resolved fresh against
+   * the CURRENT `parties` on every render — never the object captured when
+   * the row was clicked. Read this once and pass the one value to all three
+   * places that need it (the panel's own render, `isPanelOpen`,
+   * `useDismissOnDeadSpace`'s open flag) rather than re-deriving it, or a
+   * caller that only updates the panel render site leaves the other two
+   * stale.
+   */
+  panelParty: RosterPartyRow | null
+  /** Drives `FamilyDetailsPanel`'s exit animation. */
+  requestClose: boolean
+  /** Call from a party's own click handler (a row, a card, a mark). */
+  openParty: (party: RosterPartyRow) => void
+  /** `FamilyDetailsPanel`'s `onClose` — the animation has finished. */
+  closePanel: () => void
+  /** Dead-space dismissal: start the exit animation without closing yet. */
+  requestPanelClose: () => void
+}
+
+/**
+ * The `panelParty` derivation triplicated across `HouseholdRosterTable`,
+ * `LodgingBoard` and `LodgingMap` (kindred#2139) — one definition, because
+ * three drifted out of sync the moment a fourth surface needed the same
+ * "which party is the details panel open for" question answered.
+ *
+ * STORES `selectedKey: string | null`, not the party object itself
+ * (kindred#2137's recommended fix). That makes "is the selection still in
+ * the roster" and "get its current data" the SAME lookup:
+ *
+ *   parties.find((p) => partyKey(p) === selectedKey)
+ *
+ * A stored object answers the first question by comparing keys anyway
+ * (`partyKey(p) === partyKey(selected)`) and then hands back the STALE
+ * captured object instead of the live match — kindred#2137 bug 3. An
+ * optimistic drag placement (`dragPlacement.ts`'s `applyPlacement`) returns a
+ * new party object with a changed `unit_code`/`unit_name` at the same
+ * `partyKey`, so the stale-object shape shows the pre-drag cabin until the
+ * panel is closed and reopened.
+ *
+ * MEMOIZED on `[parties, selectedKey]` — this lands on `LodgingMap`'s pan hot
+ * path, where `setView` fires on every `pointermove` and re-renders the whole
+ * map with an unchanged `parties` reference. Without memoization every pan
+ * frame re-scans the roster; `useMemo` skips that entirely when neither
+ * input moved. The scan itself is also O(N), not O(2N): `selectedKey` is a
+ * plain string computed once at `openParty` time, so `.find` never
+ * recomputes `partyKey` for the selection inside its own callback the way
+ * the old triplicated code did (`partyKey(selected)` sitting inside
+ * `.some()`, once per candidate).
+ *
+ * CLEARS `selectedKey` (and any pending `requestClose`) DURING RENDER when
+ * the derived `panelParty` resolves to `null` but a selection is still on
+ * record — React's own "storing information from previous renders" pattern,
+ * the same one `WeekendRosterPage.tsx` already uses for its session-change
+ * reset. This is deliberately NOT a `useEffect` + `setState`: all three call
+ * sites this hook replaces carried a comment explaining that an Effect adds
+ * an extra commit pass a render-time correction avoids, and calling
+ * `setState` conditionally in the render body does not add a paint — React
+ * discards this render's output and re-renders synchronously with the
+ * corrected state before anything commits.
+ *
+ * This is what closes kindred#2137 bugs 1 and 2 for free: without it,
+ * `selectedKey` outlives its own party's departure from `parties` (a
+ * weekend switch, a refetch), and if the SAME key re-matches later (the
+ * household is enrolled in a weekend staff already had cached), the panel
+ * silently reopens and re-issues a real PHI fetch for a household nobody
+ * asked to see. `requestClose` has the identical latch: a dead-space click
+ * starts the exit animation, the party departs before the 300ms animation
+ * finishes, the element unmounts before `onClose` can fire, and
+ * `requestClose` stays latched `true` — so when the party reappears the
+ * panel mounts already mid-exit. Clearing both together closes both paths in
+ * one place.
+ */
+export function usePanelParty(parties: RosterPartyRow[]): UsePanelPartyResult {
+  const [selectedKey, setSelectedKey] = useState<string | null>(null)
+  const [requestClose, setRequestClose] = useState(false)
+
+  const panelParty = useMemo<RosterPartyRow | null>(() => {
+    if (selectedKey === null) return null
+    return parties.find((p) => partyKey(p) === selectedKey) ?? null
+  }, [parties, selectedKey])
+
+  if (selectedKey !== null && panelParty === null) {
+    setSelectedKey(null)
+    if (requestClose) setRequestClose(false)
+  }
+
+  const openParty = useCallback((party: RosterPartyRow) => {
+    setRequestClose(false)
+    setSelectedKey(partyKey(party))
+  }, [])
+
+  const closePanel = useCallback(() => {
+    setSelectedKey(null)
+    setRequestClose(false)
+  }, [])
+
+  const requestPanelClose = useCallback(() => {
+    setRequestClose(true)
+  }, [])
+
+  return { panelParty, requestClose, openParty, closePanel, requestPanelClose }
+}


### PR DESCRIPTION
## What

#2137 and #2139's bullets 1–2 are the same change: extracting the triplicated `panelParty` derivation into one shared `usePanelParty` hook (`frontend/src/hooks/usePanelParty.ts`) is what turns #2137's three near-identical fixes into a single edit. This PR does both together, plus #2139's remaining cleanups, which touch the same three files.

## Part A — the shared hook

`usePanelParty(parties)` replaces the triplicated `selected`/`requestClose`/`panelParty` state in `HouseholdRosterTable`, `LodgingBoard` and `LodgingMap`. It stores `selectedKey: string | null` instead of the full party object, so "is the selection still in the roster" and "get its current data" become the same `parties.find((p) => partyKey(p) === selectedKey)` lookup.

Memoized (`useMemo` on `[parties, selectedKey]`) because it lands on `LodgingMap`'s pan hot path, where `setView` fires on every `pointermove`. The old code also called `partyKey(selected)` inside the `.some()` callback — 2N `partyKey` calls per scan instead of N — which storing a precomputed string key fixes as a side effect.

Lives in `frontend/src/hooks/`, not `components/weekend/`, matching where `useDismissOnDeadSpace` (called one line after it at every call site) already lives. Not added to `hooks/index.ts` — that barrel is selective and `useDismissOnDeadSpace` is imported directly, same pattern.

## Part B — the correctness bugs (#2137)

All four fixed by the same render-time clear inside `usePanelParty`:

1. **`selected` never cleared on departure → silent reopen.** Switch weekend A → B (A's party drops out, panel closes) → back to A (already cached this session, same `partyKey` matches again) → panel silently reopens with no click and re-issues a real PHI fetch. `usePanelParty` clears `selectedKey` during render when the derived `panelParty` resolves null — React's "storing information from previous renders" pattern, not a `useEffect`.
2. **`requestClose` latches across the same unmount path.** A dead-space click starts the exit animation; the party departs before the 300ms animation finishes; the panel unmounts before `onClose` can fire; `requestClose` stays latched `true`, so a later reopen mounts already mid-exit. Cleared alongside `selectedKey` in the same place. Updated the now-inaccurate comment in `FamilyDetailsPanel.tsx` that claimed "`requestClose` needs no equivalent" — true only for the same-click family-switch path, not this one.
3. **Stale captured object vs. live row.** The old `selected !== null && parties.some(...) ? selected : null` returns the object captured at click time, not the element `.some()` actually matched — so an optimistic drag placement's new `unit_code` never reached an already-open panel. `usePanelParty` does a fresh `.find` every render instead.
4. **`LodgingMap`'s `pinnedKey`/`dwellKey` carry the identical latch**, applied the same shape. `openCluster` itself already derived correctly (fresh `.find` against current `clusters`); only the reset was missing. Correctness/UX defect only — `MapUnitPopover` renders no PHI.

None of this touches `useHouseholdMedical`'s `staleTime: 0, gcTime: 0` — that stays exactly as it is.

## Part C — the cleanups (#2139 remainder)

- **`HouseholdRosterTable`'s row key** now uses the `partyKey` it already imports instead of a hand-rolled string that disagreed with it on an unresolved household (both ids 0). **Not a bug fix** — production has zero unresolved households across 2023–2026 (see `partyKey.ts`'s own docstring) — purely consistency, now that `partyKey` is imported into the file anyway.
- **Deleted a byte-identical duplicated `describe` block** in `LodgingMap.test.tsx` (verified identical before removing).
- Did **not** implement #2139's "`FamilyDetailsPanel` takes `partyKey` + `parties` and does the lookup itself" proposal — that issue explicitly says not to, since both parents still need the resolved value for `isPanelOpen` and `useDismissOnDeadSpace`'s open flag. `usePanelParty` is the enforcement point instead.

## Test coverage

Every existing test in all three files stopped at one rerender, which passes against the broken implementation as well as the fixed one. New coverage:

- A third rerender back to the **original** parties (A → B → A) in `HouseholdRosterTable.test.tsx`, `LodgingBoard.test.tsx` and `LodgingMap.test.tsx` — catches the resurrection bug.
- A rerender where the selected party's own content changes (a different `unit_code`/`unit_name`, mimicking an optimistic drag) — catches the stale-object bug.
- Assertions on `isPanelOpen` and `useDismissOnDeadSpace`'s open flag on both `LodgingBoard` and `LodgingMap` — nothing asserted on either before, so reverting them to `selected !== null` would still pass the whole suite.
- `LodgingMap`-specific: the `pinnedKey`/`dwellKey` cluster-dissolve-and-reappear case.
- **The actual PHI fetch.** All three files mocked `useHouseholdMedical` to a constant, so `MedicalNarrative`'s fetch — the exact harm #2062 named — was never exercised by any assertion. Each file now has a `medicalFetchMode` toggle (`vi.hoisted`) that flips its `useHouseholdMedical` mock to the REAL hook, driven through a mocked `fetchHouseholdMedical` service call + mocked `useApiWithAuth` — the same harness `useWeekendRoster.test.tsx` already uses to drive its own hooks for real, rather than inventing a new one. The rest of each file's ~30 tests never flip the toggle and are unaffected.
- `usePanelParty.test.tsx` — new hook-level unit tests for all of the above plus a targeted memoization test (spies on `parties.find` call count across an unrelated rerender).

Also, per this issue chain's own note: the tree had already drifted from the issue text in one place — #2139's own citation of "`MedicalNarrative.test.tsx` already drives the real hook with a QueryClient" doesn't hold on the current tree; that file (like `FamilyDetailsPanel.test.tsx`) mocks `useHouseholdMedical` directly rather than driving it through a QueryClient + mocked service. The actual working example of that harness is `useWeekendRoster.test.tsx`, which is what the new PHI-fetch tests copy.

## TDD

Every new behavior was written test-first and confirmed RED, then implemented to GREEN. Anything that passed on first write was mutation-checked (production code reverted to the pre-fix shape, confirmed RED, restored) — covers all four `usePanelParty` unit tests that could plausibly pass vacuously, the memoization test, the `isPanelOpen` wiring on both `LodgingBoard` and `LodgingMap`, the `pinnedKey`/`dwellKey` latch fix, and the "actual PHI fetch" tests in all three component files.

Closes #2137.
Closes #2139.
