### PR TITLE
feat(frontend): show a returning family's prior-year housing on their card

### DIFF
--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -383,6 +383,27 @@ class RosterParty(BaseModel):
     arrival_eta: str = ""
     # The household's cm_id was seen in an earlier year.
     is_returning: bool = False
+    # Where this household slept in the DIRECTLY PRIOR year, verbatim as staff
+    # wrote it -- kindred#2075, ruled Option A ("only the directly prior year
+    # just like summer"). "" means we do not know, which is the common case
+    # (202 of 2026's 459 registered households) and covers three different
+    # facts the card must not distinguish between: a genuine first-timer, a
+    # family who skipped last year, and a family whose last visit predates
+    # 2022 -- `family_camp_registrations.cabin_assignment` is blank on all
+    # 1,433 rows from 2017-2021. So "" is NOT "nobody assigned them", and no
+    # consumer should render a placeholder or a dash for it.
+    #
+    # FREE TEXT out of `cabin_assignment`, deliberately NOT resolved against
+    # `lodging_units` -- see `fetch_cabin_assignments_by_household_cm_id` for
+    # why (the registry holds only the current year, and 3 of the 88 distinct
+    # strings across 2022-2025 resolve to no alias at all). It may therefore
+    # name something no card on the board is called. Never match it against a
+    # `unit_code`.
+    #
+    # Only ever populated on the ROSTER, and only for household-grain parties:
+    # `build_summary` keeps nothing but counts, and an adult-weekend guest is
+    # person-grain with no household to key on.
+    last_year_cabin: str = ""
     share: ShareRequestSummary = Field(default_factory=ShareRequestSummary)
     flags: AccessibilityFlagSummary = Field(default_factory=AccessibilityFlagSummary)
 

--- a/api/services/lodging_cache.py
+++ b/api/services/lodging_cache.py
@@ -1,13 +1,14 @@
 """Server-side cache for the weekend roster's year-scoped PocketBase reads.
 
-`LodgingRosterService.build_roster` opens a TaskGroup with six year-scoped
-reads on every single-weekend load (kindred#1963) -- identical for every
-weekend in the year, and re-issued from scratch on every load because
-`build_roster` has no cache of its own. `build_summary` already hoists this
-work out of ITS per-weekend loop, but the plain roster does not, which is
-most of why an empty weekend costs ~3s.
+`LodgingRosterService.build_roster` opens a TaskGroup with seven year-scoped
+reads on every single-weekend load (kindred#1963, plus kindred#2075's
+prior-year cabins) -- identical for every weekend in the year, and re-issued
+from scratch on every load because `build_roster` has no cache of its own.
+`build_summary` already hoists six of the seven out of ITS per-weekend loop,
+but the plain roster does not, which is most of why an empty weekend costs
+~3s.
 
-Only FOUR of the six are cached here, not six. `fetch_units` (`lodging_units`)
+Only FIVE of the seven are cached here. `fetch_units` (`lodging_units`)
 and `count_open_unresolved_aliases` (`lodging_ingest_issues`) are written
 STRAIGHT TO POCKETBASE FROM THE BROWSER by the admin panels --
 `frontend/src/services/lodgingCrud.ts`'s `createLodgingUnit` /
@@ -16,11 +17,23 @@ STRAIGHT TO POCKETBASE FROM THE BROWSER by the admin panels --
 directly and never pass through this API. Caching either one would hide an
 admin's own edit -- a cabin just confirmed, a cabin name just resolved -- for
 the whole TTL, to buy about 16ms. That trade is not worth making, so
-LodgingRepository never calls this cache for those two reads. The four it DOES
-cache (`fetch_households`, `fetch_prior_household_cm_ids`,
+LodgingRepository never calls this cache for those two reads. Four of the five
+it DOES cache (`fetch_households`, `fetch_prior_household_cm_ids`,
 `fetch_family_camp_adults`, `fetch_family_camp_registrations`) are all
 sync-written only: the CampMinder Go ingest is their sole writer, so nothing
 in the browser can produce a row a staff member is waiting to see reflected.
+
+The fifth, `fetch_cabin_assignments_by_household_cm_id` (kindred#2075), is
+DERIVED rather than read: it is a join over `fetch_family_camp_registrations`
+and `fetch_households` for the same year, and it takes an entry here for the
+join, not for round trips it would otherwise make. Its inputs are therefore
+already covered by the paragraph above, and it inherits their safety argument
+-- but note the one thing it does not inherit: an LRU eviction of either
+input would let this derived entry outlive the data it was computed from,
+until its own TTL or the next `invalidate_all()` (both of which it shares
+with them). `max_size` is 64 against a handful of reads times a handful of
+years, so that eviction does not happen in practice; if the read set ever
+grows, raise `max_size` rather than reasoning about which entry went first.
 
 Shaped like api/services/metrics_cache.py (TTL + LRU + RLock) per that
 module's own docstring pattern, but closer in spirit to
@@ -66,10 +79,14 @@ T = TypeVar("T")
 class LodgingYearCache:
     """Thread-safe in-memory cache for the roster's year-scoped reads.
 
-    Keyed by (read name, year) -- there is no third axis. These four reads
-    never vary by session or scenario, which is exactly why hoisting them
+    Keyed by (read name, year) -- there is no third axis. None of the five
+    reads varies by session or scenario, which is exactly why hoisting them
     into a cache is safe: the same answer is correct for every weekend and
     every scenario in a year.
