### PR TITLE
fix(sync): repair four data-loss defects in the staff_vehicle_info transform

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,6 +59,13 @@ linters:
         # are real field names we must match on, so the typo is data, not a bug.
         - typo: "accomodation"
           correction: "accomodation"
+        # CampMinder ships the SVI plate field under the British spelling
+        # "SVI-licence plate number" (kindred#2258). The American spelling
+        # matched nothing for the table's entire history, so the field name
+        # is data, not a bug -- matched literally in staff_vehicle_info.go
+        # and pinned by staff_vehicle_info_test.go.
+        - typo: "licence"
+          correction: "licence"
     lll:
       line-length: 120
     nakedret:

--- a/frontend/src/types/pocketbase-types.ts
+++ b/frontend/src/types/pocketbase-types.ts
@@ -44,6 +44,19 @@ export const Collections = {
   Households: 'households',
   LockedGroupMembers: 'locked_group_members',
   LockedGroups: 'locked_groups',
+  LodgingAreas: 'lodging_areas',
+  LodgingAssignmentHistory: 'lodging_assignment_history',
+  LodgingAssignments: 'lodging_assignments',
+  LodgingAssignmentsDraft: 'lodging_assignments_draft',
+  LodgingAvailability: 'lodging_availability',
+  LodgingFieldMappings: 'lodging_field_mappings',
+  LodgingFriendGroupMembers: 'lodging_friend_group_members',
+  LodgingFriendGroups: 'lodging_friend_groups',
+  LodgingIngestIssues: 'lodging_ingest_issues',
+  LodgingSessionStatus: 'lodging_session_status',
+  LodgingSlotMerges: 'lodging_slot_merges',
+  LodgingUnitAliases: 'lodging_unit_aliases',
+  LodgingUnits: 'lodging_units',
   NormalizedMappings: 'normalized_mappings',
   OriginalBunkRequests: 'original_bunk_requests',
   PaymentMethods: 'payment_methods',
@@ -442,7 +455,7 @@ export type CamperHistoryRecord = {
   session?: RecordIdString
   session_cm_id: number
   session_name?: string
-  session_type?: CamperHistorySessionTypeOptions
+  session_type: CamperHistorySessionTypeOptions
   state?: string
   status?: string
   synagogue?: string
@@ -550,7 +563,18 @@ export type DebugParseResultsRecord<Tai_raw_response = unknown, Tparsed_intents 
   updated: IsoAutoDateString
 }
 
-export type DebugPipelineRunsRecord<Tsource_fields = unknown, Tstatus_breakdown = unknown> = {
+export const DebugPipelineRunsTriggerOptions = {
+  upload: 'upload',
+  scheduled: 'scheduled',
+  manual: 'manual',
+} as const
+export type DebugPipelineRunsTriggerOptions =
+  (typeof DebugPipelineRunsTriggerOptions)[keyof typeof DebugPipelineRunsTriggerOptions]
+export type DebugPipelineRunsRecord<
+  Tsession_breakdown = unknown,
+  Tsource_fields = unknown,
+  Tstatus_breakdown = unknown,
+> = {
   created: IsoAutoDateString
   force?: boolean
   id: string
@@ -558,9 +582,11 @@ export type DebugPipelineRunsRecord<Tsource_fields = unknown, Tstatus_breakdown 
   pinned?: boolean
   run_id: string
   session?: string
+  session_breakdown?: null | Tsession_breakdown
   source_fields?: null | Tsource_fields
   status_breakdown?: null | Tstatus_breakdown
   trace_count?: number
+  trigger?: DebugPipelineRunsTriggerOptions
   updated: IsoAutoDateString
   year: number
 }
@@ -677,6 +703,23 @@ export const FamilyCampRegistrationsShareCabinGateOptions = {
 } as const
 export type FamilyCampRegistrationsShareCabinGateOptions =
   (typeof FamilyCampRegistrationsShareCabinGateOptions)[keyof typeof FamilyCampRegistrationsShareCabinGateOptions]
+
+export const FamilyCampRegistrationsShareEligibilityOptions = {
+  open: 'open',
+  named: 'named',
+  declined: 'declined',
+  unknown: 'unknown',
+} as const
+export type FamilyCampRegistrationsShareEligibilityOptions =
+  (typeof FamilyCampRegistrationsShareEligibilityOptions)[keyof typeof FamilyCampRegistrationsShareEligibilityOptions]
+
+export const FamilyCampRegistrationsShareEligibilitySourceOptions = {
+  form: 'form',
+  registration: 'registration',
+  none: 'none',
+} as const
+export type FamilyCampRegistrationsShareEligibilitySourceOptions =
+  (typeof FamilyCampRegistrationsShareEligibilitySourceOptions)[keyof typeof FamilyCampRegistrationsShareEligibilitySourceOptions]
 export type FamilyCampRegistrationsRecord = {
   accommodation_is_mandatory?: boolean
   arrival_eta?: string
@@ -694,12 +737,16 @@ export type FamilyCampRegistrationsRecord = {
   request_last_updated?: IsoDateString
   request_source_field?: string
   request_text?: string
+  share_answers_conflict?: boolean
   share_cabin_gate?: FamilyCampRegistrationsShareCabinGateOptions
   share_cabin_preference?: string
+  share_eligibility?: FamilyCampRegistrationsShareEligibilityOptions
+  share_eligibility_source?: FamilyCampRegistrationsShareEligibilitySourceOptions
   shared_cabin_modes_raw?: string
   special_occasions?: string
   updated: IsoAutoDateString
   wants_near?: boolean
+  wants_similar_ages?: boolean
   wants_with?: boolean
   year: number
 }
@@ -942,6 +989,272 @@ export type LockedGroupsRecord = {
   name?: string
   scenario: RecordIdString
   session: RecordIdString
+  updated: IsoAutoDateString
+  year: number
+}
+
+export type LodgingAreasRecord = {
+  code: string
+  created: IsoAutoDateString
+  id: string
+  map_x?: number
+  map_y?: number
+  name: string
+  sort_order?: number
+  updated: IsoAutoDateString
+  year: number
+}
+
+export type LodgingAssignmentHistoryRecord = {
+  created: IsoAutoDateString
+  detected_at: IsoDateString
+  household_cm_id?: number
+  id: string
+  new_unit?: string
+  old_unit?: string
+  person_cm_id?: number
+  session?: RecordIdString
+  session_cm_id?: number
+  source_field?: string
+  year: number
+}
+
+export const LodgingAssignmentsSourceOptions = {
+  campminder_sync: 'campminder_sync',
+  jotform_sync: 'jotform_sync',
+  staff_manual: 'staff_manual',
+} as const
+export type LodgingAssignmentsSourceOptions =
+  (typeof LodgingAssignmentsSourceOptions)[keyof typeof LodgingAssignmentsSourceOptions]
+export type LodgingAssignmentsRecord = {
+  created: IsoAutoDateString
+  household_cm_id?: number
+  id: string
+  party_size?: number
+  person_cm_id?: number
+  session: RecordIdString
+  session_cm_id: number
+  source?: LodgingAssignmentsSourceOptions
+  staff_touched?: boolean
+  units?: RecordIdString[]
+  updated: IsoAutoDateString
+  year: number
+}
+
+export const LodgingAssignmentsDraftSourceOptions = {
+  campminder_sync: 'campminder_sync',
+  jotform_sync: 'jotform_sync',
+  staff_manual: 'staff_manual',
+} as const
+export type LodgingAssignmentsDraftSourceOptions =
+  (typeof LodgingAssignmentsDraftSourceOptions)[keyof typeof LodgingAssignmentsDraftSourceOptions]
+export type LodgingAssignmentsDraftRecord = {
+  created: IsoAutoDateString
+  household_cm_id?: number
+  id: string
+  party_size?: number
+  person_cm_id?: number
+  scenario: RecordIdString
+  session: RecordIdString
+  session_cm_id: number
+  source?: LodgingAssignmentsDraftSourceOptions
+  staff_touched?: boolean
+  units?: RecordIdString[]
+  updated: IsoAutoDateString
+  year: number
+}
+
+export type LodgingAvailabilityRecord = {
+  created: IsoAutoDateString
+  family_available?: boolean
+  id: string
+  note?: string
+  occupant_name?: string
+  session: RecordIdString
+  session_cm_id: number
+  unit: RecordIdString
+  updated: IsoAutoDateString
+  year: number
+}
+
+export type LodgingFieldMappingsRecord = {
+  created: IsoAutoDateString
+  field_cm_id: number
+  field_name?: string
+  id: string
+  is_enabled?: boolean
+  last_seen_count?: number
+  last_seen_year?: number
+  note?: string
+  prior_year_count?: number
+  target?: string
+  updated: IsoAutoDateString
+}
+
+export type LodgingFriendGroupMembersRecord = {
+  added_by?: string
+  created: IsoAutoDateString
+  group: RecordIdString
+  household_cm_id: number
+  id: string
+}
+
+export const LodgingFriendGroupsSourceOptions = {
+  staff_manual: 'staff_manual',
+  proposed: 'proposed',
+} as const
+export type LodgingFriendGroupsSourceOptions =
+  (typeof LodgingFriendGroupsSourceOptions)[keyof typeof LodgingFriendGroupsSourceOptions]
+export type LodgingFriendGroupsRecord = {
+  color: string
+  created: IsoAutoDateString
+  created_by?: string
+  id: string
+  name?: string
+  session: RecordIdString
+  session_cm_id: number
+  source: LodgingFriendGroupsSourceOptions
+  updated: IsoAutoDateString
+  year: number
+}
+
+export const LodgingIngestIssuesKindOptions = {
+  unresolved_alias: 'unresolved_alias',
+  ambiguous_alias: 'ambiguous_alias',
+  ambiguous_session: 'ambiguous_session',
+  no_session: 'no_session',
+  field_zero_values: 'field_zero_values',
+  unknown_party: 'unknown_party',
+  write_failed: 'write_failed',
+} as const
+export type LodgingIngestIssuesKindOptions =
+  (typeof LodgingIngestIssuesKindOptions)[keyof typeof LodgingIngestIssuesKindOptions]
+export type LodgingIngestIssuesRecord<Tcandidate_session_cm_ids = unknown> = {
+  candidate_session_cm_ids?: null | Tcandidate_session_cm_ids
+  created: IsoAutoDateString
+  first_seen?: IsoDateString
+  household_cm_id?: number
+  id: string
+  is_resolved?: boolean
+  kind: LodgingIngestIssuesKindOptions
+  last_seen?: IsoDateString
+  occurrences?: number
+  person_cm_id?: number
+  raw_value?: string
+  resolution_note?: string
+  resolved_alias?: RecordIdString
+  source_field?: string
+  suggested_session?: RecordIdString
+  updated: IsoAutoDateString
+  year: number
+}
+
+export const LodgingSessionStatusStatusOptions = {
+  active: 'active',
+  cancelled: 'cancelled',
+} as const
+export type LodgingSessionStatusStatusOptions =
+  (typeof LodgingSessionStatusStatusOptions)[keyof typeof LodgingSessionStatusStatusOptions]
+export type LodgingSessionStatusRecord = {
+  created: IsoAutoDateString
+  id: string
+  session_cm_id: number
+  status: LodgingSessionStatusStatusOptions
+  updated: IsoAutoDateString
+  year: number
+}
+
+export type LodgingSlotMergesRecord = {
+  combined?: boolean
+  id: string
+  scenario?: RecordIdString
+  session: RecordIdString
+  session_cm_id: number
+  unit: RecordIdString
+  year: number
+}
+
+export type LodgingUnitAliasesRecord = {
+  alias_string: string
+  created: IsoAutoDateString
+  id: string
+  member_units: RecordIdString[]
+  notes?: string
+  source_field?: string
+  updated: IsoAutoDateString
+  valid_from_year?: number
+  valid_to_year?: number
+}
+
+export const LodgingUnitsBathroomOptions = {
+  none: 'none',
+  private: 'private',
+  shared: 'shared',
+} as const
+export type LodgingUnitsBathroomOptions =
+  (typeof LodgingUnitsBathroomOptions)[keyof typeof LodgingUnitsBathroomOptions]
+
+export const LodgingUnitsInventoryClassOptions = {
+  family_pool: 'family_pool',
+  staff_default: 'staff_default',
+} as const
+export type LodgingUnitsInventoryClassOptions =
+  (typeof LodgingUnitsInventoryClassOptions)[keyof typeof LodgingUnitsInventoryClassOptions]
+
+export const LodgingUnitsHasRampOptions = {
+  yes: 'yes',
+  no: 'no',
+  partial: 'partial',
+} as const
+export type LodgingUnitsHasRampOptions =
+  (typeof LodgingUnitsHasRampOptions)[keyof typeof LodgingUnitsHasRampOptions]
+
+export const LodgingUnitsShareabilityOptions = {
+  shareable: 'shareable',
+  single_party: 'single_party',
+} as const
+export type LodgingUnitsShareabilityOptions =
+  (typeof LodgingUnitsShareabilityOptions)[keyof typeof LodgingUnitsShareabilityOptions]
+export type LodgingUnitsRecord<Tbeds = unknown> = {
+  area: RecordIdString
+  bathroom?: LodgingUnitsBathroomOptions
+  bathroom_group?: string
+  beds?: null | Tbeds
+  code: string
+  created: IsoAutoDateString
+  default_combined?: boolean
+  has_ac?: boolean
+  has_changing_table?: boolean
+  has_crib?: boolean
+  has_fridge?: boolean
+  has_heat?: boolean
+  has_kitchen?: boolean
+  has_kitchenette?: boolean
+  has_lights?: boolean
+  has_living_room?: boolean
+  has_pack_play_space?: boolean
+  has_plumbing?: boolean
+  has_power?: boolean
+  has_ramp?: LodgingUnitsHasRampOptions
+  has_shared_fridge?: boolean
+  has_space_heater?: boolean
+  has_tub?: boolean
+  id: string
+  inventory_class?: LodgingUnitsInventoryClassOptions
+  is_accessible?: boolean
+  is_active?: boolean
+  is_confirmed?: boolean
+  is_container?: boolean
+  is_weatherized?: boolean
+  map_x?: number
+  map_y?: number
+  max_beds?: number
+  name: string
+  near_bathhouse?: boolean
+  notes?: string
+  parent_unit?: RecordIdString
+  shareability?: LodgingUnitsShareabilityOptions
+  sleeps?: number
   updated: IsoAutoDateString
   year: number
 }
@@ -1204,12 +1517,15 @@ export type SolverRunsRecord<
   Tstats = unknown,
 > = {
   assignment_counts?: null | Tassignment_counts
+  break_glass_used?: boolean
   completed_at?: IsoDateString
   created: IsoAutoDateString
   details?: null | Tdetails
   error?: null | Terror
   id: string
+  infeasibility_diagnosis?: string
   logs?: null | Tlogs
+  overflow_used?: number
   progress?: number
   result?: null | Tresult
   run_id: string
@@ -1358,7 +1674,7 @@ export type StaffSkillsRecord = {
 }
 
 export type StaffVehicleInfoRecord = {
-  can_bring_others?: boolean
+  can_bring_others?: string
   created: IsoAutoDateString
   driver_name?: string
   driving_to_camp?: boolean
@@ -1366,7 +1682,9 @@ export type StaffVehicleInfoRecord = {
   id: string
   license_plate?: string
   person_id: number
+  ride_from?: string
   staff: RecordIdString
+  transport_notes?: string
   updated: IsoAutoDateString
   vehicle_make?: string
   vehicle_model?: string
@@ -1461,10 +1779,12 @@ export type DebugParseResultsResponse<
   Texpand = unknown,
 > = Required<DebugParseResultsRecord<Tai_raw_response, Tparsed_intents>> & BaseSystemFields<Texpand>
 export type DebugPipelineRunsResponse<
+  Tsession_breakdown = unknown,
   Tsource_fields = unknown,
   Tstatus_breakdown = unknown,
   Texpand = unknown,
-> = Required<DebugPipelineRunsRecord<Tsource_fields, Tstatus_breakdown>> & BaseSystemFields<Texpand>
+> = Required<DebugPipelineRunsRecord<Tsession_breakdown, Tsource_fields, Tstatus_breakdown>> &
+  BaseSystemFields<Texpand>
 export type DebugPipelineSummaryResponse<Texpand = unknown> = Required<DebugPipelineSummaryRecord> &
   BaseSystemFields<Texpand>
 export type DebugPipelineTracesResponse<Ttrace_data = unknown, Texpand = unknown> = Required<
@@ -1498,6 +1818,36 @@ export type HouseholdsResponse<Texpand = unknown> = Required<HouseholdsRecord> &
 export type LockedGroupMembersResponse<Texpand = unknown> = Required<LockedGroupMembersRecord> &
   BaseSystemFields<Texpand>
 export type LockedGroupsResponse<Texpand = unknown> = Required<LockedGroupsRecord> &
+  BaseSystemFields<Texpand>
+export type LodgingAreasResponse<Texpand = unknown> = Required<LodgingAreasRecord> &
+  BaseSystemFields<Texpand>
+export type LodgingAssignmentHistoryResponse<Texpand = unknown> =
+  Required<LodgingAssignmentHistoryRecord> & BaseSystemFields<Texpand>
+export type LodgingAssignmentsResponse<Texpand = unknown> = Required<LodgingAssignmentsRecord> &
+  BaseSystemFields<Texpand>
+export type LodgingAssignmentsDraftResponse<Texpand = unknown> =
+  Required<LodgingAssignmentsDraftRecord> & BaseSystemFields<Texpand>
+export type LodgingAvailabilityResponse<Texpand = unknown> = Required<LodgingAvailabilityRecord> &
+  BaseSystemFields<Texpand>
+export type LodgingFieldMappingsResponse<Texpand = unknown> = Required<LodgingFieldMappingsRecord> &
+  BaseSystemFields<Texpand>
+export type LodgingFriendGroupMembersResponse<Texpand = unknown> =
+  Required<LodgingFriendGroupMembersRecord> & BaseSystemFields<Texpand>
+export type LodgingFriendGroupsResponse<Texpand = unknown> = Required<LodgingFriendGroupsRecord> &
+  BaseSystemFields<Texpand>
+export type LodgingIngestIssuesResponse<
+  Tcandidate_session_cm_ids = unknown,
+  Texpand = unknown,
+> = Required<LodgingIngestIssuesRecord<Tcandidate_session_cm_ids>> & BaseSystemFields<Texpand>
+export type LodgingSessionStatusResponse<Texpand = unknown> = Required<LodgingSessionStatusRecord> &
+  BaseSystemFields<Texpand>
+export type LodgingSlotMergesResponse<Texpand = unknown> = Required<LodgingSlotMergesRecord> &
+  BaseSystemFields<Texpand>
+export type LodgingUnitAliasesResponse<Texpand = unknown> = Required<LodgingUnitAliasesRecord> &
+  BaseSystemFields<Texpand>
+export type LodgingUnitsResponse<Tbeds = unknown, Texpand = unknown> = Required<
+  LodgingUnitsRecord<Tbeds>
+> &
   BaseSystemFields<Texpand>
 export type NormalizedMappingsResponse<Texpand = unknown> = Required<NormalizedMappingsRecord> &
   BaseSystemFields<Texpand>
@@ -1599,6 +1949,19 @@ export type CollectionRecords = {
   households: HouseholdsRecord
   locked_group_members: LockedGroupMembersRecord
   locked_groups: LockedGroupsRecord
+  lodging_areas: LodgingAreasRecord
+  lodging_assignment_history: LodgingAssignmentHistoryRecord
+  lodging_assignments: LodgingAssignmentsRecord
+  lodging_assignments_draft: LodgingAssignmentsDraftRecord
+  lodging_availability: LodgingAvailabilityRecord
+  lodging_field_mappings: LodgingFieldMappingsRecord
+  lodging_friend_group_members: LodgingFriendGroupMembersRecord
+  lodging_friend_groups: LodgingFriendGroupsRecord
+  lodging_ingest_issues: LodgingIngestIssuesRecord
+  lodging_session_status: LodgingSessionStatusRecord
+  lodging_slot_merges: LodgingSlotMergesRecord
+  lodging_unit_aliases: LodgingUnitAliasesRecord
+  lodging_units: LodgingUnitsRecord
   normalized_mappings: NormalizedMappingsRecord
   original_bunk_requests: OriginalBunkRequestsRecord
   payment_methods: PaymentMethodsRecord
@@ -1661,6 +2024,19 @@ export type CollectionResponses = {
   households: HouseholdsResponse
   locked_group_members: LockedGroupMembersResponse
   locked_groups: LockedGroupsResponse
+  lodging_areas: LodgingAreasResponse
+  lodging_assignment_history: LodgingAssignmentHistoryResponse
+  lodging_assignments: LodgingAssignmentsResponse
+  lodging_assignments_draft: LodgingAssignmentsDraftResponse
+  lodging_availability: LodgingAvailabilityResponse
+  lodging_field_mappings: LodgingFieldMappingsResponse
+  lodging_friend_group_members: LodgingFriendGroupMembersResponse
+  lodging_friend_groups: LodgingFriendGroupsResponse
+  lodging_ingest_issues: LodgingIngestIssuesResponse
+  lodging_session_status: LodgingSessionStatusResponse
+  lodging_slot_merges: LodgingSlotMergesResponse
+  lodging_unit_aliases: LodgingUnitAliasesResponse
+  lodging_units: LodgingUnitsResponse
   normalized_mappings: NormalizedMappingsResponse
   original_bunk_requests: OriginalBunkRequestsResponse
   payment_methods: PaymentMethodsResponse
@@ -1690,8 +2066,8 @@ type ProcessCreateAndUpdateFields<T> = Omit<
   {
     // Omit AutoDate fields
     [
-      K in keyof T as Extract<T[K], IsoAutoDateString> extends never ? K : never
-    ]: T[K] extends infer U // Convert FileNameString to File
+      K in keyof T as Extract<T[K], IsoAutoDateString> extends never ? K : never // Convert FileNameString to File
+    ]: T[K] extends infer U
       ? U extends FileNameString | FileNameString[]
         ? U extends any[]
           ? File[]

--- a/pocketbase/pb_migrations/1500000149_staff_vehicle_info_transform_repair.js
+++ b/pocketbase/pb_migrations/1500000149_staff_vehicle_info_transform_repair.js
@@ -1,0 +1,142 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * staff_vehicle_info transform repair — four column changes in one migration.
+ *
+ * Four open issues (kindred#2258, #2262, #2268, #2273) all need a schema change on
+ * this one table. Landing them separately would mean three migrations on one
+ * table and three ten-year backfills, so they are merged here.
+ *
+ * 1. license_plate 20 -> 100.  22 of the 798 real values exceed 20 characters
+ *    (longest 83). upsertRecords sets all columns then calls Save ONCE, so an
+ *    over-cap plate fails the WHOLE row -- make, model and driver for that
+ *    staff member are lost too, and `errors` increments. 100 matches
+ *    vehicle_make/vehicle_model. None of the other columns' caps is below its
+ *    observed data (driver_name is the closest, 189 against 200), so nothing
+ *    else is widened speculatively.
+ *
+ * 2. can_bring_others bool -> text(1000).  The CampMinder field behind it,
+ *    'SVI - bring others', is an open-ended String question: 1,044 answers,
+ *    629 distinct, longest 328 characters. The bool is true on 18 of 1,772
+ *    rows and on 0 of 200 for 2026. 34% of answers match no yes/no prefix
+ *    rule in either direction, so no derived verdict is trustworthy -- the
+ *    raw sentence IS the data. Empty string means "never asked" (732
+ *    person-years); a non-empty value means they answered.
+ *
+ * 3./4. ride_from and transport_notes are new destinations for
+ *    'SVI- Where do you need a ride from' (475 staff-linked values, longest
+ *    352) and 'SVI - other' (447, longest 328), which have had nowhere to
+ *    land since the table was created. max 1000 clears both with headroom;
+ *    max 100 would truncate both.
+ *
+ * NO DATA BACKFILL HERE, deliberately. All four columns are written by the
+ * staff_vehicle_info sync, which must be re-run per year. A migration cannot
+ * compute them -- the inputs are person_custom_values rows that need the
+ * staff-gate join. Until the sync runs, the new columns are empty, which reads
+ * correctly as "not yet extracted".
+ *
+ * The existing can_bring_others booleans are DERIVED, not authoritative, which
+ * is what makes drop-then-add safe: there is nothing worth preserving through
+ * the type change, and the sync rebuilds the column from person_custom_values.
+ * They could not be preserved anyway -- 732 of the false values mean "never
+ * asked" and 1,022 mean "answered and flattened", and nothing on disk
+ * distinguishes them.
+ *
+ * PocketBase v0.23 syntax: fields.add(new Field({...})) with properties
+ * DIRECT, not inside options{}. A bare add({...}) silently does nothing.
+ * Every add is guarded, because PB records an applied migration by FILENAME --
+ * a later edit to this file would never re-run.
+ */
+
+/**
+ * Adds a field unless the collection already has one by that name.
+ * @param {core.Collection} collection
+ * @param {core.Field} field
+ */
+function addField(collection, field) {
+  if (!collection.fields.getByName(field.name)) {
+    collection.fields.add(field);
+  }
+}
+
+migrate(
+  (app) => {
+    const col = app.findCollectionByNameOrId('staff_vehicle_info');
+
+    // 1 — widen the plate.
+    const plate = col.fields.getByName('license_plate');
+    if (!plate) {
+      throw new Error('staff_vehicle_info: expected an existing "license_plate" text field');
+    }
+    plate.max = 100;
+
+    // 2 — bool -> text. Guarded on the CURRENT type so a re-run is a no-op.
+    // NOTE: on a Field returned by getByName(), `.type` is a bound Go method,
+    // not a string property (`typeof bring.type === 'function'`) -- comparing
+    // it directly to a string is always false and silently no-ops the whole
+    // block. Must be called: `bring.type()`.
+    const bring = col.fields.getByName('can_bring_others');
+    if (bring && bring.type() === 'bool') {
+      col.fields.removeByName('can_bring_others');
+      col.fields.add(
+        new Field({
+          type: 'text',
+          name: 'can_bring_others',
+          required: false,
+          presentable: false,
+          min: 0,
+          max: 1000,
+          pattern: '',
+        })
+      );
+    }
+
+    // 3/4 — new destinations.
+    addField(
+      col,
+      new Field({
+        type: 'text',
+        name: 'ride_from',
+        required: false,
+        presentable: false,
+        min: 0,
+        max: 1000,
+        pattern: '',
+      })
+    );
+    addField(
+      col,
+      new Field({
+        type: 'text',
+        name: 'transport_notes',
+        required: false,
+        presentable: false,
+        min: 0,
+        max: 1000,
+        pattern: '',
+      })
+    );
+
+    app.save(col);
+  },
+  (app) => {
+    const col = app.findCollectionByNameOrId('staff_vehicle_info');
+
+    const plate = col.fields.getByName('license_plate');
+    if (plate) {
+      plate.max = 20;
+    }
+
+    const bring = col.fields.getByName('can_bring_others');
+    if (bring && bring.type() === 'text') {
+      col.fields.removeByName('can_bring_others');
+      col.fields.add(
+        new Field({ type: 'bool', name: 'can_bring_others', required: false, presentable: false })
+      );
+    }
+
+    col.fields.removeByName('ride_from');
+    col.fields.removeByName('transport_notes');
+
+    app.save(col);
+  }
+);

--- a/pocketbase/sync/staff_applications.go
+++ b/pocketbase/sync/staff_applications.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -189,20 +190,29 @@ func (s *StaffApplicationsSync) Sync(ctx context.Context) error {
 	slog.Info("Loaded existing records", "count", len(existingRecords))
 
 	// Step 5: Upsert records
-	created, updated, errors := s.upsertRecords(ctx, records, existingRecords, year)
+	created, updated, upsertErrors := s.upsertRecords(ctx, records, existingRecords, year)
 	s.Stats.Created = created
 	s.Stats.Updated = updated
-	s.Stats.Errors = errors
+	s.Stats.Errors = upsertErrors
 
 	// Step 6: Delete orphans
-	deleted := s.deleteOrphans(ctx, records, existingRecords)
+	deleted, err := s.deleteOrphans(ctx, records, existingRecords, year)
 	s.Stats.Deleted = deleted
 
-	// WAL checkpoint
+	// WAL checkpoint BEFORE the error return below: upsertRecords has already
+	// written by this point, and the cancellation path returns with those
+	// writes still in the WAL.
 	if s.Stats.Created > 0 || s.Stats.Updated > 0 || s.Stats.Deleted > 0 {
-		if err := s.forceWALCheckpoint(); err != nil {
-			slog.Warn("WAL checkpoint failed", "error", err)
+		if cpErr := s.forceWALCheckpoint(); cpErr != nil {
+			slog.Warn("WAL checkpoint failed", "error", cpErr)
 		}
+	}
+
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("orphan sweep interrupted: %w", err)
+		}
+		return fmt.Errorf("orphan sweep refused: %w", err)
 	}
 
 	s.SyncSuccessful = true
@@ -727,7 +737,7 @@ func (s *StaffApplicationsSync) upsertRecords(
 	records map[string]*staffApplicationRecord,
 	existingRecords map[string]string,
 	year int,
-) (created, updated, errors int) {
+) (created, updated, errCount int) {
 	col, err := s.App.FindCollectionByNameOrId("staff_applications")
 	if err != nil {
 		slog.Error("Error finding staff_applications collection", "error", err)
@@ -737,7 +747,7 @@ func (s *StaffApplicationsSync) upsertRecords(
 	for _, rec := range records {
 		select {
 		case <-ctx.Done():
-			return created, updated, errors
+			return created, updated, errCount
 		default:
 		}
 
@@ -749,7 +759,7 @@ func (s *StaffApplicationsSync) upsertRecords(
 			record, err = s.App.FindRecordById("staff_applications", existingID)
 			if err != nil {
 				slog.Error("Error finding existing record", "id", existingID, "error", err)
-				errors++
+				errCount++
 				continue
 			}
 		} else {
@@ -821,7 +831,7 @@ func (s *StaffApplicationsSync) upsertRecords(
 				"year", rec.year,
 				"error", err,
 			)
-			errors++
+			errCount++
 			continue
 		}
 
@@ -832,21 +842,40 @@ func (s *StaffApplicationsSync) upsertRecords(
 		}
 	}
 
-	return created, updated, errors
+	return created, updated, errCount
 }
 
-// deleteOrphans removes records that exist in DB but not in computed set
+// deleteOrphans removes records that exist in DB but not in computed set.
+//
+// Refuses when the computed set is empty and rows exist for the year: that
+// combination is always a broken input, and sweeping on it deletes the whole
+// year and reports success (kindred#2279 Gap 2).
+//
+// This service shares staff_vehicle_info's loadPersonStaffMapping(ctx, year)
+// gate exactly, so it has the identical year-wipe path and the same two
+// upstream causes: an empty personToStaff mapping (every value fails the staff
+// gate), or an empty fieldNameMap after an upstream rename of the App-*
+// definitions (every value routes nowhere).
 func (s *StaffApplicationsSync) deleteOrphans(
 	ctx context.Context,
 	records map[string]*staffApplicationRecord,
 	existingRecords map[string]string,
-) int {
+	year int,
+) (int, error) {
+	if len(records) == 0 && len(existingRecords) > 0 {
+		return 0, fmt.Errorf(
+			"refusing to sweep %d existing staff_applications rows for year %d against an "+
+				"empty computed set (check the staff table for that year, and that the App-* "+
+				"field definitions still exist upstream)",
+			len(existingRecords), year)
+	}
+
 	deleted := 0
 
 	for key, recordID := range existingRecords {
 		select {
 		case <-ctx.Done():
-			return deleted
+			return deleted, ctx.Err()
 		default:
 		}
 
@@ -865,7 +894,7 @@ func (s *StaffApplicationsSync) deleteOrphans(
 		}
 	}
 
-	return deleted
+	return deleted, nil
 }
 
 // forceWALCheckpoint forces a SQLite WAL checkpoint

--- a/pocketbase/sync/staff_applications_test.go
+++ b/pocketbase/sync/staff_applications_test.go
@@ -2,7 +2,11 @@ package sync
 
 import (
 	"context"
+	"strings"
 	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
 )
 
 // TestStaffApplicationsLoadFieldDefinitionsTrimsNames is a regression test for
@@ -337,4 +341,116 @@ func parseAppBool(value string) bool {
 // Note: makeStaffApplicationsKey calls implementation function makeStaffAppKey
 func makeStaffApplicationsKey(personID, year int) string {
 	return makeStaffAppKey(personID, year)
+}
+
+// newStaffApplicationsTestApp builds the one collection deleteOrphans touches.
+// Like newStaffVehicleTestApp, this fixture is LAXER than production -- it
+// carries only the fields the guard reads -- so a green test here is not
+// evidence that production writes validate.
+func newStaffApplicationsTestApp(t *testing.T) core.App {
+	t.Helper()
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	apps := core.NewBaseCollection("staff_applications")
+	apps.Fields.Add(&core.TextField{Name: "staff"})
+	apps.Fields.Add(&core.NumberField{Name: "person_id"})
+	apps.Fields.Add(&core.NumberField{Name: "year"})
+	if saveErr := app.Save(apps); saveErr != nil {
+		t.Fatalf("save staff_applications: %v", saveErr)
+	}
+
+	return app
+}
+
+// seedStaffApplication writes one staff_applications row and returns its PB ID.
+func seedStaffApplication(t *testing.T, app core.App, cmID, year int) string {
+	t.Helper()
+
+	col, err := app.FindCollectionByNameOrId("staff_applications")
+	if err != nil {
+		t.Fatalf("find staff_applications: %v", err)
+	}
+	rec := core.NewRecord(col)
+	rec.Set("person_id", cmID)
+	rec.Set("year", year)
+	if saveErr := app.Save(rec); saveErr != nil {
+		t.Fatalf("save staff_applications row: %v", saveErr)
+	}
+	return rec.Id
+}
+
+// TestStaffApplicationsDeleteOrphansRefusesEmptyComputedSet is kindred#2279
+// Gap 2. staff_applications builds its computed set from the SAME
+// loadPersonStaffMapping(ctx, year) gate as staff_vehicle_info, so it has the
+// identical year-wipe path: an empty staff mapping makes every value fail the
+// gate, the computed set comes back empty, and the unguarded sweep deletes the
+// whole year and then sets SyncSuccessful = true.
+func TestStaffApplicationsDeleteOrphansRefusesEmptyComputedSet(t *testing.T) {
+	app := newStaffApplicationsTestApp(t)
+	recID := seedStaffApplication(t, app, 1001, 2026)
+
+	s := NewStaffApplicationsSync(app)
+	s.Year = 2026
+
+	existing := map[string]string{makeStaffAppKey(1001, 2026): recID}
+	deleted, err := s.deleteOrphans(context.Background(),
+		map[string]*staffApplicationRecord{}, existing, 2026)
+
+	if err == nil {
+		t.Fatal("expected an error when the computed set is empty and rows exist, got nil")
+	}
+	if !strings.Contains(err.Error(), "2026") {
+		t.Errorf("error %q does not name the year -- an operator has no way to tell which season refused", err.Error())
+	}
+	if deleted != 0 {
+		t.Errorf("deleted = %d, want 0 -- nothing may be removed on the refusal path", deleted)
+	}
+
+	remaining, err := app.FindRecordsByFilter("staff_applications", "year = 2026", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query: %v", err)
+	}
+	if len(remaining) != 1 {
+		t.Errorf("%d rows survived, want 1 -- the guard must not delete", len(remaining))
+	}
+}
+
+// TestStaffApplicationsDeleteOrphansStillSweepsGenuineOrphans proves the guard
+// did not disable orphan deletion for the normal case.
+func TestStaffApplicationsDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
+	app := newStaffApplicationsTestApp(t)
+	keepID := seedStaffApplication(t, app, 1001, 2026)
+	orphanID := seedStaffApplication(t, app, 1002, 2026)
+
+	s := NewStaffApplicationsSync(app)
+	s.Year = 2026
+
+	// 1001 is still computed; 1002 is not, and must be swept.
+	computed := map[string]*staffApplicationRecord{
+		makeStaffAppKey(1001, 2026): {personID: 1001, year: 2026},
+	}
+	existing := map[string]string{
+		makeStaffAppKey(1001, 2026): keepID,
+		makeStaffAppKey(1002, 2026): orphanID,
+	}
+
+	deleted, err := s.deleteOrphans(context.Background(), computed, existing, 2026)
+	if err != nil {
+		t.Fatalf("unexpected error on a non-empty computed set: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("deleted = %d, want 1 -- the guard must not block a genuine sweep", deleted)
+	}
+
+	remaining, err := app.FindRecordsByFilter("staff_applications", "year = 2026", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query: %v", err)
+	}
+	if len(remaining) != 1 {
+		t.Errorf("%d rows survived, want 1", len(remaining))
+	}
 }

--- a/pocketbase/sync/staff_vehicle_info.go
+++ b/pocketbase/sync/staff_vehicle_info.go
@@ -78,7 +78,7 @@ type staffVehicleInfoRecord struct {
 
 	drivingToCamp    bool
 	howGettingToCamp string
-	canBringOthers   bool
+	canBringOthers   string
 	driverName       string
 	whichFriend      string
 	vehicleMake      string
@@ -361,7 +361,11 @@ func mapSVIFieldToRecord(rec *staffVehicleInfoRecord, fieldName, value string) {
 			rec.howGettingToCamp = value
 		}
 	case colCanBringOthers:
-		rec.canBringOthers = parseSVIBoolImpl(value)
+		// Raw answer, first-non-empty-wins like every other text column.
+		// NOT parseSVIBoolImpl -- see kindred#2262.
+		if rec.canBringOthers == "" {
+			rec.canBringOthers = value
+		}
 	case "driver_name":
 		if rec.driverName == "" {
 			rec.driverName = value

--- a/pocketbase/sync/staff_vehicle_info.go
+++ b/pocketbase/sync/staff_vehicle_info.go
@@ -84,6 +84,8 @@ type staffVehicleInfoRecord struct {
 	vehicleMake      string
 	vehicleModel     string
 	licensePlate     string
+	rideFrom         string
+	transportNotes   string
 }
 
 // Sync executes the staff vehicle info extraction
@@ -380,6 +382,14 @@ func mapSVIFieldToRecord(rec *staffVehicleInfoRecord, fieldName, value string) {
 		if rec.licensePlate == "" {
 			rec.licensePlate = value
 		}
+	case "ride_from":
+		if rec.rideFrom == "" {
+			rec.rideFrom = value
+		}
+	case "transport_notes":
+		if rec.transportNotes == "" {
+			rec.transportNotes = value
+		}
 	}
 }
 
@@ -400,8 +410,14 @@ func MapSVIFieldToColumnImpl(fieldName string) string {
 		return "vehicle_make"
 	case "SVI-model vehicle":
 		return "vehicle_model"
-	case "SVI-license plate number":
+	// British spelling: this is how CampMinder publishes it. The American
+	// spelling matched nothing for the table's entire history (kindred#2258).
+	case "SVI-licence plate number":
 		return "license_plate"
+	case "SVI- Where do you need a ride from":
+		return "ride_from"
+	case "SVI - other":
+		return "transport_notes"
 	}
 	return ""
 }
@@ -503,6 +519,8 @@ func (s *StaffVehicleInfoSync) upsertRecords(
 		record.Set("vehicle_make", rec.vehicleMake)
 		record.Set("vehicle_model", rec.vehicleModel)
 		record.Set("license_plate", rec.licensePlate)
+		record.Set("ride_from", rec.rideFrom)
+		record.Set("transport_notes", rec.transportNotes)
 
 		if err := s.App.Save(record); err != nil {
 			slog.Error("Error saving staff_vehicle_info record",

--- a/pocketbase/sync/staff_vehicle_info.go
+++ b/pocketbase/sync/staff_vehicle_info.go
@@ -157,8 +157,11 @@ func (s *StaffVehicleInfoSync) Sync(ctx context.Context) error {
 	s.Stats.Errors = errors
 
 	// Step 6: Delete orphans
-	deleted := s.deleteOrphans(ctx, records, existingRecords)
+	deleted, err := s.deleteOrphans(ctx, records, existingRecords)
 	s.Stats.Deleted = deleted
+	if err != nil {
+		return fmt.Errorf("orphan sweep refused: %w", err)
+	}
 
 	// WAL checkpoint
 	if s.Stats.Created > 0 || s.Stats.Updated > 0 || s.Stats.Deleted > 0 {
@@ -556,17 +559,29 @@ func (s *StaffVehicleInfoSync) upsertRecords(
 }
 
 // deleteOrphans removes records that exist in DB but not in computed set
+// deleteOrphans removes records that exist in DB but not in computed set.
+//
+// Refuses when the computed set is empty and rows exist for the year: that
+// combination is always a broken input -- an empty personToStaff mapping makes
+// every value fail the staff gate -- and sweeping on it deletes the whole year
+// and reports success (kindred#2273).
 func (s *StaffVehicleInfoSync) deleteOrphans(
 	ctx context.Context,
 	records map[string]*staffVehicleInfoRecord,
 	existingRecords map[string]string,
-) int {
+) (int, error) {
+	if len(records) == 0 && len(existingRecords) > 0 {
+		return 0, fmt.Errorf(
+			"refusing to sweep %d existing staff_vehicle_info rows against an empty computed set "+
+				"(is the staff table populated for this year?)", len(existingRecords))
+	}
+
 	deleted := 0
 
 	for key, recordID := range existingRecords {
 		select {
 		case <-ctx.Done():
-			return deleted
+			return deleted, ctx.Err()
 		default:
 		}
 
@@ -585,7 +600,7 @@ func (s *StaffVehicleInfoSync) deleteOrphans(
 		}
 	}
 
-	return deleted
+	return deleted, nil
 }
 
 // forceWALCheckpoint forces a SQLite WAL checkpoint

--- a/pocketbase/sync/staff_vehicle_info.go
+++ b/pocketbase/sync/staff_vehicle_info.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -151,15 +152,18 @@ func (s *StaffVehicleInfoSync) Sync(ctx context.Context) error {
 	slog.Info("Loaded existing records", "count", len(existingRecords))
 
 	// Step 5: Upsert records
-	created, updated, errors := s.upsertRecords(ctx, records, existingRecords, year)
+	created, updated, upsertErrors := s.upsertRecords(ctx, records, existingRecords, year)
 	s.Stats.Created = created
 	s.Stats.Updated = updated
-	s.Stats.Errors = errors
+	s.Stats.Errors = upsertErrors
 
 	// Step 6: Delete orphans
-	deleted, err := s.deleteOrphans(ctx, records, existingRecords)
+	deleted, err := s.deleteOrphans(ctx, records, existingRecords, year)
 	s.Stats.Deleted = deleted
 	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("orphan sweep interrupted: %w", err)
+		}
 		return fmt.Errorf("orphan sweep refused: %w", err)
 	}
 
@@ -558,7 +562,6 @@ func (s *StaffVehicleInfoSync) upsertRecords(
 	return created, updated, errors
 }
 
-// deleteOrphans removes records that exist in DB but not in computed set
 // deleteOrphans removes records that exist in DB but not in computed set.
 //
 // Refuses when the computed set is empty and rows exist for the year: that
@@ -569,11 +572,13 @@ func (s *StaffVehicleInfoSync) deleteOrphans(
 	ctx context.Context,
 	records map[string]*staffVehicleInfoRecord,
 	existingRecords map[string]string,
+	year int,
 ) (int, error) {
 	if len(records) == 0 && len(existingRecords) > 0 {
 		return 0, fmt.Errorf(
-			"refusing to sweep %d existing staff_vehicle_info rows against an empty computed set "+
-				"(is the staff table populated for this year?)", len(existingRecords))
+			"refusing to sweep %d existing staff_vehicle_info rows for year %d against an "+
+				"empty computed set (is the staff table populated for that year?)",
+			len(existingRecords), year)
 	}
 
 	deleted := 0

--- a/pocketbase/sync/staff_vehicle_info.go
+++ b/pocketbase/sync/staff_vehicle_info.go
@@ -575,7 +575,7 @@ func (s *StaffVehicleInfoSync) upsertRecords(
 	records map[string]*staffVehicleInfoRecord,
 	existingRecords map[string]string,
 	year int,
-) (created, updated, errors int) {
+) (created, updated, errCount int) {
 	col, err := s.App.FindCollectionByNameOrId("staff_vehicle_info")
 	if err != nil {
 		slog.Error("Error finding staff_vehicle_info collection", "error", err)
@@ -585,7 +585,7 @@ func (s *StaffVehicleInfoSync) upsertRecords(
 	for _, rec := range records {
 		select {
 		case <-ctx.Done():
-			return created, updated, errors
+			return created, updated, errCount
 		default:
 		}
 
@@ -597,7 +597,7 @@ func (s *StaffVehicleInfoSync) upsertRecords(
 			record, err = s.App.FindRecordById("staff_vehicle_info", existingID)
 			if err != nil {
 				slog.Error("Error finding existing record", "id", existingID, "error", err)
-				errors++
+				errCount++
 				continue
 			}
 		} else {
@@ -625,7 +625,7 @@ func (s *StaffVehicleInfoSync) upsertRecords(
 				"year", rec.year,
 				"error", err,
 			)
-			errors++
+			errCount++
 			continue
 		}
 
@@ -636,7 +636,7 @@ func (s *StaffVehicleInfoSync) upsertRecords(
 		}
 	}
 
-	return created, updated, errors
+	return created, updated, errCount
 }
 
 // deleteOrphans removes records that exist in DB but not in computed set.

--- a/pocketbase/sync/staff_vehicle_info.go
+++ b/pocketbase/sync/staff_vehicle_info.go
@@ -173,6 +173,7 @@ func (s *StaffVehicleInfoSync) Sync(ctx context.Context) error {
 		"created", s.Stats.Created,
 		"updated", s.Stats.Updated,
 		"deleted", s.Stats.Deleted,
+		"skipped", s.Stats.Skipped,
 		"errors", s.Stats.Errors,
 	)
 
@@ -326,6 +327,10 @@ func (s *StaffVehicleInfoSync) loadPersonCustomValues(
 	for _, entry := range entries {
 		staffID, hasStaff := personToStaff[entry.personID]
 		if !hasStaff {
+			// Structurally correct -- `staff` is a required relation, so a row
+			// cannot be written without one -- but it must not be silent
+			// (kindred#2273).
+			s.Stats.Skipped++
 			continue
 		}
 
@@ -340,6 +345,10 @@ func (s *StaffVehicleInfoSync) loadPersonCustomValues(
 			result[key] = rec
 		}
 
+		if MapSVIFieldToColumnImpl(entry.fieldName) == "" {
+			s.Stats.Skipped++
+			continue
+		}
 		mapSVIFieldToRecord(rec, entry.fieldName, entry.value)
 	}
 

--- a/pocketbase/sync/staff_vehicle_info.go
+++ b/pocketbase/sync/staff_vehicle_info.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 
 	"github.com/pocketbase/pocketbase/core"
@@ -120,6 +121,28 @@ func (s *StaffVehicleInfoSync) Sync(ctx context.Context) error {
 		return fmt.Errorf("loading field definitions: %w", err)
 	}
 	slog.Info("Loaded field definitions", "count", len(fieldNameMap))
+
+	// Layer 1 of the kindred#2258 guard: compare the mapper against what
+	// CampMinder published THIS RUN, so an upstream rename surfaces in the log
+	// rather than as an empty column found by audit years later.
+	defNames := make([]string, 0, len(fieldNameMap))
+	for _, name := range fieldNameMap {
+		defNames = append(defNames, name)
+	}
+	unrouted, unmapped := sviRoutingReport(defNames)
+	slog.Info("SVI field routing",
+		"admitted", len(fieldNameMap),
+		"routable", len(fieldNameMap)-len(unmapped),
+	)
+	for _, column := range unrouted {
+		slog.Warn("SVI column is reachable from no CampMinder field -- renamed upstream?",
+			"column", column)
+	}
+	// Once per field NAME per run, never per value: per-value would emit
+	// ~1,700 lines per full backfill for fields working as intended.
+	for _, name := range unmapped {
+		slog.Warn("SVI field is admitted but routes to no column", "field", name)
+	}
 
 	// Step 2: Load person -> staff mapping
 	personToStaff, err := s.loadPersonStaffMapping(ctx, year)
@@ -411,6 +434,60 @@ func mapSVIFieldToRecord(rec *staffVehicleInfoRecord, fieldName, value string) {
 			rec.transportNotes = value
 		}
 	}
+}
+
+// sviTargetColumns lists every column MapSVIFieldToColumnImpl can return. It
+// is the guard's subject: each of these must be reachable from at least one
+// field name CampMinder publishes.
+var sviTargetColumns = []string{
+	colDrivingToCamp,
+	"how_getting_to_camp",
+	colCanBringOthers,
+	"driver_name",
+	"which_friend",
+	"vehicle_make",
+	"vehicle_model",
+	"license_plate",
+	"ride_from",
+	"transport_notes",
+}
+
+// sviRoutingReport compares the mapper against the field names CampMinder
+// actually published.
+//
+// unroutedColumns: target columns no published name routes to. A non-empty
+// result means a literal in MapSVIFieldToColumnImpl is misspelled or the field
+// was renamed upstream -- this is the kindred#2258 failure, and it is the
+// reason this function exists.
+//
+// unmappedFields: published SVI names that route nowhere. Expected to be
+// non-empty -- two definitions are deliberately unrouted -- so this is for
+// logging, not for failing.
+//
+// Both slices are sorted so callers and tests are deterministic.
+func sviRoutingReport(defNames []string) (unroutedColumns, unmappedFields []string) {
+	reached := make(map[string]bool, len(sviTargetColumns))
+
+	for _, name := range defNames {
+		column := MapSVIFieldToColumnImpl(normalizeFieldName(name))
+		if column == "" {
+			if isStaffVehicleInfoField(normalizeFieldName(name)) {
+				unmappedFields = append(unmappedFields, name)
+			}
+			continue
+		}
+		reached[column] = true
+	}
+
+	for _, column := range sviTargetColumns {
+		if !reached[column] {
+			unroutedColumns = append(unroutedColumns, column)
+		}
+	}
+
+	slices.Sort(unroutedColumns)
+	slices.Sort(unmappedFields)
+	return unroutedColumns, unmappedFields
 }
 
 // MapSVIFieldToColumnImpl maps CampMinder field names to database column names

--- a/pocketbase/sync/staff_vehicle_info.go
+++ b/pocketbase/sync/staff_vehicle_info.go
@@ -26,7 +26,8 @@ const (
 // Unique key: (person_id, year) - one record per staff member per year
 // Links to: staff
 //
-// Field mapping: 8 SVI-* prefixed fields covering driving plans and vehicle details.
+// Field mapping: 10 SVI-* prefixed fields covering driving plans, vehicle details
+// and transport logistics.
 type StaffVehicleInfoSync struct {
 	App            core.App
 	Year           int
@@ -183,18 +184,22 @@ func (s *StaffVehicleInfoSync) Sync(ctx context.Context) error {
 	// Step 6: Delete orphans
 	deleted, err := s.deleteOrphans(ctx, records, existingRecords, year)
 	s.Stats.Deleted = deleted
+
+	// WAL checkpoint BEFORE the error return below. upsertRecords has already
+	// written by this point, and the cancellation path returns with those writes
+	// still in the WAL. (The refusal path cannot strand writes -- it requires an
+	// empty computed set, so nothing was upserted -- but cancellation can.)
+	if s.Stats.Created > 0 || s.Stats.Updated > 0 || s.Stats.Deleted > 0 {
+		if cpErr := s.forceWALCheckpoint(); cpErr != nil {
+			slog.Warn("WAL checkpoint failed", "error", cpErr)
+		}
+	}
+
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return fmt.Errorf("orphan sweep interrupted: %w", err)
 		}
 		return fmt.Errorf("orphan sweep refused: %w", err)
-	}
-
-	// WAL checkpoint
-	if s.Stats.Created > 0 || s.Stats.Updated > 0 || s.Stats.Deleted > 0 {
-		if err := s.forceWALCheckpoint(); err != nil {
-			slog.Warn("WAL checkpoint failed", "error", err)
-		}
 	}
 
 	s.SyncSuccessful = true
@@ -642,9 +647,15 @@ func (s *StaffVehicleInfoSync) upsertRecords(
 // deleteOrphans removes records that exist in DB but not in computed set.
 //
 // Refuses when the computed set is empty and rows exist for the year: that
-// combination is always a broken input -- an empty personToStaff mapping makes
-// every value fail the staff gate -- and sweeping on it deletes the whole year
-// and reports success (kindred#2273).
+// combination is always a broken input, and sweeping on it deletes the whole
+// year and reports success (kindred#2273).
+//
+// TWO upstream faults produce it, and the error names both because they surface
+// in different places: an empty personToStaff mapping (every value fails the
+// staff gate), or an empty fieldNameMap after an upstream rename of the SVI-*
+// namespace (every value routes nowhere). The second is the kindred#2258 class
+// and shows up in the "SVI field routing" warnings Layer 1 logs earlier in the
+// same run -- naming only the staff table sends an operator to the wrong place.
 func (s *StaffVehicleInfoSync) deleteOrphans(
 	ctx context.Context,
 	records map[string]*staffVehicleInfoRecord,
@@ -654,7 +665,8 @@ func (s *StaffVehicleInfoSync) deleteOrphans(
 	if len(records) == 0 && len(existingRecords) > 0 {
 		return 0, fmt.Errorf(
 			"refusing to sweep %d existing staff_vehicle_info rows for year %d against an "+
-				"empty computed set (is the staff table populated for that year?)",
+				"empty computed set (check the staff table for that year, and the SVI field "+
+				"routing warnings above for an upstream rename)",
 			len(existingRecords), year)
 	}
 

--- a/pocketbase/sync/staff_vehicle_info_test.go
+++ b/pocketbase/sync/staff_vehicle_info_test.go
@@ -69,7 +69,15 @@ func TestMapSVIFieldToColumn(t *testing.T) {
 		// Vehicle info
 		{"SVI-make of vehicle", "vehicle_make"},
 		{"SVI-model vehicle", "vehicle_model"},
-		{"SVI-license plate number", "license_plate"},
+		// British spelling -- this is how CampMinder publishes it (kindred#2258).
+		{"SVI-licence plate number", "license_plate"},
+
+		// Transport detail that previously had no destination (kindred#2268)
+		{"SVI- Where do you need a ride from", "ride_from"},
+		{"SVI - other", "transport_notes"},
+
+		// The American spelling is NOT a CampMinder field and must not route.
+		{"SVI-license plate number", ""},
 
 		// Unknown field should return empty
 		{"Unknown-Field", ""},

--- a/pocketbase/sync/staff_vehicle_info_test.go
+++ b/pocketbase/sync/staff_vehicle_info_test.go
@@ -58,7 +58,8 @@ func TestStaffVehicleInfoServiceName(t *testing.T) {
 }
 
 // TestMapSVIFieldToColumn tests the CampMinder field name to column mapping
-// for the 8 SVI- fields used in staff vehicle info
+// for the 10 SVI- fields used in staff vehicle info, plus the two literals that
+// must NOT route: the American plate spelling and an unknown field.
 func TestMapSVIFieldToColumn(t *testing.T) {
 	tests := []struct {
 		cmField  string
@@ -451,6 +452,15 @@ func TestDeleteOrphansRefusesEmptyComputedSet(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "2026") {
 		t.Errorf("error %q does not name the year -- an operator has no way to tell which season refused", err.Error())
+	}
+	// An empty computed set has more than one cause. An upstream rename of the
+	// whole SVI-* namespace empties fieldNameMap, which empties the computed set
+	// with the staff table perfectly healthy -- that is the kindred#2258 failure
+	// class Layer 1 exists to catch. Naming only the staff table sends an
+	// operator to the wrong place.
+	if !strings.Contains(err.Error(), "routing") {
+		t.Errorf("error %q points only at the staff table -- it must also point at the "+
+			"SVI field routing report, which is where an upstream field rename shows up", err.Error())
 	}
 	if deleted != 0 {
 		t.Errorf("deleted = %d, want 0 -- nothing may be removed on the refusal path", deleted)

--- a/pocketbase/sync/staff_vehicle_info_test.go
+++ b/pocketbase/sync/staff_vehicle_info_test.go
@@ -3,6 +3,9 @@ package sync
 import (
 	"context"
 	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
 )
 
 // TestStaffVehicleInfoLoadFieldDefinitionsTrimsNames is a regression test for
@@ -197,5 +200,209 @@ func TestMapSVIFieldToRecordLeavesDrivingToCampABool(t *testing.T) {
 		if rec.drivingToCamp != want {
 			t.Errorf("drivingToCamp for %q = %v, want %v", value, rec.drivingToCamp, want)
 		}
+	}
+}
+
+// newStaffVehicleTestApp builds the five collections this service reads and
+// writes. Fields are the minimum the code under test touches, not a mirror of
+// production -- see kindred#1921 for why that distinction matters.
+func newStaffVehicleTestApp(t *testing.T) core.App {
+	t.Helper()
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	defs := core.NewBaseCollection("custom_field_defs")
+	defs.Fields.Add(&core.NumberField{Name: "cm_id"})
+	defs.Fields.Add(&core.TextField{Name: "name"})
+	if err := app.Save(defs); err != nil {
+		t.Fatalf("save custom_field_defs: %v", err)
+	}
+
+	persons := core.NewBaseCollection("persons")
+	persons.Fields.Add(&core.NumberField{Name: "cm_id"})
+	persons.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(persons); err != nil {
+		t.Fatalf("save persons: %v", err)
+	}
+
+	staff := core.NewBaseCollection("staff")
+	staff.Fields.Add(&core.NumberField{Name: "person_id"})
+	staff.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(staff); err != nil {
+		t.Fatalf("save staff: %v", err)
+	}
+
+	pcv := core.NewBaseCollection("person_custom_values")
+	pcv.Fields.Add(&core.TextField{Name: "person"})
+	pcv.Fields.Add(&core.TextField{Name: "field_definition"})
+	pcv.Fields.Add(&core.TextField{Name: "value", Max: 5000})
+	pcv.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(pcv); err != nil {
+		t.Fatalf("save person_custom_values: %v", err)
+	}
+
+	svi := core.NewBaseCollection("staff_vehicle_info")
+	svi.Fields.Add(&core.TextField{Name: "staff"})
+	svi.Fields.Add(&core.NumberField{Name: "person_id"})
+	svi.Fields.Add(&core.NumberField{Name: "year"})
+	svi.Fields.Add(&core.BoolField{Name: "driving_to_camp"})
+	svi.Fields.Add(&core.TextField{Name: "how_getting_to_camp", Max: 500})
+	svi.Fields.Add(&core.TextField{Name: "can_bring_others", Max: 1000})
+	svi.Fields.Add(&core.TextField{Name: "driver_name", Max: 200})
+	svi.Fields.Add(&core.TextField{Name: "which_friend", Max: 200})
+	svi.Fields.Add(&core.TextField{Name: "vehicle_make", Max: 100})
+	svi.Fields.Add(&core.TextField{Name: "vehicle_model", Max: 100})
+	svi.Fields.Add(&core.TextField{Name: "license_plate", Max: 100})
+	svi.Fields.Add(&core.TextField{Name: "ride_from", Max: 1000})
+	svi.Fields.Add(&core.TextField{Name: "transport_notes", Max: 1000})
+	if err := app.Save(svi); err != nil {
+		t.Fatalf("save staff_vehicle_info: %v", err)
+	}
+
+	return app
+}
+
+// seedSVI writes one person, optionally a staff row for the same year, and one
+// custom value per field name given.
+func seedSVI(t *testing.T, app core.App, cmID, year int, hasStaff bool, values map[string]string) {
+	t.Helper()
+
+	personCol, err := app.FindCollectionByNameOrId("persons")
+	if err != nil {
+		t.Fatalf("find persons: %v", err)
+	}
+	person := core.NewRecord(personCol)
+	person.Set("cm_id", cmID)
+	person.Set("year", year)
+	if err := app.Save(person); err != nil {
+		t.Fatalf("save person %d: %v", cmID, err)
+	}
+
+	if hasStaff {
+		staffCol, err := app.FindCollectionByNameOrId("staff")
+		if err != nil {
+			t.Fatalf("find staff: %v", err)
+		}
+		s := core.NewRecord(staffCol)
+		s.Set("person_id", cmID)
+		s.Set("year", year)
+		if err := app.Save(s); err != nil {
+			t.Fatalf("save staff %d: %v", cmID, err)
+		}
+	}
+
+	defsCol, err := app.FindCollectionByNameOrId("custom_field_defs")
+	if err != nil {
+		t.Fatalf("find custom_field_defs: %v", err)
+	}
+	pcvCol, err := app.FindCollectionByNameOrId("person_custom_values")
+	if err != nil {
+		t.Fatalf("find person_custom_values: %v", err)
+	}
+	for name, value := range values {
+		// Listed rather than filtered: this mirrors loadFieldDefinitions' own
+		// FindRecordsByFilter(col, "", "", 0, 0) call and needs no dbx import.
+		// A test fixture holds a dozen defs at most.
+		existing, err := app.FindRecordsByFilter("custom_field_defs", "", "", 0, 0)
+		if err != nil {
+			t.Fatalf("list field defs: %v", err)
+		}
+		var def *core.Record
+		for _, d := range existing {
+			if d.GetString("name") == name {
+				def = d
+				break
+			}
+		}
+		if def == nil {
+			def = core.NewRecord(defsCol)
+			def.Set("name", name)
+			if err := app.Save(def); err != nil {
+				t.Fatalf("save field def %q: %v", name, err)
+			}
+		}
+		v := core.NewRecord(pcvCol)
+		v.Set("person", person.Id)
+		v.Set("field_definition", def.Id)
+		v.Set("value", value)
+		v.Set("year", year)
+		if err := app.Save(v); err != nil {
+			t.Fatalf("save custom value %q: %v", name, err)
+		}
+	}
+}
+
+// TestLoadPersonCustomValuesCountsStaffGateDrops pins kindred#2273. A person
+// who answered the SVI form but has no staff row for that year has every value
+// discarded by a bare `continue`. The gate itself is correct -- `staff` is a
+// required relation, so the row cannot be written -- but a partial extraction
+// and a complete one currently produce identical output.
+func TestLoadPersonCustomValuesCountsStaffGateDrops(t *testing.T) {
+	app := newStaffVehicleTestApp(t)
+	seedSVI(t, app, 1001, 2026, true, map[string]string{
+		"SVI-are you driving to camp": "Yes",
+		"SVI-make of vehicle":         "Toyota",
+	})
+	seedSVI(t, app, 1002, 2026, false, map[string]string{
+		"SVI-are you driving to camp": "Yes",
+	})
+
+	s := NewStaffVehicleInfoSync(app)
+	s.Year = 2026
+
+	fieldNames, err := s.loadFieldDefinitions(context.Background())
+	if err != nil {
+		t.Fatalf("loadFieldDefinitions: %v", err)
+	}
+	personToStaff, err := s.loadPersonStaffMapping(context.Background(), 2026)
+	if err != nil {
+		t.Fatalf("loadPersonStaffMapping: %v", err)
+	}
+	records, err := s.loadPersonCustomValues(context.Background(), 2026, fieldNames, personToStaff)
+	if err != nil {
+		t.Fatalf("loadPersonCustomValues: %v", err)
+	}
+
+	if len(records) != 1 {
+		t.Errorf("got %d records, want 1 -- the person with no staff row must be excluded", len(records))
+	}
+	if _, ok := records[makeStaffVehicleKey(1002, 2026)]; ok {
+		t.Error("person 1002 has no staff row for 2026 and must not produce a record")
+	}
+	if s.Stats.Skipped != 1 {
+		t.Errorf("Stats.Skipped = %d, want 1 -- the gate drop must be counted", s.Stats.Skipped)
+	}
+}
+
+// TestLoadPersonCustomValuesCountsUnmappedFields pins the second silent drop
+// site. A field admitted by the SVI- prefix but routed to no column is
+// discarded with no counter and no log line.
+func TestLoadPersonCustomValuesCountsUnmappedFields(t *testing.T) {
+	app := newStaffVehicleTestApp(t)
+	seedSVI(t, app, 1001, 2026, true, map[string]string{
+		"SVI-are you driving to camp": "Yes",
+		"SVI-Unit Head Training":      "Session A", // admitted by prefix, routes nowhere
+	})
+
+	s := NewStaffVehicleInfoSync(app)
+	s.Year = 2026
+
+	fieldNames, err := s.loadFieldDefinitions(context.Background())
+	if err != nil {
+		t.Fatalf("loadFieldDefinitions: %v", err)
+	}
+	personToStaff, err := s.loadPersonStaffMapping(context.Background(), 2026)
+	if err != nil {
+		t.Fatalf("loadPersonStaffMapping: %v", err)
+	}
+	if _, err := s.loadPersonCustomValues(context.Background(), 2026, fieldNames, personToStaff); err != nil {
+		t.Fatalf("loadPersonCustomValues: %v", err)
+	}
+
+	if s.Stats.Skipped != 1 {
+		t.Errorf("Stats.Skipped = %d, want 1 -- the unmapped field must be counted", s.Stats.Skipped)
 	}
 }

--- a/pocketbase/sync/staff_vehicle_info_test.go
+++ b/pocketbase/sync/staff_vehicle_info_test.go
@@ -417,3 +417,75 @@ func TestLoadPersonCustomValuesCountsUnmappedFields(t *testing.T) {
 		t.Errorf("Stats.Skipped = %d, want 1 -- the unmapped field must be counted", s.Stats.Skipped)
 	}
 }
+
+// TestDeleteOrphansRefusesEmptyComputedSet pins the destructive path in
+// kindred#2273. An empty computed record set against a populated year is
+// always a broken input, never a legitimate "everything was removed" -- and
+// the current code deletes the year and reports success.
+func TestDeleteOrphansRefusesEmptyComputedSet(t *testing.T) {
+	app := newStaffVehicleTestApp(t)
+	col, err := app.FindCollectionByNameOrId("staff_vehicle_info")
+	if err != nil {
+		t.Fatalf("find staff_vehicle_info: %v", err)
+	}
+	rec := core.NewRecord(col)
+	rec.Set("person_id", 1001)
+	rec.Set("year", 2026)
+	if err := app.Save(rec); err != nil {
+		t.Fatalf("save existing row: %v", err)
+	}
+
+	s := NewStaffVehicleInfoSync(app)
+	s.Year = 2026
+
+	existing := map[string]string{makeStaffVehicleKey(1001, 2026): rec.Id}
+	deleted, err := s.deleteOrphans(context.Background(),
+		map[string]*staffVehicleInfoRecord{}, existing)
+
+	if err == nil {
+		t.Fatal("expected an error when the computed set is empty and rows exist, got nil")
+	}
+	if deleted != 0 {
+		t.Errorf("deleted = %d, want 0 -- nothing may be removed on the refusal path", deleted)
+	}
+
+	remaining, err := app.FindRecordsByFilter("staff_vehicle_info", "year = 2026", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query: %v", err)
+	}
+	if len(remaining) != 1 {
+		t.Errorf("%d rows survived, want 1 -- the guard must not delete", len(remaining))
+	}
+}
+
+// TestDeleteOrphansStillSweepsGenuineOrphans proves the guard did not disable
+// orphan deletion for the normal case.
+func TestDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
+	app := newStaffVehicleTestApp(t)
+	col, err := app.FindCollectionByNameOrId("staff_vehicle_info")
+	if err != nil {
+		t.Fatalf("find staff_vehicle_info: %v", err)
+	}
+	orphan := core.NewRecord(col)
+	orphan.Set("person_id", 1002)
+	orphan.Set("year", 2026)
+	if err := app.Save(orphan); err != nil {
+		t.Fatalf("save orphan: %v", err)
+	}
+
+	s := NewStaffVehicleInfoSync(app)
+	s.Year = 2026
+
+	records := map[string]*staffVehicleInfoRecord{
+		makeStaffVehicleKey(1001, 2026): {personID: 1001, year: 2026},
+	}
+	existing := map[string]string{makeStaffVehicleKey(1002, 2026): orphan.Id}
+
+	deleted, err := s.deleteOrphans(context.Background(), records, existing)
+	if err != nil {
+		t.Fatalf("deleteOrphans: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("deleted = %d, want 1", deleted)
+	}
+}

--- a/pocketbase/sync/staff_vehicle_info_test.go
+++ b/pocketbase/sync/staff_vehicle_info_test.go
@@ -206,6 +206,17 @@ func TestMapSVIFieldToRecordLeavesDrivingToCampABool(t *testing.T) {
 // newStaffVehicleTestApp builds the five collections this service reads and
 // writes. Fields are the minimum the code under test touches, not a mirror of
 // production -- see kindred#1921 for why that distinction matters.
+//
+// THIS FIXTURE IS LAXER THAN PRODUCTION, DELIBERATELY. `staff` is a plain
+// text field here, but production declares it
+// `{type: "relation", required: true, cascadeDelete: true}` against col_staff
+// (pb_migrations/1500000047_staff_vehicle_info.js:26-34). So a row with no
+// staff value SAVES here and would be REJECTED there.
+//
+// That trade is accepted because these tests exercise drop-COUNTING logic, not
+// save validation. It has one consequence a future reader must not miss:
+// a green test in this file is NOT evidence that production writes succeed.
+// Real write validation comes from running the sync against the actual schema.
 func newStaffVehicleTestApp(t *testing.T) core.App {
 	t.Helper()
 	app, err := pbtests.NewTestApp()

--- a/pocketbase/sync/staff_vehicle_info_test.go
+++ b/pocketbase/sync/staff_vehicle_info_test.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/pocketbase/pocketbase/core"
@@ -440,10 +441,13 @@ func TestDeleteOrphansRefusesEmptyComputedSet(t *testing.T) {
 
 	existing := map[string]string{makeStaffVehicleKey(1001, 2026): rec.Id}
 	deleted, err := s.deleteOrphans(context.Background(),
-		map[string]*staffVehicleInfoRecord{}, existing)
+		map[string]*staffVehicleInfoRecord{}, existing, 2026)
 
 	if err == nil {
 		t.Fatal("expected an error when the computed set is empty and rows exist, got nil")
+	}
+	if !strings.Contains(err.Error(), "2026") {
+		t.Errorf("error %q does not name the year -- an operator has no way to tell which season refused", err.Error())
 	}
 	if deleted != 0 {
 		t.Errorf("deleted = %d, want 0 -- nothing may be removed on the refusal path", deleted)
@@ -481,7 +485,7 @@ func TestDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
 	}
 	existing := map[string]string{makeStaffVehicleKey(1002, 2026): orphan.Id}
 
-	deleted, err := s.deleteOrphans(context.Background(), records, existing)
+	deleted, err := s.deleteOrphans(context.Background(), records, existing, 2026)
 	if err != nil {
 		t.Fatalf("deleteOrphans: %v", err)
 	}

--- a/pocketbase/sync/staff_vehicle_info_test.go
+++ b/pocketbase/sync/staff_vehicle_info_test.go
@@ -2,6 +2,9 @@ package sync
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -491,5 +494,43 @@ func TestDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
 	}
 	if deleted != 1 {
 		t.Errorf("deleted = %d, want 1", deleted)
+	}
+}
+
+// TestSVIRoutingReportAgainstRealFieldNames is the guard that would have
+// caught kindred#2258 on the day it was written. Every target column must be
+// reachable from at least one field name CampMinder actually publishes.
+//
+// Per COLUMN, not per literal: an extra defensive spelling is allowed to match
+// nothing, but a column that matches nothing is a dead switch arm.
+//
+// One-way only. The reverse -- every SVI definition must have a column --
+// fails by design: "SVI- who are you driving to camp" and
+// "SVI-Unit Head Training" are deliberately unrouted and carry no rows.
+func TestSVIRoutingReportAgainstRealFieldNames(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("testdata", "svi_field_names.txt"))
+	if err != nil {
+		t.Fatalf("read testdata: %v", err)
+	}
+	var names []string
+	for _, line := range strings.Split(string(raw), "\n") {
+		if line = strings.TrimRight(line, "\r"); line != "" {
+			names = append(names, line)
+		}
+	}
+	if len(names) != 12 {
+		t.Fatalf("expected 12 SVI field names in testdata, got %d", len(names))
+	}
+
+	unrouted, unmapped := sviRoutingReport(names)
+
+	if len(unrouted) != 0 {
+		t.Errorf("columns reachable from no CampMinder field: %v -- "+
+			"a literal in MapSVIFieldToColumnImpl does not match any published name", unrouted)
+	}
+
+	wantUnmapped := []string{"SVI- who are you driving to camp", "SVI-Unit Head Training"}
+	if !slices.Equal(unmapped, wantUnmapped) {
+		t.Errorf("unmapped fields = %v, want %v", unmapped, wantUnmapped)
 	}
 }

--- a/pocketbase/sync/staff_vehicle_info_test.go
+++ b/pocketbase/sync/staff_vehicle_info_test.go
@@ -157,3 +157,45 @@ func TestStaffVehicleInfoCompositeKey(t *testing.T) {
 		})
 	}
 }
+
+// TestMapSVIFieldToRecordKeepsBringOthersVerbatim pins kindred#2262. The
+// CampMinder field behind can_bring_others is an open-ended String question --
+// 1,044 answers, 629 distinct, longest 328 characters -- and routing it
+// through parseSVIBoolImpl stored `false` for 1,022 people who answered.
+// Prefix rules do not rescue it: 34% of real answers begin with neither "yes"
+// nor "no", so the sentence itself is the only honest storage.
+func TestMapSVIFieldToRecordKeepsBringOthersVerbatim(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+	}{
+		{"affirmative prose", "Yes, I can take 2 people from Oakland if they pack light"},
+		{"bare no", "No"},
+		{"seat count", "3"},
+		{"conditional", "Maybe -- depends on luggage"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &staffVehicleInfoRecord{}
+			mapSVIFieldToRecord(rec, "SVI - bring others", tc.value)
+			if rec.canBringOthers != tc.value {
+				t.Errorf("canBringOthers = %q, want the raw answer %q", rec.canBringOthers, tc.value)
+			}
+		})
+	}
+}
+
+// TestMapSVIFieldToRecordLeavesDrivingToCampABool is the guardrail. The same
+// parser serves driving_to_camp, whose source really is a two-valued enum
+// (1,780 answers, exactly 2 distinct values, 793 rows true). Nothing in
+// kindred#2262 may change it.
+func TestMapSVIFieldToRecordLeavesDrivingToCampABool(t *testing.T) {
+	for value, want := range map[string]bool{"Yes": true, "No": false, "yes": true} {
+		rec := &staffVehicleInfoRecord{}
+		mapSVIFieldToRecord(rec, "SVI-are you driving to camp", value)
+		if rec.drivingToCamp != want {
+			t.Errorf("drivingToCamp for %q = %v, want %v", value, rec.drivingToCamp, want)
+		}
+	}
+}

--- a/pocketbase/sync/staff_vehicle_info_test.go
+++ b/pocketbase/sync/staff_vehicle_info_test.go
@@ -111,7 +111,7 @@ func TestMapSVIFieldToColumn(t *testing.T) {
 // arms below ("1", "y", "true") match nothing in the live data. They are pinned
 // deliberately: this parser reads a CampMinder field, and a form that starts
 // emitting 1/0 must not silently read as all-false. Narrowing this set is a
-// behaviour change, not a cleanup.
+// behavior change, not a cleanup.
 func TestParseSVIBoolImpl(t *testing.T) {
 	cases := map[string]bool{
 		// The only two values the live field actually contains.
@@ -292,20 +292,20 @@ func seedSVI(t *testing.T, app core.App, cmID, year int, hasStaff bool, values m
 	person := core.NewRecord(personCol)
 	person.Set("cm_id", cmID)
 	person.Set("year", year)
-	if err := app.Save(person); err != nil {
-		t.Fatalf("save person %d: %v", cmID, err)
+	if saveErr := app.Save(person); saveErr != nil {
+		t.Fatalf("save person %d: %v", cmID, saveErr)
 	}
 
 	if hasStaff {
-		staffCol, err := app.FindCollectionByNameOrId("staff")
-		if err != nil {
-			t.Fatalf("find staff: %v", err)
+		staffCol, staffErr := app.FindCollectionByNameOrId("staff")
+		if staffErr != nil {
+			t.Fatalf("find staff: %v", staffErr)
 		}
 		s := core.NewRecord(staffCol)
 		s.Set("person_id", cmID)
 		s.Set("year", year)
-		if err := app.Save(s); err != nil {
-			t.Fatalf("save staff %d: %v", cmID, err)
+		if saveErr := app.Save(s); saveErr != nil {
+			t.Fatalf("save staff %d: %v", cmID, saveErr)
 		}
 	}
 
@@ -435,8 +435,8 @@ func TestDeleteOrphansRefusesEmptyComputedSet(t *testing.T) {
 	rec := core.NewRecord(col)
 	rec.Set("person_id", 1001)
 	rec.Set("year", 2026)
-	if err := app.Save(rec); err != nil {
-		t.Fatalf("save existing row: %v", err)
+	if saveErr := app.Save(rec); saveErr != nil {
+		t.Fatalf("save existing row: %v", saveErr)
 	}
 
 	s := NewStaffVehicleInfoSync(app)
@@ -476,8 +476,8 @@ func TestDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
 	orphan := core.NewRecord(col)
 	orphan.Set("person_id", 1002)
 	orphan.Set("year", 2026)
-	if err := app.Save(orphan); err != nil {
-		t.Fatalf("save orphan: %v", err)
+	if saveErr := app.Save(orphan); saveErr != nil {
+		t.Fatalf("save orphan: %v", saveErr)
 	}
 
 	s := NewStaffVehicleInfoSync(app)

--- a/pocketbase/sync/staff_vehicle_info_test.go
+++ b/pocketbase/sync/staff_vehicle_info_test.go
@@ -2,7 +2,6 @@ package sync
 
 import (
 	"context"
-	"fmt"
 	"testing"
 )
 
@@ -79,36 +78,49 @@ func TestMapSVIFieldToColumn(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.cmField, func(t *testing.T) {
-			got := MapSVIFieldToColumn(tt.cmField)
+			got := MapSVIFieldToColumnImpl(tt.cmField)
 			if got != tt.expected {
-				t.Errorf("MapSVIFieldToColumn(%q) = %q, want %q", tt.cmField, got, tt.expected)
+				t.Errorf("MapSVIFieldToColumnImpl(%q) = %q, want %q", tt.cmField, got, tt.expected)
 			}
 		})
 	}
 }
 
-// TestParseSVIBool tests boolean parsing for staff vehicle info fields
-func TestParseSVIBool(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected bool
-	}{
-		{"Yes", true},
-		{"yes", true},
-		{"YES", true},
-		{"No", false},
-		{"no", false},
-		{"NO", false},
-		{"", false},
-		{"Maybe", false},
-		{"1", false}, // Only "Yes" variants are true
+// TestParseSVIBoolImpl is the first real test of this parser. The function it
+// replaces tested a shadow copy declared in this file, so production went
+// unexercised.
+//
+// After the can_bring_others change, parseSVIBoolImpl has exactly ONE caller:
+// driving_to_camp, fed by "SVI-are you driving to camp". That field holds 1,780
+// answers with exactly two distinct values -- "Yes" and "No" -- so the tolerant
+// arms below ("1", "y", "true") match nothing in the live data. They are pinned
+// deliberately: this parser reads a CampMinder field, and a form that starts
+// emitting 1/0 must not silently read as all-false. Narrowing this set is a
+// behaviour change, not a cleanup.
+func TestParseSVIBoolImpl(t *testing.T) {
+	cases := map[string]bool{
+		// The only two values the live field actually contains.
+		"Yes": true,
+		"No":  false,
+		// Case and whitespace tolerance.
+		"yes":   true,
+		"YES":   true,
+		"  yes": true,
+		"no":    false,
+		// Tolerant arms, pinned so they cannot be dropped silently.
+		"1":    true,
+		"y":    true,
+		"true": true,
+		// Everything else is false, including the unanswered case.
+		"":      false,
+		"Maybe": false,
+		"0":     false,
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			got := parseSVIBool(tt.input)
-			if got != tt.expected {
-				t.Errorf("parseSVIBool(%q) = %v, want %v", tt.input, got, tt.expected)
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			if got := parseSVIBoolImpl(in); got != want {
+				t.Errorf("parseSVIBoolImpl(%q) = %v, want %v", in, got, want)
 			}
 		})
 	}
@@ -129,133 +141,11 @@ func TestStaffVehicleInfoCompositeKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.expected, func(t *testing.T) {
-			got := makeStaffVehicleInfoKey(tt.personID, tt.year)
+			got := makeStaffVehicleKey(tt.personID, tt.year)
 			if got != tt.expected {
-				t.Errorf("makeStaffVehicleInfoKey(%d, %d) = %q, want %q",
+				t.Errorf("makeStaffVehicleKey(%d, %d) = %q, want %q",
 					tt.personID, tt.year, got, tt.expected)
 			}
 		})
 	}
-}
-
-// TestStaffVehicleInfoFieldMapping tests that all expected fields are present
-func TestStaffVehicleInfoFieldMapping(t *testing.T) {
-	expectedFields := []string{
-		"driving_to_camp",
-		"how_getting_to_camp",
-		"can_bring_others",
-		"driver_name",
-		"which_friend",
-		"vehicle_make",
-		"vehicle_model",
-		"license_plate",
-	}
-
-	// Verify we have all 8 expected columns (excluding staff, person_id, year, created, updated)
-	if len(expectedFields) != 8 {
-		t.Errorf("Expected 8 custom fields, got %d", len(expectedFields))
-	}
-
-	// Test each field has a valid CM field mapping back
-	for _, field := range expectedFields {
-		cmField := getSVICMFieldForColumn(field)
-		if cmField == "" {
-			t.Errorf("Column %q has no CampMinder field mapping", field)
-		}
-
-		// Verify round-trip
-		backToColumn := MapSVIFieldToColumn(cmField)
-		if backToColumn != field {
-			t.Errorf("Round-trip failed: column %q -> cmField %q -> column %q",
-				field, cmField, backToColumn)
-		}
-	}
-}
-
-// TestStaffVehicleInfoBooleanFields tests that we correctly identify boolean fields
-func TestStaffVehicleInfoBooleanFields(t *testing.T) {
-	boolFields := []string{
-		"driving_to_camp",
-		"can_bring_others",
-	}
-
-	textFields := []string{
-		"how_getting_to_camp",
-		"driver_name",
-		"which_friend",
-		"vehicle_make",
-		"vehicle_model",
-		"license_plate",
-	}
-
-	for _, field := range boolFields {
-		if !isSVIBoolField(field) {
-			t.Errorf("Expected %q to be a boolean field", field)
-		}
-	}
-
-	for _, field := range textFields {
-		if isSVIBoolField(field) {
-			t.Errorf("Expected %q to be a text field, not boolean", field)
-		}
-	}
-}
-
-// Helper functions that define expected behavior - implementation must match these
-
-// MapSVIFieldToColumn maps CampMinder custom field names to database column names
-func MapSVIFieldToColumn(cmField string) string {
-	mapping := map[string]string{
-		"SVI-are you driving to camp":     "driving_to_camp",
-		"SVI-how are you get to camp":     "how_getting_to_camp",
-		"SVI - bring others":              "can_bring_others",
-		"SVI- Who is driving you to camp": "driver_name",
-		"SVI-which friend":                "which_friend",
-		"SVI-make of vehicle":             "vehicle_make",
-		"SVI-model vehicle":               "vehicle_model",
-		"SVI-license plate number":        "license_plate",
-	}
-
-	return mapping[cmField]
-}
-
-// getSVICMFieldForColumn is the reverse mapping
-func getSVICMFieldForColumn(column string) string {
-	mapping := map[string]string{
-		"driving_to_camp":     "SVI-are you driving to camp",
-		"how_getting_to_camp": "SVI-how are you get to camp",
-		"can_bring_others":    "SVI - bring others",
-		"driver_name":         "SVI- Who is driving you to camp",
-		"which_friend":        "SVI-which friend",
-		"vehicle_make":        "SVI-make of vehicle",
-		"vehicle_model":       "SVI-model vehicle",
-		"license_plate":       "SVI-license plate number",
-	}
-
-	return mapping[column]
-}
-
-// parseSVIBool parses Yes/No values to boolean
-func parseSVIBool(value string) bool {
-	switch value {
-	case "Yes", "yes", "YES":
-		return true
-	default:
-		return false
-	}
-}
-
-// isSVIBoolField returns true if the column should be parsed as boolean
-func isSVIBoolField(column string) bool {
-	switch column {
-	case "driving_to_camp", "can_bring_others":
-		return true
-	default:
-		return false
-	}
-}
-
-// makeStaffVehicleInfoKey creates the composite key for upsert logic
-func makeStaffVehicleInfoKey(personID, year int) string {
-	return fmt.Sprintf("%d|%d", personID, year)
 }

--- a/pocketbase/sync/testdata/svi_field_names.txt
+++ b/pocketbase/sync/testdata/svi_field_names.txt
@@ -1,0 +1,12 @@
+SVI - bring others
+SVI - other
+SVI- Where do you need a ride from
+SVI- Who is driving you to camp
+SVI- who are you driving to camp
+SVI-Unit Head Training
+SVI-are you driving to camp
+SVI-how are you get to camp
+SVI-licence plate number
+SVI-make of vehicle
+SVI-model vehicle
+SVI-which friend


### PR DESCRIPTION
## What this fixes

Repairs four data-loss/observability defects in the `staff_vehicle_info` sync, verified against a copy of the production snapshot across all ten years it covers (2017-2026):

| Column | Before | After |
|---|---|---|
| rows | 1772 | 1772 (no drift) |
| `license_plate` | **0** | **798** |
| `can_bring_others` | 18 `true` (1,022 answers misrepresented) | **1040** verbatim answers |
| `ride_from` | — | **475** (new) |
| `transport_notes` | — | **447** (new) |
| `driving_to_camp` | 793 | **793** (guardrail, unmoved) |
| skipped, logged | 0 (of 41 real) | **41** |

Per-year detail, before/after (`rows`, `license_plate`, `can_bring_others`, `ride_from`, `transport_notes`, `driving_to_camp`):

| Year | rows (b/a) | plate (b/a) | bring (b/a) | ride (b/a) | notes (b/a) | driving (b/a) |
|---|---|---|---|---|---|---|
| 2017 | 154/154 | 0/65 | 3/94   | n/a/47 | n/a/46 | 65/65 |
| 2018 | 174/174 | 0/67 | 3/95   | n/a/43 | n/a/54 | 66/66 |
| 2019 | 185/185 | 0/80 | 2/105  | n/a/55 | n/a/60 | 80/80 |
| 2020 | 48/48   | 0/27 | 2/28   | n/a/13 | n/a/16 | 27/27 |
| 2021 | 192/192 | 0/97 | 1/124  | n/a/44 | n/a/36 | 96/96 |
| 2022 | 202/202 | 0/87 | 2/115  | n/a/60 | n/a/44 | 85/85 |
| 2023 | 216/216 | 0/100| 3/132  | n/a/45 | n/a/52 | 100/100 |
| 2024 | 212/212 | 0/92 | 1/113  | n/a/58 | n/a/44 | 91/91 |
| 2025 | 189/189 | 0/92 | 1/118  | n/a/55 | n/a/45 | 92/92 |
| 2026 | 200/200 | 0/91 | 0/116  | n/a/55 | n/a/50 | 91/91 |
| **Total** | **1772/1772** | **0/798** | **18/1040** | **n/a/475** | **n/a/447** | **793/793** |

(`ride_from`/`transport_notes` are new columns — no "before" value existed. `bring` before is the old boolean-`true` count; after is the non-empty-text count under this repair.) Every year updated existing rows only — zero created, zero deleted — and `driving_to_camp`, the shared-parser guardrail, matched the pre-transform baseline exactly in every single year, not just in total, which is stronger evidence the parser change for `can_bring_others` did not leak into its sibling field.

A real sync of all ten years reported `errors=0` throughout; `skipped` was non-zero exactly where the (now-counted) staff gate and unmapped-field drops are known to fire (2022: 8, 2024: 4, 2026: 29).

Closes #2258.
Closes #2262.
Closes #2268.

Refs #2273 — this PR ships #2273's observability half (`Stats.Skipped` at both drop sites, the completion log) and its orphan-guard half (`deleteOrphans` refuses to sweep an empty computed set against existing rows). #2273 stays open: the roster gap it surfaced — people who answer onboarding fields but have no `staff` row for the year — is not fixed here and is now tracked at #2277. A follow-up narrowing gap in the orphan guard itself is tracked at #2279 — whose *second* gap, the sibling sync sharing the unguarded shape, is now fixed here (see below).

### Why `pocketbase-types.ts` has ~380 lines unrelated to this change

This PR adds three columns, but the regenerated types file carries far more than
three lines. That is pre-existing drift, not scope creep.

`frontend/src/types/pocketbase-types.ts` is `@generated` by `pocketbase-typegen`
from live schema introspection. It was already stale on `main`: the checked-in file
contained **zero** references to any Lodging collection while the database has
**13** of them, plus drift in `DebugPipelineRuns`, `FamilyCampRegistrations` and
`SolverRuns`. Every one of those traces to a migration already merged to `main`;
none is uncommitted work.

The file cannot be partially regenerated, and hand-editing a `@generated` file is
forbidden by `CLAUDE.md`. So regenerating it — which this change required, to add
`can_bring_others`, `ride_from` and `transport_notes` — necessarily brings the rest
of the drift with it.

Root cause of the drift: pre-push verifies **api-types** freshness but not
`pocketbase-types.ts`, so nothing ever caught it. Tracked separately as a follow-up: #2278.

### Untested path: the orphan-guard refusal is not exercised end-to-end

`deleteOrphans`'s new guard (refuse to sweep when the computed set is empty but existing rows are present) is unit-tested directly — `TestDeleteOrphansRefusesEmptyComputedSet` calls `deleteOrphans` with that exact shape and asserts the error, including that it names the year. What is **not** tested is the path above it: that `Sync` actually surfaces the refusal as a failed run (`SyncSuccessful` staying `false`, the orchestrator recording `statusFailed`) rather than the guard firing in isolation. `Sync`'s error-wrapping was traced by hand — the `deleteOrphans` error return happens before `s.SyncSuccessful = true` is reached, so a refusal does propagate — but there is no test that drives the whole `Sync` function into the empty-mapping case and asserts on the orchestrator-visible status. The ten-year verification run in this PR exercised only the success path (every year's `personToStaff` mapping was non-empty), so it does not substitute for that test either. Accepted gap for this PR; a good candidate to add alongside whichever follow-up widens the guard's threshold (#2279).

### Known limitation: the regression guard's column list is asymmetric

Task 8's regression test (`TestSVIRoutingReportAgainstRealFieldNames`, backed by `sviRoutingReport` in `staff_vehicle_info.go`) checks that every column in `sviTargetColumns` is reachable from at least one CampMinder field name — this is what catches a typo'd literal like the one that left `license_plate` empty for this table's entire history. But the check is asymmetric by construction:

- **Retiring a column and forgetting to remove it from `sviTargetColumns`** fails loudly — the guard reports it as permanently unrouted.
- **Adding a new `switch` case and forgetting to add the column to `sviTargetColumns`** fails silently — the guard simply never checks that column, and `TestMapSVIFieldToColumn`'s table-driven test only catches the omission if the same person also remembers to add a row there.

There is no cheap fix for the second direction without parsing the `switch` statement's AST to enumerate its return values independently of the hand-maintained list. Noting this here rather than fixing it speculatively — the next person adding a column to this table should know the guard does not fully cover them.

### Also fixed here: the same guard for `staff_applications` (#2279 Gap 2)

Added during review. `staff_applications` builds its computed set from the **same**
`loadPersonStaffMapping(ctx, year)` gate as `staff_vehicle_info`, so it carried the identical
year-wipe path — an empty staff mapping makes every value fail the gate, the computed set comes
back empty, and the sweep deletes the whole year before `SyncSuccessful = true` is set. Its
`deleteOrphans` had **no guard at all**, not even the `SyncSuccessful` check some siblings carry.

This is folded in rather than deferred because of sequencing, not tidiness: the handover below asks
the owner to run the backfill **per year across nine historical years**, and notes that
`staff_applications` shares the gate and is worth running alongside. Shipping the guard for one
service while recommending the operator run its unguarded twin — on precisely the years where an
incomplete `staff` table is most reachable — is the wrong order.

The guard mirrors `staff_vehicle_info`'s exactly: refuse when the computed set is empty and rows
exist, name the year, and return `(int, error)` so the cancellation path surfaces `ctx.Err()`
instead of a bare count. Mutation-checked — removing the guard turns
`TestStaffApplicationsDeleteOrphansRefusesEmptyComputedSet` red (exit 1), restoring it returns exit 0.

**Scope held deliberately narrow.** One file, one mirrored guard. #2279's Gap 1 (widening the guard
from "empty" to "suspiciously small") needs a defensible threshold and stays open, as does the audit
of the remaining ~13 `deleteOrphans` implementations. #2279's body and traps have been updated to
record what shipped and why the fold-in overrode its original advice.

Refs #2279.

## Verification

- `go build ./...`, `go test ./sync/... -count=1` (full suite, ~5 min), `bash scripts/pre-push-verify.sh` all green.
- Mutation-checked the regression guard: reverting the licence-spelling fix by hand reproduces the guard failing with `columns reachable from no CampMinder field: [license_plate]`; restoring the fix returns it to green.
- Real sync of all ten years against a copy of the production snapshot; every prediction made before running it matched the actual result exactly (see table above).




**Review round (post-open):** four findings from a `scan-it` pass applied — the WAL checkpoint moved
above the orphan-sweep error return (the cancellation path could strand `upsertRecords` writes; the
refusal path never could, since it requires an empty computed set); the refusal error and its doc
comment broadened to name *both* causes of an empty computed set and point at the `SVI field routing`
warnings, since an upstream rename of the whole `SVI-*` namespace empties the set with the staff table
perfectly healthy; and two stale "8 SVI-* fields" comments corrected to 10. `go build`,
`golangci-lint run ./...` (0 issues) and `go test ./sync/ -count=1` all green after each commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for lodging areas, assignments, availability, units, friend groups, and related scheduling data.
  - Expanded staff transportation information with pickup location, transport notes, and flexible “can bring others” details.
  - Added family-camp sharing eligibility details and enhanced solver-run diagnostics.

- **Bug Fixes**
  - Improved recognition of CampMinder transportation and vehicle fields.
  - Added safeguards to prevent accidental deletion during incomplete synchronization.
  - Improved reporting for skipped or unmapped imported values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->