### PR TITLE
feat(frontend): place a family from the unit card, behind a typeahead

### DIFF
--- a/frontend/src/components/weekend/FloatingUnplacedBadge.tsx
+++ b/frontend/src/components/weekend/FloatingUnplacedBadge.tsx
@@ -15,7 +15,7 @@ import type { RosterPartyRow } from '../../types/lodging'
 import { FloatingQueueBadge } from '../ui'
 import { UNPLACED_DROPPABLE_ID } from './dragPlacement'
 import { FamilyCard } from './FamilyCard'
-import { partyIdentityLabel } from './householdIdentity'
+import { partyIdentityLabel, partySearchText } from './householdIdentity'
 import { partyKey } from './partyKey'
 
 export interface FloatingUnplacedBadgeProps {
@@ -38,18 +38,6 @@ const sortKey = (party: RosterPartyRow): string[] => [
   party.sort_name ?? '',
   partyIdentityLabel(party),
 ]
-
-// Children and adults included so a household can be found by the name of
-// whoever the staff member happens to remember. The leading element is the
-// SAME identity the card shows (kindred#2084), not the salutation -- a
-// search for the stale salutation's wording should not resurrect it here
-// when the card itself no longer shows it.
-const getSearchText = (party: RosterPartyRow): string =>
-  [
-    partyIdentityLabel(party),
-    ...(party.adults ?? []).map((adult) => adult.display_name ?? ''),
-    ...(party.children ?? []).map((child) => child.display_name ?? ''),
-  ].join(' ')
 
 const EMPTY_STATE = (
   <div className="flex h-full flex-col items-center justify-center py-8 text-center">
@@ -75,7 +63,7 @@ export function FloatingUnplacedBadge({
     <FloatingQueueBadge
       items={parties}
       sortKey={sortKey}
-      getSearchText={getSearchText}
+      getSearchText={partySearchText}
       renderList={(visible) => (
         <div className="flex flex-col gap-1.5">
           {visible.map((party) => (

--- a/frontend/src/components/weekend/LodgingBoard.drag.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.drag.test.tsx
@@ -14,7 +14,8 @@
  * Fictional data throughout.
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { act, render } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
 import { MemoryRouter } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -321,5 +322,78 @@ describe('LodgingBoard — threading the dragged family for the needs hatch (#19
     })
     startDrag('merge:cedar-2')
     expect(cards(container).dark).not.toHaveAttribute('data-needs-fit')
+  })
+})
+
+describe('LodgingBoard — placing a family from the space itself (kindred#2080)', () => {
+  /*
+   * The board's half of the second placement path. What is pinned here is the
+   * WIRING — that the picker's choice reaches the same mutation a drop does,
+   * carrying the intent `resolveDrop` would have produced. Which placements
+   * are refused is pure and lives in `dragPlacement.test.ts`.
+   */
+  const GARCIA = party({
+    household_cm_id: 202,
+    display_name: 'Garcia',
+    sort_name: 'Garcia',
+    adults: [{ adult_number: 1, display_name: 'Liam Garcia', relationship: 'Father' }],
+  })
+
+  function boardWithUnplaced(props: Partial<Parameters<typeof LodgingBoard>[0]> = {}) {
+    return renderBoard({
+      parties: [
+        party({ unit_code: 'cedar-1', unit_name: 'Cedar 1', unit_codes: ['cedar-1'] }),
+        GARCIA,
+      ],
+      ...props,
+    })
+  }
+
+  function pickerFor(name: string) {
+    return screen.getByRole('combobox', { name: new RegExp(`place a family in ${name}`, 'i') })
+  }
+
+  it('mounts the control on an empty space while placement is live', () => {
+    boardWithUnplaced()
+    expect(pickerFor('Cedar 2')).toBeInTheDocument()
+    // Cedar 1 already holds a family, so it offers nothing — the same rule
+    // that hides Hold on an occupied card.
+    expect(
+      screen.queryByRole('combobox', { name: /place a family in cedar 1/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('offers nothing without a scenario', () => {
+    boardWithUnplaced({ scenario: '' })
+    expect(screen.queryByRole('combobox', { name: /place a family/i })).not.toBeInTheDocument()
+  })
+
+  it('offers nothing without the permission to place', () => {
+    boardWithUnplaced({ canManage: false })
+    expect(screen.queryByRole('combobox', { name: /place a family/i })).not.toBeInTheDocument()
+  })
+
+  it('lists the UNPLACED parties, never one already in a cabin', async () => {
+    const user = userEvent.setup()
+    boardWithUnplaced()
+    await user.click(pickerFor('Cedar 2'))
+    const options = screen.getAllByRole('option')
+    expect(options).toHaveLength(1)
+    expect(options[0]).toHaveTextContent('Liam Garcia')
+  })
+
+  it('writes the same intent the equivalent drop would', async () => {
+    const user = userEvent.setup()
+    boardWithUnplaced()
+    await user.click(pickerFor('Cedar 2'))
+    await user.click(screen.getByRole('option', { name: /Liam Garcia/ }))
+    expect(move).toHaveBeenCalledTimes(1)
+    expect(move.mock.calls[0]?.[0]).toEqual({
+      kind: 'place',
+      party: GARCIA,
+      unitId: 'u2',
+      unitCode: 'cedar-2',
+      unitName: 'Cedar 2',
+    })
   })
 })

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -51,7 +51,12 @@ import { useUnitAvailability } from '../../hooks/useUnitAvailability'
 import { useUnitMerge } from '../../hooks/useUnitMerge'
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
 import { areaTokens, buildBoard } from './boardLayout'
-import { mergeDragUnit, resolveDrop, resolveMergeDrop } from './dragPlacement'
+import {
+  mergeDragUnit,
+  resolveDrop,
+  resolveMergeDrop,
+  resolvePickerPlacement,
+} from './dragPlacement'
 import { FamilyCard, FamilyCardPreview } from './FamilyCard'
 import { FamilyDetailsPanel } from './FamilyDetailsPanel'
 import { FloatingUnplacedBadge } from './FloatingUnplacedBadge'
@@ -305,6 +310,33 @@ export function LodgingBoard({
     [setCombined, unitsByCode]
   )
 
+  /*
+   * kindred#2080 — the unit card's picker, resolved through the DROP path.
+   *
+   * `resolvePickerPlacement` IS `resolveDrop`, so this branch inherits every
+   * refusal the drag has (a held space, a non-combined container, a party
+   * carrying neither CampMinder id, a party already alone in the room) rather
+   * than restating any of them, and produces the same `PlacementIntent` for
+   * the same `move`. One placement path with two affordances, not two paths.
+   *
+   * `canPlace` is re-checked here for the same reason `handleDragEnd`
+   * re-checks it: the card's own gate is the affordance half, and a write
+   * gate that lives only in an affordance is one prop away from being
+   * bypassed.
+   */
+  const placeParty = useCallback(
+    (unit: LodgingUnitRow, party: RosterPartyRow) => {
+      if (!canPlace) return
+      const intent = resolvePickerPlacement({ party, unitCode: unit.code, parties, units })
+      if (intent === null) return
+      // The rejection path is the hook's — it rolls the optimistic move back
+      // and raises the toast. Catching keeps the rejected promise from
+      // surfacing as an unhandled rejection, exactly as the drop handler does.
+      void move(intent).catch(() => undefined)
+    },
+    [canPlace, move, parties, units]
+  )
+
   const writeAvailability = useCallback(
     (unit: LodgingUnitRow, write: { familyAvailable: boolean | null; reason: string }) => {
       // The rejection path is the hook's: it raises the toast. Catching here
@@ -499,6 +531,15 @@ export function LodgingBoard({
                                 pendingMergeUnitId ===
                                   unitsByCode.get(slot.unit.parent_code ?? '')?.unit_id)
                             }
+                            // kindred#2080. The board's unplaced queue,
+                            // whole and unfiltered — the picker annotates and
+                            // orders it per card rather than hiding rows, on
+                            // the owner's ruling. `board.unplaced` is the
+                            // same list `FloatingUnplacedBadge` shows, so the
+                            // two can never disagree about who still needs a
+                            // cabin.
+                            unplacedParties={board.unplaced}
+                            onPlaceParty={placeParty}
                             onOpenParty={openParty}
                           />
                         ))}

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -1841,3 +1841,109 @@ describe('LodgingUnitCard — the needs-misfit hatch (#1912)', () => {
     expect(hatchClass(container)).not.toBe('')
   })
 })
+
+describe('LodgingUnitCard — placing a family from the space itself (kindred#2080)', () => {
+  const HUE = 'hsl(160 45% 42%)'
+  const unplaced = party({
+    household_cm_id: 202,
+    display_name: 'Garcia',
+    sort_name: 'Garcia',
+    adults: [{ adult_number: 1, display_name: 'Liam Garcia', relationship: 'Father' }],
+    children: [],
+    unit_code: '',
+    unit_name: '',
+    unit_codes: [],
+  })
+
+  function renderCard(props: Record<string, unknown> = {}) {
+    const onPlaceParty = vi.fn()
+    const view = render(
+      <LodgingUnitCard
+        slot={slot()}
+        hue={HUE}
+        canPlace={true}
+        unplacedParties={[unplaced]}
+        onPlaceParty={onPlaceParty}
+        onOpenParty={vi.fn()}
+        {...props}
+      />
+    )
+    return { ...view, onPlaceParty }
+  }
+
+  it('offers the control on an empty, available space while placement is live', () => {
+    renderCard()
+    expect(screen.getByRole('combobox', { name: /place a family in cedar 1/i })).toBeInTheDocument()
+  })
+
+  it('does not grow the card until the search box is engaged', () => {
+    /*
+     * Option A's only real cost, and the owner's answer to it: the list is
+     * not rendered until a staff member clicks into the typeahead, so the
+     * card — and therefore the whole grid row of up to ~82 cards — stays put.
+     *
+     * jsdom has no layout engine, so the claim is pinned STRUCTURALLY rather
+     * than in pixels: at rest the card contains no listbox and no rows.
+     */
+    renderCard()
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    expect(screen.queryAllByRole('option')).toHaveLength(0)
+    expect(screen.queryByText('Liam Garcia')).not.toBeInTheDocument()
+  })
+
+  it('grows only once the staff member clicks in', async () => {
+    const user = userEvent.setup()
+    renderCard()
+    await user.click(screen.getByRole('combobox', { name: /place a family in cedar 1/i }))
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: /Liam Garcia/ })).toBeInTheDocument()
+  })
+
+  it('writes the placement through the board', async () => {
+    const user = userEvent.setup()
+    const { onPlaceParty } = renderCard()
+    await user.click(screen.getByRole('combobox', { name: /place a family in cedar 1/i }))
+    await user.click(screen.getByRole('option', { name: /Liam Garcia/ }))
+    expect(onPlaceParty).toHaveBeenCalledTimes(1)
+    expect(onPlaceParty.mock.calls[0]?.[0]).toMatchObject({ code: 'cedar-1' })
+    expect(onPlaceParty.mock.calls[0]?.[1]).toEqual(unplaced)
+  })
+
+  it('is ABSENT on a held space, not dimmed', () => {
+    /*
+     * A hold refuses placement outright (#2087/#2090), and Hold's own control
+     * vanishes rather than dimming in the same situation. Absent adds no
+     * fifth meaning to the board's ruled signal vocabulary — `opacity-40` is
+     * REFUSAL and is spoken for by the invalid merge target.
+     */
+    const { container } = renderCard({
+      slot: slot({ unit: unit({ family_available_override: false }) }),
+    })
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+    expect(container.querySelector('.opacity-40')).toBeNull()
+  })
+
+  it('is absent on an occupied space, mirroring Hold', () => {
+    renderCard({ slot: slot({ parties: [party()] }) })
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+  })
+
+  it('is absent without a scenario or without the permission to place', () => {
+    renderCard({ canPlace: false })
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+  })
+
+  it('is absent when the board wires no writer', () => {
+    // `undefined` is how the board spells "not writable right now" under
+    // `exactOptionalPropertyTypes`, matching `onSetAvailability`.
+    renderCard({ onPlaceParty: undefined })
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+  })
+
+  it('is absent on a container the tree has not combined', () => {
+    // `resolveDrop` refuses one as a target, so offering the control would
+    // name an action that writes nothing.
+    renderCard({ slot: slot({ unit: unit({ is_container: true, is_combined: false }) }) })
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -24,6 +24,7 @@ import {
 import { isValidMergeTarget, mergeDragId, unitDroppableId } from './dragPlacement'
 import { FamilyCard } from './FamilyCard'
 import { resolveNeedsFit } from './needsFit'
+import { PlaceFamilyPicker } from './PlaceFamilyPicker'
 import { resolveRingPrecedence } from './ringPrecedence'
 import { partyKey } from './partyKey'
 import { reservationBadge, shareabilityBadge, sharingConflictBadge } from './unitBadges'
@@ -216,6 +217,28 @@ export interface LodgingUnitCardProps {
   onMerge?: (unit: LodgingUnitRow) => void
   /** True while THIS unit's merge/split write is in flight. */
   savingMerge?: boolean
+  /**
+   * Every UNPLACED party on the weekend — the picker's list (kindred#2080).
+   *
+   * NEVER pre-filtered by fit, on the owner's ruling: 6 of 118 units carry a
+   * private bathroom against 63 parties asking for one, so a list narrowed to
+   * "what fits" would be empty most of the time. `placementCandidates`
+   * annotates and orders them instead.
+   */
+  unplacedParties?: RosterPartyRow[]
+  /**
+   * Place a family in THIS space — the activation path for the write the drag
+   * gesture makes, for a staff member who has the space on screen and not the
+   * family.
+   *
+   * `undefined` is how the board spells "not writable right now" under
+   * `exactOptionalPropertyTypes`, matching `onSetAvailability` and `onSplit`
+   * above. The board resolves the intent through `resolvePickerPlacement`,
+   * which is `resolveDrop` — there is one placement path, not two.
+   */
+  onPlaceParty?: (unit: LodgingUnitRow, party: RosterPartyRow) => void
+  /** True while THIS unit's placement write is in flight. */
+  savingPlacement?: boolean
   onOpenParty: (party: RosterPartyRow) => void
 }
 
@@ -233,6 +256,9 @@ export function LodgingUnitCard({
   onSplit,
   onMerge,
   savingMerge = false,
+  unplacedParties = [],
+  onPlaceParty,
+  savingPlacement = false,
   onOpenParty,
 }: LodgingUnitCardProps) {
   const { unit, parties, consent } = slot
@@ -462,6 +488,36 @@ export function LodgingUnitCard({
    */
   const sharingConflict = isSplitContainer ? null : sharingConflictBadge(unit, overlappingKeys.size)
 
+  /*
+   * Whether this card offers to place a family from itself (kindred#2080).
+   *
+   * ABSENT, NOT DIMMED, in every negative case — mirroring how Hold itself
+   * vanishes on an occupied card rather than greying out. That is a signal
+   * decision, not a style one: under the board's ruled vocabulary
+   * (2026-08-09) `opacity-40` MEANS refusal and is spoken for by the invalid
+   * merge target and by a held space. An absent control adds no fifth
+   * meaning to any channel.
+   *
+   * The four gates, and why each is a gate rather than a fit judgement:
+   *
+   *   - `held` — a hold blocks placement outright (#2087/#2090), and
+   *     `resolveDrop` refuses the write. Offering the control would name an
+   *     action that writes nothing.
+   *   - occupied — Hold's own rule, and the same reasoning: the card that
+   *     already holds a family is not the card staff are looking to fill.
+   *     A SECOND family still reaches a shareable space by drag, which
+   *     remains the path for a share that has to be looked at deliberately.
+   *   - `isSplitContainer` — `resolveDrop` rejects one as a target, and it
+   *     gets no card anyway; belt-and-braces, exactly as `sharing` above.
+   *   - no writer / no `canPlace` — no scenario, or no `bunking.manage`.
+   *
+   * NOT gated on the list being empty. "Everyone has a cabin" is a real
+   * answer to the question the control asks, and the picker says it; hiding
+   * the control instead would leave staff wondering where it went.
+   */
+  const canPickFamily =
+    canPlace && onPlaceParty !== undefined && !held && !isSplitContainer && parties.length === 0
+
   const cardStateClassName = [
     RING_CLASSES[ringState],
     dashed ? 'border-dashed' : '',
@@ -660,6 +716,28 @@ export function LodgingUnitCard({
             onSetAvailability?.(unit, write)
           }}
         />
+        {/* kindred#2080 — the space's own placement path, for the staff
+            member who has the cabin on screen and not the family.
+
+            Inline and in this row on the owner's ruling (option A): no
+            popover, no second surface, literally Hold's shape. Like Hold's
+            reason form it carries `w-full`, so it wraps onto its own line of
+            this flex row; unlike Hold, it renders its LIST only once the
+            search box is engaged, which is what keeps ~82 resting cards from
+            growing. */}
+        {canPickFamily && (
+          <PlaceFamilyPicker
+            unit={unit}
+            parties={unplacedParties}
+            // The registry, only so a combined house is judged by its
+            // whole-house capacity rather than by its container row's delta.
+            units={units}
+            disabled={savingPlacement}
+            onSelect={(party) => {
+              onPlaceParty(unit, party)
+            }}
+          />
+        )}
         {/* Merging is promotion to the parent: dragging this handle onto a
             sibling's card writes `combined: true` on the shared parent. Absent
             entirely on a parentless room — there is nothing to promote it to —

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -237,8 +237,6 @@ export interface LodgingUnitCardProps {
    * which is `resolveDrop` — there is one placement path, not two.
    */
   onPlaceParty?: (unit: LodgingUnitRow, party: RosterPartyRow) => void
-  /** True while THIS unit's placement write is in flight. */
-  savingPlacement?: boolean
   onOpenParty: (party: RosterPartyRow) => void
 }
 
@@ -258,7 +256,6 @@ export function LodgingUnitCard({
   savingMerge = false,
   unplacedParties = [],
   onPlaceParty,
-  savingPlacement = false,
   onOpenParty,
 }: LodgingUnitCardProps) {
   const { unit, parties, consent } = slot
@@ -732,7 +729,6 @@ export function LodgingUnitCard({
             // The registry, only so a combined house is judged by its
             // whole-house capacity rather than by its container row's delta.
             units={units}
-            disabled={savingPlacement}
             onSelect={(party) => {
               onPlaceParty(unit, party)
             }}

--- a/frontend/src/components/weekend/PlaceFamilyPicker.test.tsx
+++ b/frontend/src/components/weekend/PlaceFamilyPicker.test.tsx
@@ -91,7 +91,8 @@ function renderPicker(props: Partial<Parameters<typeof PlaceFamilyPicker>[0]> = 
   const view = render(
     <>
       {/* A preceding control, so `userEvent.tab()` has somewhere to start —
-          the Tab-reachability claim is worthless asserted from nowhere. */}
+          the Tab-reachability claim is worthless asserted from nowhere. And a
+          following one, so "Tab LEAVES the control" has somewhere to land. */}
       <button type="button">Before</button>
       <PlaceFamilyPicker
         unit={unit()}
@@ -100,6 +101,7 @@ function renderPicker(props: Partial<Parameters<typeof PlaceFamilyPicker>[0]> = 
         onSelect={onSelect}
         {...props}
       />
+      <button type="button">After</button>
     </>
   )
   return { ...view, onSelect }
@@ -310,6 +312,88 @@ describe('PlaceFamilyPicker — closing', () => {
     await user.keyboard('{Escape}')
     expect(onKeyDown).not.toHaveBeenCalled()
   })
+
+  it('does not let Escape reach a DOCUMENT listener either, which is what the panel uses', async () => {
+    /*
+     * The React-handler assertion above does not prove the claim on its own.
+     * `FamilyDetailsPanel` does not listen through React — it calls
+     * `document.addEventListener('keydown', …)`, which sits ABOVE React's root
+     * container in the bubble path. So the containment only holds if the
+     * synthetic `stopPropagation` reaches the NATIVE event, and that is what
+     * this pins. Get it wrong and Escape dismisses the open family panel from
+     * inside a card picker.
+     */
+    const user = userEvent.setup()
+    const onDocumentKeyDown = vi.fn()
+    document.addEventListener('keydown', onDocumentKeyDown)
+    try {
+      renderPicker()
+      await user.click(searchBox())
+      await user.keyboard('{Escape}')
+      expect(onDocumentKeyDown).not.toHaveBeenCalled()
+    } finally {
+      document.removeEventListener('keydown', onDocumentKeyDown)
+    }
+  })
+
+  it('closes when focus leaves the control, so an abandoned card does not stay grown', async () => {
+    /*
+     * The whole point of gating the list behind engagement is that a card only
+     * grows while somebody is using it. Dismissal on an outside MOUSEDOWN is
+     * half the story: a staff member who Tabs onward has left just as surely,
+     * and the card they left must shrink back.
+     */
+    const user = userEvent.setup()
+    renderPicker()
+    await user.click(searchBox())
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    await user.tab()
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('lets one Tab leave the whole control, however long the list is', async () => {
+    /*
+     * The rows are `<button>`s, so they are natively tab stops unless told not
+     * to be — and `aria-activedescendant` REQUIRES that focus stay on the
+     * combobox. Left alone, a keyboard user leaving a card would have to Tab
+     * past every unplaced family first: 63 of them on the 2026 weekend, per
+     * card, on a board of ~82 cards.
+     */
+    const user = userEvent.setup()
+    renderPicker()
+    await user.click(searchBox())
+    await user.tab()
+    expect(screen.getByRole('button', { name: 'After' })).toHaveFocus()
+  })
+
+  it('stops pointing at a row once the list it lived in is gone', async () => {
+    // A dangling `aria-activedescendant` names an element that no longer
+    // exists, which is what a screen reader would try to announce next.
+    const user = userEvent.setup()
+    renderPicker()
+    await user.click(searchBox())
+    await user.keyboard('{ArrowDown}')
+    expect(searchBox()).toHaveAttribute('aria-activedescendant')
+    await user.click(document.body)
+    expect(searchBox()).not.toHaveAttribute('aria-activedescendant')
+  })
+})
+
+describe('PlaceFamilyPicker — the active row stays in view', () => {
+  it('scrolls the arrow-selected row into view', async () => {
+    /*
+     * The list is a `max-h-48` scroller — about five rows — over a queue that
+     * ran to 63 parties on the 2026 weekend. Without this the highlight walks
+     * off the bottom on the sixth ArrowDown and the keyboard user is steering
+     * something they cannot see. jsdom has no layout engine, so what is pinned
+     * is the CALL; `src/test/setup.ts` stubs it.
+     */
+    const user = userEvent.setup()
+    renderPicker()
+    await user.click(searchBox())
+    await user.keyboard('{ArrowDown}')
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' })
+  })
 })
 
 describe('PlaceFamilyPicker — searching', () => {
@@ -343,15 +427,5 @@ describe('PlaceFamilyPicker — nothing left to place', () => {
     renderPicker({ parties: [] })
     await user.click(searchBox())
     expect(screen.getByText('Everyone has a cabin.')).toBeInTheDocument()
-  })
-})
-
-describe('PlaceFamilyPicker — while a write is in flight', () => {
-  it('takes no second choice', async () => {
-    const user = userEvent.setup()
-    const { onSelect } = renderPicker({ disabled: true })
-    await user.click(searchBox())
-    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
-    expect(onSelect).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/weekend/PlaceFamilyPicker.test.tsx
+++ b/frontend/src/components/weekend/PlaceFamilyPicker.test.tsx
@@ -1,0 +1,357 @@
+/**
+ * Placing a family from the space itself (kindred#2080).
+ *
+ * Two rulings are pinned here and neither is obvious from the code alone:
+ *
+ *  1. **The list is not rendered until the staff member engages the search
+ *     box.** That is what makes an inline picker affordable — the card, and
+ *     therefore the whole grid row, only grows once somebody has actually
+ *     asked for it, so the resting board never moves. jsdom has no layout
+ *     engine, so "unchanged in height" is pinned STRUCTURALLY: at rest the
+ *     control renders no listbox and no option rows at all.
+ *
+ *  2. **The list annotates and orders. It never hides.** 6 of 118 units have a
+ *     private bathroom against 63 parties asking for one, so filtering to
+ *     "what fits" would leave staff unable to place anybody.
+ *
+ * The keyboard half is not a nicety either: a typeahead that only opened on a
+ * pointer click would be a trap on a board that is already close to
+ * pointer-only.
+ *
+ * Fictional data throughout.
+ */
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+import { PlaceFamilyPicker } from './PlaceFamilyPicker'
+
+function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
+  return {
+    unit_id: 'u1',
+    code: 'cedar-1',
+    name: 'Cedar 1',
+    area_code: 'CG',
+    area_name: 'Cedar Grove',
+    sleeps: 5,
+    bathroom: 'shared',
+    bathroom_group: '',
+    near_bathhouse: false,
+    has_power: false,
+    power_coverage: 'none',
+    has_ac: false,
+    has_fridge: false,
+    is_accessible: false,
+    is_confirmed: true,
+    is_active: true,
+    is_container: false,
+    inventory_class: 'family_pool',
+    shareability: 'shareable',
+    family_available_override: null,
+    reason: '',
+    is_family_available: true,
+    map_x: 0.5,
+    map_y: 0.5,
+    ...overrides,
+  }
+}
+
+function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
+  return {
+    grain: 'household',
+    household_cm_id: 101,
+    person_cm_id: 0,
+    display_name: 'Johnson',
+    sort_name: 'Johnson',
+    adults: [{ adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' }],
+    children: [{ person_cm_id: 9001, display_name: 'Noah Johnson', age: 8, grade: 3 }],
+    party_size: 3,
+    unit_code: '',
+    unit_name: '',
+    unit_codes: [],
+    is_merged_slot: false,
+    arrival_eta: '',
+    is_returning: false,
+    ...overrides,
+  }
+}
+
+const JOHNSON = party()
+const GARCIA = party({
+  household_cm_id: 202,
+  display_name: 'Garcia',
+  sort_name: 'Garcia',
+  adults: [{ adult_number: 1, display_name: 'Liam Garcia', relationship: 'Father' }],
+  children: [{ person_cm_id: 9002, display_name: 'Mia Garcia', age: 6, grade: 1 }],
+})
+
+function renderPicker(props: Partial<Parameters<typeof PlaceFamilyPicker>[0]> = {}) {
+  const onSelect = vi.fn()
+  const view = render(
+    <>
+      {/* A preceding control, so `userEvent.tab()` has somewhere to start —
+          the Tab-reachability claim is worthless asserted from nowhere. */}
+      <button type="button">Before</button>
+      <PlaceFamilyPicker
+        unit={unit()}
+        parties={[JOHNSON, GARCIA]}
+        units={[]}
+        onSelect={onSelect}
+        {...props}
+      />
+    </>
+  )
+  return { ...view, onSelect }
+}
+
+function searchBox() {
+  return screen.getByRole('combobox', { name: /place a family in cedar 1/i })
+}
+
+describe('PlaceFamilyPicker — at rest', () => {
+  it('renders the search box and nothing else', () => {
+    // The list is what would grow the card and shift the grid row. It must
+    // not exist until somebody engages the control.
+    renderPicker()
+    expect(searchBox()).toBeInTheDocument()
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    expect(screen.queryAllByRole('option')).toHaveLength(0)
+  })
+
+  it('names no family before the list is opened', () => {
+    renderPicker()
+    expect(screen.queryByText(/Johnson/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Garcia/)).not.toBeInTheDocument()
+  })
+})
+
+describe('PlaceFamilyPicker — opening', () => {
+  it('opens the list when the search box is clicked', async () => {
+    const user = userEvent.setup()
+    renderPicker()
+    await user.click(searchBox())
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+  })
+
+  it('opens the list on keyboard focus, so Tab is not a dead end', async () => {
+    const user = userEvent.setup()
+    renderPicker()
+    await user.tab() // the "Before" button
+    await user.tab() // the search box
+    expect(searchBox()).toHaveFocus()
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+  })
+
+  it('says the list is closed until it is', async () => {
+    const user = userEvent.setup()
+    renderPicker()
+    expect(searchBox()).toHaveAttribute('aria-expanded', 'false')
+    await user.click(searchBox())
+    expect(searchBox()).toHaveAttribute('aria-expanded', 'true')
+  })
+})
+
+describe('PlaceFamilyPicker — the list annotates and orders, never hides', () => {
+  it('lists every unplaced party even when not one of them fits', async () => {
+    // The ruling, as arithmetic: a hide-filter would empty this list.
+    const user = userEvent.setup()
+    renderPicker({
+      parties: [
+        party({ household_cm_id: 1, sort_name: 'Adams', flags: { needs_private_bathroom: true } }),
+        party({ household_cm_id: 2, sort_name: 'Baker', flags: { needs_power: true } }),
+        party({ household_cm_id: 3, sort_name: 'Cole', party_size: 40 }),
+      ],
+    })
+    await user.click(searchBox())
+    expect(screen.getAllByRole('option')).toHaveLength(3)
+  })
+
+  it('annotates a misfit on its own row rather than removing it', async () => {
+    const user = userEvent.setup()
+    renderPicker({
+      parties: [party({ flags: { needs_private_bathroom: true, needs_power: true } })],
+    })
+    await user.click(searchBox())
+    const option = screen.getByRole('option')
+    expect(option).toHaveTextContent('No private bathroom')
+    expect(option).toHaveTextContent('No power')
+  })
+
+  it('orders the best fit first', async () => {
+    const user = userEvent.setup()
+    renderPicker({
+      parties: [
+        party({ household_cm_id: 1, sort_name: 'Zimmerman', flags: { needs_power: true } }),
+        party({ household_cm_id: 2, sort_name: 'Adams' }),
+      ],
+      unit: unit({ power_coverage: 'none' }),
+    })
+    await user.click(searchBox())
+    const options = screen.getAllByRole('option')
+    expect(options[0]).toHaveAttribute('data-fit', 'fits')
+    expect(options[1]).toHaveAttribute('data-fit', 'unmet')
+  })
+
+  it('says nothing at all about a party that fits', async () => {
+    const user = userEvent.setup()
+    renderPicker({ parties: [JOHNSON], unit: unit({ power_coverage: 'all' }) })
+    await user.click(searchBox())
+    const option = screen.getByRole('option')
+    expect(option).toHaveAttribute('data-fit', 'fits')
+    expect(option).not.toHaveTextContent(/No power|No private bathroom|Over capacity/)
+  })
+})
+
+describe('PlaceFamilyPicker — the row figure', () => {
+  it('counts beds the way the capacity note does', async () => {
+    /*
+     * `party_size` is 0 for a party CampMinder never sized, and `partyBeds`
+     * falls back to the headcount for exactly that case. A row reading
+     * "0 beds" beside a note reading "needs 2" would be the same party
+     * counted two ways on one line.
+     */
+    const user = userEvent.setup()
+    renderPicker({
+      parties: [
+        party({
+          party_size: 0,
+          adults: [{ adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' }],
+          children: [{ person_cm_id: 9001, display_name: 'Noah Johnson', age: 8, grade: 3 }],
+        }),
+      ],
+      unit: unit({ sleeps: 1, power_coverage: 'all' }),
+    })
+    await user.click(searchBox())
+    const option = screen.getByRole('option')
+    expect(option).toHaveTextContent('2 beds')
+    expect(option).toHaveTextContent('Over capacity · needs 2, sleeps 1')
+  })
+})
+
+describe('PlaceFamilyPicker — choosing', () => {
+  it('hands the clicked party back', async () => {
+    const user = userEvent.setup()
+    const { onSelect } = renderPicker()
+    await user.click(searchBox())
+    await user.click(screen.getByRole('option', { name: /Liam Garcia/ }))
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(onSelect.mock.calls[0]?.[0]).toEqual(GARCIA)
+  })
+
+  it('closes the list and clears the search once a family is chosen', async () => {
+    const user = userEvent.setup()
+    renderPicker()
+    await user.click(searchBox())
+    await user.type(searchBox(), 'Garcia')
+    await user.click(screen.getByRole('option', { name: /Liam Garcia/ }))
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    expect(searchBox()).toHaveValue('')
+  })
+
+  it('walks the list with the arrow keys and commits with Enter', async () => {
+    const user = userEvent.setup()
+    const { onSelect } = renderPicker()
+    await user.click(searchBox())
+    await user.keyboard('{ArrowDown}')
+    const first = screen.getAllByRole('option')[0]
+    expect(searchBox()).toHaveAttribute('aria-activedescendant', first?.id ?? 'missing')
+    await user.keyboard('{ArrowDown}')
+    const second = screen.getAllByRole('option')[1]
+    expect(searchBox()).toHaveAttribute('aria-activedescendant', second?.id ?? 'missing')
+    await user.keyboard('{Enter}')
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    // Sorted by `sort_name`, so Garcia leads and Johnson is second.
+    expect(onSelect.mock.calls[0]?.[0]).toEqual(JOHNSON)
+  })
+
+  it('walks back up the list', async () => {
+    const user = userEvent.setup()
+    const { onSelect } = renderPicker()
+    await user.click(searchBox())
+    await user.keyboard('{ArrowDown}{ArrowDown}{ArrowUp}{Enter}')
+    expect(onSelect.mock.calls[0]?.[0]).toEqual(GARCIA)
+  })
+
+  it('commits nothing when Enter is pressed with no row active', async () => {
+    const user = userEvent.setup()
+    const { onSelect } = renderPicker()
+    await user.click(searchBox())
+    await user.keyboard('{Enter}')
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+})
+
+describe('PlaceFamilyPicker — closing', () => {
+  it('closes on Escape and leaves focus on the search box', async () => {
+    const user = userEvent.setup()
+    renderPicker()
+    await user.click(searchBox())
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    await user.keyboard('{Escape}')
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    expect(searchBox()).toHaveFocus()
+  })
+
+  it('does not let Escape reach the board behind it', async () => {
+    // The weekend board and its panels close on Escape too. A picker that let
+    // the key through would close the surface the staff member is working in.
+    const user = userEvent.setup()
+    const onKeyDown = vi.fn()
+    render(
+      // A bare listener is the point: this stands in for the board behind the
+      // card, which is not an interactive element either.
+      // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+      <div onKeyDown={onKeyDown}>
+        <PlaceFamilyPicker unit={unit()} parties={[JOHNSON]} units={[]} onSelect={vi.fn()} />
+      </div>
+    )
+    await user.click(searchBox())
+    await user.keyboard('{Escape}')
+    expect(onKeyDown).not.toHaveBeenCalled()
+  })
+})
+
+describe('PlaceFamilyPicker — searching', () => {
+  it('narrows to the typed name, adults and children alike', async () => {
+    const user = userEvent.setup()
+    renderPicker()
+    await user.click(searchBox())
+    await user.type(searchBox(), 'mia')
+    const options = screen.getAllByRole('option')
+    expect(options).toHaveLength(1)
+    expect(options[0]).toHaveTextContent('Garcia')
+  })
+
+  it('borrows the queue own wording when nothing matches the search', async () => {
+    // `FloatingQueueBadge` already says this, over the same parties, in the
+    // same session vocabulary. A second phrasing of one state reads as two.
+    const user = userEvent.setup()
+    renderPicker()
+    await user.click(searchBox())
+    await user.type(searchBox(), 'zzzz')
+    expect(screen.getByText(/No parties match "zzzz"/)).toBeInTheDocument()
+    expect(screen.queryAllByRole('option')).toHaveLength(0)
+  })
+})
+
+describe('PlaceFamilyPicker — nothing left to place', () => {
+  it('reuses the unplaced queue own copy rather than inventing a second string', async () => {
+    // The ONLY way this list can be empty: everybody is housed. There is no
+    // "nothing fits" state to write copy for, because nothing is ever hidden.
+    const user = userEvent.setup()
+    renderPicker({ parties: [] })
+    await user.click(searchBox())
+    expect(screen.getByText('Everyone has a cabin.')).toBeInTheDocument()
+  })
+})
+
+describe('PlaceFamilyPicker — while a write is in flight', () => {
+  it('takes no second choice', async () => {
+    const user = userEvent.setup()
+    const { onSelect } = renderPicker({ disabled: true })
+    await user.click(searchBox())
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/weekend/PlaceFamilyPicker.tsx
+++ b/frontend/src/components/weekend/PlaceFamilyPicker.tsx
@@ -1,0 +1,267 @@
+/**
+ * Place a family from the space itself (kindred#2080).
+ *
+ * ## Inline, in the card, in Hold's shape
+ *
+ * Owner ruling 2026-08-09: option A. This is not a popover and not a second
+ * surface — it is a control that lives in the unit card's own badge row,
+ * exactly as `UnitAvailabilityControl` does, and it grows the card in place
+ * the same way Hold's reason form does. Its children carry `w-full`, so it
+ * wraps onto its own line inside that flex row rather than fighting the chips
+ * for space; that is the precedent Hold set and the reason the card needed no
+ * new layout to host this.
+ *
+ * ## The list does not exist until somebody asks for it
+ *
+ * The second half of the ruling, and the half that makes an inline picker
+ * affordable at all: **the list is not rendered until the staff member
+ * engages the search box.** A card that grew on mount would push its whole
+ * grid row down on ~82 cards at once. Engaging one card grows one card.
+ *
+ * "Engages" means POINTER OR KEYBOARD. A typeahead that only opened on click
+ * would be a trap on a board already close to pointer-only, so this opens on
+ * focus — which covers a Tab arrival as well as a click — is arrow-navigable,
+ * and closes on Escape without letting the key reach the surfaces behind it.
+ *
+ * ## It never hides a family
+ *
+ * See `placementCandidates.ts` for the arithmetic. Rows are annotated and
+ * ordered by fit; nothing is withheld and nothing is refused here. The only
+ * refusals on this path are the drag path's own, inherited whole through
+ * `resolvePickerPlacement` → `resolveDrop`.
+ *
+ * The fit annotations live in the LIST ROWS. They deliberately touch none of
+ * the card's three ruled signal channels (dim = refusal, hatch = advisory
+ * misfit, forest tint = open), and draw no ring — kindred#2179 struck the last
+ * one an hour before this was written.
+ */
+import { useEffect, useId, useRef, useState } from 'react'
+
+import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+import { partyIdentityLabel } from './householdIdentity'
+import { partyKey } from './partyKey'
+import { candidateSearchText, placementCandidates } from './placementCandidates'
+import { partyBeds } from './rosterAttention'
+
+export interface PlaceFamilyPickerProps {
+  /** The card this control is mounted on. */
+  unit: LodgingUnitRow
+  /**
+   * Every UNPLACED party, exactly as the queue holds them. NEVER pre-filtered
+   * by fit — that is the ruling, not a caller convenience.
+   */
+  parties: RosterPartyRow[]
+  /**
+   * The whole registry. Needed only to total a combined house's capacity;
+   * `[]` is correct for every leaf card.
+   */
+  units?: LodgingUnitRow[]
+  onSelect: (party: RosterPartyRow) => void
+  /** A placement write from this card is in flight. */
+  disabled?: boolean
+}
+
+/**
+ * Notes are advisory, so they get the board's advisory ink rather than its
+ * destructive red — an over-capacity placement is permitted and routinely
+ * made. `partial` stays muted: "some rooms have power" is a qualification, not
+ * a warning.
+ */
+const NOTE_TONE: Record<'partial' | 'unmet', string> = {
+  unmet: 'text-amber-700 dark:text-amber-400',
+  partial: 'text-muted-foreground',
+}
+
+export function PlaceFamilyPicker({
+  unit,
+  parties,
+  units = [],
+  onSelect,
+  disabled = false,
+}: PlaceFamilyPickerProps) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  /** -1 is "no row active", which is the state Enter must do nothing in. */
+  const [activeIndex, setActiveIndex] = useState(-1)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  // Unique per mounted card. ~82 of these can be on the board at once, and
+  // `aria-activedescendant` points at an id — a shared one would aim every
+  // card's screen reader at the first card's rows.
+  const baseId = useId()
+  const listId = `${baseId}-list`
+
+  useEffect(() => {
+    if (!open) return
+    const handler = (event: MouseEvent) => {
+      if (containerRef.current?.contains(event.target as Node) === true) return
+      setOpen(false)
+    }
+    document.addEventListener('mousedown', handler)
+    return () => {
+      document.removeEventListener('mousedown', handler)
+    }
+  }, [open])
+
+  const trimmed = query.trim()
+  const needle = trimmed.toLowerCase()
+  // Annotated and ordered FIRST, then narrowed by what the staff member
+  // typed. The typed filter is the user's own; it is not a fit gate, and it
+  // is the only thing that ever removes a row.
+  const candidates = placementCandidates(parties, unit, units).filter(
+    (candidate) =>
+      needle === '' || candidateSearchText(candidate.party).toLowerCase().includes(needle)
+  )
+
+  const close = () => {
+    setOpen(false)
+    setActiveIndex(-1)
+  }
+
+  const choose = (party: RosterPartyRow) => {
+    onSelect(party)
+    setQuery('')
+    close()
+  }
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Escape') {
+      if (!open) return
+      // The board and its detail panel both close on Escape. Dismissing this
+      // list must not also dismiss the surface it is sitting in.
+      event.stopPropagation()
+      event.preventDefault()
+      close()
+      inputRef.current?.focus()
+      return
+    }
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      setOpen(true)
+      setActiveIndex((index) => Math.min(index + 1, candidates.length - 1))
+      return
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      setOpen(true)
+      setActiveIndex((index) => (index <= 0 ? candidates.length - 1 : index - 1))
+      return
+    }
+    if (event.key === 'Enter') {
+      // Never a submit: this control can be mounted inside Hold's own form.
+      event.preventDefault()
+      const chosen = candidates[activeIndex]
+      if (chosen !== undefined) choose(chosen.party)
+    }
+  }
+
+  const activeId =
+    activeIndex >= 0 && activeIndex < candidates.length
+      ? `${baseId}-${String(activeIndex)}`
+      : undefined
+
+  return (
+    <div ref={containerRef} className="flex w-full flex-col gap-1">
+      <input
+        ref={inputRef}
+        type="text"
+        role="combobox"
+        // Named for the cabin, exactly as Hold's own button is: ~82 controls
+        // all called "Place a family" is unusable with a screen reader.
+        aria-label={`Place a family in ${unit.name}`}
+        placeholder="Place a family…"
+        value={query}
+        disabled={disabled}
+        aria-expanded={open}
+        aria-autocomplete="list"
+        // Unconditional, though the listbox only exists while open: the
+        // combobox role REQUIRES it (jsx-a11y/role-has-required-aria-props),
+        // and a reference to a not-yet-rendered id is the standard combobox
+        // shape rather than a dangling pointer.
+        aria-controls={listId}
+        {...(activeId === undefined ? {} : { 'aria-activedescendant': activeId })}
+        onFocus={() => {
+          setOpen(true)
+        }}
+        onClick={() => {
+          setOpen(true)
+        }}
+        onChange={(event) => {
+          setQuery(event.target.value)
+          setOpen(true)
+          // The row that was active is not the row that is active now — the
+          // list under it just changed. Enter on a stale index would place a
+          // family the staff member is no longer looking at.
+          setActiveIndex(-1)
+        }}
+        onKeyDown={onKeyDown}
+        // Hold's reason input, to the class. Same control, same card, same
+        // shape (CLAUDE.md §4).
+        className="border-border bg-background text-foreground placeholder:text-muted-foreground/60 focus:border-primary/50 focus:ring-primary/10 w-full rounded-md border px-1.5 py-1 text-sm focus:ring-2 focus:outline-none"
+      />
+
+      {open && (
+        <div
+          id={listId}
+          role="listbox"
+          aria-label={`Families to place in ${unit.name}`}
+          className="border-border bg-background max-h-48 overflow-y-auto rounded-md border"
+        >
+          {parties.length === 0 ? (
+            /* The ONLY way this list is empty, because nothing is ever
+               hidden. `FloatingUnplacedBadge` already says this over the same
+               parties — one state, one sentence. */
+            <p className="text-muted-foreground px-2 py-3 text-center text-sm italic">
+              Everyone has a cabin.
+            </p>
+          ) : candidates.length === 0 ? (
+            /* A typo, not a fit verdict. `FloatingQueueBadge`'s own wording,
+               in the same "parties" vocabulary an adult weekend needs. */
+            <p className="text-muted-foreground px-2 py-3 text-center text-sm">
+              {`No parties match "${trimmed}"`}
+            </p>
+          ) : (
+            candidates.map((candidate, index) => (
+              <button
+                key={partyKey(candidate.party)}
+                id={`${baseId}-${String(index)}`}
+                type="button"
+                role="option"
+                aria-selected={index === activeIndex}
+                data-fit={candidate.fit}
+                // Keeps focus on the combobox through the click, so Escape and
+                // the arrows still work after a mis-click on a row.
+                onMouseDown={(event) => {
+                  event.preventDefault()
+                }}
+                onMouseEnter={() => {
+                  setActiveIndex(index)
+                }}
+                onClick={() => {
+                  choose(candidate.party)
+                }}
+                className={`flex w-full flex-col gap-0.5 px-2 py-1.5 text-left text-sm ${
+                  index === activeIndex ? 'bg-muted' : ''
+                }`}
+              >
+                <span className="flex items-baseline gap-1.5">
+                  <span className="truncate">{partyIdentityLabel(candidate.party)}</span>
+                  <span className="text-muted-foreground ml-auto text-xs tabular-nums">
+                    {`${String(partyBeds(candidate.party))} beds`}
+                  </span>
+                </span>
+                {candidate.notes.length > 0 && (
+                  <span
+                    className={`text-xs ${NOTE_TONE[candidate.fit === 'unmet' ? 'unmet' : 'partial']}`}
+                  >
+                    {candidate.notes.join(' · ')}
+                  </span>
+                )}
+              </button>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/weekend/PlaceFamilyPicker.tsx
+++ b/frontend/src/components/weekend/PlaceFamilyPicker.tsx
@@ -23,6 +23,13 @@
  * focus — which covers a Tab arrival as well as a click — is arrow-navigable,
  * and closes on Escape without letting the key reach the surfaces behind it.
  *
+ * It also closes when focus LEAVES, which is the same rule stated from the
+ * other end: a card that was Tabbed away from has been abandoned as surely as
+ * one clicked away from, and must shrink back. Focus itself never enters the
+ * list — the rows are `tabIndex={-1}` and the combobox keeps focus through
+ * `aria-activedescendant` — so one Tab leaves the whole control however many
+ * families are in it.
+ *
  * ## It never hides a family
  *
  * See `placementCandidates.ts` for the arithmetic. Rows are annotated and
@@ -35,12 +42,12 @@
  * misfit, forest tint = open), and draw no ring — kindred#2179 struck the last
  * one an hour before this was written.
  */
-import { useEffect, useId, useRef, useState } from 'react'
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
-import { partyIdentityLabel } from './householdIdentity'
+import { partyIdentityLabel, partySearchText } from './householdIdentity'
 import { partyKey } from './partyKey'
-import { candidateSearchText, placementCandidates } from './placementCandidates'
+import { placementCandidates } from './placementCandidates'
 import { partyBeds } from './rosterAttention'
 
 export interface PlaceFamilyPickerProps {
@@ -57,8 +64,6 @@ export interface PlaceFamilyPickerProps {
    */
   units?: LodgingUnitRow[]
   onSelect: (party: RosterPartyRow) => void
-  /** A placement write from this card is in flight. */
-  disabled?: boolean
 }
 
 /**
@@ -72,13 +77,7 @@ const NOTE_TONE: Record<'partial' | 'unmet', string> = {
   partial: 'text-muted-foreground',
 }
 
-export function PlaceFamilyPicker({
-  unit,
-  parties,
-  units = [],
-  onSelect,
-  disabled = false,
-}: PlaceFamilyPickerProps) {
+export function PlaceFamilyPicker({ unit, parties, units = [], onSelect }: PlaceFamilyPickerProps) {
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
   /** -1 is "no row active", which is the state Enter must do nothing in. */
@@ -91,32 +90,65 @@ export function PlaceFamilyPicker({
   const baseId = useId()
   const listId = `${baseId}-list`
 
+  /**
+   * Shut, and forget which row was active.
+   *
+   * Both halves, always. A dismissal that dropped `open` but left
+   * `activeIndex` would leave `aria-activedescendant` naming a row that no
+   * longer exists — the next thing a screen reader would try to announce.
+   */
+  const close = useCallback(() => {
+    setOpen(false)
+    setActiveIndex(-1)
+  }, [])
+
   useEffect(() => {
     if (!open) return
     const handler = (event: MouseEvent) => {
       if (containerRef.current?.contains(event.target as Node) === true) return
-      setOpen(false)
+      close()
     }
     document.addEventListener('mousedown', handler)
     return () => {
       document.removeEventListener('mousedown', handler)
     }
-  }, [open])
+  }, [open, close])
+
+  /*
+   * The active row follows the arrows THROUGH the scroller.
+   *
+   * The list is `max-h-48` — about five rows — over a queue that ran to 63
+   * unplaced parties on the 2026 weekend, so without this the highlight walks
+   * off the bottom on the sixth ArrowDown and the keyboard user is steering
+   * something they cannot see. `block: 'nearest'` scrolls the list only when
+   * the row is actually out of view, and never moves the page.
+   */
+  useEffect(() => {
+    if (activeIndex < 0) return
+    document.getElementById(`${baseId}-${String(activeIndex)}`)?.scrollIntoView({
+      block: 'nearest',
+    })
+  }, [activeIndex, baseId])
 
   const trimmed = query.trim()
   const needle = trimmed.toLowerCase()
   // Annotated and ordered FIRST, then narrowed by what the staff member
   // typed. The typed filter is the user's own; it is not a fit gate, and it
   // is the only thing that ever removes a row.
-  const candidates = placementCandidates(parties, unit, units).filter(
-    (candidate) =>
-      needle === '' || candidateSearchText(candidate.party).toLowerCase().includes(needle)
+  //
+  // Memoised because ~82 of these are mounted at once and every one of them
+  // holds the WHOLE unplaced queue: recomputed on each render, one board
+  // re-render (a drag starting, a panel opening) would re-annotate and re-sort
+  // that queue eighty-two times over. `parties` is `board.unplaced` and
+  // `units` the registry, both already memo-stable in `LodgingBoard`.
+  const candidates = useMemo(
+    () =>
+      placementCandidates(parties, unit, units).filter(
+        (candidate) =>
+          needle === '' || partySearchText(candidate.party).toLowerCase().includes(needle)
+      ),
+    [parties, unit, units, needle]
   )
-
-  const close = () => {
-    setOpen(false)
-    setActiveIndex(-1)
-  }
 
   const choose = (party: RosterPartyRow) => {
     onSelect(party)
@@ -161,7 +193,25 @@ export function PlaceFamilyPicker({
       : undefined
 
   return (
-    <div ref={containerRef} className="flex w-full flex-col gap-1">
+    <div
+      ref={containerRef}
+      className="flex w-full flex-col gap-1"
+      /*
+       * Focus leaving the control closes it, and that is the other half of
+       * "the card only grows while somebody is using it". Dismissal on an
+       * outside MOUSEDOWN alone leaves a card that was Tabbed away from
+       * standing open — grown, and holding a listbox nobody is looking at.
+       *
+       * `relatedTarget` is where focus WENT: `null` (focus fell to the body)
+       * and anything outside this container both count as leaving. A click on
+       * a row never gets here — the row's `onMouseDown` keeps focus on the
+       * combobox precisely so it does not.
+       */
+      onBlur={(event) => {
+        if (event.currentTarget.contains(event.relatedTarget)) return
+        close()
+      }}
+    >
       <input
         ref={inputRef}
         type="text"
@@ -171,7 +221,6 @@ export function PlaceFamilyPicker({
         aria-label={`Place a family in ${unit.name}`}
         placeholder="Place a family…"
         value={query}
-        disabled={disabled}
         aria-expanded={open}
         aria-autocomplete="list"
         // Unconditional, though the listbox only exists while open: the
@@ -228,6 +277,12 @@ export function PlaceFamilyPicker({
                 type="button"
                 role="option"
                 aria-selected={index === activeIndex}
+                // Out of the tab order, because `aria-activedescendant` means
+                // focus never leaves the combobox. A `<button>` is a tab stop
+                // by default, so without this every row is one: Tabbing off a
+                // card would walk the staff member through all 63 unplaced
+                // parties first, on each of ~82 cards.
+                tabIndex={-1}
                 data-fit={candidate.fit}
                 // Keeps focus on the combobox through the click, so Escape and
                 // the arrows still work after a mis-click on a row.

--- a/frontend/src/components/weekend/dragPlacement.test.ts
+++ b/frontend/src/components/weekend/dragPlacement.test.ts
@@ -17,6 +17,7 @@ import {
   partyGrainBody,
   resolveDrop,
   resolveMergeDrop,
+  resolvePickerPlacement,
   unitDroppableId,
 } from './dragPlacement'
 import { partyKey } from './partyKey'
@@ -640,5 +641,106 @@ describe('applyPlacement', () => {
       unitName: 'Cedar 1',
     })
     expect(next.parties?.[1]).toEqual(other)
+  })
+})
+
+describe('resolvePickerPlacement', () => {
+  /*
+   * kindred#2080's placement path. The point of these tests is that there is
+   * only ONE path: the picker must produce the intent the equivalent DROP
+   * would produce, and inherit every refusal, rather than growing a parallel
+   * set of rules that can drift.
+   */
+  it('produces the same intent an equivalent drop would', () => {
+    const p = party()
+    const viaPicker = resolvePickerPlacement({
+      party: p,
+      unitCode: 'cedar-1',
+      parties: [p],
+      units: [CEDAR_1],
+    })
+    const viaDrop = resolveDrop({
+      activeId: partyKey(p),
+      overId: unitDroppableId('cedar-1'),
+      parties: [p],
+      units: [CEDAR_1],
+    })
+    expect(viaPicker).toEqual(viaDrop)
+    expect(viaPicker).toEqual({
+      kind: 'place',
+      party: p,
+      unitId: 'u1',
+      unitCode: 'cedar-1',
+      unitName: 'Cedar 1',
+    })
+  })
+
+  it('inherits the held-space refusal rather than adding a second one', () => {
+    // #2087/#2199 put the refusal in `resolveDrop` precisely because #2080
+    // reaches placement without touching a `useDroppable`. A picker-layer
+    // check of its own would be the second copy that comment exists to
+    // prevent.
+    const p = party()
+    const held = unit({ family_available_override: false })
+    expect(
+      resolvePickerPlacement({ party: p, unitCode: 'cedar-1', parties: [p], units: [held] })
+    ).toBeNull()
+  })
+
+  it('refuses a party carrying neither CampMinder id', () => {
+    const nameless = party({ household_cm_id: 0, person_cm_id: 0, display_name: 'Unresolved' })
+    expect(
+      resolvePickerPlacement({
+        party: nameless,
+        unitCode: 'cedar-1',
+        parties: [nameless],
+        units: [CEDAR_1],
+      })
+    ).toBeNull()
+  })
+
+  it('refuses a container the tree has not combined', () => {
+    const split = unit({ is_container: true, is_combined: false })
+    const p = party()
+    expect(
+      resolvePickerPlacement({ party: p, unitCode: 'cedar-1', parties: [p], units: [split] })
+    ).toBeNull()
+  })
+
+  it('refuses a unit the payload does not carry', () => {
+    const p = party()
+    expect(
+      resolvePickerPlacement({ party: p, unitCode: 'nowhere-9', parties: [p], units: [CEDAR_1] })
+    ).toBeNull()
+  })
+
+  it('does nothing for a party already alone in that unit', () => {
+    // Every write flips one-way `staff_touched`, so a no-op must stay a no-op
+    // on this path too.
+    const settled = party({ unit_code: 'cedar-1', unit_name: 'Cedar 1', unit_codes: ['cedar-1'] })
+    expect(
+      resolvePickerPlacement({
+        party: settled,
+        unitCode: 'cedar-1',
+        parties: [settled],
+        units: [CEDAR_1],
+      })
+    ).toBeNull()
+  })
+
+  it('resolves the party against the CURRENT roster, not the row it was handed', () => {
+    // The list is rendered from a snapshot. If a refetch lands between render
+    // and click, the party the row closed over may be gone — and inventing a
+    // write for a party the roster no longer has is how a placement lands on
+    // a stale identity.
+    const stale = party({ household_cm_id: 999, display_name: 'Departed' })
+    expect(
+      resolvePickerPlacement({
+        party: stale,
+        unitCode: 'cedar-1',
+        parties: [party()],
+        units: [CEDAR_1],
+      })
+    ).toBeNull()
   })
 })

--- a/frontend/src/components/weekend/dragPlacement.ts
+++ b/frontend/src/components/weekend/dragPlacement.ts
@@ -242,6 +242,45 @@ export function resolveDrop({
   }
 }
 
+export interface ResolvePickerPlacementArgs {
+  /** The row the staff member clicked, as the list rendered it. */
+  party: RosterPartyRow
+  /** The card the picker is mounted on. */
+  unitCode: string
+  parties: RosterPartyRow[]
+  units: LodgingUnitRow[]
+}
+
+/**
+ * The unit card's picker (kindred#2080), resolved through the DROP path.
+ *
+ * A thin adapter and nothing more, and that is the whole design: the second
+ * placement path must not be a second set of rules. Everything that makes a
+ * drop a no-op or a refusal — a held space (#2087), a non-combined container,
+ * a party carrying neither CampMinder id, a party already alone in this room —
+ * is inherited here for free because the answer is literally `resolveDrop`'s.
+ * A picker-layer copy of any of them is the drift this exists to prevent.
+ *
+ * The party is re-resolved out of `parties` by its own key rather than trusted
+ * from the row: the list renders from a snapshot, and a refetch landing
+ * between render and click would otherwise write a placement for a party the
+ * roster no longer carries. `resolveDrop` does that lookup already, so passing
+ * the KEY rather than the object is what gets it.
+ */
+export function resolvePickerPlacement({
+  party,
+  unitCode,
+  parties,
+  units,
+}: ResolvePickerPlacementArgs): PlacementIntent | null {
+  return resolveDrop({
+    activeId: partyKey(party),
+    overId: unitDroppableId(unitCode),
+    parties,
+    units,
+  })
+}
+
 /**
  * The roster payload as it will look once the write lands — the optimistic
  * update.

--- a/frontend/src/components/weekend/householdIdentity.test.ts
+++ b/frontend/src/components/weekend/householdIdentity.test.ts
@@ -17,6 +17,7 @@ import {
   partyFamilyLabel,
   partyHeadcount,
   partyIdentityLabel,
+  partySearchText,
 } from './householdIdentity'
 
 function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
@@ -708,5 +709,48 @@ describe('dedupeAdultNames -- kindred#2180', () => {
     ])
     expect(run.names).toEqual(['Olivia Marie', 'Noah'])
     expect(run.sharedSurname).toBe('Johnson')
+  })
+})
+
+describe('partySearchText', () => {
+  /*
+   * ONE search text for one queue. `FloatingUnplacedBadge` and the unit
+   * card's placement picker (kindred#2080) search the SAME list of unplaced
+   * parties; two copies of this construction that drifted would mean a
+   * household findable in one and not the other.
+   */
+  it('finds a household by any member, adult or child', () => {
+    const text = partySearchText(
+      party({
+        adults: [{ adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' }],
+        children: [{ person_cm_id: 9001, display_name: 'Noah Johnson', age: 8, grade: 3 }],
+      })
+    ).toLowerCase()
+    expect(text).toContain('emma johnson')
+    expect(text).toContain('noah johnson')
+  })
+
+  it('leads with the identity the card shows, not CampMinder salutation', () => {
+    // kindred#2084: `display_name` is the mailing_title salutation and
+    // disagreed with the attending-adult list on 26.7% of 2026 households.
+    // Searching for the stale wording must not resurrect it here.
+    const text = partySearchText(
+      party({
+        display_name: 'The Garcia Family',
+        adults: [{ adult_number: 1, display_name: 'Liam Garcia', relationship: 'Father' }],
+        children: [],
+      })
+    )
+    expect(text).toContain('Liam Garcia')
+    expect(text).not.toContain('The Garcia Family')
+  })
+
+  it('still names a person-grain guest, who has no household identity', () => {
+    // An adult weekend's parties are person-grain; `partyIdentityLabel`
+    // falls back to `display_name` for them and this must not go blank.
+    const text = partySearchText(
+      party({ grain: 'person', person_cm_id: 501, display_name: 'Liam Garcia', adults: [] })
+    )
+    expect(text).toContain('Liam Garcia')
   })
 })

--- a/frontend/src/components/weekend/householdIdentity.ts
+++ b/frontend/src/components/weekend/householdIdentity.ts
@@ -85,6 +85,30 @@ export function partyIdentityLabel(party: RosterPartyRow): string {
 }
 
 /**
+ * Text a staff member might type to find this party.
+ *
+ * Children and adults both, so a household can be found by whoever the staff
+ * member happens to remember. The LEADING element is `partyIdentityLabel`,
+ * the same identity the card shows (kindred#2084) -- `display_name` is
+ * CampMinder's `mailing_title` salutation, which disagreed with the real
+ * attending-adult list on 26.7% of 2026's rostered households, and a search
+ * that still matched it would resurrect wording the card deliberately
+ * stopped showing.
+ *
+ * ONE construction, shared, for the same reason the identity label above is
+ * shared: `FloatingUnplacedBadge`'s queue and the unit card's placement
+ * picker (kindred#2080) search the SAME list of unplaced parties. Two copies
+ * that drifted would leave a household findable in one and not the other.
+ */
+export function partySearchText(party: RosterPartyRow): string {
+  return [
+    partyIdentityLabel(party),
+    ...(party.adults ?? []).map((adult) => adult.display_name ?? ''),
+    ...(party.children ?? []).map((child) => child.display_name ?? ''),
+  ].join(' ')
+}
+
+/**
  * `party.adults`, with any blank or placeholder `family_camp_adults` slot
  * dropped -- for every OTHER place that lists or counts a party's adults, not
  * just the identity label.

--- a/frontend/src/components/weekend/placementCandidates.test.ts
+++ b/frontend/src/components/weekend/placementCandidates.test.ts
@@ -1,0 +1,272 @@
+/**
+ * The picker's list: every unplaced party, annotated and ordered, never cut.
+ *
+ * The rule these tests pin is an owner ruling (2026-08-07, restated
+ * 2026-08-09) and it is the OPPOSITE of the instinct: 6 of 118 units carry a
+ * private bathroom against 63 parties asking for one, so a hide-filter would
+ * empty the list. `placementCandidates` must therefore return exactly as many
+ * rows as it was given, every time.
+ *
+ * Fictional data throughout.
+ */
+import { describe, expect, it } from 'vitest'
+
+import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+import { candidateFit, candidateSearchText, placementCandidates } from './placementCandidates'
+
+function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
+  return {
+    unit_id: 'u1',
+    code: 'cedar-1',
+    name: 'Cedar 1',
+    area_code: 'CG',
+    area_name: 'Cedar Grove',
+    sleeps: 5,
+    bathroom: 'shared',
+    bathroom_group: '',
+    near_bathhouse: false,
+    has_power: false,
+    power_coverage: 'unknown',
+    has_ac: false,
+    has_fridge: false,
+    is_accessible: false,
+    is_confirmed: true,
+    is_active: true,
+    is_container: false,
+    inventory_class: 'family_pool',
+    shareability: 'shareable',
+    family_available_override: null,
+    reason: '',
+    is_family_available: true,
+    map_x: 0.5,
+    map_y: 0.5,
+    ...overrides,
+  }
+}
+
+function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
+  return {
+    grain: 'household',
+    household_cm_id: 101,
+    person_cm_id: 0,
+    display_name: 'Johnson',
+    sort_name: 'Johnson',
+    adults: [{ adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' }],
+    children: [{ person_cm_id: 9001, display_name: 'Noah Johnson', age: 8, grade: 3 }],
+    party_size: 3,
+    unit_code: '',
+    unit_name: '',
+    unit_codes: [],
+    is_merged_slot: false,
+    arrival_eta: '',
+    is_returning: false,
+    ...overrides,
+  }
+}
+
+describe('candidateFit', () => {
+  it('reports a party with no recorded needs as fitting, with nothing to say', () => {
+    const result = candidateFit(party(), unit(), [])
+    expect(result.fit).toBe('fits')
+    expect(result.notes).toEqual([])
+  })
+
+  it('annotates a private-bathroom need against a shared bathroom', () => {
+    const result = candidateFit(
+      party({ flags: { needs_private_bathroom: true } }),
+      unit({ bathroom: 'shared' }),
+      []
+    )
+    expect(result.fit).toBe('unmet')
+    expect(result.notes).toContain('No private bathroom')
+  })
+
+  it('says nothing when the space HAS a private bathroom', () => {
+    const result = candidateFit(
+      party({ flags: { needs_private_bathroom: true } }),
+      unit({ bathroom: 'private' }),
+      []
+    )
+    expect(result.fit).toBe('fits')
+    expect(result.notes).toEqual([])
+  })
+
+  it('says nothing when nobody has recorded the bathroom', () => {
+    // The absence of evidence is not evidence of absence — the same bar
+    // `needsFit`'s `unknown` coverage and `rosterAttention`'s `is_confirmed`
+    // gate already apply. Marking an unrecorded room would assert something
+    // about a space nobody has measured.
+    const result = candidateFit(
+      party({ flags: { needs_private_bathroom: true } }),
+      unit({ bathroom: 'unknown' }),
+      []
+    )
+    expect(result.fit).toBe('fits')
+    expect(result.notes).toEqual([])
+  })
+
+  it('annotates a power need against a building where no room has power', () => {
+    const result = candidateFit(
+      party({ flags: { needs_power: true } }),
+      unit({ power_coverage: 'none' }),
+      []
+    )
+    expect(result.fit).toBe('unmet')
+    expect(result.notes).toContain('No power')
+  })
+
+  it('softens a power need to partial when SOME rooms have power', () => {
+    const result = candidateFit(
+      party({ flags: { needs_power: true } }),
+      unit({ power_coverage: 'some' }),
+      []
+    )
+    expect(result.fit).toBe('partial')
+    expect(result.notes).toContain('Some rooms have power')
+  })
+
+  it('reads power off the leaf-resolved coverage, never the container row own flag', () => {
+    // Twelve of the fourteen 2026 family-pool containers record
+    // `has_power = 0` while every leaf beneath them has power. Judging by the
+    // raw flag would mark twelve entirely-powered buildings unpowered.
+    const result = candidateFit(
+      party({ flags: { needs_power: true } }),
+      unit({ has_power: false, power_coverage: 'all', is_container: true, is_combined: true }),
+      []
+    )
+    expect(result.fit).toBe('fits')
+    expect(result.notes).toEqual([])
+  })
+
+  it('annotates a party that does not fit the recorded capacity', () => {
+    const result = candidateFit(party({ party_size: 6 }), unit({ sleeps: 4 }), [])
+    expect(result.fit).toBe('unmet')
+    expect(result.notes).toContain('Over capacity · needs 6, sleeps 4')
+  })
+
+  it('says nothing about capacity nobody has recorded', () => {
+    const result = candidateFit(party({ party_size: 6 }), unit({ sleeps: null }), [])
+    expect(result.fit).toBe('fits')
+    expect(result.notes).toEqual([])
+  })
+
+  it('measures a combined house by its whole-house capacity, not its own row', () => {
+    // `effectiveSleeps`: a container's own `sleeps` is the delta for space
+    // belonging to no single room, PLUS its rooms. Reading the house row
+    // alone would call a 7-bed house a 1-bed one.
+    const house = unit({
+      unit_id: 'u9',
+      code: 'gt-house',
+      name: 'Granite House',
+      sleeps: 1,
+      is_container: true,
+      is_combined: true,
+    })
+    const rooms = [
+      unit({
+        unit_id: 'u10',
+        code: 'gt-house-a',
+        name: 'Granite A',
+        sleeps: 3,
+        parent_code: 'gt-house',
+      }),
+      unit({
+        unit_id: 'u11',
+        code: 'gt-house-b',
+        name: 'Granite B',
+        sleeps: 3,
+        parent_code: 'gt-house',
+      }),
+    ]
+    const result = candidateFit(party({ party_size: 6 }), house, [house, ...rooms])
+    expect(result.fit).toBe('fits')
+    expect(result.notes).toEqual([])
+  })
+
+  it('takes the WORST verdict and keeps every note', () => {
+    const result = candidateFit(
+      party({ flags: { needs_private_bathroom: true, needs_power: true } }),
+      unit({ bathroom: 'shared', power_coverage: 'some' }),
+      []
+    )
+    expect(result.fit).toBe('unmet')
+    expect(result.notes).toEqual(['No private bathroom', 'Some rooms have power'])
+  })
+})
+
+describe('placementCandidates', () => {
+  it('never drops a party, however badly it fits', () => {
+    // The ruling, stated as arithmetic: filtering to "what fits" would leave
+    // staff unable to place anybody.
+    const parties = [
+      party({ household_cm_id: 1, sort_name: 'Garcia', flags: { needs_private_bathroom: true } }),
+      party({ household_cm_id: 2, sort_name: 'Johnson', flags: { needs_power: true } }),
+      party({ household_cm_id: 3, sort_name: 'Nguyen', party_size: 99 }),
+    ]
+    const rows = placementCandidates(
+      parties,
+      unit({ bathroom: 'shared', power_coverage: 'none' }),
+      []
+    )
+    expect(rows).toHaveLength(3)
+    expect(rows.every((row) => row.fit === 'unmet')).toBe(true)
+  })
+
+  it('orders the best fit first, then partial, then unmet', () => {
+    const fitting = party({ household_cm_id: 1, sort_name: 'Zimmerman' })
+    const partial = party({ household_cm_id: 2, sort_name: 'Adams', flags: { needs_power: true } })
+    const unmet = party({
+      household_cm_id: 3,
+      sort_name: 'Baker',
+      flags: { needs_private_bathroom: true },
+    })
+    const rows = placementCandidates(
+      [unmet, partial, fitting],
+      unit({ bathroom: 'shared', power_coverage: 'some' }),
+      []
+    )
+    expect(rows.map((row) => row.fit)).toEqual(['fits', 'partial', 'unmet'])
+    expect(rows.map((row) => row.party.household_cm_id)).toEqual([1, 2, 3])
+  })
+
+  it('breaks a tie on sort_name, so the order is stable rather than payload order', () => {
+    const rows = placementCandidates(
+      [
+        party({ household_cm_id: 1, sort_name: 'Rodriguez' }),
+        party({ household_cm_id: 2, sort_name: 'Garcia' }),
+        party({ household_cm_id: 3, sort_name: 'Nguyen' }),
+      ],
+      unit(),
+      []
+    )
+    expect(rows.map((row) => row.party.sort_name)).toEqual(['Garcia', 'Nguyen', 'Rodriguez'])
+  })
+})
+
+describe('candidateSearchText', () => {
+  it('finds a household by any member, adult or child', () => {
+    const text = candidateSearchText(
+      party({
+        adults: [{ adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' }],
+        children: [{ person_cm_id: 9001, display_name: 'Noah Johnson', age: 8, grade: 3 }],
+      })
+    ).toLowerCase()
+    expect(text).toContain('emma johnson')
+    expect(text).toContain('noah johnson')
+  })
+
+  it('leads with the identity the card shows, not CampMinder salutation', () => {
+    // kindred#2084: `display_name` is the mailing_title salutation and
+    // disagreed with the attending-adult list on 26.7% of 2026 households.
+    // Searching for the stale wording must not resurrect it here.
+    const text = candidateSearchText(
+      party({
+        display_name: 'The Garcia Family',
+        adults: [{ adult_number: 1, display_name: 'Liam Garcia', relationship: 'Father' }],
+        children: [],
+      })
+    )
+    expect(text).toContain('Liam Garcia')
+    expect(text).not.toContain('The Garcia Family')
+  })
+})

--- a/frontend/src/components/weekend/placementCandidates.test.ts
+++ b/frontend/src/components/weekend/placementCandidates.test.ts
@@ -12,7 +12,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
-import { candidateFit, candidateSearchText, placementCandidates } from './placementCandidates'
+import { candidateFit, placementCandidates } from './placementCandidates'
 
 function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
   return {
@@ -240,33 +240,5 @@ describe('placementCandidates', () => {
       []
     )
     expect(rows.map((row) => row.party.sort_name)).toEqual(['Garcia', 'Nguyen', 'Rodriguez'])
-  })
-})
-
-describe('candidateSearchText', () => {
-  it('finds a household by any member, adult or child', () => {
-    const text = candidateSearchText(
-      party({
-        adults: [{ adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' }],
-        children: [{ person_cm_id: 9001, display_name: 'Noah Johnson', age: 8, grade: 3 }],
-      })
-    ).toLowerCase()
-    expect(text).toContain('emma johnson')
-    expect(text).toContain('noah johnson')
-  })
-
-  it('leads with the identity the card shows, not CampMinder salutation', () => {
-    // kindred#2084: `display_name` is the mailing_title salutation and
-    // disagreed with the attending-adult list on 26.7% of 2026 households.
-    // Searching for the stale wording must not resurrect it here.
-    const text = candidateSearchText(
-      party({
-        display_name: 'The Garcia Family',
-        adults: [{ adult_number: 1, display_name: 'Liam Garcia', relationship: 'Father' }],
-        children: [],
-      })
-    )
-    expect(text).toContain('Liam Garcia')
-    expect(text).not.toContain('The Garcia Family')
   })
 })

--- a/frontend/src/components/weekend/placementCandidates.ts
+++ b/frontend/src/components/weekend/placementCandidates.ts
@@ -1,0 +1,234 @@
+/**
+ * Which family to put in THIS space — the list behind the unit card's
+ * typeahead (kindred#2080).
+ *
+ * ## It annotates and orders. It never hides.
+ *
+ * Owner ruling 2026-08-07, restated 2026-08-09, and it is the opposite of what
+ * a "filtered picker" instinct suggests. The reason is arithmetic rather than
+ * taste: of 118 production 2026 units, **6** carry a private bathroom and
+ * **49 have no power**, while of 459 2026 registrations **63** ask for a
+ * private bathroom and **47** ask for power. A list filtered to "what fits"
+ * would be empty most of the time, which would make this new path WEAKER than
+ * the drag it exists to shorten — staff would go back to dragging.
+ *
+ * So `placementCandidates` returns exactly as many rows as it is given, always.
+ * The fit verdict is an ANNOTATION and a SORT KEY, never a gate. The refusals
+ * that do exist are the drag path's own, in `resolveDrop`, and they are
+ * refusals of writes that cannot succeed rather than fit judgements.
+ *
+ * This is a DELIBERATE DIVERGENCE from summer (CLAUDE.md §4). Summer's
+ * `BunkSwapModal` is the same interaction — a picker started from a bunk — and
+ * it DOES hide, via `utils/bunkSwap.ts`'s `isEligibleSwapTarget`. Two things
+ * make that right there and wrong here: summer's filter removes a handful of
+ * ineligible bunks from a long list where this one would remove nearly
+ * everything, and summer's gender rule is a HARD constraint where amenity fit
+ * on this board is explicitly advisory (`dragPlacement.ts`: "It never
+ * validates fit").
+ *
+ * ## Why this is not `partyAttention`
+ *
+ * `partyAttention` answers "does this party's CURRENT cabin fit?" and returns
+ * `{ level: 'unplaced' }` before it ever reads its unit argument — so every
+ * row in this list, all of them unplaced by definition, would annotate
+ * identically no matter which unit was passed. Its `needs_private_bathroom`
+ * check reads `party.effective_bathroom`, the server's verdict on the
+ * placement the party already has, which is exactly the wrong question for a
+ * CANDIDATE. This asks the other question, off the candidate unit's own
+ * fields.
+ *
+ * ## Why this is not `needsFit`
+ *
+ * `needsFit` (kindred#1912) answers the same shape of question for the card's
+ * drag-time hatch, and shares this module's `fits/partial/unmet` vocabulary
+ * and its `worseOf` precedence — imported, not re-declared. What it does not
+ * share is the DIMENSION TABLE, deliberately: its list drives a mark painted
+ * on ~82 cards mid-drag and is seeded with power alone, whereas a row in this
+ * list has room for a sentence. Adding bathroom and capacity there to reach
+ * them here would have changed a shipped board treatment as a side effect.
+ *
+ * The power rule is therefore stated in both places. ⚠️ CHANGE ONE, CHANGE
+ * BOTH — same field (`power_coverage`, never the raw `has_power`), same
+ * grading, same `unknown → fits`.
+ */
+import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+import { partyIdentityLabel } from './householdIdentity'
+import { worseOf, type NeedsFit } from './needsFit'
+import { effectiveSleeps, partyBeds } from './rosterAttention'
+
+/** The picker's verdict for one party against one space. `needsFit`'s vocabulary. */
+export type CandidateFitLevel = NeedsFit
+
+export interface PlacementCandidate {
+  party: RosterPartyRow
+  fit: CandidateFitLevel
+  /**
+   * What is wrong, in staff words, worst dimension first. EMPTY for a party
+   * that fits — there is nothing to say, and a row reading "fine" on every
+   * card says nothing at all.
+   *
+   * Never PHI, and never a tracker id: these strings are printed to staff.
+   */
+  notes: string[]
+}
+
+/** One row's worth of verdict. `null` notes mean "nothing to say". */
+interface DimensionVerdict {
+  fit: CandidateFitLevel
+  note: string | null
+}
+
+const FITS: DimensionVerdict = { fit: 'fits', note: null }
+
+/**
+ * Does the space give this party its own bathroom?
+ *
+ * Reads `unit.bathroom` — the candidate row's own field, which is also what
+ * the card's amenity strip prints, so the annotation can never contradict the
+ * card it sits inside. It is NOT `party.effective_bathroom`: that is the
+ * server's answer about the placement the party already has, and every party
+ * in this list has none.
+ *
+ * `unknown` (and an absent field) report `fits` with no note. The absence of
+ * evidence is not evidence of absence — the same bar `needsFit`'s `unknown`
+ * coverage and `rosterAttention`'s `is_confirmed` gate already apply.
+ */
+function bathroomVerdict(party: RosterPartyRow, unit: LodgingUnitRow): DimensionVerdict {
+  if (party.flags?.needs_private_bathroom !== true) return FITS
+  const bathroom = unit.bathroom ?? 'unknown'
+  if (bathroom === 'private' || bathroom === 'unknown') return FITS
+  // Same wording as `rosterAttention`'s `VERIFIABLE_NEEDS` entry for this
+  // need. Staff read both surfaces; two phrasings of one fact read as two
+  // facts.
+  return { fit: 'unmet', note: 'No private bathroom' }
+}
+
+/**
+ * Does the space have power where this party needs it?
+ *
+ * ⚠️ The twin of `needsFit`'s only dimension — see the module doc. Uses
+ * `power_coverage`, the server's resolution over the unit's LEAF descendants,
+ * never the raw `has_power`: twelve of the fourteen 2026 family-pool
+ * containers record `has_power = 0` while every leaf beneath them has power,
+ * so the raw flag marks twelve entirely-powered buildings unpowered.
+ *
+ * SOME is softer than NONE here, as it is there: a building where some rooms
+ * have power is a real improvement on one where none do.
+ */
+function powerVerdict(party: RosterPartyRow, unit: LodgingUnitRow): DimensionVerdict {
+  if (party.flags?.needs_power !== true) return FITS
+  const coverage = unit.power_coverage ?? 'unknown'
+  if (coverage === 'none') return { fit: 'unmet', note: 'No power' }
+  if (coverage === 'some') return { fit: 'partial', note: 'Some rooms have power' }
+  return FITS
+}
+
+/**
+ * Will they all sleep here?
+ *
+ * ANNOTATED, NEVER REFUSED — the owner was explicit: drag permits an
+ * over-capacity placement today, so the picker must too. Beds, not people:
+ * `partyBeds` is the roster's own reading, which already drops blank and
+ * placeholder adult slots and discounts a child under 18 months.
+ *
+ * `effectiveSleeps` rather than `unit.sleeps`, so a combined house is judged
+ * by its whole-house total (its own delta plus its rooms) rather than by
+ * whatever the container row happens to carry. An unmeasured space says
+ * nothing: `null` is "nobody has counted", not "sleeps nobody".
+ */
+function capacityVerdict(
+  party: RosterPartyRow,
+  unit: LodgingUnitRow,
+  units: LodgingUnitRow[]
+): DimensionVerdict {
+  const capacity = effectiveSleeps(unit, units)
+  if (capacity === null) return FITS
+  const beds = partyBeds(party)
+  if (beds <= capacity) return FITS
+  return {
+    fit: 'unmet',
+    note: `Over capacity · needs ${String(beds)}, sleeps ${String(capacity)}`,
+  }
+}
+
+/**
+ * How well one party fits one candidate space.
+ *
+ * `needs_accommodation` and `accommodation_is_mandatory` are deliberately
+ * absent, for the reason `rosterAttention`'s `VERIFIABLE_NEEDS` gives: they
+ * name no specific amenity, so no field on any cabin settles them and an
+ * annotation here could only restate the flag. And there is no step-free
+ * dimension to add — `is_accessible` exists on the UNIT with nothing on the
+ * party side asking for it.
+ *
+ * @param units The whole registry, needed only to total a combined house's
+ *   capacity. `[]` is correct for every leaf.
+ */
+export function candidateFit(
+  party: RosterPartyRow,
+  unit: LodgingUnitRow,
+  units: LodgingUnitRow[] = []
+): PlacementCandidate {
+  const verdicts = [
+    bathroomVerdict(party, unit),
+    powerVerdict(party, unit),
+    capacityVerdict(party, unit, units),
+  ]
+  let fit: CandidateFitLevel = 'fits'
+  const notes: string[] = []
+  for (const verdict of verdicts) {
+    fit = worseOf(verdict.fit, fit)
+    if (verdict.note !== null) notes.push(verdict.note)
+  }
+  return { party, fit, notes }
+}
+
+/** Best first — the reverse of `needsFit`'s worst-first `FIT_ORDER`. */
+const DISPLAY_ORDER: readonly CandidateFitLevel[] = ['fits', 'partial', 'unmet']
+
+/**
+ * Text a staff member might type to find this party.
+ *
+ * Children and adults included so a household can be found by whoever the
+ * staff member happens to remember. The LEADING element is
+ * `partyIdentityLabel`, the same identity the card shows (kindred#2084) —
+ * `display_name` is CampMinder's `mailing_title` salutation, which disagreed
+ * with the real attending-adult list on 26.7% of 2026's rostered households,
+ * and a search that still matched it would resurrect wording the card
+ * deliberately stopped showing.
+ *
+ * The same construction `FloatingUnplacedBadge`'s own `getSearchText` uses,
+ * over the same queue of unplaced parties. Two searches over one list that
+ * disagreed about which names count would be the worse outcome.
+ */
+export function candidateSearchText(party: RosterPartyRow): string {
+  return [
+    partyIdentityLabel(party),
+    ...(party.adults ?? []).map((adult) => adult.display_name ?? ''),
+    ...(party.children ?? []).map((child) => child.display_name ?? ''),
+  ].join(' ')
+}
+
+/**
+ * Every party, annotated and ordered by fit. NOTHING IS OMITTED — see the
+ * module doc for why that is a ruling rather than an oversight.
+ *
+ * Ties break on `sort_name` then the identity label, the same key
+ * `FloatingUnplacedBadge` sorts its queue by, so the two lists of the same
+ * parties do not disagree about their order.
+ */
+export function placementCandidates(
+  parties: RosterPartyRow[],
+  unit: LodgingUnitRow,
+  units: LodgingUnitRow[] = []
+): PlacementCandidate[] {
+  return parties
+    .map((party) => candidateFit(party, unit, units))
+    .sort((a, b) => {
+      const byFit = DISPLAY_ORDER.indexOf(a.fit) - DISPLAY_ORDER.indexOf(b.fit)
+      if (byFit !== 0) return byFit
+      const bySort = (a.party.sort_name ?? '').localeCompare(b.party.sort_name ?? '')
+      if (bySort !== 0) return bySort
+      return partyIdentityLabel(a.party).localeCompare(partyIdentityLabel(b.party))
+    })
+}

--- a/frontend/src/components/weekend/placementCandidates.ts
+++ b/frontend/src/components/weekend/placementCandidates.ts
@@ -187,29 +187,6 @@ export function candidateFit(
 const DISPLAY_ORDER: readonly CandidateFitLevel[] = ['fits', 'partial', 'unmet']
 
 /**
- * Text a staff member might type to find this party.
- *
- * Children and adults included so a household can be found by whoever the
- * staff member happens to remember. The LEADING element is
- * `partyIdentityLabel`, the same identity the card shows (kindred#2084) —
- * `display_name` is CampMinder's `mailing_title` salutation, which disagreed
- * with the real attending-adult list on 26.7% of 2026's rostered households,
- * and a search that still matched it would resurrect wording the card
- * deliberately stopped showing.
- *
- * The same construction `FloatingUnplacedBadge`'s own `getSearchText` uses,
- * over the same queue of unplaced parties. Two searches over one list that
- * disagreed about which names count would be the worse outcome.
- */
-export function candidateSearchText(party: RosterPartyRow): string {
-  return [
-    partyIdentityLabel(party),
-    ...(party.adults ?? []).map((adult) => adult.display_name ?? ''),
-    ...(party.children ?? []).map((child) => child.display_name ?? ''),
-  ].join(' ')
-}
-
-/**
  * Every party, annotated and ordered by fit. NOTHING IS OMITTED — see the
  * module doc for why that is a ruling rather than an oversight.
  *

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -41,6 +41,12 @@ globalThis.IntersectionObserver = class IntersectionObserver {
   }
 } as unknown as typeof IntersectionObserver
 
+// jsdom has no layout engine and does not implement scrollIntoView at all, so
+// any component that keeps an active row in view throws without this. Stubbed
+// globally beside the other layout APIs above; a test that wants to ASSERT on
+// it can still reassign its own mock (`LodgingUnitsPanel.test.tsx` does).
+Element.prototype.scrollIntoView = vi.fn()
+
 // Mock ResizeObserver (required for Headless UI components)
 globalThis.ResizeObserver = class ResizeObserver {
   disconnect() {}


### PR DESCRIPTION
## What

Staff can now place a family **from the space itself**: an inline typeahead on the unit card, in the shape "Hold" already established.

Closes #2080.

## The two rulings this is built to

**Option A — inline, list gated behind the typeahead.** The picker lives inside the unit card's badge row, carrying `w-full` exactly as Hold's reason form does so it wraps onto its own line. No popover, no second surface. The **list is not rendered until the search box is engaged**, which is what makes an inline picker affordable: the card — and therefore the whole grid row of up to ~82 cards — only grows once a staff member has actually asked for it, so the resting board never moves.

**The list annotates and orders. It never hides.** 6 of 118 units carry a private bathroom against 63 parties asking for one, and 49 units have no power against 47 parties asking for it. A list filtered to "what fits" would be empty most of the time, making this path *weaker* than the drag it shortens. So every unplaced party appears, each annotated with how it misfits, sorted best-fit first.

Consequently there is **no "nothing fits" empty state**. The list can only be empty when everyone is housed, and that state reuses `FloatingUnplacedBadge`'s own sentence, "Everyone has a cabin." A search matching nothing is a different condition and borrows `FloatingQueueBadge`'s existing `No parties match "…"`.

This is a deliberate divergence from summer's `BunkSwapModal`, which *does* hide via `isEligibleSwapTarget`. Justified at the divergence (`placementCandidates.ts` module doc): summer's filter removes a handful of ineligible bunks from a long list, and its gender rule is a hard constraint — amenity fit on this board is explicitly advisory.

## One placement path, two affordances

`resolvePickerPlacement` **is** `resolveDrop`, wrapped. The held-space refusal (#2087/#2199), the non-combined-container refusal, the missing-CampMinder-id refusal and the already-in-this-room no-op are inherited whole rather than restated, and the write goes through the same `move` → `applyPlacement` optimistic update. `dragPlacement.test.ts` pins that the picker and an equivalent drop produce an identical intent.

The party is re-resolved out of the current roster by key rather than trusted from the rendered row, so a refetch landing between render and click cannot write a placement for a party the roster no longer carries.

## Signals

The Place control is **absent** on a held or occupied card, not dimmed — mirroring how Hold itself vanishes. `opacity-40` means REFUSAL in the board's ruled vocabulary (2026-08-09) and this adds no fifth meaning to it. Fit annotations live in the **list rows** as text; they touch none of the card's three channels, and nothing here draws a ring of any kind (#2179 struck the last one).

## Accessibility

Opens on keyboard focus as well as pointer click, arrow-navigable with `aria-activedescendant`, Enter commits, Escape closes and returns focus without letting the key reach the board behind it, reachable by Tab. Each of those has its own test.

## New files

| File | What |
|---|---|
| `placementCandidates.ts` | Pure: fit verdict, notes, ordering. Never filters. |
| `PlaceFamilyPicker.tsx` | The inline combobox. |

`needsFit.ts` is deliberately **not** extended — its dimension list drives a mark painted on ~82 cards mid-drag, and adding bathroom/capacity there to reach them here would have changed a shipped board treatment as a side effect. The power rule is stated in both, with a change-one-change-both note.

## Verification

- `vitest run` — 439 files, 6581 tests, exit 0
- `tsc --noEmit` — exit 0
- `eslint` on every touched file — 0 errors; the 3 remaining warnings are all pre-existing on `main` (verified by running eslint against the main worktree)
- `scripts/dev/verify-no-hardcoded-lodging.sh` — OK
- Mutation-checked: hide-filter, reversed order, `unknown`-bathroom marking, raw `has_power`, own-`sleeps` capacity, list-always-rendered, no-open-on-focus, Escape propagation, invented empty copy, and each of the four card gates — all confirmed RED, then restored.

## Not in scope

`MapUnitPopover` offers no equivalent control; the issue is about the board card. Worth its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