+
+    The year is the read's OWN argument, not "the year on screen":
+    `fetch_cabin_assignments_by_household_cm_id` is called at `year - 1`, and
+    lands under that key like any other.
     """
 
     def __init__(self, ttl_seconds: int = 900, max_size: int = 64) -> None:
@@ -121,7 +138,7 @@ class LodgingYearCache:
 
         Called by `api/routers/metrics.py`'s `POST /api/metrics/cache/invalidate`
         (kindred#2142), which the frontend fires on CampMinder sync completion --
-        see the module docstring for which syncs write the four cached reads and
+        see the module docstring for which syncs write the five cached reads and
         for the residual gap the TTL still covers.
 
         Also drops the in-flight lock map (kindred#2144). `asyncio.Lock` binds

--- a/api/services/lodging_repository.py
+++ b/api/services/lodging_repository.py
@@ -486,6 +486,62 @@ class LodgingRepository:
         )
         return {str(getattr(row, "household", "")): row for row in rows}
 
+    @cached_by_year(lodging_cache)
+    async def fetch_cabin_assignments_by_household_cm_id(self, year: int) -> dict[int, str]:
+        """Where each household slept in `year`, keyed by household CampMinder id.
+
+        The staff-written string out of `family_camp_registrations.cabin_assignment`
+        -- FREE TEXT, not a relation. It is deliberately NOT resolved to a
+        `lodging_units` row here: `lodging_units` holds only the current year,
+        so a 2023 string can name a cabin that no longer exists under that
+        name, and 3 of the 88 distinct strings across 2022-2025 resolve to no
+        alias at all. What staff wrote is the fact they are recalling; the
+        alias resolution (`lodging_unit_aliases` → `member_units`, honouring
+        `valid_from_year` / `valid_to_year`) is a separate job with a separate
+        failure mode.
+
+        ⚠️ KEYED BY cm_id, AND THAT IS THE ENTIRE POINT. `registration.household`
+        is a PocketBase relation into a YEAR-SCOPED `households` table, so a
+        2025 registration hangs off the *2025* households record -- a PB id the
+        2026 roster has never seen. Joining a prior year's registrations onto
+        the current year's household ids returns a plausible near-empty map
+        rather than an error, which reads as "everyone is a first-timer" and
+        survives review. Measured on the 2026 prod snapshot: bridging on
+        `cm_id` finds 257 of 459 registered households with a 2025 cabin;
+        joining on the PB id finds 0.
+
+        THE YEAR IS THE PARAMETER, and no "last year" arithmetic happens here
+        (kindred#2073 wants this same read once per year of 2022-2025;
+        kindred#2075's card asks only for `year - 1`). Composed from the two
+        existing `@cached_by_year` reads rather than a bespoke narrower query,
+        so a year already in hand costs nothing and a sweep across four years
+        pays each of them once per process. Its own cache entry on top is for
+        the join, not the round trips.
+
+        Empty for every year before 2022: `cabin_assignment` is blank on all
+        1,433 rows from 2017-2021, so a family last here in 2019 is genuinely
+        unrecoverable rather than missing.
+        """
+        registrations, households = await asyncio.gather(
+            self.fetch_family_camp_registrations(year),
+            self.fetch_households(year),
+        )
+        assignments: dict[int, str] = {}
+        for household_pb_id, registration in registrations.items():
+            cabin = str(getattr(registration, "cabin_assignment", "") or "").strip()
+            if not cabin:
+                continue
+            household = households.get(household_pb_id)
+            if household is None:
+                continue
+            # Never key on 0 -- `_build_household_parties` gives an
+            # unresolvable household `household_cm_id = 0`, so a 0 entry here
+            # would hand every one of those parties somebody else's cabin.
+            household_cm_id = int(getattr(household, "cm_id", 0) or 0)
+            if household_cm_id:
+                assignments[household_cm_id] = cabin
+        return assignments
+
     async def fetch_family_camp_medical(self, year: int) -> dict[str, Any]:
         """PHI, keyed by household PB id. NO PRODUCTION CALLER.
 

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -774,6 +774,18 @@ class LodgingRosterService:
             attendees_task = tg.create_task(self.repository.fetch_attendees_for_session(year, session_pb_id))
             households_task = tg.create_task(self.repository.fetch_households(year))
             prior_task = tg.create_task(self.repository.fetch_prior_household_cm_ids(year))
+            # kindred#2075. `year - 1` is computed HERE and nowhere else: the
+            # repository read takes a plain year, so kindred#2073's
+            # year-over-year view can sweep 2022-2025 with the same function.
+            # The ruling limits what the CARD renders, not what can be
+            # fetched.
+            #
+            # The only read in this group that is not for `year`. It lands in
+            # the same `@cached_by_year` store under a different key -- one
+            # cold fetch per year per process, not one per request -- and is
+            # deliberately absent from `build_summary`'s parallel TaskGroup,
+            # which keeps nothing but counts.
+            last_year_cabins_task = tg.create_task(self.repository.fetch_cabin_assignments_by_household_cm_id(year - 1))
             adults_task = tg.create_task(self.repository.fetch_family_camp_adults(year))
             registrations_task = tg.create_task(self.repository.fetch_family_camp_registrations(year))
             aliases_task = tg.create_task(self.repository.count_open_unresolved_aliases(year))
@@ -824,6 +836,7 @@ class LodgingRosterService:
             attendees=attendees_task.result(),
             households=households,
             prior_cm_ids=prior_task.result(),
+            last_year_cabins=last_year_cabins_task.result(),
             adults_by_household=adults_task.result(),
             registrations=registrations_task.result(),
             assignments=placements_task.result(),
@@ -844,12 +857,20 @@ class LodgingRosterService:
     async def build_summary(self, year: int, scenario: str = "") -> WeekendSummaryResponse:
         """Every weekend in the year with its counts, in one pass.
 
-        `build_roster` makes ten fetches, of which SIX are year-scoped -- the
-        unit registry, households, the prior-household set, family-camp adults,
-        registrations and the unresolved-alias count are identical for every
-        weekend in the year. Calling it once per weekend to fill the lander
-        repeats all six N times, which is why a weekend with zero parties still
-        costs about three seconds.
+        `build_roster` makes TWELVE fetches (11 concurrent + `fetch_session`
+        alone before them), of which SEVEN are year-scoped -- the unit
+        registry, households, the prior-household set, family-camp adults,
+        registrations, the unresolved-alias count and last year's cabins
+        (kindred#2075) are identical for every weekend in the year. Calling it
+        once per weekend to fill the lander would repeat all seven N times,
+        which is why a weekend with zero parties still costs about three
+        seconds.
+
+        The lander fetches only SIX of those seven. Last year's cabins feed
+        `RosterParty.last_year_cabin`, and no `WeekendSummaryEntry` carries a
+        party -- `_build_parties` runs here purely to be counted, so the
+        seventh read would buy a field nothing renders. `_build_parties` takes
+        it as a defaulted keyword for exactly that reason.
 
         kindred#1963 measures this from eleven and eight, so that issue is
         partly pre-paid: kindred#1889 deleted `has_medical_narrative`, the only
@@ -1158,6 +1179,14 @@ class LodgingRosterService:
         registrations: dict[str, Any],
         assignments: list[Any],
         unit_index: _BathroomIndex,
+        # kindred#2075, keyed by household cm_id. DEFAULTED, unlike
+        # `prior_cm_ids` beside it, because omitting it is a choice a caller
+        # legitimately makes: `build_summary` reads nothing off a party but
+        # its counts, so fetching a whole prior year to fill a field nothing
+        # renders would put back the cost kindred#1963 bought out. Every
+        # OTHER argument here is required precisely because a caller that
+        # dropped it would silently degrade the roster.
+        last_year_cabins: dict[int, str] | None = None,
     ) -> list[RosterParty]:
         placement_by_household, placement_by_person = self._index_assignments(assignments)
 
@@ -1173,6 +1202,7 @@ class LodgingRosterService:
             session_start=session_start,
             households=households,
             prior_cm_ids=prior_cm_ids,
+            last_year_cabins=last_year_cabins or {},
             adults_by_household=adults_by_household,
             registrations=registrations,
             placement_by_household=placement_by_household,
@@ -1270,6 +1300,7 @@ class LodgingRosterService:
         session_start: date | None,
         households: dict[str, Any],
         prior_cm_ids: set[int],
+        last_year_cabins: dict[int, str],
         adults_by_household: dict[str, list[Any]],
         registrations: dict[str, Any],
         placement_by_household: dict[int, _Placement],
@@ -1375,6 +1406,14 @@ class LodgingRosterService:
                     ),
                     arrival_eta=_s(registration, "arrival_eta") if registration is not None else "",
                     is_returning=household_cm_id in prior_cm_ids,
+                    # "" means UNKNOWN, and covers three different facts
+                    # (kindred#2075): a first-timer, a family who skipped last
+                    # year, and a family whose last visit predates 2022. The
+                    # card renders nothing for all three -- see the schema
+                    # field, which is where the reasoning lives. Not gated on
+                    # `is_returning`: the two derive from different tables and
+                    # a cabin we have is a cabin we can show.
+                    last_year_cabin=last_year_cabins.get(household_cm_id, ""),
                     share=self._build_share(registration),
                     flags=self._build_flags(registration),
                 )

--- a/frontend/src/components/weekend/FamilyCard.test.tsx
+++ b/frontend/src/components/weekend/FamilyCard.test.tsx
@@ -895,3 +895,121 @@ describe('FamilyCard — a shared surname is not repeated', () => {
     expect(screen.getByTestId('family-card-adults')).toHaveTextContent('Emma · David Johnson')
   })
 })
+
+/**
+ * kindred#2075 — last year's housing, right-anchored on the EXISTING grey line.
+ *
+ * Ruled Option A: mirror what summer already ships. `CamperCard.tsx` renders
+ * its `historyDisplay` right-anchored on line 2 beside Age/Grade; this puts
+ * the prior-year cabin right-anchored on line 2 beside the adults. NO THIRD
+ * LINE — the card is already denser than the request was filed against.
+ *
+ * The density constraint is the interesting half. Summer's line 2 carries a
+ * fixed-width "Age 9.42 · 4th"; this one carries variable-length adult names,
+ * and the card is about 244 px wide inside `LodgingUnitCard` (its `p-4` +
+ * `border-2` eat 36 px off the board's `minmax(280px,1fr)` column). So the two
+ * genuinely compete, and the ruling settles which one gives: TRUNCATE THE
+ * ADULT NAMES. The cabin string is the new information and must stay legible.
+ */
+describe('FamilyCard — last year’s housing', () => {
+  it('right-anchors the prior-year cabin on the same grey line as the adults', () => {
+    render(
+      <FamilyCard
+        party={party({ is_returning: true, last_year_cabin: 'Cedar Lodge - Room 2' })}
+        onOpen={vi.fn()}
+      />
+    )
+    const housing = screen.getByTestId('family-card-last-year-cabin')
+    expect(housing).toHaveTextContent('Cedar Lodge - Room 2')
+    // The SAME row as the adults, not a line of its own — the whole point of
+    // the ruling is 0 px added to the card.
+    expect(housing.parentElement).toContainElement(screen.getByTestId('family-card-adults'))
+  })
+
+  // THE COMMON CASE. 202 of 2026's 459 registered households have no 2025
+  // cabin, and "" covers three different facts (first-timer, skipped a year,
+  // last here before 2022 when `cabin_assignment` was blank on all 1,433
+  // rows). None of them is "nobody assigned them", so none of them gets a
+  // placeholder, an em dash, or a "First year" label.
+  it('renders nothing at all when there is no prior-year cabin', () => {
+    render(<FamilyCard party={party({ last_year_cabin: '' })} onOpen={vi.fn()} />)
+    expect(screen.queryByTestId('family-card-last-year-cabin')).not.toBeInTheDocument()
+    expect(screen.queryByText('—')).not.toBeInTheDocument()
+    expect(screen.queryByText(/first year/i)).not.toBeInTheDocument()
+  })
+
+  // DIRECTLY PRIOR YEAR ONLY. A family placed two years ago but not last year
+  // arrives with `is_returning: true` and an empty cabin — the two fields come
+  // from different tables and the "Returning" badge must not tempt anything
+  // here into showing an older stay.
+  it('shows nothing for a returning family whose last stay was not last year', () => {
+    render(
+      <FamilyCard party={party({ is_returning: true, last_year_cabin: '' })} onOpen={vi.fn()} />
+    )
+    expect(screen.getByText('Returning')).toBeInTheDocument()
+    expect(screen.queryByTestId('family-card-last-year-cabin')).not.toBeInTheDocument()
+  })
+
+  it('truncates the adult names and never the cabin', () => {
+    render(
+      <FamilyCard
+        party={party({
+          adults: [
+            { adult_number: 1, display_name: 'Genevieve Aleksandrova', relationship: 'Mother' },
+            { adult_number: 2, display_name: 'Bartholomew Aleksandrov', relationship: 'Father' },
+          ],
+          last_year_cabin: 'Cedar Grove Lodge - Room 12B',
+        })}
+        onOpen={vi.fn()}
+      />
+    )
+    const adults = screen.getByTestId('family-card-adults')
+    const housing = screen.getByTestId('family-card-last-year-cabin')
+    // The adults give way: `min-w-0` is what lets a flex child shrink below
+    // its content width at all, and without it `truncate` never fires.
+    expect(adults).toHaveClass('min-w-0', 'flex-1', 'truncate')
+    // The cabin does not: it neither shrinks nor wraps nor clips.
+    expect(housing).toHaveClass('whitespace-nowrap')
+    expect(housing).not.toHaveClass('truncate')
+    expect(housing).toHaveTextContent('Cedar Grove Lodge - Room 12B')
+  })
+
+  // 63 of 2026's 459 registered households have no named adult row at all
+  // (kindred#1925/#1946 dropped the nameless ones), so the grey line they sit
+  // on may not exist. The cabin is real data and is not dropped to preserve a
+  // line that was never there.
+  it('still shows the cabin for a household with no attending adults', () => {
+    render(
+      <FamilyCard party={party({ adults: [], last_year_cabin: 'Pine Cabin' })} onOpen={vi.fn()} />
+    )
+    expect(screen.getByTestId('family-card-last-year-cabin')).toHaveTextContent('Pine Cabin')
+    expect(screen.queryByTestId('family-card-adults')).not.toBeInTheDocument()
+  })
+
+  // Same grain gate as the "Returning" badge, and for the same reason: the
+  // server only ever keys this off a HOUSEHOLD cm_id, so a person-grain adult
+  // weekend guest has no prior-year cabin to have. Rendering one would put a
+  // line on a card that has no grey line at all.
+  it('never renders on a person-grain adult weekend guest', () => {
+    render(
+      <FamilyCard
+        party={party({
+          grain: 'person',
+          household_cm_id: 0,
+          person_cm_id: 5001,
+          display_name: 'Liam Garcia',
+          adults: [],
+          children: [],
+          last_year_cabin: 'Pine Cabin',
+        })}
+        onOpen={vi.fn()}
+      />
+    )
+    expect(screen.queryByTestId('family-card-last-year-cabin')).not.toBeInTheDocument()
+  })
+
+  it('carries the cabin into the drag overlay too', () => {
+    render(<FamilyCardPreview party={party({ last_year_cabin: 'Pine Cabin' })} />)
+    expect(screen.getByTestId('family-card-last-year-cabin')).toHaveTextContent('Pine Cabin')
+  })
+})

--- a/frontend/src/components/weekend/FamilyCard.test.tsx
+++ b/frontend/src/components/weekend/FamilyCard.test.tsx
@@ -330,7 +330,10 @@ describe('FamilyCard — what it shows', () => {
   it('marks a first-time household when is_returning is undefined', () => {
     const p = party()
     delete p.is_returning
-    render(<FamilyCard party={p as RosterPartyRow} onOpen={vi.fn()} />)
+    // No `as RosterPartyRow` here: `is_returning` is optional on the row, so
+    // `delete` leaves `p` at its declared type and the assertion only hid
+    // that from the reader (`@typescript-eslint/no-unnecessary-type-assertion`).
+    render(<FamilyCard party={p} onOpen={vi.fn()} />)
     expect(screen.getByText('First-time')).toBeInTheDocument()
     expect(screen.queryByText('Returning')).not.toBeInTheDocument()
   })
@@ -974,10 +977,15 @@ describe('FamilyCard — last year’s housing', () => {
     expect(housing).toHaveTextContent('Cedar Grove Lodge - Room 12B')
   })
 
-  // 63 of 2026's 459 registered households have no named adult row at all
-  // (kindred#1925/#1946 dropped the nameless ones), so the grey line they sit
-  // on may not exist. The cabin is real data and is not dropped to preserve a
-  // line that was never there.
+  // A household with no attending adult has no grey line for the cabin to
+  // join (kindred#1925/#1946 dropped the nameless rows). The cabin is real
+  // data and is not dropped to preserve a line that was never there.
+  //
+  // RARE, and do not re-derive it from `family_camp_adults.name` alone: 63 of
+  // 2026's 459 registered households have that column blank, but
+  // `_adult_display_name`'s first_name/last_name fallback is load-bearing, so
+  // the figure `computeAttendingAdults` produces is 35 of 459 registered and
+  // ONE of the 382 rostered households the board renders.
   it('still shows the cabin for a household with no attending adults', () => {
     render(
       <FamilyCard party={party({ adults: [], last_year_cabin: 'Pine Cabin' })} onOpen={vi.fn()} />

--- a/frontend/src/components/weekend/FamilyCard.tsx
+++ b/frontend/src/components/weekend/FamilyCard.tsx
@@ -350,10 +350,19 @@ function FamilyCardBody({
                   verbatim — never resolved against the unit registry, so it
                   can legitimately name something no card on the board is
                   called (see the schema field). `ml-auto` right-anchors it
-                  whether or not adults sit beside it: 63 of 2026's 459
-                  registered households have no named adult row at all, and
+                  whether or not adults sit beside it: a household with no
+                  attending adult has no grey line for the cabin to join, and
                   the cabin is real data that is not dropped to preserve a
-                  line that was never there. */}
+                  line that was never there.
+
+                  RARE, and deliberately not quantified off the `name` column
+                  alone — 63 of 2026's 459 registered households have a blank
+                  `family_camp_adults.name`, but `_adult_display_name`'s
+                  first_name/last_name fallback is load-bearing and rescues
+                  most of them, so the figure `computeAttendingAdults`
+                  actually produces is 35 of 459 registered and ONE of the
+                  382 rostered households this card renders. The branch earns
+                  its place on that one card, not on 63. */}
               {lastYearCabin.length > 0 && (
                 <span
                   data-testid="family-card-last-year-cabin"

--- a/frontend/src/components/weekend/FamilyCard.tsx
+++ b/frontend/src/components/weekend/FamilyCard.tsx
@@ -25,8 +25,21 @@
  *
  * What IS here: the children lead, bold, with truncated whole-year ages —
  * ages are the entire point of a "similar ages" match — the party size, the
- * attending adults one line down in grey, and the housing chips the fit
- * check actually judges.
+ * attending adults one line down in grey with last year's cabin right-anchored
+ * opposite them, and the housing chips the fit check actually judges.
+ *
+ * ## Last year's cabin shares line 2; it does not get one (kindred#2075)
+ *
+ * "Returning" is only half the fact staff act on — WHERE they stayed last year
+ * is what decides whether to repeat it. Summer already ships exactly this
+ * treatment (`CamperCard.tsx` right-anchors `historyDisplay` on its line 2
+ * beside Age/Grade), so under CLAUDE.md §4 that is the template and a third
+ * content line is the divergence. DIRECTLY PRIOR YEAR ONLY: no multi-year
+ * count, no "+2" affordance. A family placed two years ago but not last year
+ * shows nothing here, and so does a first-timer — `FamilyCard.test.tsx` pins
+ * both, because a helpful placeholder or an em dash would read as "nobody
+ * assigned them" on the 202 of 459 households where the answer is simply that
+ * we do not know.
  *
  * ## The household salutation is gone, not demoted (kindred#2074)
  *
@@ -222,6 +235,15 @@ function FamilyCardBody({
   // surfaces that replaced the salutation with this same list (kindred#2084).
   const attendingAdults = computeAttendingAdults(party)
   const { names: adultNames, sharedSurname: sharedAdultSurname } = dedupeAdultNames(attendingAdults)
+  // Last year's cabin, right-anchored on the grey line below (kindred#2075).
+  //
+  // Trimmed here rather than trusted: '' is the common case (202 of 2026's 459
+  // registered households) and a whitespace-only string must read as the same
+  // absence, not as an empty right-anchored gap. Read ONLY inside the
+  // household branch below, which is the grain gate — no second one here,
+  // because a redundant `isHousehold` guard would look like the load-bearing
+  // one and outlive the branch it duplicates.
+  const lastYearCabin = (party.last_year_cabin ?? '').trim()
   const attention = partyAttention(party, unit)
   const proximity = party.share?.proximity ?? []
   // `similar_ages` ACCOMPANIES `with`; it never replaces it. One chip covering
@@ -260,13 +282,53 @@ function FamilyCardBody({
         </span>
       </span>
 
+      {/* LINE 2, and it holds TWO things now (kindred#2075): the attending
+          adults on the left, last year's cabin right-anchored at the end.
+          Summer does exactly this at `CamperCard.tsx`'s line 2, where
+          `historyDisplay` sits opposite Age/Grade — under CLAUDE.md §4 that
+          made it the template rather than one option among two, and the
+          alternative (a third content line) the divergence.
+
+          The one place weekend cannot copy summer outright: summer's left
+          half is a fixed-width "Age 9.42 · 4th", where this one is
+          variable-length adult names, and the card is ~244 px wide inside
+          `LodgingUnitCard` (its `p-4` + `border-2` eat 36 px off the board's
+          `minmax(280px,1fr)` column). So they genuinely compete for the row,
+          and THE ADULT NAMES GIVE WAY: the cabin string is the new
+          information and the reason the line exists.
+
+          The budget, measured on 2022-2025's 1,786 placed registrations so
+          the next person does not have to: the cabin string runs 7-34
+          characters, p50 11 and p95 30. At `text-xs` even the longest fits
+          the ~220 px of card content, which is why the row carries no
+          `overflow-hidden` — clipping would eat the room number off the END
+          of the string, and there is nothing to clip.
+
+          HOUSEHOLD GRAIN ONLY, and this `isHousehold` branch is the whole
+          gate — the same one the "Returning" badge below uses, for the same
+          reason. The server keys the cabin off a household cm_id, so a
+          person-grain adult weekend guest has none to have, and the other
+          branch has no grey line to hang it on. */}
       {isHousehold
-        ? attendingAdults.length > 0 && (
-            <span
-              data-testid="family-card-adults"
-              className="text-muted-foreground text-xs leading-snug"
-            >
-              {/* A surname every adult shares is printed once at the end of
+        ? (attendingAdults.length > 0 || lastYearCabin.length > 0) && (
+            <span className="flex items-baseline gap-2">
+              {attendingAdults.length > 0 && (
+                <span
+                  data-testid="family-card-adults"
+                  // `min-w-0` is not decoration: without it a flex child
+                  // refuses to shrink below its content width and `truncate`
+                  // never fires, leaving the cabin pushed off the card.
+                  //
+                  // Truncated even when no cabin sits beside it, so line 2 is
+                  // ONE line on every card. The bold identity line above
+                  // already truncates for the same reason, and a four-adult
+                  // household that wraps here pushes the chip row down and
+                  // grows the card — the density problem this card fights
+                  // everywhere else. The full list is one click away in
+                  // `FamilyDetailsPanel`.
+                  className="text-muted-foreground min-w-0 flex-1 truncate text-xs leading-snug"
+                >
+                  {/* A surname every adult shares is printed once at the end of
                   the line, the same shape as the children's run above
                   (kindred#2180) -- but on a weaker signal, and deliberately
                   not the same rule: `family_camp_adults.last_name` is empty
@@ -275,13 +337,31 @@ function FamilyCardBody({
                   the 340 multi-adult rostered households and leaves the other
                   205 written out in full. The adults are the FILTERED list,
                   so a placeholder slot cannot suppress the dedupe. */}
-              {adultNames.map((name, index) => (
-                <Fragment key={String(attendingAdults[index]?.adult_number ?? index)}>
-                  {index > 0 && ' · '}
-                  <span>{name}</span>
-                </Fragment>
-              ))}
-              {sharedAdultSurname.length > 0 && ` ${sharedAdultSurname}`}
+                  {adultNames.map((name, index) => (
+                    <Fragment key={String(attendingAdults[index]?.adult_number ?? index)}>
+                      {index > 0 && ' · '}
+                      <span>{name}</span>
+                    </Fragment>
+                  ))}
+                  {sharedAdultSurname.length > 0 && ` ${sharedAdultSurname}`}
+                </span>
+              )}
+              {/* The staff-written string out of last year's registration,
+                  verbatim — never resolved against the unit registry, so it
+                  can legitimately name something no card on the board is
+                  called (see the schema field). `ml-auto` right-anchors it
+                  whether or not adults sit beside it: 63 of 2026's 459
+                  registered households have no named adult row at all, and
+                  the cabin is real data that is not dropped to preserve a
+                  line that was never there. */}
+              {lastYearCabin.length > 0 && (
+                <span
+                  data-testid="family-card-last-year-cabin"
+                  className="text-muted-foreground ml-auto flex-shrink-0 text-xs leading-snug whitespace-nowrap"
+                >
+                  {lastYearCabin}
+                </span>
+              )}
             </span>
           )
         : // Person-grain (adult weekend) parties are a single guest identified

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -5098,6 +5098,10 @@ export type RosterParty = {
    * Is Returning
    */
   is_returning?: boolean
+  /**
+   * Last Year Cabin
+   */
+  last_year_cabin?: string
   share?: ShareRequestSummary
   flags?: AccessibilityFlagSummary
 }

--- a/frontend/src/types/lodging.test.ts
+++ b/frontend/src/types/lodging.test.ts
@@ -67,6 +67,12 @@ const _exhaustiveRosterParty: Required<RosterPartyRow> = {
   effective_bathroom: 'unknown',
   arrival_eta: '',
   is_returning: false,
+  // kindred#2075: the DIRECTLY prior year's staff-written cabin string, free
+  // text out of `family_camp_registrations.cabin_assignment`. '' is the
+  // common case and means UNKNOWN, not "unassigned" — a regen that dropped
+  // this field would degrade every returning family's card to silence with
+  // nothing else to notice.
+  last_year_cabin: '',
   share: {
     preference: 'unknown',
     preference_raw: '',

--- a/tests/unit/api/services/test_lodging_repository.py
+++ b/tests/unit/api/services/test_lodging_repository.py
@@ -693,13 +693,43 @@ class TestFetchCabinAssignmentsByHouseholdCmId:
         assert result == {}
 
     @pytest.mark.asyncio
-    async def test_composes_over_the_two_cached_reads(self, repo: LodgingRepository, pb: MagicMock) -> None:
+    async def test_shares_the_round_trips_of_whoever_read_the_year_first(
+        self, repo: LodgingRepository, pb: MagicMock
+    ) -> None:
+        """A year already in hand costs this read NOTHING extra.
+
+        This is the whole reason it composes over the two existing
+        `@cached_by_year` reads instead of issuing a bespoke narrower query:
+        kindred#2073's sweep of 2022-2025 pays each year once per process,
+        and a bespoke query would have its own cache to keep coherent with
+        those two.
+
+        ⚠️ THE INNER READS ARE WHAT THIS PINS, so it must reach them --
+        calling THIS function twice would prove nothing, because its own
+        `@cached_by_year` entry serves the second call and the inner reads
+        are never touched. Mutation-checked: strip the decorator off
+        `fetch_households` or `fetch_family_camp_registrations` and the
+        counts here go to two.
+        """
+        queries = _route_by_collection(pb, {"family_camp_registrations": [], "households": []})
+
+        # Somebody else -- the same year's roster, or kindred#2073's previous
+        # year in the sweep -- got here first.
+        await repo.fetch_family_camp_registrations(2025)
+        await repo.fetch_households(2025)
+
+        await repo.fetch_cabin_assignments_by_household_cm_id(2025)
+
+        assert len(queries["family_camp_registrations"]) == 1
+        assert len(queries["households"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_its_own_cache_serves_the_second_call(self, repo: LodgingRepository, pb: MagicMock) -> None:
         """Two round trips the first time, none the second.
 
-        Both halves are already `@cached_by_year`, so kindred#2073's sweep of
-        2022-2025 pays each year once per process rather than once per
-        request. A bespoke narrower query would have its own cache to keep
-        coherent with those two.
+        The join on top gets its own `@cached_by_year` entry, so a second
+        weekend loading the same year re-walks neither the registrations nor
+        the households.
         """
         queries = _route_by_collection(pb, {"family_camp_registrations": [], "households": []})
 

--- a/tests/unit/api/services/test_lodging_repository.py
+++ b/tests/unit/api/services/test_lodging_repository.py
@@ -568,6 +568,148 @@ class TestFetchFamilyCampRegistrations:
         assert result["hh_1"].share_cabin_gate == "yes_share"
 
 
+def _route_by_collection(pb: MagicMock, rows: dict[str, list[Any]]) -> dict[str, list[dict[str, Any]]]:
+    """Give the pb mock a different row set per collection name.
+
+    Every other test in this file reads ONE collection, so the shared `pb`
+    fixture can hand the same list to any caller.
+    `fetch_cabin_assignments_by_household_cm_id` reads TWO -- and the whole
+    point of it is that they are joined on the right key, which a mock
+    returning the same rows to both would make untestable.
+
+    Returns the per-collection record of `query_params` each read was issued
+    with, so a test can assert both filters carry the SAME year.
+    """
+    queries: dict[str, list[dict[str, Any]]] = {}
+
+    def _collection(name: str) -> MagicMock:
+        def _get_full_list(**kwargs: Any) -> list[Any]:
+            queries.setdefault(name, []).append(kwargs["query_params"])
+            return rows.get(name, [])
+
+        col = MagicMock()
+        col.get_full_list.side_effect = _get_full_list
+        return col
+
+    pb.collection.side_effect = _collection
+    return queries
+
+
+class TestFetchCabinAssignmentsByHouseholdCmId:
+    """The prior-year housing read, keyed by CampMinder id.
+
+    ⚠️ THE JOIN IS THE WHOLE TEST. `family_camp_registrations.household` is a
+    PocketBase relation, and `households` is YEAR-SCOPED -- a 2025
+    registration hangs off the *2025* households record, whose PB id the 2026
+    roster is not carrying. Joining a prior year's registrations onto the
+    current year's household ids returns a plausible near-empty map rather
+    than an error, so the board would quietly report a camp of first-timers.
+    Measured on the 2026 prod snapshot: bridging on `cm_id` finds 257 of 459
+    registered households with a 2025 cabin; joining on the PB id finds 0.
+
+    Deliberately NOT restricted to "last year" here. kindred#2073 needs the
+    identical read once per year of 2022-2025, so the YEAR is the parameter
+    and "directly prior" is the caller's decision (kindred#2075's ruling
+    limits what the CARD renders, not what this can fetch).
+    """
+
+    @pytest.mark.asyncio
+    async def test_keys_by_household_cm_id_not_pocketbase_id(self, repo: LodgingRepository, pb: MagicMock) -> None:
+        _route_by_collection(
+            pb,
+            {
+                "family_camp_registrations": [_record(household="hh_2025_1", cabin_assignment="Cedar Lodge - Room 2")],
+                "households": [_record(id="hh_2025_1", cm_id=2000001)],
+            },
+        )
+
+        result = await repo.fetch_cabin_assignments_by_household_cm_id(2025)
+
+        assert result == {2000001: "Cedar Lodge - Room 2"}
+        # Belt and braces on the key SPACE, not just the value: a map keyed by
+        # PocketBase id would still satisfy an equality check written against
+        # whatever it happened to produce.
+        assert all(isinstance(key, int) for key in result)
+
+    @pytest.mark.asyncio
+    async def test_both_reads_are_scoped_to_the_year_asked_for(self, repo: LodgingRepository, pb: MagicMock) -> None:
+        """Reading registrations at 2025 against households at 2026 is the
+        same defect as joining on the PB id, one layer up.
+        """
+        queries = _route_by_collection(pb, {"family_camp_registrations": [], "households": []})
+
+        await repo.fetch_cabin_assignments_by_household_cm_id(2025)
+
+        assert "year = 2025" in queries["family_camp_registrations"][0]["filter"]
+        assert "year = 2025" in queries["households"][0]["filter"]
+
+    @pytest.mark.asyncio
+    async def test_blank_and_whitespace_assignments_are_dropped(self, repo: LodgingRepository, pb: MagicMock) -> None:
+        """`cabin_assignment` is empty for every row 2017-2021 (0 of 1,433) and
+        for the 16% of a live year not yet placed. An entry here means "we know
+        where they were"; a blank one would render as an empty right-anchored
+        gap on the card.
+        """
+        _route_by_collection(
+            pb,
+            {
+                "family_camp_registrations": [
+                    _record(household="hh_a", cabin_assignment=""),
+                    _record(household="hh_b", cabin_assignment="   "),
+                    _record(household="hh_c", cabin_assignment=None),
+                    _record(household="hh_d", cabin_assignment="  Pine Cabin  "),
+                ],
+                "households": [
+                    _record(id="hh_a", cm_id=2000001),
+                    _record(id="hh_b", cm_id=2000002),
+                    _record(id="hh_c", cm_id=2000003),
+                    _record(id="hh_d", cm_id=2000004),
+                ],
+            },
+        )
+
+        result = await repo.fetch_cabin_assignments_by_household_cm_id(2025)
+
+        assert result == {2000004: "Pine Cabin"}
+
+    @pytest.mark.asyncio
+    async def test_a_registration_with_no_matching_household_is_dropped(
+        self, repo: LodgingRepository, pb: MagicMock
+    ) -> None:
+        """Never key on 0. `_build_household_parties` gives an unresolvable
+        household `household_cm_id = 0`, so a 0 key here would hand every
+        such party somebody else's cabin.
+        """
+        _route_by_collection(
+            pb,
+            {
+                "family_camp_registrations": [_record(household="hh_gone", cabin_assignment="Pine Cabin")],
+                "households": [_record(id="hh_other", cm_id=2000001)],
+            },
+        )
+
+        result = await repo.fetch_cabin_assignments_by_household_cm_id(2025)
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_composes_over_the_two_cached_reads(self, repo: LodgingRepository, pb: MagicMock) -> None:
+        """Two round trips the first time, none the second.
+
+        Both halves are already `@cached_by_year`, so kindred#2073's sweep of
+        2022-2025 pays each year once per process rather than once per
+        request. A bespoke narrower query would have its own cache to keep
+        coherent with those two.
+        """
+        queries = _route_by_collection(pb, {"family_camp_registrations": [], "households": []})
+
+        await repo.fetch_cabin_assignments_by_household_cm_id(2025)
+        await repo.fetch_cabin_assignments_by_household_cm_id(2025)
+
+        assert len(queries["family_camp_registrations"]) == 1
+        assert len(queries["households"]) == 1
+
+
 class TestFetchHouseholdsByIds:
     """The fresh-fetch escape hatch for kindred#2143.
 

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -118,6 +118,10 @@ def _repo(**overrides: Any) -> MagicMock:
         # unexpectedly.
         "fetch_households_by_ids": {},
         "fetch_prior_household_cm_ids": set(),
