### PR TITLE
fix(api,frontend): a write-in should survive a merge or a split, and block placement either way

### DIFF
--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -137,6 +137,36 @@ class WeekendSessionListResponse(BaseModel):
     sessions: list[WeekendSessionSummary] = Field(default_factory=list)
 
 
+class WriteInCover(BaseModel):
+    """The write-in that closes a space, wherever in the tree it was recorded.
+
+    A write-in names ONE unit, but it is a fact about a physical space, and a
+    building's space contains its rooms'. The board draws whichever level the
+    tree currently resolves to (`drawn_units`), and merging or splitting moves
+    that level under staff's feet -- so a write-in recorded on a merged
+    building went silent the moment somebody split it back to rooms, and one
+    recorded on a room said nothing on the building's card after a merge. Both
+    left the same hole: a family could be dropped into a space somebody is
+    already sleeping in.
+
+    Resolved on READ, never cascaded on write. A row per leaf would duplicate
+    one fact across rows that then drift -- clear one room and the others still
+    close the space -- and would strand orphans behind a re-merge. There is
+    still exactly one `lodging_availability` row; this says which units it
+    covers, and `unit_id` is the row it belongs to, so a card that inherited
+    the write-in can still clear it at the source rather than dead-ending.
+    """
+
+    # The unit the row actually names -- NOT necessarily the unit carrying this
+    # cover. `unit_id` is what a clear must target; the code and name are what
+    # the card says when the write-in came from somewhere else.
+    unit_id: str = ""
+    unit_code: str = ""
+    unit_name: str = ""
+    occupant_name: str = ""
+    note: str = ""
+
+
 class LodgingUnitSummary(BaseModel):
     """One row of the lodging registry, as the roster sees it."""
 
@@ -245,6 +275,20 @@ class LodgingUnitSummary(BaseModel):
     # from 1500000148 onward.
     reason: str = ""
     is_family_available: bool = False
+    # The write-in that closes this space, resolved through the unit tree --
+    # this unit's own row, else the nearest ancestor's, else the nearest
+    # descendant's. None means no write-in covers it.
+    #
+    # The three fields above stay STRICTLY this unit's own row: they are what
+    # the write path reads back and what `is_family_available` is derived from,
+    # and folding an inherited fact into them would make a room look like it
+    # carried a row it does not have. Ask this field "is somebody in this
+    # space", and those fields "what does this unit's own row say".
+    #
+    # Only a write-in travels. A release (`family_available_override is True`)
+    # names no occupant and closes nothing, so inheriting it would silently
+    # open every room beneath a released building.
+    write_in: WriteInCover | None = None
     map_x: float | None = None
     map_y: float | None = None
 

--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -280,9 +280,9 @@ class LodgingUnitSummary(BaseModel):
     # descendant's. None means no write-in covers it.
     #
     # The three fields above stay STRICTLY this unit's own row: they are what
-    # the write path reads back and what `is_family_available` is derived from,
-    # and folding an inherited fact into them would make a room look like it
-    # carried a row it does not have. Ask this field "is somebody in this
+    # the write path reads back, and `family_available_override` alone is what
+    # `is_family_available` is derived from. Folding an inherited fact into any
+    # of them would make a room look like it carried a row it does not have. Ask this field "is somebody in this
     # space", and those fields "what does this unit's own row say".
     #
     # Only a write-in travels. A release (`family_available_override is True`)

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -46,6 +46,7 @@ from api.schemas.lodging import (
     WeekendSessionSummary,
     WeekendSummaryEntry,
     WeekendSummaryResponse,
+    WriteInCover,
 )
 from api.services.lodging_rules import (
     amenity_coverage,
@@ -462,6 +463,91 @@ def resolve_combined(*, default: bool, override: bool | None, session_override: 
     if session_override is not None:
         return session_override
     return default
+
+
+def write_in_covers(units: list[LodgingUnitSummary]) -> dict[str, WriteInCover]:
+    """Which units each write-in closes, keyed by unit code.
+
+    THE UNIT A ROW NAMES IS NOT THE ONLY SPACE IT CLOSES. A write-in is a fact
+    about a physical space and a building's space contains its rooms', but the
+    board draws whichever level the tree resolves to (`drawn_units`) and a
+    merge or a split moves that level under staff's feet. A write-in recorded
+    on a merged building went silent the moment somebody split it; one recorded
+    on a room said nothing on the building's card after a merge. Either way a
+    family could be dropped into a space somebody is already sleeping in.
+
+    Order, highest first: the unit's OWN row, else the nearest ANCESTOR's, else
+    the nearest DESCENDANT's. Own beats inherited because it is the more
+    specific statement about the same space; an ancestor beats a descendant
+    because a building closed whole says something about every room in it,
+    where one room says only that the building is no longer free to let whole.
+
+    RESOLVED FROM OWN ROWS ONLY, never transitively through a cover computed
+    for somebody else -- which is what keeps a caretaker in room A off room B.
+    A closes its building (a whole-house let is no longer available); the
+    building does not then close B, because that would take a lettable room off
+    the board for no reason.
+
+    Only a write-in travels. `True` is a staff cabin OPENED to families for the
+    weekend: it names no occupant and closes nothing, so inheriting it would
+    silently open every room beneath a released building.
+
+    Cycle-guarded on both walks. The server refuses to write a parent cycle
+    (#1899), but one already in the data must not spin the roster build --
+    the same backstop `drawn_units` and the frontend's `coveredCodes` carry.
+    """
+    # A blank `code` is a valid if unfortunate registry value and would occupy
+    # the same key `parent_code == ""` uses for "no parent" -- the collision
+    # `drawn_units._parent_of` guards. Excluded here and never looked up.
+    by_code = {unit.code: unit for unit in units if unit.code}
+    children: dict[str, list[LodgingUnitSummary]] = {}
+    for unit in units:
+        if unit.parent_code:
+            children.setdefault(unit.parent_code, []).append(unit)
+    # Sorted so two identical payloads never disagree about WHICH row a card
+    # names when a building has several written-into rooms beneath it.
+    for bucket in children.values():
+        bucket.sort(key=lambda child: child.code)
+
+    def _is_written_in(unit: LodgingUnitSummary) -> bool:
+        return unit.family_available_override is False
+
+    def _nearest_ancestor(unit: LodgingUnitSummary) -> LodgingUnitSummary | None:
+        seen = {unit.code}
+        cursor = by_code.get(unit.parent_code) if unit.parent_code else None
+        while cursor is not None and cursor.code not in seen:
+            if _is_written_in(cursor):
+                return cursor
+            seen.add(cursor.code)
+            cursor = by_code.get(cursor.parent_code) if cursor.parent_code else None
+        return None
+
+    def _nearest_descendant(unit: LodgingUnitSummary) -> LodgingUnitSummary | None:
+        seen = {unit.code}
+        queue = list(children.get(unit.code, []))
+        while queue:
+            node = queue.pop(0)
+            if node.code in seen:
+                continue
+            seen.add(node.code)
+            if _is_written_in(node):
+                return node
+            queue.extend(children.get(node.code, []))
+        return None
+
+    covers: dict[str, WriteInCover] = {}
+    for unit in units:
+        source = unit if _is_written_in(unit) else (_nearest_ancestor(unit) or _nearest_descendant(unit))
+        if source is None:
+            continue
+        covers[unit.code] = WriteInCover(
+            unit_id=source.unit_id,
+            unit_code=source.code,
+            unit_name=source.name,
+            occupant_name=source.occupant_name,
+            note=source.reason,
+        )
+    return covers
 
 
 def drawn_units(units: list[LodgingUnitSummary]) -> list[LodgingUnitSummary]:
@@ -1306,6 +1392,12 @@ class LodgingRosterService:
                     map_y=map_y,
                 )
             )
+        # A SECOND PASS, and it has to be: a unit's cover can come from a row
+        # on a unit built after it, so there is no order in which one pass
+        # would see every own-row it needs.
+        covers = write_in_covers(summaries)
+        for summary in summaries:
+            summary.write_in = covers.get(summary.code)
         return summaries
 
     # -------------------------------------------------------------- parties

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -537,6 +537,13 @@ def write_in_covers(units: list[LodgingUnitSummary]) -> dict[str, WriteInCover]:
 
     covers: dict[str, WriteInCover] = {}
     for unit in units:
+        # Blank codes are excluded from BOTH sides, not just the lookup above.
+        # `_build_units` reads this map back by code, so one blank-coded row
+        # written into would hand its occupant to every other blank-coded row
+        # through the shared `""` key -- a unit reporting somebody sleeping in
+        # a space on the strength of a row it does not hold.
+        if not unit.code:
+            continue
         source = unit if _is_written_in(unit) else (_nearest_ancestor(unit) or _nearest_descendant(unit))
         if source is None:
             continue
@@ -548,6 +555,18 @@ def write_in_covers(units: list[LodgingUnitSummary]) -> dict[str, WriteInCover]:
             note=source.reason,
         )
     return covers
+
+
+def _resolve_write_in_covers(units: list[LodgingUnitSummary]) -> None:
+    """Attach each unit's resolved write-in cover, in place.
+
+    The mutating counterpart to `write_in_covers`, mirroring
+    `_resolve_power_coverage`: the pure function is what the tests reason
+    about, and this is the one line the response path calls.
+    """
+    covers = write_in_covers(units)
+    for unit in units:
+        unit.write_in = covers.get(unit.code)
 
 
 def drawn_units(units: list[LodgingUnitSummary]) -> list[LodgingUnitSummary]:
@@ -989,6 +1008,16 @@ class LodgingRosterService:
         # get at the counts, but its `WeekendSummaryEntry` carries no `units`
         # -- so resolving coverage there would be work no response can read.
         _resolve_power_coverage(unit_summaries, unit_index)
