### PR TITLE
fix(frontend): trap focus inside ui/Modal so aria-modal is honoured

### DIFF
--- a/frontend/src/components/ui/Modal.test.tsx
+++ b/frontend/src/components/ui/Modal.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { Modal } from './Modal'
 
 describe('Modal', () => {
@@ -355,6 +355,164 @@ describe('Modal', () => {
 
       const dialog = screen.getByRole('dialog')
       expect(dialog).toHaveClass('z-[100]')
+    })
+  })
+
+  describe('focus management', () => {
+    it('moves focus inside the dialog when it opens', () => {
+      render(
+        <Modal isOpen={true} onClose={() => {}} title="Focus Test">
+          <input placeholder="First field" />
+        </Modal>
+      )
+
+      const dialog = screen.getByRole('dialog')
+      expect(dialog.contains(document.activeElement)).toBe(true)
+    })
+
+    it('restores focus to the previously focused element when the dialog closes', () => {
+      const trigger = document.createElement('button')
+      trigger.textContent = 'Open modal'
+      document.body.appendChild(trigger)
+      trigger.focus()
+      expect(document.activeElement).toBe(trigger)
+
+      const { rerender } = render(
+        <Modal isOpen={true} onClose={() => {}}>
+          <p>Modal content</p>
+        </Modal>
+      )
+      expect(document.activeElement).not.toBe(trigger)
+
+      rerender(
+        <Modal isOpen={false} onClose={() => {}}>
+          <p>Modal content</p>
+        </Modal>
+      )
+
+      expect(document.activeElement).toBe(trigger)
+      trigger.remove()
+    })
+
+    it('Tab wraps from the last focusable element to the first', () => {
+      render(
+        <Modal isOpen={true} onClose={() => {}} title="Wrap Test">
+          <input placeholder="Field" />
+          <button>Save</button>
+        </Modal>
+      )
+
+      const saveButton = screen.getByRole('button', { name: 'Save' })
+      saveButton.focus()
+      expect(document.activeElement).toBe(saveButton)
+
+      fireEvent.keyDown(document, { key: 'Tab' })
+
+      const closeButton = screen.getByRole('button', { name: /close/i })
+      expect(document.activeElement).toBe(closeButton)
+    })
+
+    it('Shift+Tab wraps from the first focusable element to the last', () => {
+      render(
+        <Modal isOpen={true} onClose={() => {}} title="Wrap Test">
+          <input placeholder="Field" />
+          <button>Save</button>
+        </Modal>
+      )
+
+      const closeButton = screen.getByRole('button', { name: /close/i })
+      closeButton.focus()
+
+      fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+
+      const saveButton = screen.getByRole('button', { name: 'Save' })
+      expect(document.activeElement).toBe(saveButton)
+    })
+
+    it('cycles through every focusable element type, not just buttons', () => {
+      render(
+        <Modal isOpen={true} onClose={() => {}} title="All Fields">
+          <input placeholder="Text field" />
+          <select>
+            <option>A</option>
+          </select>
+          <textarea placeholder="Notes" />
+          <a href="#anchor">Link</a>
+        </Modal>
+      )
+
+      // DOM order: close button, input, select, textarea, link.
+      const closeButton = screen.getByRole('button', { name: /close/i })
+      expect(document.activeElement).toBe(closeButton)
+
+      fireEvent.keyDown(document, { key: 'Tab' })
+      expect(document.activeElement).toBe(screen.getByPlaceholderText('Text field'))
+
+      fireEvent.keyDown(document, { key: 'Tab' })
+      expect(document.activeElement?.tagName).toBe('SELECT')
+
+      fireEvent.keyDown(document, { key: 'Tab' })
+      expect(document.activeElement).toBe(screen.getByPlaceholderText('Notes'))
+
+      fireEvent.keyDown(document, { key: 'Tab' })
+      expect(document.activeElement).toBe(screen.getByRole('link', { name: 'Link' }))
+
+      // Wraps back to the close button after the last focusable element.
+      fireEvent.keyDown(document, { key: 'Tab' })
+      expect(document.activeElement).toBe(closeButton)
+    })
+  })
+
+  describe('background inert', () => {
+    // ui/Modal targets `#root` (the app's mount point in index.html) rather
+    // than document.body, since document.body also hosts the portal itself —
+    // marking body inert would make the dialog inert too. Tests recreate that
+    // element since jsdom doesn't load index.html.
+    beforeEach(() => {
+      const root = document.createElement('div')
+      root.id = 'root'
+      document.body.appendChild(root)
+    })
+
+    afterEach(() => {
+      document.getElementById('root')?.remove()
+    })
+
+    it('marks the app root inert while the dialog is open', () => {
+      render(
+        <Modal isOpen={true} onClose={() => {}}>
+          <p>Content</p>
+        </Modal>
+      )
+
+      expect(document.getElementById('root')).toHaveAttribute('inert')
+    })
+
+    it('does not mark the app root inert while the dialog is closed', () => {
+      render(
+        <Modal isOpen={false} onClose={() => {}}>
+          <p>Content</p>
+        </Modal>
+      )
+
+      expect(document.getElementById('root')).not.toHaveAttribute('inert')
+    })
+
+    it('removes inert from the app root once the dialog closes', () => {
+      const { rerender } = render(
+        <Modal isOpen={true} onClose={() => {}}>
+          <p>Content</p>
+        </Modal>
+      )
+      expect(document.getElementById('root')).toHaveAttribute('inert')
+
+      rerender(
+        <Modal isOpen={false} onClose={() => {}}>
+          <p>Content</p>
+        </Modal>
+      )
+
+      expect(document.getElementById('root')).not.toHaveAttribute('inert')
     })
   })
 

