### PR TITLE
feat(frontend): drag a map pin to set a unit's coordinates, behind an edit-mode toggle

### DIFF
--- a/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
@@ -988,15 +988,47 @@ describe('LodgingUnitForm — fields staff have no use for', () => {
     expect(screen.getByRole('button', { name: /set it manually/i })).toBeInTheDocument()
   })
 
-  it('asks for no map coordinates, which mean nothing without the map', () => {
-    // Typing 0.4389 into a number field is not how a pin gets placed; dragging
-    // it on the map view is. Omitting the keys leaves any stored coordinate
-    // untouched on update, exactly as a blank field did.
+  it('offers the pin, not two number fields', () => {
+    // kindred#2013. Typing 0.4389 into a number field is not how a pin gets
+    // placed; dragging it onto the cabin is. The coordinate is edited on the
+    // map itself and saved there — it is NOT a field of this form's payload,
+    // which is what keeps the (0,0) guarantee below true by construction.
     renderUnit(UNIT)
 
     expect(screen.queryByLabelText('Map X')).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Map Y')).not.toBeInTheDocument()
-    expect(screen.queryByText(/map position/i)).not.toBeInTheDocument()
+    expect(screen.getByText('Map position')).toBeInTheDocument()
+    expect(screen.getByLabelText(/edit position/i)).not.toBeChecked()
+  })
+
+  it('offers no pin on create, since there is no record to write one to', () => {
+    render(
+      <LodgingUnitForm areas={AREAS} units={[]} year={2026} onSaved={vi.fn()} onCancel={vi.fn()} />
+    )
+
+    expect(screen.queryByText('Map position')).not.toBeInTheDocument()
+  })
+
+  it('offers no pin for a container, which the map never draws', () => {
+    // A building carries its rooms' positions through its children, so
+    // `buildMapModel` draws the children and never the container itself.
+    renderUnit({ ...UNIT, is_container: true })
+
+    expect(screen.queryByText('Map position')).not.toBeInTheDocument()
+  })
+
+  it('withdraws the pin the moment the unit is declared a building', async () => {
+    // Read LIVE off the checkbox, not off the stored record: a staffer who has
+    // just ticked "this is a building" has already made the ruling.
+    const user = userEvent.setup()
+    renderUnit(UNIT)
+    expect(screen.getByText('Map position')).toBeInTheDocument()
+
+    await user.click(
+      screen.getByLabelText('This is a building or building area with multiple bedrooms.')
+    )
+
+    expect(screen.queryByText('Map position')).not.toBeInTheDocument()
   })
 
   it('leaves a stored coordinate alone when saving a unit that has one', async () => {

--- a/frontend/src/components/admin/lodging/LodgingUnitForm.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitForm.tsx
@@ -24,10 +24,17 @@
  *
  *    `sleeps` is the ONLY field with an omission rule, because it is the only
  *    one here whose blank means something. `map_x` / `map_y` used to be the
- *    other half of this paragraph; they are no longer edited on this form at
- *    all, and a stored coordinate now survives a save because the key is
- *    UNCONDITIONALLY ABSENT — not because a guard omits it when blank. Anyone
- *    wiring the map editor back in has to add that guard, not assume it.
+ *    other half of this paragraph, and a stored coordinate survives a save
+ *    because those keys are UNCONDITIONALLY ABSENT from the payload — not
+ *    because a guard omits them when blank.
+ *
+ *    THAT IS STILL TRUE now the map editor is back (kindred#2013), and it is
+ *    true BY CONSTRUCTION rather than by a guard: `UnitMapPositionField`
+ *    writes the coordinate itself on pointer-up, the way
+ *    `LodgingAreasDrawer` writes an area's centroid on blur. It never feeds
+ *    this payload, so there is no blank field here that could land as a 0
+ *    and turn "unpositioned" into "positioned at the top-left". Anyone
+ *    moving the coordinate INTO this payload has to add that guard first.
  *
  * 3. The season is captured WHEN THE EDITOR OPENS, not read live. Units are
  *    year-scoped since 1500000141 and this form always submits `year`, so a
@@ -56,6 +63,7 @@ import { combinedAncestor, directChildren } from './unitTree'
 import { UnitAmenityFieldset } from './UnitAmenityFieldset'
 import { UnitCapacityFields } from './UnitCapacityFields'
 import { UnitIdentityFields } from './UnitIdentityFields'
+import { UnitMapPositionField } from './UnitMapPositionField'
 
 export interface LodgingUnitFormProps {
   areas: LodgingAreaRecord[]
@@ -80,6 +88,13 @@ export interface LodgingUnitFormProps {
   year: number
   onSaved: () => void
   onCancel: () => void
+  /**
+   * A map coordinate landed (kindred#2013). SEPARATE from `onSaved`, which
+   * closes the editor: the pin saves on pointer-up and the staffer is still
+   * working, so the host may only refresh the cached registry here — it must
+   * not dismiss the form out from under them.
+   */
+  onPositionSaved?: (() => void) | undefined
 }
 
 /**
@@ -111,6 +126,7 @@ export function LodgingUnitForm({
   year,
   onSaved,
   onCancel,
+  onPositionSaved,
 }: LodgingUnitFormProps) {
   const [identity, setIdentity] = useState({
     name: unit?.name ?? '',
@@ -327,6 +343,18 @@ export function LodgingUnitForm({
           </div>
         )}
       </div>
+
+      {/* EDIT ONLY, and only for a room. A unit being created has no id to
+          write a coordinate to, and a CONTAINER never gets a pin at all — a
+          building carries its rooms' positions through its children, so
+          `buildMapModel` draws the children and never the building. Read
+          LIVE off `isContainer`, like the capacity flag above: a staffer who
+          has just ticked "this is a building" has already made the ruling.
+          The pin writes on pointer-up and is NOT part of this form's payload
+          — see UnitMapPositionField's header. */}
+      {unit && !isContainer && (
+        <UnitMapPositionField unit={unit} onPositionSaved={onPositionSaved} />
+      )}
 
       <label className="text-sm sm:col-span-2">
         <span className={LABEL}>Notes</span>

--- a/frontend/src/components/admin/lodging/LodgingUnitsPanel.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitsPanel.tsx
@@ -291,6 +291,13 @@ export function LodgingUnitsPanel() {
                 unit={editing === 'new' ? undefined : editing}
                 year={currentYear}
                 onSaved={refresh}
+                // NOT `refresh` (kindred#2013): the map pin saves on
+                // pointer-up while the staffer is still editing, so the
+                // cached registry has to hear about it but the editor must
+                // stay open.
+                onPositionSaved={() => {
+                  invalidateLodgingRegistryQueries(queryClient)
+                }}
                 onCancel={() => {
                   setEditing(null)
                 }}

--- a/frontend/src/components/admin/lodging/UnitMapPositionField.test.tsx
+++ b/frontend/src/components/admin/lodging/UnitMapPositionField.test.tsx
@@ -8,7 +8,7 @@
  * to satisfy and is not an afterthought: with edit mode off, a pointer gesture
  * over this canvas must be incapable of moving a pin or writing a coordinate.
  */
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -78,14 +78,24 @@ function canvasOf(): HTMLElement {
   return canvas
 }
 
-function press(canvas: HTMLElement, x: number, y: number) {
-  fireEvent.pointerDown(canvas, { pointerId: 1, clientX: x, clientY: y })
+function press(canvas: HTMLElement, x: number, y: number, pointerId = 1) {
+  fireEvent.pointerDown(canvas, { pointerId, button: 0, buttons: 1, clientX: x, clientY: y })
 }
-function move(canvas: HTMLElement, x: number, y: number) {
-  fireEvent.pointerMove(canvas, { pointerId: 1, clientX: x, clientY: y })
+/**
+ * A move made WITH THE BUTTON STILL DOWN, which is the only kind a real drag
+ * produces. `buttons` is not decoration here: a move that arrives with no
+ * button held means the release happened somewhere this canvas never saw, and
+ * the field ends the gesture on it — see "released away from the canvas".
+ */
+function move(canvas: HTMLElement, x: number, y: number, pointerId = 1) {
+  fireEvent.pointerMove(canvas, { pointerId, buttons: 1, clientX: x, clientY: y })
 }
-function lift(canvas: HTMLElement, x: number, y: number) {
-  fireEvent.pointerUp(canvas, { pointerId: 1, clientX: x, clientY: y })
+/** The pointer merely passing over the canvas, nothing held down. */
+function hover(canvas: HTMLElement, x: number, y: number, pointerId = 1) {
+  fireEvent.pointerMove(canvas, { pointerId, buttons: 0, clientX: x, clientY: y })
+}
+function lift(canvas: HTMLElement, x: number, y: number, pointerId = 1) {
+  fireEvent.pointerUp(canvas, { pointerId, button: 0, buttons: 0, clientX: x, clientY: y })
 }
 
 const pin = () => screen.queryByTestId('unit-map-pin')
@@ -122,6 +132,15 @@ describe('UnitMapPositionField — the gate', () => {
 
     expect(pin()?.style.left).toBe(before)
     expect(updateLodgingUnit).not.toHaveBeenCalled()
+  })
+
+  it('leaves native touch scrolling alone while the gate is shut', () => {
+    // `touch-none` is what stops a finger from scrolling the page. It belongs
+    // to the drag, so it may only exist while the drag does — otherwise the
+    // gate would still be taxing every staffer who scrolls past this canvas.
+    render(<UnitMapPositionField unit={UNIT} />)
+
+    expect(screen.getByTestId('unit-map-canvas').className).not.toContain('touch-none')
   })
 
   it('offers the gate as a real checkbox, reachable by keyboard', () => {
@@ -233,6 +252,43 @@ describe('UnitMapPositionField — a drag commits on pointer-up', () => {
     expect(payload).toEqual({ map_x: 0, map_y: 1 })
   })
 
+  it('lets the last drop win when two writes are in flight at once', async () => {
+    // Two drops inside one round-trip. Whichever request answers first, the
+    // pin has to end up where the staffer last put it — an older response
+    // landing late must not drag it back, and must not blank a drop that has
+    // not been answered yet.
+    const answer: Array<() => void> = []
+    updateLodgingUnit.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          answer.push(() => {
+            resolve()
+          })
+        })
+    )
+    render(<UnitMapPositionField unit={UNIT} />)
+    await enableEditing()
+    const canvas = canvasOf()
+
+    press(canvas, 400, 240)
+    lift(canvas, 400, 240)
+    press(canvas, 600, 480)
+    lift(canvas, 600, 480)
+    await waitFor(() => {
+      expect(updateLodgingUnit).toHaveBeenCalledTimes(2)
+    })
+
+    await act(async () => {
+      answer[1]?.()
+    })
+    expect(pin()?.style.left).toBe('60%')
+
+    await act(async () => {
+      answer[0]?.()
+    })
+    expect(pin()?.style.left).toBe('60%')
+  })
+
   it('puts the stored position back when the write is refused', async () => {
     updateLodgingUnit.mockRejectedValue(new Error('Network request failed'))
     render(<UnitMapPositionField unit={UNIT} />)
@@ -247,6 +303,120 @@ describe('UnitMapPositionField — a drag commits on pointer-up', () => {
       expect(toastError).toHaveBeenCalled()
     })
     expect(pin()?.style.left).toBe(before)
+  })
+})
+
+describe('UnitMapPositionField — a gesture that goes wrong commits nothing', () => {
+  it('ends the gesture when the pointer is released away from the canvas', async () => {
+    // A drag out of the canvas and a release out there: the pointerup lands on
+    // whatever is under the cursor, never here. A real browser hands the
+    // gesture back through pointer capture, but if it does not, the field must
+    // NOT stay armed — a still-live drag turns a later mouse-over into a pin
+    // that follows the cursor and the next click into a silent write.
+    render(<UnitMapPositionField unit={UNIT} />)
+    await enableEditing()
+    const canvas = canvasOf()
+    const stored = pin()?.style.left
+
+    press(canvas, 300, 160)
+    move(canvas, 500, 300)
+    fireEvent.pointerUp(document.body, { pointerId: 1, clientX: 4000, clientY: 4000 })
+    hover(canvas, 900, 700)
+
+    expect(pin()?.style.left).toBe(stored)
+    lift(canvas, 900, 700)
+    expect(updateLodgingUnit).not.toHaveBeenCalled()
+  })
+
+  it('captures the pointer, so a release outside is still delivered here', async () => {
+    // The browser-side half of the test above. jsdom implements no pointer
+    // capture at all, so the canvas has to be given one to observe: in a real
+    // browser this is what makes the drag survive leaving the canvas, and the
+    // `buttons` check is only the fallback for when it is unavailable.
+    render(<UnitMapPositionField unit={UNIT} />)
+    await enableEditing()
+    const canvas = canvasOf()
+    const setPointerCapture = vi.fn()
+    Object.assign(canvas, { setPointerCapture })
+
+    press(canvas, 300, 160, 9)
+
+    expect(setPointerCapture).toHaveBeenCalledWith(9)
+  })
+
+  it('ignores a right-click, which places nothing', async () => {
+    // The context menu opens and the pointerup arrives all the same, so an
+    // unguarded handler would write wherever the staffer right-clicked.
+    render(<UnitMapPositionField unit={UNIT} />)
+    await enableEditing()
+    const canvas = canvasOf()
+    const stored = pin()?.style.left
+
+    fireEvent.pointerDown(canvas, {
+      pointerId: 1,
+      button: 2,
+      buttons: 2,
+      clientX: 900,
+      clientY: 700,
+    })
+    fireEvent.pointerUp(canvas, { pointerId: 1, button: 2, buttons: 0, clientX: 900, clientY: 700 })
+
+    expect(pin()?.style.left).toBe(stored)
+    expect(updateLodgingUnit).not.toHaveBeenCalled()
+  })
+
+  it('ignores a second finger landing during a drag', async () => {
+    // Two fingers on a touchscreen are one pinch, not two placements. Only the
+    // pointer that started the drag may move it or end it.
+    render(<UnitMapPositionField unit={UNIT} />)
+    await enableEditing()
+    const canvas = canvasOf()
+
+    press(canvas, 300, 160)
+    press(canvas, 900, 700, 2)
+    move(canvas, 950, 750, 2)
+    lift(canvas, 950, 750, 2)
+
+    expect(updateLodgingUnit).not.toHaveBeenCalled()
+
+    move(canvas, 400, 240)
+    lift(canvas, 400, 240)
+
+    await waitFor(() => {
+      expect(updateLodgingUnit).toHaveBeenCalledTimes(1)
+    })
+    const [, payload] = updateLodgingUnit.mock.calls[0] as [string, Partial<LodgingUnitInput>]
+    expect(payload).toEqual({ map_x: 0.4, map_y: 0.3 })
+  })
+
+  it('commits nothing when the browser takes the gesture away', async () => {
+    render(<UnitMapPositionField unit={UNIT} />)
+    await enableEditing()
+    const canvas = canvasOf()
+    const stored = pin()?.style.left
+
+    press(canvas, 300, 160)
+    move(canvas, 900, 700)
+    fireEvent.pointerCancel(canvas, { pointerId: 1 })
+
+    expect(pin()?.style.left).toBe(stored)
+    lift(canvas, 900, 700)
+    expect(updateLodgingUnit).not.toHaveBeenCalled()
+  })
+
+  it('abandons a drag in flight when the gate is switched back off', async () => {
+    render(<UnitMapPositionField unit={UNIT} />)
+    await enableEditing()
+    const canvas = canvasOf()
+    const stored = pin()?.style.left
+
+    press(canvas, 300, 160)
+    move(canvas, 900, 700)
+    fireEvent.click(screen.getByLabelText(/edit position/i))
+
+    expect(screen.getByLabelText(/edit position/i)).not.toBeChecked()
+    expect(pin()?.style.left).toBe(stored)
+    expect(updateLodgingUnit).not.toHaveBeenCalled()
   })
 })
 
@@ -267,6 +437,32 @@ describe('UnitMapPositionField — an unset pair is not the origin', () => {
     render(<UnitMapPositionField unit={UNSET} />)
 
     expect(updateLodgingUnit).not.toHaveBeenCalled()
+  })
+
+  it('never writes the (0,0) that MEANS unplaced, even off the top-left corner', async () => {
+    // The trap arriving through the fix, by its other door. A drag off the
+    // top-left clamps to exactly the origin — and the origin is the sentinel
+    // `hasCoordinates` reads as "no position at all", so storing it would
+    // UNPLACE the unit through the gesture meant to place it. Every other edge
+    // is a real coordinate and keeps clamping to the edge.
+    render(<UnitMapPositionField unit={UNIT} />)
+    await enableEditing()
+    const canvas = canvasOf()
+
+    press(canvas, 300, 160)
+    lift(canvas, -80, -60)
+
+    await waitFor(() => {
+      expect(updateLodgingUnit).toHaveBeenCalledTimes(1)
+    })
+    const [, payload] = updateLodgingUnit.mock.calls[0] as [string, Partial<LodgingUnitInput>]
+    expect(payload).not.toEqual({ map_x: 0, map_y: 0 })
+    expect(payload.map_x).toBeGreaterThan(0)
+    expect(payload.map_y).toBeGreaterThan(0)
+    // ...and still the top-left corner to any eye: a ten-thousandth of the
+    // map is a third of a pixel at full render.
+    expect(payload.map_x).toBeLessThan(0.001)
+    expect(payload.map_y).toBeLessThan(0.001)
   })
 
   it('places an unplaced unit where the staffer presses', async () => {

--- a/frontend/src/components/admin/lodging/UnitMapPositionField.test.tsx
+++ b/frontend/src/components/admin/lodging/UnitMapPositionField.test.tsx
@@ -1,0 +1,303 @@
+/**
+ * The map-pin editor, and above all the GATE in front of it.
+ *
+ * kindred#2013 was ruled "option B, behind an explicit edit mode": a drag
+ * commits the moment the pointer lifts — the same save-on-interaction shape
+ * `LodgingAreasDrawer`'s centroid inputs use — but nothing is draggable until
+ * the staffer says so. The first test below is the one the whole ruling exists
+ * to satisfy and is not an afterthought: with edit mode off, a pointer gesture
+ * over this canvas must be incapable of moving a pin or writing a coordinate.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const updateLodgingUnit = vi.fn()
+
+vi.mock('../../../services/lodgingCrud', () => ({
+  updateLodgingUnit: (...args: unknown[]) => updateLodgingUnit(...args),
+}))
+
+const toastError = vi.fn()
+
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: (...args: unknown[]) => toastError(...args) },
+}))
+
+import type { LodgingUnitInput, LodgingUnitRecord } from '../../../types/lodging'
+import { UnitMapPositionField } from './UnitMapPositionField'
+
+const UNIT: LodgingUnitRecord = {
+  id: 'u1',
+  area: 'area_1',
+  name: 'Cabin A',
+  code: 'cabin-a',
+  parent_unit: '',
+  map_x: 0.3,
+  map_y: 0.2,
+  sleeps: 0,
+  beds: null,
+  bathroom: 'none',
+  bathroom_group: '',
+  near_bathhouse: false,
+  has_power: false,
+  has_ac: false,
+  has_fridge: false,
+  is_accessible: false,
+  has_tub: false,
+  has_kitchenette: false,
+  has_crib: false,
+  has_changing_table: false,
+  has_shared_fridge: false,
+  inventory_class: 'family_pool',
+  shareability: '',
+  is_confirmed: false,
+  is_active: true,
+  is_container: false,
+  default_combined: false,
+  notes: '',
+}
+
+/** jsdom performs no layout, so the canvas has to be told how big it is. */
+const RECT_WIDTH = 1000
+const RECT_HEIGHT = 800
+
+function canvasOf(): HTMLElement {
+  const canvas = screen.getByTestId('unit-map-canvas')
+  vi.spyOn(canvas, 'getBoundingClientRect').mockReturnValue({
+    left: 0,
+    top: 0,
+    width: RECT_WIDTH,
+    height: RECT_HEIGHT,
+    right: RECT_WIDTH,
+    bottom: RECT_HEIGHT,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  })
+  return canvas
+}
+
+function press(canvas: HTMLElement, x: number, y: number) {
+  fireEvent.pointerDown(canvas, { pointerId: 1, clientX: x, clientY: y })
+}
+function move(canvas: HTMLElement, x: number, y: number) {
+  fireEvent.pointerMove(canvas, { pointerId: 1, clientX: x, clientY: y })
+}
+function lift(canvas: HTMLElement, x: number, y: number) {
+  fireEvent.pointerUp(canvas, { pointerId: 1, clientX: x, clientY: y })
+}
+
+const pin = () => screen.queryByTestId('unit-map-pin')
+
+async function enableEditing() {
+  const user = userEvent.setup()
+  await user.click(screen.getByLabelText(/edit position/i))
+}
+
+beforeEach(() => {
+  updateLodgingUnit.mockReset()
+  updateLodgingUnit.mockResolvedValue({ ...UNIT })
+  toastError.mockReset()
+})
+
+describe('UnitMapPositionField — the gate', () => {
+  it('starts with edit mode off', () => {
+    render(<UnitMapPositionField unit={UNIT} />)
+
+    expect(screen.getByLabelText(/edit position/i)).not.toBeChecked()
+  })
+
+  it('cannot move a pin or write a coordinate while edit mode is off', () => {
+    // THE test this whole ruling exists for. A pan, a scroll or a touch-drag
+    // across this canvas is an accident, not an edit, and with the gate shut
+    // there must be no handler for it to reach at all.
+    render(<UnitMapPositionField unit={UNIT} />)
+    const canvas = canvasOf()
+    const before = pin()?.style.left
+
+    press(canvas, 900, 700)
+    move(canvas, 100, 100)
+    lift(canvas, 100, 100)
+
+    expect(pin()?.style.left).toBe(before)
+    expect(updateLodgingUnit).not.toHaveBeenCalled()
+  })
+
+  it('offers the gate as a real checkbox, reachable by keyboard', () => {
+    // The map surface is 99% pointer-driven and the empty-rooms toggle is its
+    // last keyboard-reachable control (see LodgingMap's accessibility note).
+    // A pointer-only gate here would repeat the mistake that note warns about.
+    render(<UnitMapPositionField unit={UNIT} />)
+    const toggle = screen.getByLabelText(/edit position/i)
+
+    expect(toggle).toHaveProperty('tagName', 'INPUT')
+    expect(toggle).toHaveAttribute('type', 'checkbox')
+  })
+
+  it('can be switched on from the keyboard alone', async () => {
+    const user = userEvent.setup()
+    render(<UnitMapPositionField unit={UNIT} />)
+
+    screen.getByLabelText(/edit position/i).focus()
+    await user.keyboard(' ')
+
+    expect(screen.getByLabelText(/edit position/i)).toBeChecked()
+  })
+
+  it('is visibly distinct while it is on, so nobody leaves it enabled unawares', async () => {
+    render(<UnitMapPositionField unit={UNIT} />)
+    expect(screen.queryByText(/editing/i)).not.toBeInTheDocument()
+
+    await enableEditing()
+
+    expect(screen.getByText(/editing/i)).toBeInTheDocument()
+    expect(screen.getByTestId('unit-map-canvas').className).toContain('ring-primary')
+  })
+})
+
+describe('UnitMapPositionField — a drag commits on pointer-up', () => {
+  it('writes the dropped coordinate once the pointer lifts', async () => {
+    render(<UnitMapPositionField unit={UNIT} />)
+    await enableEditing()
+    const canvas = canvasOf()
+
+    press(canvas, 300, 160)
+    move(canvas, 400, 240)
+    lift(canvas, 400, 240)
+
+    await waitFor(() => {
+      expect(updateLodgingUnit).toHaveBeenCalledTimes(1)
+    })
+    const [id, payload] = updateLodgingUnit.mock.calls[0] as [string, Partial<LodgingUnitInput>]
+    expect(id).toBe('u1')
+    expect(payload).toEqual({ map_x: 0.4, map_y: 0.3 })
+  })
+
+  it('writes nothing while the pointer is still down, but moves the pin', () => {
+    render(<UnitMapPositionField unit={UNIT} />)
+    const toggle = screen.getByLabelText(/edit position/i)
+    fireEvent.click(toggle)
+    const canvas = canvasOf()
+    const before = pin()?.style.left
+
+    // Grabbing AWAY from the stored point on purpose: pressing on it would be
+    // caught by the unchanged-coordinate skip below, and this test would pass
+    // just as happily against an implementation that wrote on pointer-DOWN.
+    press(canvas, 200, 400)
+    move(canvas, 400, 240)
+
+    expect(pin()?.style.left).not.toBe(before)
+    expect(updateLodgingUnit).not.toHaveBeenCalled()
+  })
+
+  it('rounds to the precision the canvas can actually express', async () => {
+    render(<UnitMapPositionField unit={UNIT} />)
+    await enableEditing()
+    const canvas = canvasOf()
+
+    press(canvas, 123.456, 321.987)
+    lift(canvas, 123.456, 321.987)
+
+    await waitFor(() => {
+      expect(updateLodgingUnit).toHaveBeenCalledTimes(1)
+    })
+    const [, payload] = updateLodgingUnit.mock.calls[0] as [string, Partial<LodgingUnitInput>]
+    expect(payload).toEqual({ map_x: 0.1235, map_y: 0.4025 })
+  })
+
+  it('does not re-write a coordinate that did not change', () => {
+    // Mirrors saveCentroid's `if (value === area[axis]) return`.
+    render(<UnitMapPositionField unit={UNIT} />)
+    fireEvent.click(screen.getByLabelText(/edit position/i))
+    const canvas = canvasOf()
+
+    press(canvas, 300, 160)
+    lift(canvas, 300, 160)
+
+    expect(updateLodgingUnit).not.toHaveBeenCalled()
+  })
+
+  it('clamps a drop dragged off the edge back onto the map', async () => {
+    render(<UnitMapPositionField unit={UNIT} />)
+    await enableEditing()
+    const canvas = canvasOf()
+
+    press(canvas, 300, 160)
+    lift(canvas, -400, 5000)
+
+    await waitFor(() => {
+      expect(updateLodgingUnit).toHaveBeenCalledTimes(1)
+    })
+    const [, payload] = updateLodgingUnit.mock.calls[0] as [string, Partial<LodgingUnitInput>]
+    expect(payload).toEqual({ map_x: 0, map_y: 1 })
+  })
+
+  it('puts the stored position back when the write is refused', async () => {
+    updateLodgingUnit.mockRejectedValue(new Error('Network request failed'))
+    render(<UnitMapPositionField unit={UNIT} />)
+    await enableEditing()
+    const canvas = canvasOf()
+    const before = pin()?.style.left
+
+    press(canvas, 900, 600)
+    lift(canvas, 900, 600)
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalled()
+    })
+    expect(pin()?.style.left).toBe(before)
+  })
+})
+
+describe('UnitMapPositionField — an unset pair is not the origin', () => {
+  const UNSET: LodgingUnitRecord = { ...UNIT, map_x: 0, map_y: 0 }
+
+  it('draws no pin for a unit that was never placed', () => {
+    render(<UnitMapPositionField unit={UNSET} />)
+
+    expect(pin()).not.toBeInTheDocument()
+    expect(screen.getByText(/no position yet/i)).toBeInTheDocument()
+  })
+
+  it('writes nothing for an unplaced unit until someone actually places it', () => {
+    // The (0,0) trap, arriving through the fix: a unit with no position must
+    // not be quietly written to the top-left corner just because the editor
+    // was opened on it.
+    render(<UnitMapPositionField unit={UNSET} />)
+
+    expect(updateLodgingUnit).not.toHaveBeenCalled()
+  })
+
+  it('places an unplaced unit where the staffer presses', async () => {
+    render(<UnitMapPositionField unit={UNSET} />)
+    await enableEditing()
+    const canvas = canvasOf()
+
+    press(canvas, 500, 400)
+    lift(canvas, 500, 400)
+
+    await waitFor(() => {
+      expect(updateLodgingUnit).toHaveBeenCalledTimes(1)
+    })
+    const [, payload] = updateLodgingUnit.mock.calls[0] as [string, Partial<LodgingUnitInput>]
+    expect(payload).toEqual({ map_x: 0.5, map_y: 0.5 })
+    expect(pin()).toBeInTheDocument()
+  })
+})
+
+describe('UnitMapPositionField — the registry has to hear about it', () => {
+  it('tells its host a position landed, so the cached registry can be refreshed', async () => {
+    const onPositionSaved = vi.fn()
+    render(<UnitMapPositionField unit={UNIT} onPositionSaved={onPositionSaved} />)
+    await enableEditing()
+    const canvas = canvasOf()
+
+    press(canvas, 400, 240)
+    lift(canvas, 400, 240)
+
+    await waitFor(() => {
+      expect(onPositionSaved).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/frontend/src/components/admin/lodging/UnitMapPositionField.tsx
+++ b/frontend/src/components/admin/lodging/UnitMapPositionField.tsx
@@ -1,0 +1,254 @@
+/**
+ * Put this unit's pin where the cabin actually is.
+ *
+ * `/manage/lodging` used to expose the position as two number inputs; PR #2024
+ * deleted them and nothing replaced them, so correcting a coordinate meant
+ * editing the database. Typing `0.4389` was never how a pin gets placed
+ * anyway — dragging it onto the cabin is (kindred#2013).
+ *
+ * SAVES ON POINTER-UP, and that is a ruling rather than a shortcut. It is the
+ * same save-on-interaction shape `LodgingAreasDrawer`'s centroid inputs use
+ * (`saveCentroid`, save-on-blur): a direct manipulation that then asked for a
+ * second, separate commit would be two commits for one intention. This is
+ * therefore NOT part of the form's payload — `LodgingUnitForm` still omits
+ * `map_x`/`map_y` from every submit, which is what keeps its (0,0) guarantee
+ * intact (see that file's header, point 2).
+ *
+ * AND IT IS GATED. The objection to saving on pointer-up was that an
+ * accidental drag persists the instant a finger lifts, and the answer is that
+ * accidents cannot start: with `editing` off this canvas carries NO pointer
+ * handlers at all, so a pan, a scroll or a touch-drag across it is incapable
+ * of moving anything. That is a stronger guarantee than a handler that checks
+ * a flag, and it is why the handlers are spread conditionally below rather
+ * than written with an early return inside.
+ *
+ * THE GATE IS A REAL CHECKBOX, for the reason LodgingMap's accessibility note
+ * gives about the empty-rooms toggle: that toggle is the map's last
+ * keyboard-reachable control, and a pointer-only control here would repeat the
+ * mistake the note exists to warn about. The DRAG itself is pointer-only —
+ * honestly so, exactly as the weekend map's pan is — and the accessible
+ * equivalent is the units table this editor is opened from.
+ *
+ * AN UNSET PAIR IS NOT THE ORIGIN. `hasCoordinates` decides whether this unit
+ * has a position at all; an unplaced one draws no pin and writes nothing until
+ * someone presses on the map. Opening this editor must never be what turns
+ * "unpositioned" into "positioned at the top-left".
+ */
+import { useEffect, useRef, useState } from 'react'
+import toast from 'react-hot-toast'
+
+import { MapBaseLayer } from '../../weekend/MapBaseLayer'
+import { hasCoordinates } from '../../weekend/mapModel'
+import { IDENTITY_VIEW, MAP_ASPECT } from '../../weekend/mapViewport'
+import { updateLodgingUnit } from '../../../services/lodgingCrud'
+import type { LodgingUnitRecord } from '../../../types/lodging'
+import { SECTION } from './lodgingStyles'
+
+/**
+ * Four decimals — one part in 10,000 against a 3300px render, so roughly a
+ * third of a pixel. Finer than an area centroid's `step="0.001"` because a
+ * cabin is a building and an area is a whole zone, and coarse enough that the
+ * stored value stays readable.
+ */
+const PRECISION = 4
+
+interface Point {
+  x: number
+  y: number
+}
+
+function round(value: number): number {
+  return Number(value.toFixed(PRECISION))
+}
+
+/** 0-1, and never outside it: a pin dragged past the edge belongs on the edge. */
+function clamp01(value: number): number {
+  return Math.min(1, Math.max(0, value))
+}
+
+/** The pin is placed as a PERCENTAGE of an aspect-locked box, so it needs no
+ *  measurement and cannot drift out of register with the backdrop. */
+function percent(value: number): string {
+  return `${(value * 100).toFixed(PRECISION)}%`
+}
+
+export interface UnitMapPositionFieldProps {
+  /** Edit only. A unit being created has no id to write a coordinate to. */
+  unit: LodgingUnitRecord
+  /**
+   * A coordinate landed. The host invalidates the lodging registry queries
+   * with this — the write bypasses the form's own save, so nothing else would
+   * tell the cached registry the map moved.
+   */
+  onPositionSaved?: (() => void) | undefined
+}
+
+export function UnitMapPositionField({ unit, onPositionSaved }: UnitMapPositionFieldProps) {
+  const [editing, setEditing] = useState(false)
+  // The last position the SERVER accepted, and the only thing a failed write
+  // has to fall back to. Seeded once, like every other initialiser in this
+  // form — `LodgingUnitsPanel` keys the form on the record, so switching to
+  // another unit remounts rather than reusing this instance.
+  const [saved, setSaved] = useState<Point | null>(
+    hasCoordinates(unit) ? { x: unit.map_x, y: unit.map_y } : null
+  )
+  // What the pointer is currently proposing. Null between gestures, so the pin
+  // renders from `saved` at rest and there is no second copy to keep in step.
+  const [draft, setDraft] = useState<Point | null>(null)
+  const draggingRef = useRef(false)
+  const canvasRef = useRef<HTMLDivElement>(null)
+
+  // Measured for the SAME reason LodgingMap measures: the backdrop is laid out
+  // in real pixels because it is transform-scaled. The pin is not — it sits at
+  // a percentage of an aspect-locked box, which needs no measurement and
+  // cannot drift out of register with the image.
+  const [size, setSize] = useState({ width: 0, height: 0 })
+  useEffect(() => {
+    const node = canvasRef.current
+    if (!node) return
+    const measure = () => {
+      setSize({ width: node.clientWidth, height: node.clientHeight })
+    }
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(node)
+    return () => {
+      observer.disconnect()
+    }
+  }, [])
+  // jsdom performs no layout, so clientWidth is 0 there — the same fallback
+  // LodgingMap uses, for the same reason.
+  const width = size.width > 0 ? size.width : 1000
+  const height = size.height > 0 ? size.height : 1000 / MAP_ASPECT
+
+  const position = draft ?? saved
+
+  /** Where in 0-1 map space did this pointer land? */
+  const pointAt = (event: React.PointerEvent<HTMLDivElement>): Point | null => {
+    const rect = event.currentTarget.getBoundingClientRect()
+    if (rect.width <= 0 || rect.height <= 0) return null
+    return {
+      x: clamp01((event.clientX - rect.left) / rect.width),
+      y: clamp01((event.clientY - rect.top) / rect.height),
+    }
+  }
+
+  const commit = async (point: Point) => {
+    const next = { x: round(point.x), y: round(point.y) }
+    // Mirrors saveCentroid's `if (value === area[axis]) return` — a press that
+    // put the pin back where it already was is not an edit.
+    if (saved?.x === next.x && saved.y === next.y) {
+      setDraft(null)
+      return
+    }
+    try {
+      await updateLodgingUnit(unit.id, { map_x: next.x, map_y: next.y })
+      setSaved(next)
+      onPositionSaved?.()
+    } catch (error) {
+      // The stored position goes back, for the reason `saveField` puts a
+      // refused value back in the areas drawer: a pin left where the server
+      // refused to put it is indistinguishable from a saved one.
+      toast.error(error instanceof Error ? error.message : 'Failed to save the map position')
+    } finally {
+      setDraft(null)
+    }
+  }
+
+  const dragHandlers = {
+    onPointerDown: (event: React.PointerEvent<HTMLDivElement>) => {
+      const point = pointAt(event)
+      if (!point) return
+      draggingRef.current = true
+      setDraft(point)
+    },
+    onPointerMove: (event: React.PointerEvent<HTMLDivElement>) => {
+      if (!draggingRef.current) return
+      const point = pointAt(event)
+      if (point) setDraft(point)
+    },
+    onPointerUp: (event: React.PointerEvent<HTMLDivElement>) => {
+      if (!draggingRef.current) return
+      draggingRef.current = false
+      const point = pointAt(event) ?? draft
+      if (point) void commit(point)
+    },
+    // The browser took the gesture away. Nothing is committed, and the draft
+    // has to go or the pin stays where a cancelled drag left it.
+    onPointerCancel: () => {
+      draggingRef.current = false
+      setDraft(null)
+    },
+  }
+
+  // A FRAGMENT, not a wrapper: every section of this form renders as one so
+  // its heading is a direct child of the form grid and `SECTION`'s `first:`
+  // rules resolve against the real first section (see ./lodgingStyles).
+  return (
+    <>
+      <h3 className={SECTION}>Map position</h3>
+      <div className="sm:col-span-2">
+        <div
+          ref={canvasRef}
+          data-testid="unit-map-canvas"
+          data-editing={editing ? 'true' : 'false'}
+          style={{ aspectRatio: `${String(MAP_ASPECT)}` }}
+          className={`bg-muted/40 relative w-full overflow-hidden rounded-xl select-none ${
+            editing
+              ? 'ring-primary cursor-crosshair touch-none ring-2'
+              : 'border-border cursor-default border'
+          }`}
+          {...(editing ? dragHandlers : {})}
+        >
+          <MapBaseLayer view={IDENTITY_VIEW} width={width} height={height} />
+          {position && (
+            <span
+              data-testid="unit-map-pin"
+              style={{ left: percent(position.x), top: percent(position.y) }}
+              className={`bg-primary absolute z-10 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white shadow ${
+                editing ? 'cursor-grab' : ''
+              }`}
+            />
+          )}
+          {!position && (
+            <p className="text-muted-foreground bg-card/90 border-border absolute top-3 left-3 rounded-md border px-2 py-1 text-xs">
+              No position yet — switch on Edit position and press where this unit sits.
+            </p>
+          )}
+        </div>
+
+        {/* The map's own control row, in the admin surface's grammar. The
+            checkbox is the precedent LodgingMap's empty-rooms toggle sets: a
+            real <input> inside a real <label>, never re-invented as a div. */}
+        <div className="text-muted-foreground mt-2 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs">
+          <label className="inline-flex cursor-pointer items-center gap-1.5">
+            <input
+              type="checkbox"
+              checked={editing}
+              onChange={(event) => {
+                setEditing(event.target.checked)
+                // A draft belongs to a gesture, and switching the gate off
+                // ends any gesture in flight without committing it.
+                if (!event.target.checked) {
+                  draggingRef.current = false
+                  setDraft(null)
+                }
+              }}
+            />
+            Edit position
+          </label>
+          {editing && (
+            <span className="text-primary font-semibold">
+              Editing — drag the pin, or press where the unit sits. Saves straight away.
+            </span>
+          )}
+          <span className="ml-auto tabular-nums">
+            {position
+              ? `x ${position.x.toFixed(PRECISION)} · y ${position.y.toFixed(PRECISION)}`
+              : 'not placed'}
+          </span>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/frontend/src/components/admin/lodging/UnitMapPositionField.tsx
+++ b/frontend/src/components/admin/lodging/UnitMapPositionField.tsx
@@ -22,6 +22,11 @@
  * a flag, and it is why the handlers are spread conditionally below rather
  * than written with an early return inside.
  *
+ * INSIDE the gate a drag is still one pointer's primary-button gesture, and
+ * the handlers say why at each guard: a right-click delivers a pointerup all
+ * the same, a second finger must not seize a drag in flight, and a release
+ * the canvas never sees must END the gesture rather than leave it armed.
+ *
  * THE GATE IS A REAL CHECKBOX, for the reason LodgingMap's accessibility note
  * gives about the empty-rooms toggle: that toggle is the map's last
  * keyboard-reachable control, and a pointer-only control here would repeat the
@@ -66,6 +71,26 @@ function clamp01(value: number): number {
   return Math.min(1, Math.max(0, value))
 }
 
+/** The finest step this field can express, and so the smallest nudge that is
+ *  still a different coordinate. */
+const EPSILON = 10 ** -PRECISION
+
+/**
+ * (0,0) IS THE SENTINEL for "never placed" — it is what `hasCoordinates` reads
+ * as no position at all — so it is the one pair a placement may never write.
+ * A drag off the TOP-LEFT corner clamps to exactly it, and storing that would
+ * UNPLACE the unit through the very gesture meant to place it: the pin would
+ * be gone the next time this editor opened.
+ *
+ * Only the exact corner is special-cased. Every other edge is a real
+ * coordinate and goes on clamping to the edge, and a ten-thousandth of the map
+ * is a third of a pixel at full render — the pin does not visibly move.
+ */
+function offOrigin(point: Point): Point {
+  if (point.x === 0 && point.y === 0) return { x: EPSILON, y: EPSILON }
+  return point
+}
+
 /** The pin is placed as a PERCENTAGE of an aspect-locked box, so it needs no
  *  measurement and cannot drift out of register with the backdrop. */
 function percent(value: number): string {
@@ -95,7 +120,12 @@ export function UnitMapPositionField({ unit, onPositionSaved }: UnitMapPositionF
   // What the pointer is currently proposing. Null between gestures, so the pin
   // renders from `saved` at rest and there is no second copy to keep in step.
   const [draft, setDraft] = useState<Point | null>(null)
-  const draggingRef = useRef(false)
+  // THE POINTER THAT OWNS THE GESTURE, not a bare boolean. A drag belongs to
+  // one pointer: a second finger landing mid-drag, or the stray pointerup of a
+  // pointer that never pressed here, must not be able to move or commit it.
+  const draggingRef = useRef<number | null>(null)
+  /** Which write is the current one; see `commit`. */
+  const writeSeq = useRef(0)
   const canvasRef = useRef<HTMLDivElement>(null)
 
   // Measured for the SAME reason LodgingMap measures: the backdrop is laid out
@@ -133,16 +163,31 @@ export function UnitMapPositionField({ unit, onPositionSaved }: UnitMapPositionF
     }
   }
 
+  /** The gesture is over and nothing is being written: forget the draft, or
+   *  the pin sits at a position no one ever saved. */
+  const abandon = () => {
+    draggingRef.current = null
+    setDraft(null)
+  }
+
   const commit = async (point: Point) => {
-    const next = { x: round(point.x), y: round(point.y) }
+    const next = offOrigin({ x: round(point.x), y: round(point.y) })
     // Mirrors saveCentroid's `if (value === area[axis]) return` — a press that
     // put the pin back where it already was is not an edit.
+    // (`saved?.x` then a bare `saved.y`: the first comparison narrows `saved`
+    // to non-null, so the second chain would be flagged as unnecessary.)
     if (saved?.x === next.x && saved.y === next.y) {
       setDraft(null)
       return
     }
+    // THE LAST DROP WINS, not the last response. Two drags inside one
+    // round-trip are easy to make and the requests can answer out of order; an
+    // older one landing late would otherwise drag the pin back to where it is
+    // no longer, and its `finally` would blank a drop still waiting.
+    const seq = ++writeSeq.current
     try {
       await updateLodgingUnit(unit.id, { map_x: next.x, map_y: next.y })
+      if (seq !== writeSeq.current) return
       setSaved(next)
       onPositionSaved?.()
     } catch (error) {
@@ -151,33 +196,58 @@ export function UnitMapPositionField({ unit, onPositionSaved }: UnitMapPositionF
       // refused to put it is indistinguishable from a saved one.
       toast.error(error instanceof Error ? error.message : 'Failed to save the map position')
     } finally {
-      setDraft(null)
+      if (seq === writeSeq.current) setDraft(null)
     }
   }
 
   const dragHandlers = {
     onPointerDown: (event: React.PointerEvent<HTMLDivElement>) => {
+      // A placement is a PRIMARY-button press. A right-click opens the context
+      // menu and still delivers its pointerup here, so without this guard it
+      // would write a coordinate wherever the menu was opened.
+      if (event.button !== 0) return
+      // One gesture at a time: the second finger of a pinch must not seize a
+      // drag the first is in the middle of.
+      if (draggingRef.current !== null) return
       const point = pointAt(event)
       if (!point) return
-      draggingRef.current = true
+      draggingRef.current = event.pointerId
+      // KEEP THE GESTURE OURS once the pointer leaves the canvas. Without
+      // capture, a drag released outside is delivered to whatever is under the
+      // cursor instead, this handler's pointerup never runs, and the field is
+      // left armed — a later mouse-over then drags the pin and the next click
+      // writes it. jsdom implements no pointer capture, hence the try.
+      try {
+        event.currentTarget.setPointerCapture(event.pointerId)
+      } catch {
+        // Unsupported, or the pointer is already gone. Neither is a reason to
+        // refuse the drag; the `buttons` check below is the fallback.
+      }
       setDraft(point)
     },
     onPointerMove: (event: React.PointerEvent<HTMLDivElement>) => {
-      if (!draggingRef.current) return
+      if (draggingRef.current !== event.pointerId) return
+      // No button is down, so the release happened somewhere we never saw it
+      // and this is a plain hover. Ending the gesture here is what stops the
+      // pin from following an unpressed cursor if capture was unavailable.
+      if (event.buttons === 0) {
+        abandon()
+        return
+      }
       const point = pointAt(event)
       if (point) setDraft(point)
     },
     onPointerUp: (event: React.PointerEvent<HTMLDivElement>) => {
-      if (!draggingRef.current) return
-      draggingRef.current = false
+      if (draggingRef.current !== event.pointerId) return
+      draggingRef.current = null
       const point = pointAt(event) ?? draft
       if (point) void commit(point)
     },
     // The browser took the gesture away. Nothing is committed, and the draft
     // has to go or the pin stays where a cancelled drag left it.
-    onPointerCancel: () => {
-      draggingRef.current = false
-      setDraft(null)
+    onPointerCancel: (event: React.PointerEvent<HTMLDivElement>) => {
+      if (draggingRef.current !== event.pointerId) return
+      abandon()
     },
   }
 
@@ -229,10 +299,7 @@ export function UnitMapPositionField({ unit, onPositionSaved }: UnitMapPositionF
                 setEditing(event.target.checked)
                 // A draft belongs to a gesture, and switching the gate off
                 // ends any gesture in flight without committing it.
-                if (!event.target.checked) {
-                  draggingRef.current = false
-                  setDraft(null)
-                }
+                if (!event.target.checked) abandon()
               }}
             />
             Edit position

--- a/frontend/src/components/weekend/LodgingMap.tsx
+++ b/frontend/src/components/weekend/LodgingMap.tsx
@@ -58,6 +58,7 @@ import { FamilyCard } from './FamilyCard'
 import { FamilyDetailsPanel } from './FamilyDetailsPanel'
 import { FloatingUnplacedBadge } from './FloatingUnplacedBadge'
 import { indexUnitsByCode, resolvePartyUnit } from './rosterAttention'
+import { MapBaseLayer } from './MapBaseLayer'
 import { clusterByProximity, type Cluster } from './mapClustering'
 import { BATHHOUSE_BLUE } from './mapColors'
 import { buildMapModel, type MapUnit } from './mapModel'
@@ -74,15 +75,9 @@ import {
 } from './mapViewport'
 import { resolveRingPrecedence } from './ringPrecedence'
 
-/** Served from the private repo, exactly as the logos are. */
-const MAP_IMAGE_URL = '/local/assets/camp-map.webp'
-
 /** Below this a pointer gesture is a click, above it a pan. Capturing the
  *  pointer any earlier retargets the click away from the mark under it. */
 const DRAG_THRESHOLD_PX = 4
-
-/** Default scrim over the map so the marks read against a busy illustration. */
-const DEFAULT_FADE = 25
 
 /**
  * Dwell before the peek opens, per spec §7 and tuned in the mockup.
@@ -152,7 +147,6 @@ export function LodgingMap({ parties, units, year, sessionCmId = 0 }: LodgingMap
   const wasDraggingRef = useRef(false)
   const [view, setView] = useState<Viewport>(IDENTITY_VIEW)
   const [size, setSize] = useState({ width: 0, height: 0 })
-  const [imageFailed, setImageFailed] = useState(false)
   // Empty rooms are DRAWN by default: the map's job when you arrive is the
   // whole site, and the toggle is a question you bring to it rather than one
   // the surface should ask for you.
@@ -512,46 +506,9 @@ export function LodgingMap({ parties, units, year, sessionCmId = 0 }: LodgingMap
               dragRef.current = null
             }}
           >
-            {!imageFailed && (
-              <img
-                data-testid="map-backdrop"
-                src={MAP_IMAGE_URL}
-                alt=""
-                loading="lazy"
-                onError={() => {
-                  setImageFailed(true)
-                }}
-                style={{
-                  width,
-                  height,
-                  transform: `translate(${String(view.tx)}px, ${String(view.ty)}px) scale(${String(view.k)})`,
-                  // LOAD-BEARING, not incidental. The marks are placed at
-                  // `u * size * k + t`, which matches this image only while it
-                  // scales about its top-left. With the CSS default of 50% 50%
-                  // an image point lands at `k*a + (1-k)*w/2 + t` — an offset
-                  // that is ZERO ONLY AT k=1, so the map would look
-                  // pixel-perfect at rest and drift further out of register the
-                  // more you zoom. jsdom performs no layout, so no test here can
-                  // catch it; the algebra is the only guard.
-                  transformOrigin: '0 0',
-                }}
-                className="pointer-events-none absolute top-0 left-0 max-w-none"
-              />
-            )}
-            {/* Pinned at DEFAULT_FADE, not a control anymore (kindred#1997):
-                marks reading against a busy illustration is not a question
-                the user should be asked. */}
-            <div
-              data-testid="map-scrim"
-              aria-hidden="true"
-              style={{ opacity: DEFAULT_FADE / 100 }}
-              className="bg-card pointer-events-none absolute inset-0"
-            />
-            {imageFailed && (
-              <p className="text-muted-foreground pointer-events-none absolute top-3 left-3 text-xs">
-                Map image unavailable — showing positions only.
-              </p>
-            )}
+            {/* The illustration, its scrim and the art-missing notice, shared
+                with the admin unit editor's pin canvas (kindred#2013). */}
+            <MapBaseLayer view={view} width={width} height={height} />
 
             {clusters.map((cluster) => {
               const key = clusterKey(cluster)

--- a/frontend/src/components/weekend/MapBaseLayer.tsx
+++ b/frontend/src/components/weekend/MapBaseLayer.tsx
@@ -1,0 +1,89 @@
+/**
+ * The camp map's base layer: the illustration, the scrim that keeps marks
+ * legible over it, and the notice that stands in when the art is missing.
+ *
+ * EXTRACTED FROM `LodgingMap` (kindred#2013) rather than written a second
+ * time. The admin unit editor needs the same backdrop under its draggable pin,
+ * and a second renderer would be a second thing to keep registered with
+ * `MAP_ASPECT`, with the private art's path, and with how that art's ABSENCE
+ * is reported. Nothing about roster, clustering or peeks lives here — this is
+ * the picture and nothing else, which is what makes it shareable.
+ *
+ * IMPORT BY DIRECT PATH, never through `../weekend`'s barrel (kindred#1964).
+ * The barrel re-exports `LodgingBoard`/`LodgingMap`, and
+ * `WeekendRosterPage.chunkGraph.test.ts` asserts neither is reachable by a
+ * STATIC import edge; the admin surface is eager, so a barrel import from
+ * there would drag the whole weekend map into the app's first load.
+ *
+ * IMAGE-FAILURE STATE LIVES HERE, not in the caller. It is a fact about this
+ * one <img> element and nothing above it ever read it — keeping it local is
+ * what lets both callers get the fallback for free.
+ */
+import { useState } from 'react'
+
+import type { Viewport } from './mapViewport'
+
+/** Served from the private repo, exactly as the logos are. */
+export const MAP_IMAGE_URL = '/local/assets/camp-map.webp'
+
+/** Default scrim over the map so the marks read against a busy illustration. */
+export const DEFAULT_FADE = 25
+
+export interface MapBaseLayerProps {
+  /** Pan/zoom of the surface drawing over this layer. */
+  view: Viewport
+  /** Canvas size in real pixels; the image is laid out against it. */
+  width: number
+  height: number
+  /** Scrim strength, 0-100. */
+  fade?: number
+}
+
+export function MapBaseLayer({ view, width, height, fade = DEFAULT_FADE }: MapBaseLayerProps) {
+  const [imageFailed, setImageFailed] = useState(false)
+
+  return (
+    <>
+      {!imageFailed && (
+        <img
+          data-testid="map-backdrop"
+          src={MAP_IMAGE_URL}
+          alt=""
+          loading="lazy"
+          onError={() => {
+            setImageFailed(true)
+          }}
+          style={{
+            width,
+            height,
+            transform: `translate(${String(view.tx)}px, ${String(view.ty)}px) scale(${String(view.k)})`,
+            // LOAD-BEARING, not incidental. The marks are placed at
+            // `u * size * k + t`, which matches this image only while it
+            // scales about its top-left. With the CSS default of 50% 50%
+            // an image point lands at `k*a + (1-k)*w/2 + t` — an offset
+            // that is ZERO ONLY AT k=1, so the map would look
+            // pixel-perfect at rest and drift further out of register the
+            // more you zoom. jsdom performs no layout, so no test here can
+            // catch it; the algebra is the only guard.
+            transformOrigin: '0 0',
+          }}
+          className="pointer-events-none absolute top-0 left-0 max-w-none"
+        />
+      )}
+      {/* Pinned at DEFAULT_FADE, not a control anymore (kindred#1997):
+          marks reading against a busy illustration is not a question
+          the user should be asked. */}
+      <div
+        data-testid="map-scrim"
+        aria-hidden="true"
+        style={{ opacity: fade / 100 }}
+        className="bg-card pointer-events-none absolute inset-0"
+      />
+      {imageFailed && (
+        <p className="text-muted-foreground pointer-events-none absolute top-3 left-3 text-xs">
+          Map image unavailable — showing positions only.
+        </p>
+      )}
+    </>
+  )
+}

--- a/frontend/src/components/weekend/MapBaseLayer.tsx
+++ b/frontend/src/components/weekend/MapBaseLayer.tsx
@@ -26,7 +26,13 @@ import type { Viewport } from './mapViewport'
 /** Served from the private repo, exactly as the logos are. */
 export const MAP_IMAGE_URL = '/local/assets/camp-map.webp'
 
-/** Default scrim over the map so the marks read against a busy illustration. */
+/**
+ * The scrim over the map, so the marks read against a busy illustration.
+ *
+ * A CONSTANT AND NOT A PROP (kindred#1997): "Fade map" used to be a control
+ * and was deliberately retired, so a `fade` override here would quietly hand
+ * one caller the knob every caller had taken away.
+ */
 export const DEFAULT_FADE = 25
 
 export interface MapBaseLayerProps {
@@ -35,11 +41,9 @@ export interface MapBaseLayerProps {
   /** Canvas size in real pixels; the image is laid out against it. */
   width: number
   height: number
-  /** Scrim strength, 0-100. */
-  fade?: number
 }
 
-export function MapBaseLayer({ view, width, height, fade = DEFAULT_FADE }: MapBaseLayerProps) {
+export function MapBaseLayer({ view, width, height }: MapBaseLayerProps) {
   const [imageFailed, setImageFailed] = useState(false)
 
   return (
@@ -76,7 +80,7 @@ export function MapBaseLayer({ view, width, height, fade = DEFAULT_FADE }: MapBa
       <div
         data-testid="map-scrim"
         aria-hidden="true"
-        style={{ opacity: fade / 100 }}
+        style={{ opacity: DEFAULT_FADE / 100 }}
         className="bg-card pointer-events-none absolute inset-0"
       />
       {imageFailed && (

--- a/frontend/src/components/weekend/mapModel.ts
+++ b/frontend/src/components/weekend/mapModel.ts
@@ -104,8 +104,13 @@ export interface MapModel {
  * function as its defence-in-depth partner. This is the second line, not the
  * only one; it stays because it is the guard that has been holding this up so
  * far, and because the same payload shape is reachable from a cached client.
+ *
+ * TAKES THE PAIR, not a whole row (kindred#2013), so the admin registry's
+ * `LodgingUnitRecord` can be judged by the same rule the roster's
+ * `LodgingUnitRow` is. A second copy of "both axes zero means unset" is
+ * exactly how the (0,0) trap gets back in.
  */
-export function hasCoordinates(unit: LodgingUnitRow): boolean {
+export function hasCoordinates(unit: Pick<LodgingUnitRow, 'map_x' | 'map_y'>): boolean {
   const x = unit.map_x
   const y = unit.map_y
   if (x === null || x === undefined || y === null || y === undefined) return false


### PR DESCRIPTION
`/manage/lodging` used to expose a unit's map position as two number inputs; PR #2024 deleted them and nothing replaced them, so correcting a pin meant editing the database. Typing `0.4389` was never how a pin gets placed anyway — dragging it onto the cabin is.

Built to the owner's 2026-08-09 ruling: **option B, behind an explicit edit mode.**

## The gate

A drag commits on pointer-up — the same save-on-interaction shape `LodgingAreasDrawer`'s centroid inputs already use (`saveCentroid`, save-on-blur) — but **nothing is draggable until edit mode is switched on**, and it is off by default.

With the gate shut the canvas carries **no pointer handlers at all** (`{...(editing ? dragHandlers : {})}`), so a pan, a scroll or a touch-drag across it is *structurally* incapable of moving a pin, rather than being stopped by a flag a later edit could get wrong. `touch-none` is likewise only applied while editing, so native touch scrolling over the map is untouched when the gate is shut. That is the most important test in this PR and it is mutation-checked: removing the conditional spread turns it red and nothing else.

The gate is a real `<input type="checkbox">` inside a real `<label>`, matching the empty-rooms toggle that `LodgingMap`'s accessibility note names as the map's last keyboard-reachable control. Shipping a pointer-only toggle would have made the surface entirely pointer-driven; the checkbox is focusable and space-togglable, and there is a test for exactly that. While it is on, the canvas takes a `ring-primary` ring and an "Editing —…" line appears in the control row, so nobody leaves it enabled without noticing.

## The (0,0) rule survives, by construction

The coordinate is **not** part of the form's payload. `UnitMapPositionField` writes it itself, so `LodgingUnitForm` still omits `map_x`/`map_y` from every submit — the existing "leaves a stored coordinate alone" test is unchanged and still green. There is no blank field here that could land as a `0` and turn "unpositioned" into "positioned at the top-left", which is the trap `LodgingUnitForm`'s header warns arrives *through* this fix. An unplaced unit draws no pin, says so, and writes nothing until someone presses on the map.

Containers get no pin — the map draws their children, never them — and the check reads live off the "this is a building" checkbox. Create gets no pin either: there is no record id to write to yet.

## The base layer

Extracted the illustration, its scrim and the art-missing notice into `weekend/MapBaseLayer.tsx`, imported by direct path (never the `weekend` barrel, per #1964). `LodgingMap.tsx`'s diff is that extraction and nothing else — no reflow — because #2179 needs this file next. `WeekendRosterPage.chunkGraph.test.ts` still passes: the shared module lands in its own chunk and neither weekend route chunk gains a static edge to `LodgingMap`.

`hasCoordinates` now takes `Pick<LodgingUnitRow, 'map_x' | 'map_y'>` so the admin registry's `LodgingUnitRecord` is judged by the same rule, rather than a second copy of "both axes zero means unset".

## Partial close

**Only the drag half is buildable.** The label-guide overlay depends on 191 label positions living in a private base-map PDF the owner holds; no agent in this repo can produce or verify that asset, and CI will never see it. It was deliberately not invented. This issue therefore closes **partially** — reopen or split if the overlay should stay tracked.

## Also not built

Keyboard *operation* of the drag itself. The toggle is keyboard-reachable as required; moving the pin is pointer-only, honestly so, exactly as the weekend map's pan is. The accessible equivalent remains the units table this editor is opened from.

## Verification

- `vitest run` — 431 files, 6294 tests, exit 0
- `tsc --noEmit` — exit 0
- `eslint` on every touched file — 0 errors
- `WeekendRosterPage.chunkGraph.test.ts` (real `vite build`) — 3/3
- Mutation-checked: dropping the edit-mode gate, dropping the `hasCoordinates` guard, committing on pointer-down and dropping the container guard each turn the intended test red and are restored.

Closes #2013.