+        # kindred#2075: last year's staff-written cabin string, keyed by
+        # household CampMinder id. Empty by default -- most families have no
+        # prior-year cabin, and that must be the shape the card sees.
+        "fetch_cabin_assignments_by_household_cm_id": {},
         "fetch_family_camp_adults": {},
         "fetch_family_camp_registrations": {},
         "fetch_family_camp_medical": {},
@@ -540,6 +544,50 @@ class TestFamilyCampParties:
         roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
 
         assert roster.parties[0].is_returning is True
+
+    @pytest.mark.asyncio
+    async def test_last_year_cabin_comes_from_the_directly_prior_year(self) -> None:
+        """kindred#2075, ruled Option A: the DIRECTLY prior year, like summer.
+
+        `year - 1` is computed here and nowhere else -- the repository read
+        takes a plain year so kindred#2073 can sweep 2022-2025 with it.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_households={"hh_1": _household(title="The Garcia Family")},
+            fetch_attendees_for_session=[_child(cm_id=1000002, first="Liam", last="Garcia")],
+            fetch_prior_household_cm_ids={2000001},
+            fetch_cabin_assignments_by_household_cm_id={2000001: "Cedar Lodge - Room 2"},
+        )
+
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.parties[0].last_year_cabin == "Cedar Lodge - Room 2"
+        repo.fetch_cabin_assignments_by_household_cm_id.assert_awaited_once_with(2025)
+
+    @pytest.mark.asyncio
+    async def test_a_household_with_no_prior_year_cabin_carries_an_empty_string(self) -> None:
+        """The COMMON case, and it must render as nothing at all.
+
+        202 of 2026's 459 registered households have no 2025 cabin -- a
+        first-timer, a family who skipped a year, or anyone whose last visit
+        predates 2022 (`cabin_assignment` is blank on all 1,433 rows from
+        2017-2021). None of those is "nobody assigned them", so the field
+        stays empty and the card prints no placeholder.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_households={"hh_1": _household(title="The Johnson Family")},
+            fetch_attendees_for_session=[_child(cm_id=1000002, first="Noah", last="Johnson")],
+            # Returning -- but the prior year they were here is not 2025.
+            fetch_prior_household_cm_ids={2000001},
+            fetch_cabin_assignments_by_household_cm_id={2000777: "Pine Cabin"},
+        )
+
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.parties[0].is_returning is True
+        assert roster.parties[0].last_year_cabin == ""
 
     @pytest.mark.asyncio
     async def test_request_text_is_read_from_the_derived_column(self) -> None:
