### PR TITLE
feat(pb,frontend): a write-in is a named global occupant, not an availability hold

### DIFF
--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -216,9 +216,28 @@ class LodgingUnitSummary(BaseModel):
     # meaning "the opposite of this unit's current default", which an ordinary
     # registry edit would silently invert (1500000135).
     family_available_override: bool | None = None
+    # WHO is in the room. A hold IS a write-in (owner ruling, kindred#2078):
+    # staff do not reserve an empty cabin, they record an occupant the system
+    # does not know about -- most often non-rostered weekend staff. Read
+    # straight off the availability row's `occupant_name` column, which unlike
+    # `note`/`reason` below carries the SAME name on both sides, so there is
+    # no second translation to keep in step.
+    #
+    # Display only, like `reason`. The rule never branches on it: what closes
+    # a cabin is `family_available_override`, and an occupant with no override
+    # is not a state any writer can produce.
+    occupant_name: str = ""
     # Display only. The rule never branches on it. Read from the availability
     # row's `note` column -- see the migration header on why `note` was kept
     # rather than renamed.
+    #
+    # OPTIONAL since kindred#2078, and empty on every historical row by
+    # construction: 1500000148 moved each existing note into `occupant_name`
+    # and cleared the column behind it, because the same string rendered as
+    # both the occupant's name and the card's italic reason line printed
+    # twice on one card. Nothing should "repair" that emptiness by copying
+    # `occupant_name` back -- the note is PROSPECTIVE, for write-ins recorded
+    # from 1500000148 onward.
     reason: str = ""
     is_family_available: bool = False
     map_x: float | None = None
@@ -716,12 +735,26 @@ class AvailabilityWriteRequest(BaseModel):
     session_cm_id: int = Field(..., gt=0)
     unit_id: str = Field(..., min_length=1)
     family_available: bool | None = None
+    # WHO is being written in (kindred#2078). REQUIRED through the control and
+    # permissive here, exactly the split `reason` already makes below and for
+    # the same reason: a row written by an ingest or a fixture has no author to
+    # ask, and a clear (`family_available: null`) sends neither field because
+    # it DELETES the row.
+    #
+    # Same name as the column, deliberately. `reason`/`note` carry two names
+    # only because 1500000135 reused a column that already existed; there is no
+    # such inheritance here, so this write path gains no second translation.
+    occupant_name: str = Field("", max_length=500)
     # Stored in the `note` COLUMN. 1500000135 kept `note` rather than adding
     # `reason` and dropping it -- identical semantics, one less schema change
     # on an empty table. The API name is the design doc's; the column name is
     # the one that already existed. `set_availability` (write) and
     # `_build_units` (read) are the only two places they meet, and a third
     # would mean renaming the column instead.
+    #
+    # OPTIONAL at the control since kindred#2078 -- the occupant is the
+    # required half now, and the note is the "say why, so next week's staff
+    # can act on it" affordance riding beside it.
     reason: str = Field("", max_length=500)
 
 

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -1210,6 +1210,11 @@ class LodgingRosterService:
         # than renamed to `reason`); surfaced to the API as `reason`. This and
         # `set_availability` are the only two places that translate.
         reason_by_unit = {_s(row, "unit"): _s(row, "note") for row in availability}
+        # WHO is in the room (kindred#2078). Travels BESIDE the decision like
+        # `reason`, and translated nowhere: the column and the API field share
+        # one name, so unlike `note`/`reason` there is nothing here that can
+        # drift out of step with a writer.
+        occupant_by_unit = {_s(row, "unit"): _s(row, "occupant_name") for row in availability}
 
         # id -> code, so the parent relation can be published as a code.
         code_by_id = {_s(unit, "id"): _s(unit, "code") for unit in units}
@@ -1293,6 +1298,7 @@ class LodgingRosterService:
                     # to the Literal on its own.
                     shareability=cast(Shareability, unit_shareability(_s(unit, "shareability"))),
                     family_available_override=override,
+                    occupant_name=occupant_by_unit.get(_s(unit, "id"), ""),
                     reason=reason_by_unit.get(_s(unit, "id"), ""),
                     is_family_available=is_family_available(inventory_class, override),
                     map_x=map_x,

--- a/api/services/lodging_write_service.py
+++ b/api/services/lodging_write_service.py
@@ -575,6 +575,11 @@ class LodgingWriteService:
         the only two places that translate between the two names -- see
         AvailabilityWriteRequest.
 
