### PR TITLE
fix(frontend): build the weekend Visual Guide on ui/Modal

### DIFF
--- a/frontend/src/components/BunkingLegend.test.tsx
+++ b/frontend/src/components/BunkingLegend.test.tsx
@@ -6,7 +6,7 @@
  * corresponding entry in the legend. This test fails if someone adds a new
  * indicator without updating the legend.
  */
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect } from 'vitest'
 import { BunkingLegendButton, WeekendLegendButton } from './BunkingLegend'
@@ -125,6 +125,33 @@ describe('BunkingLegend', () => {
       expect(screen.getByText(/production mode/i)).toBeInTheDocument()
     })
   })
+
+  /** kindred#2156: the guide is built on `ui/Modal` rather than hand-rolled
+   *  chrome, so it must pick up Modal's Escape handler, its `document.body`
+   *  portal and its named close button. */
+  describe('built on ui/Modal (kindred#2156)', () => {
+    it('closes on Escape', async () => {
+      await openLegend()
+      expect(screen.getByText('Visual Guide')).toBeInTheDocument()
+
+      fireEvent.keyDown(document, { key: 'Escape' })
+
+      expect(screen.queryByText('Visual Guide')).not.toBeInTheDocument()
+    })
+
+    it('renders via a portal into document.body, not the trigger container', async () => {
+      const { container } = render(<BunkingLegendButton />)
+      await userEvent.click(screen.getByRole('button', { name: /show visual guide/i }))
+
+      expect(container.querySelector('[role="dialog"]')).toBeNull()
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+
+    it('has a close button with an accessible name', async () => {
+      await openLegend()
+      expect(screen.getByRole('button', { name: /close modal/i })).toBeInTheDocument()
+    })
+  })
 })
 
 /**
@@ -213,5 +240,23 @@ describe('WeekendLegendButton', () => {
     await userEvent.click(screen.getByRole('button', { name: /show visual guide/i }))
     await userEvent.click(screen.getByRole('button', { name: /got it/i }))
     expect(screen.queryByText('Visual Guide')).not.toBeInTheDocument()
+  })
+
+  it('closes on Escape (kindred#2156)', async () => {
+    render(<WeekendLegendButton />)
+    await userEvent.click(screen.getByRole('button', { name: /show visual guide/i }))
+    expect(screen.getByText('Visual Guide')).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(screen.queryByText('Visual Guide')).not.toBeInTheDocument()
+  })
+
+  it('renders via a portal into document.body, not the trigger container (kindred#2156)', async () => {
+    const { container } = render(<WeekendLegendButton />)
+    await userEvent.click(screen.getByRole('button', { name: /show visual guide/i }))
+
+    expect(container.querySelector('[role="dialog"]')).toBeNull()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/BunkingLegend.tsx
+++ b/frontend/src/components/BunkingLegend.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
 import {
   HelpCircle,
-  X,
   Lock,
   AlertTriangle,
   Users,
@@ -11,6 +10,7 @@ import {
   History,
 } from 'lucide-react'
 
+import { Modal } from './ui/Modal'
 import { BATHHOUSE_BLUE, CONSENT_AMBER } from './weekend/mapColors'
 
 /** What one legend row and one legend section share: an icon and a title.
@@ -61,45 +61,57 @@ interface VisualGuideModalProps {
  * section shape and the `LegendEntry` primitive are the one shell both use.
  * Copying this file to give the weekend its own guide would be the thing
  * CLAUDE.md §4 names by name.
+ *
+ * Built on `ui/Modal` (kindred#2156) rather than hand-rolled chrome, so the
+ * guide inherits Modal's Escape-key listener, its `document.body` portal
+ * and a named close button — none of which this component provided when it
+ * painted its own `fixed inset-0` shell. Traded away deliberately: the
+ * card's `animate-fade-in`/`animate-scale-in` open animation, which Modal
+ * doesn't have and isn't gaining one here — adding a pass-through animation
+ * prop to `Modal.tsx` would edit the same file kindred#2025 is adding a
+ * focus trap to in parallel, turning two independent PRs into a merge
+ * conflict for a cosmetic difference.
  */
 function VisualGuideModal({ isOpen, onClose, sections }: VisualGuideModalProps) {
-  if (!isOpen) return null
-
   return (
-    <div className="animate-fade-in fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
-      <div className="card-lodge shadow-lodge-lg animate-scale-in max-h-[90vh] w-full max-w-2xl overflow-hidden">
-        {/* Header */}
-        <div className="bg-muted/50 border-border flex items-center justify-between border-b px-6 py-4">
-          <h2 className="font-display text-foreground flex items-center gap-2 text-xl font-bold">
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      size="lg"
+      noPadding
+      scrollable
+      ariaLabelledBy="visual-guide-title"
+      header={
+        <div className="bg-muted/50 border-border flex items-center border-b px-6 py-4">
+          <h2
+            id="visual-guide-title"
+            className="font-display text-foreground flex items-center gap-2 text-xl font-bold"
+          >
             <HelpCircle className="text-primary h-5 w-5" />
             Visual Guide
           </h2>
-          <button onClick={onClose} className="btn-ghost p-2">
-            <X className="h-6 w-6" />
-          </button>
         </div>
-
-        {/* Content */}
-        <div className="max-h-[calc(90vh-8rem)] space-y-8 overflow-y-auto p-6">
-          {sections.map((section) => (
-            <section key={section.title}>
-              <h3 className="text-muted-foreground mb-4 flex items-center gap-2 text-sm font-medium tracking-wider uppercase">
-                {section.icon}
-                {section.title}
-              </h3>
-              <div className="space-y-4">{section.content}</div>
-            </section>
-          ))}
-        </div>
-
-        {/* Footer */}
+      }
+      footer={
         <div className="bg-muted/50 border-border flex justify-end border-t px-6 py-4">
           <button onClick={onClose} className="btn-primary">
             Got it
           </button>
         </div>
+      }
+    >
+      <div className="space-y-8 p-6">
+        {sections.map((section) => (
+          <section key={section.title}>
+            <h3 className="text-muted-foreground mb-4 flex items-center gap-2 text-sm font-medium tracking-wider uppercase">
+              {section.icon}
+              {section.title}
+            </h3>
+            <div className="space-y-4">{section.content}</div>
+          </section>
+        ))}
       </div>
-    </div>
+    </Modal>
   )
 }
 


