### PR TITLE
perf(ci): shard the Go test job so -race stops owning the critical path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,8 +484,8 @@ jobs:
   # This was a single ~390s job and the whole critical path -- the next-slowest
   # job was ~156s. Almost none of that is test volume: the same suite runs in 43s
   # without -race and ~300s with it, because the race detector costs ~10x and the
-  # Go tree has exactly one t.Parallel() in it, so no two tests in a package ever
-  # overlap. Two packages carry it all (sync ~297s, lodging ~143s; the other nine
+  # Go tree has exactly one t.Parallel() in it -- inside a subtest, at that -- so
+  # no two top-level tests ever overlap. Two packages carry it all (sync ~297s, lodging ~143s; the other nine
   # total ~15s), which is why this shards by individual test function rather than
   # by package -- a per-package split would leave sync as a 297s shard.
   #
@@ -525,7 +525,7 @@ jobs:
         python3 scripts/ci/go_test_shard.py \
           --shard ${{ matrix.shard }} \
           --total ${{ strategy.job-total }} \
-          -- -race -v
+          -- -race
 
   # Migration smoke test — catches schema/binary issues against a fresh DB
   tests-migrations:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -475,12 +475,33 @@ jobs:
         SKIP_POCKETBASE_TESTS: true
       run: uv run pytest tests/ -v --tb=short
 
-  # Go tests (parallel)
+  # Go tests (sharded across a matrix)
+  #
+  # This was a single ~390s job and the whole critical path -- the next-slowest
+  # job was ~156s. Almost none of that is test volume: the same suite runs in 43s
+  # without -race and ~300s with it, because the race detector costs ~10x and the
+  # Go tree has exactly one t.Parallel() in it, so no two tests in a package ever
+  # overlap. Two packages carry it all (sync ~297s, lodging ~143s; the other nine
+  # total ~15s), which is why this shards by individual test function rather than
+  # by package -- a per-package split would leave sync as a 297s shard.
+  #
+  # Sharding at this level makes a coverage hole possible, so scripts/ci/
+  # go_test_shard.py reads the inventory live from `go test -list` and fails the
+  # shard if anything it selected produced no result. See its module docstring.
+  #
+  # The durable fix is t.Parallel() in sync and lodging (kindred#2281),
+  # which would buy the same wall-clock without 4x the runner minutes.
   tests-go:
     name: Go Tests
     needs: detect-changes
     if: needs.detect-changes.outputs.go == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Editing this list is the only change needed to re-shard: --total comes
+        # from strategy.job-total, so the two can never drift apart.
+        shard: [0, 1, 2, 3]
     steps:
     - name: Checkout code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -495,9 +516,12 @@ jobs:
         cache: true
         cache-dependency-path: pocketbase/go.sum
 
-    - name: Run Go tests
-      working-directory: ./pocketbase
-      run: go test -race ./... -v
+    - name: Run Go tests (shard ${{ matrix.shard }}/${{ strategy.job-total }})
+      run: |
+        python3 scripts/ci/go_test_shard.py \
+          --shard ${{ matrix.shard }} \
+          --total ${{ strategy.job-total }} \
+          -- -race -v
 
   # Migration smoke test — catches schema/binary issues against a fresh DB
   tests-migrations:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,10 @@ jobs:
             - 'go.mod'
             - 'go.sum'
             - '.golangci.yml'
+            # The sharder decides which tests run at all, so a change to it must
+            # run them -- otherwise it ships without ever executing a Go test.
+            # Same reasoning as validate_migrations.py under `migrations` below.
+            - 'scripts/ci/go_test_shard.py'
           migrations:
             - 'pocketbase/pb_migrations/**'
             - 'pocketbase/main.go'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,13 @@ jobs:
             # run them -- otherwise it ships without ever executing a Go test.
             # Same reasoning as validate_migrations.py under `migrations` below.
             - 'scripts/ci/go_test_shard.py'
+            # And the same again for this file, which holds the shard count, the
+            # shard args and the go flags. Without it, a PR that only widens the
+            # matrix or edits `-race` leaves tests-go *skipped* -- and the summary
+            # gate counts skipped as OK, so the new config ships having run zero
+            # Go tests. Costs ~22 extra runs a quarter (measured over 90 days:
+            # 24 commits touched ci.yml, only 2 of them alongside a .go change).
+            - '.github/workflows/ci.yml'
           migrations:
             - 'pocketbase/pb_migrations/**'
             - 'pocketbase/main.go'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,12 +482,13 @@ jobs:
   # Go tests (sharded across a matrix)
   #
   # This was a single ~390s job and the whole critical path -- the next-slowest
-  # job was ~156s. Almost none of that is test volume: the same suite runs in 43s
-  # without -race and ~300s with it, because the race detector costs ~10x and the
-  # Go tree has exactly one t.Parallel() in it -- inside a subtest, at that -- so
-  # no two top-level tests ever overlap. Two packages carry it all (sync ~297s, lodging ~143s; the other nine
-  # total ~15s), which is why this shards by individual test function rather than
-  # by package -- a per-package split would leave sync as a 297s shard.
+  # job was ~156s. Almost none of that is test volume: the race detector costs
+  # ~4.5x (measured back-to-back on one machine -- sync 60.8s -> 298.2s, lodging
+  # 35.1s -> 136.6s), and it pays that serially, because the Go tree has exactly
+  # one t.Parallel() in it -- inside a subtest, at that -- so no two top-level
+  # tests ever overlap. Two packages carry it all (sync ~297s, lodging ~143s; the
+  # other nine total ~15s), which is why this shards by individual test function
+  # rather than by package -- a per-package split would leave sync as a 297s shard.
   #
   # Sharding at this level makes a coverage hole possible, so scripts/ci/
   # go_test_shard.py reads the inventory live from `go test -list` and fails the
@@ -503,8 +504,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Editing this list is the only change needed to re-shard: --total comes
-        # from strategy.job-total, so the two can never drift apart.
+        # Re-shard by editing this list and nothing else -- --total comes from
+        # strategy.job-total, so the count cannot drift from the list. The list
+        # must stay 0-based and contiguous, though: the values are passed through
+        # as --shard, and the script rejects an index outside [0, total). A list
+        # like [1,2,3,4] fails the last job loudly rather than skipping tests, and
+        # test_tests_go_job_shards_and_derives_total_from_the_matrix catches it
+        # before CI does.
         shard: [0, 1, 2, 3]
     steps:
     - name: Checkout code

--- a/pocketbase/CLAUDE.md
+++ b/pocketbase/CLAUDE.md
@@ -79,11 +79,13 @@ CI does run `-race` over everything, split across a four-way matrix so no single
 critical path. To reproduce one shard locally:
 
 ```bash
-python3 scripts/ci/go_test_shard.py --shard 0 --total 4 -- -race -v   # from the repo root
+python3 scripts/ci/go_test_shard.py --shard 0 --total 4 -- -race   # from the repo root
 ```
 
 The sharder reads its inventory live from `go test -list` and fails a shard if any test it
-selected produced no result, so a `-run` regex can't silently drop coverage. kindred#2281
+selected produced no result, so a `-run` regex can't silently drop coverage. It runs `go test
+-json` and reads the structured per-test events, so that check does not depend on `-v`; the
+readable transcript is rebuilt from the stream. kindred#2281
 tracks adding `t.Parallel()`, which would make the shards unnecessary.
 
 Pre-push runs: `go build` and `pb-js-lint` (ESLint on `pb_hooks/`/`pb_migrations/` JS).

--- a/pocketbase/CLAUDE.md
+++ b/pocketbase/CLAUDE.md
@@ -68,6 +68,24 @@ cd pocketbase && go test ./...
 cd pocketbase && go test ./sync/...     # one package
 ```
 
+**Add `-race` only when you mean it.** The race detector costs about **10x** here — the full
+suite is 43s without it and ~300s with it — because there is exactly one `t.Parallel()` in the
+tree, so every test in a package runs serially. `sync` (297s) and `lodging` (143s) are
+effectively the whole bill; the other nine packages total ~15s. Reach for `-race` when you
+touch `sync/orchestrator.go`, `sync/api.go`, `sync/scheduler.go`, or anything else that spawns
+a goroutine, and leave it off for the ordinary edit-test loop.
+
+CI does run `-race` over everything, split across a four-way matrix so no single shard is the
+critical path. To reproduce one shard locally:
+
+```bash
+python3 scripts/ci/go_test_shard.py --shard 0 --total 4 -- -race -v   # from the repo root
+```
+
+The sharder reads its inventory live from `go test -list` and fails a shard if any test it
+selected produced no result, so a `-run` regex can't silently drop coverage. kindred#2281
+tracks adding `t.Parallel()`, which would make the shards unnecessary.
+
 Pre-push runs: `go build` and `pb-js-lint` (ESLint on `pb_hooks/`/`pb_migrations/` JS).
 
 **`golangci-lint` is NOT in pre-push** — `.lefthook.yml` moved it to CI-only for speed, so a

