### PR TITLE
feat(frontend): hatch spaces that cannot meet a family's needs during the drag

### DIFF
--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -91,6 +91,18 @@ EffectiveBathroom = Literal["unknown", "none", "private", "shared"]
 # here. It is never coerced into either.
 Shareability = Literal["unknown", "shareable", "single_party"]
 
+# How much of a slot carries one amenity, resolved over its LEAF descendants
+# (kindred#1912). Three grains rather than a bool because both boolean
+# policies fall out of it for free -- `OR == != "none"`, `AND == == "all"` --
+# and because what SOME means differs per criterion: for `is_accessible`, some
+# is worse than none, since a building advertising two step-free rooms out of
+# ten invites the placement that lands in one of the other eight.
+#
+# "unknown" is the absence of evidence, exactly as EffectiveBathroom and
+# Shareability spell their own. `has_power = False` on an unconfirmed row
+# means "nobody has said", not "there is no power". See `amenity_coverage`.
+AmenityCoverage = Literal["all", "some", "none", "unknown"]
+
 # The STAFF-OWNED weekend status, from lodging_session_status (1500000142).
 # Unlike every other vocabulary in this module it mirrors no Go ingest, because
 # there is no ingest: CampMinder's Sessions API has no status concept at all,
@@ -140,6 +152,18 @@ class LodgingUnitSummary(BaseModel):
     bathroom_group: str = ""
     near_bathhouse: bool = False
     has_power: bool = False
