### PR TITLE
docs(sync): write the read-time active-enrolment rule for derived tables

### DIFF
--- a/docs/architecture/sync-layer.md
+++ b/docs/architecture/sync-layer.md
@@ -177,6 +177,49 @@ After implementation, verify ALL of these work:
 | Global table in historical sync | Unnecessary re-sync of static data | Check if table has `year` field - if not, it's global |
 | Missing `SyncJobToCollections` entry | Sheet always re-exported even when no changes | Add sync job to mapping in `table_exporter.go` |
 
+## Reading Derived Informational Tables (Active-Enrolment Filtering)
+
+A derived informational table must be filtered by **active enrolment at read time** — an `attendees`
+row with `status_id = 2` for that person and that year — never swept by deletion. This is a read-side
+rule, not a sync change: rows for a cancelled camper or a staffer who left mid-season stay in the
+table by design. None of these tables has a history table behind it, so a delete is unrecoverable — a
+re-registration, a correction, or a later re-enrolment cannot get a deleted row back.
+
+⚠️ **The filter is per-(person, year) and must not be applied across years.** A staffer who worked a
+prior session, or a camper attending a second session, keeps their historical rows — that is why a
+read-side filter is correct where a delete is not: the filter is scoped to the view's own year, a
+delete is not.
+
+⛔ **`family_camp_registrations` must never be touched, swept, or filtered destructively.** Its
+`cabin_assignment` column is populated on 427 / 423 / 472 / 464 rows for 2022 / 2023 / 2024 / 2025 and
+is the only pre-2026 placement history anywhere in the database.
+
+**Which tables the predicate applies to** (measured 2026-08-08 against the production snapshot — cited
+as measured on that date, not re-derived live):
+
+| Table | Grain | 2026 rows | no active enrolment (2026) | 2025 |
+|---|---|---|---|---|
+| `camper_dietary` | person × year | 895 | 64 (7.2%) | 145 / 1084 (13.4%) |
+| `camper_transportation` | person × session | 1661 | 10 (0.6%) | 11 / 1969 |
+| `quest_registrations` | person × year | 69 | 1 | 0 / 64 |
+| `staff_skills` | person, not enrolment | 401 | predicate does not apply — staff are not attendees | — |
+| `household_demographics` | household, not enrolment | 1603 | predicate does not apply — household-grain | — |
+
+**The point worth stating plainly: a dashboard that reads `camper_dietary` unfiltered ships a 7.2%
+(2026) / 13.4% (2025) error.** That gap is the whole reason this rule exists: the three
+enrolment-grain tables above (`camper_dietary`, `camper_transportation`, `quest_registrations`) each
+carry stale rows for people no longer actively enrolled, at the percentages measured.
+
+**No reader applies this filter today, because these three tables have no reader today.**
+`table_exporter.go`'s `SyncJobToCollections` map is *not* a reader — its own comment says it exists
+only so the export-skip optimisation knows which collections a sync job writes; nothing there touches
+a row. The one real live reader, `GetReadableYearExports()`, covers `staff_skills` and
+`household_demographics` — the two tables above where the predicate does **not** apply, since staff
+are not attendees and the household grain has no per-person enrolment to check. This rule is written
+down for whoever builds the first reader of `camper_dietary`, `camper_transportation`, or
+`quest_registrations` — a future staff dashboard or PDF export — so that reader doesn't inherit the
+error above silently.
+
 ## Python Request Processor (`bunking/sync/bunk_request_processor/`)
 Unified processor for all 5 bunk request field types:
 