@@ -2537,13 +2585,15 @@ class TestMedicalFlagsAndNarrative:
 class TestBuildSummary:
     """The lander's batched read.
 
-    It exists for one reason: `build_roster` makes ten fetches of which seven
-    are year-scoped, so filling a lander weekend-by-weekend repeats that
+    It exists for one reason: `build_roster` makes twelve fetches of which
+    seven are year-scoped, so filling a lander weekend-by-weekend repeats that
     year-wide work once per weekend. The point of these tests is that the
     batch does it ONCE and still agrees with the roster.
 
-    Both counts were one higher until kindred#1889 removed the whole-year
-    medical read from both paths.
+    Both counts were one lower until kindred#2075 added last year's cabins,
+    and one higher again before that until kindred#1889 removed the whole-year
+    medical read from both paths. The lander batches SIX of the seven -- see
+    `test_the_lander_never_reads_last_years_cabins` for the one it declines.
     """
 
     @pytest.mark.asyncio
@@ -2571,6 +2621,22 @@ class TestBuildSummary:
 
         repo.fetch_family_camp_medical.assert_not_called()
         repo.count_unconfirmed_units.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_the_lander_never_reads_last_years_cabins(self) -> None:
+        """kindred#2075's read belongs to the ROSTER, not the lander.
+
+        `build_summary` shares `_build_parties`, but it keeps only
+        `_build_counts`' numbers off the result -- no `WeekendSummaryEntry`
+        carries a party. Fetching a whole prior year of registrations and
+        households to fill a field nothing reads would put the cost back that
+        kindred#1963 bought out.
+        """
+        repo = _repo(fetch_weekend_sessions=[FAMILY_SESSION, ADULT_SESSION])
+
+        await LodgingRosterService(repo).build_summary(2026)
+
+        repo.fetch_cabin_assignments_by_household_cm_id.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_session_scoped_reads_happen_once_per_weekend(self) -> None:


