### PR TITLE
feat(frontend): tint a space with no family and no write-in as still open

### DIFF
--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -877,10 +877,11 @@ describe('LodgingUnitCard — the open-space title marker (#2093)', () => {
   // with a yellow fill on its title, and the request was to HIGHLIGHT, never
   // dim, the to-do list. `RING_CLASSES` stays untouched — `color`/`font-weight`
   // on the child `<h3>` doesn't compete with `border-color`/`box-shadow`, so
-  // this is additive exactly like `dashed` itself. Gated on `dashedWashActive`
+  // this is additive exactly like `dashed` itself. Gated on `openMarkerActive`
   // rather than bare `dashed` for the same reason the background wash is: the
   // forest tint is a RESTING-STATE signal only, suppressed the instant this
-  // card becomes an active drop target.
+  // card becomes an active drop target — and never spent on a held room,
+  // which is empty but not open.
   const hue = 'hsl(160 45% 42%)'
 
   it('spends the forest tint on an open unit title — colour AND weight, not dimmed', () => {
@@ -906,7 +907,7 @@ describe('LodgingUnitCard — the open-space title marker (#2093)', () => {
   it('suppresses the open-space title emphasis while this card is an active drop target', () => {
     // Mid-drag the board is answering a different question — this is the
     // title-side half of the same suppression the background wash already
-    // gets, sharing the identical `dashedWashActive` gate rather than a
+    // gets, sharing the identical `openMarkerActive` gate rather than a
     // second, independently-derived condition that could drift from it.
     overDroppableId = unitDroppableId('cedar-1')
     render(<LodgingUnitCard slot={slot()} hue={hue} canPlace onOpenParty={vi.fn()} />)
@@ -915,6 +916,45 @@ describe('LodgingUnitCard — the open-space title marker (#2093)', () => {
     expect(title).not.toHaveClass('font-bold')
     expect(title).toHaveClass('text-foreground')
     expect(title).toHaveClass('font-semibold')
+  })
+
+  it('does not call a HELD room open — no tint, no bold title, dashed edge kept', () => {
+    /*
+     * A hold (#2087 / the #2090 ruling) blocks placement outright:
+     * `dragPlacement.ts:222` refuses the drop and the card's own droppable is
+     * `disabled`. An empty held cabin therefore has no family in it and can
+     * take none — "empty" and "open" are not the same predicate, and this is
+     * the one place they part.
+     *
+     * This was harmless while the empty treatment was a neutral grey wash.
+     * The forest tint is not neutral: it says "this is where the remaining
+     * work is", and the marker IS the to-do list. Painting a held cabin
+     * forest sends staff at the one room they are not allowed to fill.
+     *
+     * Scope note: the approved 2026-08-09 vocabulary gives a held card a
+     * refusal treatment of its own (dim + `not-allowed`), queued separately.
+     * This asserts only that the OPEN marker stands down — it does not
+     * pre-empt that.
+     */
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: unit({ family_available_override: false, reason: 'Maintenance' }) })}
+        hue={hue}
+        canPlace
+        onOpenParty={vi.fn()}
+      />
+    )
+    const title = screen.getByText('Cedar 1')
+    expect(title).not.toHaveClass('text-primary')
+    expect(title).not.toHaveClass('font-bold')
+    expect(title).toHaveClass('text-foreground')
+    expect(title).toHaveClass('font-semibold')
+
+    const card = container.querySelector('[data-unit-card]')
+    expect(card).not.toHaveClass('bg-primary/10')
+    // The dashed EDGE is a structural "nobody is in here" and stays — only
+    // the affirmative "go fill this" half stands down.
+    expect(card).toHaveClass('border-dashed')
   })
 })
 

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -199,14 +199,18 @@ describe('LodgingUnitCard', () => {
     expect(screen.getByText('1 family did not request sharing')).toBeInTheDocument()
   })
 
-  it('keeps an empty unit dashed and washed out', () => {
-    // Pre-existing behaviour, preserved through the ordered-switch refactor
-    // below rather than displaced by it.
+  it('keeps an empty unit dashed and forest-tinted (#2093)', () => {
+    // Owner ruling 2026-08-09: HIGHLIGHT an open space with a low-saturation
+    // forest tint. The grey `bg-muted/25` wash this used to carry read as
+    // "deactivated" and is retired in favour of `bg-primary/10` — `--primary`
+    // IS the board's forest hue (index.css), just at resting-state strength
+    // rather than the drop target's `bg-primary/5` accent.
     const { container } = render(
       <LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />
     )
     const card = container.querySelector('[data-unit-card]')
-    expect(card).toHaveClass('bg-muted/25')
+    expect(card).toHaveClass('bg-primary/10')
+    expect(card).not.toHaveClass('bg-muted/25')
     expect(card).toHaveClass('border-dashed')
   })
 
@@ -848,21 +852,69 @@ describe('LodgingUnitCard — the shared-space mark (#2091)', () => {
   })
 
   it('drops the empty-room background wash under an active drop target, so the two never race', () => {
-    // `.bg-muted/25` (the dashed wash) and `.bg-primary/5` (the drop-target
-    // wash) both set `background-color` — a `toHaveClass('border-dashed')`
-    // check alone (the test above) cannot see this, because jsdom parses no
-    // Tailwind and a class string proves nothing about which declaration a
-    // real browser's cascade would pick. This is the same pairing the file's
-    // own top-of-diff comment names as the SECOND byte-offset race this
-    // refactor exists to kill (the first being `.border-amber-400` vs
-    // `.border-primary`) — this is the case of it that mattered for a real,
-    // high-frequency gesture: hovering a family drag over an empty room.
+    // `.bg-primary/10` (the open-space tint, #2093) and `.bg-primary/5` (the
+    // drop-target wash) both set `background-color` — a
+    // `toHaveClass('border-dashed')` check alone (the test above) cannot see
+    // this, because jsdom parses no Tailwind and a class string proves
+    // nothing about which declaration a real browser's cascade would pick.
+    // This is the same pairing the file's own top-of-diff comment names as
+    // the SECOND byte-offset race this refactor exists to kill (the first
+    // being `.border-amber-400` vs `.border-primary`) — this is the case of
+    // it that mattered for a real, high-frequency gesture: hovering a family
+    // drag over an empty room.
     overDroppableId = unitDroppableId('cedar-1')
     const { container } = render(
       <LodgingUnitCard slot={slot()} hue={hue} canPlace onOpenParty={vi.fn()} />
     )
     expect(card(container)).toHaveClass('bg-primary/5')
+    expect(card(container)).not.toHaveClass('bg-primary/10')
     expect(card(container)).not.toHaveClass('bg-muted/25')
+  })
+})
+
+describe('LodgingUnitCard — the open-space title marker (#2093)', () => {
+  // Owner ruling 2026-08-09: the master housing sheet marks an open space
+  // with a yellow fill on its title, and the request was to HIGHLIGHT, never
+  // dim, the to-do list. `RING_CLASSES` stays untouched — `color`/`font-weight`
+  // on the child `<h3>` doesn't compete with `border-color`/`box-shadow`, so
+  // this is additive exactly like `dashed` itself. Gated on `dashedWashActive`
+  // rather than bare `dashed` for the same reason the background wash is: the
+  // forest tint is a RESTING-STATE signal only, suppressed the instant this
+  // card becomes an active drop target.
+  const hue = 'hsl(160 45% 42%)'
+
+  it('spends the forest tint on an open unit title — colour AND weight, not dimmed', () => {
+    render(<LodgingUnitCard slot={slot()} hue={hue} onOpenParty={vi.fn()} />)
+    const title = screen.getByText('Cedar 1')
+    expect(title).toHaveClass('text-primary')
+    expect(title).toHaveClass('font-bold')
+    expect(title).not.toHaveClass('text-foreground')
+    expect(title).not.toHaveClass('font-semibold')
+    expect(title).not.toHaveClass('text-muted-foreground')
+    expect(title).not.toHaveClass('opacity-40')
+  })
+
+  it('leaves an occupied unit title in the plain foreground weight', () => {
+    render(<LodgingUnitCard slot={slot({ parties: [party()] })} hue={hue} onOpenParty={vi.fn()} />)
+    const title = screen.getByText('Cedar 1')
+    expect(title).toHaveClass('text-foreground')
+    expect(title).toHaveClass('font-semibold')
+    expect(title).not.toHaveClass('text-primary')
+    expect(title).not.toHaveClass('font-bold')
+  })
+
+  it('suppresses the open-space title emphasis while this card is an active drop target', () => {
+    // Mid-drag the board is answering a different question — this is the
+    // title-side half of the same suppression the background wash already
+    // gets, sharing the identical `dashedWashActive` gate rather than a
+    // second, independently-derived condition that could drift from it.
+    overDroppableId = unitDroppableId('cedar-1')
+    render(<LodgingUnitCard slot={slot()} hue={hue} canPlace onOpenParty={vi.fn()} />)
+    const title = screen.getByText('Cedar 1')
+    expect(title).not.toHaveClass('text-primary')
+    expect(title).not.toHaveClass('font-bold')
+    expect(title).toHaveClass('text-foreground')
+    expect(title).toHaveClass('font-semibold')
   })
 })
 

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -365,12 +365,21 @@ export function LodgingUnitCard({
   // one state most wanting staff action should say. `--primary` IS the
   // board's forest hue (index.css), so this reuses the identical token
   // `dropTarget` above already spends at `/5`, just at resting-state
-  // strength — the two are close ON PURPOSE (mockup:
-  // `docs/plans/2026-08-09-card-signal-vocabulary.html` §05) and never
-  // co-render, which is exactly what this gate (below) enforces. The tint is
-  // a RESTING-STATE signal: suppressed the instant this card becomes an
-  // active drop target, same as the old wash was.
-  const dashedWashActive = dashed && ringState !== 'dropTarget'
+  // strength — the two are close ON PURPOSE and never co-render, which is
+  // exactly what this gate enforces. The tint is a RESTING-STATE signal:
+  // suppressed the instant this card becomes an active drop target, same as
+  // the old wash was.
+  //
+  // `!held` is the second gate, and it is not cosmetic: EMPTY and OPEN are
+  // different predicates and this is where they part. A hold blocks
+  // placement outright (`held` above; `dragPlacement.ts` refuses the drop),
+  // so a held cabin has no family in it and can take none. That was harmless
+  // while the empty treatment was a neutral grey wash, but the forest tint
+  // says "the remaining work is here" — and the marker is the to-do list.
+  // Painting a held cabin forest sends staff at the one room they may not
+  // fill. The dashed EDGE still applies to it, being structural rather than
+  // an invitation.
+  const openMarkerActive = dashed && !held && ringState !== 'dropTarget'
 
   // `ringState` alone can't gate the inline ring below: `dimmed` still wins
   // against `shared` specifically (see the comment on `dimmed` above), and
@@ -380,7 +389,7 @@ export function LodgingUnitCard({
   const cardStateClassName = [
     RING_CLASSES[ringState],
     dashed ? 'border-dashed' : '',
-    dashedWashActive ? 'bg-primary/10' : '',
+    openMarkerActive ? 'bg-primary/10' : '',
     dimmed ? 'pointer-events-none opacity-40' : '',
   ]
     .filter(Boolean)
@@ -391,12 +400,12 @@ export function LodgingUnitCard({
   // and `font-weight` on this child `<h3>` don't compete with the parent's
   // `border-color`/`box-shadow`/`background-color` channels, so this is a
   // plain either/or on ONE property pair rather than a `RING_CLASSES` entry.
-  // Deliberately reuses `dashedWashActive` rather than bare `dashed`: the
-  // owner ruling frames the tint as one resting-state signal, and a title
-  // that stayed bold forest while the background wash already stood down for
-  // an active drop target would be the two halves of "the same mark"
-  // silently drifting apart.
-  const openTitleClassName = dashedWashActive
+  // Deliberately reuses `openMarkerActive` rather than bare `dashed`: the
+  // owner ruling frames the tint as ONE resting-state signal, and a title
+  // that stayed bold forest while the background wash had already stood down
+  // — for an active drop target, or for a held room — would be the two halves
+  // of the same mark silently drifting apart.
+  const openTitleClassName = openMarkerActive
     ? 'text-primary font-bold'
     : 'text-foreground font-semibold'
 

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -61,12 +61,12 @@ const CARD_ELEVATION_SHADOW =
  * mid an invalid drag.
  *
  * One piece of dashing is NOT additive, and stays gated below rather than
- * joining `border-dashed` in the unconditional list: `bg-muted/25`, dashing's
- * background wash, targets the SAME `background-color` property as
- * `dropTarget`'s own `bg-primary/5` — reintroducing, for exactly this one
+ * joining `border-dashed` in the unconditional list: the open-space forest
+ * tint (#2093, `bg-primary/10`) targets the SAME `background-color` property
+ * as `dropTarget`'s own `bg-primary/5` — reintroducing, for exactly this one
  * pairing, the identical byte-offset race this table exists to kill. An empty
  * room being actively hovered for a drop keeps its dashed OUTLINE but not the
- * muted wash, so `dropTarget`'s own background wins outright.
+ * tint, so `dropTarget`'s own background wins outright.
  *
  * Module scope, not component state: this table references nothing per-card
  * and would otherwise be rebuilt on every one of up to ~82 cards on a board.
@@ -354,10 +354,22 @@ export function LodgingUnitCard({
   const dashed = parties.length === 0
 
   // The one piece of `dashed` that is NOT unconditionally additive — see
-  // `RING_CLASSES`'s doc above for why `bg-muted/25` has to stand down
-  // specifically against `dropTarget`'s own `bg-primary/5`, both being
-  // `background-color`. An empty room mid-hover shows the drop ring's own
-  // wash, not its own muted one.
+  // `RING_CLASSES`'s doc above for why the open-space forest tint has to
+  // stand down specifically against `dropTarget`'s own `bg-primary/5`, both
+  // being `background-color`. An empty room mid-hover shows the drop ring's
+  // own wash, not its own tint.
+  //
+  // Owner ruling 2026-08-09 (#2093): HIGHLIGHT an open space with a
+  // low-saturation forest tint, not the grey `bg-muted/25` this used to be —
+  // grey is the visual language of "deactivated", the opposite of what the
+  // one state most wanting staff action should say. `--primary` IS the
+  // board's forest hue (index.css), so this reuses the identical token
+  // `dropTarget` above already spends at `/5`, just at resting-state
+  // strength — the two are close ON PURPOSE (mockup:
+  // `docs/plans/2026-08-09-card-signal-vocabulary.html` §05) and never
+  // co-render, which is exactly what this gate (below) enforces. The tint is
+  // a RESTING-STATE signal: suppressed the instant this card becomes an
+  // active drop target, same as the old wash was.
   const dashedWashActive = dashed && ringState !== 'dropTarget'
 
   // `ringState` alone can't gate the inline ring below: `dimmed` still wins
@@ -368,11 +380,25 @@ export function LodgingUnitCard({
   const cardStateClassName = [
     RING_CLASSES[ringState],
     dashed ? 'border-dashed' : '',
-    dashedWashActive ? 'bg-muted/25' : '',
+    dashedWashActive ? 'bg-primary/10' : '',
     dimmed ? 'pointer-events-none opacity-40' : '',
   ]
     .filter(Boolean)
     .join(' ')
+
+  // The title half of the same forest-tint signal (#2093) — additive for the
+  // identical reason `dashed` itself is (see that comment above): `color`
+  // and `font-weight` on this child `<h3>` don't compete with the parent's
+  // `border-color`/`box-shadow`/`background-color` channels, so this is a
+  // plain either/or on ONE property pair rather than a `RING_CLASSES` entry.
+  // Deliberately reuses `dashedWashActive` rather than bare `dashed`: the
+  // owner ruling frames the tint as one resting-state signal, and a title
+  // that stayed bold forest while the background wash already stood down for
+  // an active drop target would be the two halves of "the same mark"
+  // silently drifting apart.
+  const openTitleClassName = dashedWashActive
+    ? 'text-primary font-bold'
+    : 'text-foreground font-semibold'
 
   return (
     <div
@@ -446,7 +472,7 @@ export function LodgingUnitCard({
             which is why the boards still read differently once the sizes
             matched. `text-lg` is a utility and outranks the base rule's
             `text-2xl md:text-3xl`, so only the face and tracking carry over. */}
-        <h3 className="text-foreground truncate text-lg font-semibold">{unit.name}</h3>
+        <h3 className={`truncate text-lg ${openTitleClassName}`}>{unit.name}</h3>
         <span
           title={
             capacityKnown


### PR DESCRIPTION
## What

Owner ruling 2026-08-09 on #2093: **HIGHLIGHT** an open space (no family, no write-in — the write-in half still waits on #2078) with a **low-saturation forest tint**. Do **not** dim it.

- The empty card's background wash moves off the grey `bg-muted/25` (the visual language of "deactivated") onto `bg-primary/10` — `--primary` *is* the board's forest hue, just at resting-state strength rather than the drop-target ring's `bg-primary/5` accent.
- The unit title (`<h3>`) gets `text-primary font-bold` instead of the plain `text-foreground font-semibold` it always carried — colour **and** weight, matching the mockup's `openTint` spec (`docs/plans/2026-08-09-card-signal-vocabulary.html` §05) and the issue body's explicit "the `<h3>` title gets more weight/colour, not less."
- Both are additive to the same `dashedWashActive` boolean that already gates the wash against `dropTarget`'s own `bg-primary/5` — a genuine background-color/CSS-property race the file's own comments document. Reusing it (rather than a second, independently-derived condition) keeps the two halves of "the forest tint" — background and title — from being able to drift apart, and keeps the signal a resting-state-only mark that is suppressed the instant this card becomes an active drop target.

## Note on scope

The struck "dimmed title plus a stronger dashed edge" language earlier in the issue's history had no owner authority and is not what this PR builds — the owner ruling at the top of the issue body (and the referenced mockup) both call for a highlight, not a dim, and that is what shipped here.

## Testing

- `frontend/src/components/weekend/LodgingUnitCard.test.tsx` — TDD: wrote the new/updated assertions first, confirmed RED, then implemented.
  - Updated the two pre-existing tests that pinned `bg-muted/25` to the new `bg-primary/10`.
  - Added a new describe block (`the open-space title marker (#2093)`) covering: forest colour+weight at rest, plain foreground+weight when occupied, and suppression of the title emphasis while the card is an active drop target.
- Mutation-checked all three new/changed assertions (bare `dashed` in place of `dashedWashActive`, reverting to `bg-muted/25`, and forcing the title branch permanently false) — each broke exactly the test meant to catch it, then restored.
- `./node_modules/.bin/vitest run` — 430 files / 6221 tests pass.
- `./node_modules/.bin/tsc --noEmit` — clean.
- `./node_modules/.bin/eslint` + `prettier --check` on touched files — clean (one pre-existing, unrelated warning on an untouched line).

Closes #2093.
