### PR TITLE
fix(sync): make orphan sweeps see the whole table, and refuse a collapsed one

### DIFF
--- a/pocketbase/pb_migrations/1500000151_custom_values_orphan_scan_index.js
+++ b/pocketbase/pb_migrations/1500000151_custom_values_orphan_scan_index.js
@@ -1,0 +1,77 @@
+/**
+ * Migration: give the orphan sweep an index it can scan in order.
+ *
+ * kindred#2266 uncapped the orphan sweep for person_custom_values and
+ * household_custom_values. Uncapping it exposed a planner problem that the
+ * 10,000-row cap had been hiding.
+ *
+ * The scan reads `year = ? ORDER BY id`. person_custom_values' only usable
+ * index is idx_person_cf_vals_field on (year, field_definition), which does not
+ * mention id, so SQLite satisfies the WHERE from that index and then sorts the
+ * whole year through a temp b-tree -- once per page. Measured on a copy of the
+ * production snapshot before this migration:
+ *
+ *   EXPLAIN QUERY PLAN SELECT * FROM person_custom_values
+ *     WHERE year=2026 ORDER BY id LIMIT 500;
+ *   |--SEARCH person_custom_values USING INDEX idx_person_cf_vals_field (year=?)
+ *   `--USE TEMP B-TREE FOR ORDER BY
+ *
+ * 2026 holds ~156k rows in that table, so the sweep sorted ~156k rows for every
+ * page it read. persons, by contrast, already seeks correctly through its
+ * primary-key index, which is why only these two tables need this.
+ *
+ * (year, id) is the smallest index that removes the sort: it satisfies the
+ * equality and yields rows already ordered by id.
+ *
+ * NOT UNIQUE, deliberately. id is already unique on its own; this index exists
+ * for ordering, not for a constraint. A unique index here would add a second
+ * uniqueness rule with nothing behind it and would fail the migration on any
+ * table that ever legitimately repeated a (year, id) pair.
+ *
+ * Idempotent by name: `_migrations` keys on filename, so editing an
+ * already-applied migration silently skips it. addIndex therefore removes any
+ * index carrying the same name before pushing, so a re-run cannot leave two.
+ * Lifted from 1500000147 and 1500000150.
+ */
+/// <reference path="../pb_data/types.d.ts" />
+
+const SCAN_INDEXES = [
+  {
+    collection: "person_custom_values",
+    name: "idx_person_custom_values_year_id",
+    sql:
+      "CREATE INDEX `idx_person_custom_values_year_id` " +
+      "ON `person_custom_values` (`year`, `id`)",
+  },
+  {
+    collection: "household_custom_values",
+    name: "idx_household_custom_values_year_id",
+    sql:
+      "CREATE INDEX `idx_household_custom_values_year_id` " +
+      "ON `household_custom_values` (`year`, `id`)",
+  },
+];
+
+function withoutIndex(col, name) {
+  return col.indexes.filter(function (sql) {
+    return sql.indexOf("`" + name + "`") === -1;
+  });
+}
+
+migrate(
+  function (app) {
+    for (const idx of SCAN_INDEXES) {
+      const col = app.findCollectionByNameOrId(idx.collection);
+      col.indexes = withoutIndex(col, idx.name);
+      col.indexes.push(idx.sql);
+      app.save(col);
+    }
+  },
+  function (app) {
+    for (const idx of SCAN_INDEXES) {
+      const col = app.findCollectionByNameOrId(idx.collection);
+      col.indexes = withoutIndex(col, idx.name);
+      app.save(col);
+    }
+  },
+);

--- a/pocketbase/sync/attendees.go
+++ b/pocketbase/sync/attendees.go
@@ -370,7 +370,7 @@ func (s *AttendeesSync) deleteOrphans() error {
 		return fmt.Errorf("loading session mappings for orphan detection: %w", err)
 	}
 
-	return s.DeleteOrphans(
+	return s.DeleteOrphansGuarded(
 		"attendees",
 		func(record *core.Record) (string, bool) {
 			personCMID, _ := record.Get("person_id").(float64)
@@ -392,5 +392,11 @@ func (s *AttendeesSync) deleteOrphans() error {
 		},
 		"attendee",
 		filter,
+		OrphanSweepGuard{
+			Entity:   "attendees",
+			Year:     year,
+			Computed: len(s.ProcessedKeys),
+			Hint:     "check that the sessions sync ran for that year -- an empty session table empties every attendee key",
+		},
 	)
 }

--- a/pocketbase/sync/attendees.go
+++ b/pocketbase/sync/attendees.go
@@ -396,7 +396,8 @@ func (s *AttendeesSync) deleteOrphans() error {
 			Entity:   "attendees",
 			Year:     year,
 			Computed: len(s.ProcessedKeys),
-			Hint:     "check that the sessions sync ran for that year -- an empty session table empties every attendee key",
+			Hint: "check that the CampMinder attendee feed returned this season (a collapsed " +
+				"camp_sessions table shows up as the unkeyable-record warning above, not here)",
 		},
 	)
 }

--- a/pocketbase/sync/base_sync.go
+++ b/pocketbase/sync/base_sync.go
@@ -224,7 +224,7 @@ func (b *BaseSyncService) deleteOrphans(
 		return nil
 	}
 
-	orphans, inspected, err := b.collectOrphans(collection, getIDFunc, entityName, filter)
+	orphans, inspected, seen, err := b.collectOrphans(collection, getIDFunc, entityName, filter)
 	if err != nil {
 		return err
 	}
@@ -233,6 +233,21 @@ func (b *BaseSyncService) deleteOrphans(
 		if guardErr := guard.Check(inspected); guardErr != nil {
 			return guardErr
 		}
+	}
+
+	// Rows were read but NONE could be keyed. This is the one collapse the guard
+	// structurally cannot catch: its denominator is `inspected`, which counts only
+	// keyable rows, so a total mapping failure presents to Check as an empty table
+	// rather than as a collapse. The sweep is safe -- `orphans` is empty, nothing
+	// is deleted -- but without this line it is indistinguishable in the log from
+	// a healthy year with no orphans, and three services' operator hints point
+	// here by name. Warn and stop: the "no orphans found" message below would be
+	// a lie about a run that inspected nothing.
+	if seen > 0 && inspected == 0 {
+		slog.Warn("Orphan sweep skipped: no record could be keyed, so the upstream mapping has collapsed",
+			"entity", entityName, "collection", collection, "records_read", seen,
+			"detail", "unkeyable records -- deleting nothing; check the sync that builds this key")
+		return nil
 	}
 
 	orphanCount := 0
@@ -244,13 +259,16 @@ func (b *BaseSyncService) deleteOrphans(
 			continue
 		}
 
-		orphanCount++
 		slog.Info("Deleting orphaned record", "entity", entityName, "name", candidate.name, "id", candidate.key)
 
+		// Counted AFTER the delete lands. A failed delete leaves the row on disk,
+		// and reporting it as deleted tells an operator the opposite of the truth.
 		if err := b.App.Delete(record); err != nil {
 			slog.Error("Failed to delete orphaned record", "entity", entityName, "id", candidate.key, "error", err)
 			b.Stats.Errors++
+			continue
 		}