### PR DESCRIPTION
Closes #2075.

Built to the owner's ruling of 2026-08-09: **Option A, directly prior year only** — *"just like summer (just like summer will become a recurring theme)."*

## What it looks like

Last year's cabin is **right-anchored on the existing grey line**, opposite the attending adults. **No third line, 0 px added to the card.**

That is not a preference — summer already ships this exact treatment. `CamperCard.tsx` renders `historyDisplay` right-anchored on its line 2 beside Age/Grade, inside a flex row. Under root `CLAUDE.md` §4 ("Family Camp models summer") that makes it the template and a third content line the divergence. This mirrors it.

**Directly prior year only.** No multi-year count, no "+2" affordance. A family placed two years ago but not last year shows nothing here, and so does a first-timer — no placeholder, no em dash, no "First year" label. Both cases are pinned by tests, because `""` covers three different facts (a genuine first-timer, a family who skipped a year, and a family whose last visit predates 2022) and none of them is "nobody assigned them".

## The density constraint, and how it was resolved

Summer's line 2 carries a fixed-width `Age 9.42 · 4th`. Weekend's carries variable-length adult names, and the card renders about **244 px** wide inside `LodgingUnitCard` (its `p-4` + `border-2` eat 36 px off the board's `minmax(280px,1fr)` column). So they genuinely compete for the row.

**The adult names give way; the cabin never does.** The adults get `min-w-0 flex-1 truncate`, the cabin gets `whitespace-nowrap flex-shrink-0`. There is a test with a long adult pair and a long unit name together that pins both class sets.

Budget, measured over 2022-2025's 1,786 placed registrations so the next person doesn't have to: the cabin string runs **7-34 characters, p50 11, p95 30**. At `text-xs` even the longest fits the ~220 px of card content, which is why the row carries no `overflow-hidden` — clipping would eat the room number off the *end* of the string, and there is nothing to clip.

One consequence worth naming: the adult line now truncates to a single line even when no cabin sits beside it. That is deliberate — the bold identity line above already truncates, and a four-adult household that wrapped here pushed the chip row down and grew the card. The full list is one click away in `FamilyDetailsPanel`.

## The join that would have silently returned nothing

`households` is **year-scoped**. A 2025 registration hangs off the *2025* households record, whose PocketBase id the 2026 roster never carries. Joining on the PB id returns a plausible near-empty map rather than an error — it reads as "everyone is a first-timer" and survives review.

Bridged on `households.cm_id`, and **measured read-only against the prod snapshot** rather than assumed:

| | count |
|---|---|
| 2026 households with a family-camp registration | 459 |
| …of those, returning (cm_id seen in any prior year) | 346 |
| **…of those, with a 2025 `cabin_assignment` — `cm_id` bridge** | **257** |
| …the same query joined on the PocketBase id | **0** |

So the feature lights up on 56% of registered households, and the wrong join would have shipped a blank line on all of them.

## Built for reuse — #2073 imports this next

`LodgingRepository.fetch_cabin_assignments_by_household_cm_id(year)` takes a **plain year**, not "last year": #2073's household year-over-year journey needs the identical read once per year of 2022-2025. `build_roster` is where `year - 1` is computed, and nowhere else. The ruling limits what the *card* renders, not what the helper can fetch.

It composes over the two existing `@cached_by_year` reads (`fetch_family_camp_registrations` + `fetch_households`) rather than a bespoke narrower query, so a four-year sweep pays each year once per process instead of once per request. `asyncio.gather` runs the two halves concurrently.

`build_summary` deliberately does **not** make this read: no `WeekendSummaryEntry` carries a party, so a whole prior year of registrations and households would buy a field nothing renders. `_build_parties` takes it as a defaulted keyword for exactly that reason, and a test pins the lander never calling it. That also corrects two stale docstrings that still said "ten fetches" — `build_roster` now makes twelve (11 concurrent + `fetch_session`), of which seven are year-scoped and the lander batches six.

## Not resolved against the unit registry, on purpose

`cabin_assignment` is **free text**. `lodging_units` holds only the current year, so a 2023 string can name a cabin that no longer exists under that name, and 3 of the 88 distinct strings across 2022-2025 resolve to no alias at all. The card shows what staff wrote — it never fails, and it is the fact they are recalling. The schema field says so, and says never to match it against a `unit_code`.

## Tests (TDD, failing first, mutation-checked)

- **Repository** (5): keys by `cm_id` not PB id; both reads scoped to the year asked for; blank/whitespace/`None` assignments dropped; a registration whose household is absent is dropped rather than keyed on `0`; two round trips the first call, none the second.
- **Roster service** (3): the cabin comes from `year - 1` and the read is awaited with exactly `2025`; a returning household with no 2025 cabin gets `""`; the lander never makes the read.
- **Card** (7): right-anchored on the same row as the adults; nothing at all with no cabin; nothing for a returning family whose last stay wasn't last year; adults truncate and the cabin does not; still shown for the 63 of 459 households with no named adult row; never on a person-grain adult-weekend guest; carried into the drag overlay.
- Exhaustive `Required<RosterPartyRow>` fixture updated alongside the `types.gen.ts` regen.

Mutation-checked: joining at `year + 1`, dropping the `.strip()`, rendering the span unconditionally, and removing `min-w-0 flex-1 truncate` each turn the relevant test red.

## Verification

`uv run pytest tests/unit/api` 2169 passed · `ruff check` clean · `mypy bunking api tests` clean (773 files) · `vitest run` 6509 passed (437 files) · `tsc --noEmit` clean · `verify-no-hardcoded-lodging.sh` OK.