### PR DESCRIPTION
## Summary

`VisualGuideModal` (backing both `BunkingLegendButton` and `WeekendLegendButton`) hand-rolled its own modal shell instead of using the app's shared `ui/Modal` primitive, so it was missing:

- Escape-to-close
- the `document.body` portal (so it escapes ancestor stacking contexts, e.g. `z-[60]` panels)
- a close button with an accessible name (the old one was a bare `<X>` icon)

This swaps the chrome onto `Modal`'s `header`/`footer` slots. The `sections` parameterisation from #1997 is unchanged — summer and weekend still render entirely different content through the one shared shell.

## Owner ruling

Per the owner: adopt `ui/Modal` and accept the resulting visual change. The card's `animate-fade-in`/`animate-scale-in` open animation is gone — `Modal` has no animation prop and none was added, deliberately, since a pass-through prop would touch `Modal.tsx`, which #2025 is adding a focus trap to in parallel. This PR does not modify `Modal.tsx` at all (verified via `git diff --name-only origin/main...HEAD`).

## Test plan

- [x] Added failing tests first (Escape closes, portal into `document.body`, close button has an accessible name) for both `BunkingLegendButton` and `WeekendLegendButton`; confirmed they failed against the old implementation, then implemented.
- [x] `./node_modules/.bin/vitest run src/components/BunkingLegend.test.tsx src/components/ui/Modal.test.tsx` — 59 passed
- [x] `./node_modules/.bin/tsc --noEmit` — clean
- [x] `./node_modules/.bin/eslint` / `./node_modules/.bin/prettier --check` — clean
- [x] `git diff --name-only origin/main...HEAD` — only `BunkingLegend.tsx` and its test; `Modal.tsx` untouched

Closes #2156.