+        # A SECOND PASS, and it has to be: a unit's cover can come from a row
+        # on a unit built after it, so there is no order in which one pass over
+        # `_build_units` would see every own-row it needs.
+        #
+        # Only on THIS path, for the identical reason `_resolve_power_coverage`
+        # above is: `build_summary` builds its own units to get at the counts,
+        # but its `WeekendSummaryEntry` carries no `units`, so resolving covers
+        # there would be work no response can read -- once per weekend, across
+        # every weekend of the year, on every lander request.
+        _resolve_write_in_covers(unit_summaries)
         parties = self._build_parties(
             session_type=session_type,
             session_start=_as_date(_s(session, "start_date")),
@@ -1392,12 +1421,6 @@ class LodgingRosterService:
                     map_y=map_y,
                 )
             )
-        # A SECOND PASS, and it has to be: a unit's cover can come from a row
-        # on a unit built after it, so there is no order in which one pass
-        # would see every own-row it needs.
-        covers = write_in_covers(summaries)
-        for summary in summaries:
-            summary.write_in = covers.get(summary.code)
         return summaries
 
     # -------------------------------------------------------------- parties

--- a/frontend/src/components/weekend/LodgingBoard.availability.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.availability.test.tsx
@@ -201,3 +201,46 @@ describe('LodgingBoard — the control becomes a write', () => {
     await Promise.resolve()
   })
 })
+
+describe('LodgingBoard — clearing a write-in this card inherited', () => {
+  /*
+   * The row names one unit; it closes a SPACE. Split a written-into building
+   * and its ROOMS inherit the write-in, while the building — no longer drawn —
+   * has nowhere to offer the clear from. The room offers it, and both the write
+   * and the in-flight disable have to follow the row rather than the card.
+   */
+  const COVER = {
+    unit_id: 'u-house',
+    unit_code: 'house',
+    unit_name: 'House',
+    occupant_name: 'Liam Garcia',
+    note: '',
+  }
+  const room = unit({ unit_id: 'u-room', code: 'house-a', name: 'House A', write_in: COVER })
+
+  it('sends the unit that HOLDS the row, not the card it was clicked on', async () => {
+    const user = userEvent.setup()
+    renderBoard({ units: [room] })
+
+    await user.click(screen.getByRole('button', { name: 'Clear House A' }))
+
+    expect(setAvailability).toHaveBeenCalledWith({
+      unitId: 'u-house',
+      unitName: 'House',
+      familyAvailable: null,
+      occupantName: '',
+      reason: '',
+    })
+  })
+
+  it('disables the card while the row it points at is being written', async () => {
+    // `pendingUnitId` names the unit the WRITE targets, which for an inherited
+    // clear is never this card's own id — so keying the disable on the card
+    // alone leaves the button live for the whole write and invites a second
+    // click on a row that is already going away.
+    pendingUnitId = 'u-house'
+    renderBoard({ units: [room] })
+
+    expect(screen.getByRole('button', { name: 'Clear House A' })).toBeDisabled()
+  })
+})

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -64,6 +64,7 @@ import { LodgingUnitCard } from './LodgingUnitCard'
 import { partyKey } from './partyKey'
 import { resolvePartyUnit } from './rosterAttention'
 import type { UnitAvailabilityWrite } from './UnitAvailabilityControl'
