### PR TITLE
fix(sync,pb): store one household demographics row per camper, not one per family

### DIFF
--- a/docs/architecture/sync-layer.md
+++ b/docs/architecture/sync-layer.md
@@ -203,7 +203,7 @@ as measured on that date, not re-derived live):
 | `camper_transportation` | person × session | 1661 | 10 (0.6%) | 11 / 1969 |
 | `quest_registrations` | person × year | 69 | 1 | 0 / 64 |
 | `staff_skills` | person, not enrolment | 401 | predicate does not apply — staff are not attendees | — |
-| `household_demographics` | household, not enrolment | 1603 | predicate does not apply — household-grain | — |
+| `household_demographics` | **(household, person, year)** — re-grained by kindred#2260 | ~2210 projected | **predicate DOES apply** to the person-attributed rows (~2181 of ~2210 for 2026); the ~29 `person_id = 0` rows carry genuinely household-level answers and are outside it | — |
 
 **The point worth stating plainly: a dashboard that reads `camper_dietary` unfiltered ships a 7.2%
 (2026) / 13.4% (2025) error.** That gap is the whole reason this rule exists: the three
@@ -214,11 +214,19 @@ carry stale rows for people no longer actively enrolled, at the percentages meas
 `table_exporter.go`'s `SyncJobToCollections` map is *not* a reader — its own comment says it exists
 only so the export-skip optimisation knows which collections a sync job writes; nothing there touches
 a row. The one real live reader, `GetReadableYearExports()`, covers `staff_skills` and
-`household_demographics` — the two tables above where the predicate does **not** apply, since staff
-are not attendees and the household grain has no per-person enrolment to check. This rule is written
-down for whoever builds the first reader of `camper_dietary`, `camper_transportation`, or
-`quest_registrations` — a future staff dashboard or PDF export — so that reader doesn't inherit the
-error above silently.
+`household_demographics`. ⚠️ **Only the first of those is now outside the predicate.** Staff are not
+attendees, so `staff_skills` genuinely has no enrolment to check. `household_demographics` used to be
+in the same position and **is not any more**: kindred#2260 re-grained it to one row per (household,
+person, year), so all but ~29 of its ~2210 2026 rows are attributed to a specific camper.
+`loadPersonHouseholdMapping` admits any person with a household that year **regardless of enrolment
+status**, so a cancelled camper keeps a row — and that row is exported, unfiltered, beside Jewish
+identity, family description and custody answers. Anyone adding or changing a reader of this table
+must decide the enrolment question deliberately rather than inheriting the old "household-grain, does
+not apply" answer, which was true before that change and is false now.
+
+This rule is written down for whoever builds the first reader of `camper_dietary`,
+`camper_transportation`, or `quest_registrations` — a future staff dashboard or PDF export — so that
+reader doesn't inherit the error above silently.
 
 ## Python Request Processor (`bunking/sync/bunk_request_processor/`)
 Unified processor for all 5 bunk request field types:

--- a/frontend/src/types/pocketbase-types.ts
+++ b/frontend/src/types/pocketbase-types.ts
@@ -951,6 +951,8 @@ export type HouseholdDemographicsRecord = {
   military_family?: boolean
   parent_immigrant?: boolean
   parent_immigrant_origin?: string
+  person?: RecordIdString
+  person_id?: number
   updated: IsoAutoDateString
   year: number
 }

--- a/pocketbase/pb_migrations/1500000150_household_demographics_person_grain.js
+++ b/pocketbase/pb_migrations/1500000150_household_demographics_person_grain.js
@@ -1,0 +1,170 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: re-grain household_demographics to one row per (household, person,
+ * year). Resolves kindred#2260; part of kindred#2257.
+ *
+ * WHAT WAS WRONG. The table held one row per (household, year), and the
+ * summer-side columns were filled from the `HH-` custom fields that each CAMPER
+ * in the household answered. `mapPersonFieldToRecord` folded them together
+ * first-non-empty-wins, so a household where two campers answered the same
+ * question differently kept one answer and discarded the rest: 7,781 answers
+ * across ten years, 627 in 2026, in 7,593 household-year-column cells. The
+ * survivor was not even chosen -- the loader paged with no ORDER BY, so it was
+ * whichever row the SQLite planner's index yielded first.
+ *
+ * WHY THE GRAIN MOVES RATHER THAN A COLLAPSE RULE BEING PICKED. These values
+ * are pipe-delimited multi-selects. Measured over all 7,593 colliding cells,
+ * the newest answer contains every token its siblings carry in only 1,098
+ * (14%); in the other 6,495 (86%) a newest-wins rule still loses tokens. A
+ * union is not available either -- real data pairs "Prefer not to answer" with
+ * a named affiliation for the same household, which cannot be merged into one
+ * string that means anything. The answers are given per camper, so they are now
+ * stored per camper. Nothing has to be invented.
+ *
+ * THE GRAIN TRIPLE. kindred#2257: the write key, the orphan key and the unique
+ * index must move together. This file is the third leg only. The other two are
+ * `MakeCompositeKey`/`upsertRecords` and `deleteOrphans` in
+ * pocketbase/sync/household_demographics.go, changed in the same commit.
+ * Shipping this index alone would be worse than shipping nothing: a
+ * household-grain write key never presents two rows for one household-year, so
+ * a widened index never fires and looks safe right up until the write key
+ * moves under it.
+ *
+ * NO DATA MIGRATION, AND NONE IS NEEDED. Every row is recomputed from
+ * person_custom_values on each sync run, and that source is intact -- it holds
+ * the raw answers under UNIQUE(year, person, field_definition) with zero
+ * duplicate key groups. The 17,646 existing rows arrive here with person_id 0,
+ * which is exactly the household-level row's key, so nothing collides under the
+ * new unique index. The first run after this migration rewrites them: the
+ * household-level rows keep their _family columns and have their _summer
+ * columns cleared, and the per-camper rows are created alongside. Rows for
+ * households whose answers were all person-level are swept as orphans and
+ * re-created at the right grain. Expected shape for 2026: 2,181 camper rows +
+ * 29 household rows, against 1,612 today.
+ *
+ * person_id 0 IS LOAD-BEARING. Household-level answers come from
+ * household_custom_values, which is already one row per household per field.
+ * They are not copied onto every camper -- they land on a person-less row.
+ * SQLite treats 0 as a value, not a NULL, so the unique index keeps exactly one
+ * such row per household-year rather than silently allowing many.
+ *
+ * WHY person_id KEYS THE INDEX AND `person` DOES NOT. CLAUDE.md section 1: all
+ * cross-table relationships use CampMinder ids, never PocketBase ids. The
+ * person-keyed derived tables all follow it -- attendees, camper_dietary and
+ * quest_registrations are unique on `person_id` while carrying a relation
+ * beside it -- and 1500000147 re-keyed four lodging tables off their relations
+ * for exactly this reason. The `person` relation is added too, because it is
+ * what an expand-based read and the table exporter join through; it is a
+ * handle, not the identity. Verified against the production snapshot: zero
+ * persons rows carry cm_id <= 0, and grouping the source answers by person PB
+ * id and by person CampMinder id both give 24,288 rows, so the two keys select
+ * the same grain.
+ *
+ * API RULES ARE DELIBERATELY UNCHANGED, and this is a decision rather than an
+ * oversight. This table holds sensitive-category data (Jewish identity and
+ * affiliation, LGBTQ and interfaith family description, custody arrangements),
+ * and the re-grain does raise its granularity: a row used to say "this family",
+ * and now says "this camper answered this". But that exact attribution, at that
+ * exact grain, already sits one table over in person_custom_values -- which is
+ * this table's source and is itself `@request.auth.is_admin = true` on all five
+ * rules, as are camper_dietary, family_camp_medical, financial_aid_applications
+ * and household_custom_values. Tightening this one table below its own source
+ * would deny an admin a fact they can read next door, which is theatre rather
+ * than protection. Superuser-only writes were considered on the grounds that
+ * every row is computed and a hand-edit would be silently reverted by the next
+ * sync; rejected because the Go sync writes through core.App and bypasses these
+ * rules either way, so the change would buy nothing and make one table diverge
+ * from ten identical siblings for no stated reason. It is not PHI, so no
+ * lodging.phi gate applies.
+ */
+
+const OLD_INDEX =
+  "CREATE UNIQUE INDEX `idx_household_demographics_hh_year` " +
+  "ON `household_demographics` (`household`, `year`)";
+
+const NEW_INDEX =
+  "CREATE UNIQUE INDEX `idx_household_demographics_hh_person_year` " +
+  "ON `household_demographics` (`household`, `person_id`, `year`)";
+
+/**
+ * Drop the named indexes, then add the replacements.
+ *
+ * Matched on NAME rather than on the columns, so the down path -- which
+ * replaces an index that no longer mentions person_id -- removes the right one.
+ * Idempotent by construction: editing an already-applied migration silently
+ * skips it (`_migrations` keys on filename), so a re-run must not push a second
+ * index under the same name. Lifted from 1500000147.
+ */
+function replaceIndex(col, dropName, addSQL) {
+  col.indexes = col.indexes.filter(function (sql) {
+    return sql.indexOf("`" + dropName + "`") === -1;
+  });
+  col.indexes.push(addSQL);
+}
+
+migrate(
+  (app) => {
+    const personsCol = app.findCollectionByNameOrId("persons");
+    const collection = app.findCollectionByNameOrId("household_demographics");
+
+    // The camper who gave the answer. Empty on the household-level row.
+    // cascadeDelete matches the `household` relation this table already
+    // carries: a person leaving takes their own demographics row with them,
+    // and the next sync recomputes whatever should still be there.
+    collection.fields.add(
+      new Field({
+        type: "relation",
+        name: "person",
+        required: false,
+        presentable: false,
+        collectionId: personsCol.id,
+        cascadeDelete: true,
+        minSelect: null,
+        maxSelect: 1,
+      })
+    );
+
+    // The durable identity, and the column the unique index keys on.
+    // 0 = the household-level row. onlyInt because CampMinder ids are integers
+    // and a fractional value here would key a row nothing could look up.
+    collection.fields.add(
+      new Field({
+        type: "number",
+        name: "person_id",
+        required: false,
+        presentable: false,
+        min: 0,
+        max: null,
+        onlyInt: true,
+      })
+    );
+
+    replaceIndex(collection, "idx_household_demographics_hh_year", NEW_INDEX);
+
+    app.save(collection);
+  },
+  (app) => {
+    const collection = app.findCollectionByNameOrId("household_demographics");
+
+    // Narrow the index BEFORE dropping the columns it names, and be honest
+    // about what going back means: the old index is unique on
+    // (household, year), so it cannot be created while the per-camper rows
+    // exist. Delete them first -- they are recomputed on the next sync run
+    // either way, and the answers themselves live in person_custom_values, not
+    // here.
+    app
+      .db()
+      .newQuery("DELETE FROM household_demographics WHERE person_id > 0")
+      .execute();
+
+    replaceIndex(
+      collection,
+      "idx_household_demographics_hh_person_year",
+      OLD_INDEX
+    );
+    collection.fields.removeByName("person");
+    collection.fields.removeByName("person_id");
+
+    app.save(collection);
+  }
+);

