### PR TITLE
refactor(frontend): delete the household roster's per-row attention stripe

### DIFF
--- a/frontend/src/components/weekend/HouseholdRosterRow.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterRow.tsx
@@ -6,10 +6,12 @@
  * Adult weekends: individuals enrol directly, so the party is one person and
  * has no children.
  *
- * The left rail is the page's scanning spine. It is drawn ONLY for parties
- * that need something — a weekend that is fully placed and unconstrained shows
- * no rails at all, so the design tells the truth about the weekend's state
- * instead of decorating every row equally.
+ * Attention level (required a decision vs settled) is carried by the section
+ * heading in `HouseholdRosterTable`, not by this row — a per-row left-edge
+ * stripe used to repeat it here, but the stripe colour was CONSTANT within a
+ * section and so restated the heading the row was already sitting under
+ * (kindred#2072-rail). Deleted rather than kept for consistency's sake: a
+ * constant is not a signal.
  */
 import { Clock, Repeat, Star } from 'lucide-react'
 import { Fragment } from 'react'
@@ -60,15 +62,6 @@ const NO_FLAGS: AccessibilityFlags = {
   needs_accommodation: false,
   accommodation_is_mandatory: false,
   has_infant: false,
-}
-
-/** Settled parties get no rail — absence is the signal. */
-const RAIL: Record<AttentionLevel, string> = {
-  required: 'border-red-500',
-  unmet: 'border-red-500',
-  unplaced: 'border-amber-500',
-  unverified: 'border-sky-400 dark:border-sky-500',
-  settled: 'border-transparent',
 }
 
 const REASON_TONE: Record<AttentionLevel, string> = {
@@ -125,7 +118,7 @@ export function HouseholdRosterRow({ party, showRequests, unit, onOpen }: Househ
     // and still satisfies `clickoutsidePredicate`'s `isInteractive` check
     // (`button` is already in its selector list).
     <tr className="border-border/40 border-b align-top">
-      <td className={`border-l-[3px] ${RAIL[attention.level]}`}>
+      <td>
         {/* THE EXPLICIT OPEN CONTROL (kindred#2222). The cell used to be one
             `<button>` wrapping every line, including the Returning/
             First-time badges — a `<button>`'s content model forbids an

--- a/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
@@ -136,6 +136,35 @@ describe('HouseholdRosterTable', () => {
     expect(names.indexOf('Waiting Family')).toBeLessThan(names.indexOf('Settled Family'))
   })
 
+  it('carries attention level and count on the section header alone, with no per-row stripe', () => {
+    // kindred#2072-rail: the row's left border used to repeat the section it
+    // already sits under -- CONSTANT within a section, so it added no
+    // information (the same fence #2179 applied to the shared-space ring).
+    // The section header is now the sole carrier: it names the level AND
+    // says how many parties are in it.
+    render(
+      <HouseholdRosterTable
+        year={2026}
+        parties={[
+          party({ display_name: 'Settled Family', unit_name: 'Ridge A' }),
+          party({ display_name: 'Waiting Family', unit_name: '', household_cm_id: 2000002 }),
+        ]}
+      />,
+      { wrapper }
+    )
+
+    const heading = screen.getByText('Needs a cabin')
+    expect(heading.closest('th')).toHaveTextContent('1')
+
+    // No attention-keyed left border on the row that used to carry it.
+    const waitingNameEl = screen
+      .getAllByTestId('household-row-name')
+      .find((el) => el.textContent === 'Waiting Family')
+    const nameCell = waitingNameEl?.closest('td')
+    expect(nameCell?.className ?? '').not.toMatch(/border-l-\[3px\]/)
+    expect(nameCell?.className ?? '').not.toMatch(/border-(red|amber|sky)-(400|500)/)
+  })
+
   it('does not draw section headings when every party shares one state', () => {
     // An untouched adult weekend: heading the whole roster "Needs a cabin"
     // repeats what the banner already said.


### PR DESCRIPTION
## What

Deletes the household roster's 3px left-edge attention stripe (`RAIL` in `HouseholdRosterRow.tsx`) — the RAIL half of #2072, and only that half.

## Why

`HouseholdRosterTable.tsx` already renders a section header per attention level, carrying the level's label (`ATTENTION_LABEL`) and its count (`section.parties.length`). Every row inside that section then repeated the same level as a 3px coloured left border. **Within a section the stripe colour is constant** — it restated the heading the row was already sitting under and carried no information of its own. That is exactly the fence #2179 applied when it struck the shared-space ring: a constant is not a signal.

If the gutter half of #2072 (see below) never ships, nothing is lost: the section header is, and remains, the sole carrier of attention level in this view.

Not justified as "unplaced families aren't visible anyway" — that's false for the roster table specifically (`HouseholdRosterTable.tsx` says outright that unplaced parties sit above settled ones in this view). That framing only applies to the board, where unplaced families sit in a separate picker.

## Scope — this is a SPLIT issue, and only one half runs here

`#2072` has two halves:

- ✅ **This PR** — delete the roster's rail. Runnable now, no staff input needed.
- ⏸ **HELD** — the per-need glyph gutter on `FamilyCard`. Fully designed but waiting on a staff conversation about which needs should get a glyph (today's three flags are what the data happens to carry, not necessarily what staff want shown). Not built here — no glyph, icon, hue, or gutter touches `FamilyCard.tsx` in this PR.

**#2072 stays OPEN on the gutter half. This PR closes nothing.**

## What changed

- `HouseholdRosterRow.tsx`: deleted the module-local, unexported `RAIL` const and the `border-l-[3px] ${RAIL[attention.level]}` className on the row's first `<td>`. Updated the file's module docstring, which described the now-deleted rail as "the page's scanning spine."
- `HouseholdRosterTable.test.tsx`: added a test pinning the section header as the sole carrier of attention level (asserts both the label text and the count), and asserting the row's identity cell carries no attention-keyed left border.

Confirmed no other file imports or reads `RAIL`, and nothing else depends on the border for layout or hit area — the stretched-link overlay introduced by #2227 positions off `absolute inset-0` on its own wrapper, unrelated to the `<td>`'s border.

## Verification

- `tsc --noEmit`: exit 0
- `vitest run src/components/weekend/HouseholdRosterTable.test.tsx`: 40/40 passed, exit 0
- `vitest run src/components/weekend/` (full directory, in case another suite renders these components): 1097/1097 passed across 39 files, exit 0
- `prettier --check` on both touched files: exit 0, no changes needed
- `eslint` on both touched files: exit 0, 0 errors (3 pre-existing warnings elsewhere in the test file, unrelated to this diff)
- Push verified by `git fetch -q && git rev-list --count origin/<branch>..HEAD` = 0 (not by tool exit code, per standing instructions)

### TDD / mutation-check transcript

1. Wrote the new test first, ran it against the pre-deletion code: **RED**, failing on `not.toMatch(/border-l-\[3px\]/)` with actual `"border-l-[3px] border-amber-500"` — confirms the test fails for the right reason before any implementation change.
2. Deleted `RAIL` and the className: test went **GREEN**, along with the other 39 in the file.
3. Mutation-check 1: blanked `section.label` in `HouseholdRosterTable.tsx` → new test went **RED** (`getByText('Needs a cabin')` threw). Restored.
4. Mutation-check 2: blanked `section.parties.length` → new test went **RED** (`toHaveTextContent('1')` failed, received `"Needs a cabin"` with no count). Restored.
5. Final diff on `HouseholdRosterTable.tsx` confirmed empty (`git diff` shows no changes to that file) — the mutation checks left no residue.

## Deliberately NOT done

- No glyph gutter, no new hue tokens, no `FamilyCard.tsx` changes — that half is held per the owner's ruling in #2072, pending a staff conversation about which needs get a glyph.
- Did not touch `LodgingUnitCard.tsx`, `MapUnitPopover.tsx`, `ui/modalStack.ts`, or `ui/Modal.tsx` — out of scope, owned by concurrent wave items.

## Anchors re-derived against current main

The issue body and spec anchors were written before #2227 (which converted `HouseholdRosterRow` to the stretched-link pattern) and #2228 merged. Re-grepped for `RAIL` and `border-l-` on the current tree before touching anything — both were still at the line numbers the spec guessed (`RAIL` at :66, the className at :128), but this was verified, not assumed.