+import { writeInSource } from './writeIn'
 
 export interface LodgingBoardProps {
   parties: RosterPartyRow[]
@@ -347,13 +348,18 @@ export function LodgingBoard({
   )
 
   const writeAvailability = useCallback(
-    (unit: LodgingUnitRow, write: UnitAvailabilityWrite) => {
+    (write: UnitAvailabilityWrite) => {
       // The rejection path is the hook's: it raises the toast. Catching here
       // keeps the rejected promise from surfacing as an unhandled rejection,
       // exactly as the drop handler does.
       void setAvailability({
-        unitId: unit.unit_id,
-        unitName: unit.name,
+        // FROM THE WRITE, not from the card. An inherited write-in is cleared
+        // at the unit that holds the row, which may be this card's building or
+        // one of its rooms — and that unit has no card of its own, which is
+        // precisely why the clear is offered here. `availabilityAction`
+        // resolves the target; passing `unit` again would delete nothing.
+        unitId: write.unitId,
+        unitName: write.unitName,
         familyAvailable: write.familyAvailable,
         occupantName: write.occupantName,
         reason: write.reason,
@@ -506,7 +512,19 @@ export function LodgingBoard({
                             hue={area.hue}
                             canPlace={canPlace}
                             canSetAvailability={canSetAvailability}
-                            savingAvailability={pendingUnitId === slot.unit.unit_id}
+                            // THIS card's unit, or the one holding the
+                            // write-in it inherited. `pendingUnitId` names the
+                            // unit the WRITE targets, and for an inherited
+                            // clear that is never this card's own id — so
+                            // keying the disable on the card alone leaves the
+                            // button live for the whole write. Same shape as
+                            // `savingMerge` below, and for the same reason:
+                            // the unit written is not always the unit drawn.
+                            savingAvailability={
+                              pendingUnitId === slot.unit.unit_id ||
+                              (pendingUnitId !== '' &&
+                                pendingUnitId === writeInSource(slot.unit)?.unitId)
+                            }
                             onSetAvailability={writeAvailability}
                             canMerge={canMergeUnits}
                             mergeSourceUnit={draggingMergeUnit}

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -38,7 +38,7 @@ import {
 } from './unitBadges'
 import { UnitAvailabilityControl } from './UnitAvailabilityControl'
 import type { UnitAvailabilityWrite } from './UnitAvailabilityControl'
-import { writeInOccupant } from './writeIn'
+import { writeInOccupant, writeInSource } from './writeIn'
 import { WriteInCard } from './WriteInCard'
 
 /**
@@ -163,7 +163,14 @@ export interface LodgingUnitCardProps {
   canSetAvailability?: boolean
   /** True while THIS unit's availability write is in flight. */
   savingAvailability?: boolean
-  onSetAvailability?: (unit: LodgingUnitRow, write: UnitAvailabilityWrite) => void
+  /**
+   * NO UNIT PARAMETER. The write NAMES the unit it targets (`unitId` on
+   * `UnitAvailabilityWrite`), which for an inherited write-in is this card's
+   * building or one of its rooms rather than the card itself. Passing the card
+   * alongside it would offer the caller the wrong one of the two, which is the
+   * bug this shape removes rather than documents.
+   */
+  onSetAvailability?: (write: UnitAvailabilityWrite) => void
   /**
    * Merge/split is writable: the user holds `bunking.manage` and a weekend is
    * selected.
@@ -449,6 +456,10 @@ export function LodgingUnitCard({
   // using it as a PROXY for "is somebody in this room". Naming the fact once
   // is what stops the tint being keyed on a spelling.
   const writeIn = writeInOccupant(unit)
+  // WHOSE row it is. Undefined whenever it is this card's own, so the common
+  // case says nothing extra — see `WriteInCard`'s own prop doc.
+  const writeInAt = writeInSource(unit)
+  const writeInAtName = writeInAt !== null && !writeInAt.isOwn ? writeInAt.unitName : undefined
   const held = writeIn !== null
   const { setNodeRef: setUnitDropRef, isOver: isUnitOver } = useDroppable({
     id: unitDroppableId(unit.code),
@@ -864,7 +875,7 @@ export function LodgingUnitCard({
           occupied={parties.length > 0}
           isSaving={savingAvailability}
           onSubmit={(write) => {
-            onSetAvailability?.(unit, write)
+            onSetAvailability?.(write)
           }}
         />
         {/* kindred#2080 — the space's own placement path, for the staff
@@ -1002,7 +1013,7 @@ export function LodgingUnitCard({
             below: a card carrying both is not a state any writer produces
             (#2090 rules the two mutually exclusive), but if a legacy row ever
             does, hiding one of them would drop somebody from the board. */}
-        {writeIn !== null && <WriteInCard occupant={writeIn} />}
+        {writeIn !== null && <WriteInCard occupant={writeIn} atUnitName={writeInAtName} />}
         {parties.length === 0 && writeIn === null ? (
           /* Summer's wording in family vocabulary — `BunkCard` says "Drop
              campers here". An empty slot's job is to be a target, and "Empty"

--- a/frontend/src/components/weekend/UnitAvailabilityControl.test.tsx
+++ b/frontend/src/components/weekend/UnitAvailabilityControl.test.tsx
@@ -327,8 +327,45 @@ describe('UnitAvailabilityControl', () => {
     expect(onSubmit).not.toHaveBeenCalled()
   })
 
-  it('offers nothing on a building row', () => {
+  it('offers nothing on a SPLIT container', () => {
+    // It gets no card, so there is nothing here to act on.
     renderControl({ unit: unit({ is_container: true }) })
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('offers to write into a MERGED building', async () => {
+    // The staff-facing half of the container fix. A merged building IS the
+    // card the board draws in place of its rooms, so it is the only surface a
+    // write-in for that building can be recorded on -- merging is exactly what
+    // takes its rooms' own cards away.
+    const user = userEvent.setup()
+    const { onSubmit } = renderControl({
+      unit: unit({
+        unit_id: 'u3',
+        code: 'clouds-rest',
+        name: 'Clouds Rest',
+        is_container: true,
+        is_combined: true,
+      }),
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Write in Clouds Rest' }))
+    await user.type(screen.getByRole('textbox', { name: /^occupant$/i }), 'Liam Garcia')
+    await user.click(screen.getByRole('button', { name: /^write in$/i }))
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      familyAvailable: false,
+      occupantName: 'Liam Garcia',
+      reason: '',
+    })
+  })
+
+  it('still offers nothing on a MERGED building that holds a family (#2090)', () => {
+    renderControl({
+      unit: unit({ is_container: true, is_combined: true }),
+      occupied: true,
+    })
 
     expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })

--- a/frontend/src/components/weekend/UnitAvailabilityControl.test.tsx
+++ b/frontend/src/components/weekend/UnitAvailabilityControl.test.tsx
@@ -115,6 +115,8 @@ describe('UnitAvailabilityControl', () => {
     await user.click(screen.getByRole('button', { name: /^write in$/i }))
 
     expect(onSubmit).toHaveBeenCalledWith({
+      unitId: 'u1',
+      unitName: 'Cedar 1',
       familyAvailable: false,
       occupantName: 'Emma Johnson',
       reason: '',
@@ -131,6 +133,8 @@ describe('UnitAvailabilityControl', () => {
     await user.click(screen.getByRole('button', { name: /^write in$/i }))
 
     expect(onSubmit).toHaveBeenCalledWith({
+      unitId: 'u1',
+      unitName: 'Cedar 1',
       familyAvailable: false,
       occupantName: 'Liam Garcia',
       reason: 'Back Monday',
@@ -150,6 +154,8 @@ describe('UnitAvailabilityControl', () => {
     await user.click(screen.getByRole('button', { name: /^write in$/i }))
 
     expect(onSubmit).toHaveBeenCalledWith({
+      unitId: 'u1',
+      unitName: 'Cedar 1',
       familyAvailable: false,
       occupantName: 'burst pipe',
       reason: '',
@@ -167,6 +173,8 @@ describe('UnitAvailabilityControl', () => {
     await user.click(screen.getByRole('button', { name: /^release$/i }))
 
     expect(onSubmit).toHaveBeenCalledWith({
+      unitId: 'u2',
+      unitName: 'Aspen Lodge',
       familyAvailable: true,
       occupantName: '',
       reason: 'Overflow weekend',
@@ -274,7 +282,13 @@ describe('UnitAvailabilityControl', () => {
 
     await user.click(screen.getByRole('button', { name: /clear/i }))
 
-    expect(onSubmit).toHaveBeenCalledWith({ familyAvailable: null, occupantName: '', reason: '' })
+    expect(onSubmit).toHaveBeenCalledWith({
+      unitId: 'u1',
+      unitName: 'Cedar 1',
+      familyAvailable: null,
+      occupantName: '',
+      reason: '',
+    })
     expect(screen.queryByRole('textbox', { name: /^occupant$/i })).not.toBeInTheDocument()
   })
 
@@ -355,6 +369,8 @@ describe('UnitAvailabilityControl', () => {
     await user.click(screen.getByRole('button', { name: /^write in$/i }))
 
     expect(onSubmit).toHaveBeenCalledWith({
+      unitId: 'u3',
+      unitName: 'Clouds Rest',
       familyAvailable: false,
       occupantName: 'Liam Garcia',
       reason: '',
@@ -385,5 +401,42 @@ describe('UnitAvailabilityControl', () => {
 
     expect(screen.getByRole('textbox', { name: /^occupant$/i })).toHaveValue('')
     expect(screen.getByRole('textbox', { name: /note/i })).toHaveValue('')
+  })
+})
+
+describe('a write-in this unit inherited from elsewhere in the tree', () => {
+  /*
+   * The row names one unit; it closes a SPACE. Split a written-into building
+   * and its rooms inherit the write-in — and the building, having no card any
+   * more, has nowhere to offer the clear from. So the inheriting card offers
+   * it, and the write has to name the unit that HOLDS the row: sending this
+   * card's own id would delete nothing.
+   */
+  const ROOM_UNDER_A_WRITTEN_IN_HOUSE = unit({
+    unit_id: 'u-room',
+    code: 'house-a',
+    name: 'House A',
+    write_in: {
+      unit_id: 'u-house',
+      unit_code: 'house',
+      unit_name: 'House',
+      occupant_name: 'Liam Garcia',
+      note: '',
+    },
+  })
+
+  it('offers to clear it, and names the unit that actually holds the row', async () => {
+    const user = userEvent.setup()
+    const { onSubmit } = renderControl({ unit: ROOM_UNDER_A_WRITTEN_IN_HOUSE })
+
+    await user.click(screen.getByRole('button', { name: /clear/i }))
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      unitId: 'u-house',
+      unitName: 'House',
+      familyAvailable: null,
+      occupantName: '',
+      reason: '',
+    })
   })
 })

--- a/frontend/src/components/weekend/UnitAvailabilityControl.tsx
+++ b/frontend/src/components/weekend/UnitAvailabilityControl.tsx
@@ -56,6 +56,20 @@ import type { LodgingUnitRow } from '../../types/lodging'
 import { availabilityAction } from './unitBadges'
 
 export interface UnitAvailabilityWrite {
+  /**
+   * The unit the write NAMES, which is not always the card it came from.
+   *
+   * A write-in covers a space and the board draws whichever level the unit
+   * tree resolves to, so a room can inherit its building's write-in and a
+   * merged building one of its rooms'. There is one `lodging_availability` row
+   * either way, and clearing it has to target the unit that HOLDS it — the
+   * card's own id would delete nothing, and the unit holding the row has no
+   * card to offer the clear from. `availabilityAction` resolves which; this
+   * only carries it.
+   */
+  unitId: string
+  /** That unit's name, for the confirmation toast. */
+  unitName: string
   familyAvailable: boolean | null
   /** Who is in the room. `''` on a release and on a clear. */
   occupantName: string
@@ -158,6 +172,8 @@ export function UnitAvailabilityControl({
               return
             }
             onSubmit({
+              unitId: action.unitId,
+              unitName: action.unitName,
               familyAvailable: action.familyAvailable,
               // The note NEVER stands in for the occupant, and the occupant
               // never doubles as the note: two fields, two facts. Collapsing
@@ -244,7 +260,13 @@ export function UnitAvailabilityControl({
             setIsOpen(true)
             return
           }
-          onSubmit({ familyAvailable: action.familyAvailable, occupantName: '', reason: '' })
+          onSubmit({
+            unitId: action.unitId,
+            unitName: action.unitName,
+            familyAvailable: action.familyAvailable,
+            occupantName: '',
+            reason: '',
+          })
         }}
         className="border-border text-muted-foreground hover:text-foreground hover:border-foreground/30 rounded-full border px-1.5 py-0.5 text-xs font-medium disabled:opacity-40"
       >

--- a/frontend/src/components/weekend/WriteInCard.test.tsx
+++ b/frontend/src/components/weekend/WriteInCard.test.tsx
@@ -74,3 +74,26 @@ describe('WriteInCard', () => {
     expect(WRITE_IN_FRAME).toBe(match?.[1])
   })
 })
+
+describe('a write-in the card INHERITED from elsewhere in the tree', () => {
+  /*
+   * The row names one unit; it closes a SPACE. Split a written-into building
+   * and its rooms carry the occupant; merge over a written-into room and the
+   * building does. Printing the name alone on the inheriting card would say
+   * this room's own row names them — and staff would go looking on a card that
+   * no longer exists for the Clear that is right in front of them.
+   */
+  it('says which unit the write-in is recorded at', () => {
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} atUnitName="House" />)
+
+    expect(screen.getByText('Written in at House')).toBeInTheDocument()
+  })
+
+  it('says nothing extra when the row is the card’s own', () => {
+    // The overwhelmingly common case, and the one that must stay quiet: a line
+    // on every written-into card restating the card's own name is chrome.
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} />)
+
+    expect(screen.queryByText(/written in at/i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/weekend/WriteInCard.tsx
+++ b/frontend/src/components/weekend/WriteInCard.tsx
@@ -37,9 +37,19 @@ export const WRITE_IN_FRAME =
 
 export interface WriteInCardProps {
   occupant: WriteInOccupant
+  /**
+   * The unit the row is recorded at, when that is NOT the card drawing this.
+   *
+   * A write-in names one unit and closes a space: split a written-into
+   * building and its rooms carry the occupant, merge over a written-into room
+   * and the building does. Undefined on the card whose own row it is, which is
+   * the overwhelmingly common case — a line restating the card's own name on
+   * every written-into card is chrome staff learn to read past.
+   */
+  atUnitName?: string | undefined
 }
 
-export function WriteInCard({ occupant }: WriteInCardProps) {
+export function WriteInCard({ occupant, atUnitName }: WriteInCardProps) {
   const named = occupant.name !== ''
 
   return (
@@ -67,6 +77,16 @@ export function WriteInCard({ occupant }: WriteInCardProps) {
         // renders nothing at all until a write-in is recorded from that
         // migration onward. That emptiness is correct, not a bug.
         <span className="text-muted-foreground text-xs leading-tight">{occupant.note}</span>
+      )}
+      {atUnitName !== undefined && atUnitName !== '' && (
+        // WHERE the row lives, not a second occupant fact — which is why it
+        // sits under the note in the same muted key rather than beside the
+        // name. Without it the card asserts this room's own row names them,
+        // and the staff member goes looking for the Clear on a card the merge
+        // or split has taken away, when it is on this one.
+        <span className="text-muted-foreground text-xs leading-tight italic">
+          {`Written in at ${atUnitName}`}
+        </span>
       )}
     </div>
   )

--- a/frontend/src/components/weekend/dragPlacement.test.ts
+++ b/frontend/src/components/weekend/dragPlacement.test.ts
@@ -325,6 +325,61 @@ describe('resolveDrop', () => {
     ).toBeNull()
   })
 
+  it('refuses a drop into a ROOM of a building somebody is written into', () => {
+    // The split case. Staff wrote into the whole house while it was merged,
+    // then split it: the row still names the house, which now has no card, and
+    // without the server's resolved cover this drop went through — a family
+    // into a space somebody is already sleeping in, with nothing on screen to
+    // warn them. The refusal reads the COVER, so both directions of the tree
+    // arrive here as the same fact.
+    const room = unit({
+      code: 'house-a',
+      write_in: {
+        unit_id: 'id-house',
+        unit_code: 'house',
+        unit_name: 'House',
+        occupant_name: 'Liam Garcia',
+        note: '',
+      },
+    })
+    const p = party()
+    expect(
+      resolveDrop({
+        activeId: partyKey(p),
+        overId: unitDroppableId('house-a'),
+        parties: [p],
+        units: [room],
+      })
+    ).toBeNull()
+  })
+
+  it('refuses a whole-house drop when one of its ROOMS is written into', () => {
+    // The mirror case, and the one that predates the split fix: merge a
+    // building over a written-into room and the room stops being drawn, so the
+    // building's card said nothing about the caretaker in it and took the drop.
+    const house = unit({
+      code: 'house',
+      is_container: true,
+      is_combined: true,
+      write_in: {
+        unit_id: 'id-house-a',
+        unit_code: 'house-a',
+        unit_name: 'House A',
+        occupant_name: 'Ava Martinez',
+        note: '',
+      },
+    })
+    const p = party()
+    expect(
+      resolveDrop({
+        activeId: partyKey(p),
+        overId: unitDroppableId('house'),
+        parties: [p],
+        units: [house],
+      })
+    ).toBeNull()
+  })
+
   it('still accepts a drop onto an ordinary unheld unit (regression guard)', () => {
     const unheld = unit({ family_available_override: null, is_family_available: true })
     const p = party()

--- a/frontend/src/components/weekend/dragPlacement.ts
+++ b/frontend/src/components/weekend/dragPlacement.ts
@@ -29,6 +29,7 @@
 import type { LodgingUnitRow, RosterPartyRow, WeekendRoster } from '../../types/lodging'
 import { occupiedCodes } from './boardLayout'
 import { partyKey } from './partyKey'
+import { writeInOccupant } from './writeIn'
 
 /**
  * The queue droppable. One id, imported by the badge that registers it and
@@ -223,7 +224,13 @@ export function resolveDrop({
   // `useDroppable`, so a refusal only on that hook's `disabled` flag would be
   // silently bypassed by it. `LodgingUnitCard` also disables its droppable
   // for the drag affordance, but this is what actually enforces it.
-  if (unit.family_available_override === false) return null
+  // Read through `writeInOccupant`, never the raw column: the row names one
+  // unit but closes a SPACE, and the board draws whichever level the tree
+  // resolves to. Split a written-into building and this drop lands in one of
+  // its rooms; merge over a written-into room and it lands on the building.
+  // The column answers only for the unit it sits on, so both of those went
+  // through — a family into a space somebody is already sleeping in.
+  if (writeInOccupant(unit) !== null) return null
   // A COMBINED container IS a card now — Task 6 draws its own row in place of
   // its rooms (unitLevel.ts, `drawnUnits`) — so it must accept a drop exactly
   // like any other drawn unit. A NON-combined container still carries only

--- a/frontend/src/components/weekend/unitBadges.test.ts
+++ b/frontend/src/components/weekend/unitBadges.test.ts
@@ -199,6 +199,11 @@ describe('availabilityAction', () => {
       label: 'Write in',
       familyAvailable: false,
       prompt: 'occupant',
+      // The write NAMES a unit, and for every action but an inherited clear
+      // that unit is the card's own. Asserted rather than left off, so the
+      // pair cannot quietly go missing from the payload the board sends.
+      unitId: 'u1',
+      unitName: 'Cedar 1',
     })
   })
 
@@ -207,7 +212,14 @@ describe('availabilityAction', () => {
     // cabins are never released; it does not prove it, so the capability stays.
     expect(
       availabilityAction(unit({ inventory_class: 'staff_default', is_family_available: false }))
-    ).toEqual({ kind: 'release', label: 'Release', familyAvailable: true, prompt: 'reason' })
+    ).toEqual({
+      kind: 'release',
+      label: 'Release',
+      familyAvailable: true,
+      prompt: 'reason',
+      unitId: 'u1',
+      unitName: 'Cedar 1',
+    })
   })
 
   it('offers to clear a held family cabin, and asks for no reason to do it', () => {
@@ -217,7 +229,14 @@ describe('availabilityAction', () => {
       availabilityAction(
         unit({ family_available_override: false, reason: 'Burst pipe', is_family_available: false })
       )
-    ).toEqual({ kind: 'clear', label: 'Clear', familyAvailable: null, prompt: 'none' })
+    ).toEqual({
+      kind: 'clear',
+      label: 'Clear',
+      familyAvailable: null,
+      prompt: 'none',
+      unitId: 'u1',
+      unitName: 'Cedar 1',
+    })
   })
 
   it('offers to clear a released staff cabin', () => {
@@ -404,5 +423,77 @@ describe('sharingConflictBadge', () => {
     const withoutField = unit()
     delete (withoutField as Partial<LodgingUnitRow>).shareability
     expect(sharingConflictBadge(withoutField, 2)).toBeNull()
+  })
+})
+
+describe('a write-in inherited from elsewhere in the tree', () => {
+  /*
+   * The board draws whichever level the tree resolves to, so the card carrying
+   * a write-in is often not the unit the row names: split a written-into
+   * building and its rooms carry it; merge over a written-into room and the
+   * building does. Both must BADGE the fact and both must be able to CLEAR it
+   * — a card that inherits a write-in and cannot undo it is a dead end, since
+   * the unit holding the row has no card at all.
+   */
+  const coverFromBuilding = {
+    unit_id: 'id-house',
+    unit_code: 'house',
+    unit_name: 'House',
+    occupant_name: 'Liam Garcia',
+    note: '',
+  }
+
+  it('badges a room whose BUILDING was written into', () => {
+    expect(reservationBadge(unit({ code: 'house-a', write_in: coverFromBuilding }))?.label).toBe(
+      'Write-in'
+    )
+  })
+
+  it('offers to clear it, naming the unit that actually holds the row', () => {
+    const action = availabilityAction(unit({ code: 'house-a', write_in: coverFromBuilding }))
+
+    expect(action?.kind).toBe('clear')
+    // The WRITE TARGET, not the card. Sending this card's own id would delete
+    // nothing: the row belongs to the building, and the room has none.
+    expect(action?.unitId).toBe('id-house')
+    expect(action?.unitName).toBe('House')
+  })
+
+  it('clears an inherited write-in even on an occupied card', () => {
+    // Same reasoning the own-row branch already carries: a clear only ever
+    // REDUCES the conflict, so occupancy is never the state that needs it
+    // blocked.
+    expect(
+      availabilityAction(unit({ code: 'house-a', write_in: coverFromBuilding }), true)?.kind
+    ).toBe('clear')
+  })
+
+  it('names the card’s OWN unit when the write-in starts here', () => {
+    const action = availabilityAction(unit())
+
+    expect(action?.kind).toBe('hold')
+    expect(action?.unitId).toBe('u1')
+    expect(action?.unitName).toBe('Cedar 1')
+  })
+
+  it('badges a MERGED building written into through one of its rooms', () => {
+    const fromRoom = {
+      unit_id: 'id-house-a',
+      unit_code: 'house-a',
+      unit_name: 'House A',
+      occupant_name: 'Ava Martinez',
+      note: '',
+    }
+
+    expect(
+      reservationBadge(
+        unit({ code: 'house', is_container: true, is_combined: true, write_in: fromRoom })
+      )?.label
+    ).toBe('Write-in')
+    expect(
+      availabilityAction(
+        unit({ code: 'house', is_container: true, is_combined: true, write_in: fromRoom })
+      )?.unitId
+    ).toBe('id-house-a')
   })
 })

--- a/frontend/src/components/weekend/unitBadges.test.ts
+++ b/frontend/src/components/weekend/unitBadges.test.ts
@@ -64,6 +64,34 @@ describe('reservationBadge', () => {
     })
   })
 
+  it('still says Building on a MERGED building nobody has written into', () => {
+    // The structural fact does not stop being true because the card is drawn.
+    // "Building" is the fallback here, not the first answer.
+    expect(reservationBadge(unit({ is_container: true, is_combined: true }))?.label).toBe(
+      'Building'
+    )
+  })
+
+  it('says Write-in on a MERGED building somebody has been written into', () => {
+    // A combined container IS the card the board draws (`drawnUnits`) and IS a
+    // drop target (`resolveDrop`), so it reads its availability like any other
+    // drawn unit. Badging it "Building" while `availabilityAction` offers to
+    // CLEAR the write-in is the exact drift this module exists to prevent.
+    expect(
+      reservationBadge(
+        unit({ is_container: true, is_combined: true, family_available_override: false })
+      )?.label
+    ).toBe('Write-in')
+  })
+
+  it('keeps saying Building on a SPLIT container carrying an override', () => {
+    // A split container gets no card at all, so there is nothing to badge and
+    // no action to agree with. Unchanged, deliberately.
+    expect(
+      reservationBadge(unit({ is_container: true, family_available_override: false }))?.label
+    ).toBe('Building')
+  })
+
   it('leaves an ordinary available family cabin unbadged', () => {
     expect(reservationBadge(unit())).toBeNull()
   })
@@ -242,11 +270,38 @@ describe('availabilityAction', () => {
     expect(availabilityAction(unit(), false)?.kind).toBe('hold')
   })
 
-  it('offers nothing on a building row', () => {
-    // A container is a whole-building aggregate, not a bookable room. Holding
-    // one would write an availability row against a unit no family can be
-    // placed into, and the board draws no card for it anyway.
+  it('offers nothing on a SPLIT container', () => {
+    // Still nothing, and for the reason that survived: a split container gets
+    // no card (`drawnUnits` descends past it) and `resolveDrop` rejects it as
+    // a target, so an availability row written against it is one no surface
+    // could ever show or act on.
     expect(availabilityAction(unit({ is_container: true }))).toBeNull()
+  })
+
+  it('offers a write-in on a MERGED building', () => {
+    // The gate used to refuse EVERY container, on the premise that a container
+    // gets no card and no family can be placed into one. Merge-by-drag (#2012)
+    // made both halves false for a COMBINED container: it is the one card the
+    // board draws in place of its rooms, and `dragPlacement` accepts it as a
+    // drop target. Refusing it here left the four `default_combined` buildings
+    // in the 2026 registry with no write-in path at all — their rooms have no
+    // cards to carry one either.
+    expect(availabilityAction(unit({ is_container: true, is_combined: true }))?.kind).toBe('hold')
+  })
+
+  it('offers to clear a MERGED building that has been written into', () => {
+    expect(
+      availabilityAction(
+        unit({ is_container: true, is_combined: true, family_available_override: false })
+      )?.kind
+    ).toBe('clear')
+  })
+
+  it('offers nothing on a MERGED building that already holds a family (#2090)', () => {
+    // The occupancy rule is untouched: a write-in and a placement stay mutually
+    // exclusive. A combined container simply now REACHES that rule instead of
+    // being refused a step earlier for being a container.
+    expect(availabilityAction(unit({ is_container: true, is_combined: true }), true)).toBeNull()
   })
 })
 

--- a/frontend/src/components/weekend/unitBadges.test.ts
+++ b/frontend/src/components/weekend/unitBadges.test.ts
@@ -497,3 +497,57 @@ describe('a write-in inherited from elsewhere in the tree', () => {
     ).toBe('id-house-a')
   })
 })
+
+describe('the badge and the clear must name the SAME row', () => {
+  /*
+   * `availabilityAction` lives beside `reservationBadge` so the two cannot
+   * drift — a card badged "Write-in" that offers to "Write in" says two things
+   * about one cabin. Once a write-in can be INHERITED, that invariant grows
+   * teeth: a card can carry its own availability row AND a relative's
+   * write-in at the same time, and one control has two rows to choose from.
+   * It must clear the one the badge is naming, or the toast reports success
+   * for a row the staff member was not looking at.
+   */
+  const coverFromBuilding = {
+    unit_id: 'id-house',
+    unit_code: 'house',
+    unit_name: 'House',
+    occupant_name: 'Liam Garcia',
+    note: '',
+  }
+
+  it('clears the BUILDING’s write-in on a room carrying a stale release of its own', () => {
+    // Reachable through the API, which does not check an override against the
+    // unit's role — `true` on a family_pool row agrees with that role and no
+    // surface writes it, but nothing deletes one either. The badge reads
+    // "Write-in" here, so the clear must be the write-in.
+    const stale = unit({
+      unit_id: 'u-room',
+      code: 'house-a',
+      name: 'House A',
+      family_available_override: true,
+      write_in: coverFromBuilding,
+    })
+
+    expect(reservationBadge(stale)?.label).toBe('Write-in')
+    expect(availabilityAction(stale)?.unitId).toBe('id-house')
+  })
+
+  it('still clears its OWN row on a released staff cabin, which is what its badge names', () => {
+    // The other side of the same rule, and why this is not simply "the cover
+    // always wins": a released staff cabin badges "Released" off its own row,
+    // so that is the row its clear has to name — even when a relative's
+    // write-in also covers it.
+    const released = unit({
+      unit_id: 'u-room',
+      code: 'house-a',
+      name: 'House A',
+      inventory_class: 'staff_default',
+      family_available_override: true,
+      write_in: coverFromBuilding,
+    })
+
+    expect(reservationBadge(released)?.label).toBe('Released')
+    expect(availabilityAction(released)?.unitId).toBe('u-room')
+  })
+})

--- a/frontend/src/components/weekend/unitBadges.ts
+++ b/frontend/src/components/weekend/unitBadges.ts
@@ -23,6 +23,7 @@
  * burst pipe" are the same fact about availability.
  */
 import type { LodgingUnitRow } from '../../types/lodging'
+import { writeInOccupant, writeInSource } from './writeIn'
 
 export interface UnitBadge {
   label: string
@@ -84,7 +85,13 @@ export function reservationBadge(unit: LodgingUnitRow): UnitBadge | null {
   // It still does not read `occupant_name`: "written in for a caretaker" and
   // "written in for a burst pipe" are the same fact about availability, which
   // is the same reason the reason text never reached this badge.
-  if (unit.inventory_class !== 'staff_default' && unit.family_available_override === false) {
+  // Read through `writeInOccupant`, never the raw `family_available_override`.
+  // The board draws whichever level the tree resolves to, so the card carrying
+  // a write-in is often not the unit whose row it is: split a written-into
+  // building and its ROOMS carry it; merge over a written-into room and the
+  // BUILDING does. The column answers only for the unit it sits on, which is
+  // how a write-in went silent the moment somebody merged or split around it.
+  if (unit.inventory_class !== 'staff_default' && writeInOccupant(unit) !== null) {
     return {
       label: 'Write-in',
       className: 'bg-slate-200 text-slate-800 dark:bg-slate-800 dark:text-slate-200',
@@ -210,6 +217,20 @@ export interface AvailabilityAction {
   familyAvailable: boolean | null
   /** What the control collects before it may write — see `AvailabilityPrompt`. */
   prompt: AvailabilityPrompt
+  /**
+   * The unit the write NAMES, which is not always the card it is offered on.
+   *
+   * A write-in covers a space, and the board draws whichever level the tree
+   * resolves to — so a room can inherit its building's write-in, and a merged
+   * building one of its rooms'. There is exactly one `lodging_availability`
+   * row either way, and clearing it has to target the unit that HOLDS it:
+   * sending the card's own id would delete nothing, and the unit holding the
+   * row has no card to offer the clear from. Every other action names the
+   * card's own unit.
+   */
+  unitId: string
+  /** That unit's name, for the confirmation toast. */
+  unitName: string
 }
 
 /**
@@ -276,8 +297,27 @@ export function availabilityAction(
   // `!== null` and not truthiness: null (no row for this weekend) and false
   // (closed this weekend) are different answers, and collapsing them makes
   // either "Write in" or "Clear" unreachable across most of the board.
+  const own = { unitId: unit.unit_id, unitName: unit.name }
   if (unit.family_available_override !== null && unit.family_available_override !== undefined) {
-    return { kind: 'clear', label: 'Clear', familyAvailable: null, prompt: 'none' }
+    return { kind: 'clear', label: 'Clear', familyAvailable: null, prompt: 'none', ...own }
+  }
+  // A write-in this unit INHERITED — its building's, or one of its rooms'.
+  // Offered before the `occupied` gate below for the reason that gate's own
+  // comment gives: a clear only ever REDUCES the conflict, so occupancy is
+  // never the state that needs it blocked. Without this branch the card is a
+  // dead end: it badges a write-in it cannot undo, and the unit holding the
+  // row has no card at all — which is exactly what a merge or a split does to
+  // it.
+  const source = writeInSource(unit)
+  if (source !== null) {
+    return {
+      kind: 'clear',
+      label: 'Clear',
+      familyAvailable: null,
+      prompt: 'none',
+      unitId: source.unitId,
+      unitName: source.unitName,
+    }
   }
   // NO SURFACE REACHES THIS BRANCH TODAY, and that is deliberate rather than
   // an oversight. Releasing a staff cabin to families is a registry edit on the
@@ -288,12 +328,12 @@ export function availabilityAction(
   // state this branch describes. Kept, unused, because the write path behind it
   // still exists; see the design spec's §7.3 "stays, unused and noted".
   if (unit.inventory_class === 'staff_default') {
-    return { kind: 'release', label: 'Release', familyAvailable: true, prompt: 'reason' }
+    return { kind: 'release', label: 'Release', familyAvailable: true, prompt: 'reason', ...own }
   }
   // An already-occupied space offers no write-in: the fix for #2090. Only
   // reachable here, past both branches above, so an already-held unit keeps
   // its `clear` action regardless of occupancy — clearing only ever REDUCES
   // the conflict, so it is never the state that needs blocking.
   if (occupied) return null
-  return { kind: 'hold', label: 'Write in', familyAvailable: false, prompt: 'occupant' }
+  return { kind: 'hold', label: 'Write in', familyAvailable: false, prompt: 'occupant', ...own }
 }

--- a/frontend/src/components/weekend/unitBadges.ts
+++ b/frontend/src/components/weekend/unitBadges.ts
@@ -43,9 +43,20 @@ export function reservationBadge(unit: LodgingUnitRow): UnitBadge | null {
     label: 'Staff',
     className: 'bg-violet-100 text-violet-800 dark:bg-violet-950/40 dark:text-violet-300',
   }
-  if (unit.is_container === true) {
-    return { label: 'Building', className: 'bg-muted text-muted-foreground' }
-  }
+  const building = { label: 'Building', className: 'bg-muted text-muted-foreground' }
+  // A SPLIT container is pure grouping: `drawnUnits` descends past it, so
+  // nothing draws this badge for one and there is no action for it to agree
+  // with. It answers "Building" and stops.
+  //
+  // A COMBINED one does not stop here, and that is the fix. Merge-by-drag
+  // (#2012) made it the one card the board draws in place of its rooms and a
+  // legitimate drop target (`dragPlacement`), so it reads its availability
+  // like any other drawn unit. It still lands on "Building" below when it has
+  // nothing more specific to say -- being a whole building does not stop being
+  // true -- but a write-in on it now BADGES as one, because
+  // `availabilityAction` now offers to clear it and a card that says
+  // "Building" while offering "Clear" says two things about one cabin.
+  if (unit.is_container === true && unit.is_combined !== true) return building
   // Each override branch is read AGAINST the unit's role, and both compare to
   // an explicit `true`/`false` rather than testing truthiness: null (no row for
   // this weekend, so the role decides) and false (closed this weekend) are
@@ -79,6 +90,10 @@ export function reservationBadge(unit: LodgingUnitRow): UnitBadge | null {
       className: 'bg-slate-200 text-slate-800 dark:bg-slate-800 dark:text-slate-200',
     }
   }
+  // AFTER both override branches and BEFORE `staff`, so the only behaviour a
+  // combined container gains is the two overrides. A combined staff building
+  // with no override reads "Building" exactly as it did.
+  if (unit.is_container === true) return building
   if (unit.inventory_class === 'staff_default') return staff
   return null
 }
@@ -244,8 +259,20 @@ export function availabilityAction(
   unit: LodgingUnitRow,
   occupied = false
 ): AvailabilityAction | null {
-  // A container is a whole-building aggregate, never a bookable room.
-  if (unit.is_container === true) return null
+  // A SPLIT container is a whole-building aggregate, never a bookable room:
+  // `drawnUnits` descends past it and `resolveDrop` rejects it as a target, so
+  // an availability row written against one is a row no surface could show or
+  // act on.
+  //
+  // A COMBINED one is the opposite on both counts since merge-by-drag (#2012)
+  // -- it IS the card the board draws in place of its rooms, and it IS a drop
+  // target -- so it takes a write-in like any other drawn unit. Refusing every
+  // container here left the four `default_combined` buildings in the 2026
+  // registry with no write-in path at all: not on the building's own card, and
+  // not on its rooms either, because a merge is precisely what takes their
+  // cards away. The gate is spelled exactly as `dragPlacement`'s and
+  // `LodgingUnitCard`'s `isSplitContainer` are, so the three cannot drift.
+  if (unit.is_container === true && unit.is_combined !== true) return null
   // `!== null` and not truthiness: null (no row for this weekend) and false
   // (closed this weekend) are different answers, and collapsing them makes
   // either "Write in" or "Clear" unreachable across most of the board.

--- a/frontend/src/components/weekend/unitBadges.ts
+++ b/frontend/src/components/weekend/unitBadges.ts
@@ -298,26 +298,50 @@ export function availabilityAction(
   // (closed this weekend) are different answers, and collapsing them makes
   // either "Write in" or "Clear" unreachable across most of the board.
   const own = { unitId: unit.unit_id, unitName: unit.name }
-  if (unit.family_available_override !== null && unit.family_available_override !== undefined) {
-    return { kind: 'clear', label: 'Clear', familyAvailable: null, prompt: 'none', ...own }
+  const clear = (target: { unitId: string; unitName: string }): AvailabilityAction => ({
+    kind: 'clear',
+    label: 'Clear',
+    familyAvailable: null,
+    prompt: 'none',
+    ...target,
+  })
+  /*
+   * THE THREE CLEAR BRANCHES ARE ORDERED TO MIRROR `reservationBadge` ABOVE,
+   * and that ordering is the rule rather than an accident of writing.
+   *
+   * Once a write-in can be INHERITED, a card can carry its own availability
+   * row AND a relative's write-in at once — two rows, one control. This module
+   * already promises the badge and the action cannot drift ("a card badged
+   * 'Write-in' that offers to 'Write in' says two things about one cabin"), so
+   * the clear names whichever row the badge names. Anything else reports
+   * success for a row the staff member was not looking at, and leaves the fact
+   * they meant to remove sitting on the card.
+   */
+  // A released staff cabin badges "Released" off its OWN row, so that is the
+  // row its clear names — even when a relative's write-in also covers it.
+  if (unit.inventory_class === 'staff_default' && unit.family_available_override === true) {
+    return clear(own)
   }
-  // A write-in this unit INHERITED — its building's, or one of its rooms'.
+  // The write-in COVERING this space, which badges "Write-in". Its own row
+  // when it has one — the server resolves own first — else its building's or
+  // one of its rooms'.
+  //
   // Offered before the `occupied` gate below for the reason that gate's own
   // comment gives: a clear only ever REDUCES the conflict, so occupancy is
-  // never the state that needs it blocked. Without this branch the card is a
-  // dead end: it badges a write-in it cannot undo, and the unit holding the
-  // row has no card at all — which is exactly what a merge or a split does to
-  // it.
+  // never the state that needs it blocked. Without this branch an inheriting
+  // card is a dead end: it badges a write-in it cannot undo, and the unit
+  // holding the row has no card at all — which is exactly what a merge or a
+  // split does to it.
   const source = writeInSource(unit)
   if (source !== null) {
-    return {
-      kind: 'clear',
-      label: 'Clear',
-      familyAvailable: null,
-      prompt: 'none',
-      unitId: source.unitId,
-      unitName: source.unitName,
-    }
+    return clear({ unitId: source.unitId, unitName: source.unitName })
+  }
+  // Any other override of its own. Reachable for a `true` on a family-pool
+  // row: it AGREES with that unit's role so no surface writes one and the
+  // badge stays silent, but the API does not check an override against the
+  // role, and nothing deletes one already stored.
+  if (unit.family_available_override !== null && unit.family_available_override !== undefined) {
+    return clear(own)
   }
   // NO SURFACE REACHES THIS BRANCH TODAY, and that is deliberate rather than
   // an oversight. Releasing a staff cabin to families is a registry edit on the

--- a/frontend/src/components/weekend/writeIn.test.ts
+++ b/frontend/src/components/weekend/writeIn.test.ts
@@ -13,7 +13,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { LodgingUnitRow } from '../../types/lodging'
-import { writeInOccupant } from './writeIn'
+import { writeInOccupant, writeInSource } from './writeIn'
 
 function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
   return {
@@ -111,5 +111,70 @@ describe('writeInOccupant', () => {
         })
       )
     ).toEqual({ name: '', note: 'Back Monday' })
+  })
+})
+
+describe('a write-in resolved through the unit tree', () => {
+  /*
+   * THE ROW NAMES ONE UNIT; IT CLOSES A SPACE. The server resolves which units
+   * a write-in covers (`write_in_covers`), because the board draws whichever
+   * level the tree resolves to and a merge or split moves that level under
+   * staff's feet. Read through this module, both directions arrive as the same
+   * fact — which is the whole reason the fact has a name.
+   */
+  const inherited = unit({
+    code: 'house-a',
+    write_in: {
+      unit_id: 'id-house',
+      unit_code: 'house',
+      unit_name: 'House',
+      occupant_name: 'Liam Garcia',
+      note: 'Back Monday',
+    },
+  })
+
+  it('names the occupant of a room its BUILDING was written into', () => {
+    expect(writeInOccupant(inherited)).toEqual({ name: 'Liam Garcia', note: 'Back Monday' })
+  })
+
+  it('reports the row it came from, and that it is not this unit’s own', () => {
+    expect(writeInSource(inherited)).toEqual({
+      unitId: 'id-house',
+      unitCode: 'house',
+      unitName: 'House',
+      isOwn: false,
+    })
+  })
+
+  it('marks a unit’s OWN row as its own, so the card does not attribute it elsewhere', () => {
+    const own = unit({
+      code: 'cedar-1',
+      family_available_override: false,
+      write_in: {
+        unit_id: 'u1',
+        unit_code: 'cedar-1',
+        unit_name: 'Cedar 1',
+        occupant_name: 'Emma Johnson',
+        note: '',
+      },
+    })
+
+    expect(writeInSource(own)?.isOwn).toBe(true)
+  })
+
+  it('falls back to the unit’s own row when the payload carries no cover at all', () => {
+    // A payload from a server older than the resolution pass has no `write_in`
+    // — Pydantic fields with a default render OPTIONAL in TypeScript. The only
+    // wrong answer to give there is a PERMISSIVE one: reading the absence as
+    // "nobody is in it" would re-open a closed cabin and invite a drop into an
+    // occupied room, which is the exact failure the cover exists to prevent.
+    expect(
+      writeInOccupant(unit({ family_available_override: false, occupant_name: 'Emma Johnson' }))
+    ).toEqual({ name: 'Emma Johnson', note: '' })
+  })
+
+  it('says nothing when neither a cover nor an own row closes the space', () => {
+    expect(writeInOccupant(unit())).toBeNull()
+    expect(writeInSource(unit())).toBeNull()
   })
 })

--- a/frontend/src/components/weekend/writeIn.ts
+++ b/frontend/src/components/weekend/writeIn.ts
@@ -23,7 +23,7 @@
  * string rendered as both the occupant's NAME and the card's italic reason line
  * printed twice on one card. A fallback would restore that by another route.
  */
-import type { LodgingUnitRow } from '../../types/lodging'
+import type { LodgingUnitRow, WriteInCoverRow } from '../../types/lodging'
 
 /** Who is in a room, and anything staff said about them. */
 export interface WriteInOccupant {
@@ -54,6 +54,68 @@ export interface WriteInOccupant {
  * the others is the failure `reservationBadge` documents at length.
  */
 export function writeInOccupant(unit: LodgingUnitRow): WriteInOccupant | null {
+  const cover = coveringWriteIn(unit)
+  if (cover === null) return null
+  return { name: (cover.occupant_name ?? '').trim(), note: (cover.note ?? '').trim() }
+}
+
+/** Where a unit's write-in is recorded, or `null` if none covers it. */
+export interface WriteInSource {
+  /** The unit the `lodging_availability` row belongs to — a clear's target. */
+  unitId: string
+  unitCode: string
+  unitName: string
+  /** Whether the row is this unit's own, rather than inherited through the tree. */
+  isOwn: boolean
+}
+
+/**
+ * WHICH unit holds the write-in covering this one.
+ *
+ * A SECOND function rather than more fields on `WriteInOccupant`, because the
+ * two answer different questions and only one of them is display. "Who is in
+ * this space" is what the card prints; "whose row is this" is what a CLEAR has
+ * to name, and sending the card's own id for an inherited write-in would
+ * delete nothing at all — the room has no row. Keeping them apart is also what
+ * left every existing reader of the occupant untouched.
+ */
+export function writeInSource(unit: LodgingUnitRow): WriteInSource | null {
+  const cover = coveringWriteIn(unit)
+  if (cover === null) return null
+  const unitCode = cover.unit_code ?? ''
+  return {
+    unitId: cover.unit_id ?? '',
+    unitCode,
+    unitName: cover.unit_name ?? '',
+    isOwn: unitCode === unit.code,
+  }
+}
+
+/**
+ * The server-resolved cover, else this unit's OWN row synthesised as one.
+ *
+ * ## Why the fallback is not a code smell
+ *
+ * `write_in` is resolved server-side (`write_in_covers`) and is present on
+ * every unit the current API builds, so in practice the second branch only
+ * fires for a payload from an older server — Pydantic fields with a default
+ * render OPTIONAL in TypeScript, so the key simply arrives missing.
+ *
+ * The direction of the fallback is the point. Reading a missing cover as
+ * "nobody is in it" would OPEN a cabin the row says is closed and invite a
+ * drop into an occupied room, which is the precise failure the cover exists to
+ * prevent. `shareabilityBadge` makes the same argument at its own default: on
+ * missing evidence the only wrong answer is a permissive one.
+ */
+function coveringWriteIn(unit: LodgingUnitRow): WriteInCoverRow | null {
+  const cover = unit.write_in
+  if (cover !== null && cover !== undefined) return cover
   if (unit.family_available_override !== false) return null
-  return { name: (unit.occupant_name ?? '').trim(), note: (unit.reason ?? '').trim() }
+  return {
+    unit_id: unit.unit_id,
+    unit_code: unit.code,
+    unit_name: unit.name,
+    occupant_name: unit.occupant_name ?? '',
+    note: unit.reason ?? '',
+  }
 }

--- a/frontend/src/types/api-generated/index.ts
+++ b/frontend/src/types/api-generated/index.ts
@@ -682,6 +682,7 @@ export type {
   WeekendSummaryResponse,
   WeeklyDataPoint,
   WeekOption,
+  WriteInCover,
   YearEnrollment,
   YearMetrics,
   YearsAtCampBreakdown,

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -2205,6 +2205,7 @@ export type LodgingUnitSummary = {
    * Is Family Available
    */
   is_family_available?: boolean
+  write_in?: WriteInCover | null
   /**
    * Map X
    */
@@ -7158,6 +7159,50 @@ export type WeeklyDataPoint = {
    * 'snapshot', 'reconstructed', or 'mixed'
    */
   data_source: string
+}
+
+/**
+ * WriteInCover
+ *
+ * The write-in that closes a space, wherever in the tree it was recorded.
+ *
+ * A write-in names ONE unit, but it is a fact about a physical space, and a
+ * building's space contains its rooms'. The board draws whichever level the
+ * tree currently resolves to (`drawn_units`), and merging or splitting moves
+ * that level under staff's feet -- so a write-in recorded on a merged
+ * building went silent the moment somebody split it back to rooms, and one
+ * recorded on a room said nothing on the building's card after a merge. Both
+ * left the same hole: a family could be dropped into a space somebody is
+ * already sleeping in.
+ *
+ * Resolved on READ, never cascaded on write. A row per leaf would duplicate
+ * one fact across rows that then drift -- clear one room and the others still
+ * close the space -- and would strand orphans behind a re-merge. There is
+ * still exactly one `lodging_availability` row; this says which units it
+ * covers, and `unit_id` is the row it belongs to, so a card that inherited
+ * the write-in can still clear it at the source rather than dead-ending.
+ */
+export type WriteInCover = {
+  /**
+   * Unit Id
+   */
+  unit_id?: string
+  /**
+   * Unit Code
+   */
+  unit_code?: string
+  /**
+   * Unit Name
+   */
+  unit_name?: string
+  /**
+   * Occupant Name
+   */
+  occupant_name?: string
+  /**
+   * Note
+   */
+  note?: string
 }
 
 /**

--- a/frontend/src/types/lodging.test.ts
+++ b/frontend/src/types/lodging.test.ts
@@ -209,6 +209,12 @@ const _exhaustiveLodgingUnit: Required<LodgingUnitRow> = {
   occupant_name: '',
   reason: '',
   is_family_available: true,
+  // The write-in COVERING this space, resolved through the unit tree by the
+  // server — this unit's own row, else its nearest ancestor's, else its
+  // nearest descendant's. Distinct from the three fields above, which stay
+  // strictly this unit's own row: a room can be closed by a write-in it does
+  // not hold, which is what a merge or a split does to one.
+  write_in: null,
   map_x: 0.5,
   map_y: 0.5,
 }

--- a/frontend/src/types/lodging.ts
+++ b/frontend/src/types/lodging.ts
@@ -34,6 +34,7 @@ import type {
   WeekendSessionSummary,
   WeekendSummaryEntry,
   WeekendSummaryResponse,
+  WriteInCover,
 } from './api-generated'
 import type { BedInventory } from './beds'
 
@@ -51,6 +52,13 @@ export type RosterPartyRow = RosterParty
 export type RosterCountSummary = RosterCounts
 /** One row of the lodging registry as the roster sees it. */
 export type LodgingUnitRow = LodgingUnitSummary
+/**
+ * The write-in covering a unit's space, resolved through the tree by the
+ * server. Read it through `writeInOccupant`/`writeInSource`, never inline: the
+ * point of naming the fact once is that the board's five consumers cannot
+ * drift onto different spellings of it.
+ */
+export type WriteInCoverRow = WriteInCover
 /** A household's cabin-sharing request, unresolved. */
 export type ShareRequest = ShareRequestSummary
 /** Derived accessibility booleans. Never narrative text. */

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -30,11 +30,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from api.schemas.lodging import LodgingUnitSummary
 from api.services.lodging_roster_service import (
     SUMMARY_ENTRY_CONCURRENCY,
     LodgingRosterService,
     SessionNotFoundError,
     _BathroomIndex,
+    write_in_covers,
 )
 
 
@@ -1023,6 +1025,70 @@ class TestUnitsAndCounts:
         assert roster.counts.units_reserved == 1
         assert roster.counts.units_staff_housing == 1
         assert roster.counts.beds_family_available == 0
+
+    @pytest.mark.asyncio
+    async def test_a_write_in_on_a_building_reaches_the_rooms_beneath_it(self) -> None:
+        # THE WIRING, not the resolver -- `TestWriteInCovers` pins the rule
+        # itself. This is the pass that puts the answer on the payload, and it
+        # is a SECOND pass over the summaries for a reason: a unit's cover can
+        # come from a row on a unit built after it, so there is no single order
+        # in which one pass sees every own-row it needs.
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("u1", "house", "House", is_container=True, default_combined=True),
+                _unit("u2", "house-a", "House A", sleeps=4, parent_unit="u1"),
+            ],
+            fetch_availability=[
+                _rec(unit="u1", family_available=False, occupant_name="Liam Garcia", note="Back Monday")
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        by_code = {u.code: u for u in roster.units}
+        # The room holds no row of its own -- and is closed all the same.
+        assert by_code["house-a"].family_available_override is None
+        assert by_code["house-a"].write_in is not None
+        assert by_code["house-a"].write_in.unit_id == "u1"
+        assert by_code["house-a"].write_in.occupant_name == "Liam Garcia"
+        assert by_code["house-a"].write_in.note == "Back Monday"
+        # And the building still reads as its own, so the card that holds the
+        # row does not start attributing it elsewhere.
+        assert by_code["house"].write_in is not None
+        assert by_code["house"].write_in.unit_code == "house"
+
+    @pytest.mark.asyncio
+    async def test_a_write_in_on_a_room_reaches_the_building_over_it(self) -> None:
+        # The mirror, through the same pass: merge a building over a
+        # written-into room and the room stops being drawn, so without this the
+        # building's card said nothing about the caretaker in it.
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("u1", "house", "House", is_container=True, default_combined=True),
+                _unit("u2", "house-a", "House A", sleeps=4, parent_unit="u1"),
+            ],
+            fetch_availability=[_rec(unit="u2", family_available=False, occupant_name="Ava Martinez")],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        by_code = {u.code: u for u in roster.units}
+        assert by_code["house"].write_in is not None
+        assert by_code["house"].write_in.unit_id == "u2"
+        assert by_code["house"].write_in.occupant_name == "Ava Martinez"
+
+    @pytest.mark.asyncio
+    async def test_an_ordinary_open_cabin_carries_no_cover_at_all(self) -> None:
+        # The common case by far, and the one that must stay None: a cover on
+        # every unit would close the whole board.
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[_unit("u1", "ridge-a", "Ridge A", sleeps=5)],
+            fetch_availability=[],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.units[0].write_in is None
 
     @pytest.mark.asyncio
     async def test_a_true_override_beats_a_false_default(self) -> None:
@@ -4048,3 +4114,140 @@ class TestHouseholdJourney:
 
         assert journey.years == []
         repo.fetch_cabin_assignments_by_household_cm_id.assert_not_called()
+
+
+class TestWriteInCovers:
+    """Which space a write-in closes, once the tree is taken into account.
+
+    THE UNIT A ROW NAMES IS NOT THE ONLY SPACE IT CLOSES. A write-in is a fact
+    about a physical space, and a building's space contains its rooms'. The
+    board draws whichever level the tree currently resolves to (`drawn_units`),
+    and merging or splitting moves that level under staff's feet -- so a
+    write-in recorded on a merged building went silent the moment somebody
+    split it, and one recorded on a room said nothing on the building's card
+    after a merge. Both left the same hole: a family could be dropped into a
+    space somebody is already sleeping in.
+
+    Resolved on READ rather than cascaded on write. Writing a row per leaf
+    would duplicate a single fact across rows that then drift -- clear one room
+    and the others still close the space -- and would leave orphans behind a
+    re-merge. There is still exactly ONE row; this decides which units it
+    covers.
+
+    Fictional data throughout.
+    """
+
+    @staticmethod
+    def _unit(code: str, **kwargs: Any) -> LodgingUnitSummary:
+        return LodgingUnitSummary(unit_id=f"id-{code}", code=code, name=code.title(), **kwargs)
+
+    def test_a_room_inherits_the_write_in_of_the_building_above_it(self) -> None:
+        # The SPLIT case. Staff wrote into the whole house while it was merged,
+        # then split it back to rooms: the row still names the house, which now
+        # has no card at all.
+        house = self._unit(
+            "house",
+            is_container=True,
+            family_available_override=False,
+            occupant_name="Liam Garcia",
+            reason="Back Monday",
+        )
+        room = self._unit("house-a", parent_code="house")
+
+        covers = write_in_covers([house, room])
+
+        assert covers["house-a"].unit_code == "house"
+        assert covers["house-a"].occupant_name == "Liam Garcia"
+        assert covers["house-a"].note == "Back Monday"
+
+    def test_a_building_surfaces_the_write_in_of_a_room_beneath_it(self) -> None:
+        # The MERGE case, and the mirror of the one above: the row names a room
+        # that stopped being drawn when staff merged the building over it.
+        house = self._unit("house", is_container=True, is_combined=True)
+        written_room = self._unit(
+            "house-a", parent_code="house", family_available_override=False, occupant_name="Liam Garcia"
+        )
+        other_room = self._unit("house-b", parent_code="house")
+
+        covers = write_in_covers([house, written_room, other_room])
+
+        assert covers["house"].unit_code == "house-a"
+        assert covers["house"].occupant_name == "Liam Garcia"
+
+    def test_a_sibling_room_is_not_covered(self) -> None:
+        # The one direction that must NOT propagate. A caretaker in room A says
+        # nothing about room B, and closing B too would take a lettable room
+        # off the board for no reason. It reaches B's BUILDING (above) without
+        # reaching B, because each unit resolves from OWN rows only -- never
+        # transitively through a cover it just computed for somebody else.
+        house = self._unit("house", is_container=True)
+        written_room = self._unit(
+            "house-a", parent_code="house", family_available_override=False, occupant_name="Liam Garcia"
+        )
+        other_room = self._unit("house-b", parent_code="house")
+
+        covers = write_in_covers([house, written_room, other_room])
+
+        assert "house-b" not in covers
+        assert covers["house"].unit_code == "house-a"
+
+    def test_a_units_own_write_in_beats_an_inherited_one(self) -> None:
+        house = self._unit("house", is_container=True, family_available_override=False, occupant_name="Liam Garcia")
+        room = self._unit("house-a", parent_code="house", family_available_override=False, occupant_name="Ava Martinez")
+
+        covers = write_in_covers([house, room])
+
+        assert covers["house-a"].unit_code == "house-a"
+        assert covers["house-a"].occupant_name == "Ava Martinez"
+
+    def test_the_nearest_ancestor_wins(self) -> None:
+        block = self._unit("block", is_container=True, family_available_override=False, occupant_name="Ava Martinez")
+        house = self._unit(
+            "house",
+            parent_code="block",
+            is_container=True,
+            family_available_override=False,
+            occupant_name="Liam Garcia",
+        )
+        room = self._unit("house-a", parent_code="house")
+
+        covers = write_in_covers([block, house, room])
+
+        assert covers["house-a"].unit_code == "house"
+
+    def test_a_release_is_not_a_write_in(self) -> None:
+        # `True` is a staff cabin OPENED to families for the weekend. It names
+        # no occupant and closes nothing, so it must not travel: inheriting it
+        # would silently open every room beneath a released building.
+        house = self._unit("house", is_container=True, inventory_class="staff_default", family_available_override=True)
+        room = self._unit("house-a", parent_code="house")
+
+        covers = write_in_covers([house, room])
+
+        assert covers == {}
+
+    def test_a_unit_with_nothing_on_its_path_is_absent(self) -> None:
+        assert write_in_covers([self._unit("cedar-1")]) == {}
+
+    def test_a_parent_cycle_does_not_hang(self) -> None:
+        # The server guards against writing one (#1899), but a cycle already in
+        # the data must not spin the roster build.
+        a = self._unit("a", parent_code="b", is_container=True)
+        b = self._unit("b", parent_code="a", is_container=True)
+
+        assert write_in_covers([a, b]) == {}
+
+    def test_several_written_rooms_pick_one_deterministically(self) -> None:
+        # A building over two written-into rooms is closed either way; the
+        # point is that two identical payloads never disagree about WHICH row
+        # the card names, which a set-ordered walk would not guarantee.
+        house = self._unit("house", is_container=True, is_combined=True)
+        room_b = self._unit(
+            "house-b", parent_code="house", family_available_override=False, occupant_name="Ava Martinez"
+        )
+        room_a = self._unit(
+            "house-a", parent_code="house", family_available_override=False, occupant_name="Liam Garcia"
+        )
+
+        assert write_in_covers([house, room_b, room_a])["house"].unit_code == "house-a"
+        assert write_in_covers([house, room_a, room_b])["house"].unit_code == "house-a"

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -4237,6 +4237,19 @@ class TestWriteInCovers:
 
         assert write_in_covers([a, b]) == {}
 
+    def test_a_blank_coded_unit_never_lends_its_cover_to_another(self) -> None:
+        # "" is the same key `parent_code == ""` uses for "no parent", which is
+        # why `by_code` drops a blank-coded unit on the LOOKUP side. The result
+        # map has to drop it too, or two blank-coded rows share one key and the
+        # second reads the first's occupant off a row it does not hold.
+        #
+        # A blank code is a valid if unfortunate registry value, so this is bad
+        # data meeting a collision, not a state the schema forbids.
+        written = self._unit("", family_available_override=False, occupant_name="Liam Garcia")
+        other = LodgingUnitSummary(unit_id="id-other", code="", name="Other")
+
+        assert write_in_covers([written, other]) == {}
+
     def test_several_written_rooms_pick_one_deterministically(self) -> None:
         # A building over two written-into rooms is closed either way; the
         # point is that two identical payloads never disagree about WHICH row


### PR DESCRIPTION
## The bug

On the weekend lodging board, a **merged building** offered no way to write in an occupant — empty or full. Reported from the GUI: *"appears not able to allow a write in on a full merged building."*

Investigating that surfaced a second, larger problem behind it, and this PR fixes both.

---

## Part 1 — a merged building could not take a write-in (commit 1)

`availabilityAction` refused **every** container, before it ever looked at occupancy:

```ts
if (unit.is_container === true) return null   // "never a bookable room"
```

True when written; merge-by-drag (#2012) made it false for a *combined* container, which is **the one card the board draws** in place of its rooms (`drawnUnits`) and **a legitimate drop target** — `dragPlacement` rejects only a *split* one. Every other consumer already used that narrower gate (`isSplitContainer`, `shareabilityBadge`, `sharingConflictBadge`); `availabilityAction` and `reservationBadge` were the outliers.

So a merged building was the only drawn unit on the board with no write-in path, and **merging is precisely what takes its rooms' own cards away**. That left the four `default_combined` buildings in the 2026 registry unable to record an occupant at all.

**Fix:** refuse only a split container, spelled exactly as the other three gates. `reservationBadge` follows — a card badged "Building" while offering "Clear" says two things about one cabin — and still falls back to "Building" when there is nothing more specific to say.

---

## Part 2 — the write-in did not survive a merge or a split (commit 2)

A write-in names **one unit**, but it is a fact about a **space**, and a building's space contains its rooms'. The board draws whichever level the tree resolves to, and merge/split moves that level under staff's feet:

| Staff do this | Before |
|---|---|
| write into a merged building, then **split** it | the row still names the building, which now has no card — the write-in goes silent |
| write into a room, then **merge** the building over it | the room stops being drawn — the building's card says nothing about the occupant |

Not a display nit. `resolveDrop` read the raw column, which answers only for the unit it sits on, so **a family could be dropped into a space somebody is already sleeping in**, with nothing on screen to warn anyone. The merge-side half of that predates the write-in control entirely.

Splitting is not a workaround for Part 1 either: a container-level placement fans down onto every leaf, so after a split all rooms read occupied and none offers the control.

### Resolved on read, never cascaded on write

A row per leaf would duplicate one fact across rows that then drift — clear one room and the others still close the space — and would strand orphans behind a re-merge, which is exactly the failure a cascade looks like it prevents. **There is still exactly one `lodging_availability` row.**

`write_in_covers` (API) resolves it, highest first:

1. the unit's **own** row
2. the nearest **ancestor**'s
3. the nearest **descendant**'s

Own beats inherited as the more specific statement about one space. An ancestor beats a descendant because a building closed whole says something about every room in it, where one room says only that the building is no longer free to let whole.

Resolved from **own rows only**, never transitively through a cover computed for somebody else — which keeps a caretaker in room A off room B while still closing their building. Only a write-in travels: a release names no occupant and closes nothing, so inheriting it would silently open every room beneath a released building. Both walks are cycle-guarded, the same backstop `drawn_units` carries.

### Clearing from a card that does not hold the row

A card that inherits a write-in has to be able to clear it — the unit holding the row has no card of its own, which is exactly what the merge or split did to it. So `WriteInCover` carries the source `unit_id`; `AvailabilityAction` and `UnitAvailabilityWrite` carry the write target; `onSetAvailability` **drops its unit parameter** so a caller cannot pick the wrong one of the two; and the in-flight disable follows the row rather than the card. `WriteInCard` prints "Written in at House" when the row is somewhere else, and stays quiet when it is the card's own.

`family_available_override` / `occupant_name` / `reason` stay **strictly the unit's own row** — they are what the write path reads back and what `is_family_available` derives from. Ask `write_in` "is somebody in this space", and those "what does this unit's own row say".

---

## What is deliberately NOT changed

**#2090's occupancy rule.** A write-in and a placement stay mutually exclusive, so a merged building that already holds a family still offers nothing — a combined container now *reaches* that rule instead of being refused a step earlier for being a container.

## Tests

TDD throughout — every assertion written and verified failing first (the frontend control test verified against a reverted implementation).

- **`write_in_covers`** — inherits down, rolls up, own beats inherited, nearest ancestor wins, a **sibling room is not covered**, a release is not a write-in, cycles terminate, multiple written rooms pick deterministically.
- **Wiring** — through `build_roster`: a building's write-in reaches its rooms, a room's reaches its building, an ordinary open cabin carries no cover.
- **`dragPlacement`** — a drop into a room of a written-into building is refused; a whole-house drop is refused when one of its rooms is written into.
- **`unitBadges` / `writeIn` / `UnitAvailabilityControl` / `LodgingBoard` / `WriteInCard`** — badge, clear-at-source, the write target, the in-flight disable, the attribution line, plus the Part 1 regression guards.

`6087` Python and `1143` frontend tests pass. Pre-push verification green (ruff, mypy, api-types freshness, prettier, eslint, tsc, vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lodging availability now carries write-in details across related buildings, rooms, and combined units.
  * Write-in cards identify the unit where the occupant was originally entered.
  * Availability actions clearly target the correct source unit, including inherited write-ins.
  * Unit badges and availability controls now reflect inherited occupancy and support combined buildings.

* **Bug Fixes**
  * Clearing an inherited write-in updates the unit that owns it.
  * Placement is blocked when a space is occupied through a related unit’s write-in.
  * Loading indicators remain active while source-unit changes are being saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->