### PR TITLE
fix(frontend): widen modalStack to a token stack so Escape owns only the topmost overlay

### DIFF
--- a/frontend/src/components/ConfirmActionPopover.test.tsx
+++ b/frontend/src/components/ConfirmActionPopover.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen, fireEvent } from '@testing-library/react'
+import { useState } from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import { ConfirmActionPopover } from './ConfirmActionPopover'
+import { Modal } from './ui/Modal'
 
 describe('ConfirmActionPopover', () => {
   const defaultProps = {
@@ -164,5 +166,142 @@ describe('ConfirmActionPopover', () => {
     // Scroll would desync the popover from its captured anchor; dismiss instead.
     fireEvent.scroll(document, {})
     expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('ConfirmActionPopover — over a ui/Modal (kindred#2205)', () => {
+  // `AllCamperRequestsModal.tsx` and `RequestReviewPanel.tsx` both render
+  // exactly this composition: `<Modal>…{confirming && <ConfirmActionPopover
+  // />}</Modal>`. The popover portals independently of the Modal, so both
+  // attach their own `keydown` Escape listener to `document` — without the
+  // shared overlay token stack, one press fires both, and the popover
+  // cancelling itself takes the whole modal down with it.
+  //
+  // The popover mounts CONDITIONALLY, after a later click — not alongside
+  // the Modal in its first render — matching the real host exactly. That
+  // ordering matters: React fires mount effects bottom-up, so a popover
+  // mounted in the SAME commit as its parent Modal would register its token
+  // before the Modal's own, inverting who is "topmost". Only a popover that
+  // opens in a later, separate commit is guaranteed to land on top of an
+  // already-registered Modal, which is what every real caller does.
+  function ModalWithPopover({
+    onCloseModal,
+    onCancelPopover,
+  }: {
+    onCloseModal: () => void
+    onCancelPopover: () => void
+  }) {
+    const [confirming, setConfirming] = useState(false)
+    return (
+      <Modal isOpen={true} onClose={onCloseModal} title="Camper requests">
+        <button onClick={() => setConfirming(true)}>Decline</button>
+        {confirming && (
+          <ConfirmActionPopover
+            isOpen
+            anchorRect={{ top: 200, left: 300, width: 40, height: 40 }}
+            action="approve"
+            onConfirm={vi.fn()}
+            onCancel={() => {
+              setConfirming(false)
+              onCancelPopover()
+            }}
+          />
+        )}
+      </Modal>
+    )
+  }
+
+  it('one Escape closes only the popover, never the modal beneath it', () => {
+    const onCloseModal = vi.fn()
+    const onCancelPopover = vi.fn()
+    render(<ModalWithPopover onCloseModal={onCloseModal} onCancelPopover={onCancelPopover} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Decline' }))
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onCancelPopover).toHaveBeenCalledTimes(1)
+    expect(onCloseModal).not.toHaveBeenCalled()
+  })
+
+  it('a second Escape, once the popover is gone, closes the modal', () => {
+    const onCloseModal = vi.fn()
+    const onCancelPopover = vi.fn()
+    render(<ModalWithPopover onCloseModal={onCloseModal} onCancelPopover={onCancelPopover} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Decline' }))
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onCancelPopover).toHaveBeenCalledTimes(1)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onCloseModal).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT act on Escape when a further overlay opens on top of it', () => {
+    // The popover's own `isTopOverlay` gate, isolated from the Modal's — a
+    // second overlay (e.g. another `ui/Modal`) opened after the popover must
+    // own the key instead. Nothing in the app stacks a third overlay on a
+    // popover today, but the popover registers in the SAME shared stack as
+    // everything else, so it has to honour "am I topmost?" too, not just
+    // "is a Modal open somewhere below me?".
+    function Scene({
+      onCancelPopover,
+      onCloseNested,
+    }: {
+      onCancelPopover: () => void
+      onCloseNested: () => void
+    }) {
+      const [nested, setNested] = useState(false)
+      return (
+        <>
+          <ConfirmActionPopover
+            isOpen
+            anchorRect={{ top: 200, left: 300, width: 40, height: 40 }}
+            action="approve"
+            onConfirm={vi.fn()}
+            onCancel={onCancelPopover}
+          />
+          <button onClick={() => setNested(true)}>Open nested</button>
+          <Modal isOpen={nested} onClose={onCloseNested} title="Nested">
+            <p>Nested content</p>
+          </Modal>
+        </>
+      )
+    }
+
+    const onCancelPopover = vi.fn()
+    const onCloseNested = vi.fn()
+    render(<Scene onCancelPopover={onCancelPopover} onCloseNested={onCloseNested} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Open nested' }))
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onCloseNested).toHaveBeenCalledTimes(1)
+    expect(onCancelPopover).not.toHaveBeenCalled()
+  })
+
+  it('releases its overlay token on unmount, so the stack does not leak', () => {
+    const { unmount } = render(
+      <ConfirmActionPopover
+        isOpen={true}
+        anchorRect={{ top: 200, left: 300, width: 40, height: 40 }}
+        action="approve"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+    unmount()
+
+    // A fresh Modal opening afterward must be topmost immediately — a leaked
+    // popover token would silently no-op its Escape.
+    const onClose = vi.fn()
+    render(
+      <Modal isOpen={true} onClose={onClose} title="Fresh">
+        <p>Content</p>
+      </Modal>
+    )
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onClose).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/components/ConfirmActionPopover.test.tsx
+++ b/frontend/src/components/ConfirmActionPopover.test.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import { ConfirmActionPopover } from './ConfirmActionPopover'
 import { Modal } from './ui/Modal'
+import { hasOpenModal } from './ui/modalStack'
 
 describe('ConfirmActionPopover', () => {
   const defaultProps = {
@@ -291,6 +292,11 @@ describe('ConfirmActionPopover — over a ui/Modal (kindred#2205)', () => {
       />
     )
     unmount()
+
+    // The direct assertion — see Modal.test.tsx's equivalent leak test for
+    // why the "fresh overlay is still topmost" check below cannot catch a
+    // leak on its own (a newly-acquired token is always last in the stack).
+    expect(hasOpenModal()).toBe(false)
 
     // A fresh Modal opening afterward must be topmost immediately — a leaked
     // popover token would silently no-op its Escape.

--- a/frontend/src/components/ConfirmActionPopover.tsx
+++ b/frontend/src/components/ConfirmActionPopover.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 
+import { acquireOverlayToken, isTopOverlay, releaseOverlayToken } from './ui/modalStack'
+
 export interface ConfirmActionPopoverProps {
   isOpen: boolean
   anchorRect: Pick<DOMRect, 'top' | 'left' | 'width' | 'height'>
@@ -24,9 +26,15 @@ export function ConfirmActionPopover({
 
     const previouslyFocused = document.activeElement as HTMLElement | null
     confirmButtonRef.current?.focus()
+    // kindred#2205: this popover portals independently of `ui/Modal`, so a
+    // host rendering `<Modal><ConfirmActionPopover /></Modal>`
+    // (`AllCamperRequestsModal.tsx`, `RequestReviewPanel.tsx`) has two
+    // separate `document` Escape listeners. Only the topmost overlay acts.
+    const token = acquireOverlayToken()
 
     function handleKeyDown(e: KeyboardEvent) {
       if (e.key === 'Escape') {
+        if (!isTopOverlay(token)) return
         onCancel()
       } else if (e.key === 'Tab') {
         const buttons = popoverRef.current
@@ -66,6 +74,7 @@ export function ConfirmActionPopover({
       document.removeEventListener('keydown', handleKeyDown)
       document.removeEventListener('mousedown', handleMouseDown)
       document.removeEventListener('scroll', handleScroll, true)
+      releaseOverlayToken(token)
       previouslyFocused?.focus()
     }
   }, [isOpen, onCancel])

--- a/frontend/src/components/ScenarioManagementModal.overlayStack.test.tsx
+++ b/frontend/src/components/ScenarioManagementModal.overlayStack.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * kindred#2205's actual reproduction, not a hypothetical: `ScenarioManagementModal`
+ * always renders an outer `ui/Modal` (`:137`), and opens a SECOND `ui/Modal`
+ * on top of it in three separate places — the delete/clear confirmation
+ * (`:271`), `ScenarioEditModal` (`:317`), `NewScenarioModal` (`:325`). Both
+ * modals in every pair register their own bubble-phase `document` Escape
+ * listener, so before `ui/modalStack`'s overlay token stack, one keypress
+ * closed the inner AND the outer modal together, in all three places.
+ *
+ * `ScenarioManagementModal.test.tsx` mocks `ScenarioEditModal` and
+ * `NewScenarioModal` to `null` for its own (unrelated) assertions — that mock
+ * would hide exactly the composition this file exists to pin, so this is a
+ * separate file that renders the real children instead.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+
+vi.mock('../hooks/useSyncStatusAPI', () => ({
+  useSyncStatusAPI: () => ({ data: undefined }),
+}))
+
+vi.mock('../hooks/useCurrentYear', async () => {
+  const actual = await vi.importActual<object>('../hooks/useCurrentYear')
+  return { ...actual, useYear: () => 2026 }
+})
+
+import ScenarioManagementModal from './ScenarioManagementModal'
+import { ScenarioContext } from '../hooks/useScenario'
+import type { ScenarioContextType, Scenario } from '../hooks/useScenario'
+
+function makeContext(overrides: Partial<ScenarioContextType> = {}): ScenarioContextType {
+  const scenarios: Scenario[] = [
+    {
+      id: 'scenario-1',
+      name: 'Dorm Cabin Plan A',
+      session_cm_id: 1000001,
+      is_active: true,
+      description: '',
+      created: '2026-04-01T00:00:00Z',
+      updated: '2026-04-01T00:00:00Z',
+    },
+  ]
+  return {
+    currentScenario: null,
+    isProductionMode: true,
+    scenarios,
+    isLoading: false,
+    isMutating: false,
+    error: null,
+    loadScenarios: vi.fn().mockResolvedValue(undefined),
+    createScenario: vi.fn(),
+    selectScenario: vi.fn(),
+    updateScenario: vi.fn().mockResolvedValue(undefined),
+    deleteScenario: vi.fn().mockResolvedValue(undefined),
+    clearScenario: vi.fn().mockResolvedValue('Cleared 0 assignments from scenario for year 2026'),
+    ...overrides,
+  }
+}
+
+function renderModal(onClose: () => void) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>
+      <ScenarioContext value={makeContext()}>{children}</ScenarioContext>
+    </QueryClientProvider>
+  )
+  return render(<ScenarioManagementModal sessionId={1000001} onClose={onClose} />, { wrapper })
+}
+
+describe('ScenarioManagementModal — the confirm dialog (:271) on top of the outer modal (:137)', () => {
+  it('one Escape closes only the confirm dialog', async () => {
+    const onClose = vi.fn()
+    renderModal(onClose)
+    await userEvent.click(screen.getByRole('button', { name: /clear assignments/i }))
+    expect(screen.getByText('Clear Assignments?')).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(screen.queryByText('Clear Assignments?')).not.toBeInTheDocument()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('a second Escape then closes the outer modal', async () => {
+    const onClose = vi.fn()
+    renderModal(onClose)
+    await userEvent.click(screen.getByRole('button', { name: /clear assignments/i }))
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByText('Clear Assignments?')).not.toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('ScenarioManagementModal — ScenarioEditModal (:317) on top of the outer modal (:137)', () => {
+  it('one Escape closes only the edit modal', async () => {
+    const onClose = vi.fn()
+    renderModal(onClose)
+    await userEvent.click(screen.getByRole('button', { name: /edit scenario/i }))
+    expect(screen.getByText('Edit Scenario')).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(screen.queryByText('Edit Scenario')).not.toBeInTheDocument()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('a second Escape then closes the outer modal', async () => {
+    const onClose = vi.fn()
+    renderModal(onClose)
+    await userEvent.click(screen.getByRole('button', { name: /edit scenario/i }))
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByText('Edit Scenario')).not.toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('ScenarioManagementModal — NewScenarioModal (:325) on top of the outer modal (:137)', () => {
+  it('one Escape closes only the create modal', async () => {
+    // "Create New Scenario" names both the trigger button (still on the
+    // outer modal, behind this one) and the new modal's own title — the
+    // heading role disambiguates.
+    const onClose = vi.fn()
+    renderModal(onClose)
+    await userEvent.click(screen.getByRole('button', { name: /create new scenario/i }))
+    expect(screen.getByRole('heading', { name: 'Create New Scenario' })).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(screen.queryByRole('heading', { name: 'Create New Scenario' })).not.toBeInTheDocument()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('a second Escape then closes the outer modal', async () => {
+    const onClose = vi.fn()
+    renderModal(onClose)
+    await userEvent.click(screen.getByRole('button', { name: /create new scenario/i }))
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('heading', { name: 'Create New Scenario' })).not.toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/components/ui/Modal.test.tsx
+++ b/frontend/src/components/ui/Modal.test.tsx
@@ -569,4 +569,97 @@ describe('Modal', () => {
       expect(screen.queryByTestId('modal-body')).not.toBeInTheDocument()
     })
   })
+
+  describe('Escape ownership when a second `ui/Modal` opens on top (kindred#2205)', () => {
+    // `ScenarioManagementModal.tsx` renders exactly this: an outer Modal that
+    // is always open, plus a confirmation/edit/create Modal opened on top of
+    // it. Both attach their Escape listener to `document`, so without the
+    // overlay token stack, one press closed the child AND the parent
+    // underneath it in three separate places in that one file.
+    function StackedModals({
+      onCloseOuter,
+      onCloseInner,
+    }: {
+      onCloseOuter: () => void
+      onCloseInner: () => void
+    }) {
+      return (
+        <>
+          <Modal isOpen={true} onClose={onCloseOuter} title="Outer">
+            <p>Outer content</p>
+          </Modal>
+          <Modal isOpen={true} onClose={onCloseInner} title="Inner">
+            <p>Inner content</p>
+          </Modal>
+        </>
+      )
+    }
+
+    it('one Escape closes only the topmost (later-mounted) modal', () => {
+      const onCloseOuter = vi.fn()
+      const onCloseInner = vi.fn()
+      render(<StackedModals onCloseOuter={onCloseOuter} onCloseInner={onCloseInner} />)
+
+      fireEvent.keyDown(document, { key: 'Escape' })
+
+      expect(onCloseInner).toHaveBeenCalledTimes(1)
+      expect(onCloseOuter).not.toHaveBeenCalled()
+    })
+
+    it('a second Escape, after the inner modal is gone, closes the one beneath it', () => {
+      const onCloseOuter = vi.fn()
+      const onCloseInner = vi.fn()
+      const { rerender } = render(
+        <StackedModals onCloseOuter={onCloseOuter} onCloseInner={onCloseInner} />
+      )
+
+      fireEvent.keyDown(document, { key: 'Escape' })
+      expect(onCloseInner).toHaveBeenCalledTimes(1)
+
+      // The real component would stop rendering the inner Modal once its
+      // `onClose` fires and the parent flips its `isOpen` state; simulate
+      // that here rather than pulling in ScenarioManagementModal's own state.
+      rerender(
+        <>
+          <Modal isOpen={true} onClose={onCloseOuter} title="Outer">
+            <p>Outer content</p>
+          </Modal>
+          <Modal isOpen={false} onClose={onCloseInner} title="Inner">
+            <p>Inner content</p>
+          </Modal>
+        </>
+      )
+
+      fireEvent.keyDown(document, { key: 'Escape' })
+
+      expect(onCloseOuter).toHaveBeenCalledTimes(1)
+      expect(onCloseInner).toHaveBeenCalledTimes(1)
+    })
+
+    it('releases its overlay token on unmount, so the stack does not leak', () => {
+      // A leaked token would leave `hasOpenModal()` permanently true, which
+      // silently disables Escape for every container that stands down while
+      // "a modal" is open (`weekend/FamilyDetailsPanel`) — worse than the bug
+      // this stack exists to fix.
+      const { unmount } = render(
+        <Modal isOpen={true} onClose={() => {}} title="Solo">
+          <p>Content</p>
+        </Modal>
+      )
+      unmount()
+
+      // A fresh modal opening afterward must be topmost immediately — if the
+      // old token were still in the stack, this one's Escape would silently
+      // no-op.
+      const onClose = vi.fn()
+      render(
+        <Modal isOpen={true} onClose={onClose} title="Fresh">
+          <p>Content</p>
+        </Modal>
+      )
+      fireEvent.keyDown(document, { key: 'Escape' })
+
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+  })
 })

--- a/frontend/src/components/ui/Modal.test.tsx
+++ b/frontend/src/components/ui/Modal.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { Modal } from './Modal'
+import { hasOpenModal } from './modalStack'
 
 describe('Modal', () => {
   describe('when isOpen is false', () => {
@@ -647,6 +648,13 @@ describe('Modal', () => {
         </Modal>
       )
       unmount()
+
+      // The direct assertion: a leaked token leaves the stack non-empty even
+      // with nothing open. LIFO ordering means the "fresh modal is still
+      // topmost" check below would pass even with a leak underneath it — a
+      // newly-acquired token is always last — so it cannot catch a leak on
+      // its own; this is the one that actually pins "does not leak".
+      expect(hasOpenModal()).toBe(false)
 
       // A fresh modal opening afterward must be topmost immediately — if the
       // old token were still in the stack, this one's Escape would silently

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -3,7 +3,14 @@ import { useEffect, useRef } from 'react'
 import type { ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 
-import { acquireBackgroundInert, releaseBackgroundInert } from './modalStack'
+import {
+  acquireBackgroundInert,
+  acquireOverlayToken,
+  isTopOverlay,
+  releaseBackgroundInert,
+  releaseOverlayToken,
+  type OverlayToken,
+} from './modalStack'
 
 interface ModalProps {
   isOpen: boolean
@@ -105,12 +112,26 @@ export function Modal({
 }: ModalProps) {
   const contentRef = useRef<HTMLDivElement>(null)
   const previouslyFocusedRef = useRef<HTMLElement | null>(null)
+  // kindred#2205: which of possibly several stacked overlays this instance
+  // is. Read by the Escape branch below, written by the mount effect that
+  // acquires it — see that effect for why they're split.
+  const overlayTokenRef = useRef<OverlayToken | null>(null)
 
   useEffect(() => {
     if (!isOpen) return
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
+        // Only the topmost overlay acts on a given Escape press. Without
+        // this, a second `ui/Modal` (or any other overlay participating in
+        // the same stack — `ConfirmActionPopover`, `ui/Tooltip`) opened on
+        // top of this one would still leave THIS listener firing too, and
+        // one keypress would close both — `ScenarioManagementModal.tsx` hits
+        // this three times over (its confirm dialog, `ScenarioEditModal`,
+        // `NewScenarioModal`, all opened on top of its always-open outer
+        // Modal).
+        const token = overlayTokenRef.current
+        if (token !== null && !isTopOverlay(token)) return
         onClose()
         return
       }
@@ -152,6 +173,8 @@ export function Modal({
 
     previouslyFocusedRef.current = document.activeElement as HTMLElement | null
     acquireBackgroundInert()
+    const token = acquireOverlayToken()
+    overlayTokenRef.current = token
 
     const container = contentRef.current
     const focusable = container ? getFocusable(container) : []
@@ -159,6 +182,8 @@ export function Modal({
 
     return () => {
       releaseBackgroundInert()
+      releaseOverlayToken(token)
+      overlayTokenRef.current = null
       previouslyFocusedRef.current?.focus()
       previouslyFocusedRef.current = null
     }

--- a/frontend/src/components/ui/Tooltip.test.tsx
+++ b/frontend/src/components/ui/Tooltip.test.tsx
@@ -6,7 +6,7 @@
  * travelling onto the bubble to read it.
  */
 import { act, fireEvent, render, screen } from '@testing-library/react'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { Modal } from './Modal'
@@ -314,6 +314,69 @@ describe('Tooltip — inside a real ui/Modal', () => {
     const onClose = vi.fn()
     render(<ModalHost onClose={onClose} />)
     fireEvent.keyDown(trigger(), { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('Tooltip — a stale hover bubble does not outrank a modal opened on top of it (kindred#2205)', () => {
+  /**
+   * The capture-phase listener runs before ANY bubble-phase overlay,
+   * regardless of which one opened more recently — that's what makes it able
+   * to beat `ui/Modal`'s own bubble listener when the tooltip is INSIDE the
+   * dialog (the describe block above). It is exactly as able to beat a
+   * dialog that opens OUTSIDE and AFTER it, which is a fresh instance of the
+   * bug this file's stack exists to fix, not the one it was built for.
+   *
+   * The repro: the pointer rests on a background tooltip trigger (hover
+   * opens the bubble) without moving away — plausible when the modal is
+   * opened by a click or Tab elsewhere while the mouse stays put. Escape is
+   * then pressed to dismiss the freshly-opened, topmost modal, not the
+   * incidental hover state underneath it.
+   */
+  function Scene({ onCloseModal }: { onCloseModal: () => void }) {
+    const [modalOpen, setModalOpen] = useState(false)
+    return (
+      <>
+        <Tooltip content="Background hint, incidentally hovered.">Answers disagree</Tooltip>
+        <button onClick={() => setModalOpen(true)}>Open modal</button>
+        <Modal isOpen={modalOpen} onClose={onCloseModal} title="Weekend lodging">
+          <p>Dialog content</p>
+        </Modal>
+      </>
+    )
+  }
+
+  it('lets Escape close the modal that opened on top of it, not the stale bubble', () => {
+    const onCloseModal = vi.fn()
+    render(<Scene onCloseModal={onCloseModal} />)
+
+    fireEvent.pointerEnter(trigger())
+    expect(screen.getByRole('tooltip')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open modal' }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    fireEvent.keyDown(document.body, { key: 'Escape' })
+
+    expect(onCloseModal).toHaveBeenCalledTimes(1)
+  })
+
+  it('releases its overlay token once the bubble closes, so the stack does not leak', () => {
+    const { unmount } = renderChip()
+    fireEvent.pointerEnter(trigger())
+    expect(screen.getByRole('tooltip')).toBeInTheDocument()
+    unmount()
+
+    // A fresh modal opening afterward must be topmost immediately — a
+    // leaked tooltip token would silently swallow its Escape instead.
+    const onClose = vi.fn()
+    render(
+      <Modal isOpen onClose={onClose} title="Fresh">
+        <p>Content</p>
+      </Modal>
+    )
+    fireEvent.keyDown(document, { key: 'Escape' })
+
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/components/ui/Tooltip.test.tsx
+++ b/frontend/src/components/ui/Tooltip.test.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { Modal } from './Modal'
+import { hasOpenModal } from './modalStack'
 import { Tooltip } from './Tooltip'
 
 afterEach(() => {
@@ -366,6 +367,11 @@ describe('Tooltip — a stale hover bubble does not outrank a modal opened on to
     fireEvent.pointerEnter(trigger())
     expect(screen.getByRole('tooltip')).toBeInTheDocument()
     unmount()
+
+    // The direct assertion — see Modal.test.tsx's equivalent leak test for
+    // why the "fresh overlay is still topmost" check below cannot catch a
+    // leak on its own (a newly-acquired token is always last in the stack).
+    expect(hasOpenModal()).toBe(false)
 
     // A fresh modal opening afterward must be topmost immediately — a
     // leaked tooltip token would silently swallow its Escape instead.

--- a/frontend/src/components/ui/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip.tsx
@@ -50,10 +50,16 @@
  *      still requires a way out that does not move the pointer. So a
  *      `document` listener in the CAPTURE phase, which runs before the event
  *      has reached anything and can therefore stop every bubble-phase host
- *      listener with one `stopPropagation`.
+ *      listener with one `stopPropagation` — but ONLY once it has confirmed,
+ *      via `ui/modalStack`'s overlay token stack, that this bubble is the
+ *      TOPMOST open overlay. Capture always runs first regardless of open
+ *      order, so an ungated version can beat a dialog that opens outside and
+ *      AFTER a bubble a hovering pointer left open — kindred#2205's second
+ *      finding, fixed the same way as the bubble-phase collision it names.
  *
- *    Either way the event is swallowed ONLY while a bubble is showing, and
- *    only for Escape; anything else passes straight through.
+ *    Either way the event is swallowed ONLY while a bubble is showing AND
+ *    this bubble is topmost, and only for Escape; anything else passes
+ *    straight through.
  */
 import {
   useEffect,
@@ -65,6 +71,8 @@ import {
   type ReactNode,
 } from 'react'
 import { createPortal } from 'react-dom'
+
+import { acquireOverlayToken, isTopOverlay, releaseOverlayToken } from './modalStack'
 
 export interface TooltipProps {
   /** The sentence the bubble carries. Also the trigger's accessible description. */
@@ -189,10 +197,24 @@ export function Tooltip({
   // The pointer-opened half of the Escape story — see decision 4 in the file
   // header for why this is the CAPTURE phase and why it only exists while
   // focus is somewhere other than the trigger.
+  //
+  // kindred#2205: capture always runs before ANY bubble-phase overlay, no
+  // matter which one opened more recently — that's what lets it beat
+  // `ui/Modal`'s listener when the bubble is INSIDE the dialog. Left
+  // ungated, it is exactly as able to beat a dialog that opens OUTSIDE and
+  // AFTER a stale hover bubble (mouse resting on a trigger while a click or
+  // Tab elsewhere opens a modal) — a fresh instance of the same defect. This
+  // component still registers in the shared overlay stack and only acts —
+  // swallowing the key and dismissing itself — while it is the topmost
+  // overlay; otherwise it lets the event continue so whichever overlay
+  // really is on top (its own bubble-phase listener, gated the same way)
+  // gets it.
   useEffect(() => {
     if (!open || focused) return
+    const token = acquireOverlayToken()
     const onEscapeCapture = (event: KeyboardEvent) => {
       if (event.key !== 'Escape') return
+      if (!isTopOverlay(token)) return
       event.stopPropagation()
       setPinned(false)
       setHovering(false)
@@ -201,6 +223,7 @@ export function Tooltip({
     document.addEventListener('keydown', onEscapeCapture, true)
     return () => {
       document.removeEventListener('keydown', onEscapeCapture, true)
+      releaseOverlayToken(token)
     }
   }, [open, focused])
 

--- a/frontend/src/components/ui/modalStack.test.ts
+++ b/frontend/src/components/ui/modalStack.test.ts
@@ -1,0 +1,118 @@
+/**
+ * The token-stack half of `modalStack.ts` (kindred#2205).
+ *
+ * `hasOpenModal`/the background-inert counter (`Modal.test.tsx`) already
+ * cover the count. This file is the escape-ownership half: which overlay,
+ * among several independently-portalled ones, gets to act on a single
+ * Escape keypress.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { acquireOverlayToken, hasOpenModal, isTopOverlay, releaseOverlayToken } from './modalStack'
+
+describe('modalStack — the overlay token stack', () => {
+  // The stack is module-scope, shared across every test in this file (and
+  // every other file importing it in the same worker). A test that leaves a
+  // token unreleased doesn't just fail its own assertion — it silently
+  // poisons every test that runs after it. Fail loudly, at the source,
+  // instead of debugging a confusing failure two tests later.
+  afterEach(() => {
+    expect(hasOpenModal()).toBe(false)
+  })
+
+  it('the only registered token is topmost', () => {
+    const token = acquireOverlayToken()
+    expect(isTopOverlay(token)).toBe(true)
+    releaseOverlayToken(token)
+  })
+
+  it('the most recently acquired token is topmost, not the first', () => {
+    const first = acquireOverlayToken()
+    const second = acquireOverlayToken()
+
+    expect(isTopOverlay(second)).toBe(true)
+    expect(isTopOverlay(first)).toBe(false)
+
+    releaseOverlayToken(second)
+    releaseOverlayToken(first)
+  })
+
+  it('releasing the topmost token promotes the one beneath it', () => {
+    const first = acquireOverlayToken()
+    const second = acquireOverlayToken()
+
+    releaseOverlayToken(second)
+
+    expect(isTopOverlay(first)).toBe(true)
+    releaseOverlayToken(first)
+  })
+
+  it('releasing a token that is NOT topmost does not disturb who is', () => {
+    // The case the fix has to get right: a background dialog closing (e.g.
+    // ScenarioManagementModal's outer Modal, torn down by something other
+    // than Escape) must not hand ownership to the wrong overlay, or silently
+    // steal it from the one actually on top.
+    const bottom = acquireOverlayToken()
+    const top = acquireOverlayToken()
+
+    releaseOverlayToken(bottom)
+
+    expect(isTopOverlay(top)).toBe(true)
+    releaseOverlayToken(top)
+  })
+
+  it('a token nobody registered, or one already released, is never topmost', () => {
+    const registered = acquireOverlayToken()
+    const neverRegistered = Symbol('overlay-token')
+
+    expect(isTopOverlay(neverRegistered)).toBe(false)
+
+    releaseOverlayToken(registered)
+    expect(isTopOverlay(registered)).toBe(false)
+  })
+
+  it('releasing an already-released token is a no-op, not a crash or a double-pop', () => {
+    const first = acquireOverlayToken()
+    const second = acquireOverlayToken()
+
+    releaseOverlayToken(second)
+    releaseOverlayToken(second) // already gone — must not touch `first`
+
+    expect(isTopOverlay(first)).toBe(true)
+    releaseOverlayToken(first)
+  })
+
+  it('hasOpenModal reflects whether the stack is empty, not a particular overlay', () => {
+    expect(hasOpenModal()).toBe(false)
+
+    const token = acquireOverlayToken()
+    expect(hasOpenModal()).toBe(true)
+
+    releaseOverlayToken(token)
+    expect(hasOpenModal()).toBe(false)
+  })
+
+  it('mounting and unmounting several overlays, in any order, returns the stack to empty', () => {
+    // The leak this guards against: a token that never gets released leaves
+    // `hasOpenModal()` permanently true, which silently disables Escape for
+    // every container that stands down while "a modal" is open (e.g.
+    // `weekend/FamilyDetailsPanel`) — worse than the bug being fixed here.
+    const a = acquireOverlayToken()
+    const b = acquireOverlayToken()
+    const c = acquireOverlayToken()
+
+    // Unmount out of acquisition order, as a real component tree would if
+    // the middle overlay closes first.
+    releaseOverlayToken(b)
+    releaseOverlayToken(a)
+    releaseOverlayToken(c)
+
+    expect(hasOpenModal()).toBe(false)
+
+    // And the stack is usable again afterward — a leaked token would make
+    // this next overlay topmost-forever or never-topmost, either wrong.
+    const fresh = acquireOverlayToken()
+    expect(isTopOverlay(fresh)).toBe(true)
+    releaseOverlayToken(fresh)
+    expect(hasOpenModal()).toBe(false)
+  })
+})

--- a/frontend/src/components/ui/modalStack.ts
+++ b/frontend/src/components/ui/modalStack.ts
@@ -10,6 +10,12 @@
  * both a component and a plain function breaks Fast Refresh
  * (`react-refresh/only-export-components`). Nothing here renders, so this is
  * the file that rule asks for.
+ *
+ * Deliberately its own counter, separate from the overlay token stack below:
+ * `inert` is a "is ANY real dialog blocking the background" question that
+ * only `ui/Modal` answers, while the token stack tracks every
+ * independently-portalled overlay (tooltips, confirm popovers) that has no
+ * business making the rest of the page inert.
  */
 
 let openDialogs = 0
@@ -29,7 +35,53 @@ export function releaseBackgroundInert(): void {
 }
 
 /**
- * Whether any `ui/Modal` is currently open.
+ * kindred#2205. A LIFO stack of tokens, one per currently-open,
+ * independently-portalled overlay — `ui/Modal`, `ConfirmActionPopover`,
+ * `ui/Tooltip`'s pointer-opened bubble. Each acquires a token on open and
+ * releases it on close; whichever token is on TOP owns the next Escape
+ * keypress, and only that one.
+ *
+ * This widens the plain open-dialog counter above rather than replacing it.
+ * The counter answers "is any `ui/Modal` open" (for `inert`); this answers
+ * "which overlay, among however many are stacked, gets Escape right now" —
+ * `ui/Modal` alone couldn't answer that once a second `ui/Modal` (or a
+ * non-Modal overlay) opens on top of a first, because a bare count has no way
+ * to ask "am I the topmost one?".
+ *
+ * A `symbol` per acquisition, not an incrementing id: identity comparison is
+ * all `isTopOverlay` needs, and a symbol can't collide with a stale numeric
+ * id a caller forgot to bump.
+ */
+export type OverlayToken = symbol
+
+const overlayStack: OverlayToken[] = []
+
+/** Registers a new overlay as the current topmost. Release it on close. */
+export function acquireOverlayToken(): OverlayToken {
+  const token = Symbol('overlay')
+  overlayStack.push(token)
+  return token
+}
+
+/**
+ * Releases a token, wherever it sits in the stack — not only from the top.
+ * An overlay in the middle can close first (e.g. a background `ui/Modal`
+ * dismissed by something other than Escape while a popover on top of it
+ * stays open), and removing by identity rather than by popping keeps the
+ * overlay still on top correctly on top.
+ */
+export function releaseOverlayToken(token: OverlayToken): void {
+  const index = overlayStack.indexOf(token)
+  if (index !== -1) overlayStack.splice(index, 1)
+}
+
+/** Whether `token` is the topmost registered overlay right now. */
+export function isTopOverlay(token: OverlayToken): boolean {
+  return overlayStack.length > 0 && overlayStack[overlayStack.length - 1] === token
+}
+
+/**
+ * Whether any overlay — `ui/Modal` or otherwise — is currently open.
  *
  * For a CONTAINER that closes itself on Escape and can host a dialog —
  * `weekend/FamilyDetailsPanel` is the first, via kindred#2073's "see members"
@@ -38,12 +90,13 @@ export function releaseBackgroundInert(): void {
  * Escape dismisses the dialog AND the surface underneath it, which is not
  * what the key was pressed for.
  *
- * Reads the same counter the inert bookkeeping uses rather than keeping a
- * second one, because that counter already IS "how many ui/Modals are open" —
- * incremented in the open effect, decremented in its cleanup. Deliberately a
- * function, not an exported boolean: a module-scope value read at import time
- * would freeze at `false`.
+ * Reads the overlay stack's length, not the `inert` counter above: a
+ * container needs to stand down for ANY overlay on top of it, `ui/Modal` or
+ * not — the case this function was named for still holds (`ui/Modal` was the
+ * only registrant when it shipped), it's just no longer the only kind that
+ * counts. Deliberately a function, not an exported boolean: a module-scope
+ * value read at import time would freeze at `false`.
  */
 export function hasOpenModal(): boolean {
-  return openDialogs > 0
+  return overlayStack.length > 0
 }


### PR DESCRIPTION
## What

Closes #2205. Widens `ui/modalStack.ts` from a plain open-dialog counter into a LIFO **overlay token stack** (`acquireOverlayToken` / `releaseOverlayToken` / `isTopOverlay`), and wires every independently-portalled overlay that owns a bubble-phase (or capture-phase) Escape handler into it, so a single Escape keypress acts on the topmost overlay only.

## Why this is a summer bug, not a weekend a11y nit

`ScenarioManagementModal.tsx` — used by both summer and weekend scenario management — renders an always-open outer `ui/Modal` (`:137`) with **three** modals opening on top of it: the delete/clear confirmation (`:271`), `ScenarioEditModal` (`:317`), and `NewScenarioModal` (`:325`). All four anchors were re-derived by grep against `main`, not carried over from the issue body. Before this fix, one Escape closed the child modal **and** the outer modal underneath it, in all three places.

## The defect

`ConfirmActionPopover` portals independently of `ui/Modal` and never touched the old counter, so `<Modal><ConfirmActionPopover /></Modal>` (`AllCamperRequestsModal.tsx`, `RequestReviewPanel.tsx`) had the same double-close bug from the popover side.

## The mechanism (adopted, not redesigned)

- `modalStack.ts` keeps its existing `openDialogs` counter (background `inert`, `ui/Modal`-only — unchanged) and adds a separate token stack for Escape ownership, since every independently-portalled overlay participates, not only `ui/Modal`.
- `Modal.tsx` and `ConfirmActionPopover.tsx` acquire a token on open, release it on close/unmount, and gate their Escape branch on `isTopOverlay(token)`.
- `hasOpenModal()` (read by `weekend/FamilyDetailsPanel.tsx`) now reads `stack.length > 0` — same call site, same semantics, correct for the wider stack.

## The `ui/Tooltip.tsx` capture-phase check (flagged in the issue, resolved here)

Checked whether `ui/Tooltip`'s capture-phase Escape handler (shipped in #2221) created a **fresh instance** of the same defect. It does: a capture-phase `document` listener always runs before any bubble-phase overlay listener, **regardless of which one opened more recently**. Constructed the case — mouse rests on a background tooltip trigger (hover-opens the bubble) while a click or Tab elsewhere opens a `ui/Modal` on top of it — and confirmed it live: `ui/Tooltip.test.tsx`, "lets Escape close the modal that opened on top of it, not the stale bubble", failed RED before the fix (`onCloseModal` called 0 times instead of 1). Fixed the same way: the capture handler now acquires a token too and only acts while topmost.

## A composition trap the tests had to route around

Testing "Modal, then ConfirmActionPopover mounted in the very same render" gave the WRONG order — React fires mount effects bottom-up (child before parent), so a popover mounted in the same commit as its parent Modal registers its token *before* the Modal's, inverting "topmost". Every real caller (`AllCamperRequestsModal.tsx`) renders the popover conditionally, well after the Modal's own mount — a separate, later commit — which is what actually guarantees correct ordering. The `ConfirmActionPopover` test host was rewritten to match that real shape (a button click flips local state to mount the popover), and the file explains why in a comment.

## Files changed

- `frontend/src/components/ui/modalStack.ts` — token stack
- `frontend/src/components/ui/modalStack.test.ts` (new) — unit tests for the stack itself: ordering, mid-stack release, never-registered/already-released tokens, leak-on-teardown
- `frontend/src/components/ui/Modal.tsx` + `Modal.test.tsx` — acquire/release + Escape gate; new describe block for two real stacked `Modal`s
- `frontend/src/components/ConfirmActionPopover.tsx` + `.test.tsx` — acquire/release + Escape gate; popover-over-modal, modal-over-popover (isolates the popover's own gate, not just the Modal's), and a leak test
- `frontend/src/components/ui/Tooltip.tsx` + `.test.tsx` — capture-phase gate; the stale-hover-bubble-vs-modal reproduction; file-header comment (decision 4) updated to describe the new behavior
- `frontend/src/components/ScenarioManagementModal.overlayStack.test.tsx` (new) — all three real modal-on-modal reproductions, unmocked (the existing `ScenarioManagementModal.test.tsx` mocks `ScenarioEditModal`/`NewScenarioModal` to `null` for unrelated assertions, which would hide exactly this composition)

Not touched: `HouseholdRosterRow.tsx`, `HouseholdRosterTable.test.tsx` — owned by a concurrent wave item.

## Verification

- `tsc --noEmit`: exit 0 (before and after rebase onto latest `main`)
- Targeted vitest (`modalStack`, `Modal`, `ConfirmActionPopover`, `Tooltip`, `ScenarioManagementModal` x2, `FamilyDetailsPanel`): **151/151 passed**, exit 0
- Full frontend suite (`vitest run`, no path filter): **6725/6726 passed**. The one failure (`eslintA11yLayering.guard.test.ts`) is a 5s-timeout on ESLint rule calculation under full-suite parallel load — reran in isolation and it passed 2/2 in 2.01s. Pre-existing, unrelated to this diff (confirmed the test file is untouched by `git diff`).
- `prettier --check`, `eslint`: clean on every touched file
- **TDD**: every new/changed assertion was written first, run, and confirmed RED before the corresponding fix landed (transcripts below).
- **Mutation-checked** every fix by reverting its gate and re-running the relevant test file, confirming RED, then restoring:
  - `Modal.tsx` gate removed → both new "Escape ownership" tests failed (`Modal.test.tsx`)
  - `ConfirmActionPopover.tsx` gate removed → its own dedicated "does NOT act on Escape when a further overlay opens on top of it" test failed (the two Modal-composition tests did NOT fail on this mutation alone — they depend on `Modal.tsx`'s gate, not the popover's, which is why that isolating test exists)
  - `Tooltip.tsx` gate removed → the stale-hover-bubble test failed
  - `Modal.tsx` gate removed again, `ScenarioManagementModal.overlayStack.test.tsx` run standalone → all 6 tests failed (all three modal-on-modal pairs)

## Deliberately not done

- Did not touch `HouseholdRosterRow.tsx` / `HouseholdRosterTable.test.tsx` (owned elsewhere this wave).
- Did not redesign the mechanism — the token stack was the issue's settled, adopted shape.

Closes #2205.