### PR TITLE
feat(frontend): order the housing board's spaces by the Manage screen's rank

### DIFF
--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -145,6 +145,11 @@ class LodgingUnitSummary(BaseModel):
     name: str
     area_code: str = ""
     area_name: str = ""
+    # The Manage screen's area rank (kindred#2076), read straight off
+    # `lodging_areas.sort_order` -- the board keys its area order off this,
+    # not off the area name. 0 for a unit with no expanded area, same
+    # treatment `area_code`/`area_name` already give that case.
+    area_sort_order: int = 0
     # None means UNKNOWN. PocketBase stores an unset number as 0, so the
     # service maps 0 -> None here; never render "sleeps 0".
     sleeps: int | None = None

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -1256,6 +1256,7 @@ class LodgingRosterService:
                     name=_s(unit, "name"),
                     area_code=_s(area, "code") if area is not None else "",
                     area_name=_s(area, "name") if area is not None else "",
+                    area_sort_order=_i(area, "sort_order") if area is not None else 0,
                     sleeps=unit_capacity(_i(unit, "sleeps")),
                     # The units INVENTORY evaluates each unit as its own
                     # one-element slot, so a room that only clears the

--- a/frontend/src/components/weekend/boardLayout.test.ts
+++ b/frontend/src/components/weekend/boardLayout.test.ts
@@ -35,6 +35,7 @@ function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
     name: 'Cedar 1',
     area_code: 'CG',
     area_name: 'Cedar Grove',
+    area_sort_order: 0,
     sleeps: 5,
     bathroom: 'shared',
     bathroom_group: '',
