### PR TITLE
feat(frontend): extend the whole-building marker to the map (#2174)

### DIFF
--- a/frontend/src/components/weekend/LodgingMap.test.tsx
+++ b/frontend/src/components/weekend/LodgingMap.test.tsx
@@ -1158,3 +1158,64 @@ describe('LodgingMap — no placement scaffolding (kindred#2183)', () => {
     expect(screen.getByRole('checkbox', { name: /Empty rooms/i })).toBeInTheDocument()
   })
 })
+
+describe('LodgingMap — extends the whole-building marker to the popover (kindred#2174)', () => {
+  // A halved house, same shape as `LodgingUnitCard.test.tsx`'s own fixture:
+  // `up-r1`/`up-r2` share the `upstairs` parent, so together they ARE a
+  // building under the immediate-parent grain ruled on #2008. Positioned far
+  // apart so each keeps its OWN mark rather than proximity-clustering into
+  // one — this is testing that `LodgingMap` computes `wholeBuildingHolders`
+  // over the FULL registry and threads it down, not the cluster-summary
+  // rendering itself (that is `MapUnitPopover.test.tsx`'s job).
+  const halvedHouseUnits = [
+    unit({ unit_id: 'up', code: 'upstairs', name: 'Upstairs', is_container: true }),
+    unit({
+      unit_id: 'r1',
+      code: 'up-r1',
+      name: 'Up Back',
+      parent_code: 'upstairs',
+      map_x: 0.1,
+      map_y: 0.1,
+    }),
+    unit({
+      unit_id: 'r2',
+      code: 'up-r2',
+      name: 'Up Front',
+      parent_code: 'upstairs',
+      map_x: 0.9,
+      map_y: 0.9,
+    }),
+  ]
+  const holder = party({
+    display_name: 'Johnson',
+    unit_code: 'up-r1',
+    unit_name: 'Up Back',
+    unit_codes: ['up-r1', 'up-r2'],
+  })
+
+  it('badges the room of a party whose placement covers the whole building', async () => {
+    // Which mark is `up-r1` vs `up-r2` is not asserted — `holder` occupies
+    // BOTH, so whichever the click opens shows the same party and the same
+    // badge. What this pins is that `LodgingMap` computed
+    // `wholeBuildingHolders` over the FULL registry and threaded it down;
+    // `MapUnitPopover.test.tsx` already pins the badge's own render rules.
+    render(<LodgingMap parties={[holder]} units={halvedHouseUnits} year={2026} />, { wrapper })
+    await userEvent.click(screen.getAllByTestId('map-mark')[0] as HTMLElement)
+    expect(screen.getByText('Whole building')).toBeInTheDocument()
+  })
+
+  it('does not badge a party holding only one room of the pair', async () => {
+    const oneRoom = party({
+      display_name: 'Garcia',
+      household_cm_id: 9002,
+      unit_code: 'up-r1',
+      unit_name: 'Up Back',
+      unit_codes: ['up-r1'],
+    })
+    render(<LodgingMap parties={[oneRoom]} units={halvedHouseUnits} year={2026} />, { wrapper })
+    await userEvent.click(screen.getAllByTestId('map-mark')[0] as HTMLElement)
+    expect(screen.queryByText('Whole building')).not.toBeInTheDocument()
+    await userEvent.click(screen.getAllByTestId('map-mark')[1] as HTMLElement)
+    expect(screen.queryByText('Whole building')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/weekend/LodgingMap.tsx
+++ b/frontend/src/components/weekend/LodgingMap.tsx
@@ -56,6 +56,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useDismissOnDeadSpace } from '../../hooks/useDismissOnDeadSpace'
 import { usePanelParty } from '../../hooks/usePanelParty'
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+import { wholeBuildingHolders } from './boardLayout'
 import { FamilyCard } from './FamilyCard'
 import { FamilyDetailsPanel } from './FamilyDetailsPanel'
 import { FloatingUnplacedBadge } from './FloatingUnplacedBadge'
@@ -126,6 +127,14 @@ export function LodgingMap({ parties, units, year, sessionCmId = 0 }: LodgingMap
   // pointermove, and an unmemoised call would re-run buildBoard — area bucketing,
   // sorting, hue assignment, the lot — on every frame of a drag.
   const model = useMemo(() => buildMapModel(parties, units), [parties, units])
+  // kindred#2174: the board's own placement fact (kindred#2008), extended to
+  // the map. Computed here rather than inside `buildMapModel` or the popover
+  // itself — `MapUnitPopover` only ever sees a cluster's own members
+  // (`MapUnit[]`), not the full registry `wholeBuildingHolders` needs, and
+  // `LodgingMap` already holds both `parties` and `units` as props. Read
+  // against each party's OWN occupied leaves, so a combined card split
+  // between two disjoint-room households marks neither of them.
+  const wholeBuildingKeys = useMemo(() => wholeBuildingHolders(parties, units), [parties, units])
 
   const canvasRef = useRef<HTMLDivElement>(null)
   const dragRef = useRef<{
@@ -690,6 +699,7 @@ export function LodgingMap({ parties, units, year, sessionCmId = 0 }: LodgingMap
                   units={openCluster.members.map((member) => member.item)}
                   hue={openCluster.members[0]?.item.hue ?? ''}
                   onOpenParty={openParty}
+                  wholeBuildingKeys={wholeBuildingKeys}
                 />
               </div>
             )}

--- a/frontend/src/components/weekend/MapUnitPopover.test.tsx
+++ b/frontend/src/components/weekend/MapUnitPopover.test.tsx
@@ -8,6 +8,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
 import type { MapUnit } from './mapModel'
 import { MapUnitPopover } from './MapUnitPopover'
+import { partyKey } from './partyKey'
 
 function row(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
   return {
@@ -837,5 +838,110 @@ describe('MapUnitPopover — a container, master-detail (kindred#2183)', () => {
     )
     expect(screen.getByText('9')).toBeInTheDocument()
     expect(screen.queryByText('1')).not.toBeInTheDocument()
+  })
+})
+
+describe('MapUnitPopover — the whole-building marker, extended from the board (kindred#2174)', () => {
+  // `wholeBuildingKeys` is computed by `LodgingMap` from the full registry
+  // (`wholeBuildingHolders(parties, units)`, kindred#2008) and handed down as
+  // one prop — this popover never re-derives the grain from its own `units`,
+  // which is only a cluster's members and cannot answer the question alone.
+
+  it('badges the DetailCard tags row when the room’s occupant holds the whole building', () => {
+    const johnson = party('Johnson')
+    render(
+      <MapUnitPopover
+        units={[mapUnit(row(), [johnson])]}
+        hue={HUE}
+        onOpenParty={vi.fn()}
+        wholeBuildingKeys={new Set([partyKey(johnson)])}
+      />
+    )
+    expect(screen.getByText('Whole building')).toBeInTheDocument()
+  })
+
+  it('does not badge an ordinary room, with no `wholeBuildingKeys` supplied at all', () => {
+    render(
+      <MapUnitPopover
+        units={[mapUnit(row(), [party('Johnson')])]}
+        hue={HUE}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.queryByText('Whole building')).not.toBeInTheDocument()
+  })
+
+  it('does not badge a room whose occupant is not in the holder set', () => {
+    const johnson = party('Johnson')
+    render(
+      <MapUnitPopover
+        units={[mapUnit(row(), [johnson])]}
+        hue={HUE}
+        onOpenParty={vi.fn()}
+        // A DIFFERENT party's key — the set is non-empty but doesn't name this one.
+        wholeBuildingKeys={new Set(['household-9999'])}
+      />
+    )
+    expect(screen.queryByText('Whole building')).not.toBeInTheDocument()
+  })
+
+  it('badges the ClusterSummary chip for the family that holds the whole building, and not the other', () => {
+    const johnson = party('Johnson')
+    johnson.household_cm_id = 9001
+    const garcia = party('Garcia')
+    garcia.household_cm_id = 9002
+    const house = [
+      mapUnit(row({ unit_id: 'u1', code: 'cedar-back', name: 'Cedar Lodge Back', sleeps: 2 }), [
+        johnson,
+      ]),
+      mapUnit(row({ unit_id: 'u2', code: 'cedar-loft', name: 'Cedar Lodge Loft', sleeps: 2 }), [
+        garcia,
+      ]),
+    ]
+    render(
+      <MapUnitPopover
+        units={house}
+        hue={HUE}
+        onOpenParty={vi.fn()}
+        wholeBuildingKeys={new Set([partyKey(johnson)])}
+      />
+    )
+    const chips = screen.getAllByTestId('map-popover-family')
+    const johnsonChip = chips.find((node) => node.textContent.includes('Johnson'))
+    const garciaChip = chips.find((node) => node.textContent.includes('Garcia'))
+    if (!johnsonChip || !garciaChip) throw new Error('expected both family chips')
+    expect(johnsonChip.textContent).toContain('Whole building')
+    expect(garciaChip.textContent).not.toContain('Whole building')
+  })
+
+  it('renders the whole-building badge and a write-in badge together, legibly', () => {
+    // #2078 added the write-in badge (via `reservationBadge`, unit-level, in
+    // the DetailCard's status list) after this issue was filed. It is
+    // orthogonal to `wholeBuildingKeys` (party-keyed) — a room can carry both
+    // — and the two must render as two distinct, readable badges, not collide
+    // into one string.
+    const johnson = party('Johnson')
+    render(
+      <MapUnitPopover
+        units={[
+          mapUnit(
+            row({
+              family_available_override: false,
+              occupant_name: 'Emma Johnson',
+              is_family_available: false,
+            }),
+            [johnson]
+          ),
+        ]}
+        hue={HUE}
+        onOpenParty={vi.fn()}
+        wholeBuildingKeys={new Set([partyKey(johnson)])}
+      />
+    )
+    const writeIn = screen.getByText('Write-in')
+    const wholeBuilding = screen.getByText('Whole building')
+    expect(writeIn).toBeInTheDocument()
+    expect(wholeBuilding).toBeInTheDocument()
+    expect(writeIn).not.toBe(wholeBuilding)
   })
 })

--- a/frontend/src/components/weekend/MapUnitPopover.tsx
+++ b/frontend/src/components/weekend/MapUnitPopover.tsx
@@ -20,7 +20,7 @@
  * `sleeps: null` is UNKNOWN and says so. "Sleeps 0" would be a lie about a
  * cabin nobody has measured.
  */
-import { Accessibility, Bath, Plug, Refrigerator, Snowflake } from 'lucide-react'
+import { Accessibility, Bath, Home, Plug, Refrigerator, Snowflake } from 'lucide-react'
 import { type ReactNode, useState } from 'react'
 
 import type { RosterPartyRow } from '../../types/lodging'
@@ -53,6 +53,41 @@ export interface MapUnitPopoverProps {
   units: MapUnit[]
   hue: string
   onOpenParty: (party: RosterPartyRow) => void
+  /**
+   * Party keys holding an entire building this weekend (kindred#2008's
+   * placement marker, extended to the map by kindred#2174). Computed by
+   * `LodgingMap` from `boardLayout.ts`'s `wholeBuildingHolders(parties,
+   * units)` — the full registry, which this popover never receives — and
+   * handed down as one `Set`. Never re-derived here: this popover's own
+   * `units` prop is only a cluster's members, and cannot answer the question
+   * alone (see `MapUnitPopoverProps.units`'s own doc).
+   *
+   * Optional and defaulting to empty so the ~50 existing call sites that
+   * predate this prop keep compiling and keep meaning "nobody holds a whole
+   * building here" rather than needing a threaded-through empty set.
+   */
+  wholeBuildingKeys?: Set<string>
+}
+
+/** Referentially stable so an omitted `wholeBuildingKeys` never re-triggers
+ *  a memoised child on every render. */
+const NO_WHOLE_BUILDING_HOLDERS: Set<string> = new Set()
+
+/**
+ * The board's own "Whole building" chip (`FamilyCard.tsx`'s `Chip` with
+ * `tone="building"`), reproduced rather than imported: that `Chip` is local
+ * to `FamilyCard.tsx` and not exported, and exporting it is a `FamilyCard.tsx`
+ * change outside this fix's scope. Same label, same indigo tokens, same
+ * `Home` icon, so the fact reads identically on both surfaces — mirroring the
+ * board's vocabulary, not inventing a second one for it.
+ */
+function WholeBuildingBadge() {
+  return (
+    <span className="inline-flex items-center gap-0.5 rounded-full bg-indigo-100 px-1.5 py-0.5 text-[10px] font-semibold whitespace-nowrap text-indigo-800 dark:bg-indigo-950/50 dark:text-indigo-300">
+      <Home className="h-2.5 w-2.5 flex-shrink-0" aria-hidden="true" />
+      Whole building
+    </span>
+  )
 }
 
 /**
@@ -129,9 +164,10 @@ interface DetailCardProps {
   entry: MapUnit
   hue: string
   onOpenParty: (party: RosterPartyRow) => void
+  wholeBuildingKeys: Set<string>
 }
 
-function DetailCard({ entry, hue, onOpenParty }: DetailCardProps) {
+function DetailCard({ entry, hue, onOpenParty, wholeBuildingKeys }: DetailCardProps) {
   const { unit, parties, consent, capacity } = entry
   // `capacity`, NOT `unit.sleeps` (kindred#2183). They are the same number for
   // every ordinary room, and different for the one case this card could not
@@ -163,6 +199,11 @@ function DetailCard({ entry, hue, onOpenParty }: DetailCardProps) {
   // drift"). Rendered through the shared helper, never re-derived, so the
   // wording and the silence on `single_party` match the board exactly.
   const sharing = shareabilityBadge(unit)
+  // ANY occupant, not the first: a shared room's second party could not
+  // itself hold the whole building (holding every leaf leaves no room for
+  // another household), but checking `some` rather than assuming
+  // `parties[0]` keeps this from silently depending on array order.
+  const holdsWholeBuilding = parties.some((party) => wholeBuildingKeys.has(partyKey(party)))
 
   return (
     <div className="flex min-w-[11rem] flex-col gap-1.5">
@@ -250,8 +291,18 @@ function DetailCard({ entry, hue, onOpenParty }: DetailCardProps) {
           </span>
         </div>
       )}
-      {tags.length > 0 && (
+      {(tags.length > 0 || holdsWholeBuilding) && (
         <ul className="flex flex-wrap gap-1">
+          {/* Its own indigo/`Home` token, not pushed into `tags` above: those
+              render as hue-coloured pills, which would put this fact in a
+              SECOND visual language from the board's own indigo chip for the
+              same fact — exactly what kindred#2174 rules out. Same tags ROW,
+              different token, on purpose. */}
+          {holdsWholeBuilding && (
+            <li>
+              <WholeBuildingBadge />
+            </li>
+          )}
           {tags.map((tag) => (
             <li
               key={tag}
@@ -363,6 +414,7 @@ interface ClusterSummaryProps {
   /** The building name the cells share, or '' for a cluster of unrelated cabins. */
   prefix: string
   onOpenParty: (party: RosterPartyRow) => void
+  wholeBuildingKeys: Set<string>
 }
 
 /**
@@ -375,7 +427,13 @@ interface ClusterSummaryProps {
  * fields exist for exactly this reason and are computed in `buildMapModel`,
  * which is the only place with the registry needed to walk a house's rooms.
  */
-function ClusterSummary({ units, hue, prefix, onOpenParty }: ClusterSummaryProps) {
+function ClusterSummary({
+  units,
+  hue,
+  prefix,
+  onOpenParty,
+  wholeBuildingKeys,
+}: ClusterSummaryProps) {
   const rooms = units.reduce((total, entry) => total + entry.roomCount, 0)
   // A drawn unit is taken as a WHOLE: a family holding a combined house holds
   // every room in it, which is what "combined" means.
@@ -440,8 +498,14 @@ function ClusterSummary({ units, hue, prefix, onOpenParty }: ClusterSummaryProps
                   style={{ borderColor: notConsented ? CONSENT_AMBER : hue }}
                   className="bg-card hover:bg-muted/60 flex w-full flex-col items-start gap-0.5 rounded-md border px-1.5 py-1 text-left"
                 >
-                  <span className="text-foreground text-[11px] font-semibold">
-                    {partyPeopleLabel(party)}
+                  <span className="flex items-center gap-1">
+                    <span className="text-foreground text-[11px] font-semibold">
+                      {partyPeopleLabel(party)}
+                    </span>
+                    {/* kindred#2174: the same fact as the DetailCard's tags-row
+                        badge, on the OTHER surface the ruling named — this
+                        family's chip, not the cluster mark or a new ring. */}
+                    {wholeBuildingKeys.has(partyKey(party)) && <WholeBuildingBadge />}
                   </span>
                   {/* SAID IN WORDS. The amber border alone would be colour as
                       the sole signal (WCAG 1.4.1), and this chip is the only
@@ -606,7 +670,12 @@ function FootprintGrid({
   )
 }
 
-export function MapUnitPopover({ units, hue, onOpenParty }: MapUnitPopoverProps) {
+export function MapUnitPopover({
+  units,
+  hue,
+  onOpenParty,
+  wholeBuildingKeys = NO_WHOLE_BUILDING_HOLDERS,
+}: MapUnitPopoverProps) {
   // LOCAL and nothing leaves the popover: which room of a container is being
   // read is not a fact the map, the board or the URL has any use for.
   const [pickedUnitId, setPickedUnitId] = useState<string | null>(null)
@@ -638,11 +707,22 @@ export function MapUnitPopover({ units, hue, onOpenParty }: MapUnitPopoverProps)
       className="bg-card shadow-lodge-sm max-w-[15rem] rounded-xl border-2 p-2"
     >
       {units.length === 1 && lone ? (
-        <DetailCard entry={lone} hue={hue} onOpenParty={onOpenParty} />
+        <DetailCard
+          entry={lone}
+          hue={hue}
+          onOpenParty={onOpenParty}
+          wholeBuildingKeys={wholeBuildingKeys}
+        />
       ) : (
         <div className="flex flex-col gap-2">
           {picked === null ? (
-            <ClusterSummary units={units} hue={hue} prefix={prefix} onOpenParty={onOpenParty} />
+            <ClusterSummary
+              units={units}
+              hue={hue}
+              prefix={prefix}
+              onOpenParty={onOpenParty}
+              wholeBuildingKeys={wholeBuildingKeys}
+            />
           ) : (
             <div className="flex flex-col gap-1.5">
               <button
@@ -654,7 +734,12 @@ export function MapUnitPopover({ units, hue, onOpenParty }: MapUnitPopoverProps)
               >
                 {prefix === '' ? '← All rooms' : `← All of ${prefix}`}
               </button>
-              <DetailCard entry={picked} hue={hue} onOpenParty={onOpenParty} />
+              <DetailCard
+                entry={picked}
+                hue={hue}
+                onOpenParty={onOpenParty}
+                wholeBuildingKeys={wholeBuildingKeys}
+              />
             </div>
           )}
           <FootprintGrid


### PR DESCRIPTION
## What

#2008 shipped the "whole building" placement marker on the roster board only (`FamilyCard`'s indigo `Home` chip, `LodgingUnitCard`'s per-slot computation). The map's `MapUnitPopover` carried no equivalent signal, so a household holding an entire building looked identical to any ordinary multi-room placement on the map.

Per the owner ruling on #2174, this adds a **badge in `MapUnitPopover`**, in the two places named:

1. **`DetailCard`'s tags row** — a room's own popover, badged when its occupying party is a whole-building holder.
2. **`ClusterSummary`'s family chip** — a cluster/building's master-detail popover, badged per family that holds the whole building.

The badge reproduces the board's own visual vocabulary (indigo tokens, `Home` icon, "Whole building" label) rather than pushing the fact into the existing hue-coloured `tags` pill list, which would have put the same fact in a second visual language. `FamilyCard`'s `Chip` component is private to that file and out of this fix's scope, so the badge is a small local component instead of a shared import.

**Explicitly does not** do either of the two options the ruling rejected:
- **No new `resolveRingPrecedence` tier** — that ladder is shared with the board, so a new tier would change board behaviour too.
- **No corner glyph on the cluster mark** — the map's mark represents a proximity *cluster*, which can span more than one building; a glyph asserting "whole building" on it would be a category error.

## Plumbing

`MapUnitPopover` only ever receives a cluster's own `MapUnit[]`, not the full registry `wholeBuildingHolders` needs. `LodgingMap` already holds both `parties` and `units` as props and renders `<MapUnitPopover>` itself, so it computes `wholeBuildingHolders(parties, units)` in a `useMemo` and passes the resulting `Set<string>` down as one new prop (`wholeBuildingKeys`, optional, defaulting to empty so the ~50 pre-existing `MapUnitPopover` test call sites keep compiling unchanged).

## Verification (run from `frontend/`)

- `./node_modules/.bin/vitest run src/components/weekend/MapUnitPopover.test.tsx src/components/weekend/LodgingMap.test.tsx` — **113 passed, exit 0**
- `./node_modules/.bin/vitest run src/components/weekend/` (full surface regression) — **1100 passed, 39 files, exit 0**
- `./node_modules/.bin/tsc --noEmit` — **exit 0**
- `./node_modules/.bin/eslint` on the four touched files — **exit 0, 0 errors** (4 pre-existing warnings remain in `LodgingMap.tsx`/`.test.tsx`, unrelated to this diff and unchanged by it — verified against `git stash`)
- `./node_modules/.bin/prettier --check` — **exit 0**

**TDD**: tests written first for `MapUnitPopover.test.tsx` and confirmed RED (exit 1, 3 of 5 new tests failing on the expected assertions) before any implementation. `LodgingMap.test.tsx`'s two new tests were added once the plumbing existed, so instead **mutation-checked**: broke the `DetailCard` occupant check, the `ClusterSummary` chip check, and the `LodgingMap → MapUnitPopover` prop threading in turn — each broke exactly the test written to pin it (confirmed by exit code), then restored.

## Deliberately not done

- Did not touch `LodgingUnitCard.tsx` — owned by a concurrent wave item.
- Did not export `FamilyCard`'s `Chip` component — that's a `FamilyCard.tsx` change outside this fix's scope; the badge is reproduced locally instead, matching its label/tokens/icon exactly.
- Did not cite or rely on the issue body's "fires rarely, 1-2 a weekend" estimate — it is explicitly flagged single-source and uncertified.

Closes #2174.