### PR TITLE
feat(scripts): detect a renumbered migration before PocketBase fails to boot

### DIFF
--- a/docs/reference/pocketbase-migrations.md
+++ b/docs/reference/pocketbase-migrations.md
@@ -252,7 +252,7 @@ The numbering rule tells you to bump above HEAD when a competing PR takes your n
 
 ### The mechanism
 
-`_migrations` keys on the **exact filename**. PocketBase's `isMigrationApplied` (`core/migrations_runner.go:265-272`) is a `WHERE file = ?` lookup, so `1500000146_foo.js` is unapplied no matter what row `1500000144_foo.js` has. Renaming an applied migration makes PB see a brand new one:
+`_migrations` keys on the **exact filename**. PocketBase's `isMigrationApplied` (`core/migrations_runner.go:265-275`) is a `WHERE file = ?` lookup, so `1500000146_foo.js` is unapplied no matter what row `1500000144_foo.js` has. Renaming an applied migration makes PB see a brand new one:
 
 - an **ALTER** migration silently re-runs
 - a **CREATE** migration fails the boot with `Collection name must be unique (case insensitive)` — an error naming neither the file nor the cause
@@ -280,14 +280,27 @@ sqlite3 pocketbase/pb_data/data.db \
    VALUES ('<NEW>_<slug>.js', strftime('%s','now')*1000000);"
 ```
 
-**Case 2 — content differs.** Your database carries a schema that exists nowhere else, and only a re-apply converges it. **Count rows before you drop anything:**
+**Case 2 — content differs.** Your database carries a schema that exists nowhere else, and only a re-apply converges it. **What you do next depends on whether the migration CREATEs or ALTERs, and getting that backwards destroys data.**
+
+**Case 2a — the migration CREATEs the collections.** These are the ones that fail the boot outright. **Count rows before you drop anything:**
 
 ```bash
 sqlite3 'file:pocketbase/pb_data/data.db?mode=ro' 'SELECT count(*) FROM <collection>;'
 ```
 
-- **All zero** → drop the collections the migration creates, then boot normally.
+- **All zero** → drop the collections **that this migration creates**, then boot normally.
 - **Any non-zero** → **do not drop.** Export first, or reseed the dev database from a prod snapshot. "Drop the collection and re-run" is the recipe that works on an empty table and silently destroys a populated one.
+
+**Case 2b — the migration ALTERs an existing collection.** ⛔ **Do not drop anything.** The collection it targets was created by a *different, earlier* migration that is still recorded as applied — so dropping it destroys that migration's work and a normal boot will **not** recreate it, because PocketBase already believes it ran.
+
+An ALTER in this state has silently re-run rather than failed, so the damage is usually nil: the convention here is idempotent `fields.add()`, which converges toward whatever the file declares. Verify rather than assume — compare the live column set against the file:
+
+```bash
+sqlite3 'file:pocketbase/pb_data/data.db?mode=ro' \
+  "SELECT fields FROM _collections WHERE name='<collection>';" | python3 -m json.tool | grep '"name"'
+```
+
+If it matches the migration's declaration, record the new filename as applied per Case 1 and move on. If it does not — the usual cause is a field the file *removed*, which no re-run can undo — hand-drop that field, or reseed the dev database. There is no automatic recovery for a removal.
 
 **Re-apply by booting the server** (`./scripts/start_dev.sh`) rather than by hand. Migrations run from `apis.Serve` at `apis/serve.go:66-70`, so a normal boot applies them.
 

--- a/docs/reference/pocketbase-migrations.md
+++ b/docs/reference/pocketbase-migrations.md
@@ -245,3 +245,56 @@ Skill artifacts:
 Cleanup mechanism: PB v0.23 has a built-in `migrate history-sync` subcommand (`RemoveMissingAppliedMigrations` in `core/migrations_runner.go`) that DELETEs every `_migrations` row whose file is no longer on disk. `pocketbase/main.go` registers an `OnServe` hook that calls this on every server boot, so prod's `_migrations` self-heals after each consolidation merge. Idempotent — no-op on clean DBs.
 
 Numbering: gaps may appear in `pb_migrations/` numbering after consolidation. Per CLAUDE.md "PocketBase Migration Numbering Rule", new migrations must use a number greater than the highest existing filename on `origin/main` — never fill consolidation gaps.
+
+## Renumbering a migration you have already applied locally
+
+The numbering rule tells you to bump above HEAD when a competing PR takes your number. Do that **before you first boot the branch.** If you renumber a migration your dev database has already applied, that database is now broken in a way nothing else in this repo will catch — and `scripts/dev/verify-migration-history.sh` exists because of it (kindred#2245).
+
+### The mechanism
+
+`_migrations` keys on the **exact filename**. PocketBase's `isMigrationApplied` (`core/migrations_runner.go:265-272`) is a `WHERE file = ?` lookup, so `1500000146_foo.js` is unapplied no matter what row `1500000144_foo.js` has. Renaming an applied migration makes PB see a brand new one:
+
+- an **ALTER** migration silently re-runs
+- a **CREATE** migration fails the boot with `Collection name must be unique (case insensitive)` — an error naming neither the file nor the cause
+
+**history-sync is not what breaks this, and believing it is will send you to the wrong place.** `apis.Serve` runs `RunAllMigrations()` and returns on error at `apis/serve.go:66-70`, before the router is built and before `OnServe` fires — so on a *failing* boot, history-sync never runs at all. What it does is erase the evidence on every *successful* boot: `RemoveMissingAppliedMigrations` is `DELETE FROM _migrations WHERE file NOT IN (on-disk names)`, so any boot taken while the renamed file is absent from your branch removes the old row. Afterwards `_migrations` looks perfectly clean and the only remaining signal is that a collection exists which no applied migration created.
+
+There is a second, quieter half. If the file's **content** also changed after you applied it — a stripped field, a changed rule — that edit never reaches your database either, for the same filename-keyed reason. You end up with a schema that exists in no other database and in no version of the file on `main`. The fresh-DB verifiers (`verify-consolidation.sh`, `verify-lodging-schema.sh`) run against empty throwaway databases and cannot observe it.
+
+### Recovery
+
+**Work out which case you are in first. Do not skip this — the two fixes are different, and the obvious one destroys data.**
+
+```bash
+# Find the old name and diff it against the new file
+git log --all --diff-filter=A --oneline -- 'pocketbase/pb_migrations/*_<slug>.js'
+git show <old-sha>:pocketbase/pb_migrations/<OLD>_<slug>.js \
+  | diff - pocketbase/pb_migrations/<NEW>_<slug>.js
+```
+
+**Case 1 — content identical (a pure renumber).** Your database already holds exactly what the new file creates. Record the new name as applied; nothing needs to run:
+
+```bash
+sqlite3 pocketbase/pb_data/data.db \
+  "INSERT OR IGNORE INTO _migrations (file, applied)
+   VALUES ('<NEW>_<slug>.js', strftime('%s','now')*1000000);"
+```
+
+**Case 2 — content differs.** Your database carries a schema that exists nowhere else, and only a re-apply converges it. **Count rows before you drop anything:**
+
+```bash
+sqlite3 'file:pocketbase/pb_data/data.db?mode=ro' 'SELECT count(*) FROM <collection>;'
+```
+
+- **All zero** → drop the collections the migration creates, then boot normally.
+- **Any non-zero** → **do not drop.** Export first, or reseed the dev database from a prod snapshot. "Drop the collection and re-run" is the recipe that works on an empty table and silently destroys a populated one.
+
+**Re-apply by booting the server** (`./scripts/start_dev.sh`) rather than by hand. Migrations run from `apis.Serve` at `apis/serve.go:66-70`, so a normal boot applies them.
+
+> ⚠️ **Do not pass `--migrationsDir` to `pocketbase migrate up`.** `main.go:203-209` hands `migrationsDir` to `jsvm.MustRegister` while it still holds its `""` default — cobra does not parse argv until `app.Start()` runs, much later. An explicitly-passed directory is therefore ignored and **JS migrations are silently skipped**, which reads as "nothing to apply". The unflagged default resolves correctly; leave it alone.
+
+### Why an idempotent CREATE is the wrong fix
+
+The tempting fix is a skip-if-exists guard on the `CREATE`. It is worse than the failure it prevents. The boot would succeed, `_migrations` would record the migration as applied, and a divergent schema would stay in place permanently with nothing left to reveal it. Prod and CI apply from scratch and would never show the difference.
+
+Note the asymmetry, because it does not condemn idempotency in general: an idempotent `fields.add()` on an ALTER **converges** toward the file's declaration — it adds what is missing. A skip-if-exists CREATE **diverges** — it accepts whatever shape is already there. Keep the former; it is the documented convention. Reject the latter.

--- a/pocketbase/CLAUDE.md
+++ b/pocketbase/CLAUDE.md
@@ -28,6 +28,8 @@ NEXT=$((HIGHEST + 1))
 
 Do not backfill gaps left by past consolidation runs — those numbers are "burned" to preserve a monotonically increasing record. Once merged to `main`, the file is frozen; if a competing PR landed and took your number, bump above the new HEAD.
 
+⚠️ **Renumber BEFORE you first boot the branch, not after.** `_migrations` keys on the exact filename, so renaming a migration your dev database already applied makes PocketBase treat it as brand new: an ALTER silently re-runs and a CREATE fails the boot with `Collection name must be unique`. `scripts/dev/verify-migration-history.sh` catches it (and `start_dev.sh` runs it before every boot), but the recovery is manual and depends on whether the file's content changed too — see `docs/reference/pocketbase-migrations.md` § "Renumbering a migration you have already applied locally". Do not reach for the obvious drop-and-re-run; it destroys local data when the table is not empty.
+
 ### History-sync (why consolidation is safe)
 
 `main.go` registers an `OnServe` hook that runs `migrate history-sync` on every server boot. It reconciles prod's `_migrations` table against the on-disk file list automatically — no per-round helper migrations needed when consolidating. Skill: `consolidate-migrations`.

--- a/scripts/dev/test-verify-migration-history.sh
+++ b/scripts/dev/test-verify-migration-history.sh
@@ -7,7 +7,7 @@
 #   2 — harness error (unreadable DB, missing migrations dir, sqlite3 absent, ...)
 #
 # kindred#2245. The hazard: PocketBase's isMigrationApplied keys on the EXACT
-# filename (core/migrations_runner.go:265-272), so renumbering a migration that
+# filename (core/migrations_runner.go:265-275), so renumbering a migration that
 # a dev DB already applied makes PB treat it as brand new. An ALTER silently
 # re-runs; a CREATE fails the boot with "Collection name must be unique".
 #
@@ -153,11 +153,22 @@ echo "PASS: single-quoted name: extracted"
 echo
 echo "=== TEST 6: .go rows with no file on disk are NEVER reported ==="
 # PB's own system migrations are compiled in, not on disk. Treating them as
-# stale would fire on every single boot, and deleting them breaks the next one
+# stale would fire on every boot, and deleting them breaks the next one
 # (pocketbase/main.go documents this).
+#
+# The fixture MUST carry an unapplied .js file. CHECK 1 reads STALE only from
+# inside its loop over UNAPPLIED, so an empty migrations dir means the .go rows
+# are never examined and this test asserts nothing. That was the original bug:
+# both this test and TEST 7 stayed green with their filters deleted.
+#
+# Honest note on what this can and cannot pin: the `grep '\.js$'` filter is
+# belt-and-braces, and no fixture can make it load-bearing. CHECK 1 matches on
+# the slug, and the slug includes the extension — `init.go` can never equal
+# `init.js` — so a .go row is inert whether or not it is filtered out. This
+# test pins the observable contract; TEST 7 is the one that pins a filter.
 DB6="$SCRATCH/t6.db"; DIR6="$SCRATCH/t6-migrations"
 make_db "$DB6"
-mkdir -p "$DIR6"
+make_migrations_dir "$DIR6" 1500000146_lodging_friend_groups.js
 add_migration_row "$DB6" "1640988000_init.go"
 add_migration_row "$DB6" "1717233556_v0.23_migrate.go"
 add_migration_row "$DB6" "1778828400_normalize_indexes.go"
@@ -166,22 +177,28 @@ OUT=$("$VERIFY_SCRIPT" --db "$DB6" --migrations-dir "$DIR6" 2>&1)
 rc=$?
 set -e
 [[ $rc -eq 0 ]] || fail "expected exit 0 — .go system migrations must be ignored, got $rc" "$OUT"
-echo "PASS: .go rows ignored"
+echo "PASS: .go rows ignored while CHECK 1's loop is actually running"
 
 echo
 echo "=== TEST 7: the gitignored *_updated_users.js outlier is excluded ==="
-# pocketbase/CLAUDE.md documents this file as intentionally untracked, so it
-# is applied but absent from a fresh checkout's pb_migrations/.
+# pocketbase/CLAUDE.md documents this file as intentionally untracked, so it is
+# applied but absent from a fresh checkout's pb_migrations/.
+#
+# Load-bearing by construction: the on-disk file shares the outlier's SLUG at a
+# different number, which is exactly CHECK 1's renumber fingerprint. Without
+# the `grep -v '_updated_users\.js$'` filter this fixture reports a renumber
+# and exits 1. Delete that filter and this test goes red.
 DB7="$SCRATCH/t7.db"; DIR7="$SCRATCH/t7-migrations"
 make_db "$DB7"
 mkdir -p "$DIR7"
+printf 'migrate((app) => {}, (app) => {})\n' > "$DIR7/1900000000_updated_users.js"
 add_migration_row "$DB7" "1769791931_updated_users.js"
 set +e
 OUT=$("$VERIFY_SCRIPT" --db "$DB7" --migrations-dir "$DIR7" 2>&1)
 rc=$?
 set -e
 [[ $rc -eq 0 ]] || fail "expected exit 0 — *_updated_users.js is a documented outlier, got $rc" "$OUT"
-echo "PASS: updated_users outlier excluded"
+echo "PASS: updated_users outlier excluded even on a slug collision"
 
 echo
 echo "=== TEST 8: an unapplied migration that collides with NOTHING is clean ==="
@@ -219,6 +236,57 @@ set -e
 grep -q "docs/reference/pocketbase-migrations.md" <<<"$OUT" \
   || fail "failure output must cite docs/reference/pocketbase-migrations.md" "$OUT"
 echo "PASS: recovery doc cited"
+
+echo
+echo "=== TEST 11: a case-ONLY collision must be caught ==="
+# PocketBase's uniqueness is case-insensitive — its own boot error says so — so
+# a migration creating `lodging_friend_groups` collides with a live
+# `LODGING_FRIEND_GROUPS`. A case-sensitive comparison here is a false CLEAN,
+# which is the one failure direction that makes a detector worthless.
+DB11="$SCRATCH/t11.db"; DIR11="$SCRATCH/t11-migrations"
+make_db "$DB11"
+make_migrations_dir "$DIR11" 1500000146_lodging_friend_groups.js
+add_collection_row "$DB11" "LODGING_FRIEND_GROUPS"
+set +e
+OUT=$("$VERIFY_SCRIPT" --db "$DB11" --migrations-dir "$DIR11" 2>&1)
+rc=$?
+set -e
+[[ $rc -eq 1 ]] || fail "expected exit 1 for a case-only collision, got $rc" "$OUT"
+echo "PASS: case-only collision caught"
+
+echo
+echo "=== TEST 12: an absent DB returns 0 even when sqlite3 is unavailable ==="
+# The tool check must NOT preempt the absent-database early return. start_dev.sh
+# treats any non-zero as fatal, so getting this backwards makes a first run on a
+# fresh clone depend on sqlite3 being installed — a dependency this check would
+# be introducing purely by the order of its own guards.
+#
+# The stub PATH carries bash alone — the `/usr/bin/env bash` shebang needs to
+# resolve it, and the absent-DB path uses nothing but shell builtins after
+# that. sqlite3 and python3 are both genuinely unreachable here.
+STUBBIN="$SCRATCH/stub-path"; mkdir -p "$STUBBIN"
+ln -sf "$(command -v bash)" "$STUBBIN/bash"
+if PATH="$STUBBIN" command -v sqlite3 >/dev/null 2>&1; then
+  fail "test setup is wrong: sqlite3 is still reachable on the stub PATH"
+fi
+set +e
+OUT=$(PATH="$STUBBIN" "$VERIFY_SCRIPT" --db "$SCRATCH/nope.db" --migrations-dir "$REAL_MIGRATIONS" 2>&1)
+rc=$?
+set -e
+[[ $rc -eq 0 ]] || fail "expected exit 0 for an absent DB with no sqlite3 on PATH, got $rc" "$OUT"
+echo "PASS: absent DB short-circuits before the tool check"
+
+echo
+echo "=== TEST 13: a dangling --db is a harness error, not a silent exit 1 ==="
+# `shift 2` on a one-element argv fails under `set -e` and exits 1 with no
+# output, which collides with the exit code meaning "diagnosed problem".
+set +e
+OUT=$("$VERIFY_SCRIPT" --db 2>&1)
+rc=$?
+set -e
+[[ $rc -eq 2 ]] || fail "expected exit 2 for a valueless --db, got $rc" "$OUT"
+grep -q "requires a path" <<<"$OUT" || fail "a valueless --db must say what is wrong" "$OUT"
+echo "PASS: dangling --db reports a harness error"
 
 echo
 echo "All tests passed."

--- a/scripts/dev/test-verify-migration-history.sh
+++ b/scripts/dev/test-verify-migration-history.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# Test for verify-migration-history.sh
+#
+# Verifies the documented exit contract:
+#   0 — the dev DB's _migrations history is consistent with pb_migrations/ on disk
+#   1 — a diagnosed problem (renumbered migration, or a CREATE that will collide)
+#   2 — harness error (unreadable DB, missing migrations dir, sqlite3 absent, ...)
+#
+# kindred#2245. The hazard: PocketBase's isMigrationApplied keys on the EXACT
+# filename (core/migrations_runner.go:265-272), so renumbering a migration that
+# a dev DB already applied makes PB treat it as brand new. An ALTER silently
+# re-runs; a CREATE fails the boot with "Collection name must be unique".
+#
+# Two cases must BOTH be caught, and the second is the load-bearing one:
+#
+#   (i)  the stale _migrations row still exists  — TEST 3
+#   (ii) history-sync already ate it             — TEST 4
+#
+# Case (ii) is what actually happened: RemoveMissingAppliedMigrations
+# (DELETE FROM _migrations WHERE file NOT IN (on-disk names)) runs from the
+# OnServe hook on every SUCCESSFUL boot, so any boot during the window when
+# `main` did not yet carry the renumbered file destroys the evidence. A
+# detector that only implements TEST 3 would have reported clean on the very
+# machine that could not boot.
+
+set -euo pipefail
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$HERE/../.." && pwd)
+VERIFY_SCRIPT="$HERE/verify-migration-history.sh"
+REAL_MIGRATIONS="$REPO_ROOT/pocketbase/pb_migrations"
+
+if [[ ! -x "$VERIFY_SCRIPT" ]]; then
+  echo "FAIL: $VERIFY_SCRIPT not executable or missing" >&2
+  exit 1
+fi
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "FAIL: sqlite3 not on PATH (needed to build fixtures)" >&2
+  exit 1
+fi
+
+SCRATCH=$(mktemp -d -t pb-mighist-test-XXXX)
+trap 'rm -rf "$SCRATCH"' EXIT INT TERM
+
+# Build a scratch DB carrying only the two tables the detector reads.
+# $1 = db path. Reads newline-separated "file" rows on stdin for _migrations.
+make_db() {
+  local db="$1"
+  sqlite3 "$db" \
+    "CREATE TABLE _migrations (file TEXT PRIMARY KEY, applied INTEGER);
+     CREATE TABLE _collections (id TEXT PRIMARY KEY, name TEXT);"
+}
+
+add_migration_row() { sqlite3 "$1" "INSERT INTO _migrations (file, applied) VALUES ('$2', 1);"; }
+add_collection_row() { sqlite3 "$1" "INSERT INTO _collections (id, name) VALUES ('pbc_$RANDOM$RANDOM', '$2');"; }
+
+# A migrations dir holding just the named real migration files.
+make_migrations_dir() {
+  local dir="$1"; shift
+  mkdir -p "$dir"
+  local f
+  for f in "$@"; do
+    cp "$REAL_MIGRATIONS/$f" "$dir/$f"
+  done
+}
+
+fail() { echo "FAIL: $1" >&2; [[ -n "${2:-}" ]] && echo "$2" >&2; exit 1; }
+
+echo "=== TEST 1: the repo's own dev DB and migration set must be consistent ==="
+# Not a fixture — the real thing. If this goes red, either the detector has a
+# false positive or the machine genuinely needs the recovery in
+# docs/reference/pocketbase-migrations.md.
+REPO_DB="$REPO_ROOT/pocketbase/pb_data/data.db"
+if [[ -f "$REPO_DB" ]]; then
+  set +e
+  OUT=$("$VERIFY_SCRIPT" --db "$REPO_DB" --migrations-dir "$REAL_MIGRATIONS" 2>&1)
+  rc=$?
+  set -e
+  if [[ $rc -ne 0 ]]; then
+    fail "expected exit 0 against the repo's own DB, got $rc" "$OUT"
+  fi
+  echo "PASS: the repo's dev DB is consistent with pb_migrations/"
+else
+  echo "SKIP: no pocketbase/pb_data/data.db in this checkout"
+fi
+
+echo
+echo "=== TEST 2: an ABSENT database is exit 0, not a harness error ==="
+# A fresh clone has no pb_data/. That is not a fault, and returning 2 here
+# would make start_dev.sh refuse to boot on a first run.
+set +e
+OUT=$("$VERIFY_SCRIPT" --db "$SCRATCH/definitely-not-here.db" --migrations-dir "$REAL_MIGRATIONS" 2>&1)
+rc=$?
+set -e
+[[ $rc -eq 0 ]] || fail "expected exit 0 for an absent DB, got $rc" "$OUT"
+echo "PASS: absent DB returns 0"
+
+echo
+echo "=== TEST 3: stale-row renumber fingerprint (the evidence survived) ==="
+# _migrations remembers 1500000144_lodging_friend_groups.js; only
+# 1500000146_lodging_friend_groups.js is on disk. Same slug, different number.
+DB3="$SCRATCH/t3.db"; DIR3="$SCRATCH/t3-migrations"
+make_db "$DB3"
+make_migrations_dir "$DIR3" 1500000146_lodging_friend_groups.js
+add_migration_row "$DB3" "1500000144_lodging_friend_groups.js"
+set +e
+OUT=$("$VERIFY_SCRIPT" --db "$DB3" --migrations-dir "$DIR3" 2>&1)
+rc=$?
+set -e
+[[ $rc -eq 1 ]] || fail "expected exit 1 for a renumbered migration, got $rc" "$OUT"
+grep -q "1500000144_lodging_friend_groups.js" <<<"$OUT" || fail "output must name the OLD filename" "$OUT"
+grep -q "1500000146_lodging_friend_groups.js" <<<"$OUT" || fail "output must name the NEW filename" "$OUT"
+echo "PASS: renumber detected and both filenames reported"
+
+echo
+echo "=== TEST 4: collision predictor — history-sync already ate the row ==="
+# THE LOAD-BEARING CASE. _migrations carries NO trace of the old name, so the
+# fingerprint in TEST 3 has nothing to match on. The only remaining signal is
+# that an UNAPPLIED migration creates a collection that already exists.
+DB4="$SCRATCH/t4.db"; DIR4="$SCRATCH/t4-migrations"
+make_db "$DB4"
+make_migrations_dir "$DIR4" 1500000146_lodging_friend_groups.js
+add_collection_row "$DB4" "lodging_friend_groups"
+add_collection_row "$DB4" "lodging_friend_group_members"
+set +e
+OUT=$("$VERIFY_SCRIPT" --db "$DB4" --migrations-dir "$DIR4" 2>&1)
+rc=$?
+set -e
+[[ $rc -eq 1 ]] || fail "expected exit 1 when an unapplied CREATE would collide, got $rc" "$OUT"
+grep -q "lodging_friend_groups" <<<"$OUT" || fail "output must name the colliding collection" "$OUT"
+grep -q "1500000146_lodging_friend_groups.js" <<<"$OUT" || fail "output must name the migration file" "$OUT"
+echo "PASS: collision predicted with no _migrations evidence at all"
+
+echo
+echo "=== TEST 5: SINGLE-quoted name: must be extracted ==="
+# 1500000139_lodging_slot_merges.js writes name: 'lodging_slot_merges'. A
+# double-quote-only regex misses it and reports clean. This repo has already
+# shipped one scanner that passed because it only looked for sampled needles
+# (verify-no-hardcoded-lodging.sh); do not add a second.
+DB5="$SCRATCH/t5.db"; DIR5="$SCRATCH/t5-migrations"
+make_db "$DB5"
+make_migrations_dir "$DIR5" 1500000139_lodging_slot_merges.js
+add_collection_row "$DB5" "lodging_slot_merges"
+set +e
+OUT=$("$VERIFY_SCRIPT" --db "$DB5" --migrations-dir "$DIR5" 2>&1)
+rc=$?
+set -e
+[[ $rc -eq 1 ]] || fail "expected exit 1 — a single-quoted name: was not extracted, got $rc" "$OUT"
+grep -q "lodging_slot_merges" <<<"$OUT" || fail "output must name the single-quoted collection" "$OUT"
+echo "PASS: single-quoted name: extracted"
+
+echo
+echo "=== TEST 6: .go rows with no file on disk are NEVER reported ==="
+# PB's own system migrations are compiled in, not on disk. Treating them as
+# stale would fire on every single boot, and deleting them breaks the next one
+# (pocketbase/main.go documents this).
+DB6="$SCRATCH/t6.db"; DIR6="$SCRATCH/t6-migrations"
+make_db "$DB6"
+mkdir -p "$DIR6"
+add_migration_row "$DB6" "1640988000_init.go"
+add_migration_row "$DB6" "1717233556_v0.23_migrate.go"
+add_migration_row "$DB6" "1778828400_normalize_indexes.go"
+set +e
+OUT=$("$VERIFY_SCRIPT" --db "$DB6" --migrations-dir "$DIR6" 2>&1)
+rc=$?
+set -e
+[[ $rc -eq 0 ]] || fail "expected exit 0 — .go system migrations must be ignored, got $rc" "$OUT"
+echo "PASS: .go rows ignored"
+
+echo
+echo "=== TEST 7: the gitignored *_updated_users.js outlier is excluded ==="
+# pocketbase/CLAUDE.md documents this file as intentionally untracked, so it
+# is applied but absent from a fresh checkout's pb_migrations/.
+DB7="$SCRATCH/t7.db"; DIR7="$SCRATCH/t7-migrations"
+make_db "$DB7"
+mkdir -p "$DIR7"
+add_migration_row "$DB7" "1769791931_updated_users.js"
+set +e
+OUT=$("$VERIFY_SCRIPT" --db "$DB7" --migrations-dir "$DIR7" 2>&1)
+rc=$?
+set -e
+[[ $rc -eq 0 ]] || fail "expected exit 0 — *_updated_users.js is a documented outlier, got $rc" "$OUT"
+echo "PASS: updated_users outlier excluded"
+
+echo
+echo "=== TEST 8: an unapplied migration that collides with NOTHING is clean ==="
+# The ordinary case: a genuinely new migration waiting to be applied. It must
+# not be confused with a renumber, or every pull would fail the boot.
+DB8="$SCRATCH/t8.db"; DIR8="$SCRATCH/t8-migrations"
+make_db "$DB8"
+make_migrations_dir "$DIR8" 1500000146_lodging_friend_groups.js
+set +e
+OUT=$("$VERIFY_SCRIPT" --db "$DB8" --migrations-dir "$DIR8" 2>&1)
+rc=$?
+set -e
+[[ $rc -eq 0 ]] || fail "expected exit 0 for a normal pending migration, got $rc" "$OUT"
+echo "PASS: a normal pending migration is not flagged"
+
+echo
+echo "=== TEST 9: a missing migrations directory is a harness error (2) ==="
+DB9="$SCRATCH/t9.db"
+make_db "$DB9"
+set +e
+OUT=$("$VERIFY_SCRIPT" --db "$DB9" --migrations-dir "$SCRATCH/no-such-dir" 2>&1)
+rc=$?
+set -e
+[[ $rc -eq 2 ]] || fail "expected exit 2 for a missing migrations dir, got $rc" "$OUT"
+echo "PASS: missing migrations dir returns 2"
+
+echo
+echo "=== TEST 10: the failure message must cite the recovery documentation ==="
+# The PocketBase error a user actually sees ("Collection name must be unique")
+# contains no term they could search the docs for. If this script does not
+# hand them the page, nothing will.
+set +e
+OUT=$("$VERIFY_SCRIPT" --db "$DB4" --migrations-dir "$DIR4" 2>&1)
+set -e
+grep -q "docs/reference/pocketbase-migrations.md" <<<"$OUT" \
+  || fail "failure output must cite docs/reference/pocketbase-migrations.md" "$OUT"
+echo "PASS: recovery doc cited"
+
+echo
+echo "All tests passed."

--- a/scripts/dev/verify-migration-history.sh
+++ b/scripts/dev/verify-migration-history.sh
@@ -2,7 +2,7 @@
 # Detect a renumbered PocketBase migration before the server fails to boot.
 #
 # kindred#2245. PocketBase's isMigrationApplied keys on the EXACT filename
-# (core/migrations_runner.go:265-272), so renaming a migration a dev database
+# (core/migrations_runner.go:265-275), so renaming a migration a dev database
 # has already applied makes PB treat it as brand new. An ALTER silently
 # re-runs; a CREATE dies with "Collection name must be unique (case
 # insensitive)", which names neither the cause nor anything searchable.
@@ -41,10 +41,17 @@ REPO_ROOT=$(cd "$HERE/../.." && pwd)
 DB=""
 MIGRATIONS_DIR=""
 
+# A dangling `--db` with no value must not fall through to `shift 2`, which
+# fails under `set -e` and exits 1 with no message — colliding with the exit
+# code that means "diagnosed problem" and reporting a real fault as a finding.
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --db) DB="${2:-}"; shift 2 ;;
-    --migrations-dir) MIGRATIONS_DIR="${2:-}"; shift 2 ;;
+    --db)
+      [[ $# -ge 2 ]] || { echo "error: --db requires a path" >&2; exit 2; }
+      DB="$2"; shift 2 ;;
+    --migrations-dir)
+      [[ $# -ge 2 ]] || { echo "error: --migrations-dir requires a path" >&2; exit 2; }
+      MIGRATIONS_DIR="$2"; shift 2 ;;
     -h|--help) sed -n '2,30p' "${BASH_SOURCE[0]}"; exit 0 ;;
     *) echo "error: unknown argument '$1'" >&2; exit 2 ;;
   esac
@@ -59,20 +66,25 @@ if [[ -z "$DB" ]]; then
 fi
 [[ -n "$MIGRATIONS_DIR" ]] || MIGRATIONS_DIR="$REPO_ROOT/pocketbase/pb_migrations"
 
-for tool in sqlite3 python3; do
-  command -v "$tool" >/dev/null 2>&1 || { echo "error: $tool not on PATH" >&2; exit 2; }
-done
+# A checkout that has never booted has no database. That is not a fault, and
+# failing here would stop start_dev.sh on a first run.
+#
+# ORDER MATTERS: this must precede the tool check below. Otherwise a fresh
+# clone without sqlite3 exits 2, and start_dev.sh treats any non-zero as fatal
+# — so the check would introduce a hard dependency on exactly the first-run
+# path it is meant to wave through.
+if [[ ! -f "$DB" ]]; then
+  exit 0
+fi
 
 if [[ ! -d "$MIGRATIONS_DIR" ]]; then
   echo "error: migrations directory not found: $MIGRATIONS_DIR" >&2
   exit 2
 fi
 
-# A checkout that has never booted has no database. That is not a fault, and
-# failing here would stop start_dev.sh on a first run.
-if [[ ! -f "$DB" ]]; then
-  exit 0
-fi
+for tool in sqlite3 python3; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "error: $tool not on PATH" >&2; exit 2; }
+done
 
 query() {
   sqlite3 "file:${DB}?mode=ro" "$1" 2>/dev/null || {
@@ -126,6 +138,15 @@ done <<<"$UNAPPLIED"
 # For every unapplied migration, the collections it CREATEs. If one already
 # exists, the boot is going to fail on it.
 #
+# KNOWN LIMITATION, accepted: this does not simulate migration ORDER. If one
+# unapplied migration drops collection X and a later unapplied one recreates
+# it, this reports a collision the boot would not actually hit. Constructible
+# (verified), but it needs a drop and a recreate split across two NEW
+# migrations rather than written as one — and the cost of simulating order to
+# suppress it is far higher than the cost of a rare, loud, easily-read false
+# positive. The ordinary drop-then-recreate shape does not reach here at all,
+# because the deleting migration is already applied.
+#
 # Both quote styles are required: 1500000139_lodging_slot_merges.js writes
 # name: 'lodging_slot_merges', and a double-quote-only pattern misses it
 # silently. This repo has already shipped one scanner that passed because it
@@ -152,7 +173,12 @@ while IFS= read -r file; do
   [[ -n "$file" ]] || continue
   while IFS= read -r coll; do
     [[ -n "$coll" ]] || continue
-    if grep -Fxq "$coll" <<<"$EXISTING"; then
+    # -i, not just -Fxq: PocketBase's uniqueness is CASE-INSENSITIVE — its own
+    # error says so — so a migration creating `Example` collides with a live
+    # `example`. Every migration in the tree is lowercase snake_case today, so
+    # this needs a convention violation to fire; it costs one flag to be right
+    # anyway, and the cost of being wrong is a false CLEAN.
+    if grep -Fxiq "$coll" <<<"$EXISTING"; then
       report "" \
         "COLLECTION ALREADY EXISTS — an unapplied migration would re-create it." \
         "" \

--- a/scripts/dev/verify-migration-history.sh
+++ b/scripts/dev/verify-migration-history.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Detect a renumbered PocketBase migration before the server fails to boot.
+#
+# kindred#2245. PocketBase's isMigrationApplied keys on the EXACT filename
+# (core/migrations_runner.go:265-272), so renaming a migration a dev database
+# has already applied makes PB treat it as brand new. An ALTER silently
+# re-runs; a CREATE dies with "Collection name must be unique (case
+# insensitive)", which names neither the cause nor anything searchable.
+#
+# Renumbering is routine here, not exotic: pocketbase/CLAUDE.md tells you to
+# bump above HEAD when a competing PR takes your number, and two lodging PRs
+# open at once is the normal state of this repo.
+#
+# Usage:
+#   verify-migration-history.sh [--db PATH] [--migrations-dir PATH]
+#
+#   --db              defaults to $PB_DATA_DIR/data.db, else
+#                     <repo>/pocketbase/pb_data/data.db
+#   --migrations-dir  defaults to <repo>/pocketbase/pb_migrations
+#
+# Exit codes:
+#   0  history is consistent, or there is no database yet (a fresh clone)
+#   1  a diagnosed problem, with the recovery cited
+#   2  harness error (missing tool, unreadable DB, missing migrations dir)
+#
+# WHY THIS RUNS BEFORE THE SERVER STARTS, NOT AFTER
+#
+# Our OnServe hook runs PB's history-sync, whose RemoveMissingAppliedMigrations
+# is `DELETE FROM _migrations WHERE file NOT IN (on-disk names)`. Every
+# SUCCESSFUL boot therefore erases the stale row that proves a renumber
+# happened. In the incident that motivated this script the row was already
+# gone: it was eaten during the ~13h window when `main` carried no
+# friend-groups migration at all. So CHECK 2 below, which reads the collection
+# side, is the load-bearing one — CHECK 1 is a bonus when the evidence lives.
+
+set -euo pipefail
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$HERE/../.." && pwd)
+
+DB=""
+MIGRATIONS_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --db) DB="${2:-}"; shift 2 ;;
+    --migrations-dir) MIGRATIONS_DIR="${2:-}"; shift 2 ;;
+    -h|--help) sed -n '2,30p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *) echo "error: unknown argument '$1'" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$DB" ]]; then
+  if [[ -n "${PB_DATA_DIR:-}" ]]; then
+    DB="$PB_DATA_DIR/data.db"
+  else
+    DB="$REPO_ROOT/pocketbase/pb_data/data.db"
+  fi
+fi
+[[ -n "$MIGRATIONS_DIR" ]] || MIGRATIONS_DIR="$REPO_ROOT/pocketbase/pb_migrations"
+
+for tool in sqlite3 python3; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "error: $tool not on PATH" >&2; exit 2; }
+done
+
+if [[ ! -d "$MIGRATIONS_DIR" ]]; then
+  echo "error: migrations directory not found: $MIGRATIONS_DIR" >&2
+  exit 2
+fi
+
+# A checkout that has never booted has no database. That is not a fault, and
+# failing here would stop start_dev.sh on a first run.
+if [[ ! -f "$DB" ]]; then
+  exit 0
+fi
+
+query() {
+  sqlite3 "file:${DB}?mode=ro" "$1" 2>/dev/null || {
+    echo "error: could not read $DB" >&2
+    exit 2
+  }
+}
+
+APPLIED=$(query "SELECT file FROM _migrations;" | sort)
+ON_DISK=$(find "$MIGRATIONS_DIR" -maxdepth 1 -type f -name '*.js' | sed 's|.*/||' | sort)
+
+UNAPPLIED=$(comm -23 <(printf '%s\n' "$ON_DISK" | grep -v '^$' || true) \
+                     <(printf '%s\n' "$APPLIED"  | grep -v '^$' || true))
+
+# STALE: applied JS migrations with no file on disk.
+#   - .go rows are PB's own compiled-in system migrations. They are never on
+#     disk, and pocketbase/main.go warns that deleting them breaks the next boot.
+#   - *_updated_users.js is a documented gitignored outlier (pocketbase/CLAUDE.md).
+STALE=$(comm -13 <(printf '%s\n' "$ON_DISK" | grep -v '^$' || true) \
+                 <(printf '%s\n' "$APPLIED"  | grep -v '^$' || true) \
+        | grep '\.js$' | grep -v '_updated_users\.js$' || true)
+
+PROBLEMS=0
+report() { PROBLEMS=$((PROBLEMS + 1)); printf '%s\n' "$@"; }
+
+# ── CHECK 1 ── renumber fingerprint, when the stale row survived ────────────
+# Same slug, different number: NNN_slug.js unapplied while MMM_slug.js is
+# recorded as applied.
+while IFS= read -r new_file; do
+  [[ -n "$new_file" ]] || continue
+  new_slug="${new_file#*_}"
+  new_num="${new_file%%_*}"
+  while IFS= read -r old_file; do
+    [[ -n "$old_file" ]] || continue
+    old_slug="${old_file#*_}"
+    old_num="${old_file%%_*}"
+    if [[ "$new_slug" == "$old_slug" && "$new_num" != "$old_num" ]]; then
+      report "" \
+        "RENUMBERED MIGRATION — this database applied it under its old name." \
+        "" \
+        "  applied as: $old_file" \
+        "  now on disk: $new_file" \
+        "" \
+        "PocketBase matches applied migrations on the exact filename, so it will" \
+        "try to run $new_file from scratch."
+    fi
+  done <<<"$STALE"
+done <<<"$UNAPPLIED"
+
+# ── CHECK 2 ── collision predictor, which survives history-sync ─────────────
+# For every unapplied migration, the collections it CREATEs. If one already
+# exists, the boot is going to fail on it.
+#
+# Both quote styles are required: 1500000139_lodging_slot_merges.js writes
+# name: 'lodging_slot_merges', and a double-quote-only pattern misses it
+# silently. This repo has already shipped one scanner that passed because it
+# only looked for a sampled set of needles; do not add a second.
+extract_created_collections() {
+  python3 - "$1" <<'PY'
+import re, sys
+
+src = open(sys.argv[1], encoding="utf-8").read()
+# Each `new Collection({ ... })` literal: the collection's own name is the
+# first `name:` appearing before the `fields:` array, since every field also
+# carries a `name:` of its own.
+for block in re.split(r"new\s+Collection\s*\(\s*\{", src)[1:]:
+    head = re.split(r"(?<![A-Za-z_])fields\s*:", block)[0]
+    m = re.search(r"""(?<![A-Za-z_])name\s*:\s*["']([A-Za-z0-9_]+)["']""", head)
+    if m:
+        print(m.group(1))
+PY
+}
+
+EXISTING=$(query "SELECT name FROM _collections;" | sort -u)
+
+while IFS= read -r file; do
+  [[ -n "$file" ]] || continue
+  while IFS= read -r coll; do
+    [[ -n "$coll" ]] || continue
+    if grep -Fxq "$coll" <<<"$EXISTING"; then
+      report "" \
+        "COLLECTION ALREADY EXISTS — an unapplied migration would re-create it." \
+        "" \
+        "  migration: $file" \
+        "  collection: $coll" \
+        "" \
+        "PocketBase will fail to boot with:" \
+        "  \"Collection name must be unique (case insensitive)\"" \
+        "" \
+        "Usually this means the migration was renumbered after this database" \
+        "applied it. The old _migrations row is gone because history-sync" \
+        "removes rows for files that are no longer on disk, on every" \
+        "successful boot."
+    fi
+  done < <(extract_created_collections "$MIGRATIONS_DIR/$file")
+done <<<"$UNAPPLIED"
+
+if [[ $PROBLEMS -gt 0 ]]; then
+  cat >&2 <<EOF
+
+────────────────────────────────────────────────────────────────────────────
+Recovery: docs/reference/pocketbase-migrations.md
+          § "Renumbering a migration you have already applied locally"
+
+Read it before dropping anything. Which fix is correct depends on whether the
+file's CONTENT changed along with its number, and the obvious fix — drop the
+collection and re-run — DESTROYS LOCAL DATA when the table is not empty.
+Database: $DB
+────────────────────────────────────────────────────────────────────────────
+EOF
+  exit 1
+fi
+
+exit 0

--- a/scripts/start_dev.sh
+++ b/scripts/start_dev.sh
@@ -59,7 +59,14 @@ lsof -ti:"$CADDY_PORT" | xargs kill -9 2>/dev/null || true
 # Hard-fail rather than warn: a warning here scrolls past under ~200 lines of
 # start-up output, and PocketBase is about to fail anyway with an error that
 # names neither the cause nor anything searchable.
-if ! "$PROJECT_ROOT/scripts/dev/verify-migration-history.sh"; then
+# Both paths are explicit on purpose. The verifier otherwise honours
+# $PB_DATA_DIR, which the PocketBase binary does NOT read — it uses pb_data
+# relative to its own working directory. With PB_DATA_DIR exported (it is a
+# live variable here: api/services/metrics_sql_connection.py reads it), the
+# check would pass against one database while PocketBase booted another.
+if ! "$PROJECT_ROOT/scripts/dev/verify-migration-history.sh" \
+        --db "$PROJECT_ROOT/pocketbase/pb_data/data.db" \
+        --migrations-dir "$PROJECT_ROOT/pocketbase/pb_migrations"; then
     echo -e "${RED}Migration history check failed -- not starting PocketBase.${NC}" >&2
     exit 1
 fi

--- a/scripts/start_dev.sh
+++ b/scripts/start_dev.sh
@@ -49,6 +49,21 @@ lsof -ti:"$VITE_PORT" | xargs kill -9 2>/dev/null || true
 lsof -ti:"$FASTAPI_PORT" | xargs kill -9 2>/dev/null || true
 lsof -ti:"$CADDY_PORT" | xargs kill -9 2>/dev/null || true
 
+# Migration-history check, BEFORE the boot (kindred#2245).
+#
+# Order matters and is not cosmetic. A successful boot fires our OnServe
+# history-sync hook, which deletes _migrations rows for files no longer on
+# disk -- i.e. it destroys the evidence that a migration was renumbered. Run
+# after the boot and the check has nothing left to find.
+#
+# Hard-fail rather than warn: a warning here scrolls past under ~200 lines of
+# start-up output, and PocketBase is about to fail anyway with an error that
+# names neither the cause nor anything searchable.
+if ! "$PROJECT_ROOT/scripts/dev/verify-migration-history.sh"; then
+    echo -e "${RED}Migration history check failed -- not starting PocketBase.${NC}" >&2
+    exit 1
+fi
+
 # Start PocketBase
 echo -e "${BLUE}Starting PocketBase on port ${POCKETBASE_PORT:-8090}...${NC}"
 cd "$PROJECT_ROOT/pocketbase"


### PR DESCRIPTION
Closes #2245.

## The hazard

`_migrations` keys on the **exact filename** — PocketBase's `isMigrationApplied` is a `WHERE file = ?` lookup (`core/migrations_runner.go:265-272`). Renumbering a migration a dev database has already applied makes PB treat it as brand new: an **ALTER silently re-runs**, and a **CREATE kills the boot** with `Collection name must be unique (case insensitive)` — an error naming neither the file nor the cause.

That happened this morning. `1500000144_lodging_friend_groups.js` was applied locally on 08-09, renumbered to `1500000146` before merge (#2169), and local `main` then refused to start. Prod and CI are structurally immune because they apply from scratch — which is exactly why this class survives review.

Renumbering is routine here, not exotic: `pocketbase/CLAUDE.md` tells you to bump above HEAD when a competing PR takes your number, and three lodging migrations merged inside 23 hours on 08-08/08-09.

## history-sync is not the cause, and that decides the design

My first diagnosis blamed history-sync for deleting the old row. Verified against v0.39.10, that is wrong twice over:

1. `apis.Serve` runs `RunAllMigrations()` and returns on error at `apis/serve.go:66-70` — before the router is built and before `OnServe` fires. On a **failing** boot our hook never runs.
2. The filename key means `146` is unapplied regardless of what row `144` has. **The renumber alone is sufficient and causal.**

What history-sync actually did was destroy the evidence: `RemoveMissingAppliedMigrations` is `DELETE FROM _migrations WHERE file NOT IN (on-disk names)`, and it ran on a successful boot during the ~13h window when `main` carried no friend-groups migration at all.

**Consequence:** the detector cannot depend on the stale row surviving. `CHECK 2`, which reads the *collection* side, is load-bearing. `CHECK 1`'s filename fingerprint is a bonus for when the evidence happens to still be there. **A detector with only CHECK 1 would have reported clean on the machine that could not boot.**

## What ships

| file | |
|---|---|
| `scripts/dev/verify-migration-history.sh` | exit 0 clean (or no DB yet), 1 diagnosed, 2 harness error |
| `scripts/dev/test-verify-migration-history.sh` | 10 tests |
| `scripts/start_dev.sh` | calls it **before** the boot, hard-fail |
| `docs/reference/pocketbase-migrations.md` | new § "Renumbering a migration you have already applied locally" |
| `pocketbase/CLAUDE.md` | one sentence at the numbering rule |

The script ignores `.go` system migrations (compiled in, never on disk, and `main.go` warns that deleting those rows breaks the next boot) and the gitignored `*_updated_users.js` outlier.

**Why before the boot:** a successful boot is the moment the evidence is erased. Hard-fail rather than warn — a warning scrolls past under ~200 lines of start-up output, and PB is about to fail anyway with a worse message.

**Why the docs matter here:** the recovery is split by whether the file's *content* changed too, because the obvious fix — drop the collection and re-run — was safe in this incident only because both collections had 0 rows. On a populated table it destroys local data. An agent handed the opaque error will reach for whatever worked last time, so the correct recipe has to be written down.

## Mutation-checked, not just green

Both load-bearing tests were verified to fail when the behaviour they pin is removed:

| mutation | result |
|---|---|
| extraction regex made double-quote-only | **TEST 5 red** — `expected exit 1 — a single-quoted name: was not extracted, got 0` |
| `CHECK 2`'s collision test neutered to `if false` | **TEST 4 red** — `expected exit 1 when an unapplied CREATE would collide, got 0` |

Restored: all 10 green.

Two extraction details the tests pin: **single-quoted `name:`** (`1500000139_lodging_slot_merges.js` writes `'lodging_slot_merges'`, and a double-quote-only pattern misses it silently — this repo has already shipped one scanner that passed because it only checked sampled needles), and taking the first `name:` **before** `fields:`, since every field carries its own.

## Also documented

`--migrationsDir` is captured into `jsvm.Config` at `main.go:203-209` while it still holds its `""` default — cobra does not parse argv until `app.Start()`, much later. Passing it explicitly therefore **silently skips every JS migration** and reads as "nothing to apply". The unflagged default resolves correctly.

## Rejected: an idempotent skip-if-exists CREATE

It would have let the boot succeed, written `1500000146` into `_migrations` asserting it applied, and left `lodging_friend_groups.intent` — a column `ba431d2a` stripped before merge — in the dev DB permanently, with nothing able to reveal it. Strictly worse than a loud ten-minute failure, because the loud one got fixed.

The asymmetry matters and does not condemn idempotency generally: an idempotent `fields.add()` on an ALTER **converges** toward the file's declaration; a skip-if-exists CREATE **diverges**, accepting whatever shape is already there. Keep the former, reject the latter.

No change to `1500000146_lodging_friend_groups.js` — every DB that already ran it will never re-read the file, so an edit would protect nobody.

## Verification

- `scripts/dev/test-verify-migration-history.sh` — **10/10 pass**
- `shellcheck` — clean on both new scripts (`start_dev.sh`'s remaining SC2086 hits are all pre-existing lines)
- `verify-migration-history.sh` — exit 0 against the real dev DB and against the worktree's seeded DB
- `markdownlint` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pre-start check that detects inconsistent or renamed migrations before launching the development server.
  * Added diagnostics and recovery guidance for migration history issues.

* **Documentation**
  * Documented migration recovery, schema divergence, data-preservation checks, and safe reapplication practices.
  * Added guidance to renumber migrations before first use.

* **Tests**
  * Added automated coverage for migration-history validation scenarios, including renamed migrations, collection conflicts, and missing files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->