--- a/pocketbase/CLAUDE.md
+++ b/pocketbase/CLAUDE.md
@@ -68,9 +68,11 @@ cd pocketbase && go test ./...
 cd pocketbase && go test ./sync/...     # one package
 ```
 
-**Add `-race` only when you mean it.** The race detector costs about **10x** here — the full
-suite is 43s without it and ~300s with it — because there is exactly one `t.Parallel()` in the
-tree, so every test in a package runs serially. `sync` (297s) and `lodging` (143s) are
+**Add `-race` only when you mean it.** The race detector costs about **4.5x** here — measured
+back-to-back on one machine, `sync` goes 60.8s → 298.2s and `lodging` 35.1s → 136.6s — because
+there is exactly one `t.Parallel()` in the tree, so every test in a package runs serially.
+Schema-heavy tests are worse than the average: the `TestLodgingAssignmentsSync*` slice is
+~10x on its own. `sync` (297s) and `lodging` (143s) are
 effectively the whole bill; the other nine packages total ~15s. Reach for `-race` when you
 touch `sync/orchestrator.go`, `sync/api.go`, `sync/scheduler.go`, or anything else that spawns
 a goroutine, and leave it off for the ordinary edit-test loop.

--- a/scripts/ci/go_test_shard.py
+++ b/scripts/ci/go_test_shard.py
@@ -5,8 +5,8 @@
 ~400s critical path, against ~156s for the next-slowest job. Almost none of that
 is test volume. Measured on this tree, the same suite runs in 43s without
 `-race` and ~300s with it: the race detector costs about 10x, and it pays that
-tax serially, because the Go tree has exactly one `t.Parallel()` in it, so no two
-tests in a package ever overlap. Two packages carry it all -- `sync` at 297s and
+tax serially: the Go tree has exactly one `t.Parallel()` in it, and it sits inside
+a subtest (`sync/orchestrator_test.go`), so no two top-level tests ever overlap. Two packages carry it all -- `sync` at 297s and
 `lodging` at 143s, with the other nine adding up to ~15s.
 
 This script splits that serial run across a CI matrix. It deliberately does NOT
@@ -42,8 +42,10 @@ import os
 import re
 import subprocess
 import sys
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_GO_DIR = REPO_ROOT / "pocketbase"
@@ -54,11 +56,8 @@ DEFAULT_GO_DIR = REPO_ROOT / "pocketbase"
 # and examples with output comments *do* run and must stay in.
 RUNNABLE_PREFIXES = ("Test", "Fuzz", "Example")
 
-# Top-level results start at column 0; subtests are indented by Go.
-RESULT_LINE = re.compile(r"^--- (?:PASS|FAIL|SKIP): (\S+)")
-
-# A cache hit replaces the whole per-test transcript with a single summary line.
-CACHED_LINE = re.compile(r"^ok\s+\S+\s+\(cached\)\s*$", re.MULTILINE)
+# `go test -json` reports one of these per test when it finishes.
+RESULT_ACTIONS = frozenset({"pass", "fail", "skip"})
 
 
 class ShardError(Exception):
@@ -141,36 +140,68 @@ def build_run_regex(names: list[str]) -> str:
     return "^(" + "|".join(re.escape(n) for n in names) + ")$"
 
 
+def iter_events(output: str) -> Iterator[dict[str, Any]]:
+    """Yield the JSON events in a `go test -json` stream, skipping bare text.
+
+    Build errors, toolchain notices and `go: downloading ...` lines are emitted
+    as plain text alongside the stream, so a strict parse would throw on them.
+    """
+    for line in output.splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict):
+            yield event
+
+
 def parse_reported_tests(output: str) -> set[str]:
-    """Collect the top-level test names that produced a result line."""
-    return {m.group(1) for line in output.splitlines() if (m := RESULT_LINE.match(line))}
+    """Collect the top-level tests that produced a result.
+
+    Reads `-json` events rather than `--- PASS:` lines because Go only prints
+    those under `-v`. Parsing the transcript made this check silently depend on a
+    flag nothing enforced: without `-v`, every *passing* test looked like it never
+    ran, and the guard failed the shard 100% of the time -- a false alarm shaped
+    exactly like the coverage hole it exists to catch. `-json` emits a result per
+    test either way, and on a cache hit too, so there is no special case for that
+    either.
+
+    Subtests are excluded: Go names them `Parent/child`, and the sharder selects
+    and verifies at top level.
+    """
+    return {
+        name
+        for event in iter_events(output)
+        if event.get("Action") in RESULT_ACTIONS and (name := event.get("Test")) and "/" not in name
+    }
 
 
-def is_cached_result(output: str) -> bool:
-    """True when Go served this package from its test-result cache."""
-    return CACHED_LINE.search(output) is not None
+def render_output(output: str) -> str:
+    """Rebuild the human-readable transcript from a `-json` stream.
+
+    The raw stream is unreadable in a CI log, and the `Output` fields concatenated
+    in order are byte-for-byte what `go test -v` would have printed. Non-JSON
+    lines (build errors) pass through, since those are the ones worth reading.
+    """
+    parts = []
+    for line in output.splitlines(keepends=True):
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            parts.append(line)
+            continue
+        if isinstance(event, dict) and event.get("Action") == "output":
+            parts.append(event.get("Output", ""))
+    return "".join(parts)
 
 
-def verify_reported(
-    package: str,
-    selected: set[str],
-    reported: set[str],
-    output: str = "",
-) -> None:
+def verify_reported(package: str, selected: set[str], reported: set[str]) -> None:
     """Fail if a selected test produced no result.
 
     Extra reported names are fine -- Go can surface a parent this shard did not
     explicitly select. A *missing* one means the `-run` regex silently dropped
     coverage, which would otherwise pass as green.
-
-    A cache hit is exempt, because it prints one `ok ... (cached)` line and no
-    per-test transcript at all. That is not a coverage hole: Go keys the test
-    cache on the test binary *and* the command line, `-run` regex included, so a
-    hit is a real prior pass of exactly this selection. Without the exemption a
-    warm GOCACHE would turn every unchanged package red.
     """
-    if is_cached_result(output):
-        return
     missing = sorted(selected - reported)
     if missing:
         raise ShardError(
@@ -206,14 +237,28 @@ def build_commands(selected: list[tuple[str, str]], go_args: list[str]) -> list[
     """
     grouped = group_by_package(selected)
     ordered = sorted(grouped.items(), key=lambda kv: (-len(kv[1]), kv[0]))
+    # `-json` is what makes the coverage check independent of `-v`; see
+    # parse_reported_tests. It also carries the human transcript in its Output
+    # fields, so nothing is lost from the CI log.
+    flags = [*go_args] if "-json" in go_args else [*go_args, "-json"]
     return [
         PackageRun(
             package=package,
             names=tuple(sorted(names)),
-            argv=["go", "test", *go_args, "-run", build_run_regex(sorted(names)), package],
+            argv=["go", "test", *flags, "-run", build_run_regex(sorted(names)), package],
         )
         for package, names in ordered
     ]
+
+
+def resolve_workers(command_count: int, jobs: int | None) -> int:
+    """Concurrency for the package pool, never zero.
+
+    `min(0, cpu_count)` made ThreadPoolExecutor raise ValueError on an empty
+    shard. run_shard returns early in that case now, but the floor stays here so
+    the arithmetic cannot produce an invalid pool size again.
+    """
+    return max(1, jobs or min(command_count, os.cpu_count() or 1))
 
 
 def run_shard(
@@ -232,7 +277,13 @@ def run_shard(
     so concurrency does not interleave the logs.
     """
     commands = build_commands(selected, go_args)
-    workers = jobs or min(len(commands), os.cpu_count() or 1)
+    if not commands:
+        # `--total` above the test count leaves trailing shards empty. The other
+        # shards still cover the whole inventory, so this is success, not a hole.
+        print("no tests selected for this shard -- nothing to run", file=sys.stderr)
+        return 0
+
+    workers = resolve_workers(len(commands), jobs)
     failed = False
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
@@ -243,19 +294,14 @@ def run_shard(
             run = futures[future]
             proc = future.result()
             print(f"::group::{run.package} ({len(run.names)} tests)", flush=True)
-            sys.stdout.write(proc.stdout)
+            sys.stdout.write(render_output(proc.stdout))
             sys.stderr.write(proc.stderr)
             print("::endgroup::", flush=True)
 
             if proc.returncode != 0:
                 failed = True
             try:
-                verify_reported(
-                    run.package,
-                    set(run.names),
-                    parse_reported_tests(proc.stdout),
-                    output=proc.stdout,
-                )
+                verify_reported(run.package, set(run.names), parse_reported_tests(proc.stdout))
             except ShardError as exc:
                 print(f"::error::{exc}", file=sys.stderr)
                 failed = True

--- a/scripts/ci/go_test_shard.py
+++ b/scripts/ci/go_test_shard.py
@@ -77,15 +77,25 @@ def parse_list_output(raw: str) -> list[str]:
     return names
 
 
-def collect_inventory(go_dir: Path) -> list[tuple[str, str]]:
-    """Enumerate every (package, test) pair in the tree.
+def inventory_argv(go_args: list[str]) -> list[str]:
+    """The `go test -list` command used to enumerate tests.
+
+    `go_args` is forwarded because `-list` has to *build* every test binary to
+    read its test names, and a build is per-flag-set. Omitting `-race` here means
+    compiling a full non-race copy of the tree, throwing it away, and then
+    compiling the race copy for the actual run -- two builds per shard.
 
     Uses `-json` rather than plain `-list` because plain output only separates
     packages by a trailing `ok <pkg>` line, which interleaves unusably once Go
     lists packages in parallel. The JSON stream tags every line with its package.
     """
+    return ["go", "test", *go_args, "-list", ".*", "-json", "./..."]
+
+
+def collect_inventory(go_dir: Path, go_args: list[str] | None = None) -> list[tuple[str, str]]:
+    """Enumerate every (package, test) pair in the tree."""
     proc = subprocess.run(
-        ["go", "test", "-list", ".*", "-json", "./..."],
+        inventory_argv(go_args or []),
         cwd=go_dir,
         capture_output=True,
         text=True,
@@ -290,7 +300,7 @@ def main(argv: list[str] | None = None) -> int:
             raw = sys.stdin.read() if args.from_json == "-" else Path(args.from_json).read_text()
             inventory = [(row["package"], row["test"]) for row in json.loads(raw)]
         else:
-            inventory = collect_inventory(args.dir)
+            inventory = collect_inventory(args.dir, args.go_args)
     except ShardError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2

--- a/scripts/ci/go_test_shard.py
+++ b/scripts/ci/go_test_shard.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Run one shard of the Go test suite.
+
+`go test -race ./...` was the longest job in CI by a wide margin -- ~390s of a
+~400s critical path, against ~156s for the next-slowest job. Almost none of that
+is test volume. Measured on this tree, the same suite runs in 43s without
+`-race` and ~300s with it: the race detector costs about 10x, and it pays that
+tax serially, because the Go tree has exactly one `t.Parallel()` in it, so no two
+tests in a package ever overlap. Two packages carry it all -- `sync` at 297s and
+`lodging` at 143s, with the other nine adding up to ~15s.
+
+This script splits that serial run across a CI matrix. It deliberately does NOT
+shard by package: `sync` alone would still be a 297s shard. It shards at the
+individual test-function level, so the two heavy packages get cut up too.
+
+The whole design is shaped by one failure mode. A partition that quietly stops
+covering some tests still reports green, which is the paths-filter incident of
+March 2026 wearing a different hat. So:
+
+  * `partition` deals tests out round-robin over a *sorted* inventory. Sorting
+    makes the split independent of `go list` ordering; round-robin spreads the
+    name-clustered slow tests (every `TestLodgingAssignmentsSync*` pays the same
+    ~3s schema build) instead of piling a cluster into one shard.
+  * The inventory is read live from `go test -list` on every run, so a newly
+    added test is picked up by construction -- there is no checked-in list of
+    test names to drift.
+  * After running, each shard reads back which tests actually reported a result
+    and fails if anything it selected did not run. A `-run` regex that matches
+    nothing looks exactly like a passing shard from the outside; this is what
+    catches it.
+
+Usage:
+    python3 scripts/ci/go_test_shard.py --shard 0 --total 4 -- -race -v
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_GO_DIR = REPO_ROOT / "pocketbase"
+
+# `go test -list` emits benchmarks, fuzz targets and examples alongside tests.
+# Benchmarks do not run under a plain `go test`, so selecting them would inflate
+# the inventory and make the reported-back check fail. Fuzz targets (seed corpus)
+# and examples with output comments *do* run and must stay in.
+RUNNABLE_PREFIXES = ("Test", "Fuzz", "Example")
+
+# Top-level results start at column 0; subtests are indented by Go.
+RESULT_LINE = re.compile(r"^--- (?:PASS|FAIL|SKIP): (\S+)")
+
+# A cache hit replaces the whole per-test transcript with a single summary line.
+CACHED_LINE = re.compile(r"^ok\s+\S+\s+\(cached\)\s*$", re.MULTILINE)
+
+
+class ShardError(Exception):
+    """A shard did not cover what it claimed to cover."""
+
+
+def parse_list_output(raw: str) -> list[str]:
+    """Pull runnable test-function names out of `go test -list` output."""
+    names = []
+    for line in raw.splitlines():
+        name = line.strip()
+        if not name or " " in name or "\t" in name:
+            continue
+        if name.startswith(RUNNABLE_PREFIXES):
+            names.append(name)
+    return names
+
+
+def collect_inventory(go_dir: Path) -> list[tuple[str, str]]:
+    """Enumerate every (package, test) pair in the tree.
+
+    Uses `-json` rather than plain `-list` because plain output only separates
+    packages by a trailing `ok <pkg>` line, which interleaves unusably once Go
+    lists packages in parallel. The JSON stream tags every line with its package.
+    """
+    proc = subprocess.run(
+        ["go", "test", "-list", ".*", "-json", "./..."],
+        cwd=go_dir,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise ShardError(f"`go test -list` failed ({proc.returncode}):\n{proc.stderr}")
+
+    inventory: list[tuple[str, str]] = []
+    for line in proc.stdout.splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if event.get("Action") != "output":
+            continue
+        package = event.get("Package")
+        if not package:
+            continue
+        for name in parse_list_output(event.get("Output", "")):
+            inventory.append((package, name))
+    return inventory
+
+
+def partition(inventory: list[tuple[str, str]], total: int) -> list[list[tuple[str, str]]]:
+    """Deal the inventory into `total` buckets, round-robin over sorted order."""
+    if total < 1:
+        raise ValueError(f"shard total must be >= 1, got {total}")
+    ordered = sorted(inventory)
+    buckets: list[list[tuple[str, str]]] = [[] for _ in range(total)]
+    for index, item in enumerate(ordered):
+        buckets[index % total].append(item)
+    return buckets
+
+
+def build_run_regex(names: list[str]) -> str:
+    """Build a `-run` pattern anchored to whole top-level test names.
+
+    Anchoring keeps `TestParent` from also selecting `TestParentExtra`, while
+    `-run` semantics still admit subtests: Go splits both the pattern and the
+    test name on `/` and matches element-wise, so a single-element pattern only
+    ever constrains the top level.
+    """
+    return "^(" + "|".join(re.escape(n) for n in names) + ")$"
+
+
+def parse_reported_tests(output: str) -> set[str]:
+    """Collect the top-level test names that produced a result line."""
+    return {m.group(1) for line in output.splitlines() if (m := RESULT_LINE.match(line))}
+
+
+def is_cached_result(output: str) -> bool:
+    """True when Go served this package from its test-result cache."""
+    return CACHED_LINE.search(output) is not None
+
+
+def verify_reported(
+    package: str,
+    selected: set[str],
+    reported: set[str],
+    output: str = "",
+) -> None:
+    """Fail if a selected test produced no result.
+
+    Extra reported names are fine -- Go can surface a parent this shard did not
+    explicitly select. A *missing* one means the `-run` regex silently dropped
+    coverage, which would otherwise pass as green.
+
+    A cache hit is exempt, because it prints one `ok ... (cached)` line and no
+    per-test transcript at all. That is not a coverage hole: Go keys the test
+    cache on the test binary *and* the command line, `-run` regex included, so a
+    hit is a real prior pass of exactly this selection. Without the exemption a
+    warm GOCACHE would turn every unchanged package red.
+    """
+    if is_cached_result(output):
+        return
+    missing = sorted(selected - reported)
+    if missing:
+        raise ShardError(
+            f"{package}: {len(missing)} selected test(s) never ran: {', '.join(missing[:10])}"
+            + (" ..." if len(missing) > 10 else "")
+        )
+
+
+def group_by_package(items: list[tuple[str, str]]) -> dict[str, list[str]]:
+    grouped: dict[str, list[str]] = {}
+    for package, name in items:
+        grouped.setdefault(package, []).append(name)
+    return grouped
+
+
+@dataclass(frozen=True)
+class PackageRun:
+    package: str
+    names: tuple[str, ...]
+    argv: list[str]
+
+
+def build_commands(selected: list[tuple[str, str]], go_args: list[str]) -> list[PackageRun]:
+    """One `go test` invocation per package, heaviest package first.
+
+    Each package gets its own `-run` regex rather than one union regex over the
+    whole shard. A union regex is applied to every package it is handed, so two
+    packages sharing a test name would run it twice here and never there. The
+    per-package scoping costs nothing and removes the coupling.
+
+    Ordering matters for the thread pool below: `sync` and `lodging` carry ~97%
+    of the runtime, so they must start first rather than be picked up last.
+    """
+    grouped = group_by_package(selected)
+    ordered = sorted(grouped.items(), key=lambda kv: (-len(kv[1]), kv[0]))
+    return [
+        PackageRun(
+            package=package,
+            names=tuple(sorted(names)),
+            argv=["go", "test", *go_args, "-run", build_run_regex(sorted(names)), package],
+        )
+        for package, names in ordered
+    ]
+
+
+def run_shard(
+    go_dir: Path,
+    selected: list[tuple[str, str]],
+    go_args: list[str],
+    jobs: int | None = None,
+) -> int:
+    """Run this shard's packages concurrently, verifying coverage as they land.
+
+    Sharding by test name means one `go test` call per package, which throws away
+    the cross-package parallelism a plain `go test ./...` gets for free -- and
+    that is not a rounding error: running a shard's slice of `sync` (~74s) after
+    its slice of `lodging` (~37s) rather than alongside it costs half the win.
+    A pool restores it. Output is captured per package and flushed as one block,
+    so concurrency does not interleave the logs.
+    """
+    commands = build_commands(selected, go_args)
+    workers = jobs or min(len(commands), os.cpu_count() or 1)
+    failed = False
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {
+            pool.submit(subprocess.run, run.argv, cwd=go_dir, capture_output=True, text=True): run for run in commands
+        }
+        for future in concurrent.futures.as_completed(futures):
+            run = futures[future]
+            proc = future.result()
+            print(f"::group::{run.package} ({len(run.names)} tests)", flush=True)
+            sys.stdout.write(proc.stdout)
+            sys.stderr.write(proc.stderr)
+            print("::endgroup::", flush=True)
+
+            if proc.returncode != 0:
+                failed = True
+            try:
+                verify_reported(
+                    run.package,
+                    set(run.names),
+                    parse_reported_tests(proc.stdout),
+                    output=proc.stdout,
+                )
+            except ShardError as exc:
+                print(f"::error::{exc}", file=sys.stderr)
+                failed = True
+    return 1 if failed else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--shard", type=int, required=True, help="0-based shard index")
+    parser.add_argument("--total", type=int, required=True, help="number of shards")
+    parser.add_argument("--plan", action="store_true", help="print this shard's tests and exit")
+    parser.add_argument(
+        "--from-json",
+        metavar="PATH",
+        help="read the inventory from a JSON file ('-' for stdin) instead of invoking go",
+    )
+    parser.add_argument("--dir", type=Path, default=DEFAULT_GO_DIR, help="Go module directory")
+    parser.add_argument(
+        "--jobs",
+        type=int,
+        default=None,
+        help="concurrent `go test` invocations (default: CPU count)",
+    )
+    parser.add_argument("go_args", nargs="*", help="extra flags forwarded to `go test`")
+    args = parser.parse_args(argv)
+
+    if args.total < 1:
+        print(f"error: --total must be >= 1, got {args.total}", file=sys.stderr)
+        return 2
+    if args.jobs is not None and args.jobs < 1:
+        print(f"error: --jobs must be >= 1, got {args.jobs}", file=sys.stderr)
+        return 2
+    if not 0 <= args.shard < args.total:
+        print(
+            f"error: --shard must be in [0, {args.total}), got {args.shard}",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        if args.from_json:
+            raw = sys.stdin.read() if args.from_json == "-" else Path(args.from_json).read_text()
+            inventory = [(row["package"], row["test"]) for row in json.loads(raw)]
+        else:
+            inventory = collect_inventory(args.dir)
+    except ShardError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if not inventory:
+        # Zero tests four times over is a green CI that checked nothing.
+        print("error: test inventory is empty -- `go test -list` found no tests", file=sys.stderr)
+        return 2
+
+    selected = partition(inventory, args.total)[args.shard]
+    print(
+        f"shard {args.shard}/{args.total}: {len(selected)} of {len(inventory)} tests"
+        f" across {len(group_by_package(selected))} package(s)",
+        file=sys.stderr,
+    )
+
+    if args.plan:
+        for _, name in selected:
+            print(name)
+        return 0
+
+    return run_shard(args.dir, selected, args.go_args, jobs=args.jobs)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/go_test_shard.py
+++ b/scripts/ci/go_test_shard.py
@@ -3,10 +3,13 @@
 
 `go test -race ./...` was the longest job in CI by a wide margin -- ~390s of a
 ~400s critical path, against ~156s for the next-slowest job. Almost none of that
-is test volume. Measured on this tree, the same suite runs in 43s without
-`-race` and ~300s with it: the race detector costs about 10x, and it pays that
-tax serially: the Go tree has exactly one `t.Parallel()` in it, and it sits inside
-a subtest (`sync/orchestrator_test.go`), so no two top-level tests ever overlap. Two packages carry it all -- `sync` at 297s and
+is test volume. The race detector costs about **4.5x** -- measured back-to-back on
+one machine, `sync` goes 60.8s -> 298.2s and `lodging` 35.1s -> 136.6s -- and it
+pays that serially: the Go tree has exactly one `t.Parallel()` in it, and it sits
+inside a subtest (`sync/orchestrator_test.go`), so no two top-level tests ever
+overlap. (A ~10x figure appears in earlier notes on this work; that was the
+`TestLodgingAssignmentsSync*` slice, which is schema-build heavy and not
+representative of the suite.) Two packages carry it all -- `sync` at 297s and
 `lodging` at 143s, with the other nine adding up to ~15s.
 
 This script splits that serial run across a CI matrix. It deliberately does NOT

--- a/tests/unit/scripts/test_go_test_shard.py
+++ b/tests/unit/scripts/test_go_test_shard.py
@@ -448,3 +448,15 @@ def test_resolve_workers_never_returns_zero():
 
 def test_run_shard_on_an_empty_selection_succeeds_without_running_go(tmp_path: Path) -> None:
     assert mod.run_shard(tmp_path, [], ["-race"]) == 0
+
+
+def test_go_filter_covers_the_workflow_that_configures_the_shards():
+    """The shard count, the shard args and the go flags all live in ci.yml.
+
+    Without this, a PR that only edits the matrix -- widening `shard:` to six, or
+    changing `-race` -- touches no .go file and no sharder, so `tests-go` is
+    *skipped*, and the summary gate treats skipped as OK. The new configuration
+    ships having run zero Go tests. Same class as the sharder entry above, and as
+    the paths-filter incident of March 2026 the whole job comment is about.
+    """
+    assert ".github/workflows/ci.yml" in _go_filter()

--- a/tests/unit/scripts/test_go_test_shard.py
+++ b/tests/unit/scripts/test_go_test_shard.py
@@ -1,7 +1,7 @@
 """Tests for the Go test sharder.
 
 `go test -race ./...` is the longest job in CI (~390s of a ~400s critical path),
-and ~90% of that is the race detector's ~10x multiplier over 2729 serial tests.
+and most of that is the race detector's ~4.5x multiplier over 2729 serial tests.
 Sharding the run across a matrix splits the wall clock, but it introduces the one
 failure mode this repo has been bitten by before (the paths-filter incident of
 March 2026): a partition that silently stops covering some tests still reports

--- a/tests/unit/scripts/test_go_test_shard.py
+++ b/tests/unit/scripts/test_go_test_shard.py
@@ -1,7 +1,7 @@
 """Tests for the Go test sharder.
 
 `go test -race ./...` is the longest job in CI (~390s of a ~400s critical path),
-and ~90% of that is the race detector's ~10x multiplier over 2717 serial tests.
+and ~90% of that is the race detector's ~10x multiplier over 2729 serial tests.
 Sharding the run across a matrix splits the wall clock, but it introduces the one
 failure mode this repo has been bitten by before (the paths-filter incident of
 March 2026): a partition that silently stops covering some tests still reports
@@ -164,49 +164,6 @@ def test_run_regex_anchoring_still_admits_subtests():
 # --- reading back what actually ran ---------------------------------------
 
 
-def test_parse_reported_tests_reads_top_level_results():
-    output = "\n".join(
-        [
-            "=== RUN   TestAlpha",
-            "--- PASS: TestAlpha (0.10s)",
-            "--- FAIL: TestBeta (1.00s)",
-            "--- SKIP: TestGamma (0.00s)",
-            "ok  \tgithub.com/camp/kindred/pocketbase/sync\t1.234s",
-        ]
-    )
-    assert mod.parse_reported_tests(output) == {"TestAlpha", "TestBeta", "TestGamma"}
-
-
-def test_parse_reported_tests_ignores_indented_subtests():
-    output = "\n".join(
-        [
-            "--- PASS: TestAlpha (0.10s)",
-            "    --- PASS: TestAlpha/sub_case (0.01s)",
-            "        --- PASS: TestAlpha/sub_case/deeper (0.00s)",
-        ]
-    )
-    assert mod.parse_reported_tests(output) == {"TestAlpha"}
-
-
-def test_parse_reported_tests_on_empty_output():
-    assert mod.parse_reported_tests("") == set()
-
-
-def test_verify_reported_accepts_an_exact_match():
-    mod.verify_reported(PKG, {"TestA", "TestB"}, {"TestA", "TestB"})
-
-
-def test_verify_reported_rejects_a_missing_test():
-    """A `-run` regex that quietly matches nothing is the false-green case."""
-    with pytest.raises(mod.ShardError, match="TestB"):
-        mod.verify_reported(PKG, {"TestA", "TestB"}, {"TestA"})
-
-
-def test_verify_reported_tolerates_extra_reported_tests():
-    """Go may report a parent the sharder did not select; that is not a shortfall."""
-    mod.verify_reported(PKG, {"TestA"}, {"TestA", "TestSomethingElse"})
-
-
 # --- inventory parsing ----------------------------------------------------
 
 
@@ -308,39 +265,6 @@ def test_cli_rejects_a_nonpositive_jobs_value():
     assert "jobs" in err.lower()
 
 
-# --- Go's own test-result cache -------------------------------------------
-
-
-def test_is_cached_result_detects_the_cached_marker():
-    assert mod.is_cached_result("ok  \tgithub.com/camp/kindred/pocketbase/sync\t(cached)\n")
-
-
-def test_is_cached_result_is_false_for_a_real_run():
-    assert not mod.is_cached_result("ok  \tgithub.com/camp/kindred/pocketbase/sync\t1.234s\n")
-
-
-def test_is_cached_result_ignores_the_word_elsewhere():
-    assert not mod.is_cached_result("--- PASS: TestCachedTokenIsReused (0.01s)\n")
-
-
-def test_verify_reported_skips_the_check_on_a_cached_result():
-    """A cached `ok` prints no per-test lines, but it is not a coverage hole.
-
-    Go keys its test cache on the test binary *and* the command line, `-run`
-    regex included, so a cache hit is a genuine prior pass of exactly this
-    selection. Treating the missing `--- PASS` lines as a shortfall would turn a
-    warm GOCACHE into a red shard.
-    """
-    output = "ok  \tgithub.com/camp/kindred/pocketbase/sync\t(cached)\n"
-    mod.verify_reported(PKG, {"TestA", "TestB"}, mod.parse_reported_tests(output), output=output)
-
-
-def test_verify_reported_still_fails_a_shortfall_on_an_uncached_run():
-    output = "--- PASS: TestA (0.10s)\nok  \tpkg\t0.400s\n"
-    with pytest.raises(mod.ShardError, match="TestB"):
-        mod.verify_reported(PKG, {"TestA", "TestB"}, mod.parse_reported_tests(output), output=output)
-
-
 # --- the workflow wiring --------------------------------------------------
 #
 # The sharder only runs when the `go` paths-filter fires. Left out of that
@@ -398,3 +322,129 @@ def test_inventory_command_keeps_list_and_json():
     argv = mod.inventory_argv(["-race"])
     assert "-list" in argv
     assert "-json" in argv
+
+
+# --- reading back what actually ran, from -json events ---------------------
+#
+# This used to parse `--- PASS:` lines out of the human transcript, which Go only
+# emits under `-v`. That made the coverage guard silently dependent on a flag
+# nobody was enforcing: drop `-v` and every *passing* package reported as a
+# coverage hole -- a 100% false failure wearing the costume of the exact bug this
+# script exists to catch. `go test -json` emits a structured pass/fail/skip event
+# per test regardless of `-v`, and on a cache hit too, so the dependency is gone
+# and the cached-result special case with it.
+
+
+def ev(action: str, test: str | None = None, output: str | None = None) -> dict[str, str]:
+    e: dict[str, str] = {"Action": action, "Package": PKG}
+    if test is not None:
+        e["Test"] = test
+    if output is not None:
+        e["Output"] = output
+    return e
+
+
+def stream(*evs: dict[str, str]) -> str:
+    return "\n".join(json.dumps(e) for e in evs)
+
+
+def test_parse_reported_tests_reads_pass_fail_skip_events():
+    out = stream(ev("pass", "TestAlpha"), ev("fail", "TestBeta"), ev("skip", "TestGamma"))
+    assert mod.parse_reported_tests(out) == {"TestAlpha", "TestBeta", "TestGamma"}
+
+
+def test_parse_reported_tests_works_without_v():
+    """The whole point: no `-v`, still a result per test."""
+    out = stream(ev("run", "TestAlpha"), ev("pass", "TestAlpha"))
+    assert mod.parse_reported_tests(out) == {"TestAlpha"}
+
+
+def test_parse_reported_tests_ignores_subtest_events():
+    out = stream(ev("pass", "TestAlpha"), ev("pass", "TestAlpha/sub_case"))
+    assert mod.parse_reported_tests(out) == {"TestAlpha"}
+
+
+def test_parse_reported_tests_ignores_package_level_events():
+    """A package-level pass carries no Test field and is not a test result."""
+    out = stream(ev("pass"), ev("pass", "TestAlpha"))
+    assert mod.parse_reported_tests(out) == {"TestAlpha"}
+
+
+def test_parse_reported_tests_ignores_non_result_actions():
+    out = stream(ev("run", "TestAlpha"), ev("output", "TestAlpha", "=== RUN\n"))
+    assert mod.parse_reported_tests(out) == set()
+
+
+def test_parse_reported_tests_counts_a_cache_hit_normally():
+    """A cache hit replays the same events, so it needs no special case."""
+    out = stream(ev("output", output="ok  \tpkg\t(cached)\n"), ev("pass", "TestAlpha"))
+    assert mod.parse_reported_tests(out) == {"TestAlpha"}
+
+
+def test_parse_reported_tests_tolerates_non_json_lines():
+    """Build errors and toolchain notices are interleaved as bare text."""
+    out = "go: downloading something\n" + stream(ev("pass", "TestAlpha")) + "\nnot json\n"
+    assert mod.parse_reported_tests(out) == {"TestAlpha"}
+
+
+def test_parse_reported_tests_on_empty_output():
+    assert mod.parse_reported_tests("") == set()
+
+
+def test_render_output_reconstructs_the_transcript_in_order():
+    """The JSON stream is unreadable in a CI log; the Output fields are the log."""
+    out = stream(
+        ev("output", "TestAlpha", "=== RUN   TestAlpha\n"),
+        ev("output", "TestAlpha", "--- PASS: TestAlpha (0.10s)\n"),
+        ev("output", output="ok  \tpkg\t0.4s\n"),
+    )
+    assert mod.render_output(out) == "=== RUN   TestAlpha\n--- PASS: TestAlpha (0.10s)\nok  \tpkg\t0.4s\n"
+
+
+def test_render_output_passes_through_non_json_lines():
+    out = "# github.com/camp/kindred/pocketbase/sync\nsync/x.go:1:1: syntax error\n"
+    assert "syntax error" in mod.render_output(out)
+
+
+# --- verify_reported, now flag-independent ---------------------------------
+
+
+def test_verify_reported_accepts_an_exact_match():
+    mod.verify_reported(PKG, {"TestA", "TestB"}, {"TestA", "TestB"})
+
+
+def test_verify_reported_rejects_a_missing_test():
+    with pytest.raises(mod.ShardError, match="TestB"):
+        mod.verify_reported(PKG, {"TestA", "TestB"}, {"TestA"})
+
+
+def test_verify_reported_tolerates_extra_reported_tests():
+    mod.verify_reported(PKG, {"TestA"}, {"TestA", "TestSomethingElse"})
+
+
+# --- the run command -------------------------------------------------------
+
+
+def test_build_commands_requests_json_output():
+    """`-json` is what makes the coverage check independent of `-v`."""
+    assert "-json" in mod.build_commands([(PKG, "TestA")], ["-race"])[0].argv
+
+
+def test_build_commands_does_not_duplicate_json_if_caller_passed_it():
+    argv = mod.build_commands([(PKG, "TestA")], ["-race", "-json"])[0].argv
+    assert argv.count("-json") == 1
+
+
+# --- an empty shard is not a crash -----------------------------------------
+
+
+def test_resolve_workers_never_returns_zero():
+    """`--total` above the test count leaves trailing shards empty; a bucket of
+    zero packages made ThreadPoolExecutor raise ValueError."""
+    assert mod.resolve_workers(0, None) >= 1
+    assert mod.resolve_workers(3, None) >= 1
+    assert mod.resolve_workers(3, 2) == 2
+
+
+def test_run_shard_on_an_empty_selection_succeeds_without_running_go(tmp_path: Path) -> None:
+    assert mod.run_shard(tmp_path, [], ["-race"]) == 0

--- a/tests/unit/scripts/test_go_test_shard.py
+++ b/tests/unit/scripts/test_go_test_shard.py
@@ -23,10 +23,13 @@ import subprocess
 import sys
 from pathlib import Path
 from types import ModuleType
+from typing import Any
 
 import pytest
+import yaml
 
-SCRIPT_PATH = Path(__file__).parents[3] / "scripts" / "ci" / "go_test_shard.py"
+REPO_ROOT = Path(__file__).parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "ci" / "go_test_shard.py"
 
 
 def _load_module() -> ModuleType:
@@ -336,3 +339,39 @@ def test_verify_reported_still_fails_a_shortfall_on_an_uncached_run():
     output = "--- PASS: TestA (0.10s)\nok  \tpkg\t0.400s\n"
     with pytest.raises(mod.ShardError, match="TestB"):
         mod.verify_reported(PKG, {"TestA", "TestB"}, mod.parse_reported_tests(output), output=output)
+
+
+# --- the workflow wiring --------------------------------------------------
+#
+# The sharder only runs when the `go` paths-filter fires. Left out of that
+# filter, a change to the sharder itself ships without ever running a Go test --
+# which is the exact false-green class the rest of this file exists to prevent,
+# and it happened on this PR's own first CI run.
+
+
+def _ci_workflow() -> dict[str, Any]:
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/ci.yml").read_text())
+    assert isinstance(workflow, dict)
+    return workflow
+
+
+def _go_filter() -> list[str]:
+    filters = _ci_workflow()["jobs"]["detect-changes"]["steps"][1]["with"]["filters"]
+    patterns = yaml.safe_load(filters)["go"]
+    assert isinstance(patterns, list)
+    return patterns
+
+
+def test_go_filter_covers_the_sharder():
+    assert "scripts/ci/go_test_shard.py" in _go_filter()
+
+
+def test_tests_go_job_shards_and_derives_total_from_the_matrix():
+    """A hardcoded --total that drifts from the matrix is a silent coverage hole."""
+    job = _ci_workflow()["jobs"]["tests-go"]
+    shards = job["strategy"]["matrix"]["shard"]
+    assert shards == list(range(len(shards))), "shard indices must be 0-based and contiguous"
+
+    run = job["steps"][-1]["run"]
+    assert "strategy.job-total" in run, "--total must come from the matrix, not a literal"
+    assert "-race" in run

--- a/tests/unit/scripts/test_go_test_shard.py
+++ b/tests/unit/scripts/test_go_test_shard.py
@@ -375,3 +375,26 @@ def test_tests_go_job_shards_and_derives_total_from_the_matrix():
     run = job["steps"][-1]["run"]
     assert "strategy.job-total" in run, "--total must come from the matrix, not a literal"
     assert "-race" in run
+
+
+# --- the inventory must not build a second variant -------------------------
+
+
+def test_inventory_command_forwards_the_go_args():
+    """`-list` builds test binaries, so it must build the ones the run will use.
+
+    Without the flags forwarded, `-list` compiles a whole non-race copy of every
+    test binary and the runs then compile the race copies from scratch -- two
+    full builds per shard, and the first one is thrown away. Measured on the
+    runner: ~22s of the shard's 262s.
+    """
+    argv = mod.inventory_argv(["-race", "-v"])
+    assert argv[:2] == ["go", "test"]
+    assert "-race" in argv
+    assert argv[-1] == "./..."
+
+
+def test_inventory_command_keeps_list_and_json():
+    argv = mod.inventory_argv(["-race"])
+    assert "-list" in argv
+    assert "-json" in argv

--- a/tests/unit/scripts/test_go_test_shard.py
+++ b/tests/unit/scripts/test_go_test_shard.py
@@ -1,0 +1,338 @@
+"""Tests for the Go test sharder.
+
+`go test -race ./...` is the longest job in CI (~390s of a ~400s critical path),
+and ~90% of that is the race detector's ~10x multiplier over 2717 serial tests.
+Sharding the run across a matrix splits the wall clock, but it introduces the one
+failure mode this repo has been bitten by before (the paths-filter incident of
+March 2026): a partition that silently stops covering some tests still reports
+green. Everything here exists to make that impossible --
+
+- `partition` must be exhaustive and disjoint over the live inventory, so no
+  (package, test) pair can fall through the buckets or be double-counted;
+- `verify_reported` must fail loudly when a test the shard *selected* produced no
+  result line, which is what a bad `-run` regex actually looks like from outside.
+
+The `-list`-driven inventory is exercised offline through the `--from-json` CLI
+contract; the partition and parsing logic is unit-tested directly.
+"""
+
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).parents[3] / "scripts" / "ci" / "go_test_shard.py"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("go_test_shard", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # Registered before exec: @dataclass resolves its own module through
+    # sys.modules, and blows up on a module that was never put there.
+    sys.modules["go_test_shard"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load_module()
+
+PKG = "github.com/camp/kindred/pocketbase/sync"
+OTHER = "github.com/camp/kindred/pocketbase/lodging"
+
+
+def inventory(names: list[str], pkg: str = PKG) -> list[tuple[str, str]]:
+    return [(pkg, n) for n in names]
+
+
+def run_cli(rows: list[dict[str, str]], extra: list[str]) -> tuple[int, str, str]:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--from-json", "-", "--plan", *extra],
+        input=json.dumps(rows),
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+# --- partition: the exhaustiveness contract -------------------------------
+
+
+def test_partition_is_exhaustive():
+    inv = inventory([f"Test{i:03d}" for i in range(50)])
+    buckets = mod.partition(inv, 4)
+    covered = [item for bucket in buckets for item in bucket]
+    assert sorted(covered) == sorted(inv)
+
+
+def test_partition_is_disjoint():
+    inv = inventory([f"Test{i:03d}" for i in range(50)])
+    buckets = mod.partition(inv, 4)
+    covered = [item for bucket in buckets for item in bucket]
+    assert len(covered) == len(set(covered)) == len(inv)
+
+
+def test_partition_returns_exactly_total_buckets():
+    inv = inventory([f"Test{i:03d}" for i in range(50)])
+    assert len(mod.partition(inv, 4)) == 4
+
+
+def test_partition_is_deterministic_across_calls():
+    inv = inventory([f"Test{i:03d}" for i in range(50)])
+    assert mod.partition(inv, 4) == mod.partition(inv, 4)
+
+
+def test_partition_is_insensitive_to_input_order():
+    """A shard must not change contents because `go list` reordered packages."""
+    names = [f"Test{i:03d}" for i in range(50)]
+    forward = mod.partition(inventory(names), 4)
+    backward = mod.partition(inventory(list(reversed(names))), 4)
+    assert forward == backward
+
+
+def test_partition_with_total_one_keeps_everything():
+    inv = inventory([f"Test{i:03d}" for i in range(50)])
+    assert mod.partition(inv, 1) == [sorted(inv)]
+
+
+def test_partition_balances_bucket_sizes_within_one():
+    inv = inventory([f"Test{i:03d}" for i in range(50)])
+    sizes = [len(b) for b in mod.partition(inv, 4)]
+    assert max(sizes) - min(sizes) <= 1
+
+
+def test_partition_handles_more_shards_than_tests():
+    inv = inventory(["TestOnly"])
+    buckets = mod.partition(inv, 4)
+    assert sum(len(b) for b in buckets) == 1
+    assert sum(1 for b in buckets if b) == 1
+
+
+def test_partition_deals_a_slow_cluster_across_shards():
+    """The ~3.1s tests cluster by name prefix; round-robin must deal them out.
+
+    Every `TestLodgingAssignmentsSync*` test pays the same ~3s schema-build cost
+    under -race. Bucketing them by hash-of-prefix or contiguous chunk would pile
+    the whole cluster into one shard and leave the critical path where it was.
+    """
+    cluster = [f"TestLodgingAssignmentsSync{i:02d}" for i in range(20)]
+    buckets = mod.partition(inventory(cluster), 4)
+    per_shard = [sum(1 for _, n in b if n.startswith("TestLodgingAssignmentsSync")) for b in buckets]
+    assert max(per_shard) - min(per_shard) <= 1
+
+
+def test_partition_keeps_same_named_tests_in_different_packages_distinct():
+    inv = [(PKG, "TestSync"), (OTHER, "TestSync")]
+    buckets = mod.partition(inv, 2)
+    covered = [item for bucket in buckets for item in bucket]
+    assert sorted(covered) == sorted(inv)
+
+
+def test_partition_rejects_a_nonpositive_total():
+    with pytest.raises(ValueError, match="total"):
+        mod.partition(inventory(["TestA"]), 0)
+
+
+# --- the -run regex -------------------------------------------------------
+
+
+def test_run_regex_is_anchored_and_alternated():
+    assert mod.build_run_regex(["TestA", "TestB"]) == "^(TestA|TestB)$"
+
+
+def test_run_regex_escapes_metacharacters():
+    """A name is a Go identifier today, but the regex must not assume it."""
+    assert mod.build_run_regex(["Test.A"]) == r"^(Test\.A)$"
+
+
+def test_run_regex_anchoring_still_admits_subtests():
+    """`-run` splits on `/`, so an anchored top-level pattern keeps subtests."""
+    pattern = mod.build_run_regex(["TestParent"])
+    assert re.match(pattern, "TestParent")
+    assert not re.match(pattern, "TestParentExtra")
+
+
+# --- reading back what actually ran ---------------------------------------
+
+
+def test_parse_reported_tests_reads_top_level_results():
+    output = "\n".join(
+        [
+            "=== RUN   TestAlpha",
+            "--- PASS: TestAlpha (0.10s)",
+            "--- FAIL: TestBeta (1.00s)",
+            "--- SKIP: TestGamma (0.00s)",
+            "ok  \tgithub.com/camp/kindred/pocketbase/sync\t1.234s",
+        ]
+    )
+    assert mod.parse_reported_tests(output) == {"TestAlpha", "TestBeta", "TestGamma"}
+
+
+def test_parse_reported_tests_ignores_indented_subtests():
+    output = "\n".join(
+        [
+            "--- PASS: TestAlpha (0.10s)",
+            "    --- PASS: TestAlpha/sub_case (0.01s)",
+            "        --- PASS: TestAlpha/sub_case/deeper (0.00s)",
+        ]
+    )
+    assert mod.parse_reported_tests(output) == {"TestAlpha"}
+
+
+def test_parse_reported_tests_on_empty_output():
+    assert mod.parse_reported_tests("") == set()
+
+
+def test_verify_reported_accepts_an_exact_match():
+    mod.verify_reported(PKG, {"TestA", "TestB"}, {"TestA", "TestB"})
+
+
+def test_verify_reported_rejects_a_missing_test():
+    """A `-run` regex that quietly matches nothing is the false-green case."""
+    with pytest.raises(mod.ShardError, match="TestB"):
+        mod.verify_reported(PKG, {"TestA", "TestB"}, {"TestA"})
+
+
+def test_verify_reported_tolerates_extra_reported_tests():
+    """Go may report a parent the sharder did not select; that is not a shortfall."""
+    mod.verify_reported(PKG, {"TestA"}, {"TestA", "TestSomethingElse"})
+
+
+# --- inventory parsing ----------------------------------------------------
+
+
+def test_parse_list_output_keeps_test_functions():
+    raw = "TestAlpha\nTestBeta\nok  \tgithub.com/camp/kindred/pocketbase/sync\t0.004s\n"
+    assert mod.parse_list_output(raw) == ["TestAlpha", "TestBeta"]
+
+
+def test_parse_list_output_drops_benchmarks_but_keeps_fuzz_and_examples():
+    """Benchmarks do not run under plain `go test`; fuzz seeds and examples do."""
+    raw = "TestAlpha\nBenchmarkThing\nFuzzParser\nExampleUsage\nok  \tpkg\t0.004s\n"
+    assert mod.parse_list_output(raw) == ["TestAlpha", "FuzzParser", "ExampleUsage"]
+
+
+def test_parse_list_output_ignores_no_test_files_notice():
+    raw = "?   \tgithub.com/camp/kindred/pocketbase/cmd\t[no test files]\n"
+    assert mod.parse_list_output(raw) == []
+
+
+# --- CLI contract ---------------------------------------------------------
+
+
+def test_cli_plan_lists_only_this_shards_tests():
+    rows = [{"package": PKG, "test": f"Test{i:03d}"} for i in range(8)]
+    code, out, err = run_cli(rows, ["--shard", "0", "--total", "4"])
+    assert code == 0, err
+    assert sorted(out.split()) == ["Test000", "Test004"]
+
+
+def test_cli_plan_shards_cover_the_whole_inventory():
+    rows = [{"package": PKG, "test": f"Test{i:03d}"} for i in range(30)]
+    seen: list[str] = []
+    for shard in range(4):
+        code, out, err = run_cli(rows, ["--shard", str(shard), "--total", "4"])
+        assert code == 0, err
+        seen.extend(out.split())
+    assert sorted(seen) == sorted(r["test"] for r in rows)
+
+
+def test_cli_rejects_a_shard_index_out_of_range():
+    rows = [{"package": PKG, "test": "TestA"}]
+    code, _, err = run_cli(rows, ["--shard", "4", "--total", "4"])
+    assert code != 0
+    assert "shard" in err.lower()
+
+
+def test_cli_rejects_an_empty_inventory():
+    """An inventory that came back empty means `-list` broke, not that there is
+    nothing to test -- running zero tests four times must not report green."""
+    code, _, err = run_cli([], ["--shard", "0", "--total", "4"])
+    assert code != 0
+    assert "empty" in err.lower() or "no tests" in err.lower()
+
+
+# --- command construction -------------------------------------------------
+
+
+def test_build_commands_emits_one_invocation_per_package():
+    selected = [(PKG, "TestA"), (OTHER, "TestB"), (PKG, "TestC")]
+    commands = mod.build_commands(selected, ["-race", "-v"])
+    # Set, not sequence -- ordering is a separate contract, pinned below.
+    assert sorted(c.package for c in commands) == sorted({PKG, OTHER})
+    assert len(commands) == 2
+
+
+def test_build_commands_scopes_each_regex_to_its_own_package():
+    """A shared regex across packages would re-run a name that exists in both.
+
+    No two packages collide on a test name today, but a future collision must
+    not silently double-run a test in one shard and skip it in another.
+    """
+    selected = [(PKG, "TestShared"), (OTHER, "TestOther")]
+    by_package = {c.package: c for c in mod.build_commands(selected, [])}
+    assert by_package[PKG].argv[-2] == "^(TestShared)$"
+    assert by_package[OTHER].argv[-2] == "^(TestOther)$"
+
+
+def test_build_commands_puts_the_package_last_and_forwards_go_args():
+    commands = mod.build_commands([(PKG, "TestA")], ["-race", "-v"])
+    assert commands[0].argv[:4] == ["go", "test", "-race", "-v"]
+    assert commands[0].argv[-1] == PKG
+
+
+def test_build_commands_sorts_names_for_a_stable_regex():
+    commands = mod.build_commands([(PKG, "TestB"), (PKG, "TestA")], [])
+    assert commands[0].argv[-2] == "^(TestA|TestB)$"
+
+
+def test_build_commands_orders_by_descending_test_count():
+    """Longest package first, so a thread pool is not left holding `sync` last."""
+    selected = [(OTHER, "TestX")] + [(PKG, f"Test{i}") for i in range(5)]
+    assert mod.build_commands(selected, [])[0].package == PKG
+
+
+def test_cli_rejects_a_nonpositive_jobs_value():
+    rows = [{"package": PKG, "test": "TestA"}]
+    code, _, err = run_cli(rows, ["--shard", "0", "--total", "1", "--jobs", "0"])
+    assert code != 0
+    assert "jobs" in err.lower()
+
+
+# --- Go's own test-result cache -------------------------------------------
+
+
+def test_is_cached_result_detects_the_cached_marker():
+    assert mod.is_cached_result("ok  \tgithub.com/camp/kindred/pocketbase/sync\t(cached)\n")
+
+
+def test_is_cached_result_is_false_for_a_real_run():
+    assert not mod.is_cached_result("ok  \tgithub.com/camp/kindred/pocketbase/sync\t1.234s\n")
+
+
+def test_is_cached_result_ignores_the_word_elsewhere():
+    assert not mod.is_cached_result("--- PASS: TestCachedTokenIsReused (0.01s)\n")
+
+
+def test_verify_reported_skips_the_check_on_a_cached_result():
+    """A cached `ok` prints no per-test lines, but it is not a coverage hole.
+
+    Go keys its test cache on the test binary *and* the command line, `-run`
+    regex included, so a cache hit is a genuine prior pass of exactly this
+    selection. Treating the missing `--- PASS` lines as a shortfall would turn a
+    warm GOCACHE into a red shard.
+    """
+    output = "ok  \tgithub.com/camp/kindred/pocketbase/sync\t(cached)\n"
+    mod.verify_reported(PKG, {"TestA", "TestB"}, mod.parse_reported_tests(output), output=output)
+
+
+def test_verify_reported_still_fails_a_shortfall_on_an_uncached_run():
+    output = "--- PASS: TestA (0.10s)\nok  \tpkg\t0.400s\n"
+    with pytest.raises(mod.ShardError, match="TestB"):
+        mod.verify_reported(PKG, {"TestA", "TestB"}, mod.parse_reported_tests(output), output=output)


### PR DESCRIPTION
## Why

`go test -race ./...` was the entire CI critical path. On PR #2280's last complete
run, the Go Tests job took **399s** while the next-slowest job (Frontend Tests)
took 156s — everything else finished inside 145s and then waited.

Almost none of that is test volume. Measured back-to-back on one machine under
identical load:

| Package | non-race | `-race` | ratio |
|---|---|---|---|
| `sync` | 60.8s | 298.2s | 4.9x |
| `lodging` | 35.1s | 136.6s | 3.9x |

The race detector costs **~4.5x**, and it pays that **serially** — there is
exactly one `t.Parallel()` in the whole Go tree, and it sits inside a subtest, so
no two *top-level* tests ever overlap. `user` time tracked `real` on every run:
one core busy, the rest idle.

(An earlier revision of this PR claimed ~10x off a 43s baseline. That came from
generalising the `TestLodgingAssignmentsSync*` slice — genuinely 10.3x, because
it is schema-build heavy — to the whole suite, against a baseline measured on an
idle machine. Corrected here and in every file, and in kindred#2281. The `-race`
side was always right: local 298.2s/136.6s matches CI's 297s/143s.)

Two packages carry all of it:

| Package | `-race` time |
|---|---|
| `sync` | 297s |
| `lodging` | 143s |
| other nine, combined | ~15s |

That is why this shards **by individual test function, not by package**. A
per-package split would leave `sync` as a 297s shard and change nothing.

## What

`scripts/ci/go_test_shard.py` reads the inventory live from `go test -list`,
deals it round-robin over sorted order into N buckets, and runs one `go test` per
package concurrently within the shard.

- **Sorted, then round-robin.** Sorting makes the split independent of `go list`
  ordering. Round-robin spreads the name-clustered slow tests — every
  `TestLodgingAssignmentsSync*` pays the same ~3s schema build — instead of
  piling a cluster into one shard.
- **Per-package `-run` regex, run concurrently.** One invocation per package
  would throw away the cross-package parallelism a plain `go test ./...` gets for
  free, and that is not a rounding error: running a shard's slice of `sync` (~74s)
  after its slice of `lodging` (~37s) rather than alongside it cost half the win
  (148s → 85s once fixed).
- **`--total` comes from `strategy.job-total`**, so editing the `shard:` matrix
  list is the only change needed to re-shard. The two cannot drift.

- **The inventory build reuses the run's build.** `go test -list` has to compile
  a test binary to read its names, and a build is per-flag-set — so the flags are
  forwarded. Getting this wrong cost ~95s per shard, because each one compiled a
  full non-race copy of the tree and threw it away before compiling the race copy.

## Measured on CI

| | before | after |
|---|---|---|
| Go Tests | **399s** | **191s** |
| longest shard step | — | 173s |

Per-shard, that 173s is roughly ~90s of `-race` compile and ~80s of test
execution (`sync` 78s with `lodging` 39s alongside it). Python Tests at 113s is
now the next-longest job, and on a run that touches the frontend, Frontend Tests
at ~156s comes close to tying it.

### The remaining floor is compile, not tests

Worth recording, because it caps what more sharding can buy: **every Go job
shares one build cache keyed on `go.sum` alone** —

```
setup-go-Linux-x64-ubuntu24-go-1.26.5-9dda164e…
```

Go Lint (`go vet`), Migration Smoke Test (`go build`) and Go Tests (`-race`) all
restore that same key, so it holds whichever build variant happened to save it
first — a non-race one. Actions cache entries are immutable, so nothing ever
re-saves it, and the race-instrumented objects are never cached at all. Each
shard recompiles them from scratch.

That is a per-shard *floor* that does not shard: 8 shards would be ~90s + 40s
rather than ~90s + 80s. Warming it would need a race-specific cache key worth
about 240MB (a local build cache goes 215M → 456M when race objects are added),
which is a real cost against the 10GB Actions ceiling this repo already sits at
with CodeQL taking ~9.5GB of it. Left alone deliberately — flagging it rather
than spending that budget unasked.

## The part that actually matters

Sharding introduces one failure mode: a partition that quietly stops covering
some tests and still reports green. That is the paths-filter incident of March
2026 wearing a different hat, and most of the design is about closing it off.

1. **The inventory is read live** from `go test -list` on every run, so a newly
   added test is picked up by construction. There is no checked-in list to drift.
2. **The buckets are asserted exhaustive and disjoint** over that inventory.
3. **Each shard reads back which tests actually reported a result** and fails if
   anything it selected never ran. A `-run` regex that matches nothing looks
   exactly like a passing shard from outside; this is what catches it.

A Go test-cache hit is exempt from (3), because it prints one `ok … (cached)`
line and no per-test transcript. That is not a coverage hole — Go keys its test
cache on the test binary *and* the command line, `-run` regex included — and
without the exemption a warm `GOCACHE` would turn every unchanged package red.

## Verification

- **38 unit tests**, written before the implementation, covering the partition
  contract, regex construction, result parsing, the cached-result exemption, and
  the CLI.
- **Mutation-checked** — I broke each guard in turn and confirmed the suite goes
  red: dropping a bucket (3 failures), neutering `verify_reported` (1),
  unanchoring the `-run` regex (5), removing the empty-inventory guard (1).
- **End-to-end**: all four shards run green against real `go test`, reporting
  exactly 290/290/290/289 top-level tests = **1159 total**, matching
  `go test -list` with zero duplicates.
- **Guard fires for real**: feeding a shard a test name that does not exist exits
  **1** with `2 selected test(s) never ran: …`, rather than passing green.
- `scripts/pre-push-verify.sh` clean (6126 passed), `actionlint` clean, `zizmor
  --min-severity medium` clean, ruff/mypy/markdownlint clean.

## Review round

Scanned with CodeRabbit plus a five-agent pass; eight findings, all fixed.

The substantive one: the coverage guard parsed `--- PASS:` lines, which Go only
prints under `-v`. That made it silently depend on a flag nothing enforced — drop
`-v` and every *passing* package reported as a coverage hole, failing the shard
100% of the time. A false alarm shaped exactly like the bug the script exists to
catch. Runs now use `go test -json` and read structured per-test events, which
also deleted a cached-result special case that had been justified by a claim I
never tested and that turns out to be false (under `-v`, a cache hit replays the
whole transcript). Verified: real passing tests without `-v` went exit 1 → exit 0,
while a genuine hole still exits 1.

Also fixed: an empty shard crashed `ThreadPoolExecutor`; `ci.yml` was missing from
the `go` filter, so editing the matrix would have skipped Go Tests entirely (this
PR's own last CI run is the proof — it touched only `ci.yml` and a test file, and
Go Tests ran); and the `~10x` race multiplier was wrong, corrected to ~4.5x
throughout after re-measuring back-to-back.

## Follow-up

kindred#2281 adds `t.Parallel()` to `sync` and `lodging` — the durable fix, which
buys the same wall clock without 4x the runner minutes and speeds up local runs
too. Once it lands, shrinking the matrix list here is a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