+        `occupant_name` is written UNTRANSLATED, because a hold IS a write-in
+        (owner ruling, kindred#2078) and the column was added for it under the
+        name the API already wanted. It is required through the control and
+        optional here; see the schema for why the requirement lives there.
+
         Both the delete and the create below race the same way the placement
         writes do, and are guarded the same two ways.
 
@@ -617,6 +622,9 @@ class LodgingWriteService:
             "year": request.year,
             "unit": request.unit_id,
             "family_available": request.family_available,
+            # WHO is in the room (kindred#2078). No translation: the API field
+            # and the column share one name, so this is the whole of it.
+            "occupant_name": request.occupant_name,
             # The API's `reason` meets the column's `note` HERE, and in
             # `_build_units` on the way back out. Nowhere else.
             "note": request.reason,

--- a/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
@@ -206,6 +206,22 @@ describe('LodgingUnitForm — create', () => {
     expect(values).toEqual(['family_pool', 'staff_default'])
   })
 
+  it('calls staff allocation "Staff housing", not "Held for staff" (kindred#2078)', () => {
+    // THREE things shared one word until this. `inventory_class` is a
+    // PERMANENT role — a cabin that houses full-time staff and was never
+    // weekend inventory — while the board's per-weekend control is now a
+    // write-in, and the stats bar counts the two separately for exactly that
+    // reason. Leaving the registry saying "Held for staff" beside a board
+    // badge saying "Write-in" would keep the collision alive in the one place
+    // staff go to set the role.
+    render(
+      <LodgingUnitForm areas={AREAS} units={[]} year={2026} onSaved={vi.fn()} onCancel={vi.fn()} />
+    )
+    const select = screen.getByLabelText<HTMLSelectElement>('Allocation')
+    const labels = [...select.options].map((option) => option.textContent)
+    expect(labels).toEqual(['Available to guests', 'Staff housing'])
+  })
+
   it('sends no sleeps value when capacity is left blank', async () => {
     createLodgingUnit.mockResolvedValue({ id: 'u1' })
     const user = userEvent.setup()
@@ -536,7 +552,7 @@ describe('LodgingUnitForm — the parent picker reflects a live allocation chang
     await user.selectOptions(screen.getByLabelText('Allocation'), 'staff_default')
 
     // Same render, no save, no remount — the picker widens to include the
-    // staff building the instant Allocation flips to "Held for staff".
+    // staff building the instant Allocation flips to "Staff housing".
     expect([...parentSelect.options].map((o) => o.value)).toEqual([
       '',
       'guest_building',

--- a/frontend/src/components/admin/lodging/LodgingUnitRow.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitRow.tsx
@@ -87,7 +87,10 @@ export function LodgingUnitRow({
         )}
       </td>
       <td className="py-1.5">
-        {unit.inventory_class === 'staff_default' ? 'Held for staff' : 'Available to guests'}
+        {/* "Staff housing", not "Held for staff" (kindred#2078) — the same
+            permanent role the Allocation select names, and deliberately not
+            the board's per-weekend write-in. */}
+        {unit.inventory_class === 'staff_default' ? 'Staff housing' : 'Available to guests'}
       </td>
       <td className="py-1.5">
         <div className="flex flex-wrap items-center gap-1.5">

--- a/frontend/src/components/admin/lodging/UnitIdentityFields.tsx
+++ b/frontend/src/components/admin/lodging/UnitIdentityFields.tsx
@@ -179,7 +179,12 @@ export function UnitIdentityFields({
           }}
         >
           <option value="family_pool">Available to guests</option>
-          <option value="staff_default">Held for staff</option>
+          {/* "Staff housing", not "Held for staff" (kindred#2078). This is a
+              PERMANENT role — a cabin that was never weekend inventory — where
+              the board's per-weekend control is now a write-in. Three surfaces
+              shared the word "held" and the stats bar already counts the two
+              facts separately. */}
+          <option value="staff_default">Staff housing</option>
         </select>
       </label>
     </>

--- a/frontend/src/components/weekend/LodgingBoard.availability.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.availability.test.tsx
@@ -139,19 +139,20 @@ function renderBoard(props: Partial<Parameters<typeof LodgingBoard>[0]> = {}) {
 
 describe('LodgingBoard — the availability gate', () => {
   it('offers the control on the CampMinder mirror, where placement is refused', () => {
-    // THE divergence from `canPlace`, and the reason this file exists. A burst
-    // pipe is a fact about the weekend, not about a plan: staff must be able to
-    // record one without first creating a scenario to record it in.
+    // THE divergence from `canPlace`, and the reason this file exists. Who is
+    // sleeping in a cabin is a fact about the weekend, not about a plan: staff
+    // must be able to record one without first creating a scenario to record
+    // it in.
     renderBoard({ scenario: '' })
 
-    expect(screen.getByRole('button', { name: 'Hold Cedar 1' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Write in Cedar 1' })).toBeInTheDocument()
   })
 
   it('offers no control without bunking.manage', () => {
     // The same gate as the endpoint, which is `require_permission(BUNKING_MANAGE)`.
     renderBoard({ canManage: false })
 
-    expect(screen.queryByRole('button', { name: 'Hold Cedar 1' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Write in Cedar 1' })).not.toBeInTheDocument()
   })
 
   it('offers no control without a weekend to write into', () => {
@@ -159,7 +160,7 @@ describe('LodgingBoard — the availability gate', () => {
     // board tests that exercise no writes.
     renderBoard({ sessionCmId: 0 })
 
-    expect(screen.queryByRole('button', { name: 'Hold Cedar 1' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Write in Cedar 1' })).not.toBeInTheDocument()
   })
 
   it('names the weekend it is writing into', () => {
@@ -170,31 +171,33 @@ describe('LodgingBoard — the availability gate', () => {
 })
 
 describe('LodgingBoard — the control becomes a write', () => {
-  it('sends the unit staff clicked, with the reason they typed', async () => {
+  it('sends the unit staff clicked, with the occupant and note they typed', async () => {
     const user = userEvent.setup()
     renderBoard()
 
-    await user.click(screen.getByRole('button', { name: 'Hold Cedar 2' }))
-    await user.type(screen.getByRole('textbox', { name: /reason/i }), 'Burst pipe')
-    await user.click(screen.getByRole('button', { name: /^hold$/i }))
+    await user.click(screen.getByRole('button', { name: 'Write in Cedar 2' }))
+    await user.type(screen.getByRole('textbox', { name: /^occupant$/i }), 'Emma Johnson')
+    await user.type(screen.getByRole('textbox', { name: /note/i }), 'Back Monday')
+    await user.click(screen.getByRole('button', { name: /^write in$/i }))
 
     expect(setAvailability).toHaveBeenCalledTimes(1)
     expect(setAvailability).toHaveBeenCalledWith({
       unitId: 'u2',
       unitName: 'Cedar 2',
       familyAvailable: false,
-      reason: 'Burst pipe',
+      occupantName: 'Emma Johnson',
+      reason: 'Back Monday',
     })
   })
 
   it('waits on the card being written, and only that one', async () => {
     // 81 cards share one mutation. A bare `isPending` would freeze the whole
-    // board while one cabin is being held.
+    // board while one cabin is being written into.
     pendingUnitId = 'u1'
     renderBoard()
 
-    expect(screen.getByRole('button', { name: 'Hold Cedar 1' })).toBeDisabled()
-    expect(screen.getByRole('button', { name: 'Hold Cedar 2' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Write in Cedar 1' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Write in Cedar 2' })).toBeEnabled()
     await Promise.resolve()
   })
 })

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -63,6 +63,7 @@ import { FloatingUnplacedBadge } from './FloatingUnplacedBadge'
 import { LodgingUnitCard } from './LodgingUnitCard'
 import { partyKey } from './partyKey'
 import { resolvePartyUnit } from './rosterAttention'
+import type { UnitAvailabilityWrite } from './UnitAvailabilityControl'
 
 export interface LodgingBoardProps {
   parties: RosterPartyRow[]
@@ -338,7 +339,7 @@ export function LodgingBoard({
   )
 
   const writeAvailability = useCallback(
-    (unit: LodgingUnitRow, write: { familyAvailable: boolean | null; reason: string }) => {
+    (unit: LodgingUnitRow, write: UnitAvailabilityWrite) => {
       // The rejection path is the hook's: it raises the toast. Catching here
       // keeps the rejected promise from surfacing as an unhandled rejection,
       // exactly as the drop handler does.
@@ -346,6 +347,7 @@ export function LodgingBoard({
         unitId: unit.unit_id,
         unitName: unit.name,
         familyAvailable: write.familyAvailable,
+        occupantName: write.occupantName,
         reason: write.reason,
       }).catch(() => undefined)
     },

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -61,6 +61,7 @@ function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
     inventory_class: 'family_pool',
     shareability: 'single_party',
     family_available_override: null,
+    occupant_name: '',
     reason: '',
     is_family_available: true,
     map_x: 0.5,
@@ -1217,9 +1218,9 @@ describe('LodgingUnitCard — the open-space title marker (#2093)', () => {
     expect(title).toHaveClass('font-semibold')
   })
 
-  it('does not call a HELD room open — no tint, no bold title, dashed edge kept', () => {
+  it('does not call a WRITTEN-INTO room open — no tint, no bold title, dashed edge kept', () => {
     /*
-     * A hold (#2087 / the #2090 ruling) blocks placement outright:
+     * A write-in (#2078; #2087 / the #2090 ruling) blocks placement outright:
      * `dragPlacement.ts:222` refuses the drop and the card's own droppable is
      * `disabled`. An empty held cabin therefore has no family in it and can
      * take none — "empty" and "open" are not the same predicate, and this is
@@ -1227,17 +1228,25 @@ describe('LodgingUnitCard — the open-space title marker (#2093)', () => {
      *
      * This was harmless while the empty treatment was a neutral grey wash.
      * The forest tint is not neutral: it says "this is where the remaining
-     * work is", and the marker IS the to-do list. Painting a held cabin
-     * forest sends staff at the one room they are not allowed to fill.
+     * work is", and the marker IS the to-do list. Painting a written-into
+     * cabin forest sends staff at the one room they are not allowed to fill.
      *
-     * Scope note: the approved 2026-08-09 vocabulary gives a held card a
+     * kindred#2078 RE-EXPRESSED this conjunct. It used to read the proxy
+     * `unit.family_available_override === false` inline under the name `held`;
+     * it now goes through `writeInOccupant`, so the tint is keyed on the fact
+     * ("somebody is in this room") rather than on a spelling. This test is
+     * what pins that the re-expression did not drop the gate.
+     *
+     * Scope note: the approved 2026-08-09 vocabulary gives such a card a
      * refusal treatment of its own (dim + `not-allowed`), queued separately.
      * This asserts only that the OPEN marker stands down — it does not
      * pre-empt that.
      */
     const { container } = render(
       <LodgingUnitCard
-        slot={slot({ unit: unit({ family_available_override: false, reason: 'Maintenance' }) })}
+        slot={slot({
+          unit: unit({ family_available_override: false, occupant_name: 'Emma Johnson' }),
+        })}
         hue={hue}
         canPlace
         onOpenParty={vi.fn()}
@@ -1251,9 +1260,130 @@ describe('LodgingUnitCard — the open-space title marker (#2093)', () => {
 
     const card = container.querySelector('[data-unit-card]')
     expect(card).not.toHaveClass('bg-primary/10')
-    // The dashed EDGE is a structural "nobody is in here" and stays — only
+    // The dashed EDGE is a structural "no family is in here" and stays — only
     // the affirmative "go fill this" half stands down.
     expect(card).toHaveClass('border-dashed')
+  })
+
+  it('withholds the tint from a write-in nobody named, too', () => {
+    // The room is closed whether or not anybody filled the name in, so the
+    // gate cannot be keyed on the NAME being present -- that would hand the
+    // one room staff may not fill straight back to the to-do marker. Reachable
+    // from a pre-1500000148 row with an empty note, or through the permissive
+    // write schema.
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: unit({ family_available_override: false }) })}
+        hue={hue}
+        canPlace
+        onOpenParty={vi.fn()}
+      />
+    )
+
+    expect(container.querySelector('[data-unit-card]')).not.toHaveClass('bg-primary/10')
+  })
+
+  it('still calls a RELEASED staff cabin open', () => {
+    // `true` and `false` are opposite answers. A release opens a room to
+    // families -- it is exactly the room the marker exists to send staff at --
+    // so reading the override for truthiness here would suppress the tint on
+    // the one card that most deserves it.
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({
+          unit: unit({
+            inventory_class: 'staff_default',
+            family_available_override: true,
+            reason: 'Overflow weekend',
+          }),
+        })}
+        hue={hue}
+        canPlace
+        onOpenParty={vi.fn()}
+      />
+    )
+
+    expect(container.querySelector('[data-unit-card]')).toHaveClass('bg-primary/10')
+  })
+})
+
+describe('the write-in occupant card (kindred#2078)', () => {
+  const hue = 'hsl(160 45% 42%)'
+
+  it('draws the occupant in the well, where the board prints occupancy', () => {
+    // The name used to be a small italic muted line under the badge row while
+    // the well below said "Drop families here" -- the room read as empty and
+    // closed when in truth it was full.
+    render(
+      <LodgingUnitCard
+        slot={slot({
+          unit: unit({
+            family_available_override: false,
+            occupant_name: 'Emma Johnson',
+            is_family_available: false,
+          }),
+        })}
+        hue={hue}
+        canPlace
+        onOpenParty={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
+    expect(screen.queryByText('Drop families here')).not.toBeInTheDocument()
+  })
+
+  it('prints the occupant ONCE, not twice', () => {
+    // 1500000148 moved every historical note into `occupant_name` and cleared
+    // the column behind it precisely so one string cannot render as both the
+    // card's italic reason line and the occupant's name.
+    render(
+      <LodgingUnitCard
+        slot={slot({
+          unit: unit({
+            family_available_override: false,
+            occupant_name: 'Liam Garcia',
+            is_family_available: false,
+          }),
+        })}
+        hue={hue}
+        canSetAvailability
+        onSetAvailability={vi.fn()}
+        onOpenParty={vi.fn()}
+      />
+    )
+
+    expect(screen.getAllByText('Liam Garcia')).toHaveLength(1)
+  })
+
+  it('does not draw an occupant card on an ordinary open room', () => {
+    render(<LodgingUnitCard slot={slot()} hue={hue} canPlace onOpenParty={vi.fn()} />)
+
+    expect(screen.getByText('Drop families here')).toBeInTheDocument()
+    expect(screen.queryByText('Occupant not named')).not.toBeInTheDocument()
+  })
+
+  it('refuses to assert a number it does not have, where 0 would be a lie', () => {
+    // A write-in occupies WHOLESALE: no party size, no partial bed arithmetic.
+    // `0/5` beside a full room is a lie and `5/5` is a different one, so the
+    // numerator takes the em dash the card already uses to refuse an
+    // unmeasured denominator.
+    render(
+      <LodgingUnitCard
+        slot={slot({
+          unit: unit({
+            family_available_override: false,
+            occupant_name: 'Emma Johnson',
+            is_family_available: false,
+          }),
+        })}
+        hue={hue}
+        canPlace
+        onOpenParty={vi.fn()}
+      />
+    )
+
+    expect(screen.getByTestId('unit-occupancy')).toHaveTextContent('—/5')
   })
 })
 

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -35,6 +35,9 @@ import {
   type UnitBadge,
 } from './unitBadges'
 import { UnitAvailabilityControl } from './UnitAvailabilityControl'
+import type { UnitAvailabilityWrite } from './UnitAvailabilityControl'
+import { writeInOccupant } from './writeIn'
+import { WriteInCard } from './WriteInCard'
 
 /**
  * The card's border/ring treatment, keyed off an ordered, MUTUALLY EXCLUSIVE
@@ -128,12 +131,6 @@ const NEEDS_HATCH_CLASSES: Record<'unmet' | 'partial', string> = {
     '[background-image:repeating-linear-gradient(45deg,transparent_0_4px,hsl(var(--foreground)_/_0.1)_4px_5px)]',
   partial:
     '[background-image:repeating-linear-gradient(45deg,transparent_0_10px,hsl(var(--foreground)_/_0.1)_10px_11px)]',
-}
-
-/** What the reserve/release control asks the board to write. */
-export interface UnitAvailabilityWrite {
-  familyAvailable: boolean | null
-  reason: string
 }
 
 export interface LodgingUnitCardProps {
@@ -390,13 +387,22 @@ export function LodgingUnitCard({
   // above — and which one dnd-kit resolves `over` to would be a tie decided
   // by hook registration order, not by which gesture is actually in flight.
   //
-  // Disabled on a HELD unit (#2087): a hold is global and blocks placement
-  // outright, per the owner ruling on #2090. This is the AFFORDANCE half —
-  // it keeps dnd-kit from ever reporting `isOver` here, so the card cannot
-  // even highlight as a target — while `resolveDrop` (`dragPlacement.ts`) is
-  // the half that actually enforces it, because #2080 adds a placement path
-  // that reaches `resolveDrop` without ever touching this hook.
-  const held = unit.family_available_override === false
+  // Disabled on a WRITTEN-INTO unit (#2078/#2087): a write-in is global and
+  // blocks placement outright, per the owner ruling on #2090. This is the
+  // AFFORDANCE half — it keeps dnd-kit from ever reporting `isOver` here, so
+  // the card cannot even highlight as a target — while `resolveDrop`
+  // (`dragPlacement.ts`) is the half that actually enforces it, because #2080
+  // adds a placement path that reaches `resolveDrop` without ever touching
+  // this hook.
+  //
+  // Read through `writeInOccupant` rather than as an inline
+  // `family_available_override === false`, which is what this was until
+  // kindred#2078. Three consumers on this card shared that expression under
+  // the name `held`, and one of them — #2093's open-tint gate below — was
+  // using it as a PROXY for "is somebody in this room". Naming the fact once
+  // is what stops the tint being keyed on a spelling.
+  const writeIn = writeInOccupant(unit)
+  const held = writeIn !== null
   const { setNodeRef: setUnitDropRef, isOver: isUnitOver } = useDroppable({
     id: unitDroppableId(unit.code),
     disabled: !canPlace || mergeDragActive || held,
@@ -469,16 +475,39 @@ export function LodgingUnitCard({
   // suppressed the instant this card becomes an active drop target, same as
   // the old wash was.
   //
-  // `!held` is the second gate, and it is not cosmetic: EMPTY and OPEN are
-  // different predicates and this is where they part. A hold blocks
-  // placement outright (`held` above; `dragPlacement.ts` refuses the drop),
-  // so a held cabin has no family in it and can take none. That was harmless
-  // while the empty treatment was a neutral grey wash, but the forest tint
-  // says "the remaining work is here" — and the marker is the to-do list.
-  // Painting a held cabin forest sends staff at the one room they may not
-  // fill. The dashed EDGE still applies to it, being structural rather than
-  // an invitation.
-  const openMarkerActive = dashed && !held && ringState !== 'dropTarget'
+  // `writeIn === null` is the second gate, and it is not cosmetic: EMPTY and
+  // OPEN are different predicates and this is where they part. A write-in
+  // blocks placement outright (`held` above; `dragPlacement.ts` refuses the
+  // drop), so a written-into cabin has no family in it and can take none.
+  // That was harmless while the empty treatment was a neutral grey wash, but
+  // the forest tint says "the remaining work is here" — and the marker is the
+  // to-do list. Painting such a cabin forest sends staff at the one room they
+  // may not fill. The dashed EDGE still applies to it, being structural
+  // rather than an invitation.
+  //
+  // Keyed on the OCCUPANT SIGNAL, never on the occupant's NAME being filled
+  // in: a write-in nobody named still closes the room, and gating on the name
+  // would hand exactly that room back to the to-do marker.
+  const openMarkerActive = dashed && writeIn === null && ringState !== 'dropTarget'
+
+  /*
+   * The corner figure, and the sentence behind it (kindred#2078).
+   *
+   * A write-in with nobody else in the room reports the em dash rather than a
+   * count: it occupies wholesale and has no party size, so any digit here
+   * would assert something nobody recorded. A card that somehow carries BOTH a
+   * write-in and a placement keeps the placement count — that is a real number
+   * about real people, and the card should not go quiet about them.
+   */
+  const wholesaleWriteIn = writeIn !== null && occupants === 0
+  const occupancyFigure = wholesaleWriteIn ? '—' : String(occupants)
+  const occupancyTooltip = wholesaleWriteIn
+    ? capacityKnown
+      ? `Written in — occupies the whole room · sleeps ${String(unit.sleeps)}`
+      : 'Written in — occupies the whole room · capacity not recorded'
+    : capacityKnown
+      ? `Sleeps ${String(unit.sleeps)} · ${String(occupants)} placed`
+      : `Capacity not recorded · ${String(occupants)} placed`
 
   /*
    * Whether this space meets the needs of the family in flight (#1912) —
@@ -650,19 +679,21 @@ export function LodgingUnitCard({
             whatever it wraps — a drawn box would collide with the dashed
             border this card already spends on "empty room". */}
         <Tooltip
-          content={
-            capacityKnown
-              ? `Sleeps ${String(unit.sleeps)} · ${String(occupants)} placed`
-              : `Capacity not recorded · ${String(occupants)} placed`
-          }
+          content={occupancyTooltip}
           data-testid="unit-occupancy"
           className={`ml-auto text-sm tabular-nums ${
             overCapacity ? 'text-destructive font-semibold' : 'text-muted-foreground'
           }`}
         >
           {/* An unmeasured room keeps the em dash as its DENOMINATOR. `0/0`
-              would be the same lie the em dash exists to refuse. */}
-          {`${String(occupants)}/${capacityKnown ? String(unit.sleeps) : '—'}`}
+              would be the same lie the em dash exists to refuse.
+
+              A write-in takes it as the NUMERATOR, for the same reason: it
+              occupies the room WHOLESALE, with no party size and no partial
+              bed arithmetic, so `0/5` beside a full room is a lie and `5/5`
+              is a different one. The em dash is this card's existing way of
+              refusing to assert a number it does not have. */}
+          {`${occupancyFigure}/${capacityKnown ? String(unit.sleeps) : '—'}`}
         </Tooltip>
       </div>
 
@@ -859,7 +890,13 @@ export function LodgingUnitCard({
         together before stretch has to do anything.
       */}
       <div className="flex min-h-[100px] flex-1 flex-col gap-2">
-        {parties.length === 0 ? (
+        {/* A write-in, drawn where the board draws occupancy (kindred#2078).
+            FIRST and unconditionally, never in an either/or with the parties
+            below: a card carrying both is not a state any writer produces
+            (#2090 rules the two mutually exclusive), but if a legacy row ever
+            does, hiding one of them would drop somebody from the board. */}
+        {writeIn !== null && <WriteInCard occupant={writeIn} />}
+        {parties.length === 0 && writeIn === null ? (
           /* Summer's wording in family vocabulary — `BunkCard` says "Drop
              campers here". An empty slot's job is to be a target, and "Empty"
              described the state without offering the action.

--- a/frontend/src/components/weekend/MapUnitPopover.test.tsx
+++ b/frontend/src/components/weekend/MapUnitPopover.test.tsx
@@ -158,16 +158,18 @@ describe('MapUnitPopover — one room', () => {
     expect(onOpenParty).toHaveBeenCalledWith(johnson)
   })
 
-  it('badges a held room, reusing the inventory and board wording', () => {
+  it('badges a written-into room, reusing the inventory and board wording', () => {
     // `reservationBadge` is the shared source for this; a second copy is how
-    // the three surfaces start disagreeing about what "Held" means.
+    // the three surfaces start disagreeing about what the word means. It
+    // INHERITED kindred#2078's rename for free, which is the point — this
+    // popover renders no availability string of its own.
     render(
       <MapUnitPopover
         units={[
           mapUnit(
             row({
               family_available_override: false,
-              reason: 'Burst pipe',
+              occupant_name: 'Emma Johnson',
               is_family_available: false,
             })
           ),
@@ -176,7 +178,7 @@ describe('MapUnitPopover — one room', () => {
         onOpenParty={vi.fn()}
       />
     )
-    expect(screen.getByText('Held')).toBeInTheDocument()
+    expect(screen.getByText('Write-in')).toBeInTheDocument()
   })
 
   it('says a deactivated room is inactive', () => {
@@ -501,7 +503,7 @@ describe('MapUnitPopover — a cluster of rooms', () => {
     expect(screen.getAllByTestId('map-popover-cell')).toHaveLength(3)
   })
 
-  it('carries a held or deactivated room’s status into the cluster cell', () => {
+  it('carries a written-into or deactivated room’s status into the cluster cell', () => {
     // The grid has no room for badges, but a cell that says nothing makes a
     // held room in a house indistinguishable from a bookable one. The tooltip
     // is free space.
@@ -519,8 +521,8 @@ describe('MapUnitPopover — a cluster of rooms', () => {
       ),
     ]
     render(<MapUnitPopover units={house} hue={HUE} onOpenParty={vi.fn()} />)
-    expect(screen.getByTitle(/Cedar 2.*Held.*Inactive/i)).toBeInTheDocument()
-    expect(screen.queryByTitle(/Cedar 1.*Held/i)).not.toBeInTheDocument()
+    expect(screen.getByTitle(/Cedar 2.*Write-in.*Inactive/i)).toBeInTheDocument()
+    expect(screen.queryByTitle(/Cedar 1.*Write-in/i)).not.toBeInTheDocument()
   })
 
   it('says WHICH room in a cluster carries the consent flag', () => {

--- a/frontend/src/components/weekend/UnitAvailabilityControl.test.tsx
+++ b/frontend/src/components/weekend/UnitAvailabilityControl.test.tsx
@@ -1,9 +1,15 @@
 /**
- * The reserve/release control: the writer this table never had.
+ * The write-in / release control: the writer this table never had.
  *
  * `PUT /api/lodging/availability` shipped with no caller anywhere in the
- * frontend, which is how `lodging_availability` reached zero rows and a request
- * model requiring a scenario nobody could supply. This control is the caller.
+ * frontend, which is how `lodging_availability` sat unwritten and a request
+ * model requiring a scenario nobody could supply went unnoticed. This control
+ * is the caller.
+ *
+ * ONE CONTROL, TWO INPUTS (owner ruling, 2026-08-09, kindred#2078). Hold IS
+ * the write-in: there is no separate "mark unavailable" action, and a note
+ * reading "burst pipe" rendering as an occupant name is an accepted cost. The
+ * control takes a REQUIRED occupant and an OPTIONAL note.
  *
  * Fictional data throughout.
  */
@@ -34,6 +40,7 @@ function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
     is_container: false,
     inventory_class: 'family_pool',
     family_available_override: null,
+    occupant_name: '',
     reason: '',
     is_family_available: true,
     map_x: 0.5,
@@ -50,9 +57,10 @@ const STAFF_CABIN = unit({
   is_family_available: false,
 })
 
-const HELD_CABIN = unit({
+const WRITTEN_IN_CABIN = unit({
   family_available_override: false,
-  reason: 'Burst pipe',
+  occupant_name: 'Emma Johnson',
+  reason: '',
   is_family_available: false,
 })
 
@@ -80,7 +88,7 @@ describe('UnitAvailabilityControl', () => {
     expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 
-  it('offers nothing to hold an OCCUPIED unit — held and occupied are mutually exclusive (#2090)', () => {
+  it('offers nothing to write into an OCCUPIED unit — a write-in and a placement are mutually exclusive (#2090)', () => {
     // A space that already has a family assigned may not also be marked
     // held. `occupied` is a fact from the slot's own parties, kept separate
     // from `canManage`'s permission gate — folding it in there would
@@ -90,21 +98,62 @@ describe('UnitAvailabilityControl', () => {
     expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 
-  it('still offers to hold an unoccupied unit (regression guard)', () => {
+  it('still offers to write into an unoccupied unit (regression guard)', () => {
     renderControl({ occupied: false })
 
-    expect(screen.getByRole('button', { name: /hold/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /write in/i })).toBeInTheDocument()
   })
 
-  it('holds a family cabin back for this weekend, with the reason staff gave', async () => {
+  it('writes an occupant into a family cabin, with no note at all', async () => {
+    // The note is OPTIONAL. This is the common path and the one that must not
+    // grow a second required field by accident.
     const user = userEvent.setup()
     const { onSubmit } = renderControl()
 
-    await user.click(screen.getByRole('button', { name: /hold/i }))
-    await user.type(screen.getByRole('textbox', { name: /reason/i }), 'Burst pipe')
-    await user.click(screen.getByRole('button', { name: /^hold$/i }))
+    await user.click(screen.getByRole('button', { name: /write in/i }))
+    await user.type(screen.getByRole('textbox', { name: /^occupant$/i }), 'Emma Johnson')
+    await user.click(screen.getByRole('button', { name: /^write in$/i }))
 
-    expect(onSubmit).toHaveBeenCalledWith({ familyAvailable: false, reason: 'Burst pipe' })
+    expect(onSubmit).toHaveBeenCalledWith({
+      familyAvailable: false,
+      occupantName: 'Emma Johnson',
+      reason: '',
+    })
+  })
+
+  it('carries the optional note beside the occupant when staff give one', async () => {
+    const user = userEvent.setup()
+    const { onSubmit } = renderControl()
+
+    await user.click(screen.getByRole('button', { name: /write in/i }))
+    await user.type(screen.getByRole('textbox', { name: /^occupant$/i }), 'Liam Garcia')
+    await user.type(screen.getByRole('textbox', { name: /note/i }), 'Back Monday')
+    await user.click(screen.getByRole('button', { name: /^write in$/i }))
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      familyAvailable: false,
+      occupantName: 'Liam Garcia',
+      reason: 'Back Monday',
+    })
+  })
+
+  it('accepts a note that is not a person, because there is no second control for one', async () => {
+    // The accepted cost, ruled on rather than prevented: a staff member who
+    // types "burst pipe" into the occupant field gets a card showing an
+    // occupant called "burst pipe". Splitting the two cases was explicitly
+    // rejected as not worth a second concept.
+    const user = userEvent.setup()
+    const { onSubmit } = renderControl()
+
+    await user.click(screen.getByRole('button', { name: /write in/i }))
+    await user.type(screen.getByRole('textbox', { name: /^occupant$/i }), 'burst pipe')
+    await user.click(screen.getByRole('button', { name: /^write in$/i }))
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      familyAvailable: false,
+      occupantName: 'burst pipe',
+      reason: '',
+    })
   })
 
   it('releases a staff cabin to families for this weekend', async () => {
@@ -117,13 +166,25 @@ describe('UnitAvailabilityControl', () => {
     await user.type(screen.getByRole('textbox', { name: /reason/i }), 'Overflow weekend')
     await user.click(screen.getByRole('button', { name: /^release$/i }))
 
-    expect(onSubmit).toHaveBeenCalledWith({ familyAvailable: true, reason: 'Overflow weekend' })
+    expect(onSubmit).toHaveBeenCalledWith({
+      familyAvailable: true,
+      occupantName: '',
+      reason: 'Overflow weekend',
+    })
   })
 
-  it('will not take a cabin out of service without saying why, and says so', async () => {
-    // A row with no reason is the one a staff member cannot act on next week:
-    // they can see the cabin is closed and have no way to learn whether the
-    // pipe has been fixed.
+  it('asks a release for a reason and NOT for an occupant', () => {
+    // Opening a staff cabin to families names nobody. Prompting for an
+    // occupant there would ask for a fact that does not exist -- which is why
+    // the flag became a three-way prompt rather than staying a boolean.
+    renderControl({ unit: STAFF_CABIN })
+
+    expect(screen.queryByRole('textbox', { name: /^occupant$/i })).not.toBeInTheDocument()
+  })
+
+  it('will not write a nameless occupant into a cabin, and says so', async () => {
+    // A write-in with no name is a closed room nobody can account for: staff
+    // can see it is unavailable and have no way to learn who is in it.
     //
     // The visible refusal is asserted, not just the absent call. An earlier
     // version disabled the submit button AND guarded in the handler; deleting
@@ -133,33 +194,61 @@ describe('UnitAvailabilityControl', () => {
     const user = userEvent.setup()
     const { onSubmit } = renderControl()
 
-    await user.click(screen.getByRole('button', { name: /hold/i }))
-    await user.click(screen.getByRole('button', { name: /^hold$/i }))
+    await user.click(screen.getByRole('button', { name: /write in/i }))
+    await user.click(screen.getByRole('button', { name: /^write in$/i }))
 
     expect(onSubmit).not.toHaveBeenCalled()
-    expect(screen.getByText(/say why/i)).toBeInTheDocument()
+    expect(screen.getByText(/say who is in it/i)).toBeInTheDocument()
   })
 
-  it('refuses an empty reason submitted from the keyboard too', async () => {
+  it('does not let the optional note stand in for the occupant', async () => {
+    // The whole point of two fields: a note is not a name, and a write-in
+    // with only a note is exactly the state 1500000148 unwound.
+    const user = userEvent.setup()
+    const { onSubmit } = renderControl()
+
+    await user.click(screen.getByRole('button', { name: /write in/i }))
+    await user.type(screen.getByRole('textbox', { name: /note/i }), 'Back Monday')
+    await user.click(screen.getByRole('button', { name: /^write in$/i }))
+
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(screen.getByText(/say who is in it/i)).toBeInTheDocument()
+  })
+
+  it('refuses an empty occupant submitted from the keyboard too', async () => {
     // Enter in the text field is a second way into the same handler, and the
     // one a staff member typing quickly will actually use.
     const user = userEvent.setup()
     const { onSubmit } = renderControl()
 
-    await user.click(screen.getByRole('button', { name: /hold/i }))
-    await user.type(screen.getByRole('textbox', { name: /reason/i }), '{Enter}')
+    await user.click(screen.getByRole('button', { name: /write in/i }))
+    await user.type(screen.getByRole('textbox', { name: /^occupant$/i }), '{Enter}')
 
     expect(onSubmit).not.toHaveBeenCalled()
-    expect(screen.getByText(/say why/i)).toBeInTheDocument()
+    expect(screen.getByText(/say who is in it/i)).toBeInTheDocument()
   })
 
-  it('treats blank space as no reason at all', async () => {
+  it('treats blank space as no occupant at all', async () => {
     const user = userEvent.setup()
     const { onSubmit } = renderControl()
 
-    await user.click(screen.getByRole('button', { name: /hold/i }))
-    await user.type(screen.getByRole('textbox', { name: /reason/i }), '   ')
-    await user.click(screen.getByRole('button', { name: /^hold$/i }))
+    await user.click(screen.getByRole('button', { name: /write in/i }))
+    await user.type(screen.getByRole('textbox', { name: /^occupant$/i }), '   ')
+    await user.click(screen.getByRole('button', { name: /^write in$/i }))
+
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(screen.getByText(/say who is in it/i)).toBeInTheDocument()
+  })
+
+  it('still refuses a release with no reason', async () => {
+    // The release branch keeps its own required field and its own wording.
+    // Reshaping the flag must not quietly retire the guardrail on the branch
+    // that still needs it.
+    const user = userEvent.setup()
+    const { onSubmit } = renderControl({ unit: STAFF_CABIN })
+
+    await user.click(screen.getByRole('button', { name: /release/i }))
+    await user.click(screen.getByRole('button', { name: /^release$/i }))
 
     expect(onSubmit).not.toHaveBeenCalled()
     expect(screen.getByText(/say why/i)).toBeInTheDocument()
@@ -169,11 +258,11 @@ describe('UnitAvailabilityControl', () => {
     const user = userEvent.setup()
     renderControl()
 
-    await user.click(screen.getByRole('button', { name: /hold/i }))
-    await user.click(screen.getByRole('button', { name: /^hold$/i }))
-    await user.type(screen.getByRole('textbox', { name: /reason/i }), 'B')
+    await user.click(screen.getByRole('button', { name: /write in/i }))
+    await user.click(screen.getByRole('button', { name: /^write in$/i }))
+    await user.type(screen.getByRole('textbox', { name: /^occupant$/i }), 'E')
 
-    expect(screen.queryByText(/say why/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/say who is in it/i)).not.toBeInTheDocument()
   })
 
   it('clears an override in one click, writing null rather than a value that agrees', async () => {
@@ -181,28 +270,57 @@ describe('UnitAvailabilityControl', () => {
     // would pin it against a later change to its role -- the reversal-encoding
     // failure spec §5.4 rejected, arriving through the UI.
     const user = userEvent.setup()
-    const { onSubmit } = renderControl({ unit: HELD_CABIN })
+    const { onSubmit } = renderControl({ unit: WRITTEN_IN_CABIN })
 
     await user.click(screen.getByRole('button', { name: /clear/i }))
 
-    expect(onSubmit).toHaveBeenCalledWith({ familyAvailable: null, reason: '' })
-    expect(screen.queryByRole('textbox', { name: /reason/i })).not.toBeInTheDocument()
+    expect(onSubmit).toHaveBeenCalledWith({ familyAvailable: null, occupantName: '', reason: '' })
+    expect(screen.queryByRole('textbox', { name: /^occupant$/i })).not.toBeInTheDocument()
   })
 
-  it('shows why a cabin is held, to whoever is looking', async () => {
-    // The reason exists to be read next week. It is shown WITHOUT
-    // bunking.manage too: knowing a cabin is closed for a burst pipe is not a
+  it('leaves a write-in\u2019s note to the occupant card and prints no italic line of its own', () => {
+    // The note used to sit here, under the badge row, as
+    // `text-muted-foreground text-sm italic`. Since kindred#2078 it rides
+    // INSIDE the occupant card in the well -- it describes the occupant, not
+    // the room -- so printing it here too would put the identical string twice
+    // on one card, which is the double-print 1500000148 was written to avoid.
+    renderControl({
+      unit: unit({
+        family_available_override: false,
+        occupant_name: 'Emma Johnson',
+        reason: 'Back Monday',
+        is_family_available: false,
+      }),
+      canManage: false,
+    })
+
+    expect(screen.queryByText('Back Monday')).not.toBeInTheDocument()
+    expect(screen.queryByText('Emma Johnson')).not.toBeInTheDocument()
+  })
+
+  it('shows why a staff cabin was released, to whoever is looking', () => {
+    // The one branch that still prints here, and the reason the line survives
+    // at all: a release has no occupant and draws no card in the well, so
+    // there is nowhere else for its reason to be read. Shown WITHOUT
+    // bunking.manage, as before -- reading why a cabin changed hands is not a
     // write, and the staff member who needs it most may not hold the
     // permission.
-    renderControl({ unit: HELD_CABIN, canManage: false })
+    renderControl({
+      unit: unit({
+        inventory_class: 'staff_default',
+        family_available_override: true,
+        reason: 'Overflow weekend',
+        is_family_available: true,
+      }),
+      canManage: false,
+    })
 
-    expect(screen.getByText('Burst pipe')).toBeInTheDocument()
-    await Promise.resolve()
+    expect(screen.getByText('Overflow weekend')).toBeInTheDocument()
   })
 
   it('does not offer a second write while this unit is being written', async () => {
     const user = userEvent.setup()
-    const { onSubmit } = renderControl({ unit: HELD_CABIN, isSaving: true })
+    const { onSubmit } = renderControl({ unit: WRITTEN_IN_CABIN, isSaving: true })
 
     await user.click(screen.getByRole('button', { name: /clear/i }))
 
@@ -215,17 +333,20 @@ describe('UnitAvailabilityControl', () => {
     expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 
-  it('abandons the reason when the form is cancelled', async () => {
-    // Reopening with the last abandoned reason still in the box is how a
-    // burst-pipe note ends up on the wrong cabin.
+  it('abandons BOTH fields when the form is cancelled', async () => {
+    // Reopening with the last abandoned entry still in the box is how one
+    // cabin's occupant ends up written into another. Two fields, two ways to
+    // get that wrong.
     const user = userEvent.setup()
     renderControl()
 
-    await user.click(screen.getByRole('button', { name: /hold/i }))
-    await user.type(screen.getByRole('textbox', { name: /reason/i }), 'Burst pipe')
+    await user.click(screen.getByRole('button', { name: /write in/i }))
+    await user.type(screen.getByRole('textbox', { name: /^occupant$/i }), 'Emma Johnson')
+    await user.type(screen.getByRole('textbox', { name: /note/i }), 'Back Monday')
     await user.click(screen.getByRole('button', { name: /cancel/i }))
-    await user.click(screen.getByRole('button', { name: /hold/i }))
+    await user.click(screen.getByRole('button', { name: /write in/i }))
 
-    expect(screen.getByRole('textbox', { name: /reason/i })).toHaveValue('')
+    expect(screen.getByRole('textbox', { name: /^occupant$/i })).toHaveValue('')
+    expect(screen.getByRole('textbox', { name: /note/i })).toHaveValue('')
   })
 })

--- a/frontend/src/components/weekend/UnitAvailabilityControl.tsx
+++ b/frontend/src/components/weekend/UnitAvailabilityControl.tsx
@@ -1,33 +1,67 @@
 /**
- * Holding a cabin back for a weekend, or releasing one to families.
+ * Writing somebody into a cabin for a weekend, or releasing one to families.
  *
- * `PUT /api/lodging/availability` shipped with no caller: `lodging_availability`
- * has never held a row, and the request model required a scenario nobody could
- * supply. Landing the model with no writer is how it drifted, so this is the
- * writer.
+ * `PUT /api/lodging/availability` shipped with no caller: the request model
+ * required a scenario nobody could supply, so nothing wrote the table. Landing
+ * the model with no writer is how it drifted, so this is the writer.
  *
- * ## One button, not a menu
+ * ## ONE control, and hold IS the write-in
  *
- * `family_available` has three reachable outcomes and a unit is always in
+ * Owner ruling, 2026-08-09 (kindred#2078). Staff never used this to reserve an
+ * empty room — they used it to record somebody sleeping in one, almost always
+ * non-rostered weekend staff — so "Hold" set the opposite expectation and the
+ * card read *empty and closed* for a room that was full.
+ *
+ * There is no second "mark unavailable" action beside it and no burst-pipe /
+ * staff-write-in split. A staff member who types "burst pipe" into the occupant
+ * field gets a card showing an occupant called "burst pipe": an ACCEPTED COST,
+ * ruled on, not worth a second concept or a discriminator column to prevent.
+ *
+ * `family_available` still has three reachable outcomes and a unit is always in
  * exactly one of them, so `availabilityAction` resolves the single action this
  * card can offer and the button IS the gate — no modal carrying its own
  * eligibility logic. Writing a value that AGREES with the unit's role is
- * deliberately unreachable: it would pin the unit against a later registry
- * edit while changing nothing staff can see.
+ * deliberately unreachable: it would pin the unit against a later registry edit
+ * while changing nothing staff can see.
  *
- * ## Why the reason is required here and not at the schema
+ * ## Two inputs, and which one is required depends on the action
  *
- * `reason` is `Field("", max_length=500)` server-side, because a row written by
- * an ingest or a fixture has no author to ask. Through this control there is
- * always an author, and a cabin taken out of service with no stated reason is
- * the row a staff member cannot act on next week — they can see it is closed
- * and have no way to learn whether the pipe has been fixed. Clearing asks for
- * none: it restores the unit's standing role rather than asserting anything.
+ * A write-in asks for a REQUIRED occupant and an OPTIONAL note. A release asks
+ * for a required reason and nothing else — opening a staff cabin to families
+ * names no occupant. That is why `availabilityAction` carries a three-way
+ * `prompt` rather than the `needsReason` boolean it used to: the question is
+ * not *whether* to ask but *what for*.
+ *
+ * ## Why the requirement lives here and not at the schema
+ *
+ * Both fields are `Field("", max_length=500)` server-side, because a row
+ * written by an ingest or a fixture has no author to ask. Through this control
+ * there is always an author, and a closed cabin with nobody named on it is the
+ * row a staff member cannot act on next week — they can see it is unavailable
+ * and have no way to learn who is in it. Clearing asks for neither: it restores
+ * the unit's standing role rather than asserting anything.
+ *
+ * ## Why no italic line under the badge row any more
+ *
+ * It used to print `unit.reason` there for every override. Since kindred#2078 a
+ * write-in draws a `WriteInCard` in the unit's well carrying both the occupant
+ * and the note, so printing the note here too would put the identical string
+ * twice on one card — the double-print 1500000148 was written to unwind. The
+ * line survives for the RELEASE branch alone, which draws no card in the well
+ * and so has nowhere else for its reason to be read.
  */
 import { useState } from 'react'
 
 import type { LodgingUnitRow } from '../../types/lodging'
 import { availabilityAction } from './unitBadges'
+
+export interface UnitAvailabilityWrite {
+  familyAvailable: boolean | null
+  /** Who is in the room. `''` on a release and on a clear. */
+  occupantName: string
+  /** Optional beside a write-in; required on a release. `''` on a clear. */
+  reason: string
+}
 
 export interface UnitAvailabilityControlProps {
   unit: LodgingUnitRow
@@ -36,7 +70,8 @@ export interface UnitAvailabilityControlProps {
    *
    * NOT the board's `canPlace`, which also requires a scenario. Availability
    * carries no scenario since 1500000135 — a burst pipe closes a cabin in
-   * every plan for that weekend — so requiring one to record it would put the
+   * every plan for that weekend, and a write-in is a fact about who is in the
+   * building rather than a draft — so requiring one to record it would put the
    * deleted dimension back at the UI layer, and staff looking at the
    * CampMinder mirror could not close a cabin at all.
    */
@@ -44,15 +79,15 @@ export interface UnitAvailabilityControlProps {
   /**
    * Whether the slot this unit sits in already holds a party this scenario —
    * a fact read off the CARD, never off availability itself. Owner ruling on
-   * #2090: held and occupied are mutually exclusive states, so an occupied
-   * unit offers no "Hold" action. Kept separate from `canManage`: folding
-   * occupancy into the permission gate would resurrect the scenario
-   * dimension 1500000135 deleted from availability.
+   * #2090: a write-in and a placement are mutually exclusive states, so an
+   * occupied unit offers no write-in action. Kept separate from `canManage`:
+   * folding occupancy into the permission gate would resurrect the scenario
+   * dimension 1500000135 deleted.
    */
   occupied: boolean
   /** True while THIS unit's write is in flight. */
   isSaving: boolean
-  onSubmit: (write: { familyAvailable: boolean | null; reason: string }) => void
+  onSubmit: (write: UnitAvailabilityWrite) => void
 }
 
 export function UnitAvailabilityControl({
@@ -62,33 +97,47 @@ export function UnitAvailabilityControl({
   isSaving,
   onSubmit,
 }: UnitAvailabilityControlProps) {
-  const [reason, setReason] = useState('')
+  // The REQUIRED field of whichever prompt is showing — an occupant for a
+  // write-in, a reason for a release. One piece of state, because exactly one
+  // of the two is ever mounted and a second would be dead on every render.
+  const [required, setRequired] = useState('')
+  // The optional note, mounted only by the write-in prompt.
+  const [note, setNote] = useState('')
   const [isOpen, setIsOpen] = useState(false)
-  const [wantsReason, setWantsReason] = useState(false)
+  const [wantsRequired, setWantsRequired] = useState(false)
   const action = availabilityAction(unit, occupied)
 
   const close = () => {
     setIsOpen(false)
-    setWantsReason(false)
-    // Cleared on the way out, not on the way in: a reason left over from an
-    // abandoned edit is how a burst-pipe note ends up on the wrong cabin.
-    setReason('')
+    setWantsRequired(false)
+    // Cleared on the way out, not on the way in: an entry left over from an
+    // abandoned edit is how one cabin's occupant ends up written into another.
+    setRequired('')
+    setNote('')
   }
 
   // Shown to everyone, including a reader without `bunking.manage`. Knowing a
-  // cabin is closed for a burst pipe is not a write, and the staff member who
-  // needs it most may not hold the permission.
+  // staff cabin was opened to families is not a write, and the staff member
+  // who needs it most may not hold the permission.
+  //
+  // RELEASE ONLY (kindred#2078). A write-in's note rides inside its occupant
+  // card in the well; repeating it here would print one string twice on one
+  // card.
   const storedReason = unit.reason ?? ''
   const explanation =
-    unit.family_available_override !== null &&
-    unit.family_available_override !== undefined &&
-    storedReason !== '' ? (
+    unit.family_available_override === true && storedReason !== '' ? (
       <span className="text-muted-foreground w-full text-sm italic">{storedReason}</span>
     ) : null
 
   if (action === null || !canManage) return explanation
 
-  if (isOpen && action.needsReason) {
+  if (isOpen && action.prompt !== 'none') {
+    const askingOccupant = action.prompt === 'occupant'
+    const requiredLabel = askingOccupant ? 'Occupant' : 'Reason'
+    const refusal = askingOccupant
+      ? 'Say who is in it, so next week’s staff know who to ask.'
+      : 'Say why, so next week’s staff can act on it.'
+
     return (
       <>
         {explanation}
@@ -96,43 +145,68 @@ export function UnitAvailabilityControl({
           className="flex w-full flex-col gap-1"
           onSubmit={(event) => {
             event.preventDefault()
-            const trimmed = reason.trim()
-            // The ONLY place an empty reason is refused. The submit button is
-            // deliberately NOT disabled while the box is empty: a disabled
-            // button plus a guard here mask each other — deleting either leaves
-            // the other quietly holding the rule, so a test can pin neither,
-            // which is exactly what a surviving mutation caught. An inert
-            // button also explains nothing to the staff member wondering why
-            // their click did nothing.
+            const trimmed = required.trim()
+            // The ONLY place an empty required field is refused. The submit
+            // button is deliberately NOT disabled while the box is empty: a
+            // disabled button plus a guard here mask each other — deleting
+            // either leaves the other quietly holding the rule, so a test can
+            // pin neither, which is exactly what a surviving mutation caught.
+            // An inert button also explains nothing to the staff member
+            // wondering why their click did nothing.
             if (trimmed === '') {
-              setWantsReason(true)
+              setWantsRequired(true)
               return
             }
-            onSubmit({ familyAvailable: action.familyAvailable, reason: trimmed })
+            onSubmit({
+              familyAvailable: action.familyAvailable,
+              // The note NEVER stands in for the occupant, and the occupant
+              // never doubles as the note: two fields, two facts. Collapsing
+              // them is the state 1500000148 spent two guarded statements
+              // unwinding.
+              occupantName: askingOccupant ? trimmed : '',
+              reason: askingOccupant ? note.trim() : trimmed,
+            })
             close()
           }}
         >
           <input
             type="text"
-            aria-label="Reason"
-            placeholder="Burst pipe, caretaker…"
-            value={reason}
+            aria-label={requiredLabel}
+            placeholder={askingOccupant ? 'Emma Johnson, burst pipe…' : 'Burst pipe, caretaker…'}
+            value={required}
             maxLength={500}
             // deliberate: this input only mounts when the staff member just clicked
-            // "Hold"/"Release" (a modal-open equivalent), and the whole point of the click is to
-            // type a reason next.
+            // "Write in"/"Release" (a modal-open equivalent), and the whole point of the
+            // click is to type into it next.
             // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus
-            aria-invalid={wantsReason && reason.trim() === ''}
+            aria-invalid={wantsRequired && required.trim() === ''}
             onChange={(event) => {
-              setReason(event.target.value)
-              setWantsReason(false)
+              setRequired(event.target.value)
+              setWantsRequired(false)
             }}
             className="border-border bg-background text-foreground placeholder:text-muted-foreground/60 focus:border-primary/50 focus:ring-primary/10 w-full rounded-md border px-1.5 py-1 text-sm focus:ring-2 focus:outline-none aria-[invalid=true]:border-amber-500"
           />
-          {wantsReason && reason.trim() === '' && (
+          {/* OPTIONAL, and only beside a write-in. It carries the "say why, so
+              next week's staff can act on it" affordance a bare name loses —
+              prospectively: 1500000148 cleared the note of every row it moved,
+              so this column is empty on all of them and that is correct. */}
+          {askingOccupant && (
+            <input
+              type="text"
+              aria-label="Note (optional)"
+              placeholder="Note (optional) — back Monday…"
+              value={note}
+              maxLength={500}
+              onChange={(event) => {
+                setNote(event.target.value)
+              }}
+              className="border-border bg-background text-foreground placeholder:text-muted-foreground/60 focus:border-primary/50 focus:ring-primary/10 w-full rounded-md border px-1.5 py-1 text-sm focus:ring-2 focus:outline-none"
+            />
+          )}
+          {wantsRequired && required.trim() === '' && (
             <span className="text-xs font-medium text-amber-700 dark:text-amber-400">
-              Say why, so next week&rsquo;s staff can act on it.
+              {refusal}
             </span>
           )}
           <div className="flex items-center gap-1.5">
@@ -163,14 +237,14 @@ export function UnitAvailabilityControl({
         type="button"
         disabled={isSaving}
         // Named for the cabin: eighty-one cards each carrying a button called
-        // "Hold" is unusable with a screen reader.
+        // "Write in" is unusable with a screen reader.
         aria-label={`${action.label} ${unit.name}`}
         onClick={() => {
-          if (action.needsReason) {
+          if (action.prompt !== 'none') {
             setIsOpen(true)
             return
           }
-          onSubmit({ familyAvailable: action.familyAvailable, reason: '' })
+          onSubmit({ familyAvailable: action.familyAvailable, occupantName: '', reason: '' })
         }}
         className="border-border text-muted-foreground hover:text-foreground hover:border-foreground/30 rounded-full border px-1.5 py-0.5 text-xs font-medium disabled:opacity-40"
       >

--- a/frontend/src/components/weekend/WeekendStatsBar.test.tsx
+++ b/frontend/src/components/weekend/WeekendStatsBar.test.tsx
@@ -88,23 +88,26 @@ describe('WeekendStatsBar', () => {
     expect(screen.getByText('(1 unmeasured space)')).toBeInTheDocument()
   })
 
-  it('notes held cabins as excluded from the space count', () => {
+  it('notes written-into cabins as excluded from the space count', () => {
+    // "held" until kindred#2078. Staff never used the control to reserve an
+    // empty room -- they used it to write in an occupant -- so the old word
+    // described the opposite of what the number counts.
     render(<WeekendStatsBar counts={counts()} bedsNeeded={223} spacesUnmeasured={0} />)
-    expect(screen.getByText('· 3 held')).toBeInTheDocument()
+    expect(screen.getByText('· 3 write-ins')).toBeInTheDocument()
   })
 
-  it('does not describe held cabins as staff housing', () => {
-    // "Held" and "staff housing" were one number until units_staff_housing
-    // split them, and the tooltip still said "Held for staff". They are
-    // different facts with different remedies: a held cabin comes back next
-    // weekend, a staff cabin never does.
+  it('does not describe written-into cabins as staff housing', () => {
+    // The two were one number until units_staff_housing split them, and the
+    // tooltip still said "Held for staff". They are different facts with
+    // different remedies: a written-into cabin comes back next weekend, a
+    // staff cabin never does.
     render(<WeekendStatsBar counts={counts()} bedsNeeded={223} spacesUnmeasured={0} />)
-    const held = screen.getByRole('button', { name: '3 held cabins' })
-    expect(held).toHaveAccessibleDescription(/excluded from spaces/i)
-    expect(held).not.toHaveAccessibleDescription(/held for staff/i)
+    const writeIns = screen.getByRole('button', { name: '3 write-ins' })
+    expect(writeIns).toHaveAccessibleDescription(/excluded from family spaces/i)
+    expect(writeIns).not.toHaveAccessibleDescription(/staff/i)
   })
 
-  it('puts the spaces, held and staff notes on tooltips keyboard and touch can reach', () => {
+  it('puts the spaces, write-in and staff notes on tooltips keyboard and touch can reach', () => {
     // kindred#2177: all three were bare `title` attributes on a `<span>`.
     render(
       <WeekendStatsBar
@@ -130,7 +133,7 @@ describe('WeekendStatsBar', () => {
   })
 
   it('reports staff housing separately, because it was never inventory', () => {
-    // 21 cabins reading as "held" would say staff took them out of service
+    // 21 cabins reading as write-ins would say staff took them out of service
     // this weekend. They were never in service.
     render(
       <WeekendStatsBar

--- a/frontend/src/components/weekend/WeekendStatsBar.tsx
+++ b/frontend/src/components/weekend/WeekendStatsBar.tsx
@@ -99,19 +99,25 @@ export function WeekendStatsBar({ counts, bedsNeeded, spacesUnmeasured }: Weeken
           <span className="text-muted-foreground tabular-nums">
             ({spare < 0 ? `${String(Math.abs(spare))} short` : `${String(spare)} spare`})
           </span>
-          {/* Held and staff housing are DIFFERENT facts with different
+          {/* Write-ins and staff housing are DIFFERENT facts with different
               remedies, and were one number until `units_staff_housing` split
-              them. A held cabin is inventory that comes back next weekend — a
-              burst pipe, a caretaker in residence. A staff cabin never does:
-              it houses full-time staff who are not enrolled per session, and
-              was never part of the weekend's inventory to begin with. */}
+              them. A written-into cabin is inventory that comes back next
+              weekend — somebody the system does not know about is sleeping in
+              it, most often non-rostered weekend staff. A staff cabin never
+              comes back: it houses full-time staff who are not enrolled per
+              session, and was never part of the weekend's inventory to begin
+              with.
+
+              "held" until kindred#2078. The count is unchanged — it is still
+              `units_reserved` — but the word was the one thing on this bar
+              that described the opposite of what staff use the control for. */}
           {unitsReserved > 0 && (
             <Tooltip
-              content="Out of service this weekend, excluded from spaces"
-              aria-label={`${String(unitsReserved)} held cabins`}
+              content="Written in for this weekend, excluded from family spaces"
+              aria-label={`${String(unitsReserved)} write-ins`}
               className="text-muted-foreground"
             >
-              · {unitsReserved} held
+              · {unitsReserved} write-ins
             </Tooltip>
           )}
           {unitsStaffHousing > 0 && (

--- a/frontend/src/components/weekend/WriteInCard.test.tsx
+++ b/frontend/src/components/weekend/WriteInCard.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * The occupant card a write-in draws in the unit's well — kindred#2078.
+ *
+ * Fictional data throughout.
+ */
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { WriteInCard, WRITE_IN_FRAME } from './WriteInCard'
+
+describe('WriteInCard', () => {
+  it('prints the occupant as a NAME, in the position the board uses for placed families', () => {
+    render(<WriteInCard occupant={{ name: 'Emma Johnson', note: '' }} />)
+
+    expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
+  })
+
+  it('carries the note INSIDE the card, describing the occupant rather than the room', () => {
+    render(<WriteInCard occupant={{ name: 'Emma Johnson', note: 'Kitchen lead, Fri–Sun' }} />)
+
+    expect(screen.getByText('Kitchen lead, Fri–Sun')).toBeInTheDocument()
+  })
+
+  it('says so plainly when nobody named the occupant', () => {
+    // Reachable from a row written before 1500000148 with an empty note, or
+    // through the permissive write schema. The room is still closed, so an
+    // EMPTY card would read as an open room the board refuses drops on.
+    render(<WriteInCard occupant={{ name: '', note: '' }} />)
+
+    expect(screen.getByText('Occupant not named')).toBeInTheDocument()
+  })
+
+  it('renders no note row at all when there is none', () => {
+    // The note ships EMPTY on every historical row by construction, so this is
+    // the common case rather than the edge one.
+    const { container } = render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} />)
+
+    expect(container.textContent).toBe('Liam Garcia')
+  })
+
+  it('does NOT mark itself as a family card', () => {
+    // `FamilyCard` sets `data-family-card` and board code queries that selector
+    // to find PLACED parties. A write-in is an occupant, not a placement: a
+    // card carrying the attribute would be counted as a family in a room no
+    // family is in.
+    const { container } = render(<WriteInCard occupant={{ name: 'Emma Johnson', note: '' }} />)
+
+    expect(container.querySelector('[data-family-card]')).toBeNull()
+  })
+
+  it('is not draggable and is not a button', () => {
+    // `FamilyCard` is a `<button>` that opens the family panel and a dnd-kit
+    // draggable. There is no panel behind a write-in and nowhere to drag it —
+    // a control that looks interactive and is not is worse than plain text.
+    const { container } = render(<WriteInCard occupant={{ name: 'Emma Johnson', note: '' }} />)
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(container.querySelector('[draggable="true"]')).toBeNull()
+  })
+
+  it("wears FamilyCard's frame verbatim, so the two cannot drift apart", () => {
+    // A SOURCE assertion, not a rendered one, and deliberately so. `CARD_FRAME`
+    // is module-private to `FamilyCard.tsx` and that file is owned by another
+    // change in flight, so this card restates the string rather than importing
+    // it. Restating it silently is how two cards that must look identical stop
+    // looking identical; this is the guard that makes the copy loud.
+    const familyCard = readFileSync(resolve(__dirname, './FamilyCard.tsx'), 'utf-8')
+    const match = /const CARD_FRAME =\s*'([^']*)'/.exec(familyCard)
+
+    expect(match).not.toBeNull()
+    expect(WRITE_IN_FRAME).toBe(match?.[1])
+  })
+})

--- a/frontend/src/components/weekend/WriteInCard.tsx
+++ b/frontend/src/components/weekend/WriteInCard.tsx
@@ -1,0 +1,73 @@
+/**
+ * A write-in, drawn in the unit's occupant well — kindred#2078.
+ *
+ * Owner ruling, 2026-08-09: a hold IS a write-in. What the row records is a
+ * person sleeping in the room, almost always non-rostered weekend staff, and
+ * until now that person appeared as a small italic muted line under the badge
+ * row while the well below said "Drop families here". The room read as *empty
+ * and closed* when in truth it was *full*. This is the same fact, printed
+ * where the board prints occupancy.
+ *
+ * ## Deliberately NOT a `FamilyCard`
+ *
+ * It wears `FamilyCard`'s frame, and none of its behaviour:
+ *
+ *   - no `data-family-card`. Board code queries that selector to find PLACED
+ *     parties; a write-in is an occupant, not a placement, and marking it would
+ *     count a family in a room no family is in.
+ *   - no `useDraggable`, and not a `<button>`. There is no family panel behind
+ *     a write-in and nowhere to drag it to, and a control that looks
+ *     interactive and is not is worse than plain text.
+ *   - no party-size figure and no chip row. A write-in is a name; nothing else
+ *     is known, and a `0` beside it would assert something.
+ *
+ * ## Why the frame is restated rather than imported
+ *
+ * `CARD_FRAME` is module-private to `FamilyCard.tsx`, and that file is owned by
+ * a sibling change in flight, so exporting it here would be an edit to somebody
+ * else's file. `WriteInCard.test.tsx` reads the literal out of `FamilyCard.tsx`
+ * and asserts the two are identical, which makes the copy loud instead of a
+ * silent drift waiting to happen.
+ */
+import type { WriteInOccupant } from './writeIn'
+
+/** `FamilyCard`'s `CARD_FRAME`, verbatim. Pinned by this module's test. */
+export const WRITE_IN_FRAME =
+  'group border-border flex w-full flex-col gap-1 rounded-xl border-2 p-2.5 text-left'
+
+export interface WriteInCardProps {
+  occupant: WriteInOccupant
+}
+
+export function WriteInCard({ occupant }: WriteInCardProps) {
+  const named = occupant.name !== ''
+
+  return (
+    <div data-write-in-card className={`${WRITE_IN_FRAME} bg-background`}>
+      <span
+        // `FamilyCard`'s own name line, minus the flex row it shares with a
+        // party-size badge this card does not have.
+        className={
+          named
+            ? 'text-foreground min-w-0 truncate text-sm leading-tight font-semibold'
+            : 'text-muted-foreground min-w-0 truncate text-sm leading-tight italic'
+        }
+      >
+        {/* STATED, not left blank. A row can reach here unnamed — the write
+            schema is permissive where the control is not, and a pre-1500000148
+            row with an empty note backfilled to nothing — and an empty card in
+            a closed room reads as an open room the board mysteriously refuses
+            drops on. */}
+        {named ? occupant.name : 'Occupant not named'}
+      </span>
+      {occupant.note !== '' && (
+        // INSIDE the card, where the old italic line sat above it: the note
+        // describes the occupant, not the room. Empty on every historical row
+        // by construction (1500000148 cleared each note it copied), so this
+        // renders nothing at all until a write-in is recorded from that
+        // migration onward. That emptiness is correct, not a bug.
+        <span className="text-muted-foreground text-xs leading-tight">{occupant.note}</span>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/weekend/rosterAttention.ts
+++ b/frontend/src/components/weekend/rosterAttention.ts
@@ -245,11 +245,12 @@ export function indexUnitsByCode(units: LodgingUnitRow[]): Map<string, LodgingUn
  *
  * They are still not the same question, which is why this survives. This one
  * asks about spaces a family could be put in RIGHT NOW, so it filters on
- * `is_family_available` and drops a cabin held back this weekend.
- * `units_capacity_unknown` asks about the planning inventory, which includes
- * that held cabin because it returns next weekend. They diverge the moment
- * anything is held — today nothing is, because `lodging_availability` has
- * never held a row.
+ * `is_family_available` and drops a cabin somebody has been written into this
+ * weekend. `units_capacity_unknown` asks about the planning inventory, which
+ * includes that cabin because it returns next weekend. They diverge the moment
+ * anything is written into — and things are: `lodging_availability` DOES hold
+ * rows in production, which the old claim here ("has never held a row") got
+ * wrong. It was measured against a development database and never re-checked.
  *
  * It sits beside the BED count on the stats bar, and beds there are
  * `beds_family_available`, so the available-only reading is the one that

--- a/frontend/src/components/weekend/unitBadges.test.ts
+++ b/frontend/src/components/weekend/unitBadges.test.ts
@@ -9,8 +9,11 @@
  * a family_pool unit was storable and meaningless. The reason survives as free
  * text on `reason` and no longer drives the badge.
  *
- * The label vocabulary is unchanged on purpose -- "Staff", "Held", "Released"
- * are already the staff-facing wording and must not drift.
+ * "Staff" and "Released" are unchanged on purpose -- they are already the
+ * staff-facing wording and must not drift. "Held" DID change, once, and only
+ * as a word: kindred#2078's owner ruling is that a hold IS a write-in, so the
+ * badge reads "Write-in" and KEEPS ITS SLATE TONE. No new colour is introduced
+ * for a fact the board already had a colour for.
  *
  * Fictional data throughout.
  */
@@ -65,15 +68,20 @@ describe('reservationBadge', () => {
     expect(reservationBadge(unit())).toBeNull()
   })
 
-  it('badges a family cabin held back for this weekend', () => {
-    // A burst pipe, a caretaker in residence. The unit is still planning
-    // inventory -- it is inventory that is unavailable, not inventory that is
-    // missing -- which is why this is "Held" and not "Staff".
+  it('badges a family cabin written into for this weekend', () => {
+    // Somebody the system does not know about is sleeping here -- most often
+    // non-rostered weekend staff. The unit is still planning inventory -- it is
+    // inventory that is unavailable, not inventory that is missing -- which is
+    // why this is "Write-in" and not "Staff".
     const badge = reservationBadge(
-      unit({ family_available_override: false, reason: 'Burst pipe', is_family_available: false })
+      unit({
+        family_available_override: false,
+        occupant_name: 'Emma Johnson',
+        is_family_available: false,
+      })
     )
 
-    expect(badge?.label).toBe('Held')
+    expect(badge?.label).toBe('Write-in')
     expect(badge?.className).toBe(
       'bg-slate-200 text-slate-800 dark:bg-slate-800 dark:text-slate-200'
     )
@@ -113,7 +121,7 @@ describe('reservationBadge', () => {
     expect(
       reservationBadge(unit({ family_available_override: false, is_family_available: false }))
         ?.label
-    ).toBe('Held')
+    ).toBe('Write-in')
   })
 
   it('does not badge a staff cabin as Released merely for lacking an override', () => {
@@ -157,12 +165,12 @@ describe('availabilityAction', () => {
   // must not say two things about one cabin: a card badged "Held" offering to
   // "Hold" it is the drift this prevents.
 
-  it('offers to hold an ordinary family cabin', () => {
+  it('offers to write somebody into an ordinary family cabin', () => {
     expect(availabilityAction(unit())).toEqual({
       kind: 'hold',
-      label: 'Hold',
+      label: 'Write in',
       familyAvailable: false,
-      needsReason: true,
+      prompt: 'occupant',
     })
   })
 
@@ -171,7 +179,7 @@ describe('availabilityAction', () => {
     // cabins are never released; it does not prove it, so the capability stays.
     expect(
       availabilityAction(unit({ inventory_class: 'staff_default', is_family_available: false }))
-    ).toEqual({ kind: 'release', label: 'Release', familyAvailable: true, needsReason: true })
+    ).toEqual({ kind: 'release', label: 'Release', familyAvailable: true, prompt: 'reason' })
   })
 
   it('offers to clear a held family cabin, and asks for no reason to do it', () => {
@@ -181,7 +189,7 @@ describe('availabilityAction', () => {
       availabilityAction(
         unit({ family_available_override: false, reason: 'Burst pipe', is_family_available: false })
       )
-    ).toEqual({ kind: 'clear', label: 'Clear', familyAvailable: null, needsReason: false })
+    ).toEqual({ kind: 'clear', label: 'Clear', familyAvailable: null, prompt: 'none' })
   })
 
   it('offers to clear a released staff cabin', () => {

--- a/frontend/src/components/weekend/unitBadges.ts
+++ b/frontend/src/components/weekend/unitBadges.ts
@@ -3,9 +3,15 @@
  * map's unit popover so the two cannot drift.
  *
  * Reserved units are BADGED, not hidden (spec §3.7): staff reason about
- * adjacency, and hiding a held room would make the site look smaller than it
- * is. Container rows are labelled so nobody mistakes a whole-building
+ * adjacency, and hiding a written-into room would make the site look smaller
+ * than it is. Container rows are labelled so nobody mistakes a whole-building
  * aggregate for a bookable room.
+ *
+ * "Held" BECAME "Write-in" (kindred#2078), and it is the only label here that
+ * has ever moved. Staff never used the control to reserve an empty room — they
+ * used it to record an occupant the system does not know about — so the old
+ * word described the opposite of what the row means. The tone did not move
+ * with it; see the branch itself.
  *
  * THREE branches became two. 1500000135 replaced the `reserved_staff` /
  * `reserved_other` / `released_to_family` enum with an explicit
@@ -52,10 +58,24 @@ export function reservationBadge(unit: LodgingUnitRow): UnitBadge | null {
       className: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300',
     }
   }
-  // A family cabin closed for this weekend -- a burst pipe, a caretaker.
+  // A family cabin somebody has been WRITTEN INTO for this weekend.
+  //
+  // "Held" until kindred#2078. Staff never used the control to reserve an
+  // empty room -- they used it to record an occupant the system does not know
+  // about, most often non-rostered weekend staff -- and "Held" set the
+  // opposite expectation: a room kept empty, when in truth it is full.
+  //
+  // ONLY THE WORD CHANGES. The slate tone stays, because the underlying fact
+  // (this cabin is not available to a family this weekend) is the one the
+  // board already had a colour for, and inventing a second colour for a
+  // renamed concept is how a palette stops meaning anything.
+  //
+  // It still does not read `occupant_name`: "written in for a caretaker" and
+  // "written in for a burst pipe" are the same fact about availability, which
+  // is the same reason the reason text never reached this badge.
   if (unit.inventory_class !== 'staff_default' && unit.family_available_override === false) {
     return {
-      label: 'Held',
+      label: 'Write-in',
       className: 'bg-slate-200 text-slate-800 dark:bg-slate-800 dark:text-slate-200',
     }
   }
@@ -173,13 +193,30 @@ export interface AvailabilityAction {
   label: string
   /** What the write sends. `null` DELETES the row. */
   familyAvailable: boolean | null
-  /**
-   * A cabin taken out of service with no stated reason is the row a staff
-   * member cannot act on next week. Clearing needs none: it restores the
-   * unit's standing role rather than asserting anything about this weekend.
-   */
-  needsReason: boolean
+  /** What the control collects before it may write — see `AvailabilityPrompt`. */
+  prompt: AvailabilityPrompt
 }
+
+/**
+ * What the control must collect before it may write.
+ *
+ * RESHAPED from a `needsReason: boolean` by kindred#2078 rather than added
+ * beside it, because that flag was never really about a reason — it was about
+ * whether the action has anything to ask. What it asks FOR now differs by
+ * action, and a boolean cannot say which:
+ *
+ *   'occupant' — a write-in. A REQUIRED occupant name plus an OPTIONAL note.
+ *                ONE control and one action: hold IS the write-in (owner
+ *                ruling, 2026-08-09), so there is no second "mark unavailable"
+ *                path and no burst-pipe / staff-write-in split.
+ *   'reason'   — a release. A required reason and nothing else: opening a
+ *                staff cabin to families names no occupant, so prompting for
+ *                one would ask for a fact that does not exist.
+ *   'none'     — a clear. It restores the unit's standing role rather than
+ *                asserting anything about this weekend, so there is nothing
+ *                to say.
+ */
+export type AvailabilityPrompt = 'occupant' | 'reason' | 'none'
 
 /**
  * The one action a unit's card offers, or null if it offers none.
@@ -192,7 +229,7 @@ export interface AvailabilityAction {
  * nothing staff can see.
  *
  * Lives beside `reservationBadge` so the two cannot drift. A card badged
- * "Held" that offers to "Hold" it says two things about one cabin.
+ * "Write-in" that offers to "Write in" says two things about one cabin.
  *
  * `occupied` names a fact from the SLOT (whether any party is placed on this
  * card this scenario), never folded into `canManage`'s permission gate.
@@ -211,9 +248,9 @@ export function availabilityAction(
   if (unit.is_container === true) return null
   // `!== null` and not truthiness: null (no row for this weekend) and false
   // (closed this weekend) are different answers, and collapsing them makes
-  // either "Hold" or "Clear" unreachable across most of the board.
+  // either "Write in" or "Clear" unreachable across most of the board.
   if (unit.family_available_override !== null && unit.family_available_override !== undefined) {
-    return { kind: 'clear', label: 'Clear', familyAvailable: null, needsReason: false }
+    return { kind: 'clear', label: 'Clear', familyAvailable: null, prompt: 'none' }
   }
   // NO SURFACE REACHES THIS BRANCH TODAY, and that is deliberate rather than
   // an oversight. Releasing a staff cabin to families is a registry edit on the
@@ -224,12 +261,12 @@ export function availabilityAction(
   // state this branch describes. Kept, unused, because the write path behind it
   // still exists; see the design spec's §7.3 "stays, unused and noted".
   if (unit.inventory_class === 'staff_default') {
-    return { kind: 'release', label: 'Release', familyAvailable: true, needsReason: true }
+    return { kind: 'release', label: 'Release', familyAvailable: true, prompt: 'reason' }
   }
-  // An already-occupied space offers no "Hold": the fix for #2090. Only
+  // An already-occupied space offers no write-in: the fix for #2090. Only
   // reachable here, past both branches above, so an already-held unit keeps
   // its `clear` action regardless of occupancy — clearing only ever REDUCES
   // the conflict, so it is never the state that needs blocking.
   if (occupied) return null
-  return { kind: 'hold', label: 'Hold', familyAvailable: false, needsReason: true }
+  return { kind: 'hold', label: 'Write in', familyAvailable: false, prompt: 'occupant' }
 }

--- a/frontend/src/components/weekend/writeIn.test.ts
+++ b/frontend/src/components/weekend/writeIn.test.ts
@@ -1,0 +1,115 @@
+/**
+ * A write-in is a named global occupant — kindred#2078.
+ *
+ * The single definition of "is somebody written into this room", and the one
+ * the board reads. It exists because #2093's forest open-tint was written
+ * against the PROXY `unit.family_available_override === false` under the name
+ * `held`, and a rename alone would have left the tint keyed on a spelling
+ * rather than on the fact.
+ *
+ * Fictional data throughout. Production `lodging_availability` notes are real
+ * family and staff names; nothing here is dumped from any database.
+ */
+import { describe, expect, it } from 'vitest'
+
+import type { LodgingUnitRow } from '../../types/lodging'
+import { writeInOccupant } from './writeIn'
+
+function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
+  return {
+    unit_id: 'u1',
+    code: 'cedar-1',
+    name: 'Cedar 1',
+    area_code: 'CG',
+    area_name: 'Cedar Grove',
+    sleeps: 4,
+    bathroom: 'shared',
+    bathroom_group: '',
+    near_bathhouse: false,
+    has_power: false,
+    has_ac: false,
+    has_fridge: false,
+    is_accessible: false,
+    is_confirmed: false,
+    is_active: true,
+    is_container: false,
+    inventory_class: 'family_pool',
+    family_available_override: null,
+    occupant_name: '',
+    reason: '',
+    is_family_available: true,
+    map_x: 0.5,
+    map_y: 0.5,
+    ...overrides,
+  }
+}
+
+describe('writeInOccupant', () => {
+  it('names the occupant of a room somebody has been written into', () => {
+    expect(
+      writeInOccupant(
+        unit({
+          family_available_override: false,
+          occupant_name: 'Emma Johnson',
+          reason: 'Kitchen lead, Fri–Sun',
+          is_family_available: false,
+        })
+      )
+    ).toEqual({ name: 'Emma Johnson', note: 'Kitchen lead, Fri–Sun' })
+  })
+
+  it('is null for a room nobody has written into', () => {
+    // `null` on the override means "no row for this weekend, ask the unit's
+    // role" — not "closed". Collapsing the two is the failure `reservationBadge`
+    // documents at length, arriving one module over.
+    expect(writeInOccupant(unit())).toBeNull()
+    expect(writeInOccupant(unit({ family_available_override: null }))).toBeNull()
+  })
+
+  it('is null for a staff cabin RELEASED to families', () => {
+    // A release opens a room; it names no occupant. `true` and `false` are
+    // opposite answers and only one of them is a write-in.
+    expect(
+      writeInOccupant(
+        unit({
+          inventory_class: 'staff_default',
+          family_available_override: true,
+          reason: 'Overflow',
+        })
+      )
+    ).toBeNull()
+  })
+
+  it('still reports a write-in whose occupant nobody named', () => {
+    // Reachable from a row written before 1500000148, or through the API,
+    // which is permissive where the control is not. The room is still closed,
+    // so reporting "no write-in" here would hand it back to the open-tint and
+    // send staff at the one room they may not fill.
+    expect(
+      writeInOccupant(unit({ family_available_override: false, is_family_available: false }))
+    ).toEqual({ name: '', note: '' })
+  })
+
+  it('treats a whitespace-only occupant as unnamed rather than as a name', () => {
+    expect(
+      writeInOccupant(
+        unit({ family_available_override: false, occupant_name: '   ', is_family_available: false })
+      )
+    ).toEqual({ name: '', note: '' })
+  })
+
+  it('does not fall back to the note when the occupant is unnamed', () => {
+    // 1500000148 MOVED every historical note into `occupant_name` and cleared
+    // the column behind it, precisely so one string cannot render twice on one
+    // card. A fallback here would restore that double-print by another route.
+    expect(
+      writeInOccupant(
+        unit({
+          family_available_override: false,
+          reason: 'Back Monday',
+          is_family_available: false,
+        })
+      )
+    ).toEqual({ name: '', note: 'Back Monday' })
+  })
+})

--- a/frontend/src/components/weekend/writeIn.ts
+++ b/frontend/src/components/weekend/writeIn.ts
@@ -1,0 +1,59 @@
+/**
+ * A write-in: a named occupant the system does not know about — kindred#2078.
+ *
+ * Owner ruling, 2026-08-09: *"only one, hold is the write in"*. Staff never
+ * used Hold to reserve an empty room. They used it to record somebody sleeping
+ * in one — almost always non-rostered weekend staff — so the room read as
+ * *empty and closed* when in truth it was *full*. There is ONE control and one
+ * action; the occupant name is what the row was always for.
+ *
+ * ## Why this is a module and not an inline `=== false`
+ *
+ * The board already had that expression, spelled `held`, in three places. One
+ * of them was load-bearing in a way a rename would have silently broken:
+ * #2093's forest open-tint suppresses itself on a written-into room, and it did
+ * so by testing `unit.family_available_override === false` — a PROXY for "is
+ * somebody in it". Reading the fact through one named function is what keeps
+ * the tint keyed on the fact rather than on a spelling.
+ *
+ * ## What is deliberately NOT here
+ *
+ * No fallback from `name` to `note`. 1500000148 moved every historical note
+ * into `occupant_name` and cleared the column behind it, because the same
+ * string rendered as both the occupant's NAME and the card's italic reason line
+ * printed twice on one card. A fallback would restore that by another route.
+ */
+import type { LodgingUnitRow } from '../../types/lodging'
+
+/** Who is in a room, and anything staff said about them. */
+export interface WriteInOccupant {
+  /**
+   * The occupant's name, or `''` when nobody named them.
+   *
+   * Empty is reachable and is not an error: the write schema is permissive
+   * where the control is not (an ingest or a fixture has no author to ask), and
+   * a row written before 1500000148 whose note was empty backfills to nothing.
+   */
+  name: string
+  /**
+   * The optional note beside the name — "so next week's staff can act on it".
+   *
+   * PROSPECTIVE ONLY. 1500000148 cleared the note of every row it copied, so
+   * no historical write-in carries one and an empty column here is correct
+   * rather than a bug.
+   */
+  note: string
+}
+
+/**
+ * The occupant written into this unit for this weekend, or `null` if none.
+ *
+ * `=== false`, never truthiness: `null` means "no availability row for this
+ * weekend, so the unit's role decides" and `true` means "a staff cabin opened
+ * to families" — a release names no occupant. Collapsing any of the three into
+ * the others is the failure `reservationBadge` documents at length.
+ */
+export function writeInOccupant(unit: LodgingUnitRow): WriteInOccupant | null {
+  if (unit.family_available_override !== false) return null
+  return { name: (unit.occupant_name ?? '').trim(), note: (unit.reason ?? '').trim() }
+}

--- a/frontend/src/hooks/useUnitAvailability.test.tsx
+++ b/frontend/src/hooks/useUnitAvailability.test.tsx
@@ -41,11 +41,12 @@ const YEAR = 2026
 const SESSION = 1000001
 const DRAFT = 'scn7x2k9qw3mnbv'
 
-const HOLD = {
+const WRITE_IN = {
   unitId: 'u1',
   unitName: 'Cedar 1',
   familyAvailable: false as boolean | null,
-  reason: 'Burst pipe',
+  occupantName: 'Emma Johnson',
+  reason: '',
 }
 
 let client: QueryClient
@@ -81,7 +82,7 @@ describe('useUnitAvailability', () => {
     const { result } = renderAvailability()
 
     await act(async () => {
-      await result.current.setAvailability(HOLD)
+      await result.current.setAvailability(WRITE_IN)
     })
 
     expect(setUnitAvailability).toHaveBeenCalledTimes(1)
@@ -90,13 +91,14 @@ describe('useUnitAvailability', () => {
       sessionCmId: SESSION,
       unitId: 'u1',
       familyAvailable: false,
-      reason: 'Burst pipe',
+      occupantName: 'Emma Johnson',
+      reason: '',
     })
   })
 
   it('refreshes EVERY scenario of the weekend, not just the one on screen', async () => {
     // The failure this pins is silent. Availability carries no scenario, so a
-    // hold recorded while a draft is open changes the mirror and every other
+    // write-in recorded while a draft is open changes the mirror and every other
     // draft as well — and the weekend queries carry a 30 minute staleTime, so
     // "stale" means half an hour of a board showing a cabin as open after
     // staff closed it. Invalidating only the visible key looks correct on the
@@ -104,7 +106,7 @@ describe('useUnitAvailability', () => {
     const { result } = renderAvailability()
 
     await act(async () => {
-      await result.current.setAvailability(HOLD)
+      await result.current.setAvailability(WRITE_IN)
     })
 
     await waitFor(() => {
@@ -125,7 +127,7 @@ describe('useUnitAvailability', () => {
 
     const { result } = renderAvailability()
     act(() => {
-      void result.current.setAvailability(HOLD)
+      void result.current.setAvailability(WRITE_IN)
     })
 
     await waitFor(() => {
@@ -141,12 +143,36 @@ describe('useUnitAvailability', () => {
     })
   })
 
+  it('confirms a write-in by NAMING the occupant, which is the fact just asserted', async () => {
+    // The toast is what a staff member checks the card against. "Cedar 1 is
+    // held for this weekend" said neither what happened nor to whom.
+    const { result } = renderAvailability()
+
+    await act(async () => {
+      await result.current.setAvailability(WRITE_IN)
+    })
+
+    expect(toastSuccess).toHaveBeenCalledWith(
+      'Emma Johnson is written into Cedar 1 for this weekend'
+    )
+  })
+
+  it('confirms a nameless write-in without pretending to a name', async () => {
+    const { result } = renderAvailability()
+
+    await act(async () => {
+      await result.current.setAvailability({ ...WRITE_IN, occupantName: '  ' })
+    })
+
+    expect(toastSuccess).toHaveBeenCalledWith('Cedar 1 is written in for this weekend')
+  })
+
   it('says what a refused write was, rather than leaving the card looking saved', async () => {
     setUnitAvailability.mockRejectedValue(new Error('Permission required: bunking.manage'))
 
     const { result } = renderAvailability()
     await act(async () => {
-      await result.current.setAvailability(HOLD).catch(() => undefined)
+      await result.current.setAvailability(WRITE_IN).catch(() => undefined)
     })
 
     expect(toastError).toHaveBeenCalledWith('Permission required: bunking.manage')
@@ -159,7 +185,7 @@ describe('useUnitAvailability', () => {
     // scenario.
     const { result } = renderAvailability(0)
 
-    await expect(result.current.setAvailability(HOLD)).rejects.toThrow(/weekend/i)
+    await expect(result.current.setAvailability(WRITE_IN)).rejects.toThrow(/weekend/i)
     expect(setUnitAvailability).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/hooks/useUnitAvailability.ts
+++ b/frontend/src/hooks/useUnitAvailability.ts
@@ -1,5 +1,5 @@
 /**
- * Holding one cabin back for a weekend, or releasing one to families.
+ * Writing somebody into one cabin for a weekend, or releasing one to families.
  *
  * ## Why this is not `useLodgingPlacement` with a different body
  *
@@ -49,11 +49,17 @@ export interface AvailabilityIntent {
   /** For the confirmation only — the write names the unit by id. */
   unitName: string
   /**
-   * `false` holds the unit back, `true` releases it, `null` DELETES the row so
-   * the unit's own role decides again. Never read for truthiness.
+   * `false` writes an occupant into the unit, `true` releases it, `null`
+   * DELETES the row so the unit's own role decides again. Never read for
+   * truthiness.
    */
   familyAvailable: boolean | null
-  /** Required by the card on a hold or a release; `''` when clearing. */
+  /**
+   * WHO is in the room (kindred#2078). Required by the card on a write-in;
+   * `''` on a release and when clearing.
+   */
+  occupantName: string
+  /** OPTIONAL on a write-in, required on a release; `''` when clearing. */
   reason: string
 }
 
@@ -68,12 +74,21 @@ export interface UseUnitAvailabilityReturn {
   pendingUnitId: string
 }
 
-/** Outcome wording, matching the badge vocabulary in `unitBadges.ts`. */
-function confirmation({ unitName, familyAvailable }: AvailabilityIntent): string {
+/**
+ * Outcome wording, matching the badge vocabulary in `unitBadges.ts`.
+ *
+ * The write-in line NAMES the occupant, because that is the fact the staff
+ * member just asserted and the one they can check the card against. It falls
+ * back to the cabin alone if the name is somehow empty — the write schema is
+ * permissive where the control is not — rather than confirming a blank.
+ */
+function confirmation({ unitName, familyAvailable, occupantName }: AvailabilityIntent): string {
   if (familyAvailable === null) return `${unitName} follows its usual role again`
-  return familyAvailable
-    ? `${unitName} is released to families for this weekend`
-    : `${unitName} is held for this weekend`
+  if (familyAvailable) return `${unitName} is released to families for this weekend`
+  const named = occupantName.trim()
+  return named === ''
+    ? `${unitName} is written in for this weekend`
+    : `${named} is written into ${unitName} for this weekend`
 }
 
 export function useUnitAvailability({
@@ -90,6 +105,7 @@ export function useUnitAvailability({
         sessionCmId,
         unitId: intent.unitId,
         familyAvailable: intent.familyAvailable,
+        occupantName: intent.occupantName,
         reason: intent.reason,
       })
     },

--- a/frontend/src/services/lodgingApi.test.ts
+++ b/frontend/src/services/lodgingApi.test.ts
@@ -216,7 +216,8 @@ describe('setUnitAvailability', () => {
     const result = await setUnitAvailability(mockFetch, {
       ...WEEKEND,
       familyAvailable: false,
-      reason: 'Burst pipe',
+      occupantName: 'Emma Johnson',
+      reason: 'Kitchen lead, Fri–Sun',
     })
 
     const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit]
@@ -224,29 +225,35 @@ describe('setUnitAvailability', () => {
     expect(options.method).toBe('PUT')
     // No scenario. The endpoint takes none since 1500000135, and sending one
     // would be a 422 against a model that no longer extends ScenarioWriteRequest.
+    //
+    // `occupant_name` travels under the column's own name (kindred#2078);
+    // only `reason` is renamed on the wire, and only because 1500000135 reused
+    // a `note` column that already existed.
     expect(JSON.parse(options.body as string)).toEqual({
       year: 2026,
       session_cm_id: 1000001,
       unit_id: 'u1',
       family_available: false,
-      reason: 'Burst pipe',
+      occupant_name: 'Emma Johnson',
+      reason: 'Kitchen lead, Fri–Sun',
     })
     expect(result).toEqual({ record_id: 'r1', deleted: false })
   })
 
-  it('sends a hold as an explicit false, never as a missing field', async () => {
+  it('sends a write-in as an explicit false, never as a missing field', async () => {
     // THE trap. `false` and `null` are different answers — false is "closed
     // this weekend", null DELETES the row and hands the question back to the
     // unit's role. Any falsy handling on the way out (`|| null`, a spread that
     // drops it, `familyAvailable ? ... : undefined`) turns "hold this cabin"
     // into "clear the override", and the write reads as a no-op that staff
-    // only notice when a family arrives at a cabin with no water.
+    // only notice when a family arrives at a cabin somebody else is sleeping in.
     const mockFetch = vi.fn().mockResolvedValue(okResponse({ record_id: 'r1', deleted: false }))
 
     await setUnitAvailability(mockFetch, {
       ...WEEKEND,
       familyAvailable: false,
-      reason: 'Burst pipe',
+      occupantName: 'Emma Johnson',
+      reason: '',
     })
 
     const body = JSON.parse((mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string)
@@ -264,6 +271,7 @@ describe('setUnitAvailability', () => {
     const result = await setUnitAvailability(mockFetch, {
       ...WEEKEND,
       familyAvailable: null,
+      occupantName: '',
       reason: '',
     })
 
@@ -283,7 +291,12 @@ describe('setUnitAvailability', () => {
     })
 
     await expect(
-      setUnitAvailability(mockFetch, { ...WEEKEND, familyAvailable: true, reason: 'Overflow' })
+      setUnitAvailability(mockFetch, {
+        ...WEEKEND,
+        familyAvailable: true,
+        occupantName: '',
+        reason: 'Overflow',
+      })
     ).rejects.toMatchObject({ status: 403, message: 'Permission required: bunking.manage' })
   })
 })

--- a/frontend/src/services/lodgingApi.ts
+++ b/frontend/src/services/lodgingApi.ts
@@ -160,7 +160,7 @@ export async function unplaceParty(
   if (!response.ok) throw await toError(response, 'Failed to unplace the party')
 }
 
-/** Holding one unit back for a weekend, or releasing one to families. */
+/** Writing somebody into one unit for a weekend, or releasing one to families. */
 export interface AvailabilityWrite {
   year: number
   sessionCmId: number
@@ -169,10 +169,19 @@ export interface AvailabilityWrite {
   /**
    * THREE values, not two. `false` closes the unit for this weekend, `true`
    * opens it, and `null` DELETES the row so the unit's own role decides again.
-   * Nothing here may be read for truthiness: `!familyAvailable` folds a hold
-   * into a clear.
+   * Nothing here may be read for truthiness: `!familyAvailable` folds a
+   * write-in into a clear.
    */
   familyAvailable: boolean | null
+  /**
+   * WHO is in the room (kindred#2078). Required through the control on a
+   * write-in; `''` on a release and on a clear.
+   *
+   * Sent under the SAME name the column carries, unlike `reason` below —
+   * `reason`/`note` carry two names only because 1500000135 reused a column
+   * that already existed.
+   */
+  occupantName: string
   /** Display only — the rule never branches on it. `''` when clearing. */
   reason: string
 }
@@ -189,7 +198,7 @@ export interface AvailabilityWrite {
  */
 export async function setUnitAvailability(
   fetchWithAuth: FetchWithAuth,
-  { year, sessionCmId, unitId, familyAvailable, reason }: AvailabilityWrite
+  { year, sessionCmId, unitId, familyAvailable, occupantName, reason }: AvailabilityWrite
 ): Promise<LodgingWriteResult> {
   const response = await fetchWithAuth(`${API_BASE}/availability`, {
     method: 'PUT',
@@ -199,6 +208,7 @@ export async function setUnitAvailability(
       session_cm_id: sessionCmId,
       unit_id: unitId,
       family_available: familyAvailable,
+      occupant_name: occupantName,
       reason,
     }),
   })

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -156,6 +156,10 @@ export type AvailabilityWriteRequest = {
    */
   family_available?: boolean | null
   /**
+   * Occupant Name
+   */
+  occupant_name?: string
+  /**
    * Reason
    */
   reason?: string
@@ -2185,6 +2189,10 @@ export type LodgingUnitSummary = {
    * Family Available Override
    */
   family_available_override?: boolean | null
+  /**
+   * Occupant Name
+   */
+  occupant_name?: string
   /**
    * Reason
    */

--- a/frontend/src/types/lodging.test.ts
+++ b/frontend/src/types/lodging.test.ts
@@ -144,7 +144,11 @@ const _exhaustiveAvailabilityWriteRequest: Required<AvailabilityWriteRequest> = 
   session_cm_id: 3000001,
   unit_id: 'unit123456789012345',
   family_available: false,
-  reason: 'Burst pipe',
+  // kindred#2078: a hold IS a write-in, so the write that closes a cabin also
+  // names WHO is in it. Required through the control, permissive at the schema
+  // — the same split `reason` makes, for the same reason.
+  occupant_name: 'Emma Johnson',
+  reason: 'Kitchen lead, Fri–Sun',
 }
 void _exhaustiveAvailabilityWriteRequest
 
@@ -198,6 +202,7 @@ const _exhaustiveLodgingUnit: Required<LodgingUnitRow> = {
   inventory_class: 'family_pool',
   shareability: 'single_party',
   family_available_override: null,
+  occupant_name: '',
   reason: '',
   is_family_available: true,
   map_x: 0.5,

--- a/pocketbase/pb_migrations/1500000148_lodging_availability_occupant_name.js
+++ b/pocketbase/pb_migrations/1500000148_lodging_availability_occupant_name.js
@@ -1,0 +1,135 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Add `occupant_name` to lodging_availability — WHO is in the room.
+ *
+ * Owner ruling, 2026-08-09 (kindred#2078): *"only one, hold is the write in"*.
+ * Staff have never used Hold to reserve an empty cabin. They use it to write
+ * in an occupant the system does not know about — almost always non-rostered
+ * weekend staff. The row already closed the cabin; it had nowhere to put the
+ * person, so the name went into `note`, which the API surfaces as `reason` and
+ * the card printed as a small italic line under the badge row.
+ *
+ * A hold IS a write-in. That is ONE control and one column more, not a second
+ * concept: a staff member who types "burst pipe" into the occupant field gets
+ * a card showing an occupant called "burst pipe", and that is an ACCEPTED COST
+ * ruled on rather than a gap to close later.
+ *
+ * ── THE BACKFILL IS BLANKET, BY RULING ──────────────────────────────────────
+ *
+ * *"all of the existing 2078 prod rows are the occupant names."* There is no
+ * mapping table and no per-row judgement: every existing `note` IS an occupant
+ * name, so it moves wholesale. Written as a PREDICATE over the table rather
+ * than a list, for the reason 1500000138's and 1500000145's backfills give — a
+ * predicate names nobody, so it cannot leak a name into this directory (which
+ * `verify-no-hardcoded-lodging.sh` scans) and cannot go stale as rows arrive.
+ *
+ * ── NON-DESTRUCTIVE, AND A TRUE RE-RUNNABLE NO-OP ───────────────────────────
+ *
+ * Two guarded statements, IN THIS ORDER:
+ *
+ *   1. copy `note` -> `occupant_name`, ONLY where `occupant_name` is empty;
+ *   2. clear `note`, ONLY where it is now byte-identical to `occupant_name`.
+ *
+ * After run 1, `note` is `''` on every row it touched, so neither predicate
+ * matches on run 2 — statement 1 skips rows that now have a name, statement 2
+ * finds no non-empty note equal to one. Nothing is lost in between: the string
+ * exists in `occupant_name` before step 2 reads it, and step 2 only clears
+ * what it can prove is already saved. This satisfies the standing "no
+ * destructive data migrations" rule.
+ *
+ * ⛔ NO `refuseIfPopulated` GUARD, and this is deliberate rather than an
+ * omission. 1500000135 carried one because it DROPPED columns and could not
+ * safely meet a populated table. This migration is ADDITIVE and the population
+ * is the entire point — refusing a populated table here would refuse the only
+ * case that matters.
+ *
+ * ── WHY CLEARING `note` IS LOAD-BEARING, NOT TIDINESS ───────────────────────
+ *
+ * `UnitAvailabilityControl.tsx` renders `unit.reason` — which IS this `note`
+ * column, translated in `_build_units` — as a standalone italic muted line
+ * under the badge row, and the approved mockup puts the same string in the
+ * occupant well as the write-in's NAME. Leaving `note` populated would print
+ * the identical string TWICE on one card.
+ *
+ * ── THE NOTE COLUMN SHIPS EMPTY EVERYWHERE, AND THAT IS CORRECT ─────────────
+ *
+ * Step 2 clears every note it copies, so NO historical row carries one. The
+ * "say why, so next week's staff can act on it" affordance is kept, but it is
+ * PROSPECTIVE ONLY — it applies to write-ins recorded from this migration
+ * onward. Nobody should later "repair" the empty column by re-populating it
+ * from `occupant_name`: that would restore the double-print this removed.
+ *
+ * ── SIZING ──────────────────────────────────────────────────────────────────
+ *
+ * `max: 2000` mirrors `note`'s own cap (1500000118), so statement 1 cannot be
+ * rejected for length by any value the column it copies from could hold. The
+ * API caps the field it accepts at 500, which is a UI-side judgement about a
+ * name and is deliberately the tighter of the two — a stored value longer than
+ * that can only have arrived from the pre-existing `note`.
+ */
+
+migrate(
+  (app) => {
+    const col = app.findCollectionByNameOrId('lodging_availability');
+
+    // Idempotent: editing an already-applied migration silently skips it
+    // (`_migrations` keys on filename), so every add in this codebase is
+    // written to tolerate the field already being present.
+    if (!col.fields.getByName('occupant_name')) {
+      col.fields.add(
+        new Field({
+          type: 'text',
+          name: 'occupant_name',
+          // NOT `required`. A required text field would refuse every existing
+          // row before statement 1 below could fill it, and would make the
+          // release branch (a staff cabin opened to families, which has no
+          // occupant at all) unwritable.
+          required: false,
+          presentable: false,
+          min: 0,
+          max: 2000,
+          pattern: '',
+        })
+      );
+      app.save(col);
+    }
+
+    // 1 — the name moves. Gated on `occupant_name = ''`, so it only ever
+    // FILLS: a value already written through the control outranks this and is
+    // never overwritten, and a second run matches nothing.
+    app
+      .db()
+      .newQuery(
+        'UPDATE lodging_availability SET occupant_name = note ' +
+          "WHERE occupant_name = '' AND note != ''"
+      )
+      .execute();
+
+    // 2 — and only then does the note go. `note = occupant_name` is the proof
+    // that the string is already saved somewhere else; a row whose note was
+    // NOT copied (because it already had an occupant) keeps its note, which is
+    // exactly right — those two are different facts.
+    app
+      .db()
+      .newQuery(
+        "UPDATE lodging_availability SET note = '' " + "WHERE note != '' AND note = occupant_name"
+      )
+      .execute();
+  },
+  (app) => {
+    // The down migration restores `note` from `occupant_name` before dropping
+    // the column, so a rollback does not take the names with it. Same guard
+    // shape: it only ever fills an empty note.
+    const col = app.findCollectionByNameOrId('lodging_availability');
+    if (!col.fields.getByName('occupant_name')) return;
+    app
+      .db()
+      .newQuery(
+        'UPDATE lodging_availability SET note = occupant_name ' +
+          "WHERE note = '' AND occupant_name != ''"
+      )
+      .execute();
+    col.fields.removeByName('occupant_name');
+    app.save(col);
+  }
+);

--- a/scripts/dev/verify-availability-writein-backfill.sh
+++ b/scripts/dev/verify-availability-writein-backfill.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Proves 1500000148's write-in backfill against a REAL PocketBase boot.
+#
+# kindred#2078: a hold IS a write-in, so every existing `lodging_availability`
+# note is an occupant name and moves into `occupant_name`, with the note
+# cleared behind it so the same string does not print twice on one card.
+#
+# A green `go test ./...` never proves the PocketBase binary boots, and a
+# fresh-DB schema check can never prove a backfill PRESERVES anything -- there
+# is nothing in a fresh DB to preserve. So this boots twice: once WITHOUT
+# 1500000148 to get a pre-migration table, seeds synthetic rows into it, then
+# boots again WITH the migration and asserts what happened to each row.
+#
+# Every seeded value is FICTIONAL. Production notes are real family and staff
+# names and must never be dumped into a fixture (CLAUDE.md section 4).
+#
+# Exit codes: 0 = all assertions passed. 1 = one or more FAILED. 2 = could not
+# run the check at all. Assertions do not short-circuit.
+set -euo pipefail
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib/pb-harness.sh
+source "$HERE/lib/pb-harness.sh"
+
+pb_harness_require_tools
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+PB_BIN="$REPO_ROOT/pocketbase/pocketbase"
+MIG_DIR="$REPO_ROOT/pocketbase/pb_migrations"
+MIGRATION="1500000148_lodging_availability_occupant_name.js"
+
+[[ -f "$MIG_DIR/$MIGRATION" ]] || { echo "error: $MIGRATION not found in $MIG_DIR" >&2; exit 2; }
+
+echo ">> building pocketbase binary..."
+pb_harness_build_binary "$REPO_ROOT/pocketbase" "$PB_BIN"
+
+SCRATCH=$(mktemp -d)
+# shellcheck disable=SC2016  # deliberate: $SCRATCH expands when the trap fires, not here
+pb_harness_install_trap 'rm -rf "$SCRATCH"'
+
+# The migration set as it stood BEFORE this change: everything but 148.
+BEFORE_DIR="$SCRATCH/pb_migrations_before"
+mkdir -p "$BEFORE_DIR"
+cp "$MIG_DIR"/*.js "$BEFORE_DIR/"
+rm -f "$BEFORE_DIR/$MIGRATION"
+
+DB_DIR="$SCRATCH/data/pb_data"
+DB="$DB_DIR/data.db"
+
+echo ">> booting WITHOUT $MIGRATION..."
+pb_harness_boot "$PB_BIN" "$DB_DIR" "$BEFORE_DIR" "$SCRATCH/boot-before.log"
+
+fail=0
+note() { echo "FAIL: $*" >&2; fail=1; }
+
+# The column must not exist yet, or the "before" state is not a before state
+# and every assertion below is vacuous.
+pre=$(sqlite3 "$DB" "SELECT COUNT(*) FROM pragma_table_info('lodging_availability') WHERE name = 'occupant_name'")
+[[ "$pre" == "0" ]] \
+  || { echo "error: occupant_name already present without $MIGRATION; the before-boot is not a before state" >&2; exit 2; }
+
+# Three synthetic rows, standing in for the shapes production actually holds:
+# a plain name, a multi-word name, and a released cabin with no note at all.
+# `unit` and `session` are plain TEXT relation columns; nothing here joins them,
+# so bare ids keep the fixture free of registry coupling.
+sqlite3 "$DB" <<'SQL'
+INSERT INTO lodging_availability (id, session, session_cm_id, year, unit, family_available, note)
+VALUES
+  ('wi000000000001', 'sess0000000001', 1000001, 2026, 'unit0000000001', 0, 'Emma Johnson'),
+  ('wi000000000002', 'sess0000000001', 1000001, 2026, 'unit0000000002', 0, 'burst pipe'),
+  ('wi000000000003', 'sess0000000001', 1000001, 2026, 'unit0000000003', 1, '');
+SQL
+
+echo ">> booting WITH $MIGRATION..."
+pb_harness_boot "$PB_BIN" "$DB_DIR" "$MIG_DIR" "$SCRATCH/boot-after.log"
+
+post=$(sqlite3 "$DB" "SELECT COUNT(*) FROM pragma_table_info('lodging_availability') WHERE name = 'occupant_name'")
+[[ "$post" == "1" ]] || note "occupant_name column absent after $MIGRATION"
+
+row() { sqlite3 "$DB" "SELECT occupant_name || '|' || note FROM lodging_availability WHERE id = '$1'"; }
+
+# 1 -- the name moved, and the note went with it rather than being printed
+# twice on the same card.
+got=$(row wi000000000001)
+[[ "$got" == "Emma Johnson|" ]] || note "row 1 is '$got' (expected 'Emma Johnson|')"
+
+# 2 -- the accepted cost, shown honestly: there is no second control for "out
+# of service", so a pipe is written in as an occupant and stays one.
+got=$(row wi000000000002)
+[[ "$got" == "burst pipe|" ]] || note "row 2 is '$got' (expected 'burst pipe|')"
+
+# 3 -- a released cabin names no occupant and had no note. Untouched.
+got=$(row wi000000000003)
+[[ "$got" == "|" ]] || note "row 3 is '$got' (expected '|')"
+
+# Nothing was deleted. The backfill only ever UPDATEs.
+n=$(sqlite3 "$DB" "SELECT COUNT(*) FROM lodging_availability")
+[[ "$n" == "3" ]] || note "row count is $n after the backfill (expected 3)"
+
+# ── RE-RUNNABILITY ──────────────────────────────────────────────────────────
+#
+# `_migrations` keys on FILENAME, so PocketBase will not re-run 148 on a second
+# boot -- which is also the lever that lets this test it honestly. A byte-for-
+# byte COPY under a later filename runs the shipped statements a second time
+# against a table run 1 has already touched. Copying the file rather than
+# re-typing the SQL here is the point: a duplicated query in this script would
+# still pass if the migration's own guards were deleted.
+RERUN_DIR="$SCRATCH/pb_migrations_rerun"
+mkdir -p "$RERUN_DIR"
+cp "$MIG_DIR"/*.js "$RERUN_DIR/"
+cp "$MIG_DIR/$MIGRATION" "$RERUN_DIR/1500000149_writein_backfill_rerun_probe.js"
+
+# A fourth row, only reachable once the column exists: an occupant already
+# written in, with a note that is genuinely a note. Statement 1 must not
+# overwrite the name, and statement 2 must not clear a note that is not a copy
+# of it -- those are two different facts about one write-in.
+sqlite3 "$DB" <<'SQL'
+INSERT INTO lodging_availability (id, session, session_cm_id, year, unit, family_available, note, occupant_name)
+VALUES ('wi000000000004', 'sess0000000001', 1000001, 2026, 'unit0000000004', 0, 'Back Monday', 'Liam Garcia');
+SQL
+
+before_all=$(sqlite3 "$DB" "SELECT id || '=' || occupant_name || '|' || note FROM lodging_availability ORDER BY id")
+
+echo ">> booting again with a re-run probe copy of $MIGRATION..."
+pb_harness_boot "$PB_BIN" "$DB_DIR" "$RERUN_DIR" "$SCRATCH/boot-rerun.log"
+
+after_all=$(sqlite3 "$DB" "SELECT id || '=' || occupant_name || '|' || note FROM lodging_availability ORDER BY id")
+[[ "$before_all" == "$after_all" ]] \
+  || note "re-running the backfill changed rows; it must be a no-op.
+before:
+$before_all
+after:
+$after_all"
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "verify-availability-writein-backfill: FAILED" >&2
+  exit 1
+fi
+echo "verify-availability-writein-backfill: OK ($PB_HARNESS_JS_MIGRATION_COUNT js migrations applied)"

--- a/scripts/dev/verify-availability-writein-backfill.sh
+++ b/scripts/dev/verify-availability-writein-backfill.sh
@@ -31,6 +31,16 @@ MIGRATION="1500000148_lodging_availability_occupant_name.js"
 
 [[ -f "$MIG_DIR/$MIGRATION" ]] || { echo "error: $MIGRATION not found in $MIG_DIR" >&2; exit 2; }
 
+# The registry loader (pocketbase/main.go) runs as a serve hook and ABORTS THE
+# BOOT with "lodging registry file present but no season is resolvable" when it
+# finds ./config/lodging_registry.json and no season. Every dev checkout that
+# ran setup-local-config.sh has that symlink, so running this from the repo
+# root -- the normal thing -- made the boot fail and the script exit 2 without
+# testing anything. Nothing here reads the registry; the year only has to
+# exist. Same fix, same reason, as verify-lodging-seed.sh, and defaulted rather
+# than forced so a caller's own season still wins.
+export CAMPMINDER_SEASON_ID="${CAMPMINDER_SEASON_ID:-2026}"
+
 echo ">> building pocketbase binary..."
 pb_harness_build_binary "$REPO_ROOT/pocketbase" "$PB_BIN"
 

--- a/scripts/dev/verify-lodging-schema.sh
+++ b/scripts/dev/verify-lodging-schema.sh
@@ -27,6 +27,16 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 PB_BIN="$REPO_ROOT/pocketbase/pocketbase"
 MIG_DIR="$REPO_ROOT/pocketbase/pb_migrations"
 
+# The registry loader (pocketbase/main.go) runs as a serve hook and ABORTS THE
+# BOOT with "lodging registry file present but no season is resolvable" when it
+# finds ./config/lodging_registry.json and no season. Every dev checkout that
+# ran setup-local-config.sh has that symlink, so running this from the repo
+# root -- the normal thing -- made the boot fail and the script exit 2 without
+# checking a single field. This check is about SHAPE, not rows, so the year
+# only has to exist. Same fix, same reason, as verify-lodging-seed.sh, and
+# defaulted rather than forced so a caller's own season still wins.
+export CAMPMINDER_SEASON_ID="${CAMPMINDER_SEASON_ID:-2026}"
+
 # Rebuild rather than assert existence: a stale binary would let this report
 # PASS against a Go model-level guard that no longer exists in the source.
 # Incremental, so it is near-free on an unchanged tree. See kindred#1922.

--- a/scripts/dev/verify-lodging-schema.sh
+++ b/scripts/dev/verify-lodging-schema.sh
@@ -165,6 +165,20 @@ far=$(field_prop lodging_availability family_available required || true)
 nt=$(field_prop lodging_availability note type || true)
 [[ "$nt" == "text" ]] || note "lodging_availability.note type is '$nt' (expected text)"
 
+# WHO is in the room (1500000148, kindred#2078). A hold IS a write-in, so the
+# row that closes a cabin also names its occupant. Untranslated: the column and
+# the API field share one name, unlike note/reason above.
+on=$(field_prop lodging_availability occupant_name type || true)
+[[ "$on" == "text" ]] || note "lodging_availability.occupant_name type is '$on' (expected text)"
+
+# NOT required, and that is load-bearing twice over: a required text field
+# would have refused every pre-1500000148 row before the backfill could fill
+# it, and the release branch (a staff cabin opened to families) has no occupant
+# to name at all.
+onr=$(field_prop lodging_availability occupant_name required || true)
+[[ "$onr" != "1" && "$onr" != "true" ]] \
+  || note "lodging_availability.occupant_name is required -- the release branch names no occupant"
+
 # Unbounded numbers must be null, not 0 (0 would reject positive values).
 mx=$(field_prop lodging_units sleeps max || true)
 [[ -z "$mx" || "$mx" == "null" ]] || note "lodging_units.sleeps max is '$mx' (expected null for unbounded)"

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -1556,6 +1556,39 @@ class TestSlotMergeTiers:
         assert roster.counts.units_capacity_unknown == 0
 
     @pytest.mark.asyncio
+    async def test_a_write_in_surfaces_its_occupant_name_beside_the_note(self) -> None:
+        """kindred#2078: a hold IS a write-in, and a write-in has an occupant.
+
+        `occupant_name` is its own column, translated nowhere -- unlike `note`,
+        which the API renames to `reason` on the way out. The two travel
+        together so the card can print the occupant as a NAME and keep the
+        note as the note.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[_unit("u1", "ridge-a", "Ridge A", sleeps=5)],
+            fetch_availability=[
+                _rec(unit="u1", family_available=False, note="Kitchen lead, Fri-Sun", occupant_name="Emma Johnson")
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        by_code = {u.code: u for u in roster.units}
+        assert by_code["ridge-a"].occupant_name == "Emma Johnson"
+        assert by_code["ridge-a"].reason == "Kitchen lead, Fri-Sun"
+
+    @pytest.mark.asyncio
+    async def test_a_unit_with_no_availability_row_names_no_occupant(self) -> None:
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[_unit("u1", "ridge-a", "Ridge A", sleeps=5)],
+            fetch_availability=[],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.units[0].occupant_name == ""
+
+    @pytest.mark.asyncio
     async def test_a_released_staff_cabin_rejoins_the_planning_inventory(self) -> None:
         """Releasing is the whole reason the capability is kept."""
         repo = _repo(

--- a/tests/unit/api/services/test_lodging_write_service.py
+++ b/tests/unit/api/services/test_lodging_write_service.py
@@ -1061,6 +1061,36 @@ class TestTheAvailabilityWriteShape:
         assert "scenario" not in data
         assert "state" not in data
 
+    def test_an_occupant_name_is_optional_at_the_schema_but_bounded(self) -> None:
+        """Required through the CONTROL, permissive at the schema.
+
+        Exactly the split `reason` already makes, and for the same reason: a
+        row written by an ingest or a fixture has no author to ask. The
+        write-in form is where the requirement lives, because that is the only
+        path with an author -- and a clear (`family_available: null`) sends
+        neither field.
+        """
+        assert AvailabilityWriteRequest(year=2026, session_cm_id=1000001, unit_id="u1").occupant_name == ""
+        with pytest.raises(ValidationError):
+            AvailabilityWriteRequest(year=2026, session_cm_id=1000001, unit_id="u1", occupant_name="x" * 501)
+
+    @pytest.mark.asyncio
+    async def test_the_occupant_name_is_stored_under_its_own_name(
+        self, write_service: LodgingWriteService, repo: MagicMock
+    ) -> None:
+        """kindred#2078. `occupant_name` is NOT translated, and that is deliberate.
+
+        `reason`/`note` carry two names because 1500000135 reused a column that
+        already existed. There is no such inheritance here, so the API name and
+        the column name are the same one and this write path has no second
+        translation to keep in step.
+        """
+        await write_service.set_availability(_availability_request(occupant_name="Emma Johnson"))
+
+        data = repo.create_availability.call_args[0][0]
+        assert data["occupant_name"] == "Emma Johnson"
+        assert data["note"] == "Burst pipe"
+
     @pytest.mark.asyncio
     async def test_a_release_writes_true_rather_than_a_state_name(
         self, write_service: LodgingWriteService, repo: MagicMock


### PR DESCRIPTION
## What changed and why

Owner ruling 2026-08-09: **staff never used "Hold" to reserve an empty cabin.** They used it to write in an occupant the system does not know about — almost always non-rostered weekend staff — so the card read *empty and closed* for a room that was full.

**ONE control, two inputs.** Hold *is* the write-in: a **required Occupant** name and an **optional Note**. There is no separate "mark unavailable" action and no burst-pipe / staff-write-in split. A note reading "burst pipe" rendering as an occupant name is an **accepted cost**, ruled on rather than prevented.

| Surface | Change |
|---|---|
| `pb_migrations/1500000148` | Adds `occupant_name` to `lodging_availability`; moves every existing `note` into it and clears the note behind it |
| `api/schemas/lodging.py` | `occupant_name` on the availability read + write schemas |
| `lodging_write_service.py` / `lodging_roster_service.py` | Persists and surfaces it, **untranslated** |
| `unitBadges.ts` | Button `Hold` → `Write in`; badge `Held` → `Write-in`, **keeping its slate tone**. `needsReason: boolean` → `prompt: 'occupant' \| 'reason' \| 'none'` |
| `UnitAvailabilityControl.tsx` | Two inputs on a write-in; the release branch keeps its single required Reason |
| `WriteInCard.tsx` (new) | The occupant, drawn in the `min-h-[100px]` well in `FamilyCard`'s frame |
| `writeIn.ts` (new) | `writeInOccupant()` — the single definition of "is somebody in this room" |
| `LodgingUnitCard.tsx` | Renders the card; numerator takes the em dash; re-expresses #2093's tint conjunct |
| `WeekendStatsBar.tsx` | `· N held` → `· N write-ins`, tooltip "Written in for this weekend, excluded from family spaces" |
| admin `LodgingUnitRow` / `UnitIdentityFields` | `staff_default`: "Held for staff" → **"Staff housing"** |

### The backfill is non-destructive and a true re-runnable no-op

Two guarded statements, in order: copy `note` → `occupant_name` **only where `occupant_name` is empty**, then clear `note` **only where it is now byte-identical to `occupant_name`**. After run 1 `note` is `''`, so neither predicate matches again.

**No `refuseIfPopulated` guard, deliberately.** `1500000135` carried one because it *dropped* columns and could not meet a populated table; 148 is additive and the population is the entire point.

Clearing `note` is load-bearing rather than tidiness: the control rendered `unit.reason` (which *is* `note`) as an italic line under the badge row, and the approved mockup puts the same string in the occupant well as the write-in's **name**. Leaving it populated printed the identical string twice on one card.

### ⚠️ The Note column ships EMPTY everywhere, and that is CORRECT

Step 2 clears every note it copies, so **no historical row carries one**. The "say why, so next week's staff can act on it" affordance is kept but is **PROSPECTIVE ONLY** — it applies to write-ins recorded from this PR onward. **Nobody should later "repair" the empty column by re-populating it from `occupant_name`**: that restores the exact double-print this removes.

### Two vocabulary collisions, one fixed and one named

- **Fixed.** `inventory_class = 'staff_default'` was labelled "Held for staff" in the admin registry while the board's per-weekend control was also "Hold" and the stats bar counted the two separately. It is now **"Staff housing"**, so a permanent role and a per-weekend write-in stop sharing one word.
- **Named, not fixed.** **"Occupant" already means *a placed family*** across `MapUnitPopover` and `LodgingUnitCard` (the "occupant well", `slotOccupancy`). The new column inherits that collision. Not renamed here — it would touch far more than this item — but the next reader deserves to know.

### The inherited landmine

#2093's forest open-tint built its "no write-in" conjunct against the **proxy** `unit.family_available_override === false`, inline, under the name `held`. It now reads `writeInOccupant(unit) === null`, so the tint is keyed on the fact rather than on a spelling — and it is gated on the **occupant signal**, never on the name being filled in, because a write-in nobody named still closes the room. Three tests pin it, one mutation-checked.

### Deliberately NOT done

- **No drop-block work.** Already shipped: `dragPlacement.ts:222` and `LodgingUnitCard.tsx` (`useDroppable`'s `disabled`) already refuse drags onto a written-into unit. Re-derived against `main` @ `126a7287`; nothing re-implemented.
- **`MapUnitPopover.tsx` untouched.** It reads `reservationBadge()` and inherited the new word for free — verified by its own tests failing on the old string and passing on the new one. No string duplicated.
- **`FamilyCard.tsx` untouched** (owned by a sibling change). `WriteInCard` restates `CARD_FRAME` and a source-reading test asserts the two are byte-identical, so the copy is loud rather than silent.
- **No `data-family-card`** on the write-in card — board code queries that selector to find *placed* parties.
- **No fourth signal channel.** Dim = refusal, hatch = advisory misfit, forest tint = open and available. This adds none and takes none.

## Verification

All exit codes read, not inferred.

```
uv run ruff check .                                    exit=0   All checks passed
uv run mypy .                                          exit=0   816 source files
uv run pytest tests/unit -q                            exit=0   6073 passed, 14 skipped
frontend: tsc --noEmit                                 exit=0
frontend: vitest run (full suite)                      exit=0   444 files, 6700 tests
frontend: eslint (touched dirs)                        exit=0   0 errors (23 pre-existing warnings)
frontend: prettier --check src/                        exit=0
pocketbase: go build ./...                             exit=0
pocketbase: go test ./...                              exit=0   all packages ok
pocketbase: golangci-lint run ./...                    exit=0   0 issues
pocketbase: npm run lint (pb-js-lint)                  exit=0
shellcheck scripts/dev/verify-availability-writein-backfill.sh   exit=0
scripts/dev/verify-lodging-schema.sh                   exit=0   108 js migrations applied
scripts/dev/verify-availability-writein-backfill.sh    exit=0   109 js migrations applied
pre-push hooks (ruff, mypy, pb-js-lint, shellcheck,
  api-types-freshness, type-check, pytest)             exit=0   6272 passed
```

**A green Go suite never proves the PocketBase binary boots**, so the migration is verified by two real boots. `verify-availability-writein-backfill.sh` (new) boots *without* 148 to get a pre-migration table, seeds synthetic rows, boots again *with* it, and asserts what happened to each row — then boots a third time against a byte-for-byte copy of the migration under a later filename (PocketBase keys `_migrations` on filename) to prove the statements are a no-op on a second run. Copying the file rather than re-typing the SQL is the point: a duplicated query in the script would still pass with the migration's guards deleted.

### Mutation checks

| What was broken | Result |
|---|---|
| Dropped `occupant_name = ''` from the migration's statement 1 | verify script **exit=1** — re-run clobbered a written-in name |
| `writeInOccupant`: `!== false` → truthiness | **1 failed** |
| Dropped `writeIn === null` from the open-tint conjunct | **2 failed** |
| `wholesaleWriteIn` → `false` | **1 failed** |
| `WriteInCard`: altered frame + added `data-family-card` | **2 failed** |
| Stats bar `write-ins` → `held` | **1 failed** |
| Toast: `occupantName.trim()` → a literal | **2 failed** |

All restored and re-run green afterwards.

## Privacy

Every fixture is **built, never dumped**. No production or development `lodging_availability` value was read into this branch — the fictional set only (Emma Johnson, Liam Garcia). The migration's backfill is a **predicate**, never a list, so it names nobody; `verify-no-hardcoded-lodging.sh` passes.

Closes #2078.