+    # The SAME question `has_power` answers, asked of the rooms a slot
+    # actually contains rather than of the row (kindred#1912). Additive, never
+    # a replacement: `has_power` is still the registry's own fact, and the
+    # amenity strip on the card renders that. This is what a drop is judged
+    # against, because a container's flags describe the container -- twelve of
+    # the fourteen 2026 family-pool containers record `has_power = 0` while
+    # every leaf beneath them has power.
+    #
+    # Defaults to "unknown" rather than "none" for the same reason
+    # `amenity_coverage` never returns "none" on missing evidence: a payload
+    # built without the resolution pass must not claim an unmet need.
+    power_coverage: AmenityCoverage = "unknown"
     has_ac: bool = False
     has_fridge: bool = False
     is_accessible: bool = False

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -614,10 +614,23 @@ def _resolve_power_coverage(units: list[LodgingUnitSummary], index: _BathroomInd
 
     Rooms that are `is_active = False` do not answer for their building -- the
     same filter `_effective_sleeps` applies when totalling a combined
-    container's rooms, and for the same reason: nobody can be placed there. A
-    unit with no leaf descendants (every ordinary room, and a childless
-    container) answers for itself, mirroring `container_bathroom`'s "nothing
-    to inherit, so the container reports what its own row says".
+    container's rooms, and for the same reason: nobody can be placed there.
+
+    A LEAF answers for itself: it has nothing beneath it to inherit from, so
+    its own row is the only fact there is. A CONTAINER never does, and that
+    asymmetry is the point of the function. Once no active room is left to
+    supply the answer the container reports `unknown`, exactly as
+    `_effective_sleeps` returns `None` in the same degenerate case ("0 is not
+    a delta over anything, it is the claim 'this house sleeps nobody'"). It is
+    tempting to fall back to the container's own flag here, on
+    `container_bathroom`'s "nothing to inherit, so the container reports what
+    its own row says" -- but that reasoning holds for `bathroom` only because
+    a container's stored `"none"` is a deliberate registry convention.
+    `has_power` is not: THIRTEEN of the fifteen 2026 containers record
+    `has_power = 0` while their rooms are powered, so the fallback would take
+    the one field this function exists to distrust and publish it as "nothing
+    here has power" -- a mark stating a fact no row supports, in the
+    plausible-looking direction.
 
     IN PLACE, on the very objects `index.units_by_code` holds, rather than
     returning a rebuilt list: a second list of summaries would leave the index
@@ -630,7 +643,7 @@ def _resolve_power_coverage(units: list[LodgingUnitSummary], index: _BathroomInd
             for code in sorted(index.leaf_codes_under(unit.code))
             if (leaf := index.units_by_code.get(code)) is not None and leaf.is_active
         ]
-        answering = rooms or [unit]
+        answering = rooms if unit.is_container else [unit]
         unit.power_coverage = cast(
             AmenityCoverage,
             # `None` where nobody has confirmed the row: an unconfirmed

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -23,6 +23,7 @@ from api.constants.lodging import INFANT_BED_EXEMPT_MONTHS, is_attending_adult_n
 from api.schemas.lodging import (
     PHI_FIELD_NAMES,
     AccessibilityFlagSummary,
+    AmenityCoverage,
     EffectiveBathroom,
     HouseholdMedicalResponse,
     LodgingUnitSummary,
@@ -44,6 +45,7 @@ from api.schemas.lodging import (
     WeekendSummaryResponse,
 )
 from api.services.lodging_rules import (
+    amenity_coverage,
     container_bathroom,
     effective_bathroom,
     is_family_available,
@@ -585,6 +587,60 @@ def _resolve_party_bathroom(unit_codes: list[str], index: _BathroomIndex) -> str
     return effective_bathroom(bathroom, group, index.group_members.get(group, frozenset()), frozenset(occupied))
 
 
+def _resolve_power_coverage(units: list[LodgingUnitSummary], index: _BathroomIndex) -> None:
+    """Fill in every unit's `power_coverage` in place — kindred#1912.
+
+    Beside `_resolve_party_bathroom` above, and for the identical reason: a
+    container's registry row describes the CONTAINER, not its rooms. Twelve of
+    the fourteen 2026 family-pool containers record `has_power = 0` while
+    every leaf beneath them has power, so the board judging a drop against the
+    row marks twelve entirely-powered buildings unpowered.
+
+    Resolved SERVER-SIDE and never stored. The admin panels write
+    `lodging_units` straight to PocketBase from the browser
+    (`frontend/src/services/lodgingCrud.ts`), bypassing FastAPI entirely, so a
+    stored `effective_has_power` column would have no recompute trigger on the
+    one path that actually edits amenities and would go stale the first time
+    staff toggled a flag.
+
+    Walks `index.leaf_codes_under`, which is the ONE walk over this tree --
+    already shared by `_resolve_party_bathroom` and `_build_counts` -- rather
+    than a second traversal of its own, because two walks over one tree are
+    free to drift. It recurses to LEAVES at any depth, which is the whole
+    point: `hc-health-center` looks split one level down (1 powered child, 2
+    not) and is not, because its two "unpowered" children are themselves
+    containers whose every leaf has power. A one-level walk gets that wrong in
+    the direction that looks plausible.
+
+    Rooms that are `is_active = False` do not answer for their building -- the
+    same filter `_effective_sleeps` applies when totalling a combined
+    container's rooms, and for the same reason: nobody can be placed there. A
+    unit with no leaf descendants (every ordinary room, and a childless
+    container) answers for itself, mirroring `container_bathroom`'s "nothing
+    to inherit, so the container reports what its own row says".
+
+    IN PLACE, on the very objects `index.units_by_code` holds, rather than
+    returning a rebuilt list: a second list of summaries would leave the index
+    pointing at the pre-resolution copies, which is exactly the kind of drift
+    the one-index-per-call rule above exists to prevent.
+    """
+    for unit in units:
+        rooms = [
+            leaf
+            for code in sorted(index.leaf_codes_under(unit.code))
+            if (leaf := index.units_by_code.get(code)) is not None and leaf.is_active
+        ]
+        answering = rooms or [unit]
+        unit.power_coverage = cast(
+            AmenityCoverage,
+            # `None` where nobody has confirmed the row: an unconfirmed
+            # `has_power = False` means "nobody has said", never "there is no
+            # power" -- the same gate `rosterAttention` already applies to the
+            # roster's own fit check.
+            amenity_coverage([room.has_power if room.is_confirmed else None for room in answering]),
+        )
+
+
 class LodgingRosterService:
     """Builds the read-only weekend roster from repository output."""
 
@@ -739,6 +795,10 @@ class LodgingRosterService:
         # same `unit_summaries` for `_build_counts` was caught in review on
         # kindred#2041's PR.
         unit_index = _BathroomIndex.build(unit_summaries)
+        # Only on THIS path. `build_summary` builds its own units and index to
+        # get at the counts, but its `WeekendSummaryEntry` carries no `units`
+        # -- so resolving coverage there would be work no response can read.
+        _resolve_power_coverage(unit_summaries, unit_index)
         parties = self._build_parties(
             session_type=session_type,
             session_start=_as_date(_s(session, "start_date")),

--- a/api/services/lodging_rules.py
+++ b/api/services/lodging_rules.py
@@ -25,6 +25,8 @@ ingest never touches.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 # Values of lodging_units.bathroom. An unset PocketBase select stores as "",
 # which means "nobody has told us yet", not "no bathroom".
 BATHROOM_VALUES = ("none", "private", "shared")
@@ -138,6 +140,61 @@ def effective_bathroom(
     if group_member_codes and group_member_codes <= merged_codes:
         return "private"
     return "shared"
+
+
+# Values of an amenity's resolved coverage over the rooms a slot actually
+# contains (kindred#1912). `unknown` is not a fourth grain -- it is the
+# absence of evidence, exactly as it is for `bathroom` and `shareability`.
+AMENITY_COVERAGE_VALUES = ("all", "some", "none", "unknown")
+
+
+def amenity_coverage(values: Sequence[bool | None]) -> str:
+    """How much of a slot carries an amenity — kindred#1912.
+
+    A container's stored amenity flags describe the CONTAINER, not its rooms.
+    That is the same shape as the settled "a container's `sleeps` is a delta
+    over its rooms" ruling, on a different column, and it is the trap this
+    function exists for: twelve of the fourteen 2026 family-pool containers
+    record `has_power = 0` while every leaf beneath them has power, so a
+    caller reading the container's own row marks twelve entirely-powered
+    buildings unpowered.
+
+    THREE grains, not a boolean, because both boolean policies fall out of it
+    for free -- `OR == result != "none"`, `AND == result == "all"` -- so a
+    per-criterion OR/AND policy map would be a strict subset of this that
+    costs more to build. What the three grains MEAN differs per criterion
+    (for `is_accessible`, SOME is worse than NONE: a building advertising two
+    step-free rooms out of ten invites the placement that lands in one of the
+    other eight), and that nuance belongs to the renderer, not here.
+
+    This function does not walk anything. Resolving which rooms answer for a
+    slot is the caller's job -- `_BathroomIndex.leaf_codes_under` in
+    `lodging_roster_service` is the ONE walk over that tree, and a second one
+    would be free to drift from it.
+
+    Args:
+        values: one entry per unit that answers for the slot -- a leaf's own
+            flag, or every leaf descendant's for a container. `None` means
+            the unit is unconfirmed, i.e. nobody has recorded the amenity;
+            `has_power = False` on an unconfirmed row means "nobody has
+            said", never "there is no power".
+
+    Returns:
+        "all" | "some" | "none" | "unknown". `unknown` whenever there is
+        nothing to judge or ANY contributing unit is unmeasured -- the same
+        all-or-nothing evidence bar `resolvePartyUnit` already applies to a
+        multi-room merge, rather than a looser standard for having more
+        rooms. Never "none" on missing evidence: this feeds a mark that
+        STATES something about a slot, and "nothing here meets the need" is
+        not a claim an unrecorded row supports.
+    """
+    if not values or any(value is None for value in values):
+        return "unknown"
+    if all(values):
+        return "all"
+    if any(values):
+        return "some"
+    return "none"
 
 
 def container_bathroom(leaf_bathroom_groups: frozenset[str]) -> tuple[str, str]:

--- a/frontend/src/components/weekend/LodgingBoard.drag.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.drag.test.tsx
@@ -14,7 +14,7 @@
  * Fictional data throughout.
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render } from '@testing-library/react'
+import { act, render } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { MemoryRouter } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -63,6 +63,8 @@ vi.mock('../../hooks/useUnitMerge', () => ({
 
 /** The last `onDragEnd` the board handed to DndContext. */
 let onDragEnd: ((event: unknown) => void) | undefined
+/** Its `onDragStart` sibling — the half the needs-misfit hatch (#1912) rides on. */
+let onDragStart: ((event: unknown) => void) | undefined
 
 vi.mock('@dnd-kit/core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@dnd-kit/core')>()
@@ -71,11 +73,14 @@ vi.mock('@dnd-kit/core', async (importOriginal) => {
     DndContext: ({
       children,
       onDragEnd: handler,
+      onDragStart: startHandler,
     }: {
       children: ReactNode
       onDragEnd: (e: unknown) => void
+      onDragStart: (e: unknown) => void
     }) => {
       onDragEnd = handler
+      onDragStart = startHandler
       return <div data-testid="dnd-context">{children}</div>
     },
   }
@@ -86,6 +91,7 @@ let client: QueryClient
 beforeEach(() => {
   vi.clearAllMocks()
   onDragEnd = undefined
+  onDragStart = undefined
   placementOptions = []
   client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 })
@@ -164,6 +170,14 @@ function renderBoard(props: Partial<Parameters<typeof LodgingBoard>[0]> = {}) {
     />,
     { wrapper }
   )
+}
+
+function startDrag(activeId: string) {
+  if (!onDragStart) throw new Error('the board never registered a drag-start handler')
+  const start = onDragStart
+  act(() => {
+    start({ active: { id: activeId } })
+  })
 }
 
 function drop(activeId: string, overId: string | null) {
@@ -248,5 +262,64 @@ describe('LodgingBoard — a drop becomes a write', () => {
       sessionCmId: 1000001,
       scenario: SCENARIO,
     })
+  })
+})
+
+describe('LodgingBoard — threading the dragged family for the needs hatch (#1912)', () => {
+  /*
+   * The card receives no drag state of its own, so the board is where the
+   * party in flight reaches all ~82 of them. That plumbing IS the frontend
+   * half of #1912; the mark itself is pinned in `LodgingUnitCard.test.tsx`.
+   *
+   * Advisory throughout: nothing here disables a droppable or dims a card.
+   */
+  const needsPower = party({
+    household_cm_id: 101,
+    flags: { needs_power: true },
+  })
+  const dark = unit({ unit_id: 'u1', code: 'cedar-1', name: 'Cedar 1', power_coverage: 'none' })
+  const lit = unit({ unit_id: 'u2', code: 'cedar-2', name: 'Cedar 2', power_coverage: 'all' })
+
+  function cards(container: HTMLElement) {
+    return {
+      dark: container.querySelector('[data-unit-code="cedar-1"]'),
+      lit: container.querySelector('[data-unit-code="cedar-2"]'),
+    }
+  }
+
+  it('marks nothing until a family is actually in flight', () => {
+    const { container } = renderBoard({ parties: [needsPower], units: [dark, lit] })
+    expect(cards(container).dark).not.toHaveAttribute('data-needs-fit')
+  })
+
+  it('marks the spaces that cannot meet the dragged family need', () => {
+    const { container } = renderBoard({ parties: [needsPower], units: [dark, lit] })
+    startDrag('household-101')
+    expect(cards(container).dark).toHaveAttribute('data-needs-fit', 'unmet')
+    expect(cards(container).lit).not.toHaveAttribute('data-needs-fit')
+  })
+
+  it("leaves the drop accepted — this is advisory, not #2087's block", () => {
+    const { container } = renderBoard({ parties: [needsPower], units: [dark, lit] })
+    startDrag('household-101')
+    expect(cards(container).dark).not.toHaveClass('opacity-40')
+    expect(cards(container).dark).not.toHaveClass('pointer-events-none')
+    drop('household-101', unitDroppableId('cedar-1'))
+    expect(move).toHaveBeenCalledTimes(1)
+  })
+
+  it('raises no hatch for a MERGE drag, which carries no family at all', () => {
+    // `handleDragStart` clears `dragging` the moment it recognises a card
+    // drag, so the misfit hatch and the invalid-merge dim can never be raised
+    // by one gesture — which is why the card needs no gate between them.
+    const { container } = renderBoard({
+      parties: [needsPower],
+      units: [
+        { ...dark, parent_code: 'east-wing' },
+        { ...lit, parent_code: 'east-wing' },
+      ],
+    })
+    startDrag('merge:cedar-2')
+    expect(cards(container).dark).not.toHaveAttribute('data-needs-fit')
   })
 })

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -468,6 +468,19 @@ export function LodgingBoard({
                             onSetAvailability={writeAvailability}
                             canMerge={canMergeUnits}
                             mergeSourceUnit={draggingMergeUnit}
+                            // The FAMILY in flight (#1912), broadcast to
+                            // every card exactly as `mergeSourceUnit` above
+                            // is: fit is a question about a pair, and the
+                            // card only ever saw the space half of it. Each
+                            // one resolves its own verdict from this, against
+                            // the server's leaf-resolved coverage.
+                            //
+                            // `dragging` and `draggingMergeUnit` are mutually
+                            // exclusive by construction (`handleDragStart`
+                            // clears one when it sets the other), so the
+                            // advisory misfit hatch and the invalid-merge dim
+                            // can never be raised by the same gesture.
+                            draggingParty={dragging}
                             onSplit={splitUnit}
                             onMerge={mergeUnit}
                             // THIS card, or its PARENT. A merge names the

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -1402,3 +1402,166 @@ describe('LodgingUnitCard shareability (kindred#2026)', () => {
     expect(screen.getByText('Sharing unset')).toBeInTheDocument()
   })
 })
+
+describe('LodgingUnitCard — the needs-misfit hatch (#1912)', () => {
+  /*
+   * The board's signal vocabulary, ruled 2026-08-09 and binding here:
+   *
+   *   dim (`opacity-40` + `pointer-events-none`) = REFUSAL — an invalid merge
+   *     target, or a held space (#2087). "You may not."
+   *   hatch (`background-image`, FULL strength) = ADVISORY MISFIT — "it will
+   *     work; nothing here meets the need". This block.
+   *   forest tint = open and available, at rest (#2093).
+   *
+   * The hatch must never touch opacity. Counted across the board there were
+   * four meanings on the opacity channel before the ruling, three of them
+   * able to appear at once mid-drag; a card dimmed for a fit miss reads as a
+   * weaker refusal rather than as a different kind of statement.
+   */
+  const hue = 'hsl(160 45% 42%)'
+  /** Enough of the arbitrary property to identify the mark, whatever its period. */
+  const HATCH = '[background-image:repeating-linear-gradient'
+  const needsPower = party({ flags: { needs_power: true } })
+
+  function card(container: HTMLElement): HTMLElement {
+    const el = container.querySelector('[data-unit-card]')
+    if (!el) throw new Error('no card rendered')
+    return el as HTMLElement
+  }
+
+  function hatchClass(container: HTMLElement): string {
+    const el = card(container)
+    return [...el.classList].find((name) => name.startsWith(HATCH)) ?? ''
+  }
+
+  it('marks nothing at rest, however badly the space fits', () => {
+    // The mark is a DRAG-STATE mark. At rest there is no family to judge it
+    // against, and a permanently hatched board says nothing at all.
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: unit({ power_coverage: 'none' }) })}
+        hue={hue}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(hatchClass(container)).toBe('')
+    expect(card(container)).not.toHaveAttribute('data-needs-fit')
+  })
+
+  it('hatches a space where no room meets the dragged family need', () => {
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: unit({ power_coverage: 'none' }) })}
+        hue={hue}
+        draggingParty={needsPower}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(hatchClass(container)).toContain('repeating-linear-gradient')
+    expect(card(container)).toHaveAttribute('data-needs-fit', 'unmet')
+  })
+
+  it('grades SOME from NONE by hatch period, never by a second channel', () => {
+    const none = render(
+      <LodgingUnitCard
+        slot={slot({ unit: unit({ power_coverage: 'none' }) })}
+        hue={hue}
+        draggingParty={needsPower}
+        onOpenParty={vi.fn()}
+      />
+    )
+    const some = render(
+      <LodgingUnitCard
+        slot={slot({ unit: unit({ power_coverage: 'some' }) })}
+        hue={hue}
+        draggingParty={needsPower}
+        onOpenParty={vi.fn()}
+      />
+    )
+    const tight = hatchClass(none.container)
+    const wide = hatchClass(some.container)
+    expect(tight).not.toBe('')
+    expect(wide).not.toBe('')
+    expect(tight).not.toBe(wide)
+    // Same ink, different spacing. If the two ever differ in their colour
+    // stop, the grade has quietly moved onto a strength channel.
+    expect(tight).toContain('hsl(var(--foreground)_/_0.1)')
+    expect(wide).toContain('hsl(var(--foreground)_/_0.1)')
+    expect(some.container.querySelector('[data-unit-card]')).toHaveAttribute(
+      'data-needs-fit',
+      'partial'
+    )
+  })
+
+  it('never dims — the hatch is advisory and a dim is a refusal', () => {
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: unit({ power_coverage: 'none' }) })}
+        hue={hue}
+        canPlace
+        draggingParty={needsPower}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(hatchClass(container)).not.toBe('')
+    expect(card(container)).not.toHaveClass('opacity-40')
+    expect(card(container)).not.toHaveClass('pointer-events-none')
+    expect([...card(container).classList].filter((n) => n.startsWith('opacity-'))).toEqual([])
+  })
+
+  it('leaves a space that meets the need unmarked mid-drag', () => {
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: unit({ power_coverage: 'all' }) })}
+        hue={hue}
+        draggingParty={needsPower}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(hatchClass(container)).toBe('')
+  })
+
+  it('marks nothing for a family that asked for nothing', () => {
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: unit({ power_coverage: 'none' }) })}
+        hue={hue}
+        draggingParty={party()}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(hatchClass(container)).toBe('')
+  })
+
+  it('judges the resolved coverage, never the container row', () => {
+    // Twelve of the fourteen 2026 family-pool containers record
+    // `has_power = 0` while every leaf beneath them has power.
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: unit({ has_power: false, power_coverage: 'all' }) })}
+        hue={hue}
+        draggingParty={needsPower}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(hatchClass(container)).toBe('')
+  })
+
+  it('composes with the open-space forest tint rather than suppressing it', () => {
+    // ORTHOGONAL properties: #2093's tint is `background-color`, this is
+    // `background-image`. Both paint, at full strength — an empty space that
+    // does not meet the need is still an empty space. No suppression logic
+    // belongs between them, and adding any would be reaching into #2093's
+    // own gate.
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: unit({ power_coverage: 'none' }) })}
+        hue={hue}
+        draggingParty={needsPower}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(card(container)).toHaveClass('bg-primary/10')
+    expect(hatchClass(container)).not.toBe('')
+  })
+})

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -23,6 +23,7 @@ import {
 } from './boardLayout'
 import { isValidMergeTarget, mergeDragId, unitDroppableId } from './dragPlacement'
 import { FamilyCard } from './FamilyCard'
