### PR TITLE
refactor(frontend): make the family card a div with an explicit inner control

### DIFF
--- a/frontend/src/components/weekend/FamilyCard.test.tsx
+++ b/frontend/src/components/weekend/FamilyCard.test.tsx
@@ -16,12 +16,31 @@
  *
  * Fictional data throughout.
  */
+import { DndContext } from '@dnd-kit/core'
 import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
 import { FamilyCard, FamilyCardPreview } from './FamilyCard'
+
+// Mirrors `LodgingBoard.drag.test.tsx`'s idiom: jsdom cannot perform a real
+// pointer drag, and `DndContext`'s sensor setup is irrelevant to what this
+// file checks (whether dnd-kit's ATTRIBUTES land on the right element, not
+// whether a drag completes), so `DndContext` is replaced with a pass-through.
+// `useDraggable` itself stays real — its `attributes` computation does not
+// read this context at all (verified against @dnd-kit/core 6.3.1's source:
+// `role`/`tabIndex` are hard-coded, not context-derived), so this exists only
+// to render the same tree the real board renders, not to make the
+// assertions below possible.
+vi.mock('@dnd-kit/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@dnd-kit/core')>()
+  return {
+    ...actual,
+    DndContext: ({ children }: { children: ReactNode }) => <>{children}</>,
+  }
+})
 
 function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
   return {
@@ -630,6 +649,60 @@ describe('FamilyCard — opening the detail panel', () => {
   it('is a real button, so it is reachable by keyboard', () => {
     render(<FamilyCard party={party()} onOpen={vi.fn()} />)
     expect(screen.getByRole('button', { name: /Johnson/ })).toBeInTheDocument()
+  })
+})
+
+describe('FamilyCard — draggable state does not recreate an ARIA button on the frame (kindred#2222 residual)', () => {
+  // The guard at "never nests an interactive control..." above never actually
+  // exercises `isDraggable={true}` — every render in this file up to here
+  // leaves it at its `false` default, so `useDraggable`'s conditional spread
+  // (`{...(isDraggable ? attributes : {})}`) always evaluates to `{}`
+  // regardless of which element it's spread onto. That means the ACTUAL
+  // regression this file exists to guard against — dnd-kit's `attributes`
+  // (which carry `role: 'button'` + `tabIndex: 0` unconditionally, per
+  // `useDraggable`'s own doc) landing back on the outer frame — has never
+  // been reachable by any assertion here. This is the one render that
+  // reaches it.
+  it('keeps dnd-kit’s attributes off the frame when the card is actually draggable', () => {
+    const { container } = render(
+      <DndContext>
+        <FamilyCard party={party()} isDraggable={true} onOpen={vi.fn()} />
+      </DndContext>
+    )
+    const frame = container.querySelector('[data-family-card]')
+    expect(frame).not.toBeNull()
+    // The frame legitimately carries dnd-kit's LISTENERS while draggable (so
+    // a drag can start from anywhere on the card) -- it must not also carry
+    // dnd-kit's ATTRIBUTES. Those are two different halves of what
+    // `useDraggable` returns, and only one belongs on this element.
+    expect(frame).not.toHaveAttribute('role')
+    expect(frame).not.toHaveAttribute('tabindex')
+    // Exactly the inner control(s) are real buttons -- the frame itself
+    // never joins that count, draggable or not.
+    const roleButtons = within(container).getAllByRole('button')
+    expect(roleButtons).toHaveLength(1)
+    expect(roleButtons[0]).toBe(frame?.querySelector('button'))
+  })
+
+  it('would still catch a bare tabIndex left on the frame even without a role', () => {
+    // The role-keyed guard above only walks INSIDE each `getAllByRole
+    // ('button')` match -- `outer.querySelectorAll('[tabindex]...')`. A
+    // `tabIndex` added directly to the FRAME, which never carries a
+    // "button" role itself, sits outside every button's subtree and is
+    // invisible to that loop no matter how draggable the card is. Scanning
+    // the whole container instead is what catches it: every element that is
+    // actually in the tab order must be one of the accessible buttons, full
+    // stop -- not "every button's descendants are clean".
+    const { container } = render(
+      <DndContext>
+        <FamilyCard party={party()} isDraggable={true} onOpen={vi.fn()} />
+      </DndContext>
+    )
+    const tabbable = Array.from(container.querySelectorAll('[tabindex]:not([tabindex="-1"])'))
+    const roleButtons = within(container).getAllByRole('button')
+    for (const el of tabbable) {
+      expect(roleButtons).toContain(el)
+    }
   })
 })
 

--- a/frontend/src/components/weekend/FamilyCard.test.tsx
+++ b/frontend/src/components/weekend/FamilyCard.test.tsx
@@ -16,7 +16,7 @@
  *
  * Fictional data throughout.
  */
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -439,17 +439,34 @@ describe('FamilyCard — what it shows', () => {
     expect(chip?.textContent).toMatch(/will not share/)
     expect(chip?.textContent).toMatch(/open to sharing/)
     expect(chip?.textContent).toMatch(/form's answer/)
-    // In the DOM is not the same as ANNOUNCED. The card is one `<button>`, so
-    // the sentence has to reach its computed accessible name or the `sr-only`
-    // span is decoration — which is what the `title` it replaced amounted to.
-    expect(screen.getByRole('button')).toHaveAccessibleName(/form's answer/)
+    // kindred#2222: the sr-only sentence is still in the DOM (asserted above
+    // via `chip?.textContent`, and jsdom does not hide `sr-only` text any
+    // more than a screen reader's ordinary reading cursor does), but the
+    // card's open control no longer wraps the chip row at all — the whole
+    // point of this refactor is that the chip row is a SIBLING of the
+    // control, not its child, so a future interactive trigger there
+    // (kindred#2212) is never nested inside another one. That means the
+    // sentence is no longer folded into the control's accessible name the
+    // way it was when the card was one big `<button>`. Closing THAT gap —
+    // giving the sentence a real accessible relationship to a trigger a
+    // touch user can reach — is kindred#2212's job, not this one's.
+    expect(screen.getByRole('button', { name: /Johnson/ })).not.toHaveAccessibleName(
+      /form's answer/
+    )
   })
 
-  it('never nests a control inside the card, which is itself a button', () => {
-    // The guard behind the chip's `sr-only` detail (kindred#2177). A nested
-    // `<button>` is invalid inside a `<button>`'s content model AND its tap
-    // would bubble into `onOpen`, so if the tooltip primitive is ever wired
-    // in here, this fails first.
+  it('never nests an interactive control inside another one — checked by ROLE, not TAG (kindred#2222)', () => {
+    // The guard behind the chip's `sr-only` detail (kindred#2177), re-keyed
+    // for kindred#2222. The original version of this guard matched on the
+    // TAG (`button button`), which a `<div>` frame defeats trivially even
+    // when it is STILL an ARIA button: `useDraggable`'s `attributes` carries
+    // `role: 'button'` + `tabIndex: 0` UNCONDITIONALLY, so a naive tag swap
+    // that still spreads them onto the frame recreates
+    // `<div role="button" tabindex="0">` — which assistive tech, and the
+    // HTML content model, still treat as a button. A tag-based selector
+    // cannot see that; a role-based one can, because `getAllByRole('button')`
+    // resolves the computed ACCESSIBLE role (explicit `role="button"` as well
+    // as a native `<button>` tag), not the literal tag name.
     const { container } = render(
       <FamilyCard
         party={party({
@@ -467,8 +484,15 @@ describe('FamilyCard — what it shows', () => {
       />
     )
     expect(screen.getByText('Wants to share')).toBeInTheDocument()
-    expect(container.querySelectorAll('button button')).toHaveLength(0)
-    expect(container.querySelectorAll('button [tabindex]')).toHaveLength(0)
+    const roleButtons = within(container).getAllByRole('button')
+    expect(roleButtons.length).toBeGreaterThan(0)
+    for (const outer of roleButtons) {
+      const nested = roleButtons.filter((el) => el !== outer && outer.contains(el))
+      expect(nested).toHaveLength(0)
+      // Catches a focusable-but-not-role="button" descendant too — e.g. an
+      // element some future edit makes tabbable without giving it a role.
+      expect(outer.querySelectorAll('[tabindex]:not([tabindex="-1"])')).toHaveLength(0)
+    }
   })
 
   it('renders no "Answers disagree" chip, and no tooltip, when there is no conflict', () => {
@@ -757,8 +781,9 @@ describe('FamilyCard — summer’s type scale', () => {
   })
 
   it('carries the same scale into the drag overlay', () => {
-    // The overlay shares `FamilyCardBody`, so this passes for free — which is
-    // the point. It fails the moment somebody hand-rolls a second body.
+    // The overlay shares `FamilyCardIdentity`/`FamilyCardChips`, so this
+    // passes for free — which is the point. It fails the moment somebody
+    // hand-rolls a second body.
     render(<FamilyCardPreview party={party()} />)
     expect(screen.getByTestId('family-card-name')).toHaveClass('text-sm')
   })

--- a/frontend/src/components/weekend/FamilyCard.test.tsx
+++ b/frontend/src/components/weekend/FamilyCard.test.tsx
@@ -445,11 +445,11 @@ describe('FamilyCard — what it shows', () => {
     // card's open control no longer wraps the chip row at all — the whole
     // point of this refactor is that the chip row is a SIBLING of the
     // control, not its child, so a future interactive trigger there
-    // (kindred#2212) is never nested inside another one. That means the
+    // (kindred#2229) is never nested inside another one. That means the
     // sentence is no longer folded into the control's accessible name the
     // way it was when the card was one big `<button>`. Closing THAT gap —
     // giving the sentence a real accessible relationship to a trigger a
-    // touch user can reach — is kindred#2212's job, not this one's.
+    // touch user can reach — is kindred#2229's job, not this one's.
     expect(screen.getByRole('button', { name: /Johnson/ })).not.toHaveAccessibleName(
       /form's answer/
     )

--- a/frontend/src/components/weekend/FamilyCard.tsx
+++ b/frontend/src/components/weekend/FamilyCard.tsx
@@ -150,13 +150,13 @@ function Chip({
    * and this chip row is a SIBLING of the card's open control, not its
    * child, so a real interactive trigger here would no longer be invalid
    * HTML or steal the click. This chip still doesn't carry one: #2222 was
-   * the structural unblock, not the tooltip wiring — that's kindred#2212.
+   * the structural unblock, not the tooltip wiring — that's kindred#2229.
    *
    * So the detail is still REAL `sr-only` TEXT, exactly as kindred#2177
    * shipped it. That is strictly more than the `title` it replaced gave —
    * `title` on a `<span>` is not reliably announced at all — and it leaves
    * one gap, honestly stated: a touch user still cannot summon this
-   * sentence. #2212 is what closes it.
+   * sentence. #2229 is what closes it.
    */
   title?: string
 }) {
@@ -239,7 +239,7 @@ function ChildList({
  * on purpose: a `<button>`'s content model forbids an interactive
  * descendant, and the chip row is exactly where kindred#2177 left a
  * `sr-only` detail sentence waiting for a real tooltip trigger
- * (kindred#2212). Swapping the card's outer frame to a `<div>` while still
+ * (kindred#2229). Swapping the card's outer frame to a `<div>` while still
  * wrapping the WHOLE body in one inner `<button>` would just move that wall
  * one level deeper — nothing would actually be unblocked. Keeping the chip
  * row OUT of the button is what does.
@@ -530,7 +530,7 @@ export function FamilyCard({
 
   return (
     // NOT a `<button>` (kindred#2222) — a `<div>` frame, so the chip row
-    // below can host a real interactive trigger (kindred#2212) as a SIBLING
+    // below can host a real interactive trigger (kindred#2229) as a SIBLING
     // instead of a forbidden nested descendant.
     //
     // `ref`/`listeners` stay HERE, not on the inner control below: dnd-kit's

--- a/frontend/src/components/weekend/FamilyCard.tsx
+++ b/frontend/src/components/weekend/FamilyCard.tsx
@@ -135,23 +135,28 @@ function Chip({
    * The chip's per-party detail, e.g. "Answers disagree"'s account of which
    * two answers disagreed (kindred#2083).
    *
-   * ## Why this is NOT `ui/Tooltip`, unlike every other chip on this surface
+   * ## Why this is still NOT `ui/Tooltip`, unlike every other chip on this surface
    *
    * kindred#2177 replaced the board's `title` attributes with a focusable
-   * tooltip, and this chip was named as the highest-leverage one. It cannot
-   * have it: THE WHOLE CARD IS A `<button>` (see `FamilyCard` below), and a
-   * `<button>`'s content model forbids interactive descendants. A nested
-   * trigger would be invalid HTML and its tap would bubble straight into
-   * `onOpen`, opening the details panel instead of the bubble.
-   * `HouseholdRosterRow`'s in-button badges hit the identical wall and take
-   * the identical way out.
+   * tooltip, and this chip was named as the highest-leverage one. It
+   * couldn't have it: THE WHOLE CARD WAS A `<button>` (see `FamilyCard`
+   * below), and a `<button>`'s content model forbids interactive
+   * descendants. A nested trigger would have been invalid HTML and its tap
+   * would have bubbled straight into `onOpen`, opening the details panel
+   * instead of the bubble. `HouseholdRosterRow`'s in-button badges hit the
+   * identical wall and took the identical way out.
    *
-   * So the detail becomes REAL `sr-only` TEXT. That is strictly more than the
-   * `title` gave — `title` on a `<span>` is not reliably announced at all —
-   * and it leaves one gap, honestly stated: a touch user still cannot summon
-   * this sentence. Closing that needs the card to stop being one big button,
-   * which is a structural change with its own blast radius, not something to
-   * slip into a tooltip sweep.
+   * kindred#2222 removed that wall — `FamilyCard`'s frame is a `<div>` now,
+   * and this chip row is a SIBLING of the card's open control, not its
+   * child, so a real interactive trigger here would no longer be invalid
+   * HTML or steal the click. This chip still doesn't carry one: #2222 was
+   * the structural unblock, not the tooltip wiring — that's kindred#2212.
+   *
+   * So the detail is still REAL `sr-only` TEXT, exactly as kindred#2177
+   * shipped it. That is strictly more than the `title` it replaced gave —
+   * `title` on a `<span>` is not reliably announced at all — and it leaves
+   * one gap, honestly stated: a touch user still cannot summon this
+   * sentence. #2212 is what closes it.
    */
   title?: string
 }) {
@@ -168,14 +173,16 @@ function Chip({
 /**
  * A party's children as one `Name (age) · Name (age)` run.
  *
- * `FamilyCardBody` renders a child list TWICE — the household bold identity
- * line and the person-grain grey secondary line — and the two differ only in
- * which age formatter they call and what wraps them. Everything else (the key
- * strategy, the separator, the missing-age omission, the blank-name fallback)
- * is one decision each, and each was drifting toward being made in two places:
- * the blank-name fallback had to be hand-applied to both copies in kindred#2074.
- * Shared for the same reason `FamilyCardPreview` shares `FamilyCardBody` —
- * so the copies cannot drift apart (kindred#2153).
+ * `FamilyCardIdentity` renders a child list TWICE — the household bold
+ * identity line and the person-grain grey secondary line — and the two
+ * differ only in which age formatter they call and what wraps them.
+ * Everything else (the key strategy, the separator, the missing-age
+ * omission, the blank-name fallback) is one decision each, and each was
+ * drifting toward being made in two places: the blank-name fallback had to
+ * be hand-applied to both copies in kindred#2074. Shared for the same reason
+ * `FamilyCardPreview` shares `FamilyCardIdentity`/`FamilyCardChips`
+ * (kindred#2222, formerly one `FamilyCardBody`) — so the copies cannot drift
+ * apart (kindred#2153).
  *
  * The caller supplies the wrapper, because the two sites want different ones:
  * the bold line's span is also the non-household branch's, and the grey line's
@@ -224,24 +231,20 @@ function ChildList({
 }
 
 /**
- * Everything the card SHOWS, with nothing about how it is picked up.
+ * Lines 1–2: the household's identity, headcount and last year's cabin.
  *
- * Split out so the drag overlay can render the card without dnd-kit — see
- * `FamilyCardPreview`. Sharing the body rather than hand-rolling a second one
- * is the only reason the overlay cannot drift away from the real card.
+ * Split out of what used to be one `FamilyCardBody` so `FamilyCard` can put
+ * ONLY this half inside its real, focusable `<button>` (kindred#2222).
+ * `FamilyCardChips` (below) sits beside it as a SIBLING rather than a child,
+ * on purpose: a `<button>`'s content model forbids an interactive
+ * descendant, and the chip row is exactly where kindred#2177 left a
+ * `sr-only` detail sentence waiting for a real tooltip trigger
+ * (kindred#2212). Swapping the card's outer frame to a `<div>` while still
+ * wrapping the WHOLE body in one inner `<button>` would just move that wall
+ * one level deeper — nothing would actually be unblocked. Keeping the chip
+ * row OUT of the button is what does.
  */
-function FamilyCardBody({
-  party,
-  unit,
-  sharedSlot,
-  holdsWholeBuilding = false,
-}: {
-  party: RosterPartyRow
-  unit?: LodgingUnitRow | undefined
-  sharedSlot: boolean
-  holdsWholeBuilding?: boolean
-}) {
-  const flags = party.flags ?? {}
+function FamilyCardIdentity({ party }: { party: RosterPartyRow }) {
   const children = party.children ?? []
   const isHousehold = party.grain === 'household'
   // The filter itself -- family_camp_adults stores adult slots 1-5 as
@@ -260,14 +263,6 @@ function FamilyCardBody({
   // because a redundant `isHousehold` guard would look like the load-bearing
   // one and outlive the branch it duplicates.
   const lastYearCabin = (party.last_year_cabin ?? '').trim()
-  const attention = partyAttention(party, unit)
-  const proximity = party.share?.proximity ?? []
-  // `similar_ages` ACCOMPANIES `with`; it never replaces it. One chip covering
-  // both is what keeps 22 households from dropping out of a "wants to share"
-  // view — a chip showing one *or* the other loses them.
-  const wantsToShare = proximity.includes('with') || proximity.includes('similar_ages')
-  const wantsNear = proximity.includes('near')
-  const conflictDetail = answersConflictDetail(party.share)
 
   return (
     <>
@@ -398,35 +393,69 @@ function FamilyCardBody({
               <ChildList children={children} formatAge={displayCampMinderAge} />
             </span>
           )}
+    </>
+  )
+}
 
-      <span className="flex flex-wrap gap-1">
-        {/* #2008: this PLACEMENT covers every leaf of a building, not merely
+/**
+ * Line 3: the chip row — housing flags, the fit verdict, share-request
+ * chips, and the Returning/First-time badges.
+ *
+ * A SIBLING of `FamilyCardIdentity`'s `<button>` (kindred#2222), never its
+ * child — see that component's doc for why. The one chip carrying a `title`
+ * today (`Chip`'s "Answers disagree" detail, kindred#2083) still renders it
+ * as `sr-only` text, exactly as kindred#2177 shipped: this refactor
+ * unblocks a real `ui/Tooltip` trigger here, it does not wire one in.
+ */
+function FamilyCardChips({
+  party,
+  unit,
+  sharedSlot,
+  holdsWholeBuilding = false,
+}: {
+  party: RosterPartyRow
+  unit?: LodgingUnitRow | undefined
+  sharedSlot: boolean
+  holdsWholeBuilding?: boolean
+}) {
+  const flags = party.flags ?? {}
+  const isHousehold = party.grain === 'household'
+  const attention = partyAttention(party, unit)
+  const proximity = party.share?.proximity ?? []
+  // `similar_ages` ACCOMPANIES `with`; it never replaces it. One chip covering
+  // both is what keeps 22 households from dropping out of a "wants to share"
+  // view — a chip showing one *or* the other loses them.
+  const wantsToShare = proximity.includes('with') || proximity.includes('similar_ages')
+  const wantsNear = proximity.includes('near')
+  const conflictDetail = answersConflictDetail(party.share)
+
+  return (
+    <span className="flex flex-wrap gap-1">
+      {/* #2008: this PLACEMENT covers every leaf of a building, not merely
             a card it happens to share — see `holdsWholeBuilding`'s doc.
             First in the row: it is a fact about the household's privacy, not
             a need or a warning, and staff scan left-to-right. */}
-        {holdsWholeBuilding && <Chip label="Whole building" tone="building" icon={Home} />}
-        {/* The needs a cabin field can actually answer — the same two the fit
+      {holdsWholeBuilding && <Chip label="Whole building" tone="building" icon={Home} />}
+      {/* The needs a cabin field can actually answer — the same two the fit
             check judges. `needs_accommodation` names no specific amenity, so
             it is carried by the verdict chip below instead of duplicated. */}
-        {flags.needs_private_bathroom === true && <Chip label="Private bathroom" tone="need" />}
-        {flags.needs_power === true && <Chip label="Power" tone="need" />}
+      {flags.needs_private_bathroom === true && <Chip label="Private bathroom" tone="need" />}
+      {flags.needs_power === true && <Chip label="Power" tone="need" />}
 
-        {attention.level === 'required' && <Chip label={ATTENTION_LABEL.required} tone="warn" />}
-        {attention.level === 'unmet' && <Chip label={attention.reason} tone="warn" />}
-        {attention.level === 'unverified' && (
-          <Chip label={ATTENTION_LABEL.unverified} tone="quiet" />
-        )}
+      {attention.level === 'required' && <Chip label={ATTENTION_LABEL.required} tone="warn" />}
+      {attention.level === 'unmet' && <Chip label={attention.reason} tone="warn" />}
+      {attention.level === 'unverified' && <Chip label={ATTENTION_LABEL.unverified} tone="quiet" />}
 
-        {/* Keyed off the RESOLVED verdict, not the registration gate. The gate
+      {/* Keyed off the RESOLVED verdict, not the registration gate. The gate
             is superseded wherever the Family Camp form answered, so a household
             that said no at registration and then named a partner is legitimately
             placed — chipping it "declined" repeats at card level exactly the
             false positive the slot flag was moved off the gate to avoid.
             Wording matches the slot: the form has no refusal option. */}
-        {sharedSlot && party.share?.eligibility === 'declined' && (
-          <Chip label={shareWordingChip(SHARE_WORDING.declined)} tone="warn" />
-        )}
-        {/* 16 households for 2026 carry disagreeing answers. Shown on the card
+      {sharedSlot && party.share?.eligibility === 'declined' && (
+        <Chip label={shareWordingChip(SHARE_WORDING.declined)} tone="warn" />
+      )}
+      {/* 16 households for 2026 carry disagreeing answers. Shown on the card
             as well as the slot, so a party sitting alone still surfaces one.
             Gated on the DETAIL, not the raw boolean (kindred#2083): a party
             this can't explain — none exist today, but a person-grain party
@@ -434,38 +463,33 @@ function FamilyCardBody({
             chip. The tooltip names which two answers disagreed and which one
             staff are acting on, matching `SharePreferenceChip`'s hover
             pattern rather than a bare unexplained flag. */}
-        {conflictDetail !== null && (
-          <Chip
-            label={shareWordingChip(SHARE_WORDING.conflict)}
-            tone="warn"
-            title={conflictDetail}
-          />
-        )}
-        {wantsToShare && <Chip label="Wants to share" tone="share" />}
-        {/* NEAR and WITH are different requests: NEAR is satisfied by map
+      {conflictDetail !== null && (
+        <Chip label={shareWordingChip(SHARE_WORDING.conflict)} tone="warn" title={conflictDetail} />
+      )}
+      {wantsToShare && <Chip label="Wants to share" tone="share" />}
+      {/* NEAR and WITH are different requests: NEAR is satisfied by map
             distance between units, WITH by putting both in one room. */}
-        {wantsNear && <Chip label="Near another family" tone="muted" />}
+      {wantsNear && <Chip label="Near another family" tone="muted" />}
 
-        {party.is_returning === true && (
-          <span className="text-forest-700 dark:text-forest-300 inline-flex items-center gap-0.5 text-xs font-semibold">
-            <Repeat className="h-2.5 w-2.5 flex-shrink-0" aria-hidden="true" />
-            Returning
-          </span>
-        )}
-        {/* `is_returning` is only ever computed for household-grain parties
+      {party.is_returning === true && (
+        <span className="text-forest-700 dark:text-forest-300 inline-flex items-center gap-0.5 text-xs font-semibold">
+          <Repeat className="h-2.5 w-2.5 flex-shrink-0" aria-hidden="true" />
+          Returning
+        </span>
+      )}
+      {/* `is_returning` is only ever computed for household-grain parties
             (`_build_household_parties` sets it from `prior_cm_ids`). An
             adult weekend guest is `grain: 'person'`, for which the field is
             never set and arrives as the Pydantic default `false` -- untracked,
             not "no". Gating on grain keeps this badge from calling every
             adult weekend regular a first-timer. */}
-        {isHousehold && party.is_returning !== true && (
-          <span className="inline-flex items-center gap-0.5 text-xs font-semibold text-amber-700 dark:text-amber-300">
-            <Star className="h-2.5 w-2.5 flex-shrink-0" aria-hidden="true" />
-            First-time
-          </span>
-        )}
-      </span>
-    </>
+      {isHousehold && party.is_returning !== true && (
+        <span className="inline-flex items-center gap-0.5 text-xs font-semibold text-amber-700 dark:text-amber-300">
+          <Star className="h-2.5 w-2.5 flex-shrink-0" aria-hidden="true" />
+          First-time
+        </span>
+      )}
+    </span>
   )
 }
 
@@ -505,20 +529,26 @@ export function FamilyCard({
   })
 
   return (
-    <button
-      type="button"
+    // NOT a `<button>` (kindred#2222) — a `<div>` frame, so the chip row
+    // below can host a real interactive trigger (kindred#2212) as a SIBLING
+    // instead of a forbidden nested descendant.
+    //
+    // `ref`/`listeners` stay HERE, not on the inner control below: dnd-kit's
+    // `listeners` is pointer/keyboard event handlers, not ARIA, so keeping
+    // them on the full frame is what lets a drag still start from ANYWHERE
+    // on the card, matching today's behaviour exactly — `onPointerDown`
+    // fired on the inner button still bubbles up here regardless. What must
+    // NOT land here is `attributes`: it carries `role: 'button'` +
+    // `tabIndex: 0` UNCONDITIONALLY (`useDraggable`'s own doc), and spreading
+    // it onto this `<div>` would silently recreate
+    // `<div role="button" tabindex="0">` — still an ARIA button, the exact
+    // defect this refactor exists to remove. `attributes` moves to the
+    // explicit inner control below instead.
+    <div
       data-family-card
       ref={setNodeRef}
-      // Spread ONLY when draggable. dnd-kit sets `aria-roledescription` and
-      // the rest regardless of its own `disabled` flag, so a read-only board
-      // would announce every card as draggable to a screen reader and offer a
-      // keyboard drag that goes nowhere.
-      {...(isDraggable ? attributes : {})}
       {...(isDraggable ? listeners : {})}
-      onClick={() => {
-        onOpen(party)
-      }}
-      className={`${CARD_FRAME} hover:border-primary/50 focus-visible:ring-ring transition-colors focus-visible:ring-2 focus-visible:outline-none ${
+      className={`${CARD_FRAME} hover:border-primary/50 transition-colors ${
         inQueue ? 'bg-card' : 'bg-background'
       } ${isDraggable ? 'cursor-grab active:cursor-grabbing' : ''} ${
         // The card stays mounted and dimmed rather than being removed: the
@@ -527,13 +557,31 @@ export function FamilyCard({
         isDragging ? 'opacity-40' : ''
       }`}
     >
-      <FamilyCardBody
+      {/* THE EXPLICIT INNER CONTROL (kindred#2222). Carries click, keyboard
+          activation (native `<button>` semantics) and the focus ring — the
+          same three the old single `<button>` carried, just narrowed to the
+          identity lines rather than the whole card. `attributes` lands here,
+          not on the frame above: a native `<button>` is already
+          `role="button"` and already `tabIndex 0`, so dnd-kit's values are
+          redundant-but-harmless here, where on the frame they would be the
+          defect. */}
+      <button
+        type="button"
+        {...(isDraggable ? attributes : {})}
+        onClick={() => {
+          onOpen(party)
+        }}
+        className="focus-visible:ring-ring flex w-full flex-col gap-1 rounded-lg text-left focus-visible:ring-2 focus-visible:outline-none"
+      >
+        <FamilyCardIdentity party={party} />
+      </button>
+      <FamilyCardChips
         party={party}
         unit={unit}
         sharedSlot={sharedSlot}
         holdsWholeBuilding={holdsWholeBuilding}
       />
-    </button>
+    </div>
   )
 }
 
@@ -566,7 +614,8 @@ export function FamilyCardPreview({
 }) {
   return (
     <div className={`${CARD_FRAME} bg-card shadow-lodge-lg border-primary/50 rotate-2`}>
-      <FamilyCardBody
+      <FamilyCardIdentity party={party} />
+      <FamilyCardChips
         party={party}
         unit={unit}
         sharedSlot={sharedSlot}

--- a/frontend/src/components/weekend/HouseholdRosterRow.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterRow.tsx
@@ -120,119 +120,145 @@ export function HouseholdRosterRow({ party, showRequests, unit, onOpen }: Househ
   return (
     // `role="button"` used to live here, overriding the native `row` role —
     // `queryAllByRole('row')` collapsed to 1 (the header alone) and the four
-    // `<td>` cells lost their owning row (kindred#2063). The affordance now
-    // lives in a real `<button>` inside the first cell instead, which keeps
-    // row/cell semantics intact and still satisfies `clickoutsidePredicate`'s
-    // `isInteractive` check (`button` is already in its selector list).
+    // `<td>` cells lost their owning row (kindred#2063). The affordance
+    // lives in the first cell instead, which keeps row/cell semantics intact
+    // and still satisfies `clickoutsidePredicate`'s `isInteractive` check
+    // (`button` is already in its selector list).
     <tr className="border-border/40 border-b align-top">
       <td className={`border-l-[3px] ${RAIL[attention.level]}`}>
-        {/* Content below stays `<span>`, never `<div>`/`<p>` — a `<button>`'s
-            content model is phrasing content only, the same reason
-            `FamilyCardBody` (this row's card-view counterpart) is spans
-            throughout. Tailwind's `block`/`flex` classes still give each span
-            the same layout its `<div>`/`<p>` had. */}
-        <button
-          type="button"
-          onClick={() => {
-            onOpen(party)
-          }}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter' || event.key === ' ') {
-              event.preventDefault()
+        {/* THE EXPLICIT OPEN CONTROL (kindred#2222). The cell used to be one
+            `<button>` wrapping every line, including the Returning/
+            First-time badges — a `<button>`'s content model forbids an
+            interactive descendant, so those badges' `sr-only` detail
+            (kindred#2177) could never become a real, touch-reachable
+            tooltip trigger (kindred#2212) without first breaking that wall.
+            The badges are laid out here as siblings of the control rather
+            than a shrunken click target, using the "stretched link" trick:
+            `hover:bg-muted/30` lives on THIS `relative` wrapper (so the
+            hover wash paints behind the text, not over it — CSS `:hover`
+            reaches every ancestor of whatever the pointer is actually over),
+            the control itself is an `absolute inset-0` button carrying the
+            click/keyboard activation and the focus ring, and the visible
+            content below is a plain, non-positioned sibling — which a
+            positioned `absolute` box always paints ABOVE regardless of DOM
+            order. Nothing in the content is interactive today, so that
+            ordering is invisible; the day kindred#2212 wires a real tooltip
+            trigger into a badge, that trigger needs its own `relative z-10`
+            (or similar) to sit above this layer and receive its own clicks
+            — the standard caveat of this pattern, not a defect on its own. */}
+        <div className="hover:bg-muted/30 relative transition-colors">
+          <button
+            type="button"
+            aria-label={partyIdentityLabel(party)}
+            onClick={() => {
               onOpen(party)
-            }
-          }}
-          className="hover:bg-muted/30 focus-visible:ring-ring block w-full cursor-pointer py-3 pr-4 pl-3 text-left transition-colors focus-visible:ring-2 focus-visible:outline-none"
-        >
-          <span className="flex flex-wrap items-center gap-x-2 gap-y-1">
-            {/* kindred#2084: this used to be `party.display_name` -- CampMinder's
-                mailing_title salutation, which disagreed with the real
-                attending-adult list on 26.7% of 2026's rostered households.
-                Reuses FamilyCard's own construction (`householdIdentity.ts`)
-                instead, so staff never learn two identities for one household. */}
-            <span
-              data-testid="household-row-name"
-              className="text-foreground text-sm font-semibold"
-            >
-              {partyIdentityLabel(party)}
-            </span>
-            {/* kindred#2177 converted the board's `title` tooltips to a
-                focusable `ui/Tooltip`. These two badges are the deliberate
-                exception, and the reason is three lines up: they sit INSIDE
-                the row's own `<button>`, whose content model is phrasing
-                content with no interactive descendants. A focusable trigger
-                here would be invalid HTML and would eat the row's click.
+            }}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault()
+                onOpen(party)
+              }
+            }}
+            className="focus-visible:ring-ring absolute inset-0 cursor-pointer rounded focus-visible:ring-2 focus-visible:outline-none"
+          />
+          {/* Content below stays `<span>`, never `<div>`/`<p>` — a `<button>`'s
+              content model is phrasing content only, the same reason
+              `FamilyCardIdentity` (this row's card-view counterpart) is spans
+              throughout. Tailwind's `block`/`flex` classes still give each span
+              the same layout its `<div>`/`<p>` had. Kept even though this is no
+              longer literally inside the button: the grammar is shared with the
+              card on purpose. */}
+          <div className="py-3 pr-4 pl-3 text-left">
+            <span className="flex flex-wrap items-center gap-x-2 gap-y-1">
+              {/* kindred#2084: this used to be `party.display_name` -- CampMinder's
+                  mailing_title salutation, which disagreed with the real
+                  attending-adult list on 26.7% of 2026's rostered households.
+                  Reuses FamilyCard's own construction (`householdIdentity.ts`)
+                  instead, so staff never learn two identities for one household.
+                  Also the control's `aria-label` above, now that this text is a
+                  sibling of the control rather than its accessible-name source. */}
+              <span
+                data-testid="household-row-name"
+                className="text-foreground text-sm font-semibold"
+              >
+                {partyIdentityLabel(party)}
+              </span>
+              {/* kindred#2177 converted the board's `title` tooltips to a
+                  focusable `ui/Tooltip`. These two badges are the deliberate
+                  exception — see the cell-level comment above for the wall and
+                  the escape from it.
 
-                Real `sr-only` text instead. That is strictly more than the
-                `title` gave — `title` on a `<span>` is not reliably announced
-                at all — and the touch gap it leaves is the smallest on the
-                board, since the badge's visible word already IS the fact and
-                the sentence only rephrases it. */}
-            {party.is_returning === true && (
-              <span className="text-forest-700 dark:text-forest-300 bg-forest-100 dark:bg-forest-900/50 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold">
-                <Repeat className="h-3 w-3 flex-shrink-0" />
-                Returning
-                <span className="sr-only">(stayed with us before)</span>
-              </span>
-            )}
-            {/* `is_returning` is only ever computed for household-grain
-                parties (`_build_household_parties` sets it from
-                `prior_cm_ids`). An adult weekend guest is `grain: 'person'`
-                (`showAdults` false), for which the field is never set and
-                arrives as the Pydantic default `false` -- untracked, not
-                "no". Gating on grain keeps this badge from calling every
-                adult weekend regular a first-timer. */}
-            {showAdults && party.is_returning !== true && (
-              <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-700 dark:bg-amber-900/50 dark:text-amber-300">
-                <Star className="h-3 w-3 flex-shrink-0" />
-                First-time
-                <span className="sr-only">(first time at camp)</span>
-              </span>
-            )}
-          </span>
-          {/* Only the two states that name a real failure get words. "No cabin
-              yet" would repeat the Cabin column's "Unassigned", and an
-              unverified need would repeat the chips under Housing needs — the
-              rail and the section heading already carry the state. */}
-          {(attention.level === 'required' || attention.level === 'unmet') && (
-            <span className={`mt-0.5 block text-xs font-medium ${REASON_TONE[attention.level]}`}>
-              {attention.level === 'required' ? 'Accommodation required' : attention.reason}
+                  Real `sr-only` text instead. That is strictly more than the
+                  `title` gave — `title` on a `<span>` is not reliably announced
+                  at all — and the touch gap it leaves is the smallest on the
+                  board, since the badge's visible word already IS the fact and
+                  the sentence only rephrases it. */}
+              {party.is_returning === true && (
+                <span className="text-forest-700 dark:text-forest-300 bg-forest-100 dark:bg-forest-900/50 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold">
+                  <Repeat className="h-3 w-3 flex-shrink-0" />
+                  Returning
+                  <span className="sr-only">(stayed with us before)</span>
+                </span>
+              )}
+              {/* `is_returning` is only ever computed for household-grain
+                  parties (`_build_household_parties` sets it from
+                  `prior_cm_ids`). An adult weekend guest is `grain: 'person'`
+                  (`showAdults` false), for which the field is never set and
+                  arrives as the Pydantic default `false` -- untracked, not
+                  "no". Gating on grain keeps this badge from calling every
+                  adult weekend regular a first-timer. */}
+              {showAdults && party.is_returning !== true && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-700 dark:bg-amber-900/50 dark:text-amber-300">
+                  <Star className="h-3 w-3 flex-shrink-0" />
+                  First-time
+                  <span className="sr-only">(first time at camp)</span>
+                </span>
+              )}
             </span>
-          )}
-          <span className="text-muted-foreground mt-1 block text-xs tabular-nums">
-            {composition(party)}
-          </span>
-          {/* Members are reference detail, not scanning material — one wrapped
-              line rather than two stacked ones, so 62 rows stay a page. An
-              adult weekend enrols the individual directly, so the party IS the
-              adult and `display_name` above already named them. */}
-          <span
-            data-testid="household-row-members"
-            className="text-muted-foreground/75 mt-0.5 block text-xs leading-snug"
-          >
-            {showAdults &&
-              adults.map((adult, index) => (
-                <Fragment
-                  key={`${String(adult.adult_number ?? index)}-${String(adult.display_name)}`}
-                >
-                  {index > 0 && ', '}
-                  {/* Each name is its own element so it stays one text node —
-                      a separator inside the span would split it. */}
-                  <span>{adult.display_name}</span>
+            {/* Only the two states that name a real failure get words. "No cabin
+                yet" would repeat the Cabin column's "Unassigned", and an
+                unverified need would repeat the chips under Housing needs — the
+                rail and the section heading already carry the state. */}
+            {(attention.level === 'required' || attention.level === 'unmet') && (
+              <span className={`mt-0.5 block text-xs font-medium ${REASON_TONE[attention.level]}`}>
+                {attention.level === 'required' ? 'Accommodation required' : attention.reason}
+              </span>
+            )}
+            <span className="text-muted-foreground mt-1 block text-xs tabular-nums">
+              {composition(party)}
+            </span>
+            {/* Members are reference detail, not scanning material — one wrapped
+                line rather than two stacked ones, so 62 rows stay a page. An
+                adult weekend enrols the individual directly, so the party IS the
+                adult and `display_name` above already named them. */}
+            <span
+              data-testid="household-row-members"
+              className="text-muted-foreground/75 mt-0.5 block text-xs leading-snug"
+            >
+              {showAdults &&
+                adults.map((adult, index) => (
+                  <Fragment
+                    key={`${String(adult.adult_number ?? index)}-${String(adult.display_name)}`}
+                  >
+                    {index > 0 && ', '}
+                    {/* Each name is its own element so it stays one text node —
+                        a separator inside the span would split it. */}
+                    <span>{adult.display_name}</span>
+                  </Fragment>
+                ))}
+              {children.map((child, index) => (
+                <Fragment key={String(child.person_cm_id ?? index)}>
+                  {(index > 0 || (showAdults && adults.length > 0)) && ' · '}
+                  <span>
+                    {child.age === null || child.age === undefined
+                      ? child.display_name
+                      : `${String(child.display_name)} (${displayCampMinderAge(child.age)})`}
+                  </span>
                 </Fragment>
               ))}
-            {children.map((child, index) => (
-              <Fragment key={String(child.person_cm_id ?? index)}>
-                {(index > 0 || (showAdults && adults.length > 0)) && ' · '}
-                <span>
-                  {child.age === null || child.age === undefined
-                    ? child.display_name
-                    : `${String(child.display_name)} (${displayCampMinderAge(child.age)})`}
-                </span>
-              </Fragment>
-            ))}
-          </span>
-        </button>
+            </span>
+          </div>
+        </div>
       </td>
 
       <td className="py-3 pr-4">

--- a/frontend/src/components/weekend/HouseholdRosterRow.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterRow.tsx
@@ -131,7 +131,7 @@ export function HouseholdRosterRow({ party, showRequests, unit, onOpen }: Househ
             First-time badges — a `<button>`'s content model forbids an
             interactive descendant, so those badges' `sr-only` detail
             (kindred#2177) could never become a real, touch-reachable
-            tooltip trigger (kindred#2212) without first breaking that wall.
+            tooltip trigger (kindred#2229) without first breaking that wall.
             The badges are laid out here as siblings of the control rather
             than a shrunken click target, using the "stretched link" trick:
             `hover:bg-muted/30` lives on THIS `relative` wrapper (so the
@@ -142,7 +142,7 @@ export function HouseholdRosterRow({ party, showRequests, unit, onOpen }: Househ
             content below is a plain, non-positioned sibling — which a
             positioned `absolute` box always paints ABOVE regardless of DOM
             order. Nothing in the content is interactive today, so that
-            ordering is invisible; the day kindred#2212 wires a real tooltip
+            ordering is invisible; the day kindred#2229 wires a real tooltip
             trigger into a badge, that trigger needs its own `relative z-10`
             (or similar) to sit above this layer and receive its own clicks
             — the standard caveat of this pattern, not a defect on its own. */}

--- a/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
@@ -4,7 +4,7 @@
  * weekends, where individuals enrol directly).
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -386,12 +386,14 @@ describe('HouseholdRosterTable', () => {
     expect(screen.getByRole('tooltip')).toHaveTextContent('Two rooms combined into one slot')
   })
 
-  it('never nests a control inside the row button', () => {
-    // kindred#2177's structural guard. The name cell IS a `<button>`, whose
-    // content model forbids interactive descendants — the reason the two
-    // badges inside it carry `sr-only` text while the "Merged" chip in the
-    // next cell gets the real tooltip. A nested trigger would also eat the
-    // row's own click.
+  it('never nests an interactive control inside another one — checked by ROLE, not TAG (kindred#2222)', () => {
+    // kindred#2177's structural guard, re-keyed for kindred#2222. The
+    // original matched on the TAG (`button button`); re-keyed onto the
+    // computed accessible ROLE instead — `getAllByRole('button')` catches
+    // both a native `<button>` and an explicit `role="button"` element, so a
+    // future regression that makes the wrapping cell itself an ARIA button
+    // (without literally being a `<button>` tag) still trips this, where a
+    // tag-only selector would not.
     const { container } = render(
       <HouseholdRosterTable
         year={2026}
@@ -411,16 +413,23 @@ describe('HouseholdRosterTable', () => {
       />,
       { wrapper }
     )
-    expect(container.querySelectorAll('button button')).toHaveLength(0)
+    const roleButtons = within(container).getAllByRole('button')
+    expect(roleButtons.length).toBeGreaterThan(0)
+    for (const outer of roleButtons) {
+      const nested = roleButtons.filter((el) => el !== outer && outer.contains(el))
+      expect(nested).toHaveLength(0)
+      expect(outer.querySelectorAll('[tabindex]:not([tabindex="-1"])')).toHaveLength(0)
+    }
   })
 
   it('spells out the returning and first-time badges in text, not a title', () => {
-    // kindred#2177, and the one place the tooltip primitive is NOT the answer:
-    // these two badges live INSIDE the row's own `<button>`, whose content
-    // model is phrasing content with no interactive descendants. A focusable
-    // trigger there would be invalid HTML and would swallow the row's click.
-    // Real `sr-only` text instead — which is strictly more than the `title`
-    // gave, since `title` on a `<span>` is not reliably announced at all.
+    // kindred#2177, and the one place the tooltip primitive is NOT the
+    // answer YET: these two badges are a SIBLING of the row's own open
+    // control (kindred#2222), not its child — a focusable trigger nested
+    // inside the control would be invalid HTML and would swallow the row's
+    // click. Real `sr-only` text instead — which is strictly more than the
+    // `title` it replaced, since `title` on a `<span>` is not reliably
+    // announced at all.
     const { rerender } = render(
       <HouseholdRosterTable year={2026} parties={[party({ is_returning: true })]} />,
       { wrapper }
@@ -428,15 +437,18 @@ describe('HouseholdRosterTable', () => {
     expect(screen.getByText('Returning')).not.toHaveAttribute('title')
     expect(screen.getByText('(stayed with us before)')).toBeInTheDocument()
     expect(screen.getByText('Returning').tagName).toBe('SPAN')
-    // In the DOM is not the same as ANNOUNCED: the row's own `<button>` takes
-    // its name from its contents, so the sentence has to survive into that
-    // computation or it is decoration.
-    expect(screen.getAllByRole('button')[0]).toHaveAccessibleName(/stayed with us before/)
+    // kindred#2222: the sentence is in the DOM (asserted above) but the
+    // badge no longer lives inside the open control, so it no longer folds
+    // into that control's accessible name — the coupling that assertion
+    // used to pin was itself a symptom of the one-big-button design this
+    // issue dismantles. Giving the sentence a real accessible relationship
+    // to a trigger a touch user can reach is kindred#2212's job.
+    expect(screen.getAllByRole('button')[0]).not.toHaveAccessibleName(/stayed with us before/)
 
     rerender(<HouseholdRosterTable year={2026} parties={[party({ is_returning: false })]} />)
     expect(screen.getByText('First-time')).not.toHaveAttribute('title')
     expect(screen.getByText('(first time at camp)')).toBeInTheDocument()
-    expect(screen.getAllByRole('button')[0]).toHaveAccessibleName(/first time at camp/)
+    expect(screen.getAllByRole('button')[0]).not.toHaveAccessibleName(/first time at camp/)
   })
 
   it('flags a returning family', () => {

--- a/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
@@ -442,7 +442,7 @@ describe('HouseholdRosterTable', () => {
     // into that control's accessible name — the coupling that assertion
     // used to pin was itself a symptom of the one-big-button design this
     // issue dismantles. Giving the sentence a real accessible relationship
-    // to a trigger a touch user can reach is kindred#2212's job.
+    // to a trigger a touch user can reach is kindred#2229's job.
     expect(screen.getAllByRole('button')[0]).not.toHaveAccessibleName(/stayed with us before/)
 
     rerender(<HouseholdRosterTable year={2026} parties={[party({ is_returning: false })]} />)

--- a/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
@@ -422,6 +422,44 @@ describe('HouseholdRosterTable', () => {
     }
   })
 
+  it('would still catch a bare tabIndex left on the row even without a role', () => {
+    // The guard immediately above only walks INSIDE each `getAllByRole
+    // ('button')` match -- `outer.querySelectorAll('[tabindex]...')`. A
+    // `tabIndex` added directly to the wrapping `<tr>`, which never carries
+    // a "button" role itself, sits outside every button's subtree and is
+    // invisible to that loop entirely. Scanning the whole container instead
+    // is what catches it: every element actually put into the tab order by
+    // an EXPLICIT `tabindex` must also carry the button role -- a subset
+    // check, not equality, because a native `<button>` is already focusable
+    // without ever needing an explicit `tabindex` attribute at all (none of
+    // this row's buttons carry one today, unlike `FamilyCard`'s draggable
+    // control, which gets its `tabIndex` explicitly from dnd-kit).
+    const { container } = render(
+      <HouseholdRosterTable
+        year={2026}
+        parties={[
+          party({
+            is_returning: true,
+            is_merged_slot: true,
+            share: {
+              preference: 'no_share',
+              preference_raw: 'No, prefer not to share',
+              proximity: [],
+              request_text: '',
+              needs_resolution: false,
+            },
+          }),
+        ]}
+      />,
+      { wrapper }
+    )
+    const tabbable = Array.from(container.querySelectorAll('[tabindex]:not([tabindex="-1"])'))
+    const roleButtons = within(container).getAllByRole('button')
+    for (const el of tabbable) {
+      expect(roleButtons).toContain(el)
+    }
+  })
+
   it('spells out the returning and first-time badges in text, not a title', () => {
     // kindred#2177, and the one place the tooltip primitive is NOT the
     // answer YET: these two badges are a SIBLING of the row's own open


### PR DESCRIPTION
## What changed and why

`FamilyCard`'s frame was one big `<button>`, and `HouseholdRosterRow`'s row button wrapped its Returning/First-time badges too — both content models forbid an interactive descendant, so kindred#2177 could only give the "Answers disagree" chip and those two badges `sr-only` text, never a real touch-reachable tooltip trigger. This PR does the owner-ruled Option 1 structural fix, done properly per the three parts Part A found:

- **(a) Frame → `<div>` + explicit inner control.** `FamilyCard`'s frame is now a non-interactive `<div>`. A real `<button>` (`FamilyCardIdentity`, lines 1–2: name/headcount/adults/last-year-cabin) carries click, keyboard activation and the focus ring. The chip row (`FamilyCardChips`, line 3) is a SIBLING of that button, not its child — so a future tooltip trigger there is never nested inside another control. `HouseholdRosterRow` uses the "stretched link" pattern for the same reason: an absolutely-positioned, `aria-label`led button covers the whole cell for click/keyboard/focus, with the Returning/First-time badges rendered as plain siblings instead of nested inside it.
- **(b) Neutralise dnd-kit's implicit `role="button"`/`tabIndex 0`.** `useDraggable`'s `attributes` carries these unconditionally. They now land on the inner control (a native `<button>`, where they're redundant-but-harmless) rather than on the frame `<div>` (where they'd silently recreate `<div role="button" tabindex="0">` — the exact defect this PR removes). `listeners` (the pointer/keyboard drag-start handlers, not ARIA) stay on the frame so a drag still starts from anywhere on the card, matching today's behaviour — `onPointerDown` fired on the inner button still bubbles up to the frame.
- **(c) Re-key both guard tests onto ROLE, not TAG.** `FamilyCard.test.tsx` and `HouseholdRosterTable.test.tsx` both had a `button button` / `button [tabindex]` guard that matched on the literal tag, which a `<div role="button" tabindex="0">` frame containing a real `<button>` would have passed trivially — the exact false-green Part A flagged. Re-keyed onto `getAllByRole('button')` (the computed accessible role, which resolves both explicit `role="button"` and native `<button>` tags) checking for nesting and for a stray `tabindex` inside any role="button" element.

Also fixed in-branch (found while touching these files): two stale doc comments that referenced the deleted `FamilyCardBody` and one that still asserted "THE WHOLE CARD IS A `<button>`" after the fix made that false.

## Deliberately NOT done here (scoped to #2212)

- No `ui/Tooltip` is actually wired into the "Answers disagree" chip or the Returning/First-time badges — this PR only unblocks that structurally. The chips still render `sr-only` text exactly as kindred#2177 shipped it.
- `FamilyCard.test.tsx`'s accessible-name assertion (previously `getByRole('button')).toHaveAccessibleName(/form's answer/)`, and the analogous assertion in `HouseholdRosterTable.test.tsx`) is now `not.toHaveAccessibleName(...)`: the sr-only sentence is still in the DOM (a screen reader's ordinary reading cursor still reaches it, and this is asserted directly), but it's no longer folded into the open control's accessible name, since the control no longer wraps it. This coupling was itself a symptom of the one-big-button design being removed; the original issue text called out this exact assertion as needing rewrite under Option 1. Giving the sentence a real accessible relationship to a touch-reachable trigger is #2212's job.
- `ui/Tooltip.tsx` untouched — its polymorphic `as` prop gap (noted in the issue) isn't needed until #2212 actually wires a trigger.

## Verification

- `cd frontend && ./node_modules/.bin/tsc --noEmit` — exit 0
- `./node_modules/.bin/vitest run src/components/weekend/FamilyCard.test.tsx src/components/weekend/HouseholdRosterTable.test.tsx` — 100 passed, exit 0
- Targeted run over every test that renders `FamilyCard` or touches these surfaces (`FamilyCard`, `HouseholdRosterTable`, `FamilyDetailsPanel`, `FloatingUnplacedBadge`, `LodgingBoard`, `LodgingUnitCard`, `MapUnitPopover`) — 331 passed, exit 0
- Full frontend suite once (broad DOM-structure change): `./node_modules/.bin/vitest run` — **442 files / 6672 tests passed, exit 0**
- `./node_modules/.bin/prettier --check` + `./node_modules/.bin/eslint` on all 4 changed files — 0 errors (pre-existing warnings on untouched lines only)

### TDD sequence
1. Re-keyed both guard tests onto `getAllByRole('button')`, and rewrote the two accessible-name assertions to the new (deliberately narrower) contract, **before** touching implementation.
2. Ran the updated test files against the unfixed implementation: the two accessible-name assertions failed as expected (RED, exit 1) — they pin behavior only the restructuring produces. The two re-keyed guard tests passed trivially against the unfixed code, since no interactive descendant exists in default fixtures yet — expected, since they guard a *future* regression, not a present one.
3. Implemented the structural change. All tests green (exit 0).

### Mutation-check transcript (required — the whole reason this issue exists)
For each re-keyed guard test, temporarily reintroduced `role="button"` + `tabIndex={0}` literally on the frame element, ran the single test, confirmed RED, then reverted and confirmed GREEN:

```
FamilyCard.test.tsx -t "never nests"
  with role="button" tabIndex={0} added to the frame <div>:
    AssertionError: expected [ …(1) ] to have a length of +0 but got 1   (exit 1)
  reverted:
    1 passed (exit 0)

HouseholdRosterTable.test.tsx -t "never nests"
  with role="button" tabIndex={0} added to the wrapping <div>:
    AssertionError: expected [ Array(1) ] to have a length of +0 but got 1   (exit 1)
  reverted:
    1 passed (exit 0)
```

Closes #2222.