--- a/frontend/src/components/ui/Modal.test.tsx
+++ b/frontend/src/components/ui/Modal.test.tsx
@@ -461,6 +461,37 @@ describe('Modal', () => {
       fireEvent.keyDown(document, { key: 'Tab' })
       expect(document.activeElement).toBe(closeButton)
     })
+
+    it('leaves focus alone on Tab when it is outside the dialog content, so a nested portal (e.g. ConfirmActionPopover rendered as a Modal child, as in AllCamperRequestsModal) keeps its own trap', () => {
+      render(
+        <Modal isOpen={true} onClose={() => {}} title="Nested Overlay Test">
+          <input placeholder="Field" />
+        </Modal>
+      )
+
+      // Simulate a child that portals outside the dialog's own contentRef
+      // subtree, exactly like ConfirmActionPopover does when it is rendered
+      // as a child of an open Modal (both portal independently to
+      // document.body, so the popover's DOM node is a *sibling* of the
+      // modal's content div, not a descendant of it).
+      const external = document.createElement('button')
+      external.textContent = 'External overlay button'
+      document.body.appendChild(external)
+      external.focus()
+      expect(document.activeElement).toBe(external)
+
+      fireEvent.keyDown(document, { key: 'Tab' })
+
+      // Modal's own trap must not hijack focus meant for the nested
+      // overlay's trap — it should no-op when activeElement isn't inside
+      // its own content.
+      expect(document.activeElement).toBe(external)
+
+      fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+      expect(document.activeElement).toBe(external)
+
+      external.remove()
+    })
   })
 
   describe('background inert', () => {

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -132,7 +132,16 @@ export function Modal({
       // existing pattern in this repo — and jsdom doesn't implement native
       // Tab focus movement at all, so tests depend on it too.
       if (e.key === 'Tab') {
-        const focusable = contentRef.current ? getFocusable(contentRef.current) : []
+        const container = contentRef.current
+        // A nested overlay (e.g. ConfirmActionPopover, rendered as a Modal
+        // child but portaled independently to document.body — see
+        // AllCamperRequestsModal.tsx) can hold focus outside this dialog's
+        // own content subtree. If it does, this trap must no-op rather than
+        // yank focus back in: both listeners are on `document`, so acting
+        // here would fight the nested overlay's own trap for every Tab
+        // press instead of leaving it to run its own cycle.
+        if (!container?.contains(document.activeElement)) return
+        const focusable = getFocusable(container)
         if (focusable.length === 0) return
         e.preventDefault()
         const idx = focusable.indexOf(document.activeElement as HTMLElement)

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,5 +1,5 @@
 import { X } from 'lucide-react'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import type { ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 
@@ -38,6 +38,44 @@ const sizeClasses = {
   xl: 'max-w-4xl',
   '2xl': 'max-w-6xl',
 } as const
+
+// Elements a keyboard user can Tab to inside the dialog. Modal content is
+// arbitrary (inputs, selects, textareas, links, buttons — not just buttons),
+// unlike the button-only queries in ConfirmActionPopover.tsx and
+// RequestReviewPanel.tsx, so this needs the real focusable set or form
+// fields get silently stranded outside the trap.
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'textarea:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ')
+
+function getFocusable(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+}
+
+// How many ui/Modal instances currently hold the app root inert. Tracked at
+// module scope, not per-instance state, so that if a second dialog ever
+// opens on top of a first, the first closing doesn't remove inert out from
+// under the second — it only comes off once nothing needs it.
+let inertHolders = 0
+
+function acquireBackgroundInert() {
+  inertHolders += 1
+  if (inertHolders === 1) {
+    document.getElementById('root')?.setAttribute('inert', '')
+  }
+}
+
+function releaseBackgroundInert() {
+  inertHolders = Math.max(0, inertHolders - 1)
+  if (inertHolders === 0) {
+    document.getElementById('root')?.removeAttribute('inert')
+  }
+}
 
 /**
  * Shared modal component for consistent modal styling across the app.
@@ -78,17 +116,57 @@ export function Modal({
   backdropInsetRight,
   headerOnDark = false,
 }: ModalProps) {
+  const contentRef = useRef<HTMLDivElement>(null)
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null)
+
   useEffect(() => {
     if (!isOpen) return
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         onClose()
+        return
+      }
+      // Manual cycling (not letting the browser's native Tab handling run)
+      // matches ConfirmActionPopover.tsx and RequestReviewPanel.tsx's
+      // existing pattern in this repo — and jsdom doesn't implement native
+      // Tab focus movement at all, so tests depend on it too.
+      if (e.key === 'Tab') {
+        const focusable = contentRef.current ? getFocusable(contentRef.current) : []
+        if (focusable.length === 0) return
+        e.preventDefault()
+        const idx = focusable.indexOf(document.activeElement as HTMLElement)
+        if (e.shiftKey) {
+          focusable[idx <= 0 ? focusable.length - 1 : idx - 1]?.focus()
+        } else {
+          focusable[idx >= focusable.length - 1 ? 0 : idx + 1]?.focus()
+        }
       }
     }
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [isOpen, onClose])
+
+  // Initial focus, background inert, and focus restoration on close. Kept
+  // separate from the keydown effect above — this one only needs to run on
+  // open/close transitions ([isOpen]), not on every render where a caller
+  // passes a new onClose identity.
+  useEffect(() => {
+    if (!isOpen) return
+
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null
+    acquireBackgroundInert()
+
+    const container = contentRef.current
+    const focusable = container ? getFocusable(container) : []
+    ;(focusable[0] ?? container)?.focus()
+
+    return () => {
+      releaseBackgroundInert()
+      previouslyFocusedRef.current?.focus()
+      previouslyFocusedRef.current = null
+    }
+  }, [isOpen])
 
   if (!isOpen) return null
 
@@ -129,7 +207,11 @@ export function Modal({
           click-only by design, which is why it and this rule are exempted here but
           not elsewhere in this wave. */}
       <div
+        ref={contentRef}
         data-testid="modal-content"
+        // -1: not a natural Tab stop, only a JS-focus fallback for the rare
+        // dialog with no focusable content of its own.
+        tabIndex={-1}
         className={`bg-card relative overflow-hidden rounded-2xl ${
           // A dark header slot paints its own chrome to the card's edge, and a
           // light 1px ring around it reads as a white outline against the


### PR DESCRIPTION
## The gap

`ui/Modal` renders `role="dialog"` with `aria-modal="true"`, which tells assistive technology the rest of the page is inert. It wasn't — there was no focus trap, no initial focus, no focus restore on close, and nothing made the background inert. A keyboard user could tab off the last control and land on the page behind the (blurred, dimmed) backdrop with no way to navigate back in.

## What changed

All in `frontend/src/components/ui/Modal.tsx`, so all 20 `ui/Modal` consumers get this for free with no call-site changes:

1. **Tab / Shift+Tab trap** over the dialog's real focusable set — links, buttons, inputs, selects, textareas (not just buttons, which is what the two existing hand-rolled traps in this repo do and would have silently stranded form fields).
2. **Initial focus** on open — first focusable element in the dialog.
3. **Focus restoration** to whatever was focused before the dialog opened, on close.
4. **`inert` on `#root`** while a dialog is open, tracked with a module-level counter so nested dialogs don't remove it out from under each other.

No new props, no call-site changes, no change to open/close animation (out of scope here — kept file-disjoint from #2156 per that issue's own note).

## Tests

Added to `frontend/src/components/ui/Modal.test.tsx`:
- Tab wraps from the last focusable element to the first
- Shift+Tab wraps from the first to the last
- cycles through every focusable element type, not just buttons
- focus lands inside the dialog on open
- focus returns to the previously-focused element on close
- `#root` gets `inert` while open, loses it once closed

All new tests were written first, confirmed failing against the unfixed component, then mutation-checked (broke the trap logic and the initial-focus/restore/inert logic independently, confirmed the relevant tests went red for the right reason, then restored).

## Verification

- `vitest run src/components/ui/Modal.test.tsx` — 38/38 pass
- `vitest run` across all 17 non-mocking `ui/Modal` consumer test files — 359/359 pass, no regressions
- `tsc --noEmit` — clean
- `eslint` on both changed files — clean

Closes #2025.