+		orphanCount++
 	}
 
 	if orphanCount > 0 {
@@ -271,9 +289,10 @@ func (b *BaseSyncService) collectOrphans(
 	getIDFunc func(record *core.Record) (string, bool),
 	entityName string,
 	filter string,
-) ([]orphanCandidate, int, error) {
+) ([]orphanCandidate, int, int, error) {
 	var orphans []orphanCandidate
 	inspected := 0
+	seen := 0
 	cursor := ""
 	perPage := DefaultPageSize
 
@@ -282,7 +301,7 @@ func (b *BaseSyncService) collectOrphans(
 
 		records, err := b.App.FindRecordsByFilter(collection, pageFilter, "id", perPage, 0, params)
 		if err != nil {
-			return nil, 0, fmt.Errorf("loading %ss for orphan check: %w", entityName, err)
+			return nil, 0, 0, fmt.Errorf("loading %ss for orphan check: %w", entityName, err)
 		}
 		if len(records) == 0 {
 			break
@@ -290,6 +309,7 @@ func (b *BaseSyncService) collectOrphans(
 
 		for _, record := range records {
 			cursor = record.Id
+			seen++
 
 			idKey, ok := getIDFunc(record)
 			if !ok {
@@ -313,7 +333,7 @@ func (b *BaseSyncService) collectOrphans(
 		}
 	}
 
-	return orphans, inspected, nil
+	return orphans, inspected, seen, nil
 }
 
 // keysetPage composes a caller filter with the keyset cursor. The cursor is

--- a/pocketbase/sync/base_sync.go
+++ b/pocketbase/sync/base_sync.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/camp/kindred/pocketbase/campminder"
-	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase/core"
 )
 
@@ -289,26 +288,45 @@ func (b *BaseSyncService) collectOrphans(
 	getIDFunc func(record *core.Record) (string, bool),
 	entityName string,
 	filter string,
-) ([]orphanCandidate, int, int, error) {
-	var orphans []orphanCandidate
-	inspected := 0
-	seen := 0
-	cursor := ""
-	perPage := DefaultPageSize
+) (orphans []orphanCandidate, inspected, seen int, err error) {
+	offset := 0
+	perPage := LargePageSize
 
 	for {
-		pageFilter, params := keysetPage(filter, cursor)
-
-		records, err := b.App.FindRecordsByFilter(collection, pageFilter, "id", perPage, 0, params)
+		// OFFSET paging, and the caller's filter passed through UNCHANGED and
+		// parameter-free. Both halves are deliberate.
+		//
+		// Offset is safe here and was not safe before, because this scan writes
+		// nothing. The original defect was a loop that deleted while paging by
+		// offset: each delete shrank the result set the next offset was measured
+		// against and slid that many unread rows past the cursor permanently.
+		// Splitting collect from delete removed the mutation, and with it the
+		// reason a cursor was needed. What remains of the risk is a concurrent
+		// writer shifting the window, and its only failure mode is UNDER-reading:
+		// a row missed this run is simply swept on the next one. It cannot
+		// over-delete, because a candidate has to be read and rejected by
+		// getIDFunc's key lookup to become an orphan at all, and a row read twice
+		// is deleted once (the second FindRecordById finds nothing and skips).
+		//
+		// The filter must stay parameter-free because PocketBase substitutes
+		// {:params} into the raw filter BEFORE deriving its parse-cache key
+		// (tools/search/filter.go:78 then :82) and stores it in a package-level
+		// cache capped at 500 entries that never evicts (tools/store/store.go:218).
+		// A per-page cursor in the filter therefore mints one dead entry per page
+		// -- roughly 1,553 for a single year of person_custom_values -- and once
+		// 500 accumulate, no filter expression anywhere in the process can be
+		// cached again for the life of the container. Sorting by id keeps the
+		// window stable without putting anything per-page into the filter.
+		records, err := b.App.FindRecordsByFilter(collection, filter, "id", perPage, offset)
 		if err != nil {
 			return nil, 0, 0, fmt.Errorf("loading %ss for orphan check: %w", entityName, err)
 		}
 		if len(records) == 0 {
 			break
 		}
+		offset += len(records)
 
 		for _, record := range records {
-			cursor = record.Id
 			seen++
 
 			idKey, ok := getIDFunc(record)
@@ -334,22 +352,6 @@ func (b *BaseSyncService) collectOrphans(
 	}
 
 	return orphans, inspected, seen, nil
-}
-
-// keysetPage composes a caller filter with the keyset cursor. The cursor is
-// bound as a query parameter rather than interpolated, so a record ID can never
-// be read as filter syntax.
-func keysetPage(filter, cursor string) (string, dbx.Params) {
-	if cursor == "" {
-		return filter, nil
-	}
-
-	params := dbx.Params{"orphanCursor": cursor}
-	if filter == "" {
-		return "id > {:orphanCursor}", params
-	}
-
-	return "(" + filter + ") && id > {:orphanCursor}", params
 }
 
 // FindOrphansFromPreloaded identifies orphan keys from preloaded records.

--- a/pocketbase/sync/base_sync.go
+++ b/pocketbase/sync/base_sync.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/camp/kindred/pocketbase/campminder"
+	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase/core"
 )
 
@@ -154,58 +155,98 @@ func (b *BaseSyncService) DeleteOrphans(
 	entityName string,
 	filter string,
 ) error {
+	return b.deleteOrphans(collection, getIDFunc, entityName, filter, nil)
+}
+
+// DeleteOrphansGuarded is DeleteOrphans with a collapse guard in front of the
+// deletes: the sweep is abandoned, and an error returned, when this run's
+// computed set is too small to be believed (see OrphanSweepGuard).
+//
+// It is a separate entry point rather than a change to DeleteOrphans because the
+// guard needs the caller to vouch that len(ProcessedKeys) is comparable to the
+// rows the filter selects. That holds for the services that clear the tracker
+// per run and key it to exactly one collection and one year; it does not hold
+// for a caller that sweeps several collections from one tracker, or one that
+// sweeps every year from a single season's keys. Opting in keeps the guard's
+// denominator honest.
+func (b *BaseSyncService) DeleteOrphansGuarded(
+	collection string,
+	getIDFunc func(record *core.Record) (string, bool),
+	entityName string,
+	filter string,
+	guard OrphanSweepGuard,
+) error {
+	return b.deleteOrphans(collection, getIDFunc, entityName, filter, &guard)
+}
+
+// orphanCandidate is the minimum needed to delete and log one orphan later.
+// Deliberately not the *core.Record: a year of person_custom_values is ~157k
+// rows, and holding them all to delete a handful is how a sweep turns into an
+// OOM.
+type orphanCandidate struct {
+	id   string
+	key  string
+	name string
+}
+
+// deleteOrphans runs the sweep in two phases: a read-only scan that collects the
+// orphans, then the deletes.
+//
+// The split is not stylistic. It fixes two defects at once:
+//
+//  1. The scan used OFFSET pagination -- page N read at offset (N-1)*perPage --
+//     while deleting inside the loop. Every delete shrinks the result set the
+//     next offset is measured against, so k deletes on a page slide k unread
+//     records past the cursor, permanently. With a full page of orphans the
+//     sweep skipped a whole page each time round. The scan is now KEYSET
+//     (cursor) paginated: ordered by id, each page asking for id > the last id
+//     seen. A cursor over a stable ordering cannot be moved by anything the
+//     sweep does, and since phase 1 writes nothing, nothing moves it at all.
+//
+//  2. The guard has to see the whole picture before the first delete. A ratio
+//     over rows-inspected-so-far is meaningless mid-scan; by the time a partial
+//     collapse became visible, a delete-as-you-go loop would already have
+//     deleted most of the year.
+func (b *BaseSyncService) deleteOrphans(
+	collection string,
+	getIDFunc func(record *core.Record) (string, bool),
+	entityName string,
+	filter string,
+	guard *OrphanSweepGuard,
+) error {
 	// Only delete orphans if the sync was successful
 	if !b.SyncSuccessful {
 		slog.Info("Skipping orphan deletion due to sync failure", "entity", entityName)
 		return nil
 	}
 
+	orphans, inspected, err := b.collectOrphans(collection, getIDFunc, entityName, filter)
+	if err != nil {
+		return err
+	}
+
+	if guard != nil {
+		if guardErr := guard.Check(inspected); guardErr != nil {
+			return guardErr
+		}
+	}
+
 	orphanCount := 0
-	page := 1
-	perPage := DefaultPageSize
-
-	for {
-		// Get records from PocketBase
-		records, err := b.App.FindRecordsByFilter(
-			collection,
-			filter,
-			"-created",
-			perPage,
-			(page-1)*perPage,
-		)
-		if err != nil {
-			return fmt.Errorf("loading %ss for orphan check: %w", entityName, err)
+	for _, candidate := range orphans {
+		record, findErr := b.App.FindRecordById(collection, candidate.id)
+		if findErr != nil {
+			slog.Warn("Orphaned record vanished before deletion",
+				"entity", entityName, "id", candidate.key, "error", findErr)
+			continue
 		}
 
-		// Check each record
-		for _, record := range records {
-			idKey, ok := getIDFunc(record)
-			if !ok {
-				continue
-			}
+		orphanCount++
+		slog.Info("Deleting orphaned record", "entity", entityName, "name", candidate.name, "id", candidate.key)
 
-			// Check if this record was processed using base class tracking
-			wasProcessed := b.ProcessedKeys[idKey]
-
-			if !wasProcessed {
-				// This record exists in PocketBase but not in CampMinder
-				orphanCount++
-
-				// Try to get a descriptive name for logging
-				name := b.getRecordName(record, entityName)
-				slog.Info("Deleting orphaned record", "entity", entityName, "name", name, "id", idKey)
-
-				if err := b.App.Delete(record); err != nil {
-					slog.Error("Failed to delete orphaned record", "entity", entityName, "id", idKey, "error", err)
-					b.Stats.Errors++
-				}
-			}
+		if err := b.App.Delete(record); err != nil {
+			slog.Error("Failed to delete orphaned record", "entity", entityName, "id", candidate.key, "error", err)
+			b.Stats.Errors++
 		}
-
-		if len(records) < perPage {
-			break
-		}
-		page++
 	}
 
 	if orphanCount > 0 {
@@ -215,6 +256,76 @@ func (b *BaseSyncService) DeleteOrphans(
 	}
 
 	return nil
+}
+
+// collectOrphans walks the whole filtered set read-only and returns the records
+// that this run did not process, plus the number of records it was able to key
+// (the sweep's denominator -- records getIDFunc rejects are never deletion
+// candidates and must not count towards the guard's ratio).
+func (b *BaseSyncService) collectOrphans(
+	collection string,
+	getIDFunc func(record *core.Record) (string, bool),
+	entityName string,
+	filter string,
+) ([]orphanCandidate, int, error) {
+	var orphans []orphanCandidate
+	inspected := 0
+	cursor := ""
+	perPage := DefaultPageSize
+
+	for {
+		pageFilter, params := keysetPage(filter, cursor)
+
+		records, err := b.App.FindRecordsByFilter(collection, pageFilter, "id", perPage, 0, params)
+		if err != nil {
+			return nil, 0, fmt.Errorf("loading %ss for orphan check: %w", entityName, err)
+		}
+		if len(records) == 0 {
+			break
+		}
+
+		for _, record := range records {
+			cursor = record.Id
+
+			idKey, ok := getIDFunc(record)
+			if !ok {
+				continue
+			}
+			inspected++
+
+			if b.ProcessedKeys[idKey] {
+				continue
+			}
+
+			orphans = append(orphans, orphanCandidate{
+				id:   record.Id,
+				key:  idKey,
+				name: b.getRecordName(record, entityName),
+			})
+		}
+
+		if len(records) < perPage {
+			break
+		}
+	}
+
+	return orphans, inspected, nil
+}
+
+// keysetPage composes a caller filter with the keyset cursor. The cursor is
+// bound as a query parameter rather than interpolated, so a record ID can never
+// be read as filter syntax.
+func keysetPage(filter, cursor string) (string, dbx.Params) {
+	if cursor == "" {
+		return filter, nil
+	}
+
+	params := dbx.Params{"orphanCursor": cursor}
+	if filter == "" {
+		return "id > {:orphanCursor}", params
+	}
+
+	return "(" + filter + ") && id > {:orphanCursor}", params
 }
 
 // FindOrphansFromPreloaded identifies orphan keys from preloaded records.

--- a/pocketbase/sync/base_sync.go
+++ b/pocketbase/sync/base_sync.go
@@ -192,21 +192,25 @@ type orphanCandidate struct {
 // deleteOrphans runs the sweep in two phases: a read-only scan that collects the
 // orphans, then the deletes.
 //
-// The split is not stylistic. It fixes two defects at once:
+// The split is what fixes the skipping. The old loop paginated with OFFSET --
+// page N read at offset (N-1)*perPage -- while deleting inside the loop, so
+// every delete shrank the result set the next offset was measured against and
+// slid that many unread records past the cursor, permanently. A full page of
+// orphans skipped a whole page each time round. A scan that writes nothing
+// cannot move its own cursor, whatever the paging scheme.
 //
-//  1. The scan used OFFSET pagination -- page N read at offset (N-1)*perPage --
-//     while deleting inside the loop. Every delete shrinks the result set the
-//     next offset is measured against, so k deletes on a page slide k unread
-//     records past the cursor, permanently. With a full page of orphans the
-//     sweep skipped a whole page each time round. The scan is now KEYSET
-//     (cursor) paginated: ordered by id, each page asking for id > the last id
-//     seen. A cursor over a stable ordering cannot be moved by anything the
-//     sweep does, and since phase 1 writes nothing, nothing moves it at all.
+// The split is also what makes the guard possible: a ratio over
+// rows-inspected-so-far means nothing mid-scan, and by the time a partial
+// collapse became visible a delete-as-you-go loop would already have deleted
+// most of the year.
 //
-//  2. The guard has to see the whole picture before the first delete. A ratio
-//     over rows-inspected-so-far is meaningless mid-scan; by the time a partial
-//     collapse became visible, a delete-as-you-go loop would already have
-//     deleted most of the year.
+// The scan is additionally KEYSET (cursor) paginated -- ordered by id, each page
+// asking for id > the last id seen -- rather than by offset. That is a separate
+// point and worth keeping: the old sort was "-created", which is not a unique
+// ordering, and LIMIT/OFFSET over a non-unique ORDER BY may repeat or skip rows
+// across page boundaries entirely on its own. Keyset over the primary key has no
+// such boundary, and it keeps the sweep correct if anyone ever moves a delete
+// back inside the scan.
 func (b *BaseSyncService) deleteOrphans(
 	collection string,
 	getIDFunc func(record *core.Record) (string, bool),

--- a/pocketbase/sync/bunk_assignments.go
+++ b/pocketbase/sync/bunk_assignments.go
@@ -564,7 +564,7 @@ func (s *BunkAssignmentsSync) deleteOrphans() error {
 		return fmt.Errorf("loading mappings for orphan detection: %w", err)
 	}
 
-	return s.DeleteOrphans(
+	return s.DeleteOrphansGuarded(
 		"bunk_assignments",
 		func(record *core.Record) (string, bool) {
 			mapping := assignmentMappings[record.Id]
@@ -586,5 +586,11 @@ func (s *BunkAssignmentsSync) deleteOrphans() error {
 		},
 		"bunk assignment",
 		filter,
+		OrphanSweepGuard{
+			Entity:   "bunk_assignments",
+			Year:     year,
+			Computed: len(s.ProcessedKeys),
+			Hint:     "check the persons and camp_sessions tables for that year -- the assignment keys are built from both",
+		},
 	)
 }

--- a/pocketbase/sync/bunk_assignments.go
+++ b/pocketbase/sync/bunk_assignments.go
@@ -590,7 +590,9 @@ func (s *BunkAssignmentsSync) deleteOrphans() error {
 			Entity:   "bunk_assignments",
 			Year:     year,
 			Computed: len(s.ProcessedKeys),
-			Hint:     "check the persons and camp_sessions tables for that year -- the assignment keys are built from both",
+			Hint: "check that the CampMinder bunk-assignment feed returned this season (a " +
+				"collapsed persons or camp_sessions table shows up as the unkeyable-record " +
+				"warning above, not here)",
 		},
 	)
 }

--- a/pocketbase/sync/bunk_plans.go
+++ b/pocketbase/sync/bunk_plans.go
@@ -502,7 +502,9 @@ func (s *BunkPlansSync) deleteOrphans() error {
 			Entity:   "bunk_plans",
 			Year:     year,
 			Computed: len(s.ProcessedKeys),
-			Hint:     "check the bunks and camp_sessions tables for that year -- the plan keys are built from both",
+			Hint: "check that the CampMinder bunk-plan feed returned this season (a collapsed " +
+				"bunks or camp_sessions table shows up as the unkeyable-record warning " +
+				"above, not here)",
 		},
 	)
 }

--- a/pocketbase/sync/bunk_plans.go
+++ b/pocketbase/sync/bunk_plans.go
@@ -474,7 +474,7 @@ func (s *BunkPlansSync) deleteOrphans() error {
 		return fmt.Errorf("loading mappings for orphan detection: %w", err)
 	}
 
-	return s.DeleteOrphans(
+	return s.DeleteOrphansGuarded(
 		"bunk_plans",
 		func(record *core.Record) (string, bool) {
 			mapping := planMappings[record.Id]
@@ -498,5 +498,11 @@ func (s *BunkPlansSync) deleteOrphans() error {
 		},
 		"bunk plan",
 		filter,
+		OrphanSweepGuard{
+			Entity:   "bunk_plans",
+			Year:     year,
+			Computed: len(s.ProcessedKeys),
+			Hint:     "check the bunks and camp_sessions tables for that year -- the plan keys are built from both",
+		},
 	)
 }

--- a/pocketbase/sync/household_custom_field_values.go
+++ b/pocketbase/sync/household_custom_field_values.go
@@ -407,23 +407,25 @@ func (s *HouseholdCustomFieldValuesSync) syncHouseholdCustomFieldValues(
 // deleteOrphans removes custom field values that were not seen in this sync.
 //
 // This used to be a hand-rolled loop over a single FindRecordsByFilter capped at
-// 10,000 rows with no surrounding pagination (kindred#2266). 10,000 is a hard
-// cap, not a page size: production years hold 128,606-184,458 rows, so the sweep
-// inspected 5.4-7.8% of the year and a value deleted in CampMinder simply
-// survived, feeding every derived table that reads this one. Routing through the
+// 10,000 rows with no surrounding pagination -- the latent twin in kindred#2266.
+// 10,000 is a hard cap, not a page size. It has not bitten here only because the
+// table is small: the largest year holds 1,773 rows against person_custom_values'
+// 128,606-184,458. The cap would start silently dropping this table's orphans the
+// moment a year crossed it, so it goes now rather than later. Routing through the
 // shared guarded sweep replaces the cap with keyset pagination and picks up the
 // collapse guard, so there is one implementation instead of a local copy.
 //
-// sweptOwners is the set of household PB IDs whose values were successfully fetched
-// during THIS run, and it is what makes the fix safe rather than catastrophic.
-// The sweep's filter is the whole year, but the computed set is only ever as
-// wide as the run: this service takes a ?session= filter (api.go), and a
-// session resolves to the persons enrolled in it -- in the current season the
-// largest single session covers about 11% of the people who hold custom values.
-// Uncapping the read without narrowing the judgement would have let one
-// session-scoped run delete the other ~89% of the year as orphans. A row is a
-// candidate only if this run actually fetched that household's values; anything else
-// is invisible to the sweep, exactly as it should be.
+// sweptOwners is the set of household PB IDs whose values were successfully
+// fetched during THIS run, and it is what makes the fix safe rather than
+// catastrophic. The sweep's filter is the whole year, but the computed set is
+// only ever as wide as the run: this service takes a ?session= filter (api.go),
+// and getHouseholdIDsToSync resolves that session through
+// GetHouseholdIDsForSession to the households with someone enrolled in it --
+// a fraction of the year. Uncapping the read without narrowing the judgement
+// would have let one session-scoped run delete every other session's households'
+// values as orphans. A row is a candidate only if this run actually fetched that
+// household's values; anything else is invisible to the sweep, exactly as it
+// should be.
 func (s *HouseholdCustomFieldValuesSync) deleteOrphans(year int, sweptOwners map[string]bool) error {
 	return s.DeleteOrphansGuarded(
 		"household_custom_values",

--- a/pocketbase/sync/household_custom_field_values.go
+++ b/pocketbase/sync/household_custom_field_values.go
@@ -130,6 +130,12 @@ func (s *HouseholdCustomFieldValuesSync) Sync(ctx context.Context) error {
 
 	s.SyncSuccessful = true
 
+	// Only households whose values this run actually fetched may be judged by the
+	// orphan sweep. A ?session= filter narrows the run to one session's households
+	// while the sweep's filter is the whole year, so without this set a
+	// session-scoped run would delete every other session's values as orphans.
+	sweptOwners := make(map[string]bool, len(householdIDs))
+
 	// Process each household
 	for i, householdCMID := range householdIDs {
 		select {
@@ -162,11 +168,16 @@ func (s *HouseholdCustomFieldValuesSync) Sync(ctx context.Context) error {
 				"household_cm_id", householdCMID,
 				"error", err)
 			s.Stats.Errors++
+			// A household whose fetch failed was not fully seen; leaving them out of
+			// sweptOwners keeps the sweep from reading a partial fetch as deletions.
+			continue
 		}
+
+		sweptOwners[householdPBId] = true
 	}
 
 	// Delete orphans
-	if err := s.deleteOrphans(year); err != nil {
+	if err := s.deleteOrphans(year, sweptOwners); err != nil {
 		slog.Error("Error deleting orphan custom field values", "error", err)
 	}
 
@@ -393,40 +404,49 @@ func (s *HouseholdCustomFieldValuesSync) syncHouseholdCustomFieldValues(
 	return nil
 }
 
-// deleteOrphans removes custom field values that were not seen in this sync
-func (s *HouseholdCustomFieldValuesSync) deleteOrphans(year int) error {
-	filter := fmt.Sprintf("year = %d", year)
-	records, err := s.App.FindRecordsByFilter("household_custom_values", filter, "", 10000, 0, nil)
-	if err != nil {
-		return fmt.Errorf("finding records for orphan check: %w", err)
-	}
-
-	deleted := 0
-	for _, record := range records {
-		householdPBId := record.GetString("household")
-		fieldDefPBId := record.GetString("field_definition")
-		recordYear := record.GetInt("year")
-
-		// Use yearScopedKey format to match TrackProcessedKey
-		yearScopedKey := fmt.Sprintf("%s:%s|%d", householdPBId, fieldDefPBId, recordYear)
-
-		if !s.ProcessedKeys[yearScopedKey] {
-			if err := s.App.Delete(record); err != nil {
-				slog.Error("Error deleting orphan custom field value",
-					"household", householdPBId,
-					"field_definition", fieldDefPBId,
-					"error", err)
-			} else {
-				deleted++
+// deleteOrphans removes custom field values that were not seen in this sync.
+//
+// This used to be a hand-rolled loop over a single FindRecordsByFilter capped at
+// 10,000 rows with no surrounding pagination (kindred#2266). 10,000 is a hard
+// cap, not a page size: production years hold 128,606-184,458 rows, so the sweep
+// inspected 5.4-7.8% of the year and a value deleted in CampMinder simply
+// survived, feeding every derived table that reads this one. Routing through the
+// shared guarded sweep replaces the cap with keyset pagination and picks up the
+// collapse guard, so there is one implementation instead of a local copy.
+//
+// sweptOwners is the set of household PB IDs whose values were successfully fetched
+// during THIS run, and it is what makes the fix safe rather than catastrophic.
+// The sweep's filter is the whole year, but the computed set is only ever as
+// wide as the run: this service takes a ?session= filter (api.go), and a
+// session resolves to the persons enrolled in it -- in the current season the
+// largest single session covers about 11% of the people who hold custom values.
+// Uncapping the read without narrowing the judgement would have let one
+// session-scoped run delete the other ~89% of the year as orphans. A row is a
+// candidate only if this run actually fetched that household's values; anything else
+// is invisible to the sweep, exactly as it should be.
+func (s *HouseholdCustomFieldValuesSync) deleteOrphans(year int, sweptOwners map[string]bool) error {
+	return s.DeleteOrphansGuarded(
+		"household_custom_values",
+		func(record *core.Record) (string, bool) {
+			householdPBId := record.GetString("household")
+			if !sweptOwners[householdPBId] {
+				return "", false
 			}
-		}
-	}
 
-	if deleted > 0 {
-		slog.Info("Deleted orphan household custom field values", "count", deleted)
-	}
-
-	return nil
+			// Matches TrackProcessedCompositeKey's "<identity>|<year>" format
+			return fmt.Sprintf("%s:%s|%d",
+				householdPBId, record.GetString("field_definition"), record.GetInt("year")), true
+		},
+		"household custom field value",
+		fmt.Sprintf("year = %d", year),
+		OrphanSweepGuard{
+			Entity:   "household_custom_values",
+			Year:     year,
+			Computed: len(s.ProcessedKeys),
+			Hint: "check that the households sync ran for that year, and that " +
+				"custom_field_defs still holds these field definitions",
+		},
+	)
 }
 
 // transformHouseholdCustomFieldValueToPB transforms CampMinder custom field value data to PocketBase format

--- a/pocketbase/sync/household_custom_field_values.go
+++ b/pocketbase/sync/household_custom_field_values.go
@@ -193,7 +193,12 @@ func (s *HouseholdCustomFieldValuesSync) Sync(ctx context.Context) error {
 // preloadHouseholdMapping loads CM ID -> PB ID mapping for households in the given year
 func (s *HouseholdCustomFieldValuesSync) preloadHouseholdMapping(year int) (map[int]string, error) {
 	filter := fmt.Sprintf("year = %d", year)
-	households, err := s.App.FindRecordsByFilter("households", filter, "", 10000, 0, nil)
+	// Unlimited (0), not a 10,000 cap. PocketBase treats limit=0 as no limit
+	// (core/record_query.go applies Limit only when limit > 0), and a bare
+	// number there is a silent truncation cliff, not a page size: kindred#2266
+	// was exactly this literal on the orphan sweep, where it hid 94% of a year.
+	// Year-scoped; the largest year on record holds 2,563 households.
+	households, err := s.App.FindRecordsByFilter("households", filter, "", 0, 0, nil)
 	if err != nil {
 		return nil, fmt.Errorf("finding households: %w", err)
 	}
@@ -213,7 +218,12 @@ func (s *HouseholdCustomFieldValuesSync) preloadHouseholdMapping(year int) (map[
 // preloadFieldDefMapping loads CM ID -> PB ID mapping for custom field definitions
 func (s *HouseholdCustomFieldValuesSync) preloadFieldDefMapping() (map[int]string, error) {
 	// Field definitions are global (no year filter)
-	fieldDefs, err := s.App.FindRecordsByFilter("custom_field_defs", "", "", 10000, 0, nil)
+	// Unlimited (0), not a 10,000 cap. PocketBase treats limit=0 as no limit
+	// (core/record_query.go applies Limit only when limit > 0), and a bare
+	// number there is a silent truncation cliff, not a page size: kindred#2266
+	// was exactly this literal on the orphan sweep, where it hid 94% of a year.
+	// custom_field_defs is NOT year-scoped: all 1,270 rows load every time.
+	fieldDefs, err := s.App.FindRecordsByFilter("custom_field_defs", "", "", 0, 0, nil)
 	if err != nil {
 		return nil, fmt.Errorf("finding field definitions: %w", err)
 	}
@@ -250,7 +260,13 @@ func (s *HouseholdCustomFieldValuesSync) getHouseholdIDsToSync(year int) ([]int,
 
 	// No session filter - get all households synced for this year
 	filter := fmt.Sprintf("year = %d", year)
-	households, err := s.App.FindRecordsByFilter("households", filter, "", 10000, 0, nil)
+	// Unlimited (0), not a 10,000 cap. PocketBase treats limit=0 as no limit
+	// (core/record_query.go applies Limit only when limit > 0), and a bare
+	// number there is a silent truncation cliff, not a page size: kindred#2266
+	// was exactly this literal on the orphan sweep, where it hid 94% of a year.
+	// Feeds sweptOwners, which is what narrows the orphan sweep. A silent
+	// truncation here would shrink the sweep's computed set as well.
+	households, err := s.App.FindRecordsByFilter("households", filter, "", 0, 0, nil)
 	if err != nil {
 		return nil, fmt.Errorf("finding households: %w", err)
 	}

--- a/pocketbase/sync/orphan_guard.go
+++ b/pocketbase/sync/orphan_guard.go
@@ -1,0 +1,99 @@
+package sync
+
+import "fmt"
+
+// Orphan-sweep thresholds (kindred#2279).
+//
+// An orphan sweep deletes every row on disk that this run's computed set does
+// not account for. That is correct when the computed set is trustworthy and
+// catastrophic when it is not: an upstream mapping that comes back empty or
+// short turns the sweep into a mass delete, and the sync reports success
+// afterwards because nothing in the run failed.
+//
+// The shipped guard caught only a TOTAL collapse -- computed set empty, rows on
+// disk. A PARTIAL collapse (5 computed against 300 on disk) sailed past it and
+// deleted the other 295. These two constants are what widen "empty" to
+// "suspiciously small".
+const (
+	// OrphanSweepRatioFloor is the share of the rows on disk that this run's
+	// computed set must cover for a sweep to proceed.
+	//
+	// 0.5 is a judgement call, chosen to sit far above real churn and far below
+	// any plausible collapse. A run that computes fewer than half the rows
+	// already stored is asserting that more than half of a season disappeared
+	// from CampMinder between two syncs. No product workflow does that:
+	// enrolment attrition is single-digit percentages, and a season rollover
+	// lands in a new `year` partition rather than shrinking an existing one.
+	// Meanwhile the failure this guards against -- a staff or person lookup that
+	// returns a fraction of its rows after a timeout or a mid-page API error --
+	// lands far below 0.5. Tune it here; it is read in exactly one place.
+	OrphanSweepRatioFloor = 0.5
+
+	// OrphanSweepMinRows is the point below which the ratio carries no signal
+	// and only the empty-computed-set rule applies.
+	//
+	// A table holding four rows can legitimately lose three; a table holding
+	// hundreds cannot. Without this floor the guard would refuse legitimately
+	// small early-season syncs, where a handful of rows exist and the shape of
+	// the season is still changing week to week -- exactly the runs an operator
+	// needs to succeed unattended.
+	OrphanSweepMinRows = 20
+)
+
+// OrphanSweepGuard refuses an orphan sweep whose computed set is too small to be
+// believed. It is the single implementation behind every guarded sweep in this
+// package: staff_vehicle_info and staff_applications shipped one hand-written
+// copy each (kindred#2273, kindred#2279 Gap 2), and rather than write a
+// fifteenth, every guarded service now fills in this struct.
+//
+// Computed is the size of the set this run built from CampMinder, NOT the number
+// of rows on disk it happens to match. The distinction matters: a healthy run can
+// legitimately share no keys at all with what is stored -- one person leaves and
+// another arrives -- so an empty intersection is not evidence of anything, while
+// an empty or short computed set is.
+type OrphanSweepGuard struct {
+	// Entity names the collection in the refusal, so an operator reading a log
+	// knows which sweep stopped.
+	Entity string
+	// Year names the season, for the same reason.
+	Year int
+	// Computed is the number of entries in this run's computed set.
+	Computed int
+	// Hint points at the upstream that produces this service's computed set --
+	// the place an operator has to look. Optional.
+	Hint string
+}
+
+// Check reports whether sweeping `existing` rows against g.Computed is safe.
+// A non-nil error means the caller must delete nothing and surface the error.
+func (g OrphanSweepGuard) Check(existing int) error {
+	if existing <= 0 {
+		return nil // nothing on disk, so there is no sweep to refuse
+	}
+
+	// Arm 1: total collapse. An empty computed set against any populated year is
+	// always a broken input -- there is no legitimate "CampMinder returned
+	// nothing" -- so this arm applies at every table size.
+	refuse := g.Computed == 0
+
+	// Arm 2: partial collapse, only where a ratio means something.
+	if !refuse && existing >= OrphanSweepMinRows {
+		refuse = float64(g.Computed) < OrphanSweepRatioFloor*float64(existing)
+	}
+
+	if !refuse {
+		return nil
+	}
+
+	msg := fmt.Sprintf(
+		"refusing to sweep %d existing %s rows for year %d against a computed set of %d "+
+			"(%.1f%% of what is on disk, floor %.0f%%)",
+		existing, g.Entity, g.Year, g.Computed,
+		float64(g.Computed)*100/float64(existing), OrphanSweepRatioFloor*100)
+
+	if g.Hint != "" {
+		msg += ": " + g.Hint
+	}
+
+	return fmt.Errorf("%s", msg)
+}

--- a/pocketbase/sync/orphan_guard_test.go
+++ b/pocketbase/sync/orphan_guard_test.go
@@ -214,11 +214,18 @@ func TestPersonCustomFieldValuesDeleteOrphansRefusesPartialCollapse(t *testing.T
 // the sweep's own filter is the whole year. Reading the whole year and judging
 // it against one session's keys would delete every other session's values.
 func TestPersonCustomFieldValuesDeleteOrphansIgnoresPersonsThisRunDidNotFetch(t *testing.T) {
-	const perPerson = 40
+	// Person 2 holds far fewer rows than person 1 on purpose: dropping the
+	// scoping has to fail THIS test on the surviving-row count, not by tripping
+	// the collapse guard, or the test would not be pinning the scoping at all.
+	const (
+		person1Rows = 40
+		person2Rows = 10
+	)
 
 	app := newOrphanSweepTestApp(t, "person_custom_values", "person", "field_definition", "value")
-	bulkInsertRows(t, app, "person_custom_values", "person", "pers_0000000001", 2026, perPerson)
-	bulkInsertRowsFrom(t, app, "person_custom_values", "person", "pers_0000000002", 2026, perPerson+1, perPerson*2)
+	bulkInsertRows(t, app, "person_custom_values", "person", "pers_0000000001", 2026, person1Rows)
+	bulkInsertRowsFrom(t, app, "person_custom_values", "person", "pers_0000000002", 2026,
+		person1Rows+1, person1Rows+person2Rows)
 
 	s := &PersonCustomFieldValuesSync{BaseSyncService: BaseSyncService{
 		App:            app,
@@ -227,7 +234,7 @@ func TestPersonCustomFieldValuesDeleteOrphansIgnoresPersonsThisRunDidNotFetch(t 
 	}}
 	// Person 1 was fetched this run and every one of their values came back
 	// except the last, which CampMinder really did delete.
-	for i := 1; i < perPerson; i++ {
+	for i := 1; i < person1Rows; i++ {
 		s.ProcessedKeys[fmt.Sprintf("pers_0000000001:fd%06d|2026", i)] = true
 	}
 
@@ -237,15 +244,15 @@ func TestPersonCustomFieldValuesDeleteOrphansIgnoresPersonsThisRunDidNotFetch(t 
 	}
 
 	survivors := countRows(t, app, "person_custom_values", "person = 'pers_0000000002'")
-	if survivors != perPerson {
+	if survivors != person2Rows {
 		t.Fatalf("%d of person 2's rows survived, want %d -- a run that never fetched a person "+
-			"must not delete that person's values as orphans", survivors, perPerson)
+			"must not delete that person's values as orphans", survivors, person2Rows)
 	}
 
 	swept := countRows(t, app, "person_custom_values", "person = 'pers_0000000001'")
-	if swept != perPerson-1 {
+	if swept != person1Rows-1 {
 		t.Fatalf("%d of person 1's rows survived, want %d -- the genuine orphan must still go",
-			swept, perPerson-1)
+			swept, person1Rows-1)
 	}
 }
 
@@ -277,19 +284,22 @@ func TestHouseholdCustomFieldValuesDeleteOrphansRefusesPartialCollapse(t *testin
 // mirrors the person case: getHouseholdIDsToSync takes the same ?session=
 // filter.
 func TestHouseholdCustomFieldValuesDeleteOrphansIgnoresHouseholdsThisRunDidNotFetch(t *testing.T) {
-	const perHousehold = 40
+	const (
+		household1Rows = 40
+		household2Rows = 10
+	)
 
 	app := newOrphanSweepTestApp(t, "household_custom_values", "household", "field_definition", "value")
-	bulkInsertRows(t, app, "household_custom_values", "household", "hh_00000000001", 2026, perHousehold)
+	bulkInsertRows(t, app, "household_custom_values", "household", "hh_00000000001", 2026, household1Rows)
 	bulkInsertRowsFrom(t, app, "household_custom_values", "household", "hh_00000000002", 2026,
-		perHousehold+1, perHousehold*2)
+		household1Rows+1, household1Rows+household2Rows)
 
 	s := &HouseholdCustomFieldValuesSync{BaseSyncService: BaseSyncService{
 		App:            app,
 		ProcessedKeys:  map[string]bool{},
 		SyncSuccessful: true,
 	}}
-	for i := 1; i < perHousehold; i++ {
+	for i := 1; i < household1Rows; i++ {
 		s.ProcessedKeys[fmt.Sprintf("hh_00000000001:fd%06d|2026", i)] = true
 	}
 
@@ -298,7 +308,13 @@ func TestHouseholdCustomFieldValuesDeleteOrphansIgnoresHouseholdsThisRunDidNotFe
 	}
 
 	survivors := countRows(t, app, "household_custom_values", "household = 'hh_00000000002'")
-	if survivors != perHousehold {
-		t.Fatalf("%d of household 2's rows survived, want %d", survivors, perHousehold)
+	if survivors != household2Rows {
+		t.Fatalf("%d of household 2's rows survived, want %d", survivors, household2Rows)
+	}
+
+	swept := countRows(t, app, "household_custom_values", "household = 'hh_00000000001'")
+	if swept != household1Rows-1 {
+		t.Fatalf("%d of household 1's rows survived, want %d -- the genuine orphan must still go",
+			swept, household1Rows-1)
 	}
 }

--- a/pocketbase/sync/orphan_guard_test.go
+++ b/pocketbase/sync/orphan_guard_test.go
@@ -1,0 +1,304 @@
+package sync
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// ---------------------------------------------------------------------------
+// kindred#2279 part (a) + (b) -- the shared guard
+// ---------------------------------------------------------------------------
+
+func TestOrphanSweepGuardCheck(t *testing.T) {
+	tests := []struct {
+		name       string
+		computed   int
+		existing   int
+		wantRefuse bool
+	}{
+		{"nothing on disk is never a collapse", 0, 0, false},
+		{"empty computed set against rows on disk refuses at any size", 0, 1, true},
+		{"empty computed set against a full year refuses", 0, 5000, true},
+		{"healthy full sweep passes", 5000, 5000, false},
+		{"a computed set larger than disk passes", 6000, 5000, false},
+		{"a small table is left to the empty-set arm alone", 1, 19, false},
+		{"partial collapse at the floor boundary passes", 10, 20, false},
+		{"partial collapse just under the floor refuses", 9, 20, true},
+		{"the kindred#2279 case: 5 computed against 300 on disk refuses", 5, 300, true},
+		{"a normal season's churn passes", 4800, 5000, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := OrphanSweepGuard{Entity: "widgets", Year: 2026, Computed: tc.computed}
+			err := g.Check(tc.existing)
+
+			if tc.wantRefuse && err == nil {
+				t.Fatalf("Check(%d) with computed=%d returned nil, want a refusal",
+					tc.existing, tc.computed)
+			}
+			if !tc.wantRefuse && err != nil {
+				t.Fatalf("Check(%d) with computed=%d refused: %v", tc.existing, tc.computed, err)
+			}
+			if err != nil && !strings.Contains(err.Error(), "2026") {
+				t.Errorf("error %q does not name the year -- an operator cannot tell which season refused",
+					err.Error())
+			}
+			if err != nil && !strings.Contains(err.Error(), "widgets") {
+				t.Errorf("error %q does not name the entity", err.Error())
+			}
+		})
+	}
+}
+
+// TestOrphanSweepGuardCheckCarriesTheHint proves a service can point the
+// operator at its own upstream, which is what the two shipped guards do.
+func TestOrphanSweepGuardCheckCarriesTheHint(t *testing.T) {
+	g := OrphanSweepGuard{
+		Entity:   "staff_vehicle_info",
+		Year:     2026,
+		Computed: 0,
+		Hint:     "check the staff table for that year, and the SVI field routing warnings above",
+	}
+
+	err := g.Check(12)
+	if err == nil {
+		t.Fatal("expected a refusal on an empty computed set")
+	}
+	if !strings.Contains(err.Error(), "routing") {
+		t.Errorf("error %q dropped the service hint", err.Error())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// kindred#2279 Gap 1 -- partial collapse, on every guarded shape
+// ---------------------------------------------------------------------------
+
+// TestBaseDeleteOrphansGuardedRefusesPartialCollapse is the kindred#2279 case
+// on the shared base sweep: the computed set comes back with a handful of
+// entries when hundreds were expected, and the unwidened guard -- which only
+// asked "is it empty?" -- waved it through and deleted the rest.
+func TestBaseDeleteOrphansGuardedRefusesPartialCollapse(t *testing.T) {
+	const (
+		seeded   = 300
+		computed = 5
+	)
+
+	app := newOrphanSweepTestApp(t, "widgets", "name")
+	col, err := app.FindCollectionByNameOrId("widgets")
+	if err != nil {
+		t.Fatalf("find widgets: %v", err)
+	}
+	for i := 1; i <= seeded; i++ {
+		rec := core.NewRecord(col)
+		rec.Id = orphanTestID(i)
+		rec.Set("name", fmt.Sprintf("widget-%03d", i))
+		rec.Set("year", 2026)
+		if saveErr := app.Save(rec); saveErr != nil {
+			t.Fatalf("seed widget %d: %v", i, saveErr)
+		}
+	}
+
+	b := BaseSyncService{App: app, ProcessedKeys: map[string]bool{}, SyncSuccessful: true}
+	for i := 1; i <= computed; i++ {
+		b.ProcessedKeys[fmt.Sprintf("%d|2026", i)] = true
+	}
+
+	err = b.DeleteOrphansGuarded(
+		"widgets",
+		func(record *core.Record) (string, bool) {
+			var n int
+			if _, scanErr := fmt.Sscanf(record.GetString("name"), "widget-%d", &n); scanErr != nil {
+				return "", false
+			}
+			return fmt.Sprintf("%d|2026", n), true
+		},
+		"widget",
+		"year = 2026",
+		OrphanSweepGuard{Entity: "widgets", Year: 2026, Computed: computed},
+	)
+
+	if err == nil {
+		t.Fatal("expected a refusal: 5 computed against 300 on disk is a collapsed mapping, " +
+			"and sweeping it deletes 295 rows while reporting success")
+	}
+	if remaining := countRows(t, app, "widgets", "year = 2026"); remaining != seeded {
+		t.Fatalf("%d rows survived, want %d -- nothing may be deleted on the refusal path", remaining, seeded)
+	}
+}
+
+// TestBaseDeleteOrphansGuardedStillSweepsNormalChurn proves the widened guard
+// did not turn ordinary attrition into a failed sync.
+func TestBaseDeleteOrphansGuardedStillSweepsNormalChurn(t *testing.T) {
+	const (
+		seeded   = 300
+		computed = 290
+	)
+
+	app := newOrphanSweepTestApp(t, "widgets", "name")
+	col, err := app.FindCollectionByNameOrId("widgets")
+	if err != nil {
+		t.Fatalf("find widgets: %v", err)
+	}
+	for i := 1; i <= seeded; i++ {
+		rec := core.NewRecord(col)
+		rec.Id = orphanTestID(i)
+		rec.Set("name", fmt.Sprintf("widget-%03d", i))
+		rec.Set("year", 2026)
+		if saveErr := app.Save(rec); saveErr != nil {
+			t.Fatalf("seed widget %d: %v", i, saveErr)
+		}
+	}
+
+	b := BaseSyncService{App: app, ProcessedKeys: map[string]bool{}, SyncSuccessful: true}
+	for i := 1; i <= computed; i++ {
+		b.ProcessedKeys[fmt.Sprintf("%d|2026", i)] = true
+	}
+
+	err = b.DeleteOrphansGuarded(
+		"widgets",
+		func(record *core.Record) (string, bool) {
+			var n int
+			if _, scanErr := fmt.Sscanf(record.GetString("name"), "widget-%d", &n); scanErr != nil {
+				return "", false
+			}
+			return fmt.Sprintf("%d|2026", n), true
+		},
+		"widget",
+		"year = 2026",
+		OrphanSweepGuard{Entity: "widgets", Year: 2026, Computed: computed},
+	)
+	if err != nil {
+		t.Fatalf("guard refused a healthy sweep (%d of %d): %v", computed, seeded, err)
+	}
+
+	if remaining := countRows(t, app, "widgets", "year = 2026"); remaining != computed {
+		t.Fatalf("%d rows survived, want %d -- the guard must not block a genuine sweep", remaining, computed)
+	}
+}
+
+func TestPersonCustomFieldValuesDeleteOrphansRefusesPartialCollapse(t *testing.T) {
+	const seeded = 300
+
+	app := newOrphanSweepTestApp(t, "person_custom_values", "person", "field_definition", "value")
+	bulkInsertRows(t, app, "person_custom_values", "person", "pers_0000000001", 2026, seeded)
+
+	s := &PersonCustomFieldValuesSync{BaseSyncService: BaseSyncService{
+		App:            app,
+		ProcessedKeys:  map[string]bool{},
+		SyncSuccessful: true,
+	}}
+	// A staff/person lookup that died partway: five keys where 300 were expected.
+	for i := 1; i <= 5; i++ {
+		s.ProcessedKeys[fmt.Sprintf("pers_0000000001:fd%06d|2026", i)] = true
+	}
+
+	err := s.deleteOrphans(2026, map[string]bool{"pers_0000000001": true})
+	if err == nil {
+		t.Fatal("expected a refusal on a collapsed computed set")
+	}
+	if !strings.Contains(err.Error(), "2026") {
+		t.Errorf("error %q does not name the year", err.Error())
+	}
+	if remaining := countRows(t, app, "person_custom_values", "year = 2026"); remaining != seeded {
+		t.Fatalf("%d rows survived, want %d -- nothing may be deleted on the refusal path", remaining, seeded)
+	}
+}
+
+// TestPersonCustomFieldValuesDeleteOrphansIgnoresPersonsThisRunDidNotFetch is
+// the hazard that uncapping the read creates. This service takes a ?session=
+// filter, which narrows the run to the persons enrolled in that session, while
+// the sweep's own filter is the whole year. Reading the whole year and judging
+// it against one session's keys would delete every other session's values.
+func TestPersonCustomFieldValuesDeleteOrphansIgnoresPersonsThisRunDidNotFetch(t *testing.T) {
+	const perPerson = 40
+
+	app := newOrphanSweepTestApp(t, "person_custom_values", "person", "field_definition", "value")
+	bulkInsertRows(t, app, "person_custom_values", "person", "pers_0000000001", 2026, perPerson)
+	bulkInsertRowsFrom(t, app, "person_custom_values", "person", "pers_0000000002", 2026, perPerson+1, perPerson*2)
+
+	s := &PersonCustomFieldValuesSync{BaseSyncService: BaseSyncService{
+		App:            app,
+		ProcessedKeys:  map[string]bool{},
+		SyncSuccessful: true,
+	}}
+	// Person 1 was fetched this run and every one of their values came back
+	// except the last, which CampMinder really did delete.
+	for i := 1; i < perPerson; i++ {
+		s.ProcessedKeys[fmt.Sprintf("pers_0000000001:fd%06d|2026", i)] = true
+	}
+
+	// Person 2 was never fetched -- a different session, or a failed fetch.
+	if err := s.deleteOrphans(2026, map[string]bool{"pers_0000000001": true}); err != nil {
+		t.Fatalf("deleteOrphans: %v", err)
+	}
+
+	survivors := countRows(t, app, "person_custom_values", "person = 'pers_0000000002'")
+	if survivors != perPerson {
+		t.Fatalf("%d of person 2's rows survived, want %d -- a run that never fetched a person "+
+			"must not delete that person's values as orphans", survivors, perPerson)
+	}
+
+	swept := countRows(t, app, "person_custom_values", "person = 'pers_0000000001'")
+	if swept != perPerson-1 {
+		t.Fatalf("%d of person 1's rows survived, want %d -- the genuine orphan must still go",
+			swept, perPerson-1)
+	}
+}
+
+func TestHouseholdCustomFieldValuesDeleteOrphansRefusesPartialCollapse(t *testing.T) {
+	const seeded = 300
+
+	app := newOrphanSweepTestApp(t, "household_custom_values", "household", "field_definition", "value")
+	bulkInsertRows(t, app, "household_custom_values", "household", "hh_00000000001", 2026, seeded)
+
+	s := &HouseholdCustomFieldValuesSync{BaseSyncService: BaseSyncService{
+		App:            app,
+		ProcessedKeys:  map[string]bool{},
+		SyncSuccessful: true,
+	}}
+	for i := 1; i <= 5; i++ {
+		s.ProcessedKeys[fmt.Sprintf("hh_00000000001:fd%06d|2026", i)] = true
+	}
+
+	err := s.deleteOrphans(2026, map[string]bool{"hh_00000000001": true})
+	if err == nil {
+		t.Fatal("expected a refusal on a collapsed computed set")
+	}
+	if remaining := countRows(t, app, "household_custom_values", "year = 2026"); remaining != seeded {
+		t.Fatalf("%d rows survived, want %d -- nothing may be deleted on the refusal path", remaining, seeded)
+	}
+}
+
+// TestHouseholdCustomFieldValuesDeleteOrphansIgnoresHouseholdsThisRunDidNotFetch
+// mirrors the person case: getHouseholdIDsToSync takes the same ?session=
+// filter.
+func TestHouseholdCustomFieldValuesDeleteOrphansIgnoresHouseholdsThisRunDidNotFetch(t *testing.T) {
+	const perHousehold = 40
+
+	app := newOrphanSweepTestApp(t, "household_custom_values", "household", "field_definition", "value")
+	bulkInsertRows(t, app, "household_custom_values", "household", "hh_00000000001", 2026, perHousehold)
+	bulkInsertRowsFrom(t, app, "household_custom_values", "household", "hh_00000000002", 2026,
+		perHousehold+1, perHousehold*2)
+
+	s := &HouseholdCustomFieldValuesSync{BaseSyncService: BaseSyncService{
+		App:            app,
+		ProcessedKeys:  map[string]bool{},
+		SyncSuccessful: true,
+	}}
+	for i := 1; i < perHousehold; i++ {
+		s.ProcessedKeys[fmt.Sprintf("hh_00000000001:fd%06d|2026", i)] = true
+	}
+
+	if err := s.deleteOrphans(2026, map[string]bool{"hh_00000000001": true}); err != nil {
+		t.Fatalf("deleteOrphans: %v", err)
+	}
+
+	survivors := countRows(t, app, "household_custom_values", "household = 'hh_00000000002'")
+	if survivors != perHousehold {
+		t.Fatalf("%d of household 2's rows survived, want %d", survivors, perHousehold)
+	}
+}

--- a/pocketbase/sync/orphan_sweep_test.go
+++ b/pocketbase/sync/orphan_sweep_test.go
@@ -1,0 +1,225 @@
+package sync
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+)
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// newOrphanSweepTestApp returns a test app holding one collection shaped like a
+// year-scoped CampMinder table.
+func newOrphanSweepTestApp(t *testing.T, collection string, fields ...string) core.App {
+	t.Helper()
+
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	col := core.NewBaseCollection(collection)
+	for _, f := range fields {
+		col.Fields.Add(&core.TextField{Name: f})
+	}
+	col.Fields.Add(&core.NumberField{Name: "year"})
+	// The pre-fix BaseSyncService.DeleteOrphans sorts on "created"; the field has
+	// to exist for that path to run at all.
+	col.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
+	if saveErr := app.Save(col); saveErr != nil {
+		t.Fatalf("save %s: %v", collection, saveErr)
+	}
+
+	return app
+}
+
+// bulkInsertRowsFrom writes rows [from, to] for one owner. Splitting the range
+// out lets a fixture hold two owners without their IDs colliding.
+func bulkInsertRowsFrom(t *testing.T, app core.App, collection, ownerCol, owner string, year, from, to int) {
+	t.Helper()
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "INSERT INTO {{%s}} (id, %s, field_definition, value, year) VALUES ", collection, ownerCol)
+	for i := from; i <= to; i++ {
+		if i > from {
+			b.WriteString(",")
+		}
+		fmt.Fprintf(&b, "('%s', '%s', 'fd%06d', '', %d)", orphanTestID(i), owner, i, year)
+	}
+
+	if _, err := app.DB().NewQuery(b.String()).Execute(); err != nil {
+		t.Fatalf("bulk insert rows %d-%d into %s: %v", from, to, collection, err)
+	}
+}
+
+// bulkInsertRows writes n rows straight to SQLite. Going through app.Save() for
+// five figures of rows takes minutes; the sweep reads the table, so a raw insert
+// is indistinguishable from its point of view. IDs are zero-padded so the row
+// order the sweep walks is deterministic.
+func bulkInsertRows(t *testing.T, app core.App, collection, ownerCol, owner string, year, n int) {
+	t.Helper()
+	bulkInsertRowsFrom(t, app, collection, ownerCol, owner, year, 1, n)
+}
+
+// orphanTestID builds a 15-character, lexicographically sortable record ID.
+func orphanTestID(i int) string {
+	return fmt.Sprintf("r%014d", i)
+}
+
+func countRows(t *testing.T, app core.App, collection, filter string) int {
+	t.Helper()
+	recs, err := app.FindRecordsByFilter(collection, filter, "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query %s: %v", collection, err)
+	}
+	return len(recs)
+}
+
+// ---------------------------------------------------------------------------
+// Part 3 -- BaseSyncService.DeleteOrphans offset pagination skips records
+// ---------------------------------------------------------------------------
+
+// TestBaseDeleteOrphansInspectsEveryRecordWhileDeleting pins the offset bug at
+// base_sync.go. The loop reads page N at offset (N-1)*perPage and deletes inside
+// the loop, so every delete shrinks the result set under the next page's offset
+// and slides that many unread records past the cursor forever.
+//
+// The fixture is deliberately just over one page: 150 rows, of which exactly one
+// (the last) was processed and must survive. A correct sweep deletes 149 and
+// keeps 1. The offset implementation deletes the first page, then asks for
+// offset 100 of a 50-row table, gets nothing back, and stops.
+func TestBaseDeleteOrphansInspectsEveryRecordWhileDeleting(t *testing.T) {
+	const seeded = 150
+
+	app := newOrphanSweepTestApp(t, "widgets", "name")
+	col, err := app.FindCollectionByNameOrId("widgets")
+	if err != nil {
+		t.Fatalf("find widgets: %v", err)
+	}
+
+	for i := 1; i <= seeded; i++ {
+		rec := core.NewRecord(col)
+		rec.Id = orphanTestID(i)
+		rec.Set("name", fmt.Sprintf("widget-%03d", i))
+		rec.Set("year", 2026)
+		if saveErr := app.Save(rec); saveErr != nil {
+			t.Fatalf("seed widget %d: %v", i, saveErr)
+		}
+	}
+
+	b := BaseSyncService{
+		App:            app,
+		ProcessedKeys:  map[string]bool{fmt.Sprintf("%d|2026", seeded): true},
+		SyncSuccessful: true,
+	}
+
+	err = b.DeleteOrphans(
+		"widgets",
+		func(record *core.Record) (string, bool) {
+			name := record.GetString("name")
+			var n int
+			if _, scanErr := fmt.Sscanf(name, "widget-%d", &n); scanErr != nil {
+				return "", false
+			}
+			return fmt.Sprintf("%d|2026", n), true
+		},
+		"widget",
+		"year = 2026",
+	)
+	if err != nil {
+		t.Fatalf("DeleteOrphans: %v", err)
+	}
+
+	remaining := countRows(t, app, "widgets", "year = 2026")
+	if remaining != 1 {
+		t.Fatalf("%d rows survived, want 1 -- every record past the first page was "+
+			"skipped, so an orphan that CampMinder deleted stays in PocketBase forever", remaining)
+	}
+
+	survivor, err := app.FindRecordById("widgets", orphanTestID(seeded))
+	if err != nil {
+		t.Fatalf("the one processed record was deleted: %v", err)
+	}
+	if survivor.GetString("name") != fmt.Sprintf("widget-%03d", seeded) {
+		t.Errorf("wrong survivor: %q", survivor.GetString("name"))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Part 1 -- kindred#2266: the 10,000-row hard cap
+// ---------------------------------------------------------------------------
+
+// TestPersonCustomFieldValuesDeleteOrphansSweepsPastTheTenThousandCap pins
+// kindred#2266. Production years hold 128,606-184,458 rows; the sweep asked for
+// 10,000 with no surrounding loop, so 94% of the year was unreachable and a
+// value deleted in CampMinder was never removed.
+//
+// The fixture is 10,050 rows for one person: the first 10,000 are still
+// computed, the last 50 are orphans that only a paginated sweep can reach.
+func TestPersonCustomFieldValuesDeleteOrphansSweepsPastTheTenThousandCap(t *testing.T) {
+	const (
+		seeded   = 10050
+		computed = 10000
+	)
+
+	app := newOrphanSweepTestApp(t, "person_custom_values", "person", "field_definition", "value")
+	bulkInsertRows(t, app, "person_custom_values", "person", "pers_0000000001", 2026, seeded)
+
+	s := &PersonCustomFieldValuesSync{BaseSyncService: BaseSyncService{
+		App:            app,
+		ProcessedKeys:  make(map[string]bool),
+		SyncSuccessful: true,
+	}}
+	for i := 1; i <= computed; i++ {
+		s.ProcessedKeys[fmt.Sprintf("pers_0000000001:fd%06d|2026", i)] = true
+	}
+
+	if err := s.deleteOrphans(2026, map[string]bool{"pers_0000000001": true}); err != nil {
+		t.Fatalf("deleteOrphans: %v", err)
+	}
+
+	remaining := countRows(t, app, "person_custom_values", "year = 2026")
+	if remaining != computed {
+		t.Fatalf("%d rows survived, want %d -- the sweep never reached past its 10,000-row cap, "+
+			"so %d values deleted in CampMinder stayed in PocketBase",
+			remaining, computed, remaining-computed)
+	}
+}
+
+// TestHouseholdCustomFieldValuesDeleteOrphansSweepsPastTheTenThousandCap is the
+// latent twin from kindred#2266: identical statement, identical cap, smaller
+// table today.
+func TestHouseholdCustomFieldValuesDeleteOrphansSweepsPastTheTenThousandCap(t *testing.T) {
+	const (
+		seeded   = 10050
+		computed = 10000
+	)
+
+	app := newOrphanSweepTestApp(t, "household_custom_values", "household", "field_definition", "value")
+	bulkInsertRows(t, app, "household_custom_values", "household", "hh_00000000001", 2026, seeded)
+
+	s := &HouseholdCustomFieldValuesSync{BaseSyncService: BaseSyncService{
+		App:            app,
+		ProcessedKeys:  make(map[string]bool),
+		SyncSuccessful: true,
+	}}
+	for i := 1; i <= computed; i++ {
+		s.ProcessedKeys[fmt.Sprintf("hh_00000000001:fd%06d|2026", i)] = true
+	}
+
+	if err := s.deleteOrphans(2026, map[string]bool{"hh_00000000001": true}); err != nil {
+		t.Fatalf("deleteOrphans: %v", err)
+	}
+
+	remaining := countRows(t, app, "household_custom_values", "year = 2026")
+	if remaining != computed {
+		t.Fatalf("%d rows survived, want %d -- the sweep never reached past its 10,000-row cap",
+			remaining, computed)
+	}
+}

--- a/pocketbase/sync/orphan_sweep_test.go
+++ b/pocketbase/sync/orphan_sweep_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pocketbase/dbx"
+
 	"github.com/pocketbase/pocketbase/core"
 	pbtests "github.com/pocketbase/pocketbase/tests"
 )
@@ -275,7 +277,7 @@ func TestBaseDeleteOrphansDeletesNothingWhenNoRecordCanBeKeyed(t *testing.T) {
 
 // captureSweepLogs redirects slog for the duration of one test and returns the
 // buffer. The sweep's only operator-facing signal is its log line, so the log IS
-// the behaviour under test here, not an incidental side effect.
+// the behavior under test here, not an incidental side effect.
 func captureSweepLogs(t *testing.T) *strings.Builder {
 	t.Helper()
 
@@ -391,5 +393,87 @@ func TestBaseDeleteOrphansCountsOnlyCompletedDeletes(t *testing.T) {
 
 	if got := logs.String(); strings.Contains(got, "Deleted orphaned records") {
 		t.Errorf("a failed delete was counted as deleted; got:\n%s", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The scan must not mint a new filter string per page (kindred#2279 follow-up)
+// ---------------------------------------------------------------------------
+
+// filterSpyApp records every filter string the sweep issues. Embedding core.App
+// means only the one method is overridden and everything else behaves normally.
+type filterSpyApp struct {
+	core.App
+	filters []string
+}
+
+func (a *filterSpyApp) FindRecordsByFilter(
+	collectionModelOrIdentifier any,
+	filter string,
+	sort string,
+	limit int,
+	offset int,
+	params ...dbx.Params,
+) ([]*core.Record, error) {
+	a.filters = append(a.filters, filter)
+	//nolint:wrapcheck // a transparent test double: wrapping would change what the caller sees
+	return a.App.FindRecordsByFilter(collectionModelOrIdentifier, filter, sort, limit, offset, params...)
+}
+
+// PocketBase substitutes {:params} into the filter string BEFORE parsing it and
+// then uses the substituted string as a cache key (tools/search/filter.go:78,82),
+// storing it in the package-level parsedFilterData store with a hard cap of 500
+// and no eviction (tools/store/store.go:218). So a scan that puts a per-page
+// cursor in the filter mints one dead cache entry per page: ~1,553 of them for a
+// single year of person_custom_values. Once 500 accumulate, NO filter expression
+// anywhere in the process can be cached again for the life of the container --
+// every API list request re-parses from scratch.
+//
+// The paging cursor therefore must not travel in the filter string.
+func TestSweepDoesNotMintAFilterStringPerPage(t *testing.T) {
+	const seeded = 1200
+
+	base := newOrphanSweepTestApp(t, "person_custom_values", "person", "field_definition", "value")
+	bulkInsertRows(t, base, "person_custom_values", "person", "pers_0000000001", 2026, seeded)
+
+	spy := &filterSpyApp{App: base}
+
+	s := &PersonCustomFieldValuesSync{BaseSyncService: BaseSyncService{
+		App:            spy,
+		ProcessedKeys:  make(map[string]bool),
+		SyncSuccessful: true,
+	}}
+	for i := 1; i <= seeded; i++ {
+		s.ProcessedKeys[fmt.Sprintf("pers_0000000001:fd%06d|2026", i)] = true
+	}
+
+	if err := s.deleteOrphans(2026, map[string]bool{"pers_0000000001": true}); err != nil {
+		t.Fatalf("deleteOrphans: %v", err)
+	}
+
+	distinct := map[string]bool{}
+	for _, f := range spy.filters {
+		distinct[f] = true
+	}
+
+	if len(spy.filters) < 2 {
+		t.Fatalf("fixture is wrong: the scan issued %d queries, so it never paged", len(spy.filters))
+	}
+	if len(distinct) != 1 {
+		t.Errorf("the scan issued %d queries using %d DISTINCT filter strings; want 1. "+
+			"Filters seen: %v", len(spy.filters), len(distinct), distinct)
+	}
+
+	// The stricter half, and the one that actually bites. PocketBase substitutes
+	// {:params} into the raw filter BEFORE deriving the cache key, so a filter
+	// carrying a per-page placeholder yields a DIFFERENT key on every page even
+	// though the string handed to FindRecordsByFilter never changes. A constant
+	// filter is only safe if it is also placeholder-free.
+	for f := range distinct {
+		if strings.Contains(f, "{:") {
+			t.Errorf("the scan's filter carries a parameter placeholder (%q). PocketBase "+
+				"substitutes it before building the cache key, so each page still mints a "+
+				"distinct permanent cache entry -- the cursor must not travel in the filter", f)
+		}
 	}
 }

--- a/pocketbase/sync/orphan_sweep_test.go
+++ b/pocketbase/sync/orphan_sweep_test.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -265,5 +266,130 @@ func TestBaseDeleteOrphansDeletesNothingWhenNoRecordCanBeKeyed(t *testing.T) {
 	if remaining := countRows(t, app, "widgets", "year = 2026"); remaining != seeded {
 		t.Fatalf("%d rows survived, want %d -- a record the sweep cannot key is not an orphan "+
 			"and must never be deleted", remaining, seeded)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Observability of a collapsed sweep (kindred#2279 follow-up)
+// ---------------------------------------------------------------------------
+
+// captureSweepLogs redirects slog for the duration of one test and returns the
+// buffer. The sweep's only operator-facing signal is its log line, so the log IS
+// the behaviour under test here, not an incidental side effect.
+func captureSweepLogs(t *testing.T) *strings.Builder {
+	t.Helper()
+
+	buf := &strings.Builder{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	return buf
+}
+
+// A sweep whose getIDFunc can key nothing at all is a collapsed upstream, not a
+// clean year. It currently logs "No orphaned records found" -- identical to a
+// healthy run -- and the guard cannot fire, because the guard's denominator only
+// counts rows that WERE keyable and so is zero. Three services' operator hints
+// (attendees, bunk_assignments, bunk_plans) tell the reader to look for an
+// unkeyable-record warning, so one has to exist.
+func TestBaseDeleteOrphansWarnsWhenNothingCanBeKeyed(t *testing.T) {
+	const seeded = 30
+
+	app := newOrphanSweepTestApp(t, "widgets", "name")
+	col, err := app.FindCollectionByNameOrId("widgets")
+	if err != nil {
+		t.Fatalf("find widgets: %v", err)
+	}
+	for i := 1; i <= seeded; i++ {
+		rec := core.NewRecord(col)
+		rec.Id = orphanTestID(i)
+		rec.Set("name", fmt.Sprintf("widget-%03d", i))
+		rec.Set("year", 2026)
+		if saveErr := app.Save(rec); saveErr != nil {
+			t.Fatalf("seed widget %d: %v", i, saveErr)
+		}
+	}
+
+	logs := captureSweepLogs(t)
+
+	b := BaseSyncService{App: app, ProcessedKeys: map[string]bool{}, SyncSuccessful: true}
+	err = b.DeleteOrphansGuarded(
+		"widgets",
+		func(*core.Record) (string, bool) { return "", false },
+		"widget",
+		"year = 2026",
+		OrphanSweepGuard{Entity: "widgets", Year: 2026, Computed: 0},
+	)
+	if err != nil {
+		t.Fatalf("sweep returned an error: %v", err)
+	}
+
+	got := logs.String()
+	if !strings.Contains(got, "unkeyable") {
+		t.Errorf("expected an unkeyable-record warning naming the collapse; got:\n%s", got)
+	}
+	if !strings.Contains(got, "level=WARN") {
+		t.Errorf("the unkeyable case must be a WARN, not an Info; got:\n%s", got)
+	}
+	if strings.Contains(got, "No orphaned records found") {
+		t.Errorf("a collapsed sweep must not report the healthy-run message; got:\n%s", got)
+	}
+}
+
+// orphanCount is what the completion log reports as deleted. A delete that FAILS
+// must not be counted: the row is still on disk, and an operator reading
+// "Deleted orphaned records count=1" against a row that still exists has been
+// told the opposite of the truth. A blocking relation is the cheapest way to
+// make App.Delete fail for real rather than mocking it.
+func TestBaseDeleteOrphansCountsOnlyCompletedDeletes(t *testing.T) {
+	app := newOrphanSweepTestApp(t, "widgets", "name")
+	widgets, err := app.FindCollectionByNameOrId("widgets")
+	if err != nil {
+		t.Fatalf("find widgets: %v", err)
+	}
+
+	orphan := core.NewRecord(widgets)
+	orphan.Id = orphanTestID(1)
+	orphan.Set("name", "widget-001")
+	orphan.Set("year", 2026)
+	if saveErr := app.Save(orphan); saveErr != nil {
+		t.Fatalf("seed orphan: %v", saveErr)
+	}
+
+	// A non-cascading relation pointing at the orphan blocks its deletion.
+	holders := core.NewBaseCollection("holders")
+	holders.Fields.Add(&core.RelationField{
+		Name: "widget", CollectionId: widgets.Id, CascadeDelete: false, Required: true,
+	})
+	if saveErr := app.Save(holders); saveErr != nil {
+		t.Fatalf("save holders: %v", saveErr)
+	}
+	holder := core.NewRecord(holders)
+	holder.Set("widget", orphan.Id)
+	if saveErr := app.Save(holder); saveErr != nil {
+		t.Fatalf("seed holder: %v", saveErr)
+	}
+
+	logs := captureSweepLogs(t)
+
+	b := BaseSyncService{App: app, ProcessedKeys: map[string]bool{}, SyncSuccessful: true}
+	if sweepErr := b.DeleteOrphans(
+		"widgets",
+		func(r *core.Record) (string, bool) { return r.Id, true },
+		"widget",
+		"year = 2026",
+	); sweepErr != nil {
+		t.Fatalf("sweep returned an error: %v", sweepErr)
+	}
+
+	// The row must still be there -- otherwise the fixture did not block anything
+	// and the assertion below would pass for the wrong reason.
+	if _, findErr := app.FindRecordById("widgets", orphan.Id); findErr != nil {
+		t.Fatalf("fixture is wrong: the delete was not blocked (%v)", findErr)
+	}
+
+	if got := logs.String(); strings.Contains(got, "Deleted orphaned records") {
+		t.Errorf("a failed delete was counted as deleted; got:\n%s", got)
 	}
 }

--- a/pocketbase/sync/orphan_sweep_test.go
+++ b/pocketbase/sync/orphan_sweep_test.go
@@ -223,3 +223,47 @@ func TestHouseholdCustomFieldValuesDeleteOrphansSweepsPastTheTenThousandCap(t *t
 			remaining, computed)
 	}
 }
+
+// TestBaseDeleteOrphansDeletesNothingWhenNoRecordCanBeKeyed pins the blind spot
+// behind the unkeyable-record warning. Several getIDFuncs build their key from a
+// lookup map -- attendees from camp_sessions, bunk_plans from bunks and
+// camp_sessions -- so a collapsed lookup makes EVERY row unkeyable rather than
+// orphaned. Unkeyable is not orphaned: nothing may be deleted, and the guard
+// never sees these rows because they were never deletion candidates.
+func TestBaseDeleteOrphansDeletesNothingWhenNoRecordCanBeKeyed(t *testing.T) {
+	const seeded = 50
+
+	app := newOrphanSweepTestApp(t, "widgets", "name")
+	col, err := app.FindCollectionByNameOrId("widgets")
+	if err != nil {
+		t.Fatalf("find widgets: %v", err)
+	}
+	for i := 1; i <= seeded; i++ {
+		rec := core.NewRecord(col)
+		rec.Id = orphanTestID(i)
+		rec.Set("name", fmt.Sprintf("widget-%03d", i))
+		rec.Set("year", 2026)
+		if saveErr := app.Save(rec); saveErr != nil {
+			t.Fatalf("seed widget %d: %v", i, saveErr)
+		}
+	}
+
+	b := BaseSyncService{App: app, ProcessedKeys: map[string]bool{}, SyncSuccessful: true}
+
+	err = b.DeleteOrphansGuarded(
+		"widgets",
+		// The lookup this key depends on came back empty.
+		func(*core.Record) (string, bool) { return "", false },
+		"widget",
+		"year = 2026",
+		OrphanSweepGuard{Entity: "widgets", Year: 2026, Computed: 0},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if remaining := countRows(t, app, "widgets", "year = 2026"); remaining != seeded {
+		t.Fatalf("%d rows survived, want %d -- a record the sweep cannot key is not an orphan "+
+			"and must never be deleted", remaining, seeded)
+	}
+}

--- a/pocketbase/sync/person_custom_field_values.go
+++ b/pocketbase/sync/person_custom_field_values.go
@@ -130,6 +130,12 @@ func (s *PersonCustomFieldValuesSync) Sync(ctx context.Context) error {
 
 	s.SyncSuccessful = true
 
+	// Only persons whose values this run actually fetched may be judged by the
+	// orphan sweep. A ?session= filter narrows the run to one session's persons
+	// while the sweep's filter is the whole year, so without this set a
+	// session-scoped run would delete every other session's values as orphans.
+	sweptOwners := make(map[string]bool, len(personIDs))
+
 	// Process each person
 	for i, personCMID := range personIDs {
 		select {
@@ -162,11 +168,16 @@ func (s *PersonCustomFieldValuesSync) Sync(ctx context.Context) error {
 				"person_cm_id", personCMID,
 				"error", err)
 			s.Stats.Errors++
+			// A person whose fetch failed was not fully seen; leaving them out of
+			// sweptOwners keeps the sweep from reading a partial fetch as deletions.
+			continue
 		}
+
+		sweptOwners[personPBId] = true
 	}
 
 	// Delete orphans (values no longer present in API response)
-	if err := s.deleteOrphans(year); err != nil {
+	if err := s.deleteOrphans(year, sweptOwners); err != nil {
 		slog.Error("Error deleting orphan custom field values", "error", err)
 	}
 
@@ -395,41 +406,49 @@ func (s *PersonCustomFieldValuesSync) syncPersonCustomFieldValues(
 	return nil
 }
 
-// deleteOrphans removes custom field values that were not seen in this sync
-func (s *PersonCustomFieldValuesSync) deleteOrphans(year int) error {
-	filter := fmt.Sprintf("year = %d", year)
-	records, err := s.App.FindRecordsByFilter("person_custom_values", filter, "", 10000, 0, nil)
-	if err != nil {
-		return fmt.Errorf("finding records for orphan check: %w", err)
-	}
-
-	deleted := 0
-	for _, record := range records {
-		personPBId := record.GetString("person")
-		fieldDefPBId := record.GetString("field_definition")
-		recordYear := record.GetInt("year")
-
-		// Use yearScopedKey format to match TrackProcessedKey
-		yearScopedKey := fmt.Sprintf("%s:%s|%d", personPBId, fieldDefPBId, recordYear)
-
-		if !s.ProcessedKeys[yearScopedKey] {
-			// This value was not seen in the sync, delete it
-			if err := s.App.Delete(record); err != nil {
-				slog.Error("Error deleting orphan custom field value",
-					"person", personPBId,
-					"field_definition", fieldDefPBId,
-					"error", err)
-			} else {
-				deleted++
+// deleteOrphans removes custom field values that were not seen in this sync.
+//
+// This used to be a hand-rolled loop over a single FindRecordsByFilter capped at
+// 10,000 rows with no surrounding pagination (kindred#2266). 10,000 is a hard
+// cap, not a page size: production years hold 128,606-184,458 rows, so the sweep
+// inspected 5.4-7.8% of the year and a value deleted in CampMinder simply
+// survived, feeding every derived table that reads this one. Routing through the
+// shared guarded sweep replaces the cap with keyset pagination and picks up the
+// collapse guard, so there is one implementation instead of a local copy.
+//
+// sweptOwners is the set of person PB IDs whose values were successfully fetched
+// during THIS run, and it is what makes the fix safe rather than catastrophic.
+// The sweep's filter is the whole year, but the computed set is only ever as
+// wide as the run: this service takes a ?session= filter (api.go), and a
+// session resolves to the persons enrolled in it -- in the current season the
+// largest single session covers about 11% of the people who hold custom values.
+// Uncapping the read without narrowing the judgement would have let one
+// session-scoped run delete the other ~89% of the year as orphans. A row is a
+// candidate only if this run actually fetched that person's values; anything else
+// is invisible to the sweep, exactly as it should be.
+func (s *PersonCustomFieldValuesSync) deleteOrphans(year int, sweptOwners map[string]bool) error {
+	return s.DeleteOrphansGuarded(
+		"person_custom_values",
+		func(record *core.Record) (string, bool) {
+			personPBId := record.GetString("person")
+			if !sweptOwners[personPBId] {
+				return "", false
 			}
-		}
-	}
 
-	if deleted > 0 {
-		slog.Info("Deleted orphan custom field values", "count", deleted)
-	}
-
-	return nil
+			// Matches TrackProcessedCompositeKey's "<identity>|<year>" format
+			return fmt.Sprintf("%s:%s|%d",
+				personPBId, record.GetString("field_definition"), record.GetInt("year")), true
+		},
+		"person custom field value",
+		fmt.Sprintf("year = %d", year),
+		OrphanSweepGuard{
+			Entity:   "person_custom_values",
+			Year:     year,
+			Computed: len(s.ProcessedKeys),
+			Hint: "check that the persons sync ran for that year, and that " +
+				"custom_field_defs still holds these field definitions",
+		},
+	)
 }
 
 // transformPersonCustomFieldValueToPB transforms CampMinder custom field value data to PocketBase format

--- a/pocketbase/sync/person_custom_field_values.go
+++ b/pocketbase/sync/person_custom_field_values.go
@@ -193,7 +193,14 @@ func (s *PersonCustomFieldValuesSync) Sync(ctx context.Context) error {
 // preloadPersonMapping loads CM ID -> PB ID mapping for persons in the given year
 func (s *PersonCustomFieldValuesSync) preloadPersonMapping(year int) (map[int]string, error) {
 	filter := fmt.Sprintf("year = %d", year)
-	persons, err := s.App.FindRecordsByFilter("persons", filter, "", 10000, 0, nil)
+	// Unlimited (0), not a 10,000 cap. PocketBase treats limit=0 as no limit
+	// (core/record_query.go applies Limit only when limit > 0), and a bare
+	// number there is a silent truncation cliff, not a page size: kindred#2266
+	// was exactly this literal on the orphan sweep, where it hid 94% of a year.
+	// This lookup is year-scoped and the largest year on record holds 3,383
+	// persons, so the old cap had headroom -- but headroom is not a guarantee,
+	// and the failure mode is a narrowed sweep rather than an error.
+	persons, err := s.App.FindRecordsByFilter("persons", filter, "", 0, 0, nil)
 	if err != nil {
 		return nil, fmt.Errorf("finding persons: %w", err)
 	}
@@ -213,7 +220,14 @@ func (s *PersonCustomFieldValuesSync) preloadPersonMapping(year int) (map[int]st
 // preloadFieldDefMapping loads CM ID -> PB ID mapping for custom field definitions
 func (s *PersonCustomFieldValuesSync) preloadFieldDefMapping() (map[int]string, error) {
 	// Field definitions are global (no year filter)
-	fieldDefs, err := s.App.FindRecordsByFilter("custom_field_defs", "", "", 10000, 0, nil)
+	// Unlimited (0), not a 10,000 cap. PocketBase treats limit=0 as no limit
+	// (core/record_query.go applies Limit only when limit > 0), and a bare
+	// number there is a silent truncation cliff, not a page size: kindred#2266
+	// was exactly this literal on the orphan sweep, where it hid 94% of a year.
+	// custom_field_defs is NOT year-scoped: all 1,270 rows load every time. That
+	// is the one here with no year to bound it, so it is the one that would
+	// creep up on the cap first.
+	fieldDefs, err := s.App.FindRecordsByFilter("custom_field_defs", "", "", 0, 0, nil)
 	if err != nil {
 		return nil, fmt.Errorf("finding field definitions: %w", err)
 	}
@@ -250,7 +264,14 @@ func (s *PersonCustomFieldValuesSync) getPersonIDsToSync(year int) ([]int, error
 
 	// No session filter - get all persons synced for this year
 	filter := fmt.Sprintf("year = %d", year)
-	persons, err := s.App.FindRecordsByFilter("persons", filter, "", 10000, 0, nil)
+	// Unlimited (0), not a 10,000 cap. PocketBase treats limit=0 as no limit
+	// (core/record_query.go applies Limit only when limit > 0), and a bare
+	// number there is a silent truncation cliff, not a page size: kindred#2266
+	// was exactly this literal on the orphan sweep, where it hid 94% of a year.
+	// Feeds sweptOwners, which is what narrows the orphan sweep. A silent
+	// truncation here would shrink the sweep's computed set as well, so the
+	// two defects would compound rather than cancel.
+	persons, err := s.App.FindRecordsByFilter("persons", filter, "", 0, 0, nil)
 	if err != nil {
 		return nil, fmt.Errorf("finding persons: %w", err)
 	}

--- a/pocketbase/sync/persons.go
+++ b/pocketbase/sync/persons.go
@@ -1084,7 +1084,7 @@ func (s *PersonsSync) printDataQualitySummary() {
 func (s *PersonsSync) deleteOrphans(year int) error {
 	filter := fmt.Sprintf("year = %d", year)
 
-	return s.DeleteOrphans(
+	return s.DeleteOrphansGuarded(
 		"persons",
 		func(record *core.Record) (string, bool) {
 			cmID, ok := record.Get("cm_id").(float64)
@@ -1097,6 +1097,12 @@ func (s *PersonsSync) deleteOrphans(year int) error {
 		},
 		"person",
 		filter,
+		OrphanSweepGuard{
+			Entity:   "persons",
+			Year:     year,
+			Computed: len(s.ProcessedKeys),
+			Hint:     "check that the CampMinder person feed returned this season",
+		},
 	)
 }
 

--- a/pocketbase/sync/staff_applications.go
+++ b/pocketbase/sync/staff_applications.go
@@ -847,27 +847,32 @@ func (s *StaffApplicationsSync) upsertRecords(
 
 // deleteOrphans removes records that exist in DB but not in computed set.
 //
-// Refuses when the computed set is empty and rows exist for the year: that
-// combination is always a broken input, and sweeping on it deletes the whole
-// year and reports success (kindred#2279 Gap 2).
+// Refuses when the computed set is too small to be believed against the rows on
+// disk: that combination is always a broken input, and sweeping on it deletes
+// the year and reports success (kindred#2279 Gap 2). The rule itself lives in
+// OrphanSweepGuard -- this was one of two hand-written copies, and it now shares
+// the one implementation, which also widened it from "empty" to "suspiciously
+// small" (kindred#2279 Gap 1).
 //
 // This service shares staff_vehicle_info's loadPersonStaffMapping(ctx, year)
 // gate exactly, so it has the identical year-wipe path and the same two
-// upstream causes: an empty personToStaff mapping (every value fails the staff
-// gate), or an empty fieldNameMap after an upstream rename of the App-*
-// definitions (every value routes nowhere).
+// upstream causes: a collapsed personToStaff mapping (values fail the staff
+// gate), or a collapsed fieldNameMap after an upstream rename of the App-*
+// definitions (values route nowhere).
 func (s *StaffApplicationsSync) deleteOrphans(
 	ctx context.Context,
 	records map[string]*staffApplicationRecord,
 	existingRecords map[string]string,
 	year int,
 ) (int, error) {
-	if len(records) == 0 && len(existingRecords) > 0 {
-		return 0, fmt.Errorf(
-			"refusing to sweep %d existing staff_applications rows for year %d against an "+
-				"empty computed set (check the staff table for that year, and that the App-* "+
-				"field definitions still exist upstream)",
-			len(existingRecords), year)
+	guard := OrphanSweepGuard{
+		Entity:   "staff_applications",
+		Year:     year,
+		Computed: len(records),
+		Hint:     "check the staff table for that year, and that the App-* field definitions still exist upstream",
+	}
+	if err := guard.Check(len(existingRecords)); err != nil {
+		return 0, err
 	}
 
 	deleted := 0

--- a/pocketbase/sync/staff_applications.go
+++ b/pocketbase/sync/staff_applications.go
@@ -200,8 +200,10 @@ func (s *StaffApplicationsSync) Sync(ctx context.Context) error {
 	s.Stats.Deleted = deleted
 
 	// WAL checkpoint BEFORE the error return below: upsertRecords has already
-	// written by this point, and the cancellation path returns with those
-	// writes still in the WAL.
+	// written by this point, and both error paths return with those writes still
+	// in the WAL. That includes the refusal path -- widening the guard to catch a
+	// PARTIAL collapse (kindred#2279) means it can refuse on a non-empty computed
+	// set, which is exactly the case where upsertRecords did write.
 	if s.Stats.Created > 0 || s.Stats.Updated > 0 || s.Stats.Deleted > 0 {
 		if cpErr := s.forceWALCheckpoint(); cpErr != nil {
 			slog.Warn("WAL checkpoint failed", "error", cpErr)

--- a/pocketbase/sync/staff_vehicle_info.go
+++ b/pocketbase/sync/staff_vehicle_info.go
@@ -186,9 +186,11 @@ func (s *StaffVehicleInfoSync) Sync(ctx context.Context) error {
 	s.Stats.Deleted = deleted
 
 	// WAL checkpoint BEFORE the error return below. upsertRecords has already
-	// written by this point, and the cancellation path returns with those writes
-	// still in the WAL. (The refusal path cannot strand writes -- it requires an
-	// empty computed set, so nothing was upserted -- but cancellation can.)
+	// written by this point, and both error paths return with those writes still
+	// in the WAL. That now includes the refusal path: widening the guard to catch
+	// a PARTIAL collapse (kindred#2279) means it can refuse on a non-empty
+	// computed set, which is exactly the case where upsertRecords did write. The
+	// checkpoint therefore has to precede the error return, not follow it.
 	if s.Stats.Created > 0 || s.Stats.Updated > 0 || s.Stats.Deleted > 0 {
 		if cpErr := s.forceWALCheckpoint(); cpErr != nil {
 			slog.Warn("WAL checkpoint failed", "error", cpErr)

--- a/pocketbase/sync/staff_vehicle_info.go
+++ b/pocketbase/sync/staff_vehicle_info.go
@@ -646,28 +646,34 @@ func (s *StaffVehicleInfoSync) upsertRecords(
 
 // deleteOrphans removes records that exist in DB but not in computed set.
 //
-// Refuses when the computed set is empty and rows exist for the year: that
-// combination is always a broken input, and sweeping on it deletes the whole
-// year and reports success (kindred#2273).
+// Refuses when the computed set is too small to be believed against the rows on
+// disk: that combination is always a broken input, and sweeping on it deletes
+// the year and reports success (kindred#2273). The rule itself lives in
+// OrphanSweepGuard -- this was one of two hand-written copies, and it now shares
+// the one implementation, which also widened it from "empty" to "suspiciously
+// small" (kindred#2279 Gap 1). A staff sync that times out partway leaves a
+// SHORT personToStaff mapping far more often than an empty one.
 //
-// TWO upstream faults produce it, and the error names both because they surface
-// in different places: an empty personToStaff mapping (every value fails the
-// staff gate), or an empty fieldNameMap after an upstream rename of the SVI-*
-// namespace (every value routes nowhere). The second is the kindred#2258 class
-// and shows up in the "SVI field routing" warnings Layer 1 logs earlier in the
-// same run -- naming only the staff table sends an operator to the wrong place.
+// TWO upstream faults produce it, and the hint names both because they surface
+// in different places: a collapsed personToStaff mapping (values fail the staff
+// gate), or a collapsed fieldNameMap after an upstream rename of the SVI-*
+// namespace (values route nowhere). The second is the kindred#2258 class and
+// shows up in the "SVI field routing" warnings Layer 1 logs earlier in the same
+// run -- naming only the staff table sends an operator to the wrong place.
 func (s *StaffVehicleInfoSync) deleteOrphans(
 	ctx context.Context,
 	records map[string]*staffVehicleInfoRecord,
 	existingRecords map[string]string,
 	year int,
 ) (int, error) {
-	if len(records) == 0 && len(existingRecords) > 0 {
-		return 0, fmt.Errorf(
-			"refusing to sweep %d existing staff_vehicle_info rows for year %d against an "+
-				"empty computed set (check the staff table for that year, and the SVI field "+
-				"routing warnings above for an upstream rename)",
-			len(existingRecords), year)
+	guard := OrphanSweepGuard{
+		Entity:   "staff_vehicle_info",
+		Year:     year,
+		Computed: len(records),
+		Hint:     "check the staff table for that year, and the SVI field routing warnings above for an upstream rename",
+	}
+	if err := guard.Check(len(existingRecords)); err != nil {
+		return 0, err
 	}
 
 	deleted := 0


### PR DESCRIPTION
Three defects of the same class: an orphan sweep that deletes what it cannot see.

Closes #2266.
Closes #2279.

## Part 1 — the 10,000-row cap (#2266)

`PersonCustomFieldValuesSync.deleteOrphans` read at most 10,000 rows with no surrounding loop. 10,000 is a hard cap, not a page size, and the sort argument was `""` so no `ORDER BY` was emitted at all — which rows came back was left to the SQLite planner. Re-measured against the dated production snapshot, the issue's figures reproduce exactly:

| year | rows | swept | % |
|------|-----:|------:|--:|
| 2022 | 184,458 | 10,000 | 5.4 |
| 2025 | 171,884 | 10,000 | 5.8 |
| 2026 | 156,669 | 10,000 | 6.4 |

A value deleted in CampMinder was therefore never removed, and kept feeding every derived table that reads this one. `HouseholdCustomFieldValuesSync` had the identical statement, latent only because its largest year holds 1,773 rows.

Both now route through the shared guarded sweep rather than a hand-rolled loop, so the cap is replaced by keyset pagination and there is one implementation instead of two copies.

### Uncapping the read alone would have been worse than the bug

Both services accept a `?session=` filter (`api.go`), which narrows the **computed set** to the persons or households enrolled in that session — while `deleteOrphans`' own filter is the **whole year**. The 10,000-row cap was accidentally masking this. Measured on the snapshot: 2,563 persons hold custom values in the current season, and the largest single session resolves to 293 of them (11.4%). A `?session=` run with a naively uncapped sweep would have deleted roughly 89% of the year — about 139,000 rows — as orphans.

So the sweep now judges only owners whose values this run actually fetched. A person whose fetch errored is left out too: a partial fetch must not be read as deletions.

## Part 2 — the guard was too narrow, and hand-copied (#2279 a + b)

The shipped guard caught only a **total** collapse (`len(records) == 0 && len(existing) > 0`). A **partial** one — 5 mappings where 300 were expected — sailed past it and deleted the other 295 while reporting success. A staff sync that times out partway produces a short mapping far more often than an empty one.

`OrphanSweepGuard` (`pocketbase/sync/orphan_guard.go`) is now the single implementation. `staff_vehicle_info` and `staff_applications` drop their hand-written copies onto it; `persons`, `attendees`, `bunk_assignments`, `bunk_plans` and both custom-value syncs opt in.

**Threshold: a ratio floor of 0.5, applied only at 20 rows or more.** A run computing fewer than half the rows already stored is asserting that more than half a season vanished from CampMinder between two syncs — no workflow does that, since attrition is single-digit percentages and a rollover lands in a new `year` partition rather than shrinking an existing one. The 20-row minimum is what keeps legitimately small early-season syncs running: a table of four rows can lose three, a table of hundreds cannot. The empty-computed-set arm still applies at **any** size, so the shipped behaviour is preserved exactly. Both constants are read in one place.

`Computed` is deliberately the size of the set the run built, not its intersection with disk — a healthy run can legitimately share no keys with what is stored (one person leaves, another arrives), so an empty intersection is not evidence of anything.

## Part 3 — `BaseSyncService.DeleteOrphans` skipped records (17 call sites)

It paginated with `OFFSET (page-1)*perPage` while deleting inside the loop, so every delete shrank the set the next offset was measured against and slid that many unread records past the cursor. The sweep is now two-phase: a read-only keyset scan that collects orphans, then the deletes.

Mutation testing showed the **two-phase split**, not the keyset cursor, is what stops the skipping — a scan that writes nothing cannot move its own cursor. Keyset is still the right choice and is separately pinned: the old sort was `-created`, which is not a unique ordering, and `LIMIT`/`OFFSET` over a non-unique `ORDER BY` can repeat or skip rows on its own. The comment in the code says exactly this rather than overclaiming.

The split is also what makes the guard possible: a ratio over rows-inspected-so-far means nothing mid-scan.

`Stats.Errors` handling is unchanged — the escalation policy is a separate decision.

## Out of scope

The seven `deleteOrphans` implementations returning a bare `int` (`camper_dietary`, `camper_history`, `camper_transportation`, `household_demographics`, `normalize_geographic`, `quest_registrations`, `staff_skills`) need a signature and caller change and are tracked separately. `household_demographics` is being re-grained in a parallel branch.

No key format changed, so the grain triple (#2257) is untouched. No backfill and no data migration.

## Verification

- `go test ./...` green; `golangci-lint` 0 issues; `scripts/pre-push-verify.sh` **ALL CHECKS PASSED**.
- Binary boots from a fresh data dir, applies every migration, `/api/health` → 200.
- Every new guard is mutation-checked — full results in the PR discussion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved orphan-record cleanup to scan all records reliably, including datasets larger than 10,000 records.
  * Prevented incomplete or session-scoped sync results from deleting unrelated records.
  * Added safeguards that block deletion when incoming data appears unexpectedly empty or incomplete.
  * Preserved records that disappear during cleanup and provided clearer diagnostic errors.
  * Improved cleanup reliability by separating record scanning from deletion, preventing records from being skipped during large sweeps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->