--- a/pocketbase/sync/camper_dietary.go
+++ b/pocketbase/sync/camper_dietary.go
@@ -42,6 +42,12 @@ const (
 // - Family Medical-Allergies -> has_allergies (bool)
 // - Family Medical-Allergy Info -> allergy_info
 // - Family Medical-Additional -> additional_medical
+//
+// Rows persist after a camper cancels; this table is never swept by deletion. A future reader
+// (e.g. a staff dashboard) must filter by active enrolment for the view's own year -- an
+// `attendees` row with status_id = 2 for that person and year -- and must not filter across
+// years. See "Reading Derived Informational Tables (Active-Enrolment Filtering)" in
+// docs/architecture/sync-layer.md.
 type CamperDietarySync struct {
 	App            core.App
 	Year           int

--- a/pocketbase/sync/camper_transportation.go
+++ b/pocketbase/sync/camper_transportation.go
@@ -44,6 +44,12 @@ const (
 //
 // Field mapping handles both new BUS-* fields and legacy "Bus to/From Camp" fields.
 // New fields take priority; legacy fields are used as fallback.
+//
+// Rows persist after a camper cancels; this table is never swept by deletion. A future reader
+// (e.g. a staff dashboard) must filter by active enrolment for the view's own year -- an
+// `attendees` row with status_id = 2 for that person and year -- and must not filter across
+// years. See "Reading Derived Informational Tables (Active-Enrolment Filtering)" in
+// docs/architecture/sync-layer.md.
 type CamperTransportationSync struct {
 	App            core.App
 	Year           int

--- a/pocketbase/sync/quest_registrations.go
+++ b/pocketbase/sync/quest_registrations.go
@@ -35,6 +35,12 @@ const (
 //
 // Field mapping: 45+ Quest-* and Q-* prefixed fields covering signatures, preferences,
 // parent questionnaires, and transportation details.
+//
+// Rows persist after a participant cancels; this table is never swept by deletion. A future
+// reader (e.g. a staff dashboard) must filter by active enrolment for the view's own year -- an
+// `attendees` row with status_id = 2 for that person and year -- and must not filter across
+// years. See "Reading Derived Informational Tables (Active-Enrolment Filtering)" in
+// docs/architecture/sync-layer.md.
 type QuestRegistrationsSync struct {
 	App            core.App
 	Year           int


### PR DESCRIPTION
## What changed and why

#2159's owner ruling cancelled the enrolment-cancellation sweep and settled on a read-side rule
instead: a derived informational table must be filtered by active enrolment at read time (an
`attendees` row with `status_id = 2` for that person and year), never swept by deletion. The doc
write is a prerequisite to closing #2159, not a follow-up, so this PR is docs-and-comments only,
landing the rule before the issue closes.

- New section in `docs/architecture/sync-layer.md`: "Reading Derived Informational Tables
  (Active-Enrolment Filtering)". States the rule, the per-(person, year) scoping (must not filter
  across years), the `family_camp_registrations` do-not-touch ceiling, and the 2026-08-08 measured
  percentages for `camper_dietary` (7.2% / 13.4%), `camper_transportation` (0.6%), and
  `quest_registrations`.
- Header-comment pointer added to the three enrolment-grain sync files: `camper_dietary.go`,
  `camper_transportation.go`, `quest_registrations.go`. Each links back to the doc section.
- `staff_skills.go` / `household_demographics.go` deliberately untouched — the predicate doesn't
  apply at their grain (person-only, household-only). `family_camp_derived.go` deliberately
  untouched — it's the `family_camp_registrations` placement-history ceiling.
- No `deleteOrphans` predicate changes, no `activeSeasonYear()` hoist, no behaviour change anywhere.

## Verification

| Command | Exit code |
|---|---|
| `cd pocketbase && go build ./...` | 0 |
| `cd pocketbase && go test ./...` | 0 (all packages `ok`, including `sync`) |
| `cd pocketbase && golangci-lint run ./sync/...` | 0 (`0 issues.`) |
| `git diff --stat` (pre-commit) | docs + Go comments only — 4 files, 61 insertions, 0 deletions |

## Did not do

- No sweep, no `deleteOrphans` predicate change, no `activeSeasonYear()` hoist — all cancelled per
  the owner ruling on #2159.
- No touch to `table_exporter.go` — the doc explicitly notes `SyncJobToCollections` is not a reader.

Closes #2159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for filtering derived enrollment-related information by active enrollment and year when displayed.
  * Clarified that dietary, transportation, and quest registration records remain available after a participant’s cancellation.
  * Documented that filtering should occur when information is read, without deleting stored records or altering registration history.
  * Defined which table types are covered and noted exclusions for staff- and household-level information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->