@@ -979,6 +980,111 @@ describe('buildBoard — area grouping and colour', () => {
     )
     expect(board.areas.map((area) => area.name)).toEqual(['Cedar Grove', 'North Ridge'])
     expect(board.areas[0]?.slots).toHaveLength(2)
+  })
+
+  it('orders areas by the Manage screen rank, NOT alphabetically (kindred#2076)', () => {
+    // Alphabetically "Cedar Grove" < "North Ridge", but the Manage screen's
+    // rank puts North Ridge first -- the board must follow the rank, not
+    // the name.
+    const board = buildBoard(
+      [],
+      [
+        unit({ area_code: 'CG', area_name: 'Cedar Grove', area_sort_order: 9 }),
+        unit({
+          unit_id: 'u2',
+          code: 'ridge-1',
+          name: 'Ridge 1',
+          area_code: 'NR',
+          area_name: 'North Ridge',
+          area_sort_order: 1,
+        }),
+      ]
+    )
+    expect(board.areas.map((area) => area.name)).toEqual(['North Ridge', 'Cedar Grove'])
+  })
+
+  it('breaks a tied (or missing) area rank by name, deterministically', () => {
+    // Two areas with the SAME rank -- kindred#2076's reorder script is
+    // documented non-atomic, so a mid-loop failure can leave two areas
+    // sharing a rank. 0 counts as "no rank" and is a tie too.
+    const board = buildBoard(
+      [],
+      [
+        unit({
+          unit_id: 'u1',
+          code: 'bend-1',
+          name: 'Bend 1',
+          area_code: 'RB',
+          area_name: 'River Bend',
+          area_sort_order: 5,
+        }),
+        unit({
+          unit_id: 'u2',
+          code: 'ridge-1',
+          name: 'Ridge 1',
+          area_code: 'NR',
+          area_name: 'North Ridge',
+          area_sort_order: 5,
+        }),
+        unit({
+          unit_id: 'u3',
+          code: 'cedar-1',
+          name: 'Cedar 1',
+          area_code: 'CG',
+          area_name: 'Cedar Grove',
+          area_sort_order: 0,
+        }),
+        unit({
+          unit_id: 'u4',
+          code: 'aspen-1',
+          name: 'Aspen 1',
+          area_code: 'AS',
+          area_name: 'Aspen',
+          area_sort_order: 0,
+        }),
+      ]
+    )
+    // Rank 5 pair breaks to name (North Ridge < River Bend); the two
+    // rank-0 areas break to name too (Aspen < Cedar Grove) and, because 0 is
+    // the lowest rank present, sort ahead of the ranked pair.
+    expect(board.areas.map((area) => area.name)).toEqual([
+      'Aspen',
+      'Cedar Grove',
+      'North Ridge',
+      'River Bend',
+    ])
+  })
+
+  it('never reorders the units WITHIN an area — only the area order changes', () => {
+    // The payload already arrives unit-alphabetical within an area (the
+    // repository's own query sorts `area.sort_order,name`); `buildBoard`
+    // must not second-guess that order once an area's rank moves it. Here
+    // the two units are handed in already-alphabetical order inside an area
+    // that the rank reorder moves to the FRONT of the board, and they must
+    // stay in that same relative order.
+    const board = buildBoard(
+      [],
+      [
+        unit({
+          area_code: 'NR',
+          area_name: 'North Ridge',
+          area_sort_order: 1,
+          code: 'ridge-1',
+          name: 'Ridge 1',
+        }),
+        unit({
+          unit_id: 'u2',
+          area_code: 'NR',
+          area_name: 'North Ridge',
+          area_sort_order: 1,
+          code: 'ridge-2',
+          name: 'Ridge 2',
+        }),
+        unit({ unit_id: 'u3', area_code: 'CG', area_name: 'Cedar Grove', area_sort_order: 9 }),
+      ]
+    )
+    expect(board.areas.map((area) => area.name)).toEqual(['North Ridge', 'Cedar Grove'])
+    expect(board.areas[0]?.slots.map((slot) => slot.unit.code)).toEqual(['ridge-1', 'ridge-2'])
   })
 
   it('keeps two areas apart when they share a blank code but not a name', () => {

--- a/frontend/src/components/weekend/boardLayout.ts
+++ b/frontend/src/components/weekend/boardLayout.ts
@@ -512,6 +512,15 @@ function areaName(unit: LodgingUnitRow): string {
 }
 
 /**
+ * The Manage screen's area rank (kindred#2076) — `lodging_areas.sort_order`,
+ * carried through on every unit in the area. 0 for a unit with no expanded
+ * area, the same value an unranked area's `sort_order` reads as.
+ */
+function areaSortOrder(unit: LodgingUnitRow): number {
+  return unit.area_sort_order ?? 0
+}
+
+/**
  * Which of these parties share an occupied LEAF code with at least one
  * OTHER party in the list — keyed by `partyKey`, the project's one stable
  * identity for a roster party.
@@ -862,7 +871,10 @@ export function buildBoard(parties: RosterPartyRow[], units: LodgingUnitRow[]): 
   // `partyKeys` rather than a running total: a family holding four rooms sits
   // on four slots, and the header says "families", not cards. Counting the
   // slot entries would report four families standing where one is.
-  const buckets = new Map<string, { name: string; slots: BoardSlot[]; partyKeys: Set<string> }>()
+  const buckets = new Map<
+    string,
+    { name: string; sortOrder: number; slots: BoardSlot[]; partyKeys: Set<string> }
+  >()
   let flaggedCount = 0
   for (const unit of drawn) {
     const slotParties = partiesByCode.get(unit.code) ?? []
@@ -872,21 +884,36 @@ export function buildBoard(parties: RosterPartyRow[], units: LodgingUnitRow[]): 
     const key = areaKey(unit)
     const bucket = buckets.get(key) ?? {
       name: areaName(unit),
+      sortOrder: areaSortOrder(unit),
       slots: [],
       partyKeys: new Set<string>(),
     }
+    // Units are pushed in the PAYLOAD's order and never re-sorted here — the
+    // repository's own query already sorts `area.sort_order,name`, so a
+    // unit's position within its area stays alphabetical without this
+    // function touching it (owner ruling, kindred#2076: "intra unit remains
+    // alpha"). Only which AREA a unit's slot lands in, and where that area
+    // falls below, changes.
     bucket.slots.push({ unit, parties: slotParties, consent })
     for (const slotParty of slotParties) bucket.partyKeys.add(partyKey(slotParty))
     buckets.set(key, bucket)
   }
 
-  // Sorted so a hue is stable for an area regardless of the payload's unit
-  // order — the map (Step 6) and the board must agree about which area is
-  // which colour, and both read this.
+  // Ordered by the Manage screen's area rank (kindred#2076) — the board
+  // must key off the SAME order staff set there (`LodgingAreasDrawer`'s
+  // reorder), not off the area name. Areas tied on rank, including two
+  // areas that both carry no rank (0), fall back to the name so the order
+  // is always fully determined — never left depending on payload order.
+  // The hue assignment below rides this same order; the owner has ruled the
+  // resulting recolour on a reorder is expected and not to be protected
+  // against (area colour carries no meaning staff read).
   const orderedKeys = [...buckets.keys()].sort((a, b) => {
-    const left = buckets.get(a)?.name ?? ''
-    const right = buckets.get(b)?.name ?? ''
-    return left.localeCompare(right)
+    const left = buckets.get(a)
+    const right = buckets.get(b)
+    const leftOrder = left?.sortOrder ?? 0
+    const rightOrder = right?.sortOrder ?? 0
+    if (leftOrder !== rightOrder) return leftOrder - rightOrder
+    return (left?.name ?? '').localeCompare(right?.name ?? '')
   })
 
   const areas: BoardArea[] = orderedKeys.map((key, index) => {

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -2122,6 +2122,10 @@ export type LodgingUnitSummary = {
    */
   area_name?: string
   /**
+   * Area Sort Order
+   */
+  area_sort_order?: number
+  /**
    * Sleeps
    */
   sleeps?: number | null

--- a/frontend/src/types/lodging.test.ts
+++ b/frontend/src/types/lodging.test.ts
@@ -181,6 +181,10 @@ const _exhaustiveLodgingUnit: Required<LodgingUnitRow> = {
   name: 'Ridge 1',
   area_code: 'RIDGE',
   area_name: 'Ridge Side',
+  // kindred#2076: the Manage screen's area rank, read off
+  // `lodging_areas.sort_order`. The board sorts its areas by this instead of
+  // the area name.
+  area_sort_order: 3,
   sleeps: 5,
   bathroom: 'shared',
   bathroom_group: '',

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -60,6 +60,10 @@ def _unit(
     parent_unit: str = "",
     shareability: str = "",
     has_power: bool = False,
+    # False builds the default RIDGE area (honouring `area_sort_order`); True
+    # resolves the expanded `area` relation to None -- the missing-area case.
+    area_missing: bool = False,
+    area_sort_order: int = 1,
 ) -> SimpleNamespace:
     return _rec(
         id=pb_id,
@@ -84,7 +88,7 @@ def _unit(
         # Blank by default: the migration leaves an unclassifiable row empty
         # rather than guessing, so "" is a state the service really sees.
         shareability=shareability,
-        expand={"area": _rec(code="RIDGE", name="Ridge Side", sort_order=1)},
+        expand={"area": None if area_missing else _rec(code="RIDGE", name="Ridge Side", sort_order=area_sort_order)},
     )
 
 
@@ -907,6 +911,39 @@ class TestUnitsAndCounts:
 
         assert roster.units[0].map_x is None
         assert roster.units[0].map_y is None
+
+    @pytest.mark.asyncio
+    async def test_area_sort_order_travels_from_the_expanded_area_to_the_summary(self) -> None:
+        """kindred#2076: the board keys area order off the Manage screen's
+        rank, which lives on the expanded `area.sort_order` column. It never
+        reached the payload before this -- see `LodgingUnitSummary`.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("u1", "ridge-a", "Ridge A", area_sort_order=7),
+                _unit("u2", "cedar-a", "Cedar A", area_sort_order=2),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        by_code = {u.code: u for u in roster.units}
+        assert by_code["ridge-a"].area_sort_order == 7
+        assert by_code["cedar-a"].area_sort_order == 2
+
+    @pytest.mark.asyncio
+    async def test_a_unit_with_no_expanded_area_reports_zero_sort_order(self) -> None:
+        """No `area` relation resolves (a dangling or unset link) means the
+        service has nothing to rank by -- 0, the schema default, same
+        treatment `area_code`/`area_name` already give a missing area.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[_unit("u1", "ridge-a", "Ridge A", area_missing=True)],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.units[0].area_sort_order == 0
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(


### PR DESCRIPTION
## What changed

The weekend lodging board sorted its area sections alphabetically by name
(`boardLayout.ts`'s `orderedKeys` comparator). That never matched the order
staff set through the admin Manage screen's areas drawer
(`LodgingAreasDrawer`, backed by `lodging_areas.sort_order`) — staff
cross-read the board against the master housing sheet, and a mismatched
order turned every lookup into a search. Per the owner ruling on #2076, this
is a code-only fix: the production data write (reordering the ten areas
through the Manage screen) is already done.

- `LodgingUnitSummary` (`api/schemas/lodging.py`) gains `area_sort_order:
  int = 0`, the Manage screen's rank for the unit's area.
- `LodgingRosterService._build_units` (`api/services/lodging_roster_service.py`)
  populates it from the expanded `area.sort_order` column (0 when a unit has
  no area — the same fallback `area_code`/`area_name` already use).
- `boardLayout.ts`'s area comparator now sorts by `area_sort_order` instead
  of `area.name`. Two areas tied on rank — including two areas that both
  carry no rank (0), which can happen because `reorderLodgingAreas` is
  documented non-atomic — fall back to name, so the order is always fully
  determined and never left depending on payload order.
- Units keep their existing order **within** an area: only which area a
  slot lands in, and where that area falls in the board, changes. Pinned
  with a test that hands two units to `buildBoard` already in alphabetical
  order, inside an area the rank reorder moves to the front, and confirms
  they stay in that same relative order.
- The area hue is intentionally left alone — it still rides the same
  ordered-key iteration, so a reorder recolours every area. The owner has
  ruled the colours arbitrary and not worth protecting (see the retraction
  banner on #2076).
- Regenerated `types.gen.ts` (whitespace-clean, `git diff -w` shows only the
  new field) and updated both `Required<>` exhaustive fixtures
  (`frontend/src/types/lodging.test.ts` and the roster service's own area
  test fixture) that the field add breaks by design.

## Also closes

Staff feedback item `adamflagg/kindred-feedback#84` — mentioned for context
only; no cross-repo `Closes` line since it would not register there.

## Verification (all commands run from the worktree root; every exit code read)

- `uv run ruff check .` — exit 0
- `uv run mypy .` — exit 0 (816 source files)
- `uv run pytest tests/unit/api/services/test_lodging_roster_service.py tests/unit/api/test_lodging_roster_units.py` — 185 passed, exit 0
- `uv run pytest tests/unit/api -k lodging` — 507 passed, exit 0
- `cd frontend && ./node_modules/.bin/tsc --noEmit` — exit 0
- `cd frontend && ./node_modules/.bin/vitest run src/components/weekend/ src/types/lodging.test.ts` — 1102 passed across 40 files, exit 0
- `cd frontend && ./node_modules/.bin/prettier --check` on touched files — clean
- `cd frontend && ./node_modules/.bin/eslint` on touched files — clean
- Pre-push hook (ruff-check, mypy, api-types-freshness, tsc, full `pytest`) — all green, 6276 passed / 41 skipped

### Mutation checks (both reverted, confirmed RED, restored)
- Python: temporarily removed the `area_sort_order=...` line from
  `_build_units` — `test_area_sort_order_travels_from_the_expanded_area_to_the_summary`
  went RED (`assert 0 == 7`), the missing-area test stayed green as expected.
  Restored, both green.
- Frontend: temporarily reverted the area comparator to the old
  `left.localeCompare(right)` on name — the new rank-order test and the
  new within-area-order test both went RED. Restored, all 88 tests in
  `boardLayout.test.ts` green.

## Deliberately not done

- No production data write and no seed migration — the ten `lodging_areas`
  ranks are already correct in prod per the owner's Manage-screen edit.
- No stable-colour mechanism for the area hues. The owner ruled the area
  colours arbitrary; reordering recolouring every area is expected.
- No per-unit `sort_order` column — the owner settled on zone-level
  ordering only (#2076's original resolution), and this PR does not
  revisit that.

Closes #2076.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lodging area display rankings to unit data.
  * Weekend boards now order areas by their configured rank, with alphabetical ordering for ties or missing ranks.
  * Preserved the existing order of units within each area.
* **Bug Fixes**
  * Areas without ranking information now receive a consistent default order.
  * Area color assignments now follow the updated area ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->