--- a/pocketbase/sync/household_demographics.go
+++ b/pocketbase/sync/household_demographics.go
@@ -191,6 +191,10 @@ type householdDemographicsRecord struct {
 func (s *HouseholdDemographicsSync) Sync(ctx context.Context) error {
 	s.Stats = Stats{}
 	s.SyncSuccessful = false
+	// Reset alongside Stats: orchestrator.go registers this service as a
+	// singleton, so a counter left standing would be reported against the next
+	// year's run as well as its own.
+	s.columnConflicts = 0
 
 	// Determine year
 	year := s.Year

--- a/pocketbase/sync/household_demographics.go
+++ b/pocketbase/sync/household_demographics.go
@@ -15,6 +15,14 @@ const serviceNameHouseholdDemographics = "household_demographics"
 // customFieldNameSynagogue is the custom field name for synagogue data
 const customFieldNameSynagogue = "Synagogue"
 
+// sortByID is the sort argument every paged read in this service passes.
+// PocketBase adds an ORDER BY only when the sort argument is non-empty
+// (core/record_query.go), so an empty one leaves the row order up to whichever
+// index the SQLite planner picks -- which is not stable ACROSS the separate
+// per-page queries a paged read issues, so a plan change between pages can skip
+// or repeat rows. `id` is unique, so it is a total order.
+const sortByID = "id"
+
 // HouseholdDemographicsSync computes household demographics from custom values.
 // This service reads from person_custom_values (HH- prefixed fields) and
 // household_custom_values, then populates the household_demographics table.
@@ -22,10 +30,21 @@ const customFieldNameSynagogue = "Synagogue"
 // Unlike CampMinder API syncs, this doesn't call external APIs - it computes
 // derived/aggregated data from existing PocketBase records.
 //
+// Grain: one row per (household, person, year).
+//
+// The table used to hold one row per (household, year), and the HH- answers of
+// every camper in a household were folded into it first-non-empty-wins. That
+// discarded 7,781 answers across ten years (627 in 2026) and the survivor was
+// whichever row SQLite's planner happened to yield first -- kindred#2260. The
+// answers are given per camper, so the table now stores them per camper.
+//
 // Field mapping:
-// - HH- prefixed person fields go to _summer columns (from summer camp registration)
-// - Household custom fields go to _family columns (from family camp registration)
-// - First non-empty value wins for multi-camper households
+//   - HH- prefixed person fields go to _summer columns (from summer camp
+//     registration) on the answering camper's row.
+//   - Household custom fields go to _family columns (from family camp
+//     registration). They are already one row per household per field, so they
+//     land on a person-less row (person_id 0) rather than being copied onto
+//     every camper.
 type HouseholdDemographicsSync struct {
 	App            core.App
 	Year           int  // Year to compute for (0 = current year from env)
@@ -33,6 +52,11 @@ type HouseholdDemographicsSync struct {
 	Debug          bool // Enable verbose debug logging
 	Stats          Stats
 	SyncSuccessful bool
+
+	// columnConflicts counts values setColumn refused to overwrite. Zero on
+	// every year of the production snapshot; a non-zero count means two field
+	// definitions share a trimmed name.
+	columnConflicts int
 }
 
 // NewHouseholdDemographicsSync creates a new household demographics sync service
@@ -114,9 +138,14 @@ func (s *HouseholdDemographicsSync) fieldEquals(existing, newVal any) bool {
 	return fmt.Sprintf("%v", existing) == fmt.Sprintf("%v", newVal)
 }
 
-// householdDemographicsRecord holds the computed demographics for a household
+// householdDemographicsRecord holds the computed demographics for one row.
+//
+// personPBID/personCMID are empty/zero on the household-level row that carries
+// the _family columns; every other row belongs to the camper who answered.
 type householdDemographicsRecord struct {
 	householdPBID string
+	personPBID    string
+	personCMID    int
 	year          int
 
 	// Family description (multi-select, pipe-separated)
@@ -174,7 +203,7 @@ func (s *HouseholdDemographicsSync) Sync(ctx context.Context) error {
 	}
 
 	// Validate year (minimum 2017 per test spec)
-	if year < 2017 || year > 2050 {
+	if !isValidDemographicsYear(year) {
 		return fmt.Errorf("invalid year %d: must be between 2017 and 2050", year)
 	}
 
@@ -211,13 +240,13 @@ func (s *HouseholdDemographicsSync) Sync(ctx context.Context) error {
 	}
 	slog.Info("Loaded household custom values", "count", len(householdValues))
 
-	// Step 5: Aggregate to household level
-	records := s.aggregateToHouseholdLevel(personValues, householdValues, year)
-	slog.Info("Aggregated to household level", "count", len(records))
+	// Step 5: Aggregate to one row per (household, person, year)
+	records := s.aggregateToRows(personValues, householdValues, year)
+	slog.Info("Aggregated to person grain", "rows", len(records), "conflicts", s.columnConflicts)
 
 	if s.DryRun {
 		slog.Info("Dry run mode - computed but not writing",
-			"households", len(records),
+			"rows", len(records),
 		)
 		s.Stats.Created = len(records)
 		s.SyncSuccessful = true
@@ -252,6 +281,7 @@ func (s *HouseholdDemographicsSync) Sync(ctx context.Context) error {
 	s.SyncSuccessful = true
 	slog.Info("Household demographics computation completed",
 		"year", year,
+		"column_conflicts", s.columnConflicts,
 		"created", s.Stats.Created,
 		"updated", s.Stats.Updated,
 		"deleted", s.Stats.Deleted,
@@ -259,6 +289,12 @@ func (s *HouseholdDemographicsSync) Sync(ctx context.Context) error {
 	)
 
 	return nil
+}
+
+// isValidDemographicsYear reports whether a year is in the range this service
+// will compute for. 2017 is the first year CampMinder data was imported.
+func isValidDemographicsYear(year int) bool {
+	return year >= 2017 && year <= 2050
 }
 
 // loadFieldDefinitions builds a map of field_definition PB ID -> field name
@@ -304,11 +340,20 @@ func IsHHField(name string) bool {
 	return strings.HasPrefix(name, "HH-")
 }
 
-// loadPersonHouseholdMapping builds a map of person PB ID -> household PB ID
+// personRef is what a person PB ID resolves to: the household that person
+// belongs to, and the CampMinder id that keys their row. CampMinder ids are the
+// identity layer here (CLAUDE.md section 1) -- the PB id is carried alongside
+// only to populate the `person` relation.
+type personRef struct {
+	householdPBID string
+	cmID          int
+}
+
+// loadPersonHouseholdMapping builds a map of person PB ID -> personRef
 func (s *HouseholdDemographicsSync) loadPersonHouseholdMapping(
 	ctx context.Context, year int,
-) (map[string]string, error) {
-	result := make(map[string]string)
+) (map[string]personRef, error) {
+	result := make(map[string]personRef)
 
 	filter := fmt.Sprintf("year = %d && household != ''", year)
 	page := 1
@@ -321,7 +366,7 @@ func (s *HouseholdDemographicsSync) loadPersonHouseholdMapping(
 		default:
 		}
 
-		records, err := s.App.FindRecordsByFilter("persons", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("persons", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying persons page %d: %w", page, err)
 		}
@@ -329,7 +374,7 @@ func (s *HouseholdDemographicsSync) loadPersonHouseholdMapping(
 		for _, record := range records {
 			householdID := record.GetString("household")
 			if householdID != "" {
-				result[record.Id] = householdID
+				result[record.Id] = personRef{householdPBID: householdID, cmID: record.GetInt("cm_id")}
 			}
 		}
 
@@ -342,16 +387,21 @@ func (s *HouseholdDemographicsSync) loadPersonHouseholdMapping(
 	return result, nil
 }
 
-// hhCustomValueEntry represents a loaded HH custom value
+// hhCustomValueEntry represents a loaded HH custom value.
+//
+// personPBID/personCMID identify the camper who gave the answer, and are
+// empty/zero for household-level (family camp) values, which have no camper.
 type hhCustomValueEntry struct {
 	householdPBID string
+	personPBID    string
+	personCMID    int
 	fieldName     string
 	value         string
 }
 
 // loadPersonCustomValues loads person custom values for HH- prefixed fields
 func (s *HouseholdDemographicsSync) loadPersonCustomValues(
-	ctx context.Context, year int, fieldNameMap map[string]string, personToHousehold map[string]string,
+	ctx context.Context, year int, fieldNameMap map[string]string, personToHousehold map[string]personRef,
 ) ([]hhCustomValueEntry, error) {
 	var result []hhCustomValueEntry
 
@@ -366,7 +416,7 @@ func (s *HouseholdDemographicsSync) loadPersonCustomValues(
 		default:
 		}
 
-		records, err := s.App.FindRecordsByFilter("person_custom_values", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("person_custom_values", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying person custom values page %d: %w", page, err)
 		}
@@ -379,12 +429,14 @@ func (s *HouseholdDemographicsSync) loadPersonCustomValues(
 			}
 
 			personID := record.GetString("person")
-			householdID := personToHousehold[personID]
+			ref := personToHousehold[personID]
 			value := record.GetString("value")
 
-			if householdID != "" && value != "" {
+			if ref.householdPBID != "" && value != "" {
 				result = append(result, hhCustomValueEntry{
-					householdPBID: householdID,
+					householdPBID: ref.householdPBID,
+					personPBID:    personID,
+					personCMID:    ref.cmID,
 					fieldName:     fieldName,
 					value:         value,
 				})
@@ -417,7 +469,7 @@ func (s *HouseholdDemographicsSync) loadHouseholdCustomValues(
 		default:
 		}
 
-		records, err := s.App.FindRecordsByFilter("household_custom_values", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("household_custom_values", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying household custom values page %d: %w", page, err)
 		}
@@ -454,43 +506,100 @@ func (s *HouseholdDemographicsSync) loadHouseholdCustomValues(
 	return result, nil
 }
 
-// aggregateToHouseholdLevel aggregates custom values to household level
-// First non-empty value wins for multi-camper households
-func (s *HouseholdDemographicsSync) aggregateToHouseholdLevel(
+// aggregateToRows groups custom values into rows at the table's grain:
+// (household, person, year) for the HH- answers a camper gave, and
+// (household, 0, year) for the household-level family camp answers.
+//
+// The map is keyed by MakeCompositeKey, the same write key upsertRecords and
+// deleteOrphans use -- the three must agree or a sweep deletes what a write
+// just created (kindred#2257, "the grain triple").
+//
+// Order-independent by construction: at this grain each column has at most one
+// contributing value, so nothing here depends on the order the loaders read
+// rows in.
+func (s *HouseholdDemographicsSync) aggregateToRows(
 	personValues []hhCustomValueEntry,
 	householdValues []hhCustomValueEntry,
 	year int,
 ) map[string]*householdDemographicsRecord {
 	records := make(map[string]*householdDemographicsRecord)
 
-	// Helper to get or create record
-	getRecord := func(householdID string) *householdDemographicsRecord {
-		if records[householdID] == nil {
-			records[householdID] = &householdDemographicsRecord{
-				householdPBID: householdID,
+	// Helper to get or create the row for one grain key
+	getRecord := func(v hhCustomValueEntry) *householdDemographicsRecord {
+		key := MakeCompositeKey(v.householdPBID, v.personCMID, year)
+		if records[key] == nil {
+			records[key] = &householdDemographicsRecord{
+				householdPBID: v.householdPBID,
+				personPBID:    v.personPBID,
+				personCMID:    v.personCMID,
 				year:          year,
 			}
 		}
-		return records[householdID]
+		return records[key]
 	}
 
 	// Process person custom values (HH- fields) -> _summer columns
 	for _, v := range personValues {
-		rec := getRecord(v.householdPBID)
+		rec := getRecord(v)
 		s.mapPersonFieldToRecord(rec, v.fieldName, v.value)
 	}
 
 	// Process household custom values -> _family columns
 	for _, v := range householdValues {
-		rec := getRecord(v.householdPBID)
+		rec := getRecord(v)
 		s.mapHouseholdFieldToRecord(rec, v.fieldName, v.value)
 	}
 
 	return records
 }
 
-// mapPersonFieldToRecord maps a HH- person field to the appropriate record field
-// Uses "first non-empty wins" strategy
+// setColumn writes a text column, and refuses to overwrite it with a different
+// value.
+//
+// At this grain a second value cannot legitimately arrive: person_custom_values
+// is UNIQUE(year, person, field_definition), household_custom_values is
+// UNIQUE(year, household, field_definition), and both mapping switches are
+// injective, so one row contributes at most one value per column. The only way
+// here is two field definitions sharing a trimmed name -- zero exist today.
+//
+// That makes this a must-be-unique rule rather than a collapse rule, and the
+// difference from the code it replaces is the whole point of kindred#2260: the
+// old `if rec.X == ""` guard silently dropped a real disagreement between two
+// campers. There is no disagreement left to drop, so anything reaching the
+// refusal below is a data fault worth hearing about rather than a routine
+// collision to resolve.
+func (s *HouseholdDemographicsSync) setColumn(rec *householdDemographicsRecord, dst *string, column, value string) {
+	if *dst == "" {
+		*dst = value
+		return
+	}
+	if *dst == value {
+		return // the same answer twice discards nothing
+	}
+	s.columnConflicts++
+	// Identifiers only. These columns hold sensitive-category answers (Jewish
+	// identity and affiliation, LGBTQ and interfaith family description, custody
+	// arrangements) and a log is a wider audience than the table's admin-only
+	// API rules; both values are recoverable from person_custom_values by
+	// anyone entitled to see them.
+	slog.Warn("Conflicting values for one demographics column at (household, person, year)",
+		"household", rec.householdPBID,
+		"person", rec.personPBID,
+		"year", rec.year,
+		"column", column,
+	)
+}
+
+// mapPersonFieldToRecord maps a HH- person field onto the answering camper's row.
+//
+// The 14 text columns go through setColumn, which is a must-be-unique rule --
+// see its comment. It replaces the `if rec.X == ""` first-non-empty-wins guard
+// that gave kindred#2260 its name: at household grain that guard let the first
+// camper read speak for the family and threw the rest away.
+//
+// The four boolean arms are unchanged. They are logical ORs over the
+// contributing values, never first-wins, so they were never part of the defect;
+// at this grain they OR over one camper's answers instead of the household's.
 func (s *HouseholdDemographicsSync) mapPersonFieldToRecord(rec *householdDemographicsRecord, fieldName, value string) {
 	// Use MapHHFieldToColumn for the field mapping
 	column := MapHHFieldToColumn(fieldName)
@@ -498,38 +607,23 @@ func (s *HouseholdDemographicsSync) mapPersonFieldToRecord(rec *householdDemogra
 		return // Unknown field
 	}
 
-	// First non-empty wins
 	switch column {
 	case "family_description":
-		if rec.familyDescription == "" {
-			rec.familyDescription = value
-		}
+		s.setColumn(rec, &rec.familyDescription, column, value)
 	case "family_description_other":
-		if rec.familyDescriptionOther == "" {
-			rec.familyDescriptionOther = value
-		}
+		s.setColumn(rec, &rec.familyDescriptionOther, column, value)
 	case "jewish_affiliation":
-		if rec.jewishAffiliation == "" {
-			rec.jewishAffiliation = value
-		}
+		s.setColumn(rec, &rec.jewishAffiliation, column, value)
 	case "jewish_affiliation_other":
-		if rec.jewishAffiliationOther == "" {
-			rec.jewishAffiliationOther = value
-		}
+		s.setColumn(rec, &rec.jewishAffiliationOther, column, value)
 	case "jewish_identities":
-		if rec.jewishIdentities == "" {
-			rec.jewishIdentities = value
-		}
+		s.setColumn(rec, &rec.jewishIdentities, column, value)
 	case "congregation_summer":
-		if rec.congregationSummer == "" {
-			rec.congregationSummer = value
-		}
+		s.setColumn(rec, &rec.congregationSummer, column, value)
 	case "jcc_summer":
-		if rec.jccSummer == "" {
-			rec.jccSummer = value
-		}
+		s.setColumn(rec, &rec.jccSummer, column, value)
 	case "military_family":
-		// Parse boolean, first true wins
+		// Logical OR over the contributing values -- order-independent
 		if !rec.militaryFamily && ParseBoolValue(value) {
 			rec.militaryFamily = true
 		}
@@ -538,13 +632,9 @@ func (s *HouseholdDemographicsSync) mapPersonFieldToRecord(rec *householdDemogra
 			rec.parentImmigrant = true
 		}
 	case "parent_immigrant_origin":
-		if rec.parentImmigrantOrigin == "" {
-			rec.parentImmigrantOrigin = value
-		}
+		s.setColumn(rec, &rec.parentImmigrantOrigin, column, value)
 	case "custody_summer":
-		if rec.custodySummer == "" {
-			rec.custodySummer = value
-		}
+		s.setColumn(rec, &rec.custodySummer, column, value)
 	case "has_custody_considerations":
 		if !rec.hasCustodyConsiderations && ParseBoolValue(value) {
 			rec.hasCustodyConsiderations = true
@@ -554,29 +644,26 @@ func (s *HouseholdDemographicsSync) mapPersonFieldToRecord(rec *householdDemogra
 			rec.awayDuringCamp = true
 		}
 	case "away_location":
-		if rec.awayLocation == "" {
-			rec.awayLocation = value
-		}
+		s.setColumn(rec, &rec.awayLocation, column, value)
 	case "away_phone":
-		if rec.awayPhone == "" {
-			rec.awayPhone = value
-		}
+		s.setColumn(rec, &rec.awayPhone, column, value)
 	case "away_from_date":
-		if rec.awayFromDate == "" {
-			rec.awayFromDate = value
-		}
+		s.setColumn(rec, &rec.awayFromDate, column, value)
 	case "away_return_date":
-		if rec.awayReturnDate == "" {
-			rec.awayReturnDate = value
-		}
+		s.setColumn(rec, &rec.awayReturnDate, column, value)
 	case "form_filler":
-		if rec.formFiller == "" {
-			rec.formFiller = value
-		}
+		s.setColumn(rec, &rec.formFiller, column, value)
 	}
 }
 
-// mapHouseholdFieldToRecord maps a household custom field to the appropriate record field
+// mapHouseholdFieldToRecord maps a household custom field onto the
+// household-level row.
+//
+// These three text columns were never part of kindred#2260 -- household_custom_values
+// is one row per household per field, so no second value could ever arrive and
+// the old first-wins guard was unreachable. They use setColumn for the same
+// reason the person arms do: one rule in this file, and a data fault that
+// cannot happen becomes audible rather than silent if it ever does.
 func (s *HouseholdDemographicsSync) mapHouseholdFieldToRecord(
 	rec *householdDemographicsRecord, fieldName, value string,
 ) {
@@ -585,21 +672,15 @@ func (s *HouseholdDemographicsSync) mapHouseholdFieldToRecord(
 		return
 	}
 
-	// First non-empty wins
 	switch column {
 	case "congregation_family":
-		if rec.congregationFamily == "" {
-			rec.congregationFamily = value
-		}
+		s.setColumn(rec, &rec.congregationFamily, column, value)
 	case "jcc_family":
-		if rec.jccFamily == "" {
-			rec.jccFamily = value
-		}
+		s.setColumn(rec, &rec.jccFamily, column, value)
 	case "custody_family":
-		if rec.custodyFamily == "" {
-			rec.custodyFamily = value
-		}
+		s.setColumn(rec, &rec.custodyFamily, column, value)
 	case "board_member":
+		// Logical OR, as on the person side
 		if !rec.boardMember && ParseBoolValue(value) {
 			rec.boardMember = true
 		}
@@ -677,11 +758,12 @@ func ParseBoolValue(value string) bool {
 	return false
 }
 
-// MakeCompositeKey creates a composite key from household PB ID and year
-// Format: "householdPBID|year"
+// MakeCompositeKey creates a composite key from household PB ID, person
+// CampMinder ID and year.
+// Format: "householdPBID|personCMID|year"
 // Exported for testing
-func MakeCompositeKey(householdPBID string, year int) string {
-	return fmt.Sprintf("%s|%d", householdPBID, year)
+func MakeCompositeKey(householdPBID string, personCMID, year int) string {
+	return fmt.Sprintf("%s|%d|%d", householdPBID, personCMID, year)
 }
 
 // loadExistingRecords loads existing household_demographics records for a year
@@ -699,14 +781,14 @@ func (s *HouseholdDemographicsSync) loadExistingRecords(ctx context.Context, yea
 		default:
 		}
 
-		records, err := s.App.FindRecordsByFilter("household_demographics", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("household_demographics", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying household_demographics page %d: %w", page, err)
 		}
 
 		for _, record := range records {
 			householdID := record.GetString("household")
-			key := MakeCompositeKey(householdID, year)
+			key := MakeCompositeKey(householdID, record.GetInt("person_id"), year)
 			result[key] = record.Id
 		}
 
@@ -739,12 +821,14 @@ func (s *HouseholdDemographicsSync) upsertRecords(
 		default:
 		}
 
-		key := MakeCompositeKey(rec.householdPBID, year)
+		key := MakeCompositeKey(rec.householdPBID, rec.personCMID, year)
 		existingID, exists := existingRecords[key]
 
 		// Build data map for comparison and setting
 		data := map[string]any{
 			"household":                  rec.householdPBID,
+			"person":                     rec.personPBID,
+			"person_id":                  rec.personCMID,
 			"year":                       rec.year,
 			"family_description":         rec.familyDescription,
 			"family_description_other":   rec.familyDescriptionOther,
@@ -782,7 +866,10 @@ func (s *HouseholdDemographicsSync) upsertRecords(
 
 			// Check if update is needed
 			needsUpdate := false
-			skipFields := map[string]bool{"id": true, "created": true, "updated": true, "household": true, "year": true}
+			skipFields := map[string]bool{
+				"id": true, "created": true, "updated": true,
+				"household": true, "person": true, "person_id": true, "year": true,
+			}
 			for field, newValue := range data {
 				if skipFields[field] {
 					continue
@@ -810,6 +897,7 @@ func (s *HouseholdDemographicsSync) upsertRecords(
 		if err := s.App.Save(record); err != nil {
 			slog.Error("Error saving household_demographics record",
 				"household", rec.householdPBID,
+				"person", rec.personPBID,
 				"year", rec.year,
 				"error", err,
 			)
@@ -827,7 +915,12 @@ func (s *HouseholdDemographicsSync) upsertRecords(
 	return created, updated, skipped, errors
 }
 
-// deleteOrphans removes records that exist in DB but not in computed set
+// deleteOrphans removes records that exist in DB but not in computed set.
+//
+// The key here is leg three of the grain triple and must match the write key in
+// upsertRecords exactly. Widen one without the other and the next run sweeps
+// away the rows the other just wrote, reporting success as it goes
+// (kindred#2257).
 func (s *HouseholdDemographicsSync) deleteOrphans(
 	ctx context.Context,
 	records map[string]*householdDemographicsRecord,
@@ -835,10 +928,23 @@ func (s *HouseholdDemographicsSync) deleteOrphans(
 ) int {
 	deleted := 0
 
+	// Refuse to empty the table. Every row is recomputed from
+	// person_custom_values on each run, so an empty computed set standing
+	// against a populated table is far more likely to be a load that came back
+	// empty than a year in which nobody answered anything -- and this sweep is
+	// the one step of this sync a re-run cannot undo.
+	if len(records) == 0 && len(existingRecords) > 0 {
+		slog.Error("Refusing to delete household_demographics orphans: nothing was computed",
+			"existing_records", len(existingRecords),
+		)
+		s.Stats.Errors++
+		return 0
+	}
+
 	// Build set of computed keys
 	computedKeys := make(map[string]bool)
 	for _, rec := range records {
-		key := MakeCompositeKey(rec.householdPBID, rec.year)
+		key := MakeCompositeKey(rec.householdPBID, rec.personCMID, rec.year)
 		computedKeys[key] = true
 	}
 

--- a/pocketbase/sync/household_demographics_test.go
+++ b/pocketbase/sync/household_demographics_test.go
@@ -2,11 +2,25 @@ package sync
 
 import (
 	"context"
+	"sort"
 	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
 )
 
 // Test constants for fictional data
 const testCongregation = "Temple Beth El"
+
+// Every test in this file calls the PRODUCTION functions.
+//
+// The suite that shipped here did not. `aggregatePersonValuesByHousehold`,
+// `buildDemographicRecord`, `buildDemographicsCompositeKey`,
+// `mapHHFieldToColumn`, `mapHouseholdFieldToColumn`, `parseBooleanCustomValue`
+// and `isHHField` were test-local reimplementations that production never
+// called, so the ten years of answers `mapPersonFieldToRecord` was discarding
+// (kindred#2260) never turned a test red. They are gone; nothing in this file
+// asserts against a copy of the code under test.
 
 // TestHouseholdDemographicsLoadFieldDefinitionsTrimsNames is a regression test
 // for kindred#1873. HH- prefixed fields are admitted by prefix, which a
@@ -60,13 +74,10 @@ func TestHouseholdDemographicsLoadFieldDefinitionsTrimsNames(t *testing.T) {
 
 // TestHouseholdDemographicsSync_Name verifies the service name is correct
 func TestHouseholdDemographicsSync_Name(t *testing.T) {
-	// The service name must be "household_demographics" for orchestrator integration
-	expectedName := serviceNameHouseholdDemographics
-
-	// Test the constant/expected name matches what the service should return
-	// (actual instance test requires PocketBase app)
-	if expectedName != serviceNameHouseholdDemographics {
-		t.Errorf("expected service name %q", expectedName)
+	// The orchestrator registers and looks this service up by name; a rename
+	// that missed one of the two registration paths would strand the job.
+	if got := NewHouseholdDemographicsSync(nil).Name(); got != "household_demographics" {
+		t.Errorf("Name() = %q, want %q", got, "household_demographics")
 	}
 }
 
@@ -89,9 +100,9 @@ func TestHouseholdDemographicsSync_YearValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			valid := isValidYearForDemographics(tt.year)
+			valid := isValidDemographicsYear(tt.year)
 			if valid != tt.wantValid {
-				t.Errorf("isValidYearForDemographics(%d) = %v, want %v", tt.year, valid, tt.wantValid)
+				t.Errorf("isValidDemographicsYear(%d) = %v, want %v", tt.year, valid, tt.wantValid)
 			}
 		})
 	}
@@ -144,9 +155,9 @@ func TestHouseholdDemographicsFieldMapping(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.fieldName, func(t *testing.T) {
-			column := mapHHFieldToColumn(tt.fieldName)
+			column := MapHHFieldToColumn(tt.fieldName)
 			if column != tt.expectedColumn {
-				t.Errorf("mapHHFieldToColumn(%q) = %q, want %q", tt.fieldName, column, tt.expectedColumn)
+				t.Errorf("MapHHFieldToColumn(%q) = %q, want %q", tt.fieldName, column, tt.expectedColumn)
 			}
 		})
 	}
@@ -159,7 +170,7 @@ func TestHouseholdCustomFieldMapping(t *testing.T) {
 		expectedColumn string
 	}{
 		// These come from household_custom_values, not person_custom_values
-		{"Synagogue", "congregation_family"},
+		{customFieldNameSynagogue, "congregation_family"},
 		{"Center", "jcc_family"},
 		{"Custody Issues", "custody_family"},
 		{"Board", "board_member"},
@@ -174,129 +185,11 @@ func TestHouseholdCustomFieldMapping(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.fieldName, func(t *testing.T) {
-			column := mapHouseholdFieldToColumn(tt.fieldName)
+			column := MapHouseholdFieldToColumn(tt.fieldName)
 			if column != tt.expectedColumn {
-				t.Errorf("mapHouseholdFieldToColumn(%q) = %q, want %q", tt.fieldName, column, tt.expectedColumn)
+				t.Errorf("MapHouseholdFieldToColumn(%q) = %q, want %q", tt.fieldName, column, tt.expectedColumn)
 			}
 		})
-	}
-}
-
-// ============================================================================
-// Aggregation Tests
-// ============================================================================
-
-// TestHouseholdDemographicsAggregation tests aggregation of person values by household
-func TestHouseholdDemographicsAggregation(t *testing.T) {
-	// Simulate person custom values for multiple family members
-	personValues := []testHHPersonCustomValue{
-		// Person 1 in household 5001 - has most fields filled
-		{HouseholdID: 5001, FieldName: "HH-Family Description", Value: "LGBTQ"},
-		{HouseholdID: 5001, FieldName: "HH-Jewish Affiliation", Value: "Reform"},
-		{HouseholdID: 5001, FieldName: "HH-Name of Congregation", Value: testCongregation},
-
-		// Person 2 in same household 5001 - some fields overlap, some empty
-		{HouseholdID: 5001, FieldName: "HH-Family Description", Value: "LGBTQ"}, // Same value (expected)
-		{HouseholdID: 5001, FieldName: "HH-Jewish Affiliation", Value: ""},      // Empty
-		{HouseholdID: 5001, FieldName: "HH-Name of Congregation", Value: ""},    // Empty
-
-		// Person 3 in different household 5002
-		{HouseholdID: 5002, FieldName: "HH-Family Description", Value: "Interfaith"},
-		{HouseholdID: 5002, FieldName: "HH-Military", Value: "Yes"},
-	}
-
-	aggregated := aggregatePersonValuesByHousehold(personValues)
-
-	// Household 5001 should have all values from the first person (first non-empty wins)
-	hh5001 := aggregated[5001]
-	if hh5001 == nil {
-		t.Fatal("household 5001 not found in aggregated data")
-		return
-	}
-	if hh5001["HH-Family Description"] != "LGBTQ" {
-		t.Errorf("household 5001 family description = %q, want %q", hh5001["HH-Family Description"], "LGBTQ")
-	}
-	if hh5001["HH-Jewish Affiliation"] != "Reform" {
-		t.Errorf("household 5001 jewish affiliation = %q, want %q", hh5001["HH-Jewish Affiliation"], "Reform")
-	}
-	if hh5001["HH-Name of Congregation"] != testCongregation {
-		t.Errorf("household 5001 congregation = %q, want %q", hh5001["HH-Name of Congregation"], testCongregation)
-	}
-
-	// Household 5002 should have its own values
-	hh5002 := aggregated[5002]
-	if hh5002 == nil {
-		t.Fatal("household 5002 not found in aggregated data")
-		return
-	}
-	if hh5002["HH-Family Description"] != "Interfaith" {
-		t.Errorf("household 5002 family description = %q, want %q", hh5002["HH-Family Description"], "Interfaith")
-	}
-	if hh5002["HH-Military"] != "Yes" {
-		t.Errorf("household 5002 military = %q, want %q", hh5002["HH-Military"], "Yes")
-	}
-}
-
-// TestHouseholdDemographicsFirstNonEmptyWins tests that first non-empty value is taken
-func TestHouseholdDemographicsFirstNonEmptyWins(t *testing.T) {
-	values := []testHHPersonCustomValue{
-		{HouseholdID: 5001, FieldName: "HH-Family Description", Value: ""},             // Empty
-		{HouseholdID: 5001, FieldName: "HH-Family Description", Value: ""},             // Empty
-		{HouseholdID: 5001, FieldName: "HH-Family Description", Value: "LGBTQ"},        // First non-empty
-		{HouseholdID: 5001, FieldName: "HH-Family Description", Value: "Kindred Alum"}, // Should be ignored
-	}
-
-	aggregated := aggregatePersonValuesByHousehold(values)
-
-	hh5001 := aggregated[5001]
-	if hh5001["HH-Family Description"] != "LGBTQ" {
-		t.Errorf("expected first non-empty value %q, got %q", "LGBTQ", hh5001["HH-Family Description"])
-	}
-}
-
-// ============================================================================
-// Summer vs Family Camp Overlap Tests
-// ============================================================================
-
-// TestHouseholdDemographicsSummerVsFamily tests that overlapping fields are stored separately
-func TestHouseholdDemographicsSummerVsFamily(t *testing.T) {
-	// Person-level HH- fields (summer camp registration)
-	personValues := []testHHPersonCustomValue{
-		{HouseholdID: 5001, FieldName: "HH-Name of Congregation", Value: testCongregation},
-		{HouseholdID: 5001, FieldName: "HH-Name of JCC", Value: "SF JCC"},
-		{HouseholdID: 5001, FieldName: "HH-special living arrangements", Value: "Shared custody"},
-	}
-
-	// Household-level custom fields (family camp registration)
-	householdValues := []testHHHouseholdCustomValue{
-		{HouseholdID: 5001, FieldName: "Synagogue", Value: "Beth Sholom"},
-		{HouseholdID: 5001, FieldName: "Center", Value: "Oakland JCC"},
-		{HouseholdID: 5001, FieldName: "Custody Issues", Value: "Week on/week off"},
-	}
-
-	// Build demographic record
-	demo := buildDemographicRecord(5001, personValues, householdValues)
-
-	// Verify summer camp fields (from person)
-	if demo.CongregationSummer != testCongregation {
-		t.Errorf("congregation_summer = %q, want %q", demo.CongregationSummer, testCongregation)
-	}
-	if demo.JCCSummer != "SF JCC" {
-		t.Errorf("jcc_summer = %q, want %q", demo.JCCSummer, "SF JCC")
-	}
-	if demo.CustodySummer != "Shared custody" {
-		t.Errorf("custody_summer = %q, want %q", demo.CustodySummer, "Shared custody")
-	}
-
-	// Verify family camp fields (from household)
-	if demo.CongregationFamily != "Beth Sholom" {
-		t.Errorf("congregation_family = %q, want %q", demo.CongregationFamily, "Beth Sholom")
-	}
-	if demo.JCCFamily != "Oakland JCC" {
-		t.Errorf("jcc_family = %q, want %q", demo.JCCFamily, "Oakland JCC")
-	}
-	if demo.CustodyFamily != "Week on/week off" {
-		t.Errorf("custody_family = %q, want %q", demo.CustodyFamily, "Week on/week off")
 	}
 }
 
@@ -336,242 +229,9 @@ func TestHouseholdDemographicsBooleanParsing(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.value, func(t *testing.T) {
-			result := parseBooleanCustomValue(tt.value)
+			result := ParseBoolValue(tt.value)
 			if result != tt.expected {
-				t.Errorf("parseBooleanCustomValue(%q) = %v, want %v", tt.value, result, tt.expected)
-			}
-		})
-	}
-}
-
-// TestHouseholdDemographicsMilitaryField tests military_family boolean field
-func TestHouseholdDemographicsMilitaryField(t *testing.T) {
-	personValues := []testHHPersonCustomValue{
-		{HouseholdID: 5001, FieldName: "HH-Military", Value: "Yes"},
-		{HouseholdID: 5002, FieldName: "HH-Military", Value: "No"},
-		{HouseholdID: 5003, FieldName: "HH-Military", Value: ""},
-	}
-
-	for _, pv := range personValues {
-		var expected bool
-		switch pv.HouseholdID {
-		case 5001:
-			expected = true
-		case 5002, 5003:
-			expected = false
-		}
-
-		result := parseBooleanCustomValue(pv.Value)
-		if result != expected {
-			t.Errorf("household %d: military = %v, want %v", pv.HouseholdID, result, expected)
-		}
-	}
-}
-
-// ============================================================================
-// Multi-Select Field Tests
-// ============================================================================
-
-// TestHouseholdDemographicsMultiSelectAggregation tests aggregation of multi-select fields
-func TestHouseholdDemographicsMultiSelectAggregation(t *testing.T) {
-	// Family Description is a multi-select field
-	// Values should be preserved as pipe-separated
-	personValues := []testHHPersonCustomValue{
-		// Multiple values for same field (different family members selecting different options)
-		{HouseholdID: 5001, FieldName: "HH-Family Description", Value: "LGBTQ|Interfaith"},
-		{HouseholdID: 5002, FieldName: "HH-Family Description", Value: "Kindred Alum"},
-		{HouseholdID: 5003, FieldName: "HH-Family Description", Value: "Single Parent|LGBTQ"},
-	}
-
-	aggregated := aggregatePersonValuesByHousehold(personValues)
-
-	// Multi-select values should be preserved as-is (first non-empty wins)
-	if aggregated[5001]["HH-Family Description"] != "LGBTQ|Interfaith" {
-		t.Errorf("household 5001: got %q", aggregated[5001]["HH-Family Description"])
-	}
-	if aggregated[5002]["HH-Family Description"] != "Kindred Alum" {
-		t.Errorf("household 5002: got %q", aggregated[5002]["HH-Family Description"])
-	}
-	if aggregated[5003]["HH-Family Description"] != "Single Parent|LGBTQ" {
-		t.Errorf("household 5003: got %q", aggregated[5003]["HH-Family Description"])
-	}
-}
-
-// ============================================================================
-// Composite Key Tests
-// ============================================================================
-
-// TestHouseholdDemographicsCompositeKey tests the unique key format
-func TestHouseholdDemographicsCompositeKey(t *testing.T) {
-	tests := []struct {
-		householdPBID string
-		year          int
-		expected      string
-	}{
-		{"abc123", 2025, "abc123|2025"},
-		{"xyz789", 2024, "xyz789|2024"},
-		{"", 2025, "|2025"}, // Edge case: empty ID
-	}
-
-	for _, tt := range tests {
-		key := buildDemographicsCompositeKey(tt.householdPBID, tt.year)
-		if key != tt.expected {
-			t.Errorf("buildDemographicsCompositeKey(%q, %d) = %q, want %q",
-				tt.householdPBID, tt.year, key, tt.expected)
-		}
-	}
-}
-
-// ============================================================================
-// Orphan Detection Tests
-// ============================================================================
-
-// TestHouseholdDemographicsOrphanDetection tests detection of orphaned records
-func TestHouseholdDemographicsOrphanDetection(t *testing.T) {
-	// Existing records in database
-	existingKeys := map[string]bool{
-		"hh001|2025": true, // Will be processed
-		"hh002|2025": true, // Will be processed
-		"hh003|2025": true, // NOT processed = orphan (household removed from year)
-	}
-
-	// Records processed from source data
-	processedKeys := map[string]bool{
-		"hh001|2025": true,
-		"hh002|2025": true,
-		// hh003 no longer has campers enrolled in 2025
-	}
-
-	// Count orphans
-	orphanCount := 0
-	for key := range existingKeys {
-		if !processedKeys[key] {
-			orphanCount++
-		}
-	}
-
-	if orphanCount != 1 {
-		t.Errorf("expected 1 orphan, got %d", orphanCount)
-	}
-}
-
-// ============================================================================
-// Full Record Construction Tests
-// ============================================================================
-
-// TestHouseholdDemographicsFullRecord tests construction of a complete demographic record
-func TestHouseholdDemographicsFullRecord(t *testing.T) {
-	personValues := []testHHPersonCustomValue{
-		{HouseholdID: 5001, FieldName: "HH-Family Description", Value: "LGBTQ|Interfaith"},
-		{HouseholdID: 5001, FieldName: "HH-Jewish Affiliation", Value: "Reform"},
-		{HouseholdID: 5001, FieldName: "HH-Name of Congregation", Value: testCongregation},
-		{HouseholdID: 5001, FieldName: "HH-Name of JCC", Value: "SF JCC"},
-		{HouseholdID: 5001, FieldName: "HH-Military", Value: "No"},
-		{HouseholdID: 5001, FieldName: "HH-parent born outside US", Value: "Yes"},
-		{HouseholdID: 5001, FieldName: "HH-if yes parent born outside US, where", Value: "Israel"},
-		{HouseholdID: 5001, FieldName: "HH-special living arrangements", Value: "Shared custody"},
-		{HouseholdID: 5001, FieldName: "HH-special living arrange-yes", Value: "Yes"},
-		{HouseholdID: 5001, FieldName: "HH-Home or Away", Value: "Home"},
-	}
-
-	householdValues := []testHHHouseholdCustomValue{
-		{HouseholdID: 5001, FieldName: "Synagogue", Value: "Beth Sholom"},
-		{HouseholdID: 5001, FieldName: "Center", Value: "Oakland JCC"},
-		{HouseholdID: 5001, FieldName: "Board", Value: "Yes"},
-	}
-
-	demo := buildDemographicRecord(5001, personValues, householdValues)
-
-	// Verify all fields
-	if demo.FamilyDescription != "LGBTQ|Interfaith" {
-		t.Errorf("family_description = %q", demo.FamilyDescription)
-	}
-	if demo.JewishAffiliation != "Reform" {
-		t.Errorf("jewish_affiliation = %q", demo.JewishAffiliation)
-	}
-	if demo.CongregationSummer != testCongregation {
-		t.Errorf("congregation_summer = %q", demo.CongregationSummer)
-	}
-	if demo.CongregationFamily != "Beth Sholom" {
-		t.Errorf("congregation_family = %q", demo.CongregationFamily)
-	}
-	if demo.JCCSummer != "SF JCC" {
-		t.Errorf("jcc_summer = %q", demo.JCCSummer)
-	}
-	if demo.JCCFamily != "Oakland JCC" {
-		t.Errorf("jcc_family = %q", demo.JCCFamily)
-	}
-	if demo.MilitaryFamily != false {
-		t.Errorf("military_family = %v", demo.MilitaryFamily)
-	}
-	if demo.ParentImmigrant != true {
-		t.Errorf("parent_immigrant = %v", demo.ParentImmigrant)
-	}
-	if demo.ParentImmigrantOrigin != "Israel" {
-		t.Errorf("parent_immigrant_origin = %q", demo.ParentImmigrantOrigin)
-	}
-	if demo.CustodySummer != "Shared custody" {
-		t.Errorf("custody_summer = %q", demo.CustodySummer)
-	}
-	if demo.HasCustodyConsiderations != true {
-		t.Errorf("has_custody_considerations = %v", demo.HasCustodyConsiderations)
-	}
-	if demo.AwayDuringCamp != false { // "Home" means not away
-		t.Errorf("away_during_camp = %v", demo.AwayDuringCamp)
-	}
-	if demo.BoardMember != true {
-		t.Errorf("board_member = %v", demo.BoardMember)
-	}
-}
-
-// ============================================================================
-// Upsert Decision Tests
-// ============================================================================
-
-// TestHouseholdDemographicsUpsertDecision tests create vs update decision
-func TestHouseholdDemographicsUpsertDecision(t *testing.T) {
-	tests := []struct {
-		name         string
-		existingKeys map[string]bool
-		newKey       string
-		expectCreate bool
-		expectUpdate bool
-	}{
-		{
-			name:         "new record - not in existing",
-			existingKeys: map[string]bool{},
-			newKey:       "hh001|2025",
-			expectCreate: true,
-			expectUpdate: false,
-		},
-		{
-			name:         "existing record - should update",
-			existingKeys: map[string]bool{"hh001|2025": true},
-			newKey:       "hh001|2025",
-			expectCreate: false,
-			expectUpdate: true,
-		},
-		{
-			name:         "different year - new record",
-			existingKeys: map[string]bool{"hh001|2025": true},
-			newKey:       "hh001|2026",
-			expectCreate: true,
-			expectUpdate: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			exists := tt.existingKeys[tt.newKey]
-
-			isCreate := !exists
-			isUpdate := exists
-
-			if isCreate != tt.expectCreate {
-				t.Errorf("create decision = %v, want %v", isCreate, tt.expectCreate)
-			}
-			if isUpdate != tt.expectUpdate {
-				t.Errorf("update decision = %v, want %v", isUpdate, tt.expectUpdate)
+				t.Errorf("ParseBoolValue(%q) = %v, want %v", tt.value, result, tt.expected)
 			}
 		})
 	}
@@ -591,7 +251,7 @@ func TestIsHHField(t *testing.T) {
 		{"HH-Jewish Affiliation", true},
 		{"HH-Military", true},
 		{"Family Camp Adult 1", false},
-		{"Synagogue", false},
+		{customFieldNameSynagogue, false},
 		{"Board", false},
 		{"hh-lowercase", false}, // Case sensitive
 		{"", false},
@@ -599,234 +259,572 @@ func TestIsHHField(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.fieldName, func(t *testing.T) {
-			result := isHHField(tt.fieldName)
+			result := IsHHField(tt.fieldName)
 			if result != tt.isHHField {
-				t.Errorf("isHHField(%q) = %v, want %v", tt.fieldName, result, tt.isHHField)
+				t.Errorf("IsHHField(%q) = %v, want %v", tt.fieldName, result, tt.isHHField)
 			}
 		})
 	}
 }
 
 // ============================================================================
-// Test Helper Types
+// Grain tests (kindred#2260) -- one row per person per household per year
 // ============================================================================
 
-type testHHPersonCustomValue struct {
-	HouseholdID int
-	FieldName   string
-	Value       string
-}
-
-type testHHHouseholdCustomValue struct {
-	HouseholdID int
-	FieldName   string
-	Value       string
-}
-
-type testDemographicRecord struct {
-	HouseholdID              int
-	Year                     int
-	FamilyDescription        string
-	FamilyDescriptionOther   string
-	JewishAffiliation        string
-	JewishAffiliationOther   string
-	JewishIdentities         string
-	CongregationSummer       string
-	CongregationFamily       string
-	JCCSummer                string
-	JCCFamily                string
-	MilitaryFamily           bool
-	ParentImmigrant          bool
-	ParentImmigrantOrigin    string
-	CustodySummer            string
-	CustodyFamily            string
-	HasCustodyConsiderations bool
-	AwayDuringCamp           bool
-	AwayLocation             string
-	AwayPhone                string
-	AwayFromDate             string
-	AwayReturnDate           string
-	FormFiller               string
-	BoardMember              bool
-}
-
-// ============================================================================
-// Test Helper Functions
-// ============================================================================
-
-// isValidYearForDemographics validates year parameter
-func isValidYearForDemographics(year int) bool {
-	return year >= 2017 && year <= 2050
-}
-
-// isHHField checks if a field name starts with "HH-"
-func isHHField(fieldName string) bool {
-	return len(fieldName) >= 3 && fieldName[:3] == "HH-"
-}
-
-// mapHHFieldToColumn maps HH- field names to demographic column names
-func mapHHFieldToColumn(fieldName string) string {
-	mapping := map[string]string{
-		"HH-Family Description":                   "family_description",
-		"HH-Family Description Other":             "family_description_other",
-		"HH-Jewish Affiliation":                   "jewish_affiliation",
-		"HH-Jewish Affiliation Other":             "jewish_affiliation_other",
-		"HH-Jewish Identities":                    "jewish_identities",
-		"HH-Name of Congregation":                 "congregation_summer",
-		"HH-Name of JCC":                          "jcc_summer",
-		"HH-Military":                             "military_family",
-		"HH-parent born outside US":               "parent_immigrant",
-		"HH-if yes parent born outside US, where": "parent_immigrant_origin",
-		"HH-special living arrangements":          "custody_summer",
-		"HH-special living arrange-yes":           "has_custody_considerations",
-		"HH-Home or Away":                         "away_during_camp",
-		"HH-Away location":                        "away_location",
-		"HH-Phone number while away":              "away_phone",
-		"HH-Away From (mm/dd/yy)":                 "away_from_date",
-		"HH-Returning (mm/dd/yy)":                 "away_return_date",
-		"HH-Who is filling out info":              "form_filler",
+// newHouseholdDemographicsTestApp returns a throwaway PocketBase app carrying
+// the three collections this service reads and writes, with
+// household_demographics shaped at the person grain.
+//
+// The unique index is declared here on purpose. It is the third leg of the
+// grain triple, and a fixture that left it off would let a household-grain
+// write key save two colliding rows and look correct doing it.
+func newHouseholdDemographicsTestApp(t *testing.T) (app core.App, households, persons *core.Collection) {
+	t.Helper()
+	testApp, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
 	}
-	return mapping[fieldName]
-}
+	t.Cleanup(testApp.Cleanup)
+	app = testApp
 
-// mapHouseholdFieldToColumn maps household custom field names to demographic column names
-func mapHouseholdFieldToColumn(fieldName string) string {
-	mapping := map[string]string{
-		"Synagogue":      "congregation_family",
-		"Center":         "jcc_family",
-		"Custody Issues": "custody_family",
-		"Board":          "board_member",
-	}
-	return mapping[fieldName]
-}
-
-// parseBooleanCustomValue parses boolean values from custom field strings
-func parseBooleanCustomValue(value string) bool {
-	if value == "" {
-		return false
-	}
-	// Trim whitespace
-	trimmed := value
-	for trimmed != "" && (trimmed[0] == ' ' || trimmed[0] == '\t') {
-		trimmed = trimmed[1:]
-	}
-	for trimmed != "" && (trimmed[len(trimmed)-1] == ' ' || trimmed[len(trimmed)-1] == '\t') {
-		trimmed = trimmed[:len(trimmed)-1]
-	}
-	if trimmed == "" {
-		return false
+	households = core.NewBaseCollection("households")
+	households.Fields.Add(&core.NumberField{Name: "cm_id"})
+	households.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(households); err != nil {
+		t.Fatalf("create households: %v", err)
 	}
 
-	// Check for true values (case insensitive)
-	lower := toLowerASCII(trimmed)
-	return lower == "yes" || lower == "true" || lower == "1" || lower == "y"
+	persons = core.NewBaseCollection("persons")
+	persons.Fields.Add(&core.NumberField{Name: "cm_id"})
+	persons.Fields.Add(&core.RelationField{Name: "household", CollectionId: households.Id, MaxSelect: 1})
+	persons.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(persons); err != nil {
+		t.Fatalf("create persons: %v", err)
+	}
+
+	demo := core.NewBaseCollection("household_demographics")
+	demo.Fields.Add(&core.RelationField{Name: "household", CollectionId: households.Id, MaxSelect: 1})
+	demo.Fields.Add(&core.RelationField{Name: "person", CollectionId: persons.Id, MaxSelect: 1})
+	demo.Fields.Add(&core.NumberField{Name: "person_id"})
+	demo.Fields.Add(&core.NumberField{Name: "year"})
+	for _, name := range []string{
+		"family_description", "family_description_other", "jewish_affiliation",
+		"jewish_affiliation_other", "jewish_identities", "congregation_summer",
+		"congregation_family", "jcc_summer", "jcc_family", "parent_immigrant_origin",
+		"custody_summer", "custody_family", "away_location", "away_phone",
+		"away_from_date", "away_return_date", "form_filler",
+	} {
+		demo.Fields.Add(&core.TextField{Name: name})
+	}
+	for _, name := range []string{
+		"military_family", "parent_immigrant", "has_custody_considerations",
+		"away_during_camp", "board_member",
+	} {
+		demo.Fields.Add(&core.BoolField{Name: name})
+	}
+	demo.AddIndex("idx_household_demographics_hh_person_year", true,
+		"`household`, `person_id`, `year`", "")
+	if err := app.Save(demo); err != nil {
+		t.Fatalf("create household_demographics: %v", err)
+	}
+
+	return app, households, persons
 }
 
-// toLowerASCII converts ASCII letters to lowercase
-func toLowerASCII(s string) string {
-	result := make([]byte, len(s))
-	for i := range len(s) {
-		c := s[i]
-		if c >= 'A' && c <= 'Z' {
-			c += 'a' - 'A'
+// hhPersonEntry is a shorthand for a person-level HH- answer in these tests.
+func hhPersonEntry(householdPBID, personPBID string, personCMID int, field, value string) hhCustomValueEntry {
+	return hhCustomValueEntry{
+		householdPBID: householdPBID,
+		personPBID:    personPBID,
+		personCMID:    personCMID,
+		fieldName:     field,
+		value:         value,
+	}
+}
+
+// hhHouseholdEntry is a shorthand for a household-level (family camp) answer.
+// Household answers carry no person, which is what puts them on their own row.
+func hhHouseholdEntry(householdPBID, field, value string) hhCustomValueEntry {
+	return hhCustomValueEntry{householdPBID: householdPBID, fieldName: field, value: value}
+}
+
+// rowKeys returns the sorted keys of a row map, for failure messages.
+func rowKeys(rows map[string]*householdDemographicsRecord) []string {
+	keys := make([]string, 0, len(rows))
+	for k := range rows {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// TestAggregateKeepsEveryPersonAnswer is the regression test for kindred#2260.
+// Two campers in one household answering the same HH- question differently used
+// to collapse to whichever row the SQLite planner yielded first; every later
+// answer was discarded with no log line and no counter. Both answers must now
+// survive, on their own row.
+func TestAggregateKeepsEveryPersonAnswer(t *testing.T) {
+	s := NewHouseholdDemographicsSync(nil)
+
+	values := []hhCustomValueEntry{
+		hhPersonEntry("hh1", "p1", 101, "HH-Jewish Affiliation", "Reform"),
+		hhPersonEntry("hh1", "p2", 102, "HH-Jewish Affiliation", "Prefer not to answer"),
+	}
+
+	rows := s.aggregateToRows(values, nil, 2026)
+
+	if len(rows) != 2 {
+		t.Fatalf("aggregateToRows produced %d rows, want 2 (one per camper): %v", len(rows), rowKeys(rows))
+	}
+	first := rows[MakeCompositeKey("hh1", 101, 2026)]
+	second := rows[MakeCompositeKey("hh1", 102, 2026)]
+	if first == nil || second == nil {
+		t.Fatalf("rows are not keyed per person: got keys %v", rowKeys(rows))
+	}
+	if first.jewishAffiliation != "Reform" {
+		t.Errorf("camper 101 jewish_affiliation = %q, want %q", first.jewishAffiliation, "Reform")
+	}
+	if second.jewishAffiliation != "Prefer not to answer" {
+		t.Errorf("camper 102 jewish_affiliation = %q, want %q", second.jewishAffiliation, "Prefer not to answer")
+	}
+	if first.personPBID != "p1" || second.personPBID != "p2" {
+		t.Errorf("person relation not carried: %q / %q", first.personPBID, second.personPBID)
+	}
+}
+
+// TestAggregateIsOrderIndependent pins the property the old code could not
+// hold. loadPersonCustomValues pages with no ORDER BY, so the input order is an
+// artifact of whichever index the planner picked; the same input supplied in a
+// different order must produce byte-identical rows.
+func TestAggregateIsOrderIndependent(t *testing.T) {
+	s := NewHouseholdDemographicsSync(nil)
+
+	values := []hhCustomValueEntry{
+		hhPersonEntry("hh1", "p1", 101, "HH-Family Description", "Interfaith"),
+		hhPersonEntry("hh1", "p1", 101, "HH-Name of Congregation", testCongregation),
+		hhPersonEntry("hh1", "p2", 102, "HH-Family Description", "Single Parent|LGBTQ"),
+		hhPersonEntry("hh1", "p2", 102, "HH-Military", "Yes"),
+		hhPersonEntry("hh2", "p3", 103, "HH-Family Description", "Kindred Alum"),
+	}
+	reversed := make([]hhCustomValueEntry, len(values))
+	for i, v := range values {
+		reversed[len(values)-1-i] = v
+	}
+
+	forward := s.aggregateToRows(values, nil, 2026)
+	backward := s.aggregateToRows(reversed, nil, 2026)
+
+	if len(forward) != len(backward) {
+		t.Fatalf("row count differs by input order: %d vs %d", len(forward), len(backward))
+	}
+	for key, want := range forward {
+		got, ok := backward[key]
+		if !ok {
+			t.Fatalf("key %q missing when the same input is supplied in reverse", key)
 		}
-		result[i] = c
-	}
-	return string(result)
-}
-
-// aggregatePersonValuesByHousehold groups person custom values by household ID
-// First non-empty value wins for each field
-func aggregatePersonValuesByHousehold(values []testHHPersonCustomValue) map[int]map[string]string {
-	result := make(map[int]map[string]string)
-
-	for _, v := range values {
-		if v.Value == "" {
-			continue
-		}
-
-		if result[v.HouseholdID] == nil {
-			result[v.HouseholdID] = make(map[string]string)
-		}
-
-		// First non-empty wins
-		if _, exists := result[v.HouseholdID][v.FieldName]; !exists {
-			result[v.HouseholdID][v.FieldName] = v.Value
-		}
-	}
-
-	return result
-}
-
-// buildDemographicsCompositeKey builds the composite key for upsert
-func buildDemographicsCompositeKey(householdPBID string, year int) string {
-	return householdPBID + "|" + itoa(year)
-}
-
-// itoa is defined in financial_aid_applications_test.go
-
-// buildDemographicRecord constructs a demographic record from custom values
-func buildDemographicRecord(
-	householdID int,
-	personValues []testHHPersonCustomValue,
-	householdValues []testHHHouseholdCustomValue,
-) testDemographicRecord {
-	// Aggregate person values
-	personAgg := make(map[string]string)
-	for _, v := range personValues {
-		if v.HouseholdID != householdID || v.Value == "" {
-			continue
-		}
-		if _, exists := personAgg[v.FieldName]; !exists {
-			personAgg[v.FieldName] = v.Value
+		if *got != *want {
+			t.Errorf("key %q differs by input order:\n forward  = %+v\n backward = %+v", key, *want, *got)
 		}
 	}
+}
 
-	// Aggregate household values
-	householdAgg := make(map[string]string)
-	for _, v := range householdValues {
-		if v.HouseholdID != householdID || v.Value == "" {
-			continue
-		}
-		if _, exists := householdAgg[v.FieldName]; !exists {
-			householdAgg[v.FieldName] = v.Value
-		}
+// TestAggregateBooleanArmsStillOR covers the five boolean arms under the
+// re-grain. They are logical ORs, not first-wins, and kindred#2260 is explicit
+// that they were never part of the defect. Two things must hold: the OR is
+// still order-independent within one camper's answers, and one camper's "No"
+// no longer speaks for a sibling who said "Yes".
+func TestAggregateBooleanArmsStillOR(t *testing.T) {
+	s := NewHouseholdDemographicsSync(nil)
+
+	// Same camper, two contributing values -- the OR must win either way round.
+	within := []hhCustomValueEntry{
+		hhPersonEntry("hh1", "p1", 101, "HH-Military", "No"),
+		hhPersonEntry("hh1", "p1", 101, "HH-Military", "Yes"),
+	}
+	key := MakeCompositeKey("hh1", 101, 2026)
+	forward := s.aggregateToRows(within, nil, 2026)[key]
+	backward := s.aggregateToRows([]hhCustomValueEntry{within[1], within[0]}, nil, 2026)[key]
+	if forward == nil || backward == nil {
+		t.Fatal("expected a row for camper 101 in both orders")
+	}
+	if !forward.militaryFamily || !backward.militaryFamily {
+		t.Errorf("military_family OR regressed: forward=%v backward=%v",
+			forward.militaryFamily, backward.militaryFamily)
 	}
 
-	// Build record
-	demo := testDemographicRecord{
-		HouseholdID: householdID,
+	// Two campers disagreeing: each keeps their own answer.
+	across := []hhCustomValueEntry{
+		hhPersonEntry("hh1", "p1", 101, "HH-Military", "No"),
+		hhPersonEntry("hh1", "p2", 102, "HH-Military", "Yes"),
+	}
+	rows := s.aggregateToRows(across, nil, 2026)
+	if got := rows[MakeCompositeKey("hh1", 101, 2026)]; got == nil || got.militaryFamily {
+		t.Errorf("camper 101 answered No; military_family = %v", got != nil && got.militaryFamily)
+	}
+	if got := rows[MakeCompositeKey("hh1", 102, 2026)]; got == nil || !got.militaryFamily {
+		t.Errorf("camper 102 answered Yes; military_family = %v", got != nil && got.militaryFamily)
+	}
+}
+
+// TestAggregateHouseholdValuesGetTheirOwnRow covers the _family columns. They
+// come from household_custom_values, which is one row per household per field,
+// so they are already at household grain and must not be duplicated onto every
+// camper's row. They land on the person-less row (person_id 0), which coexists
+// with the camper rows for the same household-year.
+func TestAggregateHouseholdValuesGetTheirOwnRow(t *testing.T) {
+	s := NewHouseholdDemographicsSync(nil)
+
+	personValues := []hhCustomValueEntry{
+		hhPersonEntry("hh1", "p1", 101, "HH-Name of Congregation", testCongregation),
+		hhPersonEntry("hh1", "p1", 101, "HH-Name of JCC", "Bayside JCC"),
+		hhPersonEntry("hh1", "p1", 101, "HH-special living arrangements", "Shared custody"),
+	}
+	householdValues := []hhCustomValueEntry{
+		hhHouseholdEntry("hh1", customFieldNameSynagogue, "Congregation Beth Shalom"),
+		hhHouseholdEntry("hh1", "Center", "Lakeside JCC"),
+		hhHouseholdEntry("hh1", "Custody Issues", "Week on/week off"),
+		hhHouseholdEntry("hh1", "Board", "Yes"),
 	}
 
-	// Map person fields (summer camp)
-	demo.FamilyDescription = personAgg["HH-Family Description"]
-	demo.FamilyDescriptionOther = personAgg["HH-Family Description Other"]
-	demo.JewishAffiliation = personAgg["HH-Jewish Affiliation"]
-	demo.JewishAffiliationOther = personAgg["HH-Jewish Affiliation Other"]
-	demo.JewishIdentities = personAgg["HH-Jewish Identities"]
-	demo.CongregationSummer = personAgg["HH-Name of Congregation"]
-	demo.JCCSummer = personAgg["HH-Name of JCC"]
-	demo.MilitaryFamily = parseBooleanCustomValue(personAgg["HH-Military"])
-	demo.ParentImmigrant = parseBooleanCustomValue(personAgg["HH-parent born outside US"])
-	demo.ParentImmigrantOrigin = personAgg["HH-if yes parent born outside US, where"]
-	demo.CustodySummer = personAgg["HH-special living arrangements"]
-	demo.HasCustodyConsiderations = parseBooleanCustomValue(personAgg["HH-special living arrange-yes"])
-	demo.FormFiller = personAgg["HH-Who is filling out info"]
+	rows := s.aggregateToRows(personValues, householdValues, 2026)
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2 (one camper row + one household row): %v", len(rows), rowKeys(rows))
+	}
 
-	// Away info
-	homeOrAway := personAgg["HH-Home or Away"]
-	// "Away" means away_during_camp = true, anything else = false
-	demo.AwayDuringCamp = toLowerASCII(homeOrAway) == "away"
-	demo.AwayLocation = personAgg["HH-Away location"]
-	demo.AwayPhone = personAgg["HH-Phone number while away"]
-	demo.AwayFromDate = personAgg["HH-Away From (mm/dd/yy)"]
-	demo.AwayReturnDate = personAgg["HH-Returning (mm/dd/yy)"]
+	camper := rows[MakeCompositeKey("hh1", 101, 2026)]
+	household := rows[MakeCompositeKey("hh1", 0, 2026)]
+	if camper == nil || household == nil {
+		t.Fatalf("expected a camper row and a household row, got keys %v", rowKeys(rows))
+	}
 
-	// Map household fields (family camp)
-	demo.CongregationFamily = householdAgg["Synagogue"]
-	demo.JCCFamily = householdAgg["Center"]
-	demo.CustodyFamily = householdAgg["Custody Issues"]
-	demo.BoardMember = parseBooleanCustomValue(householdAgg["Board"])
+	// Summer answers stay on the camper who gave them.
+	if camper.congregationSummer != testCongregation {
+		t.Errorf("camper congregation_summer = %q, want %q", camper.congregationSummer, testCongregation)
+	}
+	if camper.jccSummer != "Bayside JCC" {
+		t.Errorf("camper jcc_summer = %q, want %q", camper.jccSummer, "Bayside JCC")
+	}
+	if camper.custodySummer != "Shared custody" {
+		t.Errorf("camper custody_summer = %q, want %q", camper.custodySummer, "Shared custody")
+	}
+	if camper.congregationFamily != "" || camper.jccFamily != "" || camper.custodyFamily != "" || camper.boardMember {
+		t.Errorf("family columns leaked onto the camper row: %+v", *camper)
+	}
 
-	return demo
+	// Family answers stay on the household row.
+	if household.congregationFamily != "Congregation Beth Shalom" {
+		t.Errorf("household congregation_family = %q", household.congregationFamily)
+	}
+	if household.jccFamily != "Lakeside JCC" {
+		t.Errorf("household jcc_family = %q", household.jccFamily)
+	}
+	if household.custodyFamily != "Week on/week off" {
+		t.Errorf("household custody_family = %q", household.custodyFamily)
+	}
+	if !household.boardMember {
+		t.Error("household board_member = false, want true")
+	}
+	if household.congregationSummer != "" || household.jccSummer != "" || household.custodySummer != "" {
+		t.Errorf("summer columns leaked onto the household row: %+v", *household)
+	}
+	if household.personPBID != "" || household.personCMID != 0 {
+		t.Errorf("household row carries a person: %q / %d", household.personPBID, household.personCMID)
+	}
+}
+
+// TestAggregateFullRecord drives every arm of both mapping switches for a
+// single camper, so a case arm dropped or mis-wired during the re-grain shows
+// up as a wrong column rather than as a missing test.
+func TestAggregateFullRecord(t *testing.T) {
+	s := NewHouseholdDemographicsSync(nil)
+
+	personValues := []hhCustomValueEntry{
+		hhPersonEntry("hh1", "p1", 101, "HH-Family Description", "LGBTQ|Interfaith"),
+		hhPersonEntry("hh1", "p1", 101, "HH-Family Description Other", "Multigenerational"),
+		hhPersonEntry("hh1", "p1", 101, "HH-Jewish Affiliation", "Reform"),
+		hhPersonEntry("hh1", "p1", 101, "HH-Jewish Affiliation Other", "Renewal"),
+		hhPersonEntry("hh1", "p1", 101, "HH-Jewish Identities", "Ashkenazi|Sephardi"),
+		hhPersonEntry("hh1", "p1", 101, "HH-Name of Congregation", testCongregation),
+		hhPersonEntry("hh1", "p1", 101, "HH-Name of JCC", "Bayside JCC"),
+		hhPersonEntry("hh1", "p1", 101, "HH-Military", "No"),
+		hhPersonEntry("hh1", "p1", 101, "HH-parent born outside US", "Yes"),
+		hhPersonEntry("hh1", "p1", 101, "HH-if yes parent born outside US, where", "Israel"),
+		hhPersonEntry("hh1", "p1", 101, "HH-special living arrangements", "Shared custody"),
+		hhPersonEntry("hh1", "p1", 101, "HH-special living arrange-yes", "Yes"),
+		hhPersonEntry("hh1", "p1", 101, "HH-Home or Away", "Yes"),
+		hhPersonEntry("hh1", "p1", 101, "HH-Away location", "Cape Cod"),
+		hhPersonEntry("hh1", "p1", 101, "HH-Phone number while away", "555-0100"),
+		hhPersonEntry("hh1", "p1", 101, "HH-Away From (mm/dd/yy)", "07/01/26"),
+		hhPersonEntry("hh1", "p1", 101, "HH-Returning (mm/dd/yy)", "07/15/26"),
+		hhPersonEntry("hh1", "p1", 101, "HH-Who is filling out info", "Parent"),
+	}
+	householdValues := []hhCustomValueEntry{
+		hhHouseholdEntry("hh1", customFieldNameSynagogue, "Congregation Beth Shalom"),
+		hhHouseholdEntry("hh1", "Center", "Lakeside JCC"),
+		hhHouseholdEntry("hh1", "Custody Issues", "Week on/week off"),
+		hhHouseholdEntry("hh1", "Board", "Yes"),
+	}
+
+	rows := s.aggregateToRows(personValues, householdValues, 2026)
+	camper := rows[MakeCompositeKey("hh1", 101, 2026)]
+	if camper == nil {
+		t.Fatalf("no camper row, got keys %v", rowKeys(rows))
+	}
+
+	want := householdDemographicsRecord{
+		householdPBID:            "hh1",
+		personPBID:               "p1",
+		personCMID:               101,
+		year:                     2026,
+		familyDescription:        "LGBTQ|Interfaith",
+		familyDescriptionOther:   "Multigenerational",
+		jewishAffiliation:        "Reform",
+		jewishAffiliationOther:   "Renewal",
+		jewishIdentities:         "Ashkenazi|Sephardi",
+		congregationSummer:       testCongregation,
+		jccSummer:                "Bayside JCC",
+		militaryFamily:           false,
+		parentImmigrant:          true,
+		parentImmigrantOrigin:    "Israel",
+		custodySummer:            "Shared custody",
+		hasCustodyConsiderations: true,
+		awayDuringCamp:           true,
+		awayLocation:             "Cape Cod",
+		awayPhone:                "555-0100",
+		awayFromDate:             "07/01/26",
+		awayReturnDate:           "07/15/26",
+		formFiller:               "Parent",
+	}
+	if *camper != want {
+		t.Errorf("camper row =\n %+v\nwant\n %+v", *camper, want)
+	}
+
+	household := rows[MakeCompositeKey("hh1", 0, 2026)]
+	if household == nil {
+		t.Fatalf("no household row, got keys %v", rowKeys(rows))
+	}
+	wantHousehold := householdDemographicsRecord{
+		householdPBID:      "hh1",
+		year:               2026,
+		congregationFamily: "Congregation Beth Shalom",
+		jccFamily:          "Lakeside JCC",
+		custodyFamily:      "Week on/week off",
+		boardMember:        true,
+	}
+	if *household != wantHousehold {
+		t.Errorf("household row =\n %+v\nwant\n %+v", *household, wantHousehold)
+	}
+}
+
+// TestAggregatePreservesMultiSelectVerbatim covers the pipe-delimited
+// multi-selects, which is why kindred#2260 rejected both a newest-wins collapse
+// and a union: the newest answer is missing a token a sibling carries in 86% of
+// colliding cells, and pairs like "Prefer not to answer" against a named
+// affiliation cannot be unioned coherently. Each camper's string is stored as
+// given, untouched.
+func TestAggregatePreservesMultiSelectVerbatim(t *testing.T) {
+	s := NewHouseholdDemographicsSync(nil)
+
+	rows := s.aggregateToRows([]hhCustomValueEntry{
+		hhPersonEntry("hh1", "p1", 101, "HH-Family Description", "LGBTQ|Interfaith"),
+		hhPersonEntry("hh1", "p2", 102, "HH-Family Description", "Single Parent|LGBTQ"),
+		hhPersonEntry("hh2", "p3", 103, "HH-Family Description", "Kindred Alum"),
+	}, nil, 2026)
+
+	want := map[string]string{
+		MakeCompositeKey("hh1", 101, 2026): "LGBTQ|Interfaith",
+		MakeCompositeKey("hh1", 102, 2026): "Single Parent|LGBTQ",
+		MakeCompositeKey("hh2", 103, 2026): "Kindred Alum",
+	}
+	if len(rows) != len(want) {
+		t.Fatalf("got %d rows, want %d: %v", len(rows), len(want), rowKeys(rows))
+	}
+	for key, value := range want {
+		got := rows[key]
+		if got == nil {
+			t.Fatalf("row %q missing, got keys %v", key, rowKeys(rows))
+		}
+		if got.familyDescription != value {
+			t.Errorf("row %q family_description = %q, want %q", key, got.familyDescription, value)
+		}
+	}
+}
+
+// TestMakeCompositeKeyCarriesPerson pins leg one of the grain triple, the write
+// key. A key that omits the person collapses siblings back together no matter
+// what the index says.
+func TestMakeCompositeKeyCarriesPerson(t *testing.T) {
+	tests := []struct {
+		household string
+		personCM  int
+		year      int
+		want      string
+	}{
+		{"abc123", 5001, 2026, "abc123|5001|2026"},
+		{"abc123", 5002, 2026, "abc123|5002|2026"},
+		{"abc123", 0, 2026, "abc123|0|2026"}, // the household-level row
+		{"abc123", 5001, 2025, "abc123|5001|2025"},
+		{"xyz789", 5001, 2026, "xyz789|5001|2026"},
+	}
+
+	seen := make(map[string]bool, len(tests))
+	for _, tt := range tests {
+		got := MakeCompositeKey(tt.household, tt.personCM, tt.year)
+		if got != tt.want {
+			t.Errorf("MakeCompositeKey(%q, %d, %d) = %q, want %q",
+				tt.household, tt.personCM, tt.year, got, tt.want)
+		}
+		if seen[got] {
+			t.Errorf("MakeCompositeKey collided on %q", got)
+		}
+		seen[got] = true
+	}
+}
+
+// TestUpsertAndOrphanSweepAgreeOnGrain is the grain-triple test. kindred#2257
+// states the trap plainly: widen the write key and the unique index but not the
+// orphan key, and the next sync run deletes the rows the widening just created
+// and reports success. This drives the real write path and the real sweep
+// against a fixture carrying the real unique index, so a key that disagrees
+// with either of the other two legs fails here rather than in production.
+func TestUpsertAndOrphanSweepAgreeOnGrain(t *testing.T) {
+	app, households, persons := newHouseholdDemographicsTestApp(t)
+	ctx := context.Background()
+
+	hh := core.NewRecord(households)
+	hh.Set("cm_id", 9001)
+	hh.Set("year", 2026)
+	if err := app.Save(hh); err != nil {
+		t.Fatalf("save household: %v", err)
+	}
+	personPBIDs := make(map[int]string, 2)
+	for _, cmID := range []int{101, 102} {
+		p := core.NewRecord(persons)
+		p.Set("cm_id", cmID)
+		p.Set("household", hh.Id)
+		p.Set("year", 2026)
+		if err := app.Save(p); err != nil {
+			t.Fatalf("save person %d: %v", cmID, err)
+		}
+		personPBIDs[cmID] = p.Id
+	}
+
+	s := NewHouseholdDemographicsSync(app)
+	both := []hhCustomValueEntry{
+		hhPersonEntry(hh.Id, personPBIDs[101], 101, "HH-Jewish Affiliation", "Reform"),
+		hhPersonEntry(hh.Id, personPBIDs[102], 102, "HH-Jewish Affiliation", "Prefer not to answer"),
+	}
+
+	rows := s.aggregateToRows(both, nil, 2026)
+	existing, err := s.loadExistingRecords(ctx, 2026)
+	if err != nil {
+		t.Fatalf("loadExistingRecords: %v", err)
+	}
+	created, _, _, errs := s.upsertRecords(ctx, rows, existing, 2026)
+	if errs != 0 {
+		t.Fatalf("upsertRecords reported %d errors", errs)
+	}
+	if created != 2 {
+		t.Fatalf("upsertRecords created %d rows, want 2 (one per camper)", created)
+	}
+
+	// Leg two: the sweep must recognize both rows as computed. A household-grain
+	// orphan key matches neither and deletes the pair it just wrote.
+	existing, err = s.loadExistingRecords(ctx, 2026)
+	if err != nil {
+		t.Fatalf("loadExistingRecords after upsert: %v", err)
+	}
+	if len(existing) != 2 {
+		t.Fatalf("loadExistingRecords keyed %d rows, want 2 -- a household-grain key hides a sibling", len(existing))
+	}
+	if deleted := s.deleteOrphans(ctx, rows, existing); deleted != 0 {
+		t.Fatalf("deleteOrphans removed %d of the rows the write path just created", deleted)
+	}
+	if n := countDemographicsRows(t, app); n != 2 {
+		t.Fatalf("household_demographics holds %d rows after a no-op sweep, want 2", n)
+	}
+
+	// A camper who stops answering is a real orphan -- exactly one row goes.
+	onlyFirst := s.aggregateToRows(both[:1], nil, 2026)
+	existing, err = s.loadExistingRecords(ctx, 2026)
+	if err != nil {
+		t.Fatalf("loadExistingRecords before sweep: %v", err)
+	}
+	if deleted := s.deleteOrphans(ctx, onlyFirst, existing); deleted != 1 {
+		t.Fatalf("deleteOrphans removed %d rows, want 1", deleted)
+	}
+	if n := countDemographicsRows(t, app); n != 1 {
+		t.Fatalf("household_demographics holds %d rows, want 1", n)
+	}
+	survivor, err := app.FindFirstRecordByFilter("household_demographics", "year = 2026")
+	if err != nil {
+		t.Fatalf("find survivor: %v", err)
+	}
+	if survivor.GetInt("person_id") != 101 {
+		t.Errorf("survivor person_id = %d, want 101", survivor.GetInt("person_id"))
+	}
+	if survivor.GetString("person") != personPBIDs[101] {
+		t.Errorf("survivor person relation = %q, want %q", survivor.GetString("person"), personPBIDs[101])
+	}
+}
+
+// TestDeleteOrphansRefusesToEmptyTheTable guards the sweep against an upstream
+// load that came back empty. Every row here is recomputed from
+// person_custom_values on each run, so an empty computed set is far more likely
+// to be a failed read than a year in which nobody answered anything -- and the
+// sweep is the one step of this sync that a re-run cannot undo.
+func TestDeleteOrphansRefusesToEmptyTheTable(t *testing.T) {
+	app, households, persons := newHouseholdDemographicsTestApp(t)
+	ctx := context.Background()
+
+	hh := core.NewRecord(households)
+	hh.Set("cm_id", 9001)
+	hh.Set("year", 2026)
+	if err := app.Save(hh); err != nil {
+		t.Fatalf("save household: %v", err)
+	}
+	p := core.NewRecord(persons)
+	p.Set("cm_id", 101)
+	p.Set("household", hh.Id)
+	p.Set("year", 2026)
+	if err := app.Save(p); err != nil {
+		t.Fatalf("save person: %v", err)
+	}
+
+	s := NewHouseholdDemographicsSync(app)
+	rows := s.aggregateToRows([]hhCustomValueEntry{
+		hhPersonEntry(hh.Id, p.Id, 101, "HH-Jewish Affiliation", "Reform"),
+	}, nil, 2026)
+	existing, err := s.loadExistingRecords(ctx, 2026)
+	if err != nil {
+		t.Fatalf("loadExistingRecords: %v", err)
+	}
+	if _, _, _, errs := s.upsertRecords(ctx, rows, existing, 2026); errs != 0 {
+		t.Fatalf("upsertRecords reported %d errors", errs)
+	}
+	existing, err = s.loadExistingRecords(ctx, 2026)
+	if err != nil {
+		t.Fatalf("loadExistingRecords after upsert: %v", err)
+	}
+
+	deleted := s.deleteOrphans(ctx, map[string]*householdDemographicsRecord{}, existing)
+	if deleted != 0 {
+		t.Errorf("deleteOrphans removed %d rows against an empty computed set; want a refusal", deleted)
+	}
+	if n := countDemographicsRows(t, app); n != 1 {
+		t.Errorf("household_demographics holds %d rows, want 1 (nothing swept)", n)
+	}
+	if s.Stats.Errors == 0 {
+		t.Error("a refused sweep must be audible in Stats.Errors, got 0")
+	}
+}
+
+// countDemographicsRows returns the number of household_demographics rows.
+func countDemographicsRows(t *testing.T, app core.App) int {
+	t.Helper()
+	records, err := app.FindRecordsByFilter("household_demographics", "year > 0", "", 0, 0)
+	if err != nil {
+		t.Fatalf("count household_demographics: %v", err)
+	}
+	return len(records)
 }

--- a/pocketbase/sync/household_demographics_test.go
+++ b/pocketbase/sync/household_demographics_test.go
@@ -831,3 +831,71 @@ func countDemographicsRows(t *testing.T, app core.App) int {
 	}
 	return len(records)
 }
+
+// setColumn is the must-be-unique rule that REPLACED first-non-empty-wins, and
+// it is the behavioural core of kindred#2260. Nothing covered it, so a refactor
+// restoring `if *dst == "" { *dst = value }` -- the exact shape that discarded
+// 7,781 answers over ten years -- passed the whole suite green.
+//
+// The three arms are pinned separately because only the third one distinguishes
+// the new rule from the old one.
+func TestSetColumnIsMustBeUniqueNotFirstWins(t *testing.T) {
+	t.Run("writes into an empty column", func(t *testing.T) {
+		s := &HouseholdDemographicsSync{}
+		rec := &householdDemographicsRecord{householdPBID: "hh1", personCMID: 11, year: 2026}
+
+		s.setColumn(rec, &rec.jewishAffiliation, "jewish_affiliation", "Reform")
+
+		if rec.jewishAffiliation != "Reform" {
+			t.Errorf("column = %q, want %q", rec.jewishAffiliation, "Reform")
+		}
+		if s.columnConflicts != 0 {
+			t.Errorf("conflicts = %d, want 0 -- a first write is not a conflict", s.columnConflicts)
+		}
+	})
+
+	t.Run("the same answer twice is not a conflict", func(t *testing.T) {
+		s := &HouseholdDemographicsSync{}
+		rec := &householdDemographicsRecord{householdPBID: "hh1", personCMID: 11, year: 2026}
+
+		s.setColumn(rec, &rec.jewishAffiliation, "jewish_affiliation", "Reform")
+		s.setColumn(rec, &rec.jewishAffiliation, "jewish_affiliation", "Reform")
+
+		if s.columnConflicts != 0 {
+			t.Errorf("conflicts = %d, want 0 -- an identical repeat discards nothing", s.columnConflicts)
+		}
+	})
+
+	// The arm that matters. Under the old first-non-empty-wins code this case was
+	// silent: the second value vanished and nothing counted it. It must now be
+	// counted, and the stored value must not flip -- a silent overwrite would be
+	// the same defect pointing the other way.
+	t.Run("a genuinely different answer is counted, not swallowed", func(t *testing.T) {
+		s := &HouseholdDemographicsSync{}
+		rec := &householdDemographicsRecord{householdPBID: "hh1", personCMID: 11, year: 2026}
+
+		s.setColumn(rec, &rec.jewishAffiliation, "jewish_affiliation", "Reform")
+		s.setColumn(rec, &rec.jewishAffiliation, "jewish_affiliation", "Just Jewish")
+
+		if s.columnConflicts != 1 {
+			t.Errorf("conflicts = %d, want 1 -- a disagreement must be audible", s.columnConflicts)
+		}
+		if rec.jewishAffiliation != "Reform" {
+			t.Errorf("column = %q, want %q -- the refusal must not overwrite", rec.jewishAffiliation, "Reform")
+		}
+	})
+
+	t.Run("conflicts accumulate across columns", func(t *testing.T) {
+		s := &HouseholdDemographicsSync{}
+		rec := &householdDemographicsRecord{householdPBID: "hh1", personCMID: 11, year: 2026}
+
+		s.setColumn(rec, &rec.jewishAffiliation, "jewish_affiliation", "Reform")
+		s.setColumn(rec, &rec.jewishAffiliation, "jewish_affiliation", "Just Jewish")
+		s.setColumn(rec, &rec.familyDescription, "family_description", "Interfaith")
+		s.setColumn(rec, &rec.familyDescription, "family_description", "Multicultural")
+
+		if s.columnConflicts != 2 {
+			t.Errorf("conflicts = %d, want 2", s.columnConflicts)
+		}
+	})
+}

--- a/pocketbase/sync/household_demographics_test.go
+++ b/pocketbase/sync/household_demographics_test.go
@@ -10,7 +10,10 @@ import (
 )
 
 // Test constants for fictional data
-const testCongregation = "Temple Beth El"
+// Fictional, and verified absent from the production snapshot. tests/CLAUDE.md:
+// values that appear in real data do not belong in a public test file, and a
+// congregation name is exactly the kind of identifying detail the rule covers.
+const testCongregation = "Riverside Synagogue"
 
 // Every test in this file calls the PRODUCTION functions.
 //
@@ -480,7 +483,7 @@ func TestAggregateHouseholdValuesGetTheirOwnRow(t *testing.T) {
 		hhPersonEntry("hh1", "p1", 101, "HH-special living arrangements", "Shared custody"),
 	}
 	householdValues := []hhCustomValueEntry{
-		hhHouseholdEntry("hh1", customFieldNameSynagogue, "Congregation Beth Shalom"),
+		hhHouseholdEntry("hh1", customFieldNameSynagogue, "Oak Valley Synagogue"),
 		hhHouseholdEntry("hh1", "Center", "Lakeside JCC"),
 		hhHouseholdEntry("hh1", "Custody Issues", "Week on/week off"),
 		hhHouseholdEntry("hh1", "Board", "Yes"),
@@ -512,7 +515,7 @@ func TestAggregateHouseholdValuesGetTheirOwnRow(t *testing.T) {
 	}
 
 	// Family answers stay on the household row.
-	if household.congregationFamily != "Congregation Beth Shalom" {
+	if household.congregationFamily != "Oak Valley Synagogue" {
 		t.Errorf("household congregation_family = %q", household.congregationFamily)
 	}
 	if household.jccFamily != "Lakeside JCC" {
@@ -559,7 +562,7 @@ func TestAggregateFullRecord(t *testing.T) {
 		hhPersonEntry("hh1", "p1", 101, "HH-Who is filling out info", "Parent"),
 	}
 	householdValues := []hhCustomValueEntry{
-		hhHouseholdEntry("hh1", customFieldNameSynagogue, "Congregation Beth Shalom"),
+		hhHouseholdEntry("hh1", customFieldNameSynagogue, "Oak Valley Synagogue"),
 		hhHouseholdEntry("hh1", "Center", "Lakeside JCC"),
 		hhHouseholdEntry("hh1", "Custody Issues", "Week on/week off"),
 		hhHouseholdEntry("hh1", "Board", "Yes"),
@@ -606,7 +609,7 @@ func TestAggregateFullRecord(t *testing.T) {
 	wantHousehold := householdDemographicsRecord{
 		householdPBID:      "hh1",
 		year:               2026,
-		congregationFamily: "Congregation Beth Shalom",
+		congregationFamily: "Oak Valley Synagogue",
 		jccFamily:          "Lakeside JCC",
 		custodyFamily:      "Week on/week off",
 		boardMember:        true,

--- a/pocketbase/sync/household_demographics_test.go
+++ b/pocketbase/sync/household_demographics_test.go
@@ -15,6 +15,9 @@ import (
 // congregation name is exactly the kind of identifying detail the rule covers.
 const testCongregation = "Riverside Synagogue"
 
+// testAffiliation is shared by the aggregation tests and the setColumn tests.
+const testAffiliation = "Reform"
+
 // Every test in this file calls the PRODUCTION functions.
 //
 // The suite that shipped here did not. `aggregatePersonValuesByHousehold`,
@@ -370,7 +373,7 @@ func TestAggregateKeepsEveryPersonAnswer(t *testing.T) {
 	s := NewHouseholdDemographicsSync(nil)
 
 	values := []hhCustomValueEntry{
-		hhPersonEntry("hh1", "p1", 101, "HH-Jewish Affiliation", "Reform"),
+		hhPersonEntry("hh1", "p1", 101, "HH-Jewish Affiliation", testAffiliation),
 		hhPersonEntry("hh1", "p2", 102, "HH-Jewish Affiliation", "Prefer not to answer"),
 	}
 
@@ -384,8 +387,8 @@ func TestAggregateKeepsEveryPersonAnswer(t *testing.T) {
 	if first == nil || second == nil {
 		t.Fatalf("rows are not keyed per person: got keys %v", rowKeys(rows))
 	}
-	if first.jewishAffiliation != "Reform" {
-		t.Errorf("camper 101 jewish_affiliation = %q, want %q", first.jewishAffiliation, "Reform")
+	if first.jewishAffiliation != testAffiliation {
+		t.Errorf("camper 101 jewish_affiliation = %q, want %q", first.jewishAffiliation, testAffiliation)
 	}
 	if second.jewishAffiliation != "Prefer not to answer" {
 		t.Errorf("camper 102 jewish_affiliation = %q, want %q", second.jewishAffiliation, "Prefer not to answer")
@@ -544,7 +547,7 @@ func TestAggregateFullRecord(t *testing.T) {
 	personValues := []hhCustomValueEntry{
 		hhPersonEntry("hh1", "p1", 101, "HH-Family Description", "LGBTQ|Interfaith"),
 		hhPersonEntry("hh1", "p1", 101, "HH-Family Description Other", "Multigenerational"),
-		hhPersonEntry("hh1", "p1", 101, "HH-Jewish Affiliation", "Reform"),
+		hhPersonEntry("hh1", "p1", 101, "HH-Jewish Affiliation", testAffiliation),
 		hhPersonEntry("hh1", "p1", 101, "HH-Jewish Affiliation Other", "Renewal"),
 		hhPersonEntry("hh1", "p1", 101, "HH-Jewish Identities", "Ashkenazi|Sephardi"),
 		hhPersonEntry("hh1", "p1", 101, "HH-Name of Congregation", testCongregation),
@@ -581,7 +584,7 @@ func TestAggregateFullRecord(t *testing.T) {
 		year:                     2026,
 		familyDescription:        "LGBTQ|Interfaith",
 		familyDescriptionOther:   "Multigenerational",
-		jewishAffiliation:        "Reform",
+		jewishAffiliation:        testAffiliation,
 		jewishAffiliationOther:   "Renewal",
 		jewishIdentities:         "Ashkenazi|Sephardi",
 		congregationSummer:       testCongregation,
@@ -714,7 +717,7 @@ func TestUpsertAndOrphanSweepAgreeOnGrain(t *testing.T) {
 
 	s := NewHouseholdDemographicsSync(app)
 	both := []hhCustomValueEntry{
-		hhPersonEntry(hh.Id, personPBIDs[101], 101, "HH-Jewish Affiliation", "Reform"),
+		hhPersonEntry(hh.Id, personPBIDs[101], 101, "HH-Jewish Affiliation", testAffiliation),
 		hhPersonEntry(hh.Id, personPBIDs[102], 102, "HH-Jewish Affiliation", "Prefer not to answer"),
 	}
 
@@ -796,7 +799,7 @@ func TestDeleteOrphansRefusesToEmptyTheTable(t *testing.T) {
 
 	s := NewHouseholdDemographicsSync(app)
 	rows := s.aggregateToRows([]hhCustomValueEntry{
-		hhPersonEntry(hh.Id, p.Id, 101, "HH-Jewish Affiliation", "Reform"),
+		hhPersonEntry(hh.Id, p.Id, 101, "HH-Jewish Affiliation", testAffiliation),
 	}, nil, 2026)
 	existing, err := s.loadExistingRecords(ctx, 2026)
 	if err != nil {
@@ -833,7 +836,7 @@ func countDemographicsRows(t *testing.T, app core.App) int {
 }
 
 // setColumn is the must-be-unique rule that REPLACED first-non-empty-wins, and
-// it is the behavioural core of kindred#2260. Nothing covered it, so a refactor
+// it is the behavioral core of kindred#2260. Nothing covered it, so a refactor
 // restoring `if *dst == "" { *dst = value }` -- the exact shape that discarded
 // 7,781 answers over ten years -- passed the whole suite green.
 //
@@ -844,10 +847,10 @@ func TestSetColumnIsMustBeUniqueNotFirstWins(t *testing.T) {
 		s := &HouseholdDemographicsSync{}
 		rec := &householdDemographicsRecord{householdPBID: "hh1", personCMID: 11, year: 2026}
 
-		s.setColumn(rec, &rec.jewishAffiliation, "jewish_affiliation", "Reform")
+		s.setColumn(rec, &rec.jewishAffiliation, "jewish_affiliation", testAffiliation)
 
-		if rec.jewishAffiliation != "Reform" {
-			t.Errorf("column = %q, want %q", rec.jewishAffiliation, "Reform")
+		if rec.jewishAffiliation != testAffiliation {
+			t.Errorf("column = %q, want %q", rec.jewishAffiliation, testAffiliation)
 		}
 		if s.columnConflicts != 0 {
 			t.Errorf("conflicts = %d, want 0 -- a first write is not a conflict", s.columnConflicts)
@@ -858,8 +861,8 @@ func TestSetColumnIsMustBeUniqueNotFirstWins(t *testing.T) {
 		s := &HouseholdDemographicsSync{}
 		rec := &householdDemographicsRecord{householdPBID: "hh1", personCMID: 11, year: 2026}
 
-		s.setColumn(rec, &rec.jewishAffiliation, "jewish_affiliation", "Reform")
-		s.setColumn(rec, &rec.jewishAffiliation, "jewish_affiliation", "Reform")
+		s.setColumn(rec, &rec.jewishAffiliation, "jewish_affiliation", testAffiliation)
+		s.setColumn(rec, &rec.jewishAffiliation, "jewish_affiliation", testAffiliation)
 
 		if s.columnConflicts != 0 {
 			t.Errorf("conflicts = %d, want 0 -- an identical repeat discards nothing", s.columnConflicts)
@@ -874,14 +877,14 @@ func TestSetColumnIsMustBeUniqueNotFirstWins(t *testing.T) {
 		s := &HouseholdDemographicsSync{}
 		rec := &householdDemographicsRecord{householdPBID: "hh1", personCMID: 11, year: 2026}
 
-		s.setColumn(rec, &rec.jewishAffiliation, "jewish_affiliation", "Reform")
+		s.setColumn(rec, &rec.jewishAffiliation, "jewish_affiliation", testAffiliation)
 		s.setColumn(rec, &rec.jewishAffiliation, "jewish_affiliation", "Just Jewish")
 
 		if s.columnConflicts != 1 {
 			t.Errorf("conflicts = %d, want 1 -- a disagreement must be audible", s.columnConflicts)
 		}
-		if rec.jewishAffiliation != "Reform" {
-			t.Errorf("column = %q, want %q -- the refusal must not overwrite", rec.jewishAffiliation, "Reform")
+		if rec.jewishAffiliation != testAffiliation {
+			t.Errorf("column = %q, want %q -- the refusal must not overwrite", rec.jewishAffiliation, testAffiliation)
 		}
 	})
 
@@ -889,7 +892,7 @@ func TestSetColumnIsMustBeUniqueNotFirstWins(t *testing.T) {
 		s := &HouseholdDemographicsSync{}
 		rec := &householdDemographicsRecord{householdPBID: "hh1", personCMID: 11, year: 2026}
 
-		s.setColumn(rec, &rec.jewishAffiliation, "jewish_affiliation", "Reform")
+		s.setColumn(rec, &rec.jewishAffiliation, "jewish_affiliation", testAffiliation)
 		s.setColumn(rec, &rec.jewishAffiliation, "jewish_affiliation", "Just Jewish")
 		s.setColumn(rec, &rec.familyDescription, "family_description", "Interfaith")
 		s.setColumn(rec, &rec.familyDescription, "family_description", "Multicultural")

--- a/pocketbase/sync/table_exporter.go
+++ b/pocketbase/sync/table_exporter.go
@@ -896,11 +896,20 @@ func GetReadableYearExports() []ExportConfig {
 			},
 		},
 		// Household Demographics - HH- fields from custom values, one row per
-		// (household, person, year). The person columns are not decoration:
-		// since kindred#2260 a household contributes one row per camper who
-		// answered, so a sheet without them reads as duplicated households.
-		// Person ID 0 with no name is the household-level row carrying the
-		// _family columns.
+		// (household, person, year). Person ID is not decoration: since
+		// kindred#2260 a household contributes one row per camper who answered,
+		// so a sheet without it reads as duplicated households. Person ID 0 is
+		// the household-level row carrying the _family columns.
+		//
+		// PERSON ID, DELIBERATELY NOT THE NAME. This endpoint is gated on
+		// `sheets.export`, which Finance and Executive hold -- a wider audience
+		// than the collection's own admin-only API rules. These columns carry
+		// Jewish identity and affiliation, family description and custody
+		// answers, and putting a camper's name beside them here would narrow
+		// the attribution from a family to a named child for a non-admin role.
+		// The Persons sheet in the same workbook exports `cm_id` under the same
+		// "Person ID" header, so anyone entitled to resolve the id to a name
+		// still can, through a gate that already exists.
 		{
 			Collection: "household_demographics",
 			SheetName:  "Household Demographics",
@@ -912,14 +921,6 @@ func GetReadableYearExports() []ExportConfig {
 					RelatedCol: "households", RelatedField: "mailing_title",
 				},
 				{Field: "person_id", Header: "Person ID", Type: FieldTypeNumber},
-				{
-					Field: "person", Header: "First Name", Type: FieldTypeNestedField,
-					RelatedCol: "persons", NestedField: "first_name",
-				},
-				{
-					Field: "person", Header: "Last Name", Type: FieldTypeNestedField,
-					RelatedCol: "persons", NestedField: "last_name",
-				},
 				{Field: "year", Header: "Year", Type: FieldTypeNumber},
 				// Family description
 				{Field: "family_description", Header: "Family Description", Type: FieldTypeText},

--- a/pocketbase/sync/table_exporter.go
+++ b/pocketbase/sync/table_exporter.go
@@ -895,7 +895,12 @@ func GetReadableYearExports() []ExportConfig {
 				{Field: "value", Header: "Value", Type: FieldTypeText},
 			},
 		},
-		// Household Demographics - consolidated HH- fields from custom values
+		// Household Demographics - HH- fields from custom values, one row per
+		// (household, person, year). The person columns are not decoration:
+		// since kindred#2260 a household contributes one row per camper who
+		// answered, so a sheet without them reads as duplicated households.
+		// Person ID 0 with no name is the household-level row carrying the
+		// _family columns.
 		{
 			Collection: "household_demographics",
 			SheetName:  "Household Demographics",
@@ -905,6 +910,15 @@ func GetReadableYearExports() []ExportConfig {
 				{
 					Field: "household", Header: "Household", Type: FieldTypeRelation,
 					RelatedCol: "households", RelatedField: "mailing_title",
+				},
+				{Field: "person_id", Header: "Person ID", Type: FieldTypeNumber},
+				{
+					Field: "person", Header: "First Name", Type: FieldTypeNestedField,
+					RelatedCol: "persons", NestedField: "first_name",
+				},
+				{
+					Field: "person", Header: "Last Name", Type: FieldTypeNestedField,
+					RelatedCol: "persons", NestedField: "last_name",
 				},
 				{Field: "year", Header: "Year", Type: FieldTypeNumber},
 				// Family description

--- a/pocketbase/sync/table_exporter.go
+++ b/pocketbase/sync/table_exporter.go
@@ -901,15 +901,17 @@ func GetReadableYearExports() []ExportConfig {
 		// so a sheet without it reads as duplicated households. Person ID 0 is
 		// the household-level row carrying the _family columns.
 		//
-		// PERSON ID, DELIBERATELY NOT THE NAME. This endpoint is gated on
-		// `sheets.export`, which Finance and Executive hold -- a wider audience
-		// than the collection's own admin-only API rules. These columns carry
-		// Jewish identity and affiliation, family description and custody
-		// answers, and putting a camper's name beside them here would narrow
-		// the attribution from a family to a named child for a non-admin role.
-		// The Persons sheet in the same workbook exports `cm_id` under the same
-		// "Person ID" header, so anyone entitled to resolve the id to a name
-		// still can, through a gate that already exists.
+		// Person ID rather than the camper's name is a readability choice, not a
+		// privacy control, and an earlier version of this comment claimed
+		// otherwise. It argued that omitting the name kept the attribution
+		// behind "a gate that already exists" -- but the Persons sheet in THIS
+		// workbook maps the same "Person ID" header to first_name/last_name, so
+		// the two are one lookup apart for anyone already holding the file.
+		// There is no gate. Owner ruling 2026-08-13: the export's contents are
+		// not a concern here, because the staff who can pull this workbook can
+		// already read the same answers in CampMinder directly. Do not
+		// reintroduce a privacy rationale for this column without revisiting
+		// that ruling.
 		{
 			Collection: "household_demographics",
 			SheetName:  "Household Demographics",


### PR DESCRIPTION
`household_demographics` held one row per `(household, year)`, and its summer-side columns were filled from the `HH-` custom fields that each **camper** in that household answered. `mapPersonFieldToRecord` folded them together first-non-empty-wins, so a household where two campers answered the same question differently kept one answer and silently discarded the rest.

**Measured impact, reproduced exactly against the production snapshot before anything changed:** 7,781 answers lost across ten years in 7,593 household-year-column cells spanning 4,215 household-years; **627 answers across 621 cells and 338 households in 2026** — 64% of the 531 households with more than one camper answering. Both figures match kindred#2260 to the digit.

The survivor was not even chosen. The loader paged with no `ORDER BY`, so it was whichever row the SQLite planner's index yielded first — the same sync over the same data could store a different value after an `ANALYZE` or a planner upgrade.

## Why the grain moved instead of a collapse rule being picked

These values are pipe-delimited multi-selects. Measured over all 7,593 colliding cells, the newest answer contains every token its siblings carry in only **1,098 (14%)** — so the newest-wins rule kindred#2260's own body proposed would still lose tokens in **6,495 cells (86%)**. A union is not available either: real data pairs `Prefer not to answer` with a named affiliation for the same household, which cannot be merged into one string that means anything.

The answers are given per camper. They are now stored per camper. Nothing has to be invented, and the issue body has been corrected to record the decision so the next reader does not build newest-wins from it.

## The grain triple

kindred#2257 is explicit that two of three is worse than none. All three moved in this commit:

| Leg | Before | After |
|---|---|---|
| **Write key** | `MakeCompositeKey(household, year)` at `:742` | `MakeCompositeKey(household, person_id, year)` |
| **Orphan key** | `MakeCompositeKey(household, year)` in `deleteOrphans` | same triple. Note this service tracks orphans **locally**, not through `TrackProcessedCompositeKey` |
| **Unique index** | `idx_household_demographics_hh_year (household, year)` | `idx_household_demographics_hh_person_year (household, person_id, year)`, migration **1500000150** |

`TestUpsertAndOrphanSweepAgreeOnGrain` drives the real write path and the real sweep against a fixture carrying the real unique index, so a key that disagrees with either of the other two legs fails in the suite rather than in production.

## The person column

There was none. This adds two, matching how the repo keys person relations:

- **`person_id`** (number, `onlyInt`, 0 = the household-level row) — the durable identity and what the unique index keys on. CLAUDE.md §1: cross-table relationships use CampMinder ids, never PocketBase ids. `attendees`, `camper_dietary` and `quest_registrations` are all unique on `person_id` while carrying a relation beside it, and 1500000147 re-keyed four lodging tables off their relations for exactly this reason.
- **`person`** (relation to `persons`, `cascadeDelete: true`) — the join handle an expand-based read and the table exporter use. A handle, not the identity.

Verified against the snapshot: zero `persons` rows carry `cm_id <= 0`, and grouping the source answers by person PB id and by person CampMinder id both give **24,288** rows, so the two keys select the same grain.

## Household-level answers are not duplicated

The `_family` columns come from `household_custom_values`, which is already one row per household per field. They land on a **person-less row** (`person_id` 0) rather than being copied onto every camper. SQLite treats 0 as a value rather than a NULL, so the unique index keeps exactly one such row per household-year.

Expected 2026 shape: 2,181 camper rows + 29 household rows, against 1,612 today.

## The boolean arms are untouched

`military_family`, `parent_immigrant`, `has_custody_considerations`, `away_during_camp` and `board_member` are logical ORs, never first-wins, and were never part of the defect. **One consequence worth stating:** at this grain they OR over one camper's answers rather than the household's, so they now describe the camper who answered. That is strictly more information — the household-level OR becomes a query over the rows instead of a stored value, and kindred#2257 already praises the Family Camp booleans for OR-ing over the raw per-person slice rather than a flattened map. `TestAggregateBooleanArmsStillOR` pins both the OR and its order-independence.

## API rules: deliberately unchanged, and here is why

The team lead asked for a decision rather than an inheritance, since the re-grain raises the granularity of sensitive-category data (Jewish identity and affiliation, LGBTQ and interfaith family description, custody arrangements) from "this family" to "this camper answered this".

**Kept at `@request.auth.is_admin = true` on all five rules.** That exact attribution, at that exact grain, already sits one table over in `person_custom_values` — this table's own source — which is admin-only on all five rules, as are `camper_dietary`, `family_camp_medical`, `financial_aid_applications` and `household_custom_values`. Tightening this one table below its own source would deny an admin a fact they can read next door: theatre, not protection.

**Superuser-only writes were considered and rejected.** Every row is computed and a hand-edit would be reverted by the next sync, which is a real argument — but the Go sync writes through `core.App` and bypasses API rules either way, so the change would buy nothing while making one table diverge from ten identical siblings for no stated reason. Not PHI, so no `lodging.phi` gate applies.

One related hardening did land: the conflict log line records identifiers only, never the values. A log is a wider audience than an admin-only table, and both values are recoverable from `person_custom_values` by anyone entitled to see them.

## No data migration

kindred#2257 establishes the source is intact — `person_custom_values` holds the raw answers under `UNIQUE(year, person, field_definition)` with zero duplicate key groups. Every row re-derives on the next sync run.

**Proven against a copy of the populated 716MB database, not just a fresh one:** all **17,646** existing rows survive, every one landing at `person_id` 0 / `person` `''` with no NULLs and no unique-index collision (the old index already guaranteed one row per household-year). A SHA-256 over every demographic column of every row, ordered by id, is identical before and after — `371e2d98…f35bde` both sides, so the existing data is preserved byte-for-byte, not merely counted.

## Also in this PR, because the re-grain forces them

- **`table_exporter` gains a Person ID column.** It enumerates columns explicitly, so per-camper rows without it export as apparently duplicated households. **The camper's name is deliberately not exported** — this endpoint is gated on `sheets.export`, held by Finance and Executive, a wider audience than the collection's own admin-only rules, and a name beside these answers would narrow the attribution from a family to a named child for a non-admin role. The Persons sheet in the same workbook exports `cm_id` under the same `Person ID` header, so the id still resolves through a gate that already exists. (Raised by CodeRabbit; its finding named Bunking Staff as a holder of `sheets.export`, which it is not — that role carries `["bunking.manage","lodging.phi"]`. The substance held.) This was the one consumer that did need updating; nothing else reads the demographic columns — the rest of the references are the writer, the orchestrator's registration and phase lists, the admin Sync tab's trigger button, and the generated `pocketbase-types.ts` (regenerated here).
- **Every paged read passes an explicit `sort`.** PocketBase adds an `ORDER BY` only when the sort argument is non-empty, so page boundaries were not stable across the separate per-page queries and a plan change between pages could skip or repeat rows. Not covered by a test: provoking it requires a planner-order change that cannot be forced in-process.
- **Seven test-local shadow helpers deleted.** `aggregatePersonValuesByHousehold`, `buildDemographicRecord`, `buildDemographicsCompositeKey`, `mapHHFieldToColumn`, `mapHouseholdFieldToColumn`, `parseBooleanCustomValue` and `isHHField` were reimplementations production never called, which is why ten years of discarded answers never turned a test red. Every assertion in the file now calls the production function.

## Verification

| Check | Result |
|---|---|
| `cd pocketbase && go test ./...` | **exit 0**, all packages |
| `golangci-lint run --config ../.golangci.yml ./...` | **exit 0**, 0 issues (CI-only, not in pre-push) |
| `bash scripts/pre-push-verify.sh` | **exit 0**, ALL CHECKS PASSED |
| `scripts/dev/verify-migration-history.sh` | **exit 0** |
| Fresh-boot live schema (`sqlite_master`, never a regex over the migration text) | old index gone, `idx_household_demographics_hh_person_year` UNIQUE on `(household, person_id, year)` present; `person` relation `cascadeDelete=1 maxSelect=1`; `person_id` `onlyInt=1`; all five API rules unchanged |
| up → `migrate down 1` → `migrate up` round trip | index and both columns removed and restored correctly |
| Populated-DB migration (copy of the 716MB snapshot) | 17,646 rows in, 17,646 out, no NULLs, no collision |

### Mutation checks

Every mutation was applied to the production file, the suite run, and the file restored.

| Mutation | Result |
|---|---|
| Aggregate write key drops the person | **exit 1** — 7 tests fail |
| Orphan key stays household-grain (the exact grain-triple trap) | **exit 1** — `TestUpsertAndOrphanSweepAgreeOnGrain` |
| `loadExistingRecords` key stays household-grain | **exit 1** — `TestUpsertAndOrphanSweepAgreeOnGrain` |
| Sweep refusal guard removed | **exit 1** — `TestDeleteOrphansRefusesToEmptyTheTable` |
| `congregation_family` routed to `congregation_summer` | **exit 1** — 2 tests fail |

The orphan sweep also gained a self-contained refusal guard: an empty computed set standing against a populated table is far more likely to be a load that came back empty than a year in which nobody answered anything, and the sweep is the one step a re-run cannot undo. It refuses, logs, and increments `Stats.Errors`. Deliberately kept local to this file so it does not collide with the shared guard being hoisted on `feature/orphan-sweep-coverage`.

## Two follow-up commits on the branch

**A real-data leak in the test file, fixed here per `tests/CLAUDE.md`.** `testCongregation` was `Temple Beth El` and one household fixture used `Congregation Beth Shalom` — both are values families actually entered, matching 64 and 52 rows of `person_custom_values` in the snapshot. Replaced with `Riverside Synagogue` and `Oak Valley Synagogue`, following the Riverside/Oak Valley/Hillcrest pattern of the existing fictional-school set, and verified zero-match across `person_custom_values`, `household_custom_values` and `household_demographics`.

**Left out deliberately, and worth its own change:** `sync/normalize_geographic_test.go` carries the same two literals plus `Congregation Beth Israel` (29 rows) and `Congregation Beth El` (70 rows) across roughly 20 occurrences. It is an unrelated file and sweeping it here would mix two concerns in one review.

The second follow-up resets `columnConflicts` alongside `Stats` in `Sync`: the orchestrator registers this service as a singleton, so a count from one year's run would otherwise be reported against the next year's too.

Closes #2260.

Part of #2257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