+import { resolveNeedsFit } from './needsFit'
 import { resolveRingPrecedence } from './ringPrecedence'
 import { partyKey } from './partyKey'
 import { reservationBadge, shareabilityBadge } from './unitBadges'
@@ -85,6 +86,45 @@ const RING_CLASSES: Record<'dropTarget' | 'consentFlagged' | 'shared' | 'plain',
   plain: '',
 }
 
+/**
+ * The needs-misfit mark (#1912) — TEXTURE, and nothing else.
+ *
+ * The board's hues are committed (forest to area identity, amber to share
+ * consent, red to over-capacity), so a fifth meaning cannot have a fifth
+ * colour without collapsing the ones that exist. It cannot have an OPACITY
+ * either: the 2026-08-09 signal-vocabulary ruling assigns one channel per
+ * question, and `opacity-40` is REFUSAL ("you may not") — the invalid merge
+ * target below and #2087's held space. This mark says "it will work; nothing
+ * here meets the need", which is a different KIND of statement rather than a
+ * weaker refusal, so it stays at full contrast: legible, droppable, flagged.
+ *
+ * Additive, never a `RING_CLASSES` entry, for the reason that table's own doc
+ * gives: it exists only for channels that fight over one CSS property
+ * (`border-color`, `box-shadow`). `background-image` competes with neither —
+ * including with #2093's `bg-primary/10` open-space tint, which is
+ * `background-color`. The two compose deliberately: a drag-state mark over a
+ * resting-state marker, each still saying its own true thing.
+ *
+ * Degree is the hatch PERIOD and only the period — same angle, same ink, same
+ * alpha, tighter lines. Grading NONE from SOME on a second channel is exactly
+ * the collapse the ruling struck.
+ *
+ * An ARBITRARY PROPERTY rather than a `bg-` utility, so there is no question
+ * of Tailwind inferring `background-color` from a gradient value; and a
+ * `--foreground` token rather than a fixed ink, so the mark inverts with the
+ * theme for free. Both class strings are complete literals because Tailwind
+ * scans raw source text — a composed string emits nothing at all, which is
+ * the `forest-950` failure (#1894) CLAUDE.md §4 names. Verified against a
+ * real `vite build`: both rules are in the emitted stylesheet, setting
+ * `background-image` and no other property.
+ */
+const NEEDS_HATCH_CLASSES: Record<'unmet' | 'partial', string> = {
+  unmet:
+    '[background-image:repeating-linear-gradient(45deg,transparent_0_4px,hsl(var(--foreground)_/_0.1)_4px_5px)]',
+  partial:
+    '[background-image:repeating-linear-gradient(45deg,transparent_0_10px,hsl(var(--foreground)_/_0.1)_10px_11px)]',
+}
+
 /** What the reserve/release control asks the board to write. */
 export interface UnitAvailabilityWrite {
   familyAvailable: boolean | null
@@ -139,6 +179,21 @@ export interface LodgingUnitCardProps {
    */
   mergeSourceUnit?: LodgingUnitRow | null
   /**
+   * The FAMILY currently in flight, or `null`/`undefined` when no party drag
+   * is running — the same board-wide broadcast `mergeSourceUnit` above is,
+   * and for the same reason: every card gets the identical value and decides
+   * its own verdict from it.
+   *
+   * The card has no other way to know. Fit is a question about a PAIR, and
+   * until #1912 this component only ever saw one half of it.
+   *
+   * A merge drag never sets this — `LodgingBoard` clears `dragging` the
+   * moment it recognises a card drag — so the misfit hatch and the invalid
+   * merge dim cannot be raised by the same gesture, and no gate between them
+   * is needed here.
+   */
+  draggingParty?: RosterPartyRow | null
+  /**
    * Split a combined card back into its rooms. Rendered only on one, and
    * only when `canMerge` — `undefined` is how the board spells "not writable
    * right now" under `exactOptionalPropertyTypes`, matching `onSetAvailability`
@@ -176,6 +231,7 @@ export function LodgingUnitCard({
   onSetAvailability,
   canMerge = false,
   mergeSourceUnit = null,
+  draggingParty = null,
   onSplit,
   onMerge,
   savingMerge = false,
@@ -381,6 +437,25 @@ export function LodgingUnitCard({
   // an invitation.
   const openMarkerActive = dashed && !held && ringState !== 'dropTarget'
 
+  /*
+   * Whether this space meets the needs of the family in flight (#1912) —
+   * `'fits' | 'partial' | 'unmet'`, resolved by `needsFit.ts` against the
+   * SERVER's `power_coverage`, which is taken over the unit's leaf
+   * descendants rather than off its own row. Twelve of the fourteen 2026
+   * family-pool containers record `has_power = 0` while every leaf beneath
+   * them has power, so judging a building by the flag the amenity strip
+   * renders would mark twelve entirely-powered buildings unpowered.
+   *
+   * `'fits'` at rest, and that is the state, not a fallback: with no family
+   * in flight there is nothing to be a misfit FOR, and a board hatched all
+   * the time says nothing at all.
+   *
+   * ADVISORY. Nothing below this line touches `useDroppable`, `opacity` or
+   * `pointer-events` — the drop is still accepted, exactly as the comment on
+   * the party droppable above insists it must be.
+   */
+  const needsFit = draggingParty === null ? 'fits' : resolveNeedsFit(draggingParty, unit)
+
   // `ringState` alone can't gate the inline ring below: `dimmed` still wins
   // against `shared` specifically (see the comment on `dimmed` above), and
   // `ringState` does not know about `dimmed` by design.
@@ -390,6 +465,10 @@ export function LodgingUnitCard({
     RING_CLASSES[ringState],
     dashed ? 'border-dashed' : '',
     openMarkerActive ? 'bg-primary/10' : '',
+    // Additive and UNGATED against everything above it — see
+    // `NEEDS_HATCH_CLASSES`. `background-image` competes with no other
+    // channel on this card, tint included.
+    needsFit === 'fits' ? '' : NEEDS_HATCH_CLASSES[needsFit],
     dimmed ? 'pointer-events-none opacity-40' : '',
   ]
     .filter(Boolean)
@@ -413,6 +492,15 @@ export function LodgingUnitCard({
     <div
       data-unit-card
       data-unit-code={unit.code}
+      // ABSENT rather than `"fits"` when there is nothing to say, so the
+      // attribute is a mark rather than a per-card verdict log — and so
+      // `exactOptionalPropertyTypes` keeps it out of the DOM entirely.
+      //
+      // No ARIA counterpart, deliberately: this is a drag-state affordance,
+      // and the board registers Mouse and Touch sensors only, so there is no
+      // keyboard drag for a screen reader to be mid-way through. The roster's
+      // own `attentionSections` is where the same fact is stated in text.
+      {...(needsFit === 'fits' ? {} : { 'data-needs-fit': needsFit })}
       ref={setCardRef}
       style={{
         borderTopColor: hue,

--- a/frontend/src/components/weekend/needsFit.test.ts
+++ b/frontend/src/components/weekend/needsFit.test.ts
@@ -1,0 +1,98 @@
+/**
+ * kindred#1912 — does this space meet the dragged family's needs?
+ *
+ * Advisory, never a block: the board still accepts every drop (see
+ * `LodgingUnitCard`'s own comment on `useDroppable`), because every cabin is
+ * unconfirmed until staff walk the property and staff routinely place families
+ * against the machine's opinion and are right to. Deliberately a DIFFERENT
+ * mechanism from #2087's hard block on a held space, which is a refusal.
+ *
+ * Fictional data throughout.
+ */
+import { describe, expect, it } from 'vitest'
+
+import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+import { resolveNeedsFit } from './needsFit'
+
+function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
+  return {
+    unit_id: 'u1',
+    code: 'ridge-1',
+    name: 'Ridge 1',
+    has_power: false,
+    power_coverage: 'none',
+    ...overrides,
+  }
+}
+
+function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
+  return {
+    grain: 'household',
+    household_cm_id: 101,
+    display_name: 'Johnson',
+    ...overrides,
+  }
+}
+
+describe('resolveNeedsFit', () => {
+  it('marks nothing for a family that asked for nothing', () => {
+    expect(resolveNeedsFit(party(), unit({ power_coverage: 'none' }))).toBe('fits')
+  })
+
+  it('marks a space where no room meets the need as unmet', () => {
+    expect(
+      resolveNeedsFit(party({ flags: { needs_power: true } }), unit({ power_coverage: 'none' }))
+    ).toBe('unmet')
+  })
+
+  it('marks a space where only some rooms meet it as partial', () => {
+    expect(
+      resolveNeedsFit(party({ flags: { needs_power: true } }), unit({ power_coverage: 'some' }))
+    ).toBe('partial')
+  })
+
+  it('marks nothing when every room meets the need', () => {
+    expect(
+      resolveNeedsFit(party({ flags: { needs_power: true } }), unit({ power_coverage: 'all' }))
+    ).toBe('fits')
+  })
+
+  it('marks nothing when nobody has recorded the amenity', () => {
+    // `unknown` is the absence of evidence, and the mark STATES something
+    // about a space. "Nothing here has power" is not a claim an unconfirmed
+    // row supports — the same bar `rosterAttention` applies to the roster's
+    // own fit check.
+    expect(
+      resolveNeedsFit(party({ flags: { needs_power: true } }), unit({ power_coverage: 'unknown' }))
+    ).toBe('fits')
+  })
+
+  it('treats a payload with no coverage field at all as unrecorded', () => {
+    const bare = unit()
+    delete (bare as { power_coverage?: string }).power_coverage
+    expect(resolveNeedsFit(party({ flags: { needs_power: true } }), bare)).toBe('fits')
+  })
+
+  it('never reads the raw row — a building with no power but powered rooms fits', () => {
+    // The 12-of-14 trap: twelve of the fourteen 2026 family-pool containers
+    // record `has_power = 0` while every leaf beneath them has power. The
+    // server resolves that; this must not second-guess it off the raw flag.
+    expect(
+      resolveNeedsFit(
+        party({ flags: { needs_power: true } }),
+        unit({ has_power: false, power_coverage: 'all' })
+      )
+    ).toBe('fits')
+  })
+
+  it('takes the worst verdict across dimensions', () => {
+    // Seeded with one dimension today. This pins the combining rule so adding
+    // dimension two is a constant in the table, not a design decision.
+    expect(
+      resolveNeedsFit(
+        party({ flags: { needs_power: true, needs_private_bathroom: true } }),
+        unit({ power_coverage: 'none' })
+      )
+    ).toBe('unmet')
+  })
+})

--- a/frontend/src/components/weekend/needsFit.test.ts
+++ b/frontend/src/components/weekend/needsFit.test.ts
@@ -12,7 +12,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
-import { resolveNeedsFit } from './needsFit'
+import { resolveNeedsFit, worseOf } from './needsFit'
 
 function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
   return {
@@ -85,14 +85,41 @@ describe('resolveNeedsFit', () => {
     ).toBe('fits')
   })
 
-  it('takes the worst verdict across dimensions', () => {
-    // Seeded with one dimension today. This pins the combining rule so adding
-    // dimension two is a constant in the table, not a design decision.
+  it('ignores a need no dimension answers yet', () => {
+    // `needs_private_bathroom` is a real flag with no entry in the table, so
+    // it contributes nothing and the power verdict stands alone. This does
+    // NOT pin the combining rule — with one dimension the loop can only ever
+    // run once, so `worseOf` below is where that rule is actually pinned.
     expect(
       resolveNeedsFit(
         party({ flags: { needs_power: true, needs_private_bathroom: true } }),
         unit({ power_coverage: 'none' })
       )
     ).toBe('unmet')
+  })
+})
+
+describe('worseOf', () => {
+  /*
+   * The combining rule, tested directly rather than through
+   * `resolveNeedsFit`, because `NEEDS_DIMENSIONS` holds ONE entry: a
+   * `resolveNeedsFit` assertion would pass just as happily against a
+   * combiner that kept the LAST verdict rather than the worst, and so would
+   * pin nothing. The issue's whole claim is that dimension two is a constant
+   * in the table and not a design exercise; this is what makes that true.
+   */
+  it('keeps the worse verdict whichever side it arrives on', () => {
+    expect(worseOf('unmet', 'fits')).toBe('unmet')
+    expect(worseOf('fits', 'unmet')).toBe('unmet')
+    expect(worseOf('partial', 'fits')).toBe('partial')
+    expect(worseOf('fits', 'partial')).toBe('partial')
+    expect(worseOf('unmet', 'partial')).toBe('unmet')
+    expect(worseOf('partial', 'unmet')).toBe('unmet')
+  })
+
+  it('returns the shared verdict when both agree', () => {
+    expect(worseOf('fits', 'fits')).toBe('fits')
+    expect(worseOf('partial', 'partial')).toBe('partial')
+    expect(worseOf('unmet', 'unmet')).toBe('unmet')
   })
 })

--- a/frontend/src/components/weekend/needsFit.ts
+++ b/frontend/src/components/weekend/needsFit.ts
@@ -1,0 +1,109 @@
+/**
+ * Does this space meet the dragged family's needs? — kindred#1912.
+ *
+ * ADVISORY. It is not a blocker, and it must never become one: the board
+ * accepts every drop on purpose (see `LodgingUnitCard`'s comment on the party
+ * `useDroppable`), because no cabin is confirmed until staff walk the
+ * property and staff routinely place families against the machine's opinion.
+ * This says "nothing here has power", never "you may not".
+ *
+ * That distinction is carried by the MECHANISM, not only by the wording, and
+ * the board's signal vocabulary (owner ruling, 2026-08-09) is what keeps the
+ * two apart:
+ *
+ *   dim  (`opacity-40` + `pointer-events-none`) = REFUSAL. Owned by the
+ *        invalid merge target and by a held space (#2087). Not this.
+ *   hatch (`background-image`, at FULL strength)= ADVISORY MISFIT. This.
+ *   forest tint                                  = open and available, at rest
+ *        only (#2093).
+ *
+ * So the mark this feeds changes `background-image` and nothing else. Putting
+ * fit on opacity would have made it read as a weaker refusal rather than as a
+ * different kind of statement, which is exactly the collapse the vocabulary
+ * ruling exists to prevent.
+ *
+ * Pure, and in its own module rather than inside the card, for the same
+ * reason `ringPrecedence` and `boardLayout` are: a rule with a truth table is
+ * testable without rendering ~82 cards.
+ */
+import type { AccessibilityFlags, LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+
+/**
+ * The resolved amenity coverage the SERVER publishes, over a slot's leaf
+ * descendants rather than its own row (`amenity_coverage` in
+ * `api/services/lodging_rules.py`).
+ *
+ * Derived from the generated type, never hand-written: a change to the
+ * Pydantic Literal must become a type error here rather than a silently
+ * unreachable branch.
+ */
+type AmenityCoverage = NonNullable<LodgingUnitRow['power_coverage']>
+
+/** Worst first. The order of this array IS the precedence. */
+const FIT_ORDER = ['unmet', 'partial', 'fits'] as const
+
+export type NeedsFit = (typeof FIT_ORDER)[number]
+
+/**
+ * One needs-vs-amenity pairing.
+ *
+ * SEEDED WITH EXACTLY ONE — `needs_power` vs the server's resolved power
+ * coverage — to prove the case. A second dimension is a further entry in this
+ * array and nothing else; if adding one needs design work, dimension one was
+ * built wrong.
+ *
+ * `someIs` is the per-criterion nuance the grain deliberately does NOT carry,
+ * because the three grains do not mean the same thing for every criterion.
+ * For power, a building where some rooms have it is a real improvement on one
+ * where none do, so SOME is a softer mark. For `is_accessible`, SOME will be
+ * WORSE than NONE and must map to `unmet`: a building advertising two
+ * step-free rooms out of ten invites precisely the placement that lands in
+ * one of the other eight, where a building advertising nothing does not.
+ *
+ * There is deliberately no OR/AND policy map. Both policies fall out of the
+ * grain for free (`OR === coverage !== 'none'`, `AND === coverage === 'all'`),
+ * so a policy map would be a strict subset of this that costs more to build.
+ */
+interface NeedsDimension {
+  /** The household's asked-for need. */
+  readonly flag: keyof AccessibilityFlags
+  /** The unit's answer, resolved server-side over its leaf descendants. */
+  readonly coverage: (unit: LodgingUnitRow) => AmenityCoverage
+  /** What a partially-covered space reads as for THIS criterion. */
+  readonly someIs: Exclude<NeedsFit, 'fits'>
+}
+
+const NEEDS_DIMENSIONS: readonly NeedsDimension[] = [
+  {
+    flag: 'needs_power',
+    // `power_coverage`, never the raw `has_power`. Twelve of the fourteen
+    // 2026 family-pool containers record `has_power = 0` while every leaf
+    // beneath them has power, so the raw flag marks twelve entirely-powered
+    // buildings unpowered. `?? 'unknown'` is the Pydantic-default gotcha, not
+    // a guess: a field with a default renders optional in TypeScript.
+    coverage: (unit) => unit.power_coverage ?? 'unknown',
+    someIs: 'partial',
+  },
+]
+
+/**
+ * How well `unit` meets `party`'s needs.
+ *
+ * `unknown` coverage reports `fits`, and that is the whole point of the
+ * fourth value: the absence of evidence is not evidence of absence. An
+ * unconfirmed cabin's `has_power = false` means "nobody has said", so marking
+ * it would assert something about a space nobody has measured — the same bar
+ * `rosterAttention`'s `is_confirmed` gate already applies to the roster's own
+ * fit check, and the reason the server resolves `unknown` rather than `none`.
+ */
+export function resolveNeedsFit(party: RosterPartyRow, unit: LodgingUnitRow): NeedsFit {
+  let worst: NeedsFit = 'fits'
+  for (const dimension of NEEDS_DIMENSIONS) {
+    if (party.flags?.[dimension.flag] !== true) continue
+    const coverage = dimension.coverage(unit)
+    const verdict: NeedsFit =
+      coverage === 'none' ? 'unmet' : coverage === 'some' ? dimension.someIs : 'fits'
+    if (FIT_ORDER.indexOf(verdict) < FIT_ORDER.indexOf(worst)) worst = verdict
+  }
+  return worst
+}

--- a/frontend/src/components/weekend/needsFit.ts
+++ b/frontend/src/components/weekend/needsFit.ts
@@ -45,6 +45,20 @@ const FIT_ORDER = ['unmet', 'partial', 'fits'] as const
 export type NeedsFit = (typeof FIT_ORDER)[number]
 
 /**
+ * The worse of two verdicts, by `FIT_ORDER`.
+ *
+ * Exported, and a named function rather than an inline comparison in the
+ * loop below, because `NEEDS_DIMENSIONS` holds exactly ONE entry: the loop
+ * can never run twice, so no assertion made through `resolveNeedsFit` can
+ * distinguish "worst wins" from "the last dimension wins". The combining
+ * rule is the one part of this module that a second dimension will lean on,
+ * and it would otherwise ship untested — pinned directly instead.
+ */
+export function worseOf(a: NeedsFit, b: NeedsFit): NeedsFit {
+  return FIT_ORDER.indexOf(a) <= FIT_ORDER.indexOf(b) ? a : b
+}
+
+/**
  * One needs-vs-amenity pairing.
  *
  * SEEDED WITH EXACTLY ONE — `needs_power` vs the server's resolved power
@@ -103,7 +117,7 @@ export function resolveNeedsFit(party: RosterPartyRow, unit: LodgingUnitRow): Ne
     const coverage = dimension.coverage(unit)
     const verdict: NeedsFit =
       coverage === 'none' ? 'unmet' : coverage === 'some' ? dimension.someIs : 'fits'
-    if (FIT_ORDER.indexOf(verdict) < FIT_ORDER.indexOf(worst)) worst = verdict
+    worst = worseOf(verdict, worst)
   }
   return worst
 }

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -1898,6 +1898,10 @@ export type LodgingUnitSummary = {
    */
   has_power?: boolean
   /**
+   * Power Coverage
+   */
+  power_coverage?: 'all' | 'some' | 'none' | 'unknown'
+  /**
    * Has Ac
    */
   has_ac?: boolean

--- a/frontend/src/types/lodging.test.ts
+++ b/frontend/src/types/lodging.test.ts
@@ -129,6 +129,11 @@ const _exhaustiveLodgingUnit: Required<LodgingUnitRow> = {
   bathroom_group: '',
   near_bathhouse: false,
   has_power: false,
+  // ADDITIVE to `has_power`, never a replacement (kindred#1912): the raw flag
+  // is the registry's own fact about the ROW, and this is the same question
+  // resolved over the rooms the slot actually contains. Twelve of the
+  // fourteen 2026 family-pool containers disagree with themselves on it.
+  power_coverage: 'none',
   has_ac: false,
   has_fridge: false,
   is_accessible: false,

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -59,6 +59,7 @@ def _unit(
     default_combined: bool = False,
     parent_unit: str = "",
     shareability: str = "",
+    has_power: bool = False,
 ) -> SimpleNamespace:
     return _rec(
         id=pb_id,
@@ -72,7 +73,7 @@ def _unit(
         bathroom=bathroom,
         bathroom_group=bathroom_group,
         near_bathhouse=False,
-        has_power=False,
+        has_power=has_power,
         has_ac=False,
         has_fridge=False,
         is_accessible=False,
@@ -3382,3 +3383,131 @@ class TestPartySizeIsABedCount:
 
         seen = {call.kwargs["session_start"] for call in build_parties.call_args_list}
         assert seen == {date(2026, 9, 4), date(2026, 10, 10)}
+
+
+class TestUnitPowerCoverage:
+    """kindred#1912 -- `LodgingUnitSummary.power_coverage`, resolved over LEAF
+    descendants rather than read off the row.
+
+    A container's stored amenity flags describe the CONTAINER, not its rooms:
+    the same shape as the settled "a container's `sleeps` is a delta" ruling,
+    on a different column. Twelve of the fourteen 2026 family-pool containers
+    record `has_power = 0` while every leaf beneath them has power, so reading
+    the row marks twelve entirely-powered buildings unpowered.
+
+    Computed here rather than stored, because the admin panels write
+    `lodging_units` straight to PocketBase from the browser
+    (`frontend/src/services/lodgingCrud.ts`), bypassing FastAPI entirely -- a
+    stored `effective_has_power` would have no recompute trigger on the one
+    path that actually edits amenities.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_leaf_answers_for_itself(self) -> None:
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("u1", "ridge-1", "Ridge 1", sleeps=4, has_power=True),
+                _unit("u2", "ridge-2", "Ridge 2", sleeps=4, has_power=False),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        by_code = {u.code: u for u in roster.units}
+        assert by_code["ridge-1"].power_coverage == "all"
+        assert by_code["ridge-2"].power_coverage == "none"
+
+    @pytest.mark.asyncio
+    async def test_a_container_inherits_from_its_rooms_not_its_own_row(self) -> None:
+        """The 12-of-14 trap. The building records no power; every room has it."""
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("c1", "gt-lodge", "Lodge", is_container=True, has_power=False),
+                _unit("u1", "gt-lodge-1", "Lodge 1", sleeps=4, has_power=True, parent_unit="c1"),
+                _unit("u2", "gt-lodge-2", "Lodge 2", sleeps=4, has_power=True, parent_unit="c1"),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        by_code = {u.code: u for u in roster.units}
+        assert by_code["gt-lodge"].power_coverage == "all"
+        assert by_code["gt-lodge"].has_power is False
+
+    @pytest.mark.asyncio
+    async def test_it_resolves_to_leaves_at_any_depth_never_direct_children(self) -> None:
+        """The `hc-health-center` shape, which is why one level is not enough.
+
+        The building's two direct children are themselves containers recording
+        no power, and every leaf beneath THEM has power. A one-level walk
+        answers "none" here -- wrong in the direction that looks plausible.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("c1", "hc-block", "Health Block", is_container=True, has_power=False),
+                _unit("c2", "hc-wing-a", "Wing A", is_container=True, has_power=False, parent_unit="c1"),
+                _unit("c3", "hc-wing-b", "Wing B", is_container=True, has_power=False, parent_unit="c1"),
+                _unit("u1", "hc-a-1", "A1", sleeps=2, has_power=True, parent_unit="c2"),
+                _unit("u2", "hc-b-1", "B1", sleeps=2, has_power=True, parent_unit="c3"),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert {u.code: u.power_coverage for u in roster.units}["hc-block"] == "all"
+
+    @pytest.mark.asyncio
+    async def test_a_split_building_is_some_not_all_or_none(self) -> None:
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("c1", "gt-lodge", "Lodge", is_container=True, has_power=True),
+                _unit("u1", "gt-lodge-1", "Lodge 1", sleeps=4, has_power=True, parent_unit="c1"),
+                _unit("u2", "gt-lodge-2", "Lodge 2", sleeps=4, has_power=False, parent_unit="c1"),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert {u.code: u.power_coverage for u in roster.units}["gt-lodge"] == "some"
+
+    @pytest.mark.asyncio
+    async def test_an_unconfirmed_room_is_unknown_not_unmet(self) -> None:
+        """`has_power = False` on an unconfirmed row means "nobody has said"."""
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[_unit("u1", "ridge-1", "Ridge 1", sleeps=4, is_confirmed=False, has_power=False)],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.units[0].power_coverage == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_one_unconfirmed_room_makes_the_whole_building_unknown(self) -> None:
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("c1", "gt-lodge", "Lodge", is_container=True, has_power=True),
+                _unit("u1", "gt-lodge-1", "Lodge 1", sleeps=4, has_power=True, parent_unit="c1"),
+                _unit("u2", "gt-lodge-2", "Lodge 2", sleeps=4, has_power=True, is_confirmed=False, parent_unit="c1"),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert {u.code: u.power_coverage for u in roster.units}["gt-lodge"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_a_deactivated_room_does_not_answer_for_the_building(self) -> None:
+        """Nobody can be placed in it, so it cannot supply the building's
+        power -- the same `is_active` filter `_effective_sleeps` applies when
+        totalling a combined container's rooms."""
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("c1", "gt-lodge", "Lodge", is_container=True, has_power=False),
+                _unit("u1", "gt-lodge-1", "Lodge 1", sleeps=4, has_power=True, parent_unit="c1"),
+                _unit("u2", "gt-lodge-2", "Lodge 2", sleeps=4, has_power=False, is_active=False, parent_unit="c1"),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert {u.code: u.power_coverage for u in roster.units}["gt-lodge"] == "all"

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -3511,3 +3511,41 @@ class TestUnitPowerCoverage:
         roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
 
         assert {u.code: u.power_coverage for u in roster.units}["gt-lodge"] == "all"
+
+    @pytest.mark.asyncio
+    async def test_a_building_with_no_active_room_left_is_unknown_never_its_own_row(self) -> None:
+        """The degenerate case, ruled the same way `_effective_sleeps` rules it.
+
+        `_effective_sleeps` refuses to answer for a container once no active
+        room is left to supply the answer -- "0 is not a delta over anything,
+        it is the claim 'this house sleeps nobody'". A container's `has_power`
+        is the same kind of value: THIRTEEN of the fifteen 2026 containers
+        record `has_power = 0` while their rooms are powered, so falling back
+        to the row here would take the one field this whole function exists to
+        distrust and turn it into "nothing here has power" -- a hatch stating
+        a fact no row supports, in the plausible-looking direction.
+
+        A LEAF is different and still answers for itself: it has no rooms to
+        inherit from, so its own row is the only fact there is.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("c1", "gt-lodge", "Lodge", is_container=True, has_power=False),
+                _unit("u1", "gt-lodge-1", "Lodge 1", sleeps=4, has_power=True, is_active=False, parent_unit="c1"),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert {u.code: u.power_coverage for u in roster.units}["gt-lodge"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_a_container_that_never_had_rooms_is_unknown_too(self) -> None:
+        """Same rule, reached without anyone retiring anything."""
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[_unit("c1", "gt-lodge", "Lodge", is_container=True, has_power=False)],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.units[0].power_coverage == "unknown"

--- a/tests/unit/api/services/test_lodging_rules.py
+++ b/tests/unit/api/services/test_lodging_rules.py
@@ -16,6 +16,7 @@ Python would regress two fixes that live only on the Go side.
 import pytest
 
 from api.services.lodging_rules import (
+    amenity_coverage,
     container_bathroom,
     effective_bathroom,
     is_family_available,
@@ -145,3 +146,52 @@ class TestContainerBathroom:
 
     def test_no_leaves_inherit_nothing(self) -> None:
         assert container_bathroom(frozenset()) == ("none", "")
+
+
+class TestAmenityCoverage:
+    """kindred#1912. A container's stored amenity flags describe the
+    CONTAINER, not its rooms -- the same shape as the settled
+    "a container's `sleeps` is a delta" ruling, on a different column. In the
+    2026 registry twelve of the fourteen family-pool containers record
+    `has_power = 0` while every leaf beneath them has power, so reading a
+    container's own flag marks twelve entirely-powered buildings unpowered.
+
+    The grain is three-valued rather than boolean because both boolean
+    policies fall out of it for free (`OR == state != "none"`,
+    `AND == state == "all"`), so a per-criterion policy map would be a strict
+    subset that costs more to build.
+
+    `None` is the fourth answer and it is not a grain: it is the ABSENCE of
+    evidence, which `unit_capacity`, `unit_shareability` and
+    `effective_bathroom` each already spell as "unknown" for the same reason.
+    An unconfirmed cabin's `has_power = False` means "nobody has said", not
+    "there is no power" -- the gate `rosterAttention` already applies to the
+    roster's own fit check.
+    """
+
+    def test_every_source_has_it(self) -> None:
+        assert amenity_coverage([True, True, True]) == "all"
+
+    def test_no_source_has_it(self) -> None:
+        assert amenity_coverage([False, False]) == "none"
+
+    def test_a_mixed_set_is_some(self) -> None:
+        assert amenity_coverage([True, False, True]) == "some"
+
+    def test_a_single_source_answers_for_itself(self) -> None:
+        """A leaf has no descendants, so it is its own one-element set."""
+        assert amenity_coverage([True]) == "all"
+        assert amenity_coverage([False]) == "none"
+
+    def test_nothing_to_judge_is_unknown(self) -> None:
+        """Never "none": marking a slot we cannot see as unmet asserts a fact
+        about it, and the mark this feeds exists to state a fact."""
+        assert amenity_coverage([]) == "unknown"
+
+    def test_one_unmeasured_source_makes_the_whole_answer_unknown(self) -> None:
+        """The same all-or-nothing evidence bar `resolvePartyUnit` applies to
+        a merge: one unconfirmed room is an absence of data, not a looser
+        standard for having more rooms."""
+        assert amenity_coverage([True, None]) == "unknown"
+        assert amenity_coverage([False, None]) == "unknown"
+        assert amenity_coverage([None]) == "unknown"


### PR DESCRIPTION
A modular needs-vs-amenity fit check, evaluated **only while a family card is in flight**, that marks the spaces which cannot meet that family's need.

Seeded with exactly one dimension — `needs_power` vs the resolved power coverage — to prove the case. A second dimension is a further entry in `needsFit.ts`'s `NEEDS_DIMENSIONS` table and nothing else.

Closes #1912.

## Hatch only. No opacity change.

Per the 2026-08-09 board signal-vocabulary ruling, one channel answers one question:

| Channel | Means | Owner |
|---|---|---|
| dim (`opacity-40` + `pointer-events-none`) | **refusal** — "this cannot take the drop" | invalid merge target, held space (#2087) |
| hatch (`background-image`, **full strength**) | **advisory misfit** — "it will work; nothing here meets the need" | **this PR** |
| forest tint (`bg-primary/10`) | open and available, at rest | #2093 |

The board still accepts every drop — nothing here touches `useDroppable`, `opacity` or `pointer-events`. NONE and SOME are graded by hatch **period** (5px vs 11px), same angle, same ink, same alpha: the degree never moves onto a second channel.

The hatch is a drag-state mark and #2093's tint is a resting-state marker on `background-color`, so they compose additively and no suppression logic sits between them. `openMarkerActive` is untouched.

## Computed server-side, never stored

The admin panels write `lodging_units` straight to PocketBase from the browser, bypassing FastAPI, so a stored `effective_has_power` column would have no recompute trigger on the one path that actually edits amenities.

- `amenity_coverage()` (`api/services/lodging_rules.py`) reports `all | some | none | unknown` and walks nothing — it is a pure truth table beside `container_bathroom`.
- `_resolve_power_coverage()` (`api/services/lodging_roster_service.py`) resolves it over **leaf descendants at any depth**, reusing `_BathroomIndex.leaf_codes_under` rather than adding a second walk over the same tree. Twelve of the fourteen 2026 family-pool containers record `has_power = 0` while every leaf beneath them has power; `hc-health-center` looks split one level down and is not, which is why direct children are not enough.
- Inactive rooms do not answer for their building — the same `is_active` filter `_effective_sleeps` applies.
- An unconfirmed row reports `unknown`, never `none`: `has_power = false` there means "nobody has said". Same evidence bar `resolvePartyUnit`/`rosterAttention` already apply. All 118 registry rows are confirmed today, so the mark is live.
- Only `build_roster` runs the pass — `build_summary`'s entry carries no `units`.

`LodgingUnitSummary.power_coverage` is **additive** to `has_power`; the amenity strip still renders the raw flag.

## Verification

- TDD throughout; every new test mutation-checked (drop the at-rest gate, pair the hatch with a dim, collapse SOME onto NONE, one-level walk instead of the leaf walk, drop the `is_confirmed` gate, stop threading the party, thread it for a merge drag) — each went RED, then restored.
- `uv run pytest tests/unit/api` 2103 passed; `ruff` / `ruff format --check` / `mypy` clean.
- `vitest run src/components/weekend src/types` 788 passed; `tsc --noEmit` clean; `eslint` 0 errors.
- **Tailwind classes verified against a real `vite build`**: both rules reach the emitted stylesheet setting `background-image` and no other property — not a `forest-950`-style no-op (#1894).
- `scripts/dev/verify-no-hardcoded-lodging.sh` OK.

## Notes

- `frontend/src/components/weekend/needsFit.ts` is new — the pure rule lives outside the component for the same reason `ringPrecedence.ts` does.
- `api/schemas/lodging.py` carries the new field and its `AmenityCoverage` literal; `types.gen.ts` was regenerated (4 added lines, no whitespace churn) and the `Required<>` exhaustive fixture updated.
- Accessibility's `SOME is worse than NONE` nuance is already expressed as the per-dimension `someIs` constant, so dimension two needs no design pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
