### PR TITLE
feat(frontend): say why headcount and bed count disagree in the unit tooltip

### DIFF
--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -136,6 +136,144 @@ describe('LodgingUnitCard', () => {
     expect(screen.getByRole('tooltip')).toHaveTextContent(/Sleeps 5/)
   })
 
+  describe('the infant bed exemption clause (kindred#2212 stage 1)', () => {
+    // The card's own `occupants` figure is a BED count (`slotOccupancy` sums
+    // `partySize`, which reads the server-reported `party_size`); the reader
+    // never sees the NAMED headcount anywhere on this card. When they
+    // disagree, a bed was exempted for an infant under 18 months
+    // (`INFANT_BED_EXEMPT_MONTHS`, `api/constants/lodging.py`) and the
+    // tooltip should say so, rather than silently showing the smaller number.
+    //
+    // ⚠️ Deliberately built from `party_size` vs. named adults/children --
+    // NEVER from `PartyChild.age`, which is CampMinder `yy.mm` and carries a
+    // `0.0` unknown-age sentinel (kindred#2212). Thresholding age here would
+    // silently sweep that sentinel in as a false "infant".
+
+    it('names the exemption when a party carries more people than recorded beds', () => {
+      render(
+        <LodgingUnitCard
+          slot={slot({
+            parties: [
+              party({
+                adults: [{ adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' }],
+                children: [
+                  { person_cm_id: 9001, display_name: 'Noah Johnson', age: 8, grade: 3 },
+                  { person_cm_id: 9002, display_name: 'Ivy Johnson', age: 0.11, grade: 0 },
+                ],
+                // Headcount is 1 adult + 2 children = 3; the server reports
+                // only 2 beds, discounting the infant.
+                party_size: 2,
+              }),
+            ],
+          })}
+          hue="hsl(160 45% 42%)"
+          onOpenParty={vi.fn()}
+        />
+      )
+      const occupancy = screen.getByTestId('unit-occupancy')
+      fireEvent.focus(occupancy)
+      expect(screen.getByRole('tooltip')).toHaveTextContent(
+        'Sleeps 5 · 2 placed · an infant is exempt from the bed count'
+      )
+    })
+
+    it('says nothing extra, and leaves the existing sentence untouched, when headcount matches recorded beds', () => {
+      render(
+        <LodgingUnitCard
+          slot={slot({
+            parties: [
+              party({
+                adults: [{ adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' }],
+                children: [{ person_cm_id: 9001, display_name: 'Noah Johnson', age: 8, grade: 3 }],
+                // Headcount is 1 adult + 1 child = 2, matching the 2 beds
+                // recorded. No infant was exempted; nothing to explain.
+                party_size: 2,
+              }),
+            ],
+          })}
+          hue="hsl(160 45% 42%)"
+          onOpenParty={vi.fn()}
+        />
+      )
+      const occupancy = screen.getByTestId('unit-occupancy')
+      fireEvent.focus(occupancy)
+      // Pinned exact, not a substring match: a future edit that silently
+      // reworded the ordinary sentence must fail this test.
+      expect(screen.getByRole('tooltip')).toHaveTextContent('Sleeps 5 · 2 placed')
+      expect(screen.queryByText(/exempt/)).not.toBeInTheDocument()
+    })
+
+    it('does not mistake the 0.0 unknown-age sentinel for an infant (the 24-vs-25 case)', () => {
+      // kindred#2212: one child in the real 2026 cohort carries `age: 0.0`,
+      // CampMinder's UNKNOWN-AGE sentinel, not a newborn's age. The server
+      // never discounts that child's bed on the strength of the sentinel, so
+      // headcount and recorded beds AGREE for this household and the
+      // exemption clause must not fire -- this is exactly why the measured
+      // population is 24 affected households, not 25.
+      render(
+        <LodgingUnitCard
+          slot={slot({
+            parties: [
+              party({
+                adults: [{ adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' }],
+                children: [
+                  { person_cm_id: 9003, display_name: 'Unnamed camper', age: 0.0, grade: 0 },
+                ],
+                // Headcount is 1 adult + 1 child = 2, matching the 2 beds
+                // recorded -- the sentinel child keeps its bed.
+                party_size: 2,
+              }),
+            ],
+          })}
+          hue="hsl(160 45% 42%)"
+          onOpenParty={vi.fn()}
+        />
+      )
+      const occupancy = screen.getByTestId('unit-occupancy')
+      fireEvent.focus(occupancy)
+      expect(screen.getByRole('tooltip')).toHaveTextContent('Sleeps 5 · 2 placed')
+      expect(screen.queryByText(/exempt/)).not.toBeInTheDocument()
+    })
+
+    it('pluralizes the clause when more than one infant is exempted in a shared slot', () => {
+      render(
+        <LodgingUnitCard
+          slot={slot({
+            parties: [
+              party({
+                household_cm_id: 101,
+                display_name: 'Johnson',
+                adults: [{ adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' }],
+                children: [
+                  { person_cm_id: 9001, display_name: 'Noah Johnson', age: 8, grade: 3 },
+                  { person_cm_id: 9002, display_name: 'Ivy Johnson', age: 0.11, grade: 0 },
+                ],
+                party_size: 2,
+              }),
+              party({
+                household_cm_id: 102,
+                display_name: 'Garcia',
+                adults: [{ adult_number: 1, display_name: 'Liam Garcia', relationship: 'Father' }],
+                children: [
+                  { person_cm_id: 9004, display_name: 'Mia Garcia', age: 5, grade: 0 },
+                  { person_cm_id: 9005, display_name: 'Leo Garcia', age: 0.3, grade: 0 },
+                ],
+                party_size: 2,
+              }),
+            ],
+          })}
+          hue="hsl(160 45% 42%)"
+          onOpenParty={vi.fn()}
+        />
+      )
+      const occupancy = screen.getByTestId('unit-occupancy')
+      fireEvent.focus(occupancy)
+      expect(screen.getByRole('tooltip')).toHaveTextContent(
+        'Sleeps 5 · 4 placed · 2 infants are exempt from the bed count'
+      )
+    })
+  })
+
   it('describes the unit NAME without turning it into a tooltip trigger', () => {
     // The occupancy `<span>` carried the tooltip, never the `<h3>` beside it.
     render(<LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />)

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -545,13 +545,46 @@ export function LodgingUnitCard({
    */
   const wholesaleWriteIn = writeIn !== null && occupants === 0
   const occupancyFigure = wholesaleWriteIn ? '—' : String(occupants)
+
+  /*
+   * kindred#2212 stage 1: why headcount and bed count can disagree.
+   *
+   * `occupants` above is a BED count -- `slotOccupancy` sums `partySize`,
+   * which reads the server-reported `party_size` and falls back to headcount
+   * only when nothing was reported. The reader never sees the NAMED headcount
+   * anywhere else on this card, so when the two numbers diverge the card goes
+   * quiet about why: a child under 18 months (`INFANT_BED_EXEMPT_MONTHS`,
+   * `api/constants/lodging.py`) does not consume a bed.
+   *
+   * Deliberately built from `partyHeadcount` (named adults + every child)
+   * against the already-computed `occupants` (bed count), NEVER from
+   * `PartyChild.age` directly -- that field is CampMinder `yy.mm` and carries
+   * a `0.0` UNKNOWN-AGE SENTINEL, not a newborn's age (kindred#2212). Reading
+   * age here would silently sweep that sentinel in as a false "infant". This
+   * formula never looks at age at all, so the trap cannot fire: a party whose
+   * reported beds already equal its headcount contributes zero regardless of
+   * what any child's `age` field says.
+   *
+   * When `party_size` is unreported (0/null), `partySize` already falls back
+   * to `partyHeadcount` for that party, so it contributes nothing to the
+   * difference here either -- no separate guard needed.
+   */
+  const totalHeadcount = slot.parties.reduce((sum, p) => sum + partyHeadcount(p), 0)
+  const exemptedInfants = wholesaleWriteIn ? 0 : totalHeadcount - occupants
+  const infantExemptionClause =
+    exemptedInfants > 0
+      ? ` · ${
+          exemptedInfants === 1 ? 'an infant is' : `${String(exemptedInfants)} infants are`
+        } exempt from the bed count`
+      : ''
+
   const occupancyTooltip = wholesaleWriteIn
     ? capacityKnown
       ? `Written in — occupies the whole room · sleeps ${String(unit.sleeps)}`
       : 'Written in — occupies the whole room · capacity not recorded'
     : capacityKnown
-      ? `Sleeps ${String(unit.sleeps)} · ${String(occupants)} placed`
-      : `Capacity not recorded · ${String(occupants)} placed`
+      ? `Sleeps ${String(unit.sleeps)} · ${String(occupants)} placed${infantExemptionClause}`
+      : `Capacity not recorded · ${String(occupants)} placed${infantExemptionClause}`
 
   /*
    * Whether this space meets the needs of the family in flight (#1912) —


### PR DESCRIPTION
## What this is

Stage 1 of #2212 (owner ruling 2026-08-10: **both stages, sequenced** — this
tooltip half now, the family-card chip later behind #2222). Predecessors
#2078 and #2219-announce are both merged; the file this touches
(`LodgingUnitCard.tsx`) has moved since either landed, so all anchors below
were re-derived against current `main`, not copied from the issue body.

**This PR discharges stage 1 only.** #2212 stays open on stage 2 (the
family-card chip), which is mockup-gated and blocked on #2222. **No new
mark, badge, icon, or colour is added anywhere** — this is one extra clause
appended to the existing unit-card occupancy tooltip.

## What changed

`LodgingUnitCard.tsx`'s occupancy tooltip currently reads `Sleeps N · M
placed` (or `Capacity not recorded · M placed`), where `M` (`occupants`) is
a **bed count** — `slotOccupancy` sums `partySize`, which is the
server-reported `party_size` with fallback to headcount only when nothing
was reported. The reader never sees the **named headcount** anywhere else on
the card, so when a party's actual people-count exceeds its recorded beds
(an infant under 18 months was exempted, `INFANT_BED_EXEMPT_MONTHS`), the
card previously said nothing about why.

Now, when `Σ partyHeadcount(party) > occupants` for the slot, the tooltip
appends ` · an infant is exempt from the bed count` (or `· N infants are
exempt from the bed count` for more than one, reachable on a shared slot).
Ordinary cards — where the two numbers agree — are byte-for-byte unchanged.

## The two data traps from the issue, and how this avoids them

- **Never threshold `PartyChild.age`.** This implementation never reads
  `age` at all — the signal is purely `partyHeadcount(party) - occupants`,
  both of which are already-computed headcount/bed numbers. Because of that,
  the `0.0` unknown-age sentinel case is handled for free: a party whose
  reported beds already equal its headcount contributes zero to the
  difference regardless of what any child's `age` field says. Pinned
  explicitly in a test (the 24-vs-25 households case from the issue).
- **`has_infant` is not read anywhere in this diff.** It's false on every
  `family_camp_registrations` row in production and would never fire.

## Tests (TDD — written first, verified failing, then implementation)

Added to `LodgingUnitCard.test.tsx`, all under a new `describe` block:
1. Clause fires when a party's headcount exceeds its recorded `party_size`.
2. Clause stays silent, and the ordinary sentence is pinned **exactly**
   (not a substring match), when headcount equals recorded beds.
3. Clause stays silent when a child carries the `0.0` unknown-age sentinel
   but headcount still equals recorded beds — the 24-vs-25 pin.
4. Pluralization ("2 infants are exempt…") on a shared slot with two
   parties each exempting one infant.

## Verification (all commands run in `frontend/`, exit codes read)

- `./node_modules/.bin/vitest run src/components/weekend/LodgingUnitCard.test.tsx` → **119 passed, exit 0** (115 pre-existing + 4 new, zero regressions)
- Mutation check: loosened the trigger condition from `exemptedInfants > 0` to `exemptedInfants >= 0` → the two "stays silent" tests failed as expected (exit 1); reverted to the correct condition, suite green again.
- `./node_modules/.bin/tsc --noEmit` → **exit 0**
- `./node_modules/.bin/prettier --check src/components/weekend/LodgingUnitCard.tsx src/components/weekend/LodgingUnitCard.test.tsx` → **exit 0** (ran `--write` once to settle the new test block's formatting, then re-checked clean)
- `./node_modules/.bin/eslint src/components/weekend/LodgingUnitCard.tsx src/components/weekend/LodgingUnitCard.test.tsx` → **exit 0, 0 errors** (1 pre-existing warning on an untouched line — `vi.mock`'s `importOriginal<typeof import(...)>()` — present before this diff)
- Pre-push hook's own `tsc --noEmit` (both tsconfigs) → **green**, push succeeded
- Push verified by the remote ref moving: `git fetch -q && git rev-list --count origin/feature/issue-2212-infant-exemption-tooltip..HEAD` → **0**

## Files touched

- `frontend/src/components/weekend/LodgingUnitCard.tsx`
- `frontend/src/components/weekend/LodgingUnitCard.test.tsx`

No other file in the weekend surface was touched — this wave's other
concurrent items own `ui/Tooltip.tsx`, `ui/Modal.tsx`, `ui/modalStack.ts`,
`HouseholdRosterRow.tsx`, `MapUnitPopover.tsx`, `rosterAttention.ts`, and
`UnitAvailabilityControl.tsx`.

## What this deliberately does NOT do

- No family-card chip (stage 2) — mockup-gated, blocked on #2222, stays open on #2212.
- No new visual channel (icon/colour/badge) of any kind.
- No change to `partySize`, `partyHeadcount`, `slotOccupancy`, or any other
  shared derivation — this reads two already-exported numbers and subtracts
  them.

This PR closes nothing. #2212 remains open, tracking stage 2.