### PR TITLE
perf(tests,ci): run the sync and lodging Go suites in parallel, on three shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -518,7 +518,33 @@ jobs:
         # like [1,2,3,4] fails the last job loudly rather than skipping tests, and
         # test_tests_go_job_shards_and_derives_total_from_the_matrix catches it
         # before CI does.
-        shard: [0, 1, 2, 3]
+        #
+        # Three. Every shard pays the same ~88s `-race` compile plus ~12s of
+        # checkout and setup-go, and none of that shards -- the setup-go cache
+        # key derives from go.sum alone, so it holds whichever build variant
+        # saved it first (a non-race one), Actions cache entries are immutable,
+        # and the race objects are therefore recompiled every run. That ~100s
+        # is a floor under every job in the matrix.
+        #
+        # With the suite parallelised (kindred#2281) the execution either side
+        # of that floor is small, so returns collapse. Measured on this repo,
+        # same tree, one afternoon:
+        #
+        #   shards   shard times (s)        wall    runner-seconds
+        #   1x4      (serial, pre-2281)     ~191    ~764
+        #   2        199, 199                199     398
+        #   3        176, 173, 167           176     516
+        #   4        158, 162, 131, 152      162     603
+        #
+        # 2 -> 3 buys 23s; 3 -> 4 buys 14s, which is inside the spread a single
+        # 4-shard run already shows (131-162s, from uneven splits). Past 4 you
+        # spend ~100s of runner time per job to shave seconds. Three is the
+        # knee.
+        #
+        # Do not re-derive this from the pre-2281 numbers: those were measured
+        # when the suite ran serially, and sharding was then buying real
+        # execution time rather than mostly duplicating a compile.
+        shard: [0, 1, 2]
     steps:
     - name: Checkout code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/pocketbase/lodging/api_test.go
+++ b/pocketbase/lodging/api_test.go
@@ -30,6 +30,7 @@ func yearsFor(t *testing.T, query string) (from, to int, err error) {
 // is inside no sane season but inside the field range, so it would succeed and
 // create exactly the phantom season registry.go's own doc comment warns about.
 func TestYearsFromQueryRejectsYearsOutsideTheFieldRange(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct{ name, query, wantIn string }{
 		{"zero to", "from=2026&to=0", "to"},
 		{"below the field minimum", "from=2026&to=1999", "to"},
@@ -48,6 +49,7 @@ func TestYearsFromQueryRejectsYearsOutsideTheFieldRange(t *testing.T) {
 }
 
 func TestYearsFromQueryAcceptsARealSeasonPair(t *testing.T) {
+	t.Parallel()
 	from, to, err := yearsFor(t, "from=2026&to=2027")
 	if err != nil {
 		t.Fatalf("yearsFromQuery: %v", err)

--- a/pocketbase/lodging/hooks_test.go
+++ b/pocketbase/lodging/hooks_test.go
@@ -520,6 +520,7 @@ func assertUnitDeleteRefused(t *testing.T, err error, wantCount int) {
 }
 
 func TestDeletingAUnitWithAnAssignmentIsBlocked(t *testing.T) {
+	t.Parallel()
 	app, err := tests.NewTestApp()
 	if err != nil {
 		t.Fatalf("NewTestApp: %v", err)
@@ -550,6 +551,7 @@ func TestDeletingAUnitWithAnAssignmentIsBlocked(t *testing.T) {
 // cleanup strips this id out of each one and re-saves it unvalidated, leaving
 // parties sitting in a scenario with no cabin and nothing to say why.
 func TestGuardUnitDeleteSeesDraftPlacements(t *testing.T) {
+	t.Parallel()
 	app, err := tests.NewTestApp()
 	if err != nil {
 		t.Fatalf("NewTestApp: %v", err)
@@ -574,6 +576,7 @@ func TestGuardUnitDeleteSeesDraftPlacements(t *testing.T) {
 // the message distinguishes it — and staff acting on "1 placement" when there
 // are two would go looking in the wrong place.
 func TestDeletingAUnitCountsBothGrainsTogether(t *testing.T) {
+	t.Parallel()
 	app, err := tests.NewTestApp()
 	if err != nil {
 		t.Fatalf("NewTestApp: %v", err)
@@ -596,6 +599,7 @@ func TestDeletingAUnitCountsBothGrainsTogether(t *testing.T) {
 // member of the set would silently drop, releasing a room out from under an
 // occupied two-room slot (spec §3.4).
 func TestDeletingAUnitHeldAsALaterMemberIsBlocked(t *testing.T) {
+	t.Parallel()
 	app, err := tests.NewTestApp()
 	if err != nil {
 		t.Fatalf("NewTestApp: %v", err)
@@ -621,6 +625,7 @@ func TestDeletingAUnitHeldAsALaterMemberIsBlocked(t *testing.T) {
 // that errors — the exact state guardUnitDelete was in against a real database
 // before this change, where every unit was undeletable for the wrong reason.
 func TestDeletingAnUnusedUnitIsAllowed(t *testing.T) {
+	t.Parallel()
 	app, err := tests.NewTestApp()
 	if err != nil {
 		t.Fatalf("NewTestApp: %v", err)
@@ -664,6 +669,7 @@ func newUnits(t *testing.T, app core.App, n int) []string {
 // the writes that never pass through the sync package — a POST straight at the
 // PocketBase REST API, and 1500000134's own backfill.
 func TestAssignmentGrainXor(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name          string
 		unitCount     int
@@ -730,6 +736,7 @@ func TestAssignmentGrainXor(t *testing.T) {
 // party grain and no units, exactly as the pre-134 rows did, and `units` is
 // added by a second save. The table-driven case above only ever creates.
 func TestABackfillShapedRowPassesTheGrainGuard(t *testing.T) {
+	t.Parallel()
 	app, err := tests.NewTestApp()
 	if err != nil {
 		t.Fatalf("NewTestApp: %v", err)
@@ -778,6 +785,7 @@ func TestABackfillShapedRowPassesTheGrainGuard(t *testing.T) {
 // premise the migration's backfill is written around, not something this test
 // can close.
 func TestABackfillShapedDraftRowPassesTheGrainGuard(t *testing.T) {
+	t.Parallel()
 	app, err := tests.NewTestApp()
 	if err != nil {
 		t.Fatalf("NewTestApp: %v", err)
@@ -815,6 +823,7 @@ func TestABackfillShapedDraftRowPassesTheGrainGuard(t *testing.T) {
 // deleteRefRecords both produce the shape, so rejecting it would break paths
 // this guard does not own. Only the party grain is enforced.
 func TestDraftAssignmentGrainXor(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name          string
 		unitCount     int
@@ -871,6 +880,7 @@ func TestDraftAssignmentGrainXor(t *testing.T) {
 // the existing row without reopening it — the string never returns to the
 // queue, and the placement never resolves again.
 func TestDeletingAnAliasBehindAResolvedIssueIsBlocked(t *testing.T) {
+	t.Parallel()
 	app, err := tests.NewTestApp()
 	if err != nil {
 		t.Fatalf("NewTestApp: %v", err)
@@ -892,6 +902,7 @@ func TestDeletingAnAliasBehindAResolvedIssueIsBlocked(t *testing.T) {
 }
 
 func TestDeletingAnAliasNoIssuePointsAtIsAllowed(t *testing.T) {
+	t.Parallel()
 	app, err := tests.NewTestApp()
 	if err != nil {
 		t.Fatalf("NewTestApp: %v", err)
@@ -912,6 +923,7 @@ func TestDeletingAnAliasNoIssuePointsAtIsAllowed(t *testing.T) {
 // work item and clears the reference. That sequence must be permitted, or the
 // UI's own delete path is unreachable.
 func TestDeletingAnAliasIsAllowedOnceItsIssueIsReopened(t *testing.T) {
+	t.Parallel()
 	app, err := tests.NewTestApp()
 	if err != nil {
 		t.Fatalf("NewTestApp: %v", err)
@@ -940,6 +952,7 @@ func TestDeletingAnAliasIsAllowedOnceItsIssueIsReopened(t *testing.T) {
 // walk, and the only two walks that exist -- HasParentCycle here and
 // descendantIds in unitTree.ts -- both carry visited guards.
 func TestSelfParentingAUnitIsBlocked(t *testing.T) {
+	t.Parallel()
 	app, err := tests.NewTestApp()
 	if err != nil {
 		t.Fatalf("NewTestApp: %v", err)
@@ -958,6 +971,7 @@ func TestSelfParentingAUnitIsBlocked(t *testing.T) {
 }
 
 func TestAdoptingADescendantAsParentIsBlocked(t *testing.T) {
+	t.Parallel()
 	app, err := tests.NewTestApp()
 	if err != nil {
 		t.Fatalf("NewTestApp: %v", err)
@@ -982,6 +996,7 @@ func TestAdoptingADescendantAsParentIsBlocked(t *testing.T) {
 }
 
 func TestALegalReparentStillSaves(t *testing.T) {
+	t.Parallel()
 	app, err := tests.NewTestApp()
 	if err != nil {
 		t.Fatalf("NewTestApp: %v", err)
@@ -1015,6 +1030,7 @@ func TestALegalReparentStillSaves(t *testing.T) {
 // confirm then reports "Confirmed N of M" with no way to see why, and the only
 // escape is clearing parent_unit by hand.
 func TestAnEditThatLeavesParentUnitAloneSurvivesAPreExistingCycle(t *testing.T) {
+	t.Parallel()
 	app, err := tests.NewTestApp()
 	if err != nil {
 		t.Fatalf("NewTestApp: %v", err)
@@ -1279,6 +1295,7 @@ func TestMappingAPartylessRowStillAttemptsAReplay(t *testing.T) {
 // could point its `unit`/`units` relation at a building from a different
 // season with no error anywhere.
 func TestGuardUnitYearRejectsACrossYearRow(t *testing.T) {
+	t.Parallel()
 	app := newHooksTestApp(t)
 	unit2026 := seedUnit(t, app, "test-unit-a", 2026)
 
@@ -1307,6 +1324,7 @@ func TestGuardUnitYearRejectsACrossYearRow(t *testing.T) {
 // behavior -- it catches the binding going missing, which is a one-line edit
 // away and would otherwise be silent (kindred#2035).
 func TestGuardUnitYearRejectsACrossYearRowOnUpdate(t *testing.T) {
+	t.Parallel()
 	app := newHooksTestApp(t)
 	same := seedUnit(t, app, "test-unit-a", 2027)
 	stale := seedUnit(t, app, "test-unit-b", 2026)
@@ -1338,6 +1356,7 @@ func TestGuardUnitYearRejectsACrossYearRowOnUpdate(t *testing.T) {
 // `stale` second, so a guard that only inspected index 0 would pass this row
 // and miss the bug entirely.
 func TestGuardUnitYearChecksEveryMemberOfTheMultiRelation(t *testing.T) {
+	t.Parallel()
 	app := newHooksTestApp(t)
 	good := seedUnit(t, app, "test-unit-a", 2027)
 	stale := seedUnit(t, app, "test-unit-b", 2026)
@@ -1364,6 +1383,7 @@ func TestGuardUnitYearChecksEveryMemberOfTheMultiRelation(t *testing.T) {
 // Without this, a guard that rejected EVERY save regardless of years would
 // also pass the two refusal tests above.
 func TestGuardUnitYearAllowsAMatchingRow(t *testing.T) {
+	t.Parallel()
 	app := newHooksTestApp(t)
 	unit := seedUnit(t, app, "test-unit-a", 2027)
 
@@ -1425,6 +1445,7 @@ func TestGuardUnitYearSkipsAnAbsentCollection(t *testing.T) {
 // renders the wrong name and the wrong sort_order on the board and the map with
 // no error anywhere.
 func TestGuardUnitYearRejectsACrossYearArea(t *testing.T) {
+	t.Parallel()
 	app := newHooksTestApp(t)
 	area2026 := seedArea(t, app, "test-area-a", 2026)
 
@@ -1454,6 +1475,7 @@ func TestGuardUnitYearRejectsACrossYearArea(t *testing.T) {
 // unit tree.") says nothing about years -- so a test that accepted any error
 // would pass against a guard that never looked at the season at all.
 func TestGuardUnitYearRejectsACrossYearParentUnit(t *testing.T) {
+	t.Parallel()
 	app := newHooksTestApp(t)
 	parent2026 := seedUnit(t, app, "test-unit-a", 2026)
 	childID := seedUnit(t, app, "test-unit-b", 2027)
@@ -1479,6 +1501,7 @@ func TestGuardUnitYearRejectsACrossYearParentUnit(t *testing.T) {
 // lodging_units is the one table where that mistake would be catastrophic
 // rather than merely wrong, because it is the table the roll-forward writes.
 func TestGuardUnitYearAllowsAUnitWhoseParentAndAreaShareItsYear(t *testing.T) {
+	t.Parallel()
 	app := newHooksTestApp(t)
 	area := seedArea(t, app, "test-area-a", 2027)
 	parent := seedUnit(t, app, "test-unit-a", 2027)
@@ -1509,6 +1532,7 @@ func TestGuardUnitYearAllowsAUnitWhoseParentAndAreaShareItsYear(t *testing.T) {
 // app.FindRecordById(ref.target, rec.GetString(ref.field)) and this test goes
 // red with `resolving parent_unit ""`, while every other test here stays green.
 func TestGuardUnitYearIgnoresAnEmptyParentUnit(t *testing.T) {
+	t.Parallel()
 	app := newHooksTestApp(t)
 	area := seedArea(t, app, "test-area-a", 2027)
 
@@ -1539,6 +1563,7 @@ func TestGuardUnitYearIgnoresAnEmptyParentUnit(t *testing.T) {
 // MUTATION-CHECK: delete the `if id == rec.Id { continue }` line in
 // guardUnitYear and this test goes red; nothing else does.
 func TestGuardUnitYearSkipsAUnitsSelfReference(t *testing.T) {
+	t.Parallel()
 	app, err := tests.NewTestApp()
 	if err != nil {
 		t.Fatalf("NewTestApp: %v", err)
@@ -1581,6 +1606,7 @@ func TestGuardUnitYearSkipsAUnitsSelfReference(t *testing.T) {
 // unit's unchanged year while a real dependent (the availability row) exists,
 // which is exactly the shape a presence test would wrongly refuse.
 func TestGuardYearImmutableAllowsARoutineEditThatResendsTheSameYear(t *testing.T) {
+	t.Parallel()
 	app := newHooksTestApp(t)
 	unit := seedUnit(t, app, "test-unit-a", 2027)
 	seedAvailability(t, app, unit, 2027)
@@ -1602,6 +1628,7 @@ func TestGuardYearImmutableAllowsARoutineEditThatResendsTheSameYear(t *testing.T
 // kindred#2067's second gap: guardUnitYear checks a unit's own OUTGOING
 // relations (area, parent_unit) but never the rows pointing back AT it.
 func TestGuardYearImmutableRejectsAUnitYearChangeWithAnAvailabilityDependent(t *testing.T) {
+	t.Parallel()
 	app := newHooksTestApp(t)
 	unit := seedUnit(t, app, "test-unit-a", 2027)
 	seedAvailability(t, app, unit, 2027)
@@ -1625,6 +1652,7 @@ func TestGuardYearImmutableRejectsAUnitYearChangeWithAnAvailabilityDependent(t *
 // yearImmutableRefs getting that filter wrong for lodging_units' dependents,
 // the same way TestMultiRelationAnyMatchFilter guards countAssignments.
 func TestGuardYearImmutableRejectsAUnitYearChangeWithAnAssignmentDependent(t *testing.T) {
+	t.Parallel()
 	app := newHooksTestApp(t)
 	unit := seedUnit(t, app, "test-unit-a", 2027)
 
@@ -1657,6 +1685,7 @@ func TestGuardYearImmutableRejectsAUnitYearChangeWithAnAssignmentDependent(t *te
 // it to the bare, silently-zero-matching "units = {:id}" -- left the suite
 // green before this test existed.
 func TestGuardYearImmutableRejectsAUnitYearChangeWithADraftAssignmentDependent(t *testing.T) {
+	t.Parallel()
 	app := newHooksTestApp(t)
 	unit := seedUnit(t, app, "test-unit-a", 2027)
 
@@ -1691,6 +1720,7 @@ func TestGuardYearImmutableRejectsAUnitYearChangeWithADraftAssignmentDependent(t
 // entry's filter, so a mutation that broke ONLY it left the suite green
 // before this test existed.
 func TestGuardYearImmutableRejectsAUnitYearChangeWithASlotMergeDependent(t *testing.T) {
+	t.Parallel()
 	app := newSlotMergesTestApp(t)
 	unit := seedUnit(t, app, "test-unit-a", 2027)
 
@@ -1719,6 +1749,7 @@ func TestGuardYearImmutableRejectsAUnitYearChangeWithASlotMergeDependent(t *test
 // no check while lodging_units rows already pointing at it went silently
 // cross-season.
 func TestGuardYearImmutableRejectsAnAreaYearChangeWithAUnitDependent(t *testing.T) {
+	t.Parallel()
 	app := newHooksTestApp(t)
 	area := seedArea(t, app, "test-area-a", 2027)
 
@@ -1748,6 +1779,7 @@ func TestGuardYearImmutableRejectsAnAreaYearChangeWithAUnitDependent(t *testing.
 // guard that refused every lodging_units update would also pass every
 // refusal test in this section.
 func TestGuardYearImmutableAllowsAYearChangeWithNoDependents(t *testing.T) {
+	t.Parallel()
 	app := newHooksTestApp(t)
 	unit := seedUnit(t, app, "test-unit-a", 2027)
 
@@ -1805,6 +1837,7 @@ var unmirroredPairs = map[relationPair]string{
 // naming a dependent that no longer references the target at all, which is the
 // same drift pointing the other way.
 func TestYearRefMapsAgreeOnEveryRelation(t *testing.T) {
+	t.Parallel()
 	seenExceptions := make(map[relationPair]bool, len(unmirroredPairs))
 
 	// Forward: everything yearScopedRefs says a row points AT must appear in

--- a/pocketbase/lodging/registry_alias_target_test.go
+++ b/pocketbase/lodging/registry_alias_target_test.go
@@ -117,6 +117,7 @@ func findMisdirectedAliases(units []registryUnit, aliases []registryAlias) []mis
 }
 
 func TestFindMisdirectedAliasesCatchesTheNewTrailerClass(t *testing.T) {
+	t.Parallel()
 	units := []registryUnit{
 		{Code: "manzanita-7", Name: "Manzanita 7"},
 		{Code: "manzanita-new-trailer", Name: "New Trailer (Manzanitas)"},
@@ -136,6 +137,7 @@ func TestFindMisdirectedAliasesCatchesTheNewTrailerClass(t *testing.T) {
 }
 
 func TestFindMisdirectedAliasesAllowsACorrectlyTargetedAlias(t *testing.T) {
+	t.Parallel()
 	units := []registryUnit{{Code: "manzanita-new-trailer", Name: "New Trailer (Manzanitas)"}}
 	aliases := []registryAlias{
 		{AliasString: "New Trailer (Manzanitas)", MemberUnits: []string{"manzanita-new-trailer"}},
@@ -147,6 +149,7 @@ func TestFindMisdirectedAliasesAllowsACorrectlyTargetedAlias(t *testing.T) {
 }
 
 func TestFindMisdirectedAliasesAllowsASynonymThatNamesNoUnit(t *testing.T) {
+	t.Parallel()
 	// "Teen Village 1" is the CampMinder spelling; the unit is "Forest Village
 	// 1". The string matches no unit name, so the check must stay silent.
 	units := []registryUnit{{Code: "forest-village-1", Name: "Forest Village 1"}}
@@ -160,6 +163,7 @@ func TestFindMisdirectedAliasesAllowsASynonymThatNamesNoUnit(t *testing.T) {
 }
 
 func TestFindMisdirectedAliasesAllowsAMergeThatIncludesTheUnitItNames(t *testing.T) {
+	t.Parallel()
 	units := []registryUnit{
 		{Code: "gt-tioga-1", Name: "Tioga 1"},
 		{Code: "gt-tioga-2", Name: "Tioga 2"},
@@ -174,6 +178,7 @@ func TestFindMisdirectedAliasesAllowsAMergeThatIncludesTheUnitItNames(t *testing
 }
 
 func TestFindMisdirectedAliasesFlagsAMergeThatExcludesTheUnitItNames(t *testing.T) {
+	t.Parallel()
 	units := []registryUnit{
 		{Code: "gt-tioga-1", Name: "Tioga 1"},
 		{Code: "gt-tioga-2", Name: "Tioga 2"},
@@ -189,6 +194,7 @@ func TestFindMisdirectedAliasesFlagsAMergeThatExcludesTheUnitItNames(t *testing.
 }
 
 func TestFindMisdirectedAliasesAllowsAContainerNamingItsOwnRooms(t *testing.T) {
+	t.Parallel()
 	// The real case: "Health Center Downstairs" is a container, so booking it
 	// has to mean booking the rooms inside it.
 	units := []registryUnit{
@@ -207,6 +213,7 @@ func TestFindMisdirectedAliasesAllowsAContainerNamingItsOwnRooms(t *testing.T) {
 }
 
 func TestFindMisdirectedAliasesStillFlagsAContainerPointedOutsideItself(t *testing.T) {
+	t.Parallel()
 	// One room belongs to a different building. That is the New Trailer defect
 	// wearing a container's clothes, and the descendant exception must not
 	// swallow it.
@@ -226,6 +233,7 @@ func TestFindMisdirectedAliasesStillFlagsAContainerPointedOutsideItself(t *testi
 }
 
 func TestFindMisdirectedAliasesIgnoresCaseAndOuterSpace(t *testing.T) {
+	t.Parallel()
 	units := []registryUnit{{Code: "gt-lofty", Name: "Lofty"}}
 	aliases := []registryAlias{{AliasString: "  lofty ", MemberUnits: []string{"gt-lofty"}}}
 
@@ -235,6 +243,7 @@ func TestFindMisdirectedAliasesIgnoresCaseAndOuterSpace(t *testing.T) {
 }
 
 func TestPrivateRegistryHasNoMisdirectedAliases(t *testing.T) {
+	t.Parallel()
 	// Runs against the real file when kindred-local is linked, and skips
 	// cleanly otherwise -- matching TestPrivateRegistryHasNoStrandedContainers.
 	path := filepath.Join("..", "..", "config", "lodging_registry.json")

--- a/pocketbase/lodging/registry_inventory_test.go
+++ b/pocketbase/lodging/registry_inventory_test.go
@@ -155,6 +155,7 @@ func findStrandedContainers(units []registryUnit) []strandedContainer {
 }
 
 func TestFindStrandedContainersFlagsAWholeBuildingRowItsRoomsNeverReceived(t *testing.T) {
+	t.Parallel()
 	units := []registryUnit{
 		{Code: "house", Name: "House", IsContainer: true},
 		{Code: "house-a", Name: "House A", ParentUnit: "house"},
@@ -173,6 +174,7 @@ func TestFindStrandedContainersFlagsAWholeBuildingRowItsRoomsNeverReceived(t *te
 }
 
 func TestFindStrandedContainersAllowsACapacityOnlyAggregate(t *testing.T) {
+	t.Parallel()
 	// The intended shape: the container carries the whole-building bed count and
 	// the rooms carry the amenities. A guard keyed on capacity would flag this.
 	beds := 7
@@ -190,6 +192,7 @@ func TestFindStrandedContainersAllowsACapacityOnlyAggregate(t *testing.T) {
 }
 
 func TestFindStrandedContainersTreatsCapacityAsNotAnAmenity(t *testing.T) {
+	t.Parallel()
 	// The sharp version of the case above. There, the rooms carry amenities, so
 	// the guard short-circuits on "a room received the data" and never has to
 	// decide whether capacity counts -- it passes either way, which makes it
@@ -212,6 +215,7 @@ func TestFindStrandedContainersTreatsCapacityAsNotAnAmenity(t *testing.T) {
 }
 
 func TestFindStrandedContainersWalksNestedContainers(t *testing.T) {
+	t.Parallel()
 	// building -> per-floor containers -> rooms. A single-level check sees only
 	// the floor containers, finds no non-container children carrying data on the
 	// building itself, and reports nothing.
@@ -233,6 +237,7 @@ func TestFindStrandedContainersWalksNestedContainers(t *testing.T) {
 }
 
 func TestFindStrandedContainersIgnoresAContainerWithNoRooms(t *testing.T) {
+	t.Parallel()
 	units := []registryUnit{{Code: "house", Name: "House", IsContainer: true}}
 	units[0].HasPower = true
 
@@ -242,6 +247,7 @@ func TestFindStrandedContainersIgnoresAContainerWithNoRooms(t *testing.T) {
 }
 
 func TestFindStrandedContainersPassesWhenOneRoomCarriesTheData(t *testing.T) {
+	t.Parallel()
 	// Partial is not this defect. One room carrying the data means the row
 	// reached the rooms; whether every sibling should have it too is a data
 	// question staff own, not a structural one.
@@ -259,6 +265,7 @@ func TestFindStrandedContainersPassesWhenOneRoomCarriesTheData(t *testing.T) {
 }
 
 func TestFindStrandedContainersToleratesAParentCycle(t *testing.T) {
+	t.Parallel()
 	// validateRegistry does not reject a cycle. An unguarded descendant walk
 	// would hang the suite rather than fail it, which is the worse failure.
 	units := []registryUnit{
@@ -271,6 +278,7 @@ func TestFindStrandedContainersToleratesAParentCycle(t *testing.T) {
 }
 
 func TestPrivateRegistryHasNoStrandedContainers(t *testing.T) {
+	t.Parallel()
 	// Runs against the real file when kindred-local is linked, and skips
 	// cleanly otherwise -- the same graceful degradation SeedRegistry and
 	// verify-lodging-seed.sh already have for a clone without the private repo.

--- a/pocketbase/lodging/registry_test.go
+++ b/pocketbase/lodging/registry_test.go
@@ -286,6 +286,7 @@ func TestSeedRegistryAbsentFileIsANoOp(t *testing.T) {
 }
 
 func TestSeedRegistryCreatesAreasUnitsAndAliases(t *testing.T) {
+	t.Parallel()
 	app := newRegistryTestApp(t)
 
 	if err := seedRegistryFromFile(app, writeRegistry(t, fixtureRegistry), testYear); err != nil {
@@ -359,6 +360,7 @@ func TestSeedRegistryCreatesAreasUnitsAndAliases(t *testing.T) {
 // has never been meaningful. A loader that ignored these fields would carry
 // the sheet's answers into the file and drop them on the way to the database.
 func TestSeedRegistryWritesAmenities(t *testing.T) {
+	t.Parallel()
 	app := newRegistryTestApp(t)
 
 	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
@@ -413,6 +415,7 @@ func TestSeedRegistryWritesAmenities(t *testing.T) {
 // invisible on both sides: the file says `true`, the column says false, and
 // nothing anywhere complains.
 func TestSeedRegistryWritesDefaultCombined(t *testing.T) {
+	t.Parallel()
 	app := newRegistryTestApp(t)
 
 	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
@@ -440,6 +443,7 @@ func TestSeedRegistryWritesDefaultCombined(t *testing.T) {
 // A blank has_ramp is "not assessed", and it must reach the database blank
 // rather than as a confident "no".
 func TestSeedRegistryUnassessedRampStaysBlank(t *testing.T) {
+	t.Parallel()
 	app := newRegistryTestApp(t)
 
 	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
@@ -457,6 +461,7 @@ func TestSeedRegistryUnassessedRampStaysBlank(t *testing.T) {
 }
 
 func TestSeedRegistryWiresParentDeclaredAfterChild(t *testing.T) {
+	t.Parallel()
 	app := newRegistryTestApp(t)
 
 	if err := seedRegistryFromFile(app, writeRegistry(t, fixtureRegistry), testYear); err != nil {
@@ -481,6 +486,7 @@ func TestSeedRegistryWiresParentDeclaredAfterChild(t *testing.T) {
 // through some other path would be indistinguishable here, but a loader that
 // rejected null or wrote garbage would not.
 func TestSeedRegistryNullSleepsStoresZero(t *testing.T) {
+	t.Parallel()
 	app := newRegistryTestApp(t)
 
 	if err := seedRegistryFromFile(app, writeRegistry(t, fixtureRegistry), testYear); err != nil {
@@ -496,6 +502,7 @@ func TestSeedRegistryNullSleepsStoresZero(t *testing.T) {
 // unbounded must therefore be written and re-found as 0 — the trap 1500000121
 // documents, and the reason a re-run would otherwise die on the unique index.
 func TestSeedRegistryUnboundedAliasYearsStoreZero(t *testing.T) {
+	t.Parallel()
 	app := newRegistryTestApp(t)
 
 	if err := seedRegistryFromFile(app, writeRegistry(t, fixtureRegistry), testYear); err != nil {
@@ -527,6 +534,7 @@ func TestSeedRegistryUnboundedAliasYearsStoreZero(t *testing.T) {
 }
 
 func TestSeedRegistryAliasMembersResolveToUnitIDs(t *testing.T) {
+	t.Parallel()
 	app := newRegistryTestApp(t)
 
 	if err := seedRegistryFromFile(app, writeRegistry(t, fixtureRegistry), testYear); err != nil {
@@ -556,6 +564,7 @@ func TestSeedRegistryAliasMembersResolveToUnitIDs(t *testing.T) {
 }
 
 func TestSeedRegistryIsIdempotent(t *testing.T) {
+	t.Parallel()
 	app := newRegistryTestApp(t)
 	path := writeRegistry(t, fixtureRegistry)
 
@@ -582,6 +591,7 @@ func TestSeedRegistryIsIdempotent(t *testing.T) {
 // coordinate on the next restart, which is why this is create-if-absent and
 // not a full upsert.
 func TestSeedRegistryPreservesStaffEdits(t *testing.T) {
+	t.Parallel()
 	app := newRegistryTestApp(t)
 	path := writeRegistry(t, fixtureRegistry)
 
@@ -620,6 +630,7 @@ func TestSeedRegistryPreservesStaffEdits(t *testing.T) {
 // A parent_unit staff cleared deliberately must not be silently re-wired on the
 // next boot, for the same reason as the field edits above.
 func TestSeedRegistryDoesNotRewireAnExistingParent(t *testing.T) {
+	t.Parallel()
 	app := newRegistryTestApp(t)
 	path := writeRegistry(t, fixtureRegistry)
 
@@ -643,6 +654,7 @@ func TestSeedRegistryDoesNotRewireAnExistingParent(t *testing.T) {
 }
 
 func TestSeedRegistryMalformedJSONErrorsWithoutWriting(t *testing.T) {
+	t.Parallel()
 	app := newRegistryTestApp(t)
 
 	err := seedRegistryFromFile(app, writeRegistry(t, `{"areas": [ NOT JSON`), testYear)
@@ -658,6 +670,7 @@ func TestSeedRegistryMalformedJSONErrorsWithoutWriting(t *testing.T) {
 // unit to create area-less: `area` is a REQUIRED relation, so the alternative
 // is a save that fails deep in the loop with no useful message.
 func TestSeedRegistryUnknownAreaCodeIsAnError(t *testing.T) {
+	t.Parallel()
 	app := newRegistryTestApp(t)
 
 	body := `{"areas": [], "units": [
@@ -675,6 +688,7 @@ func TestSeedRegistryUnknownAreaCodeIsAnError(t *testing.T) {
 }
 
 func TestSeedRegistryUnknownParentCodeIsAnError(t *testing.T) {
+	t.Parallel()
 	app := newRegistryTestApp(t)
 
 	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
@@ -690,6 +704,7 @@ func TestSeedRegistryUnknownParentCodeIsAnError(t *testing.T) {
 // An alias pointing at a unit code the file does not define would otherwise
 // save with a short member list — a merge quietly missing a room.
 func TestSeedRegistryUnknownAliasMemberIsAnError(t *testing.T) {
+	t.Parallel()
 	app := newRegistryTestApp(t)
 
 	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
@@ -710,6 +725,7 @@ func TestSeedRegistryUnknownAliasMemberIsAnError(t *testing.T) {
 // Two alias rows may share a string when their windows differ (a rename), so
 // idempotency has to key on the pair the unique index keys on.
 func TestSeedRegistrySameAliasStringDifferentWindowsBothLand(t *testing.T) {
+	t.Parallel()
 	app := newRegistryTestApp(t)
 
 	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
@@ -749,6 +765,7 @@ func TestSeedRegistrySameAliasStringDifferentWindowsBothLand(t *testing.T) {
 // bug. Validation runs before any write, so a bad file changes nothing.
 
 func TestSeedRegistryDuplicateUnitCodeIsAnError(t *testing.T) {
+	t.Parallel()
 	app := newRegistryTestApp(t)
 
 	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
@@ -768,6 +785,7 @@ func TestSeedRegistryDuplicateUnitCodeIsAnError(t *testing.T) {
 }
 
 func TestSeedRegistryDuplicateAreaCodeIsAnError(t *testing.T) {
+	t.Parallel()
 	app := newRegistryTestApp(t)
 
 	body := `{"areas": [
@@ -789,6 +807,7 @@ func TestSeedRegistryDuplicateAreaCodeIsAnError(t *testing.T) {
 // the same pair TestSeedRegistrySameAliasStringDifferentWindowsBothLand
 // requires to stay legal.
 func TestSeedRegistryDuplicateAliasWindowIsAnError(t *testing.T) {
+	t.Parallel()
 	app := newRegistryTestApp(t)
 
 	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
@@ -820,6 +839,7 @@ func TestSeedRegistryDuplicateAliasWindowIsAnError(t *testing.T) {
 // the container was never deleted and the cleared parent is a staff decision
 // the loader must respect.
 func TestSeedRegistryRewiresChildrenOfARecreatedContainer(t *testing.T) {
+	t.Parallel()
 	app := newRegistryTestApp(t)
 	path := writeRegistry(t, fixtureRegistry)
 
@@ -962,6 +982,7 @@ func withYearFixtureRegistry(t *testing.T) {
 }
 
 func TestSeedRegistryStampsTheSeason(t *testing.T) {
+	t.Parallel()
 	app := newRegistryTestApp(t)
 	withYearFixtureRegistry(t)
 
@@ -978,6 +999,7 @@ func TestSeedRegistryStampsTheSeason(t *testing.T) {
 }
 
 func TestFindByCodeAndYearIgnoresOtherYears(t *testing.T) {
+	t.Parallel()
 	app := newRegistryTestApp(t)
 	withYearFixtureRegistry(t)
 
@@ -1004,6 +1026,7 @@ func TestFindByCodeAndYearIgnoresOtherYears(t *testing.T) {
 // field, rather than by id equality with something seeded once, is what makes
 // a regression here fail loudly instead of flaking.
 func TestFindByCodeIsScopedToItsYear(t *testing.T) {
+	t.Parallel()
 	app := newRegistryTestApp(t)
 
 	if err := seedRegistryFromFile(app, writeRegistry(t, fixtureRegistry), 2026); err != nil {
@@ -1033,6 +1056,7 @@ func TestFindByCodeIsScopedToItsYear(t *testing.T) {
 // OnlyInt here; without Min/Max too, a test could store year: 1 and pass on
 // data the real database would reject.
 func TestRegistryFixtureRejectsYearOutsideProductionRange(t *testing.T) {
+	t.Parallel()
 	app := newRegistryTestApp(t)
 
 	area, err := app.FindCollectionByNameOrId("lodging_areas")
@@ -1133,6 +1157,7 @@ func TestSeedRegistrySecondSeasonIsANoOpOnceOneSeasonHasRows(t *testing.T) {
 // to land all-or-nothing instead, so a failed bootstrap leaves an empty
 // registry the next boot will retry from scratch.
 func TestSeedRegistryLeavesNothingBehindWhenAPassFails(t *testing.T) {
+	t.Parallel()
 	app := newRegistryTestApp(t)
 	withYearFixtureRegistry(t)
 	lift := failUnitCreate(app, "test-unit-a-room-1") // the second of two units
@@ -1172,6 +1197,7 @@ func TestSeedRegistryLeavesNothingBehindWhenAPassFails(t *testing.T) {
 // down. Tagging only the row-check failure is what lets main.go tell them
 // apart without inspecting error strings.
 func TestSeedRegistryRowCheckFailureIsTaggedAsSuch(t *testing.T) {
+	t.Parallel()
 	app, err := tests.NewTestApp()
 	if err != nil {
 		t.Fatalf("NewTestApp: %v", err)

--- a/pocketbase/lodging/rollforward_test.go
+++ b/pocketbase/lodging/rollforward_test.go
@@ -88,6 +88,7 @@ func seedYear(t *testing.T, app core.App, year int) {
 }
 
 func TestApplyRollForwardCopiesEveryUnitAndArea(t *testing.T) {
+	t.Parallel()
 	app := newRollForwardTestApp(t)
 	seedYear(t, app, 2026) // 2 areas, 3 units, one with a parent
 
@@ -120,6 +121,7 @@ func TestApplyRollForwardCopiesEveryUnitAndArea(t *testing.T) {
 // every other roll-forward test would still pass, because none of them
 // resolve the relation, only compare ids against the row they expect.
 func TestApplyRollForwardUnitAreaPointsAtItsOwnYear(t *testing.T) {
+	t.Parallel()
 	app := newRollForwardTestApp(t)
 	seedYear(t, app, 2026)
 
@@ -160,6 +162,7 @@ func TestApplyRollForwardUnitAreaPointsAtItsOwnYear(t *testing.T) {
 }
 
 func TestApplyRollForwardIsIdempotent(t *testing.T) {
+	t.Parallel()
 	app := newRollForwardTestApp(t)
 	seedYear(t, app, 2026)
 
@@ -179,6 +182,7 @@ func TestApplyRollForwardIsIdempotent(t *testing.T) {
 }
 
 func TestApplyRollForwardLinksParentsWithinTheNewYear(t *testing.T) {
+	t.Parallel()
 	app := newRollForwardTestApp(t)
 	seedYear(t, app, 2026)
 
@@ -196,6 +200,7 @@ func TestApplyRollForwardLinksParentsWithinTheNewYear(t *testing.T) {
 }
 
 func TestApplyRollForwardPreservesCodeAcrossARename(t *testing.T) {
+	t.Parallel()
 	app := newRollForwardTestApp(t)
 	seedYear(t, app, 2026)
 
@@ -237,6 +242,7 @@ func TestApplyRollForwardPreservesCodeAcrossARename(t *testing.T) {
 }
 
 func TestPreviewRollForwardWritesNothing(t *testing.T) {
+	t.Parallel()
 	app := newRollForwardTestApp(t)
 	seedYear(t, app, 2026)
 
@@ -258,6 +264,7 @@ func TestPreviewRollForwardWritesNothing(t *testing.T) {
 // on the struct fields would NOT catch this -- nil and []string{} are both
 // falsy-empty and indistinguishable there. Only json.Marshal exposes the bug.
 func TestPreviewRollForwardEmptySourceMarshalsEmptyArraysNotNull(t *testing.T) {
+	t.Parallel()
 	app := newRollForwardTestApp(t)
 	// Deliberately no seedYear call: 2030 has no registry at all, so both
 	// passes iterate zero source rows and neither append ever runs.
@@ -293,6 +300,7 @@ func TestPreviewRollForwardEmptySourceMarshalsEmptyArraysNotNull(t *testing.T) {
 // mine to wire" -- so it would attach 2026's parent to the hand-added row
 // anyway, even though the row was reported as skipped.
 func TestApplyRollForwardDoesNotRelinkAHandAddedStandaloneUnit(t *testing.T) {
+	t.Parallel()
 	app := newRollForwardTestApp(t)
 	seedYear(t, app, 2026)
 
@@ -370,6 +378,7 @@ func failUnitCreate(app core.App, code string) (lift func()) {
 // apply must leave the target season exactly as it found it, so the retry
 // starts from a clean slate rather than from a half-built registry.
 func TestApplyRollForwardLeavesNothingBehindWhenAPassFails(t *testing.T) {
+	t.Parallel()
 	app := newRollForwardTestApp(t)
 	seedYear(t, app, 2026)
 	failUnitCreate(app, "test-unit-b") // the third unit; two are created first
@@ -412,6 +421,7 @@ func TestApplyRollForwardLeavesNothingBehindWhenAPassFails(t *testing.T) {
 // fixed by loosening the relink filter without reintroducing the hand-added-row
 // bug that filter exists to prevent (see the test above this one).
 func TestApplyRollForwardRetryAfterAFailureLinksParents(t *testing.T) {
+	t.Parallel()
 	app := newRollForwardTestApp(t)
 	seedYear(t, app, 2026)
 	lift := failUnitCreate(app, "test-unit-b")
@@ -453,6 +463,7 @@ func TestApplyRollForwardRetryAfterAFailureLinksParents(t *testing.T) {
 //
 // GREEN BEFORE AND AFTER kindred#2039: a regression guard, not a red-first test.
 func TestApplyRollForwardSurvivesTheUnitYearGuard(t *testing.T) {
+	t.Parallel()
 	app := newRollForwardTestApp(t)
 	seedYear(t, app, 2026)
 

--- a/pocketbase/main_test_parallelism_test.go
+++ b/pocketbase/main_test_parallelism_test.go
@@ -1,0 +1,305 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// The Go suite was, for its whole history, the longest job in CI: `go test
+// -race ./...` ran ~390s of a ~400s critical path. Almost none of that was test
+// volume. The race detector costs ~4.5x and it used to pay that entirely
+// serially -- the tree had exactly one t.Parallel() in it, inside a subtest, so
+// no two top-level tests ever overlapped.
+//
+// This guard is what keeps that from coming back one test at a time. A newly
+// added serial test does not fail anything, does not show up in review, and
+// costs a few seconds forever; a hundred of them put the job back where it
+// started. So sync/ and lodging/ -- the two packages that carried ~430s of the
+// ~470s -- are held to the rule here, and the tests that genuinely cannot be
+// parallel are listed below with the reason rather than left to look like an
+// oversight.
+var parallelGuardPackages = []string{"sync", "lodging"}
+
+// serialGroups names every top-level test allowed to skip t.Parallel(),
+// grouped by the reason it cannot be parallel.
+//
+// Adding a line here is a real cost, so it needs a real reason. Only two
+// exist:
+//
+//   - t.Setenv: the testing package panics outright on Setenv+Parallel, since
+//     the environment is process-global and a parallel test would leak its
+//     value into whatever else is running. Threading the value through the
+//     code under test instead of reading os.Getenv is the fix, not this list.
+//   - a package-level variable the test swaps: same problem, caught by -race
+//     rather than by a panic.
+//
+// Grouping rather than one entry per test is not only shorter -- it puts the
+// reason somewhere a reader will actually read it, and makes a group that has
+// grown suspiciously long visible as such.
+var serialGroups = []struct {
+	pkg    string
+	reason string
+	tests  []string
+}{
+	{
+		pkg:    "sync",
+		reason: "t.Setenv: exercises CAMPMINDER_SEASON_ID parsing itself",
+		tests: []string{
+			"TestParseSeasonYear_Valid",
+			"TestParseSeasonYear_Missing",
+			"TestParseSeasonYear_NonNumeric",
+			"TestParseSeasonYear_BelowRange",
+			"TestParseSeasonYear_AboveRange",
+			"TestParseSeasonYear_Boundaries",
+		},
+	},
+	{
+		// LodgingAssignmentsSync.activeSeasonYear() calls ParseSeasonYear()
+		// unconditionally to gate the #2028 orphan sweep, so these eight can
+		// only reach the sweep through the environment.
+		//
+		// They are also the most expensive tests left serial -- ~22s of the
+		// ~25s serial prefix, because each builds a fresh ~15-collection
+		// schema and that is pure CPU under the race detector. Injecting the
+		// active season instead of reading the env would recover most of it.
+		// Deliberately not done here: that is an edit to a deletion gate, and
+		// it should not ride inside a thousand-line mechanical diff where no
+		// reviewer will find it.
+		pkg:    "sync",
+		reason: "t.Setenv: orphan sweep gates on CAMPMINDER_SEASON_ID",
+		tests: []string{
+			"TestLodgingAssignmentsSyncDeletesOrphanedHouseholdMirrorRow",
+			"TestLodgingAssignmentsSyncDeletesOrphanedPersonGrainMirrorRow",
+			"TestLodgingAssignmentsSyncDeletesStaffTouchedOrphanedMirrorRow",
+			"TestLodgingAssignmentsSyncDryRunDoesNotDeleteOrphans",
+			"TestLodgingAssignmentsSyncKeepsMirrorRowForStillEnrolledHousehold",
+			"TestLodgingAssignmentsSyncSkipsMirrorDeletionWhenSessionHasZeroEnrolled",
+			"TestLodgingAssignmentsSyncSkipsOrphanSweepForHistoricalYear",
+			"TestLodgingAssignmentsSyncWritesHistoryOnOrphanDelete",
+		},
+	},
+	{
+		pkg:    "sync",
+		reason: "t.Setenv: asserts the CAMPMINDER_SEASON_ID fallback specifically",
+		tests: []string{
+			"TestReconcileLifecycleSync_FallsBackToSeasonEnv",
+			"TestReconcileLifecycleSync_RejectsMissingYearEnv",
+		},
+	},
+	{
+		pkg:    "sync",
+		reason: "t.Setenv: PROCESS_REQUESTS_TIMEOUT_MINUTES",
+		tests:  []string{"TestGetProcessRequestsTimeout"},
+	},
+	{
+		pkg:    "sync",
+		reason: "t.Setenv: API_URL points at a per-test httptest server",
+		tests:  []string{"TestBuildNormalizationLookupCompositeKeyDedup"},
+	},
+	{
+		// registryBasePath / registryAbsoluteRoots (lodging/registry.go) are
+		// the only true data races the detector found when the whole tree was
+		// made parallel at once: withRegistryBasePath writes them, and every
+		// other registry test reads them through the path resolver.
+		//
+		// Leaving the writers serial is enough to fix it, and costs nothing:
+		// Go runs every non-parallel test to completion before releasing the
+		// parallel ones, so these finish and restore the globals before any
+		// reader starts.
+		pkg:    "lodging",
+		reason: "swaps the registryBasePath / registryAbsoluteRoots globals",
+		tests: []string{
+			"TestRegistryFilePresentTrueWhenFileExistsUnderWorkingDirectory",
+			"TestRegistryFilePresentTrueViaAbsoluteRoot",
+			"TestRegistryFilePresentFalseWhenNoConfigAnywhere",
+			"TestSeedRegistryResolvesConfigUnderTheWorkingDirectory",
+			"TestSeedRegistryResolvesAbsoluteConfigRoot",
+			"TestSeedRegistryWithNoConfigAnywhereIsANoOp",
+			"TestSeedRegistryFileErrorIsNotTaggedAsARowCheckFailure",
+			"TestClassifyShareability",
+		},
+	},
+	{
+		// captureStdout redirects the process's os.Stdout; captureLogs swaps
+		// slog's default handler. Both are process-global, so a parallel test
+		// would capture some other test's output instead of its own.
+		pkg:    "lodging",
+		reason: "captureStdout / captureLogs swap process-global output",
+		tests: []string{
+			"TestGuardUnitYearSkipsAnAbsentCollection",
+			"TestIgnoringAPartylessRowDoesNotAttemptAReplay",
+			"TestMappingAPartylessRowStillAttemptsAReplay",
+			"TestMultiRelationAnyMatchFilter",
+			"TestReplayOnResolveFiresOnceNotOnItsOwnResave",
+			"TestReplayRefusalDoesNotBlockTheTick",
+			"TestSeedRegistryAbsentFileIsANoOp",
+			"TestSeedRegistrySecondSeasonIsANoOpOnceOneSeasonHasRows",
+		},
+	},
+}
+
+// serialTests flattens serialGroups to "<package>.<TestName>" -> reason.
+func serialTests() map[string]string {
+	flat := map[string]string{}
+	for _, group := range serialGroups {
+		for _, name := range group.tests {
+			flat[group.pkg+"."+name] = group.reason
+		}
+	}
+	return flat
+}
+
+// topLevelTest is one `func TestX(t *testing.T)` and whether its body calls
+// t.Parallel() directly (a call inside a subtest closure does not count -- that
+// is what the tree already had, and it parallelised nothing).
+type topLevelTest struct {
+	key      string
+	file     string
+	line     int
+	parallel bool
+}
+
+func collectTopLevelTests(t *testing.T) []topLevelTest {
+	t.Helper()
+
+	var found []topLevelTest
+	for _, pkg := range parallelGuardPackages {
+		entries, err := os.ReadDir(pkg)
+		if err != nil {
+			t.Fatalf("read %s: %v", pkg, err)
+		}
+		for _, entry := range entries {
+			if !strings.HasSuffix(entry.Name(), "_test.go") {
+				continue
+			}
+			path := filepath.Join(pkg, entry.Name())
+			fset := token.NewFileSet()
+			parsed, err := parser.ParseFile(fset, path, nil, 0)
+			if err != nil {
+				t.Fatalf("parse %s: %v", path, err)
+			}
+			for _, decl := range parsed.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Recv != nil || !strings.HasPrefix(fn.Name.Name, "Test") {
+					continue
+				}
+				if !takesTestingT(fn) {
+					continue
+				}
+				found = append(found, topLevelTest{
+					key:      pkg + "." + fn.Name.Name,
+					file:     path,
+					line:     fset.Position(fn.Pos()).Line,
+					parallel: bodyCallsParallel(fn),
+				})
+			}
+		}
+	}
+	return found
+}
+
+// takesTestingT keeps benchmarks, fuzz targets and helpers out of the census.
+func takesTestingT(fn *ast.FuncDecl) bool {
+	params := fn.Type.Params.List
+	if len(params) != 1 {
+		return false
+	}
+	star, ok := params[0].Type.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := star.X.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	return ok && pkg.Name == "testing" && sel.Sel.Name == "T"
+}
+
+// bodyCallsParallel looks only at the function's own statement list, so a
+// t.Parallel() inside a t.Run closure is correctly not counted.
+func bodyCallsParallel(fn *ast.FuncDecl) bool {
+	if fn.Body == nil {
+		return false
+	}
+	for _, stmt := range fn.Body.List {
+		expr, ok := stmt.(*ast.ExprStmt)
+		if !ok {
+			continue
+		}
+		call, ok := expr.X.(*ast.CallExpr)
+		if !ok {
+			continue
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Parallel" {
+			continue
+		}
+		if recv, ok := sel.X.(*ast.Ident); ok && recv.Name == "t" {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSyncAndLodgingTestsRunInParallel(t *testing.T) {
+	t.Parallel()
+
+	var missing []string
+	for _, tc := range collectTopLevelTests(t) {
+		if tc.parallel {
+			continue
+		}
+		if _, exempt := serialTests()[tc.key]; exempt {
+			continue
+		}
+		missing = append(missing, fmt.Sprintf("%s:%d: %s", tc.file, tc.line, tc.key))
+	}
+	sort.Strings(missing)
+
+	if len(missing) > 0 {
+		t.Errorf(
+			"%d top-level test(s) in %s do not call t.Parallel().\n"+
+				"Add t.Parallel() as the first statement, or -- if the test genuinely "+
+				"cannot be parallel -- add it to serialTests with the reason:\n  %s",
+			len(missing), strings.Join(parallelGuardPackages, "/"), strings.Join(missing, "\n  "),
+		)
+	}
+}
+
+// A stale exemption is worse than none: it reads as "this test cannot be
+// parallel" long after whatever blocked it was fixed, and nothing ever
+// rechecks it. So the list has to stay exactly as long as its reasons.
+func TestSerialTestExemptionsAreAllStillNeeded(t *testing.T) {
+	t.Parallel()
+
+	byKey := map[string]topLevelTest{}
+	for _, tc := range collectTopLevelTests(t) {
+		byKey[tc.key] = tc
+	}
+
+	var stale []string
+	for key, reason := range serialTests() {
+		tc, exists := byKey[key]
+		switch {
+		case !exists:
+			stale = append(stale, fmt.Sprintf("%s: no such test (renamed or deleted) -- reason was %q", key, reason))
+		case tc.parallel:
+			stale = append(stale, fmt.Sprintf("%s: now calls t.Parallel(), drop the exemption", key))
+		case strings.TrimSpace(reason) == "":
+			stale = append(stale, fmt.Sprintf("%s: exemption has no reason", key))
+		}
+	}
+	sort.Strings(stale)
+
+	if len(stale) > 0 {
+		t.Errorf("%d stale entr(ies) in serialTests:\n  %s", len(stale), strings.Join(stale, "\n  "))
+	}
+}

--- a/pocketbase/sync/api_permission_test.go
+++ b/pocketbase/sync/api_permission_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestPermissionCheckExactMatch(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		perms     any

--- a/pocketbase/sync/api_test.go
+++ b/pocketbase/sync/api_test.go
@@ -10,6 +10,7 @@ import (
 
 // TestCSVValidation tests CSV parsing and validation logic
 func TestCSVValidation_ValidCSV(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		csvContent     string
@@ -154,6 +155,7 @@ func validateCSVStructure(content string) CSVValidationResult {
 
 // TestStripUTF8BOM tests UTF-8 BOM stripping
 func TestStripUTF8BOM(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    []byte
@@ -211,6 +213,7 @@ func stripUTF8BOM(data []byte) ([]byte, bool) {
 
 // TestSessionParameterValidation tests session parameter parsing
 func TestSessionParameterValidation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		param       string
@@ -268,6 +271,7 @@ func parseSessionParameter(param string) (int, bool) {
 
 // TestYearParameterValidation tests year parameter parsing for historical sync
 func TestYearParameterValidation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		yearStr   string
@@ -324,6 +328,7 @@ func parseYearParameter(yearStr string, maxYear int) (int, bool) {
 
 // TestSyncTypeValidation tests sync type validation
 func TestSyncTypeValidation(t *testing.T) {
+	t.Parallel()
 	validSyncTypes := map[string]bool{
 		"session_groups":   true,
 		"sessions":         true,
@@ -374,6 +379,7 @@ func TestSyncTypeValidation(t *testing.T) {
 
 // TestStatusResponseFormat tests that status responses have expected format
 func TestStatusResponseFormat(t *testing.T) {
+	t.Parallel()
 	syncTypes := []string{
 		"session_groups",
 		"sessions",
@@ -423,6 +429,7 @@ func TestStatusResponseFormat(t *testing.T) {
 // Note: Actual session validation happens in Python via SessionRepository.resolve_session_cm_ids()
 // which accepts "all" or a numeric cm_id string. Go just passes the string through.
 func TestSessionParameterPassthrough(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		param       string
@@ -460,6 +467,7 @@ func TestSessionParameterPassthrough(t *testing.T) {
 
 // TestSourceFieldParameterValidation tests source_field query parameter parsing
 func TestSourceFieldParameterValidation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		param      string
@@ -529,6 +537,7 @@ func TestSourceFieldParameterValidation(t *testing.T) {
 
 // TestCustomValuesSyncServices tests that custom values sync services are defined
 func TestCustomValuesSyncServices(t *testing.T) {
+	t.Parallel()
 	// Verify GetCustomValuesSyncJobs returns the expected services
 	expected := []string{"person_custom_values", "household_custom_values"}
 	jobs := GetCustomValuesSyncJobs()
@@ -550,6 +559,7 @@ func TestCustomValuesSyncServices(t *testing.T) {
 
 // TestCustomValuesSyncEndpointResponse tests expected response format
 func TestCustomValuesSyncEndpointResponse(t *testing.T) {
+	t.Parallel()
 	// Test the expected response structure from the custom-values endpoint
 	// The endpoint should return:
 	// - message: string describing action taken
@@ -581,6 +591,7 @@ func TestCustomValuesSyncEndpointResponse(t *testing.T) {
 
 // TestGetConfiguredYear tests the getConfiguredYear function
 func TestGetConfiguredYear(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		envValue    string
@@ -640,6 +651,7 @@ func parseConfiguredYear(envValue string) int {
 
 // TestYearPrefixedCSVPath tests the year-prefixed CSV path generation
 func TestYearPrefixedCSVPath(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		year     int
@@ -679,6 +691,7 @@ func getYearPrefixedCSVFilename(year int) string {
 
 // TestYearPrefixedBackupFilename tests backup filename generation with year
 func TestYearPrefixedBackupFilename(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		year      int
@@ -717,6 +730,7 @@ func getYearPrefixedBackupFilename(year int, timestamp string) string {
 
 // TestRunProcessRequestsParameterParsing tests the run_process_requests query parameter
 func TestRunProcessRequestsParameterParsing(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		param     string
@@ -755,6 +769,7 @@ func parseRunProcessRequestsParam(param string) bool {
 // and run_process_requests=true are provided, the upload response should indicate
 // both sync jobs will be triggered
 func TestBunkRequestsUploadWithProcessRequests(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                  string
 		runSync               bool
@@ -810,6 +825,7 @@ func TestBunkRequestsUploadWithProcessRequests(t *testing.T) {
 
 // TestUploadYearParameterParsing tests year query parameter parsing for uploads
 func TestUploadYearParameterParsing(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		yearParam      string
@@ -893,6 +909,7 @@ func parseUploadYearParam(yearParam string, defaultYear int) (int, bool) {
 
 // TestSyncStatusIncludesConfiguredYear tests that sync status response includes configured year
 func TestSyncStatusIncludesConfiguredYear(t *testing.T) {
+	t.Parallel()
 	// This test validates the expected response format
 	// The actual handleSyncStatus function should include _configured_year
 
@@ -933,6 +950,7 @@ func TestSyncStatusIncludesConfiguredYear(t *testing.T) {
 
 // TestSyncStatusIncludesQueue tests that sync status response includes queue info
 func TestSyncStatusIncludesQueue(t *testing.T) {
+	t.Parallel()
 	// Expected queue-related keys in status response
 	expectedKeys := []string{
 		"_queue",        // Array of queued syncs
@@ -966,6 +984,7 @@ func TestSyncStatusIncludesQueue(t *testing.T) {
 
 // TestUnifiedSyncQueueResponse tests the expected 202 response structure
 func TestUnifiedSyncQueueResponse(t *testing.T) {
+	t.Parallel()
 	// When a sync is already running and a new request comes in,
 	// the API should return 202 Accepted with queue info
 
@@ -1000,6 +1019,7 @@ func TestUnifiedSyncQueueResponse(t *testing.T) {
 
 // TestCancelQueuedSyncEndpoint tests the expected behavior of the cancel endpoint
 func TestCancelQueuedSyncEndpoint(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		queueID        string
@@ -1044,6 +1064,7 @@ func TestCancelQueuedSyncEndpoint(t *testing.T) {
 
 // TestUnifiedSyncEnqueueBehavior tests the expected queuing behavior
 func TestUnifiedSyncEnqueueBehavior(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name             string
 		syncRunning      bool
@@ -1106,6 +1127,7 @@ func TestUnifiedSyncEnqueueBehavior(t *testing.T) {
 
 // TestDuplicateQueueRequest tests that duplicate requests return existing queue position
 func TestDuplicateQueueRequest(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Enqueue a sync (without custom values)
@@ -1159,6 +1181,7 @@ func TestDuplicateQueueRequest(t *testing.T) {
 
 // TestGetPhasesEndpointResponse tests the expected response from GET /api/custom/sync/phases
 func TestGetPhasesEndpointResponse(t *testing.T) {
+	t.Parallel()
 	// Expected response structure: {id, name, description, jobs[]}
 	// (PhaseInfo type defined in api.go handleGetPhases)
 
@@ -1187,6 +1210,7 @@ func TestGetPhasesEndpointResponse(t *testing.T) {
 
 // TestPhaseParameterValidation tests phase query parameter parsing
 func TestPhaseParameterValidation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		param     string
@@ -1239,6 +1263,7 @@ func parsePhaseParameter(param string) (Phase, bool) {
 
 // TestRunPhaseEndpointValidation tests run-phase endpoint parameter validation
 func TestRunPhaseEndpointValidation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		yearParam      string
@@ -1323,6 +1348,7 @@ func TestRunPhaseEndpointValidation(t *testing.T) {
 
 // TestRunPhaseResponseStructure tests the expected response from POST /api/custom/sync/run-phase
 func TestRunPhaseResponseStructure(t *testing.T) {
+	t.Parallel()
 	// Expected response when phase starts successfully
 	type RunPhaseResponse struct {
 		Message string   `json:"message"`
@@ -1356,6 +1382,7 @@ func TestRunPhaseResponseStructure(t *testing.T) {
 
 // TestRunPhaseBlockedWhenSyncRunning tests that phase sync is blocked when other sync running
 func TestRunPhaseBlockedWhenSyncRunning(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name              string
 		dailyRunning      bool
@@ -1412,6 +1439,7 @@ func TestRunPhaseBlockedWhenSyncRunning(t *testing.T) {
 
 // TestPhaseJobsInOrder tests that jobs returned by GetJobsForPhase maintain dependency order
 func TestPhaseJobsInOrder(t *testing.T) {
+	t.Parallel()
 	// Source phase jobs should be in dependency order
 	sourceJobs := GetJobsForPhase(PhaseSource)
 
@@ -1456,6 +1484,7 @@ func TestPhaseJobsInOrder(t *testing.T) {
 // when an individual job is running (not just daily/weekly/historical syncs).
 // This was a bug: handleRunPhase was missing IsAnyJobRunning() check.
 func TestRunPhaseQueuedWhenIndividualJobRunning(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name               string
 		dailyRunning       bool
@@ -1527,6 +1556,7 @@ func TestRunPhaseQueuedWhenIndividualJobRunning(t *testing.T) {
 // AFTER sync completes, not immediately after goroutine starts.
 // This was a race condition: debug was reset to false before sync ran.
 func TestDebugResetTimingSimulation(t *testing.T) {
+	t.Parallel()
 	// Simulate the incorrect behavior vs correct behavior
 
 	// Incorrect behavior (before fix):
@@ -1577,6 +1607,7 @@ func TestDebugResetTimingSimulation(t *testing.T) {
 
 // TestDebugFlagInGoroutineDefer tests the pattern of resetting debug in goroutine defer
 func TestDebugFlagInGoroutineDefer(t *testing.T) {
+	t.Parallel()
 	// This test documents the expected code pattern for the fix
 	// The debug reset should be inside the goroutine's defer, not after go func(){}()
 
@@ -1614,6 +1645,7 @@ func TestDebugFlagInGoroutineDefer(t *testing.T) {
 // This was a bug: handleRunPhase parsed the year parameter but never set it
 // on the orchestrator, causing transform jobs to use environment fallback (wrong year).
 func TestRunPhaseYearMustBeSetOnOrchestrator(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Verify initial state: currentSyncYear should be 0
@@ -1671,6 +1703,7 @@ func TestRunPhaseYearMustBeSetOnOrchestrator(t *testing.T) {
 // TestRunPhaseYearPropagationToJobs tests that when handleRunPhase sets
 // currentSyncYear, the RunSingleSync will use that year for job status.
 func TestRunPhaseYearPropagationToJobs(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Set the sync year (simulating handleRunPhase fix)
@@ -1702,6 +1735,7 @@ func TestRunPhaseYearPropagationToJobs(t *testing.T) {
 // TestRunPhaseYearNotSetBugExplanation documents the bug:
 // handleRunPhase parses year but never sets it on orchestrator.
 func TestRunPhaseYearNotSetBugExplanation(t *testing.T) {
+	t.Parallel()
 	// BEFORE FIX (BUG):
 	// Line ~2074: year, err := strconv.Atoi(yearParam)  // Parses year correctly
 	// Line ~2192: orchestrator.runSyncAndWait(ctx, jobID)  // Runs job
@@ -1729,6 +1763,7 @@ func TestRunPhaseYearNotSetBugExplanation(t *testing.T) {
 // BUG: currentSyncYear only affects status.Year, NOT what year the services query.
 // Services read their own .Year field which defaults to env var CAMPMINDER_SEASON_ID.
 func TestRunPhaseYearMustPropagateToServices(t *testing.T) {
+	t.Parallel()
 	// This test demonstrates that YearSetter interface is needed.
 	// Services have .Year field that controls which year's data they query.
 	// Setting orchestrator.currentSyncYear does NOT set service.Year.
@@ -1760,6 +1795,7 @@ func TestRunPhaseYearMustPropagateToServices(t *testing.T) {
 // safeguard. This test catches one related regression: forgetting to register the job in
 // syncJobMeta before adding it to the status list or routes.
 func TestSyncStatusListIncludesStrandedAssignmentCleanup(t *testing.T) {
+	t.Parallel()
 	// Required jobs that must be registered in syncJobMeta. handleSyncStatus's
 	// local syncTypes slice can't be inspected here; placement in the diff is
 	// the human-readable guard for that path.
@@ -1792,6 +1828,7 @@ func TestSyncStatusListIncludesStrandedAssignmentCleanup(t *testing.T) {
 // matching the behavior of the other two endpoints that already handle this case.
 // Regression test for #806.
 func TestNormalizeSession(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input string

--- a/pocketbase/sync/attendees_status_history_test.go
+++ b/pocketbase/sync/attendees_status_history_test.go
@@ -11,6 +11,7 @@ import (
 // The actual logStatusChange method requires PocketBase, but the detection
 // logic can be tested by simulating the comparison.
 func TestAttendeesSync_StatusChangeDetection(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		oldStatus      string
@@ -111,6 +112,7 @@ func TestAttendeesSync_StatusChangeDetection(t *testing.T) {
 // TestAttendeesSync_StatusMapCompleteness verifies all CampMinder status IDs
 // are mapped, ensuring the status history will always have valid status values.
 func TestAttendeesSync_StatusMapCompleteness(t *testing.T) {
+	t.Parallel()
 	statusMap := map[int]string{
 		1:   "none",
 		2:   "enrolled",
@@ -152,6 +154,7 @@ func TestAttendeesSync_StatusMapCompleteness(t *testing.T) {
 // PreloadCompositeRecords stores keys as "{person}:{session}|{year}" (base_sync.go:630),
 // so the status change detection must use the same format for lookups to match.
 func TestAttendeesSync_CompositeKeyWithYear(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		personID  int
@@ -211,6 +214,7 @@ func TestAttendeesSync_CompositeKeyWithYear(t *testing.T) {
 // extracts EffectiveDate and LastUpdatedUTC from CampMinder enrollment data
 // and includes them in the record data map.
 func TestAttendeesSync_EffectiveDateExtraction(t *testing.T) {
+	t.Parallel()
 	// Simulate the date extraction logic from processEnrollment.
 	// We test the pattern, not the full method (which needs PocketBase app).
 	tests := []struct {
@@ -303,6 +307,7 @@ func TestAttendeesSync_EffectiveDateExtraction(t *testing.T) {
 // TestAttendeesSync_RecordDataContainsEffectiveDate verifies the full recordData map
 // built in processEnrollment would contain effective_date and last_updated_utc fields.
 func TestAttendeesSync_RecordDataContainsEffectiveDate(t *testing.T) {
+	t.Parallel()
 	enrollment := map[string]any{
 		"SessionID":      float64(1001),
 		"StatusID":       float64(32), // cancelled

--- a/pocketbase/sync/base_sync_test.go
+++ b/pocketbase/sync/base_sync_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestBaseSyncService_TrackProcessedKey(t *testing.T) {
+	t.Parallel()
 	service := BaseSyncService{
 		ProcessedKeys: make(map[string]bool),
 	}
@@ -28,6 +29,7 @@ func TestBaseSyncService_TrackProcessedKey(t *testing.T) {
 }
 
 func TestBaseSyncService_IsKeyProcessed(t *testing.T) {
+	t.Parallel()
 	service := BaseSyncService{
 		ProcessedKeys: make(map[string]bool),
 	}
@@ -57,6 +59,7 @@ func TestBaseSyncService_IsKeyProcessed(t *testing.T) {
 }
 
 func TestBaseSyncService_TrackProcessedCompositeKey(t *testing.T) {
+	t.Parallel()
 	service := BaseSyncService{
 		ProcessedKeys: make(map[string]bool),
 	}
@@ -75,6 +78,7 @@ func TestBaseSyncService_TrackProcessedCompositeKey(t *testing.T) {
 }
 
 func TestBaseSyncService_ClearProcessedKeys(t *testing.T) {
+	t.Parallel()
 	service := BaseSyncService{
 		ProcessedKeys: make(map[string]bool),
 	}
@@ -109,6 +113,7 @@ func TestBaseSyncService_ClearProcessedKeys(t *testing.T) {
 }
 
 func TestBaseSyncService_ClearFieldDiffStats(t *testing.T) {
+	t.Parallel()
 	service := BaseSyncService{
 		FieldDiffStats: map[string]int{"name": 3, "email": 5},
 	}
@@ -130,6 +135,7 @@ func TestBaseSyncService_ClearFieldDiffStats(t *testing.T) {
 }
 
 func TestBaseSyncService_FindOrphansFromPreloaded(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		syncSuccessful bool

--- a/pocketbase/sync/base_sync_utils_test.go
+++ b/pocketbase/sync/base_sync_utils_test.go
@@ -7,6 +7,7 @@ import (
 
 // TestCompositeKey tests the CompositeKey function
 func TestCompositeKey(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		id       any
@@ -34,6 +35,7 @@ func TestCompositeKey(t *testing.T) {
 
 // TestFieldEquals tests field value comparison
 func TestFieldEquals(t *testing.T) {
+	t.Parallel()
 	b := &BaseSyncService{}
 
 	tests := []struct {
@@ -102,6 +104,7 @@ func TestFieldEquals(t *testing.T) {
 
 // TestParseRateLimitWait tests rate limit message parsing
 func TestParseRateLimitWait(t *testing.T) {
+	t.Parallel()
 	b := &BaseSyncService{}
 
 	tests := []struct {
@@ -154,6 +157,7 @@ func TestParseRateLimitWait(t *testing.T) {
 
 // TestNormalizeDateString tests date normalization indirectly via FieldEquals
 func TestNormalizeDateString(t *testing.T) {
+	t.Parallel()
 	b := &BaseSyncService{}
 
 	// These test cases verify date normalization through FieldEquals
@@ -182,6 +186,7 @@ func TestNormalizeDateString(t *testing.T) {
 
 // TestByteSliceHandling tests FieldEquals with byte slices (types.JSONRaw)
 func TestByteSliceHandling(t *testing.T) {
+	t.Parallel()
 	b := &BaseSyncService{}
 
 	tests := []struct {
@@ -217,6 +222,7 @@ func TestByteSliceHandling(t *testing.T) {
 
 // TestNormalizeToStringSlice tests the normalizeToStringSlice helper function
 func TestNormalizeToStringSlice(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    any
@@ -264,6 +270,7 @@ func TestNormalizeToStringSlice(t *testing.T) {
 
 // TestFieldEqualsSliceComparison tests FieldEquals with slice types (multi-select relation fields)
 func TestFieldEqualsSliceComparison(t *testing.T) {
+	t.Parallel()
 	b := &BaseSyncService{}
 
 	tests := []struct {

--- a/pocketbase/sync/bunk_assignments_test.go
+++ b/pocketbase/sync/bunk_assignments_test.go
@@ -8,6 +8,7 @@ import (
 // --- Staff inclusion tests (v3 — session-level staff in bunk_assignments) ---
 
 func TestBunkAssignmentsSync_findMatchingSession(t *testing.T) {
+	t.Parallel()
 	s := &BunkAssignmentsSync{}
 
 	tests := []struct {
@@ -65,6 +66,7 @@ func TestBunkAssignmentsSync_findMatchingSession(t *testing.T) {
 }
 
 func TestBunkAssignmentsSync_StaffSessionLookup(t *testing.T) {
+	t.Parallel()
 	// Tests the (bunkPlanCMID, bunkCMID) → sessionCMID lookup pattern
 	// used to resolve staff assignments to exact sessions.
 	//
@@ -153,6 +155,7 @@ func TestBunkAssignmentsSync_StaffSessionLookup(t *testing.T) {
 // so DeleteOrphans won't remove them. CampMinder strips assignments from
 // dismissed/resigned staff, but we preserve them in PocketBase.
 func TestBunkAssignmentsSync_NonActiveStaffOrphanProtection(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name             string
 		staffStatus      string
@@ -243,6 +246,7 @@ func TestBunkAssignmentsSync_NonActiveStaffOrphanProtection(t *testing.T) {
 // TestBunkAssignmentsSync_OrphanProtectionKeyFormat verifies that the composite
 // key format used for orphan protection matches the format used by deleteOrphans.
 func TestBunkAssignmentsSync_OrphanProtectionKeyFormat(t *testing.T) {
+	t.Parallel()
 	// The protection code uses TrackProcessedCompositeKey("personCMID:sessionCMID", year)
 	// which produces "personCMID:sessionCMID|year".
 	// The deleteOrphans code produces keys as "personCMID:sessionCMID|year".
@@ -270,6 +274,7 @@ func TestBunkAssignmentsSync_OrphanProtectionKeyFormat(t *testing.T) {
 }
 
 func TestBunkAssignmentsSync_StaffSkipLogicIntegration(t *testing.T) {
+	t.Parallel()
 	// Integration test: verifies the complete staff assignment resolution flow.
 	//
 	// When findMatchingSession returns 0 (person not in attendees),

--- a/pocketbase/sync/bunk_plans_test.go
+++ b/pocketbase/sync/bunk_plans_test.go
@@ -10,6 +10,7 @@ import (
 // Pairing must never interpret it as one. See kindred#1749: AG-6 hosting the
 // 7th/8th-grade AG session was silently dropped by the old grade heuristic.
 func TestPairAGBunksToSessions_SingleAGSession_AllAGBunksMap(t *testing.T) {
+	t.Parallel()
 	// 2026 regression case: the AG-6 cabin must map to the 7th/8th-grade AG
 	// session even though its cabin number is 6.
 	bunkNames := map[int]string{
@@ -35,6 +36,7 @@ func TestPairAGBunksToSessions_SingleAGSession_AllAGBunksMap(t *testing.T) {
 }
 
 func TestPairAGBunksToSessions_NoAGSession_EmptyPairing(t *testing.T) {
+	t.Parallel()
 	bunkNames := map[int]string{
 		104: "Aleph",
 		106: "AG-6",
@@ -51,6 +53,7 @@ func TestPairAGBunksToSessions_NoAGSession_EmptyPairing(t *testing.T) {
 }
 
 func TestPairAGBunksToSessions_TwoAGSessions_DeterministicZip(t *testing.T) {
+	t.Parallel()
 	// 2025-shaped case: two AG sessions under one plan, two AG bunks.
 	// Pairing is sorted bunk cm_id ⇄ sorted session cm_id — deterministic,
 	// no grade semantics. Sibling AG sessions share the same parent board, so
@@ -85,6 +88,7 @@ func TestPairAGBunksToSessions_TwoAGSessions_DeterministicZip(t *testing.T) {
 }
 
 func TestPairAGBunksToSessions_MoreBunksThanSessions_LeftoverToLastSession(t *testing.T) {
+	t.Parallel()
 	bunkNames := map[int]string{
 		100: "AG-3",
 		200: "AG-7",
@@ -108,6 +112,7 @@ func TestPairAGBunksToSessions_MoreBunksThanSessions_LeftoverToLastSession(t *te
 }
 
 func TestPairAGBunksToSessions_MoreSessionsThanBunks_FirstSessionsPaired(t *testing.T) {
+	t.Parallel()
 	bunkNames := map[int]string{100: "AG-5"}
 	sessionInfo := map[int]sessionInfoData{
 		1000: {Name: "AG A", SessionType: "ag"},
@@ -123,6 +128,7 @@ func TestPairAGBunksToSessions_MoreSessionsThanBunks_FirstSessionsPaired(t *test
 }
 
 func TestPairAGBunksToSessions_UnknownBunksAndSessions_Ignored(t *testing.T) {
+	t.Parallel()
 	// Bunks with no known name and sessions with no metadata (not in PB) must
 	// not participate in pairing.
 	bunkNames := map[int]string{106: "AG-6"}
@@ -143,6 +149,7 @@ func TestPairAGBunksToSessions_UnknownBunksAndSessions_Ignored(t *testing.T) {
 }
 
 func TestBunkPlansSync_createBunkPlan_WithIsActive(t *testing.T) {
+	t.Parallel()
 	// This test verifies that is_active field is extracted and stored correctly
 	// Since createBunkPlan requires a full PocketBase app, we test the data preparation logic
 
@@ -227,6 +234,7 @@ func TestBunkPlansSync_createBunkPlan_WithIsActive(t *testing.T) {
 }
 
 func TestBunkPlansSync_processBunkPlan_ExtractsIsActive(t *testing.T) {
+	t.Parallel()
 	// Test that processBunkPlan correctly passes IsActive to createBunkPlan
 	// This is a unit test for the field extraction logic
 
@@ -288,6 +296,7 @@ func TestBunkPlansSync_processBunkPlan_ExtractsIsActive(t *testing.T) {
 }
 
 func TestBunkPlansSync_CompareFieldsExcludeYear(t *testing.T) {
+	t.Parallel()
 	// Document that skipFields in createBunkPlan should only contain "year"
 	// and that is_active should be compared for idempotency
 

--- a/pocketbase/sync/bunk_requests_test.go
+++ b/pocketbase/sync/bunk_requests_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestBunkRequestsSync_PurgeOrphanedRequests_Logic(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name               string
 		csvPersonIDs       map[int]bool
@@ -62,6 +63,7 @@ func TestBunkRequestsSync_PurgeOrphanedRequests_Logic(t *testing.T) {
 }
 
 func TestFindZombieBRPersonIDs(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		csvPersonIDs   map[int]bool
@@ -128,6 +130,7 @@ func TestFindZombieBRPersonIDs(t *testing.T) {
 }
 
 func TestBunkRequestsSync_TrackCSVPersonIDs(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		validPersonIDs map[int]string

--- a/pocketbase/sync/bunks_test.go
+++ b/pocketbase/sync/bunks_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestBunksSync_transformBunkToPB_WithNewFields(t *testing.T) {
+	t.Parallel()
 	// Test the field extraction logic that should be in transformBunkToPB
 	// Since we can't easily mock the full service, we test the transformation logic directly
 
@@ -158,6 +159,7 @@ func TestBunksSync_transformBunkToPB_WithNewFields(t *testing.T) {
 }
 
 func TestBunksSync_CompareFieldsUpdated(t *testing.T) {
+	t.Parallel()
 	// This test verifies that the compareFields list in Sync() includes the new fields
 	// Since we can't easily test the actual Sync() method without a full integration test,
 	// this is a documentation test to ensure developers know these fields should be compared

--- a/pocketbase/sync/camper_dietary_test.go
+++ b/pocketbase/sync/camper_dietary_test.go
@@ -17,6 +17,7 @@ import (
 // prevents CampMinder from adding one -- this pins the fix so a future
 // occurrence is caught here instead of live.
 func TestCamperDietaryLoadFieldDefinitionsTrimsNames(t *testing.T) {
+	t.Parallel()
 	app := newFieldDefsTestApp(t, map[int]string{
 		1: "Family Medical-Dietary Needs ", // trailing space
 		2: "Family Medical-Additional",     // already clean, must be unaffected
@@ -49,6 +50,7 @@ func TestCamperDietaryLoadFieldDefinitionsTrimsNames(t *testing.T) {
 
 // TestCamperDietarySync_Name verifies the service name is correct
 func TestCamperDietarySync_Name(t *testing.T) {
+	t.Parallel()
 	expectedName := "camper_dietary"
 	if serviceNameCamperDietary != expectedName {
 		t.Errorf("expected service name %q, got %q", expectedName, serviceNameCamperDietary)
@@ -57,6 +59,7 @@ func TestCamperDietarySync_Name(t *testing.T) {
 
 // TestCamperDietaryYearValidation tests year parameter validation
 func TestCamperDietaryYearValidation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		year      int
@@ -84,6 +87,7 @@ func TestCamperDietaryYearValidation(t *testing.T) {
 
 // TestDietaryBooleanParsing tests parsing Yes/No values to boolean
 func TestDietaryBooleanParsing(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		rawValue string
@@ -115,6 +119,7 @@ func TestDietaryBooleanParsing(t *testing.T) {
 
 // TestDietaryFieldMapping tests CampMinder field to column mapping
 func TestDietaryFieldMapping(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		fieldName  string
 		wantColumn string
@@ -141,6 +146,7 @@ func TestDietaryFieldMapping(t *testing.T) {
 
 // TestDietaryCompositeKeyFormat tests composite key generation
 func TestDietaryCompositeKeyFormat(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		personID int
@@ -164,6 +170,7 @@ func TestDietaryCompositeKeyFormat(t *testing.T) {
 
 // TestIsDietaryField tests identification of dietary fields
 func TestIsDietaryField(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		fieldName     string
 		wantIsDietary bool
@@ -191,6 +198,7 @@ func TestIsDietaryField(t *testing.T) {
 
 // TestDietaryRecordBuilding tests building dietary records from source data
 func TestDietaryRecordBuilding(t *testing.T) {
+	t.Parallel()
 	fieldValues := []testDietaryFieldValue{
 		{PersonID: 12345, FieldName: "Family Medical-Dietary Needs", Value: "Yes", Year: 2025},
 		{PersonID: 12345, FieldName: "Family Medical-Dietary Explain", Value: "Vegetarian, no peanuts", Year: 2025},
@@ -238,6 +246,7 @@ func TestDietaryRecordBuilding(t *testing.T) {
 
 // TestDietaryEmptyDataHandling tests graceful handling of empty input
 func TestDietaryEmptyDataHandling(t *testing.T) {
+	t.Parallel()
 	fieldValues := []testDietaryFieldValue{}
 
 	records := buildDietaryRecords(fieldValues)
@@ -249,6 +258,7 @@ func TestDietaryEmptyDataHandling(t *testing.T) {
 
 // TestDietaryTextFieldMaxLength tests that text fields respect max length constraints
 func TestDietaryTextFieldMaxLength(t *testing.T) {
+	t.Parallel()
 	// dietary_explanation max observed: 304 chars
 	// allergy_info max observed: 605 chars
 	// additional_medical max observed: 786 chars
@@ -373,6 +383,7 @@ func findDietaryRecord(records []*testDietaryRecord, personID, year int) *testDi
 // TestCamperDietaryCompareFields verifies that the compareFields list for camper_dietary
 // contains exactly the expected fields (inclusion list pattern, not skipFields exclusion).
 func TestCamperDietaryCompareFields(t *testing.T) {
+	t.Parallel()
 	// camperDietaryCompareFields should list all fields that matter for idempotency checks,
 	// excluding PocketBase-managed fields (id, created, updated, collectionId, collectionName).
 	// Unlike other services, this includes person_id and year since the original skipFields
@@ -419,6 +430,7 @@ func TestCamperDietaryCompareFields(t *testing.T) {
 // TestCamperDietaryRecordNeedsUpdateUsesCompareFields verifies that recordNeedsUpdate
 // correctly detects when fields match (no update) and when they differ (needs update).
 func TestCamperDietaryRecordNeedsUpdateUsesCompareFields(t *testing.T) {
+	t.Parallel()
 	s := &CamperDietarySync{}
 
 	// Create a minimal collection with the fields used in comparison

--- a/pocketbase/sync/camper_history_test.go
+++ b/pocketbase/sync/camper_history_test.go
@@ -16,6 +16,7 @@ const testSynagogue = "Temple Beth El"
 // is_deleted has been dropped from the bunk_assignments schema; the filter
 // must not reference it.
 func TestBunkAssignmentsHistoryFilter(t *testing.T) {
+	t.Parallel()
 	got := bunkAssignmentsHistoryFilter(2025)
 	want := "year = 2025"
 	if got != want {
@@ -25,6 +26,7 @@ func TestBunkAssignmentsHistoryFilter(t *testing.T) {
 
 // TestCamperHistorySync_Name verifies the service name is correct
 func TestCamperHistorySync_Name(t *testing.T) {
+	t.Parallel()
 	// The service name must be "camper_history" for orchestrator integration
 	expectedName := serviceNameCamperHistory
 
@@ -38,6 +40,7 @@ func TestCamperHistorySync_Name(t *testing.T) {
 // TestCamperHistoryDeduplicatesMultiSessionCampers tests that persons enrolled in
 // multiple sessions produce exactly one camper_history record per year
 func TestCamperHistoryDeduplicatesMultiSessionCampers(t *testing.T) {
+	t.Parallel()
 	// Simulate attendee records for the same person in different sessions
 	attendees := []testAttendee{
 		{PersonID: 1001, SessionID: 100, SessionName: "Session 1", Year: 2025, Status: "enrolled"},
@@ -74,6 +77,7 @@ func TestCamperHistoryDeduplicatesMultiSessionCampers(t *testing.T) {
 
 // TestCamperHistoryComputesReturningStatus tests is_returning calculation
 func TestCamperHistoryComputesReturningStatus(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                string
 		currentYear         int
@@ -136,6 +140,7 @@ func TestCamperHistoryComputesReturningStatus(t *testing.T) {
 // TestCamperHistoryIncludesAllStatuses tests that all enrollment statuses are included
 // (not just enrolled) per user requirement
 func TestCamperHistoryIncludesAllStatuses(t *testing.T) {
+	t.Parallel()
 	// All status types that should be included
 	allStatuses := []string{
 		"enrolled",
@@ -179,6 +184,7 @@ func TestCamperHistoryIncludesAllStatuses(t *testing.T) {
 
 // TestCamperHistoryAggregatesBunkAssignments tests bunk aggregation
 func TestCamperHistoryAggregatesBunkAssignments(t *testing.T) {
+	t.Parallel()
 	assignments := []testBunkAssignment{
 		{PersonID: 1001, BunkName: "B-12", SessionID: 100},
 		{PersonID: 1001, BunkName: "B-14", SessionID: 101}, // Different session
@@ -207,6 +213,7 @@ func TestCamperHistoryAggregatesBunkAssignments(t *testing.T) {
 
 // TestCamperHistoryPriorYearData tests prior year session/bunk retrieval
 func TestCamperHistoryPriorYearData(t *testing.T) {
+	t.Parallel()
 	currentYear := 2025
 	priorYear := 2024
 
@@ -258,6 +265,7 @@ func TestCamperHistoryPriorYearData(t *testing.T) {
 
 // TestCamperHistoryHandlesEmptyData tests graceful handling of no attendees
 func TestCamperHistoryHandlesEmptyData(t *testing.T) {
+	t.Parallel()
 	attendees := []testAttendee{}
 
 	personData := aggregateByPerson(attendees)
@@ -269,6 +277,7 @@ func TestCamperHistoryHandlesEmptyData(t *testing.T) {
 
 // TestCamperHistoryYearValidation tests year parameter validation
 func TestCamperHistoryYearValidation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		year      int
@@ -296,6 +305,7 @@ func TestCamperHistoryYearValidation(t *testing.T) {
 
 // TestCamperHistoryStatusPriority tests status priority for multi-status campers
 func TestCamperHistoryStatusPriority(t *testing.T) {
+	t.Parallel()
 	// When a camper has multiple statuses across sessions,
 	// we should prefer the "best" status (enrolled > others)
 	tests := []struct {
@@ -520,6 +530,7 @@ func joinSorted(strs []string) string {
 // TestCamperHistoryExtendedDemographics tests extraction of new demographic fields
 // (household_id, gender, division_name) from person records
 func TestCamperHistoryExtendedDemographics(t *testing.T) {
+	t.Parallel()
 	// Simulate extended person data with new fields
 	persons := []testExtendedPerson{
 		{
@@ -603,6 +614,7 @@ func TestCamperHistoryExtendedDemographics(t *testing.T) {
 // TestCamperHistoryEnrollmentDateAggregation tests that enrollment_date uses the
 // earliest date when a camper is enrolled in multiple sessions
 func TestCamperHistoryEnrollmentDateAggregation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name             string
 		enrollmentDates  []string
@@ -654,6 +666,7 @@ func TestCamperHistoryEnrollmentDateAggregation(t *testing.T) {
 // TestCamperHistoryStatusAggregation tests status aggregation logic across sessions
 // Rule: "enrolled" if ANY session is enrolled, otherwise first non-empty status
 func TestCamperHistoryStatusAggregation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		statuses       []string
@@ -719,6 +732,7 @@ func TestCamperHistoryStatusAggregation(t *testing.T) {
 
 // TestCamperHistorySynagogueLookup tests synagogue lookup from household custom values
 func TestCamperHistorySynagogueLookup(t *testing.T) {
+	t.Parallel()
 	// Simulate household_custom_values data
 	// Key: household_id, Value: synagogue name (or empty if not set)
 	synagogueByHousehold := map[int]string{
@@ -774,6 +788,7 @@ func TestCamperHistorySynagogueLookup(t *testing.T) {
 // TestCamperHistoryExtendedAttendeeAggregation tests aggregation of attendee data
 // including enrollment_date and status for multi-session campers
 func TestCamperHistoryExtendedAttendeeAggregation(t *testing.T) {
+	t.Parallel()
 	// Camper 1001 enrolled in 3 sessions with different dates and all enrolled
 	// Camper 1002 enrolled in 2 sessions, one enrolled one canceled
 	// Camper 1003 single session, waitlisted
@@ -831,6 +846,7 @@ func TestCamperHistoryExtendedAttendeeAggregation(t *testing.T) {
 // TestCamperHistoryFullRecordWithNewFields tests a complete camper history record
 // with all 6 new fields populated
 func TestCamperHistoryFullRecordWithNewFields(t *testing.T) {
+	t.Parallel()
 	// This test verifies that all fields are correctly combined into a record
 	record := testCamperHistoryRecord{
 		// Existing fields
@@ -1024,6 +1040,7 @@ func lookupSynagogue(synagogueByHousehold map[int]string, householdID int) strin
 // authoritative value from the persons table instead of computing from historical data.
 // This fixes the issue where production only has current year data, so computed value is always 1.
 func TestCamperHistoryUsesCMYearsAtCamp(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                string
 		cmYearsAtCamp       int   // CampMinder's value from persons table
@@ -1094,6 +1111,7 @@ func TestCamperHistoryUsesCMYearsAtCamp(t *testing.T) {
 // TestCamperHistoryComputeFirstYearAttended tests first_year_attended calculation
 // This field stores the first year a camper ever attended summer camp (for onramp analysis)
 func TestCamperHistoryComputeFirstYearAttended(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                      string
 		currentYear               int
@@ -1172,6 +1190,7 @@ func computeFirstYearAttended(currentYear int, enrolledYears []int) int {
 // TestCamperHistorySessionTypesField tests that session_types field is populated
 // correctly from attendee sessions
 func TestCamperHistorySessionTypesField(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                 string
 		sessionTypes         []string // Session types from camp_sessions
@@ -1228,6 +1247,7 @@ func TestCamperHistorySessionTypesField(t *testing.T) {
 // TestCamperHistoryMultiSessionWithDifferentTypes tests that multi-session campers
 // correctly aggregate all their session types
 func TestCamperHistoryMultiSessionWithDifferentTypes(t *testing.T) {
+	t.Parallel()
 	// Simulate attendee records for a camper in main and AG sessions
 	attendees := []testAttendeeWithSessionType{
 		{PersonID: 1001, SessionID: 100, SessionName: "Session 2", SessionType: "main"},
@@ -1254,6 +1274,7 @@ func TestCamperHistoryMultiSessionWithDifferentTypes(t *testing.T) {
 // TestCamperHistorySessionTypesFilteringSummerOnly tests the filter logic
 // that excludes non-summer sessions from metrics
 func TestCamperHistorySessionTypesFilteringSummerOnly(t *testing.T) {
+	t.Parallel()
 	// Sample camper history records with various session types
 	records := []testCamperHistoryWithSessionTypes{
 		{PersonID: 1001, SessionTypes: "main", Grade: 6},           // Summer - include
@@ -1502,6 +1523,7 @@ type testCamperHistoryV2 struct {
 // TestV2_OneRecordPerAttendee tests that v2 creates one record per attendee,
 // not one record per person (the key behavior change from v1)
 func TestV2_OneRecordPerAttendee(t *testing.T) {
+	t.Parallel()
 	attendees := []testAttendeeV2{
 		{PersonID: 1001, SessionCMID: 100, SessionName: "Session 1", SessionType: "main", Year: 2025},
 		{PersonID: 1001, SessionCMID: 101, SessionName: "Session 2", SessionType: "main", Year: 2025},
@@ -1531,6 +1553,7 @@ func TestV2_OneRecordPerAttendee(t *testing.T) {
 
 // TestV2_UniqueConstraint tests the unique key is (person_id, session_cm_id, year)
 func TestV2_UniqueConstraint(t *testing.T) {
+	t.Parallel()
 	attendees := []testAttendeeV2{
 		{PersonID: 1001, SessionCMID: 100, Year: 2025},
 		{PersonID: 1001, SessionCMID: 100, Year: 2025}, // Duplicate - should be deduplicated
@@ -1559,6 +1582,7 @@ func TestV2_UniqueConstraint(t *testing.T) {
 
 // TestV2_BunkLookupBySession tests that bunk assignment matches the specific session
 func TestV2_BunkLookupBySession(t *testing.T) {
+	t.Parallel()
 	attendees := []testAttendeeV2{
 		{PersonID: 1001, PersonPBID: "p1001", SessionCMID: 100, SessionPBID: "s100", SessionName: "Session 1", Year: 2025},
 		{PersonID: 1001, PersonPBID: "p1001", SessionCMID: 101, SessionPBID: "s101", SessionName: "Session 2", Year: 2025},
@@ -1599,6 +1623,7 @@ func TestV2_BunkLookupBySession(t *testing.T) {
 // TestV2_IsReturningSummerOnlyConsidersSummerTypes tests that is_returning_summer
 // only considers summer session types in the prior year
 func TestV2_IsReturningSummerOnlyConsidersSummerTypes(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                 string
 		currentYear          int
@@ -1709,6 +1734,7 @@ func TestV2_IsReturningSummerOnlyConsidersSummerTypes(t *testing.T) {
 // TestV2_IsReturningFamilyOnlyConsidersFamilyTypes tests that is_returning_family
 // only considers family/adult session types in the prior year
 func TestV2_IsReturningFamilyOnlyConsidersFamilyTypes(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                 string
 		currentYear          int
@@ -1778,6 +1804,7 @@ func TestV2_IsReturningFamilyOnlyConsidersFamilyTypes(t *testing.T) {
 
 // TestV2_SessionTypeSelectValues tests that session_type field uses correct enum values
 func TestV2_SessionTypeSelectValues(t *testing.T) {
+	t.Parallel()
 	// These are all the valid session types from camp_sessions enum
 	validTypes := []string{
 		"main", "embedded", "ag", "family", "quest", "scit",
@@ -1824,6 +1851,7 @@ func TestV2_SessionTypeSelectValues(t *testing.T) {
 
 // TestV2_SessionTypeFieldPresent tests that each record has session_type
 func TestV2_SessionTypeFieldPresent(t *testing.T) {
+	t.Parallel()
 	attendees := []testAttendeeV2{
 		{PersonID: 1001, SessionCMID: 100, SessionName: "Session 1", SessionType: "main", Year: 2025},
 		{PersonID: 1001, SessionCMID: 101, SessionName: "Family Camp", SessionType: "family", Year: 2025},
@@ -1977,6 +2005,7 @@ func isFamilySessionType(sessionType string) bool {
 // TestCamperHistoryAddressDiscreteColumns tests that city/state are read
 // directly from address_city and address_state columns (not JSON parsing)
 func TestCamperHistoryAddressDiscreteColumns(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		addressCity   string
@@ -2052,6 +2081,7 @@ func TestCamperHistoryAddressDiscreteColumns(t *testing.T) {
 // from person_custom_values (HH-Name of Congregation) as primary source,
 // with household_custom_values (Synagogue) as fallback
 func TestCamperHistoryCongregationSourcePriority(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                   string
 		personCongregation     string // From person_custom_values "HH-Name of Congregation"
@@ -2114,6 +2144,7 @@ func mergeCongregationSources(personCongregation, householdSynagogue string) (re
 
 // TestCamperHistoryCongregationFieldNames tests the correct custom field names
 func TestCamperHistoryCongregationFieldNames(t *testing.T) {
+	t.Parallel()
 	// These are the expected field names in CampMinder custom values
 	personFieldName := "HH-Name of Congregation" // person_custom_values - rich data (2376 records)
 	householdFieldName := "Synagogue"            // household_custom_values - sparse data (29 records)
@@ -2138,6 +2169,7 @@ func TestCamperHistoryCongregationFieldNames(t *testing.T) {
 
 // TestCamperHistoryCompositeKeyFormat tests the composite key format used for upsert
 func TestCamperHistoryCompositeKeyFormat(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		personCMID  int
@@ -2180,6 +2212,7 @@ func TestCamperHistoryCompositeKeyFormat(t *testing.T) {
 
 // TestCamperHistoryCompositeKeyDeterministic tests that the same input always produces the same key
 func TestCamperHistoryCompositeKeyDeterministic(t *testing.T) {
+	t.Parallel()
 	// Generate key multiple times
 	keys := make([]string, 10)
 	for i := range 10 {
@@ -2196,6 +2229,7 @@ func TestCamperHistoryCompositeKeyDeterministic(t *testing.T) {
 
 // TestCamperHistoryOrphanDetection tests that records not in processed keys are identified as orphans
 func TestCamperHistoryOrphanDetection(t *testing.T) {
+	t.Parallel()
 	// Simulate existing records
 	existingKeys := map[string]bool{
 		"1001:100|2025": true, // Will be processed
@@ -2225,6 +2259,7 @@ func TestCamperHistoryOrphanDetection(t *testing.T) {
 
 // TestCamperHistoryUpsertDecision tests the create vs update decision logic
 func TestCamperHistoryUpsertDecision(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		existingKeys map[string]bool
@@ -2282,6 +2317,7 @@ func TestCamperHistoryUpsertDecision(t *testing.T) {
 // TestCamperHistoryCompareFields verifies that the compareFields list for camper_history
 // contains exactly the expected fields (inclusion list pattern, not skipFields exclusion).
 func TestCamperHistoryCompareFields(t *testing.T) {
+	t.Parallel()
 	// camperHistoryCompareFields should list all fields that matter for idempotency checks,
 	// excluding PocketBase-managed fields (id, created, updated, collectionId, collectionName)
 	// and the unique key fields (person_id, session_cm_id, year) which don't change.
@@ -2341,6 +2377,7 @@ func TestCamperHistoryCompareFields(t *testing.T) {
 // TestCamperHistoryRecordNeedsUpdateUsesCompareFields verifies that recordNeedsUpdate
 // correctly detects when fields match (no update) and when they differ (needs update).
 func TestCamperHistoryRecordNeedsUpdateUsesCompareFields(t *testing.T) {
+	t.Parallel()
 	c := &CamperHistorySync{}
 
 	// Create a minimal collection with the fields used in comparison

--- a/pocketbase/sync/camper_transportation_test.go
+++ b/pocketbase/sync/camper_transportation_test.go
@@ -14,6 +14,7 @@ import (
 // be admitted into the map and then silently fail to route. No untrimmed name
 // exists in this table today; this pins the fix against a future one.
 func TestCamperTransportationLoadFieldDefinitionsTrimsNames(t *testing.T) {
+	t.Parallel()
 	app := newFieldDefsTestApp(t, map[int]string{
 		1: "BUS-who is dropping off ", // trailing space
 		2: "BUS-to camp",              // already clean, must be unaffected
@@ -46,6 +47,7 @@ func TestCamperTransportationLoadFieldDefinitionsTrimsNames(t *testing.T) {
 
 // TestCamperTransportationSync_Name verifies the service name is correct
 func TestCamperTransportationSync_Name(t *testing.T) {
+	t.Parallel()
 	expectedName := "camper_transportation"
 	if serviceNameCamperTransportation != expectedName {
 		t.Errorf("expected service name %q, got %q", expectedName, serviceNameCamperTransportation)
@@ -54,6 +56,7 @@ func TestCamperTransportationSync_Name(t *testing.T) {
 
 // TestCamperTransportationYearValidation tests year parameter validation
 func TestCamperTransportationYearValidation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		year      int
@@ -81,6 +84,7 @@ func TestCamperTransportationYearValidation(t *testing.T) {
 
 // TestTransportationMethodParsing tests parsing of transportation method values
 func TestTransportationMethodParsing(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		rawValue string
@@ -109,6 +113,7 @@ func TestTransportationMethodParsing(t *testing.T) {
 
 // TestTransportationFieldMapping tests CampMinder field to column mapping
 func TestTransportationFieldMapping(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		fieldName  string
 		wantColumn string
@@ -146,6 +151,7 @@ func TestTransportationFieldMapping(t *testing.T) {
 
 // TestTransportationCompositeKeyFormat tests composite key generation
 func TestTransportationCompositeKeyFormat(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		personID  int
@@ -170,6 +176,7 @@ func TestTransportationCompositeKeyFormat(t *testing.T) {
 
 // TestIsTransportationField tests identification of transportation fields
 func TestIsTransportationField(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		fieldName            string
 		wantIsTransportation bool
@@ -197,6 +204,7 @@ func TestIsTransportationField(t *testing.T) {
 
 // TestLegacyFieldFallback tests that legacy fields are used when modern fields are empty
 func TestLegacyFieldFallback(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		modernValue    string
@@ -225,6 +233,7 @@ func TestLegacyFieldFallback(t *testing.T) {
 
 // TestTransportationRecordBuilding tests building transportation records from source data
 func TestTransportationRecordBuilding(t *testing.T) {
+	t.Parallel()
 	fieldValues := []testTransportFieldValue{
 		{PersonID: 12345, SessionID: 1000001, FieldName: "BUS-to camp", Value: "Bus-SF", Year: 2025},
 		{PersonID: 12345, SessionID: 1000001, FieldName: "BUS-home from camp", Value: "Flying", Year: 2025},
@@ -258,6 +267,7 @@ func TestTransportationRecordBuilding(t *testing.T) {
 
 // TestTransportationEmptyDataHandling tests graceful handling of empty input
 func TestTransportationEmptyDataHandling(t *testing.T) {
+	t.Parallel()
 	fieldValues := []testTransportFieldValue{}
 
 	records := buildTransportationRecords(fieldValues)
@@ -422,6 +432,7 @@ func findTransportRecord(records []*testTransportRecord, personID, sessionID int
 // only has a "session" relation field (PB ID), not "session_id" (CM ID).
 // The fix uses ExpandRecords() to expand the session relation and get cm_id.
 func TestExtractSessionCMIDFromExpanded(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name            string
 		sessionCMID     int
@@ -471,6 +482,7 @@ func extractSessionCMID(cmID int) int {
 // created when both person_id AND session_id (CM ID) are valid.
 // This ensures the fixed loadAttendeeMapping won't add entries with session_id=0.
 func TestAttendeeKeyRequiresValidSessionID(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		personID  int

--- a/pocketbase/sync/collect_traces_test.go
+++ b/pocketbase/sync/collect_traces_test.go
@@ -27,6 +27,7 @@ import (
 // must be false so that manual/ad-hoc runs don't collect traces unless
 // requested.
 func TestNewRequestProcessor_CollectTracesDefaultsFalse(t *testing.T) {
+	t.Parallel()
 	processor := NewRequestProcessor(nil)
 
 	if processor.CollectTraces {
@@ -38,6 +39,7 @@ func TestNewRequestProcessor_CollectTracesDefaultsFalse(t *testing.T) {
 // and historical sync registration patterns create a RequestProcessor with
 // CollectTraces=true and register it as "process_requests" in the orchestrator.
 func TestSyncRegistration_SetsCollectTracesTrue(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 	}{
@@ -80,6 +82,7 @@ func TestSyncRegistration_SetsCollectTracesTrue(t *testing.T) {
 //	collectTraces := collectTracesParam == "true" || collectTracesParam == "1"
 //	processor.CollectTraces = collectTraces
 func TestManualProcessRequests_CollectTracesFromParam(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		query string
@@ -110,6 +113,7 @@ func TestManualProcessRequests_CollectTracesFromParam(t *testing.T) {
 // is correctly serialized in the JSON body sent to the Python API. This is
 // the actual wire format that Python reads.
 func TestCollectTraces_JSONSerialization(t *testing.T) {
+	t.Parallel()
 	t.Run("collect_traces=true appears in JSON", func(t *testing.T) {
 		req := apiProcessorRequest{
 			Year:          2025,
@@ -175,6 +179,7 @@ func TestCollectTraces_JSONSerialization(t *testing.T) {
 // Note: The collect_traces=true case is covered by
 // TestCallAPIProcessor_CollectTracesField in process_requests_test.go.
 func TestCollectTraces_EndToEndFalseViaCallAPIProcessor(t *testing.T) {
+	t.Parallel()
 	var receivedCollectTraces bool
 	var fieldPresent bool
 
@@ -220,6 +225,7 @@ func TestCollectTraces_EndToEndFalseViaCallAPIProcessor(t *testing.T) {
 // RunSyncWithOptions switches from current-year to historical-year),
 // the new processor's CollectTraces value replaces the old one.
 func TestCollectTraces_OverwriteOnReRegistration(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// First registration with CollectTraces=false

--- a/pocketbase/sync/custom_field_definitions_test.go
+++ b/pocketbase/sync/custom_field_definitions_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestCustomFieldDefinitionsSync_Name(t *testing.T) {
+	t.Parallel()
 	s := &CustomFieldDefinitionsSync{}
 
 	got := s.Name()
@@ -19,6 +20,7 @@ func TestCustomFieldDefinitionsSync_Name(t *testing.T) {
 // TestTransformCustomFieldDefinitionToPB tests transformation to PocketBase format
 // Note: CampMinder API uses camelCase field names for this endpoint
 func TestTransformCustomFieldDefinitionToPB(t *testing.T) {
+	t.Parallel()
 	s := &CustomFieldDefinitionsSync{}
 
 	// Mock CampMinder API response (camelCase field names)
@@ -103,6 +105,7 @@ func TestTransformCustomFieldDefinitionToPB(t *testing.T) {
 
 // TestTransformCustomFieldDefinitionHandlesMissingFields tests handling of optional fields
 func TestTransformCustomFieldDefinitionHandlesMissingFields(t *testing.T) {
+	t.Parallel()
 	s := &CustomFieldDefinitionsSync{}
 
 	// Minimal data with only required fields (camelCase)
@@ -154,6 +157,7 @@ func TestTransformCustomFieldDefinitionHandlesMissingFields(t *testing.T) {
 
 // TestTransformCustomFieldDefinitionRequiredIDError tests error on missing ID
 func TestTransformCustomFieldDefinitionRequiredIDError(t *testing.T) {
+	t.Parallel()
 	s := &CustomFieldDefinitionsSync{}
 
 	// Missing ID field
@@ -169,6 +173,7 @@ func TestTransformCustomFieldDefinitionRequiredIDError(t *testing.T) {
 
 // TestTransformCustomFieldDefinitionRequiredNameError tests error on missing Name
 func TestTransformCustomFieldDefinitionRequiredNameError(t *testing.T) {
+	t.Parallel()
 	s := &CustomFieldDefinitionsSync{}
 
 	// Missing Name field
@@ -184,6 +189,7 @@ func TestTransformCustomFieldDefinitionRequiredNameError(t *testing.T) {
 
 // TestTransformCustomFieldDefinitionZeroIDError tests error on ID=0
 func TestTransformCustomFieldDefinitionZeroIDError(t *testing.T) {
+	t.Parallel()
 	s := &CustomFieldDefinitionsSync{}
 
 	// ID=0 (invalid)
@@ -200,6 +206,7 @@ func TestTransformCustomFieldDefinitionZeroIDError(t *testing.T) {
 
 // TestTransformCustomFieldDefinitionEmptyNameError tests error on empty Name
 func TestTransformCustomFieldDefinitionEmptyNameError(t *testing.T) {
+	t.Parallel()
 	s := &CustomFieldDefinitionsSync{}
 
 	// Empty Name
@@ -216,6 +223,7 @@ func TestTransformCustomFieldDefinitionEmptyNameError(t *testing.T) {
 
 // TestTransformCustomFieldDefinitionValidDataTypes tests all valid data types
 func TestTransformCustomFieldDefinitionValidDataTypes(t *testing.T) {
+	t.Parallel()
 	s := &CustomFieldDefinitionsSync{}
 
 	validDataTypes := []string{"None", "String", "Integer", "Decimal", "Date", "Time", "DateTime", "Boolean"}
@@ -246,6 +254,7 @@ func TestTransformCustomFieldDefinitionValidDataTypes(t *testing.T) {
 
 // TestTransformCustomFieldDefinitionValidPartitions tests all valid partitions
 func TestTransformCustomFieldDefinitionValidPartitions(t *testing.T) {
+	t.Parallel()
 	s := &CustomFieldDefinitionsSync{}
 
 	validPartitions := []string{"None", "Family", "Alumnus", "Staff", "Camper", "Parent", "Adult"}
@@ -278,6 +287,7 @@ func TestTransformCustomFieldDefinitionValidPartitions(t *testing.T) {
 
 // TestTransformCustomFieldDefinitionMultiValuePartition tests handling of multi-value partitions
 func TestTransformCustomFieldDefinitionMultiValuePartition(t *testing.T) {
+	t.Parallel()
 	s := &CustomFieldDefinitionsSync{}
 
 	// Test multi-value partition (as returned by CampMinder API)
@@ -301,6 +311,7 @@ func TestTransformCustomFieldDefinitionMultiValuePartition(t *testing.T) {
 
 // TestTransformCustomFieldDefinitionTripleValuePartition tests handling of three-value partitions
 func TestTransformCustomFieldDefinitionTripleValuePartition(t *testing.T) {
+	t.Parallel()
 	s := &CustomFieldDefinitionsSync{}
 
 	// Test three-value partition

--- a/pocketbase/sync/date_utils_test.go
+++ b/pocketbase/sync/date_utils_test.go
@@ -9,6 +9,7 @@ import (
 // All 4 services previously had their own parseDate with inconsistent format lists,
 // output formats, and error handling.
 func TestParseDate_SharedFunction(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string
@@ -112,6 +113,7 @@ func TestParseDate_SharedFunction(t *testing.T) {
 
 // TestParseDateValue tests the interface{}-accepting wrapper used by financial_transactions.go
 func TestParseDateValue(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    any
@@ -157,6 +159,7 @@ func TestParseDateValue(t *testing.T) {
 // TestParseDate_ConsistentOutputFormat ensures all parseable inputs produce
 // the same output format: "2006-01-02 15:04:05Z" (PocketBase DateTime without millis)
 func TestParseDate_ConsistentOutputFormat(t *testing.T) {
+	t.Parallel()
 	inputs := []string{
 		"2024-06-15T10:30:00Z",
 		"2024-06-15T10:30:00.000Z",

--- a/pocketbase/sync/delta_sync_test.go
+++ b/pocketbase/sync/delta_sync_test.go
@@ -7,6 +7,7 @@ import (
 // TestTransformPersonCustomFieldValue_CapturesLastUpdated verifies that
 // lastUpdated from API response is captured in the transformed data
 func TestTransformPersonCustomFieldValue_CapturesLastUpdated(t *testing.T) {
+	t.Parallel()
 	s := &PersonCustomFieldValuesSync{}
 
 	// Mock CampMinder API response with lastUpdated
@@ -29,6 +30,7 @@ func TestTransformPersonCustomFieldValue_CapturesLastUpdated(t *testing.T) {
 // TestTransformPersonCustomFieldValue_MissingLastUpdated verifies that
 // transform handles missing lastUpdated gracefully (field not set)
 func TestTransformPersonCustomFieldValue_MissingLastUpdated(t *testing.T) {
+	t.Parallel()
 	s := &PersonCustomFieldValuesSync{}
 
 	// Mock CampMinder API response WITHOUT lastUpdated
@@ -50,6 +52,7 @@ func TestTransformPersonCustomFieldValue_MissingLastUpdated(t *testing.T) {
 // TestTransformPersonCustomFieldValue_EmptyLastUpdated verifies that
 // empty lastUpdated strings are handled (treated as missing)
 func TestTransformPersonCustomFieldValue_EmptyLastUpdated(t *testing.T) {
+	t.Parallel()
 	s := &PersonCustomFieldValuesSync{}
 
 	data := map[string]any{
@@ -69,6 +72,7 @@ func TestTransformPersonCustomFieldValue_EmptyLastUpdated(t *testing.T) {
 // TestTransformHouseholdCustomFieldValue_CapturesLastUpdated verifies that
 // lastUpdated from API response is captured for household sync
 func TestTransformHouseholdCustomFieldValue_CapturesLastUpdated(t *testing.T) {
+	t.Parallel()
 	s := &HouseholdCustomFieldValuesSync{}
 
 	data := map[string]any{
@@ -90,6 +94,7 @@ func TestTransformHouseholdCustomFieldValue_CapturesLastUpdated(t *testing.T) {
 // TestTransformHouseholdCustomFieldValue_MissingLastUpdated verifies that
 // transform handles missing lastUpdated gracefully for household sync
 func TestTransformHouseholdCustomFieldValue_MissingLastUpdated(t *testing.T) {
+	t.Parallel()
 	s := &HouseholdCustomFieldValuesSync{}
 
 	data := map[string]any{

--- a/pocketbase/sync/divisions_test.go
+++ b/pocketbase/sync/divisions_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestDivisionsSync_Name(t *testing.T) {
+	t.Parallel()
 	s := &DivisionsSync{}
 
 	got := s.Name()
@@ -17,6 +18,7 @@ func TestDivisionsSync_Name(t *testing.T) {
 
 // TestTransformDivisionToPB tests that all CampMinder division fields are extracted
 func TestTransformDivisionToPB(t *testing.T) {
+	t.Parallel()
 	s := &DivisionsSync{}
 
 	// Mock CampMinder API response based on divisions endpoint schema
@@ -80,6 +82,7 @@ func TestTransformDivisionToPB(t *testing.T) {
 
 // TestTransformDivisionToPB_MinimalData tests with only required fields
 func TestTransformDivisionToPB_MinimalData(t *testing.T) {
+	t.Parallel()
 	s := &DivisionsSync{}
 
 	// Minimal data with only required fields
@@ -109,6 +112,7 @@ func TestTransformDivisionToPB_MinimalData(t *testing.T) {
 
 // TestTransformDivisionToPB_MissingID tests that missing ID returns error
 func TestTransformDivisionToPB_MissingID(t *testing.T) {
+	t.Parallel()
 	s := &DivisionsSync{}
 
 	divisionData := map[string]any{
@@ -123,6 +127,7 @@ func TestTransformDivisionToPB_MissingID(t *testing.T) {
 
 // TestTransformDivisionToPB_MissingName tests that missing Name returns error
 func TestTransformDivisionToPB_MissingName(t *testing.T) {
+	t.Parallel()
 	s := &DivisionsSync{}
 
 	divisionData := map[string]any{
@@ -137,6 +142,7 @@ func TestTransformDivisionToPB_MissingName(t *testing.T) {
 
 // TestTransformDivisionToPB_ZeroID tests that zero ID returns error
 func TestTransformDivisionToPB_ZeroID(t *testing.T) {
+	t.Parallel()
 	s := &DivisionsSync{}
 
 	divisionData := map[string]any{
@@ -152,6 +158,7 @@ func TestTransformDivisionToPB_ZeroID(t *testing.T) {
 
 // TestTransformDivisionToPB_EmptyName tests that empty Name returns error
 func TestTransformDivisionToPB_EmptyName(t *testing.T) {
+	t.Parallel()
 	s := &DivisionsSync{}
 
 	divisionData := map[string]any{

--- a/pocketbase/sync/enrollment_snapshots_test.go
+++ b/pocketbase/sync/enrollment_snapshots_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestEnrollmentSnapshotsName(t *testing.T) {
+	t.Parallel()
 	svc := NewEnrollmentSnapshotsSync(nil)
 	if svc.Name() != "enrollment_snapshots" {
 		t.Errorf("expected name enrollment_snapshots, got %s", svc.Name())
@@ -17,6 +18,7 @@ func TestEnrollmentSnapshotsName(t *testing.T) {
 }
 
 func TestEnrollmentSnapshotsStats(t *testing.T) {
+	t.Parallel()
 	svc := NewEnrollmentSnapshotsSync(nil)
 	stats := svc.GetStats()
 	if stats.Created != 0 || stats.Updated != 0 || stats.Errors != 0 {
@@ -25,6 +27,7 @@ func TestEnrollmentSnapshotsStats(t *testing.T) {
 }
 
 func TestEnrollmentSnapshotsSetYear(t *testing.T) {
+	t.Parallel()
 	svc := NewEnrollmentSnapshotsSync(nil)
 	svc.SetYear(2025)
 	if svc.Year != 2025 {
@@ -33,6 +36,7 @@ func TestEnrollmentSnapshotsSetYear(t *testing.T) {
 }
 
 func TestEnrollmentSnapshotsSetDebug(t *testing.T) {
+	t.Parallel()
 	svc := NewEnrollmentSnapshotsSync(nil)
 	svc.SetDebug(true)
 	if !svc.Debug {
@@ -45,6 +49,7 @@ func TestEnrollmentSnapshotsSetDebug(t *testing.T) {
 }
 
 func TestCountByGender(t *testing.T) {
+	t.Parallel()
 	app, err := tests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -147,6 +152,7 @@ func TestCountByGender(t *testing.T) {
 }
 
 func TestSnapshotCancelledFilterUsesBritishSpelling(t *testing.T) {
+	t.Parallel()
 	// Bug 1: The snapshot sync used 'canceled' (American) but attendees.go
 	// stores 'cancelled' (British, from CampMinder). This test verifies the
 	// filter matches actual attendee records with status = 'cancelled'.
@@ -203,6 +209,7 @@ func TestSnapshotCancelledFilterUsesBritishSpelling(t *testing.T) {
 }
 
 func TestSnapshotUsesFullTimestamp(t *testing.T) {
+	t.Parallel()
 	// Verify the format string produces a full datetime (not date-only or midnight-truncated).
 	// Use a known non-midnight time to confirm the time component is preserved.
 	sample := time.Date(2026, 6, 15, 14, 30, 45, 0, time.UTC)

--- a/pocketbase/sync/entities_test.go
+++ b/pocketbase/sync/entities_test.go
@@ -10,6 +10,7 @@ const genderMixed = "Mixed"
 
 // TestStatusEndTime tests status end time handling
 func TestStatusEndTime(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 	status := Status{
 		Type:      "test",
@@ -31,6 +32,7 @@ func TestStatusEndTime(t *testing.T) {
 
 // TestSyncServiceOrdering tests the expected ordering of sync services
 func TestSyncServiceOrdering(t *testing.T) {
+	t.Parallel()
 	// The correct order based on dependencies
 	expectedOrder := []string{
 		"sessions",         // No dependencies
@@ -87,6 +89,7 @@ func TestSyncServiceOrdering(t *testing.T) {
 
 // TestGenderMapping tests gender value mapping
 func TestGenderMapping(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input    string
 		expected string
@@ -135,6 +138,7 @@ func normalizeGender(gender string) string {
 
 // TestSessionTypeFromName tests session type extraction
 func TestSessionTypeFromName(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		expected string
@@ -194,6 +198,7 @@ func getSessionTypeForTest(name string) string {
 
 // TestYearExtraction tests year extraction from various formats
 func TestYearExtraction(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input    string
 		expected int
@@ -262,6 +267,7 @@ func (e *yearError) Error() string {
 
 // TestCMIDValidation tests CampMinder ID validation
 func TestCMIDValidation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		cmid    int
 		isValid bool
@@ -291,6 +297,7 @@ func isValidCMID(cmid int) bool {
 
 // TestBunkNameParsing tests bunk name parsing
 func TestBunkNameParsing(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		wantGender string
@@ -343,6 +350,7 @@ func parseBunkName(name string) (gender, number string) {
 
 // TestRequestTypeValidation tests bunk request type validation
 func TestRequestTypeValidation(t *testing.T) {
+	t.Parallel()
 	validTypes := []string{
 		"bunk_with",
 		"not_bunk_with",
@@ -385,6 +393,7 @@ func isValidRequestType(rt string) bool {
 
 // TestPageSizeSelection tests page size selection logic
 func TestPageSizeSelection(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		entityCount  int

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -19,6 +19,7 @@ const testEmailJohn = "john@example.com"
 
 // TestFamilyCampDerivedSync_Name verifies the service name is correct
 func TestFamilyCampDerivedSync_Name(t *testing.T) {
+	t.Parallel()
 	// The service name must be "family_camp_derived" for orchestrator integration
 	expectedName := serviceNameFamilyCampDerived
 
@@ -30,6 +31,7 @@ func TestFamilyCampDerivedSync_Name(t *testing.T) {
 
 // TestFamilyCampYearValidation tests year parameter validation
 func TestFamilyCampYearValidation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		year      int
@@ -57,6 +59,7 @@ func TestFamilyCampYearValidation(t *testing.T) {
 
 // TestAdultFieldMapping tests mapping of custom field names to adult attributes
 func TestAdultFieldMapping(t *testing.T) {
+	t.Parallel()
 	// Field mappings from the plan
 	fieldMappings := map[string]string{
 		"Family Camp Adult 1":           "name_1",
@@ -102,6 +105,7 @@ func TestAdultFieldMapping(t *testing.T) {
 
 // TestAdultDeduplication tests that adults are deduplicated across multiple children's records
 func TestAdultDeduplication(t *testing.T) {
+	t.Parallel()
 	// Simulate person custom values for same household from multiple children
 	personValues := []testPersonCustomValue{
 		// Child 1's record for household 100
@@ -147,6 +151,7 @@ func TestAdultDeduplication(t *testing.T) {
 
 // TestMultipleAdultsPerHousehold tests that multiple adults (1-5) are correctly handled
 func TestMultipleAdultsPerHousehold(t *testing.T) {
+	t.Parallel()
 	householdValues := []testHouseholdCustomValue{
 		{HouseholdCMID: 100, FieldName: "Family Camp Adult 1", Value: "John Smith"},
 		{HouseholdCMID: 100, FieldName: "Family Camp Adult 2", Value: "Jane Smith"},
@@ -182,6 +187,7 @@ func TestMultipleAdultsPerHousehold(t *testing.T) {
 
 // TestRegistrationFieldMapping tests mapping of custom fields to registration attributes
 func TestRegistrationFieldMapping(t *testing.T) {
+	t.Parallel()
 	fieldMappings := map[string]string{
 		"Family Camp Cabin":             "cabin_assignment",
 		"FAM CAMP-Share Cabins":         "share_cabin_preference",
@@ -204,6 +210,7 @@ func TestRegistrationFieldMapping(t *testing.T) {
 
 // TestMedicalInfoBlobConcatenation tests that related medical fields are concatenated
 func TestMedicalInfoBlobConcatenation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		fields   map[string]string
@@ -295,6 +302,7 @@ func TestMedicalInfoBlobConcatenation(t *testing.T) {
 
 // TestMedicalDeduplicationByHousehold tests that medical info is deduplicated per household
 func TestMedicalDeduplicationByHousehold(t *testing.T) {
+	t.Parallel()
 	personValues := []testPersonCustomValue{
 		// Child 1's medical info for household 100
 		{HouseholdCMID: 100, PersonCMID: 1001, FieldName: "Family Medical-Allergies", Value: "Yes"},
@@ -329,6 +337,7 @@ func TestMedicalDeduplicationByHousehold(t *testing.T) {
 // sentence-prefixed cases below went undetected: fixing production code could
 // not have made the old test fail.
 func TestBoolFieldParsing(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		value    string
 		expected bool
@@ -379,6 +388,7 @@ func TestBoolFieldParsing(t *testing.T) {
 
 // TestEmptyDataHandling tests graceful handling of empty input
 func TestEmptyDataHandling(t *testing.T) {
+	t.Parallel()
 	// Empty person custom values
 	personValues := []testPersonCustomValue{}
 	adultsByHousehold := deduplicateAdultsByHousehold(personValues)
@@ -402,6 +412,7 @@ func TestEmptyDataHandling(t *testing.T) {
 
 // TestFirstNonEmptyValueSelection tests that when deduplicating, we take the first non-empty value
 func TestFirstNonEmptyValueSelection(t *testing.T) {
+	t.Parallel()
 	personValues := []testPersonCustomValue{
 		// Child 1 has empty email
 		{HouseholdCMID: 100, PersonCMID: 1001, FieldName: "Family Camp Adult 1 Email", Value: ""},
@@ -429,6 +440,7 @@ func TestFirstNonEmptyValueSelection(t *testing.T) {
 // how processRegistrations routes a field kept passing against the private copy.
 // The helper is gone; this is the same coverage against the real code path.
 func TestHouseholdCabinAssignment(t *testing.T) {
+	t.Parallel()
 	s := NewFamilyCampDerivedSync(nil)
 
 	regs := s.processRegistrations([]customValueEntry{
@@ -794,6 +806,7 @@ func aggregateMedicalByHousehold(values []testPersonCustomValue) map[int]*testMe
 // TestUpsertAdultsIdempotency verifies that running the sync twice with unchanged data
 // results in all records being skipped (not created) on the second run.
 func TestUpsertAdultsIdempotency(t *testing.T) {
+	t.Parallel()
 	// Simulate computed adults from source data
 	adults := []*testAdult{
 		{HouseholdCMID: 100, AdultNumber: 1, FirstName: "John", LastName: "Smith", Email: "john@example.com"},
@@ -835,6 +848,7 @@ func TestUpsertAdultsIdempotency(t *testing.T) {
 // TestUpsertAdultsUpdateDetection verifies that modified source data results in
 // the Updated stat being incremented, not Created.
 func TestUpsertAdultsUpdateDetection(t *testing.T) {
+	t.Parallel()
 	// Existing records in database (from previous sync)
 	existingAdults := []*testAdult{
 		{HouseholdCMID: 100, AdultNumber: 1, FirstName: "John", LastName: "Smith", Email: "john@example.com"},
@@ -867,6 +881,7 @@ func TestUpsertAdultsUpdateDetection(t *testing.T) {
 // TestUpsertAdultsOrphanDeletion verifies that records removed from source data
 // are deleted (orphan cleanup).
 func TestUpsertAdultsOrphanDeletion(t *testing.T) {
+	t.Parallel()
 	// Existing records in database (from previous sync)
 	existingAdults := []*testAdult{
 		{HouseholdCMID: 100, AdultNumber: 1, FirstName: "John", LastName: "Smith", Email: "john@example.com"},
@@ -900,6 +915,7 @@ func TestUpsertAdultsOrphanDeletion(t *testing.T) {
 
 // TestUpsertRegistrationsIdempotency verifies registration upsert idempotency
 func TestUpsertRegistrationsIdempotency(t *testing.T) {
+	t.Parallel()
 	registrations := []*testRegistration{
 		{HouseholdCMID: 100, CabinAssignment: "Cabin 12", ShareCabinPreference: "Yes"},
 		{HouseholdCMID: 200, CabinAssignment: "Cabin 14", Goals: "Family bonding"},
@@ -927,6 +943,7 @@ func TestUpsertRegistrationsIdempotency(t *testing.T) {
 
 // TestUpsertMedicalIdempotency verifies medical upsert idempotency
 func TestUpsertMedicalIdempotency(t *testing.T) {
+	t.Parallel()
 	medical := []*testMedical{
 		{HouseholdCMID: 100, AllergyInfo: "Peanuts", DietaryInfo: "Vegetarian"},
 		{HouseholdCMID: 200, CPAPInfo: "Yes; needs outlet"},
@@ -954,6 +971,7 @@ func TestUpsertMedicalIdempotency(t *testing.T) {
 
 // TestCompositeKeyFormats verifies the composite key format for each table
 func TestCompositeKeyFormats(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		tableName   string
@@ -1333,6 +1351,7 @@ func newFieldDefsTestApp(t *testing.T, defs map[int]string) core.App {
 // space, while processMedical looks it up as "Family Camp-Physician". Before the
 // fix the exact-match lookup missed every Physician answer ever recorded.
 func TestLoadFieldDefinitionsTrimsNames(t *testing.T) {
+	t.Parallel()
 	app := newFieldDefsTestApp(t, map[int]string{
 		39680: "Family Camp-Physician ", // trailing space, verbatim from CampMinder
 		39681: "Family Camp-Physician If Yes",
@@ -1365,6 +1384,7 @@ func TestLoadFieldDefinitionsTrimsNames(t *testing.T) {
 // loadFieldDefinitions can rely on it — Phase B's lodging_fields.go registry
 // will be the second one. That file does not exist yet.
 func TestNormalizeFieldName(t *testing.T) {
+	t.Parallel()
 	cases := map[string]string{
 		"Family Camp-Physician ":   "Family Camp-Physician",
 		" Family Camp Cabin":       "Family Camp Cabin",
@@ -1387,6 +1407,7 @@ func TestNormalizeFieldName(t *testing.T) {
 // user-editable and CampMinder's own spelling is inconsistent ("Housing
 // Accomodation", one m, is the Adult-partition twin).
 func TestLoadFieldDefinitionsIncludesCMIDAllowlist(t *testing.T) {
+	t.Parallel()
 	app := newFieldDefsTestApp(t, map[int]string{
 		223999: "FAM Camp-Accommodation", // retired but kept for 2023/2024 backfill
 		274057: "Housing Accommodation",  // Camper successor, name heuristic misses it
@@ -1432,6 +1453,7 @@ func TestLoadFieldDefinitionsIncludesCMIDAllowlist(t *testing.T) {
 // request-layer registry in lodging_fields.go resolves the canonical name from
 // the cm_id, so the switch sees the name it was written against.
 func TestLoadFieldDefinitionsRoutesRenamedRequestFieldByCMID(t *testing.T) {
+	t.Parallel()
 	app := newFieldDefsTestApp(t, map[int]string{
 		// Staff renamed both in CampMinder. Neither new name matches anything
 		// family_camp_derived.go's switch knows about.
@@ -1466,6 +1488,7 @@ func TestLoadFieldDefinitionsRoutesRenamedRequestFieldByCMID(t *testing.T) {
 // question, so those two still collapse to one; Adult-CPAP is a different
 // person and is always additive.
 func TestProcessMedicalKeepsBothCamperAndAdultCPAPNarratives(t *testing.T) {
+	t.Parallel()
 	s := NewFamilyCampDerivedSync(nil)
 	ts := time.Date(2025, 4, 21, 0, 0, 0, 0, time.UTC)
 
@@ -1502,6 +1525,7 @@ func TestProcessMedicalKeepsBothCamperAndAdultCPAPNarratives(t *testing.T) {
 // Camper-partition names are the same question asked twice, so answering both
 // must not duplicate the sentence in the medical record.
 func TestProcessMedicalCollapsesCamperCPAPGenerations(t *testing.T) {
+	t.Parallel()
 	s := NewFamilyCampDerivedSync(nil)
 	ts := time.Date(2025, 4, 21, 0, 0, 0, 0, time.UTC)
 
@@ -1524,6 +1548,7 @@ func TestProcessMedicalCollapsesCamperCPAPGenerations(t *testing.T) {
 // read as one), so a household whose ONLY answer is the blocker cannot be the one
 // row that gets dropped before it is ever written.
 func TestProcessRegistrationsMandatoryOnlyHouseholdSurvives(t *testing.T) {
+	t.Parallel()
 	s := NewFamilyCampDerivedSync(nil)
 	ts := time.Date(2025, 4, 21, 0, 0, 0, 0, time.UTC)
 
@@ -1542,6 +1567,7 @@ func TestProcessRegistrationsMandatoryOnlyHouseholdSurvives(t *testing.T) {
 // TestProcessRegistrationsAccommodationSuccessor proves the successor field
 // actually reaches the needs_accommodation column, not merely the field map.
 func TestProcessRegistrationsAccommodationSuccessor(t *testing.T) {
+	t.Parallel()
 	s := NewFamilyCampDerivedSync(nil)
 
 	// 2026-shaped input: only the successor field is answered.
@@ -1585,6 +1611,7 @@ func TestProcessRegistrationsAccommodationSuccessor(t *testing.T) {
 // iterates person values, and a household has several people, so disagreement
 // between household members is the normal case, not an edge case.
 func TestProcessRegistrationsBoolFieldsOrAcrossPersons(t *testing.T) {
+	t.Parallel()
 	s := NewFamilyCampDerivedSync(nil)
 
 	t.Run("accommodation ORs across household members", func(t *testing.T) {
@@ -1689,6 +1716,7 @@ const testRequestText = "the Johnson family"
 // integration point. The request fields are person-partition, so two enrolled
 // children carry one parent's answer twice.
 func TestProcessRegistrationsCollapsesDuplicateRequests(t *testing.T) {
+	t.Parallel()
 	s := NewFamilyCampDerivedSync(nil)
 	ts := time.Date(2025, 4, 21, 17, 51, 0, 0, time.UTC)
 
@@ -1712,6 +1740,7 @@ func TestProcessRegistrationsCollapsesDuplicateRequests(t *testing.T) {
 // TestProcessRegistrationsParsesGateAndModes: the 3-state gate and the two edge
 // types, from the real option sentences.
 func TestProcessRegistrationsParsesGateAndModes(t *testing.T) {
+	t.Parallel()
 	s := NewFamilyCampDerivedSync(nil)
 	ts := time.Date(2025, 4, 21, 0, 0, 0, 0, time.UTC)
 
@@ -1741,6 +1770,7 @@ func TestProcessRegistrationsParsesGateAndModes(t *testing.T) {
 // TestProcessRegistrationsDerivedAccessibilityFlags: the board gets booleans,
 // never the narrative (spec 5.3).
 func TestProcessRegistrationsDerivedAccessibilityFlags(t *testing.T) {
+	t.Parallel()
 	s := NewFamilyCampDerivedSync(nil)
 	ts := time.Date(2025, 4, 21, 0, 0, 0, 0, time.UTC)
 
@@ -1776,6 +1806,7 @@ func TestProcessRegistrationsDerivedAccessibilityFlags(t *testing.T) {
 // CPAP fields are multi-option selects, and parseBoolFieldValue reads every
 // option below as true.
 func TestClassifyCPAPAnswer(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name         string
 		value        string
@@ -1809,6 +1840,7 @@ func TestClassifyCPAPAnswer(t *testing.T) {
 // integration point: the household asked for a bathroom and said so in the
 // same breath as "not CPAP related". It must not be given an outlet cabin.
 func TestProcessRegistrationsCPAPBathroomIsNotPower(t *testing.T) {
+	t.Parallel()
 	s := NewFamilyCampDerivedSync(nil)
 	ts := time.Date(2025, 4, 21, 0, 0, 0, 0, time.UTC)
 
@@ -1830,6 +1862,7 @@ func TestProcessRegistrationsCPAPBathroomIsNotPower(t *testing.T) {
 // consumer in any phase (kindred#1876). It is a housing signal, so it gets one.
 // The N/A option must not read as yes, and must not be special-cased either.
 func TestProcessRegistrationsHasInfant(t *testing.T) {
+	t.Parallel()
 	ts := time.Date(2025, 4, 21, 0, 0, 0, 0, time.UTC)
 
 	cases := []struct {
@@ -1865,6 +1898,7 @@ func TestProcessRegistrationsHasInfant(t *testing.T) {
 // TestProcessRegistrationsHasInfantORsAcrossHousehold: unlike opt_out_vip, OR
 // is fail-SAFE here -- one adult bringing an infant means the household has one.
 func TestProcessRegistrationsHasInfantORsAcrossHousehold(t *testing.T) {
+	t.Parallel()
 	s := NewFamilyCampDerivedSync(nil)
 	ts := time.Date(2025, 4, 21, 0, 0, 0, 0, time.UTC)
 
@@ -1884,6 +1918,7 @@ func TestProcessRegistrationsHasInfantORsAcrossHousehold(t *testing.T) {
 // extraFieldCMIDs but processMedical never read it, so a household where only
 // the accompanying adult answers produced an empty cpap_info. kindred#1875.
 func TestProcessMedicalCPAPIncludesAdultField(t *testing.T) {
+	t.Parallel()
 	s := NewFamilyCampDerivedSync(nil)
 	ts := time.Date(2025, 4, 21, 0, 0, 0, 0, time.UTC)
 
@@ -1901,6 +1936,7 @@ func TestProcessMedicalCPAPIncludesAdultField(t *testing.T) {
 
 // TestProcessRegistrationsOptOutMakesTheNeedAWarning: the other polarity.
 func TestProcessRegistrationsOptOutMakesTheNeedAWarning(t *testing.T) {
+	t.Parallel()
 	s := NewFamilyCampDerivedSync(nil)
 	ts := time.Date(2025, 4, 21, 0, 0, 0, 0, time.UTC)
 
@@ -1932,6 +1968,7 @@ func TestProcessRegistrationsOptOutMakesTheNeedAWarning(t *testing.T) {
 // Order is varied because a running OR is order-sensitive and a finalization
 // pass is not; asserting only one order would pass on a fix that works by luck.
 func TestProcessRegistrationsOptOutLosesToABlockerInTheSameHousehold(t *testing.T) {
+	t.Parallel()
 	ts := time.Date(2025, 4, 21, 0, 0, 0, 0, time.UTC)
 	const optOut = "Yes, please register regardless of cabin type"
 	const blocker = "No, I am only able to attend with this accommodation in place"
@@ -1969,6 +2006,7 @@ func TestProcessRegistrationsOptOutLosesToABlockerInTheSameHousehold(t *testing.
 // TestProcessRegistrationsUnansweredOptOutIsNotMandatory: the default must be
 // the softer reading, or every household with no answer becomes a blocker.
 func TestProcessRegistrationsUnansweredOptOutIsNotMandatory(t *testing.T) {
+	t.Parallel()
 	s := NewFamilyCampDerivedSync(nil)
 	ts := time.Date(2025, 4, 21, 0, 0, 0, 0, time.UTC)
 
@@ -1987,6 +2025,7 @@ func TestProcessRegistrationsUnansweredOptOutIsNotMandatory(t *testing.T) {
 // a bathroom or accommodation need are PHI and belong only in
 // family_camp_medical (spec 5.1).
 func TestProcessMedicalRoutesNarrativeToTheAdminGatedTable(t *testing.T) {
+	t.Parallel()
 	s := NewFamilyCampDerivedSync(nil)
 	ts := time.Date(2025, 4, 21, 0, 0, 0, 0, time.UTC)
 
@@ -2043,6 +2082,7 @@ func TestProcessMedicalRoutesNarrativeToTheAdminGatedTable(t *testing.T) {
 // every pass and be re-saved forever -- 35 rows on 2026 alone. Verified by hand
 // against a real sync (a third pass touched 0 rows); this pins it.
 func TestRegistrationNeedsUpdateIgnoresTheUnknownSpelling(t *testing.T) {
+	t.Parallel()
 	col := core.NewBaseCollection("family_camp_registrations")
 	col.Fields.Add(&core.TextField{Name: "share_eligibility"})
 	col.Fields.Add(&core.TextField{Name: "share_eligibility_source"})
@@ -2100,6 +2140,7 @@ func TestRegistrationNeedsUpdateIgnoresTheUnknownSpelling(t *testing.T) {
 // whether gender/date_of_birth/email/pronouns are kept. Do not "fix" this test
 // by changing the merge until that ruling lands.
 func TestProcessAdultsPersonFieldsTakeTheFirstLoadedSibling(t *testing.T) {
+	t.Parallel()
 	s := &FamilyCampDerivedSync{}
 
 	// A local constant rather than the literal twice: goconst counts repeated
@@ -2153,6 +2194,7 @@ func TestProcessAdultsPersonFieldsTakeTheFirstLoadedSibling(t *testing.T) {
 // row is real would drop them -- 196 real adults across 2022-2026 are blank in
 // first_name/last_name and populated in `name` (kindred#1945).
 func TestProcessAdultsKeepsANameOnlyAdult(t *testing.T) {
+	t.Parallel()
 	s := &FamilyCampDerivedSync{}
 
 	householdValues := []customValueEntry{
@@ -2179,6 +2221,7 @@ func TestProcessAdultsKeepsANameOnlyAdult(t *testing.T) {
 // `name` with blank split columns is the OPPOSITE case (kindred#1945/#1946
 // safety point, ~196 real adults across 2022-2026) and must still survive.
 func TestProcessAdultsDropsNamelessRows(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name            string
 		householdValues []customValueEntry
@@ -2239,6 +2282,7 @@ func TestProcessAdultsDropsNamelessRows(t *testing.T) {
 // first would pass against the OLD, buggy code too (first-non-empty already
 // gets it right by luck in that order) and would prove nothing.
 func TestProcessAdultsEmailMergePrefersWellFormedValue(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name       string
 		malformed  string
@@ -2297,6 +2341,7 @@ func TestProcessAdultsEmailMergePrefersWellFormedValue(t *testing.T) {
 // first-loaded-sibling behavior, not get silently overwritten just because
 // email now has a validity notion.
 func TestProcessAdultsEmailBothWellFormedKeepsFirstLoaded(t *testing.T) {
+	t.Parallel()
 	const first = "amy.johnson@example.com"
 	const second = "amy.j.johnson@example.org"
 
@@ -2325,6 +2370,7 @@ func TestProcessAdultsEmailBothWellFormedKeepsFirstLoaded(t *testing.T) {
 // what the merge does across the dataset, and a validity change that broke
 // it would be a regression, not a fix.
 func TestProcessAdultsEmailGapFillStillWins(t *testing.T) {
+	t.Parallel()
 	const filled = "amy.johnson@example.com"
 
 	for _, order := range []string{"blank-first", "filled-first"} {

--- a/pocketbase/sync/financial_aid_applications_test.go
+++ b/pocketbase/sync/financial_aid_applications_test.go
@@ -13,6 +13,7 @@ import (
 // the map and then silently fail to route. No untrimmed name exists in this
 // table today; this pins the fix against a future one.
 func TestFinancialAidApplicationsLoadFieldDefinitionsTrimsNames(t *testing.T) {
+	t.Parallel()
 	app := newFieldDefsTestApp(t, map[int]string{
 		1: "FA-Contact Parent Name ", // trailing space
 		2: "FA-Contact Parent Email", // already clean, must be unaffected
@@ -48,6 +49,7 @@ func TestFinancialAidApplicationsLoadFieldDefinitionsTrimsNames(t *testing.T) {
 
 // TestFinancialAidApplicationsSync_Name verifies the service name is correct
 func TestFinancialAidApplicationsSync_Name(t *testing.T) {
+	t.Parallel()
 	// The service name must be "financial_aid_applications" for orchestrator integration
 	expectedName := "financial_aid_applications"
 
@@ -59,6 +61,7 @@ func TestFinancialAidApplicationsSync_Name(t *testing.T) {
 
 // TestFAYearValidation tests year parameter validation
 func TestFAYearValidation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		year      int
@@ -86,6 +89,7 @@ func TestFAYearValidation(t *testing.T) {
 
 // TestIsFAField tests the field name matching patterns for FA fields
 func TestIsFAField(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		fieldName string
 		wantMatch bool
@@ -136,6 +140,7 @@ func TestIsFAField(t *testing.T) {
 
 // TestFAFieldMapping tests the mapping from CampMinder field names to column names
 func TestFAFieldMapping(t *testing.T) {
+	t.Parallel()
 	// Test a representative sample of field mappings
 	tests := []struct {
 		cmFieldName    string
@@ -247,6 +252,7 @@ func TestFAFieldMapping(t *testing.T) {
 
 // TestFABoolFieldParsing tests parsing of boolean custom field values
 func TestFABoolFieldParsing(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		value    string
 		expected bool
@@ -287,6 +293,7 @@ func TestFABoolFieldParsing(t *testing.T) {
 
 // TestFANumberParsing tests parsing of numeric values from text fields
 func TestFANumberParsing(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		value    string
 		expected float64
@@ -325,6 +332,7 @@ func TestFANumberParsing(t *testing.T) {
 
 // TestFACompositeKeyGeneration tests the unique key generation for upsert
 func TestFACompositeKeyGeneration(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		personID string
 		year     int
@@ -348,6 +356,7 @@ func TestFACompositeKeyGeneration(t *testing.T) {
 
 // TestFAInterestExpressionDetection tests detection of interest expression
 func TestFAInterestExpressionDetection(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		value    string
 		expected bool
@@ -379,6 +388,7 @@ func TestFAInterestExpressionDetection(t *testing.T) {
 
 // TestFADataAggregation tests that multiple custom values for the same person are aggregated correctly
 func TestFADataAggregation(t *testing.T) {
+	t.Parallel()
 	// Simulate custom values for the same person
 	values := []testFACustomValue{
 		{PersonPBID: "person1", FieldName: "FA-Contact Parent Name", Value: "John"},
@@ -417,6 +427,7 @@ func TestFADataAggregation(t *testing.T) {
 
 // TestFAEmptyDataHandling tests graceful handling of empty input
 func TestFAEmptyDataHandling(t *testing.T) {
+	t.Parallel()
 	values := []testFACustomValue{}
 	apps := aggregateFAApplications(values, 2025)
 
@@ -427,6 +438,7 @@ func TestFAEmptyDataHandling(t *testing.T) {
 
 // TestFAFieldTypeDetection tests detection of field types (bool, number, text)
 func TestFAFieldTypeDetection(t *testing.T) {
+	t.Parallel()
 	boolFields := []string{
 		"unemployment", "still_unemployed", "owns_home", "single_parent",
 		"affiliated_jcc", "russian_speaking", "gov_subsidies",
@@ -471,6 +483,7 @@ func TestFAFieldTypeDetection(t *testing.T) {
 
 // TestFAFirstNonEmptyWins tests that when a person has duplicate field values, first non-empty wins
 func TestFAFirstNonEmptyWins(t *testing.T) {
+	t.Parallel()
 	values := []testFACustomValue{
 		// First record has empty email
 		{PersonPBID: "person1", FieldName: "FA-Contact Parent Email", Value: ""},
@@ -872,6 +885,7 @@ func isFANumberColumn(column string) bool {
 
 // TestFAFieldEquals tests field equality comparisons for idempotency checking
 func TestFAFieldEquals(t *testing.T) {
+	t.Parallel()
 	s := &FinancialAidApplicationsSync{}
 
 	tests := []struct {
@@ -926,6 +940,7 @@ func TestFAFieldEquals(t *testing.T) {
 
 // TestFARecordNeedsUpdate tests the record comparison logic for idempotency
 func TestFARecordNeedsUpdate(t *testing.T) {
+	t.Parallel()
 	s := &FinancialAidApplicationsSync{}
 
 	tests := []struct {
@@ -1038,6 +1053,7 @@ func TestFARecordNeedsUpdate(t *testing.T) {
 
 // TestFAApplicationToRecordData tests conversion of faApplicationData to map
 func TestFAApplicationToRecordData(t *testing.T) {
+	t.Parallel()
 	app := &faApplicationData{
 		personPBID:        "person123",
 		householdPBID:     "household456",
@@ -1081,6 +1097,7 @@ func TestFAApplicationToRecordData(t *testing.T) {
 // TestFAUpsertIdempotencyBehavior tests that unchanged records are skipped
 // This documents the expected behavior for the idempotency fix
 func TestFAUpsertIdempotencyBehavior(t *testing.T) {
+	t.Parallel()
 	// Document the expected behavior:
 	// 1. New records → Stats.Created++
 	// 2. Existing records with no changes → Stats.Skipped++

--- a/pocketbase/sync/financial_lookups_test.go
+++ b/pocketbase/sync/financial_lookups_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestFinancialLookupsSync_Name(t *testing.T) {
+	t.Parallel()
 	s := &FinancialLookupsSync{}
 
 	got := s.Name()
@@ -20,6 +21,7 @@ func TestFinancialLookupsSync_Name(t *testing.T) {
 // =============================================================================
 
 func TestTransformFinancialCategoryToPB(t *testing.T) {
+	t.Parallel()
 	s := &FinancialLookupsSync{}
 
 	// Mock CampMinder API response (lowercase field names per OpenAPI spec)
@@ -47,6 +49,7 @@ func TestTransformFinancialCategoryToPB(t *testing.T) {
 }
 
 func TestTransformFinancialCategoryToPB_Archived(t *testing.T) {
+	t.Parallel()
 	s := &FinancialLookupsSync{}
 
 	categoryData := map[string]any{
@@ -66,6 +69,7 @@ func TestTransformFinancialCategoryToPB_Archived(t *testing.T) {
 }
 
 func TestTransformFinancialCategoryToPB_NullName(t *testing.T) {
+	t.Parallel()
 	s := &FinancialLookupsSync{}
 
 	// API allows nullable name
@@ -87,6 +91,7 @@ func TestTransformFinancialCategoryToPB_NullName(t *testing.T) {
 }
 
 func TestTransformFinancialCategoryToPB_MissingName(t *testing.T) {
+	t.Parallel()
 	s := &FinancialLookupsSync{}
 
 	// No name key at all
@@ -107,6 +112,7 @@ func TestTransformFinancialCategoryToPB_MissingName(t *testing.T) {
 }
 
 func TestTransformFinancialCategoryToPB_MissingID(t *testing.T) {
+	t.Parallel()
 	s := &FinancialLookupsSync{}
 
 	data := map[string]any{
@@ -121,6 +127,7 @@ func TestTransformFinancialCategoryToPB_MissingID(t *testing.T) {
 }
 
 func TestTransformFinancialCategoryToPB_ZeroID(t *testing.T) {
+	t.Parallel()
 	s := &FinancialLookupsSync{}
 
 	data := map[string]any{
@@ -140,6 +147,7 @@ func TestTransformFinancialCategoryToPB_ZeroID(t *testing.T) {
 // =============================================================================
 
 func TestTransformPaymentMethodToPB(t *testing.T) {
+	t.Parallel()
 	s := &FinancialLookupsSync{}
 
 	// Mock CampMinder API response (lowercase field names per OpenAPI spec)
@@ -168,6 +176,7 @@ func TestTransformPaymentMethodToPB(t *testing.T) {
 }
 
 func TestTransformPaymentMethodToPB_NullName(t *testing.T) {
+	t.Parallel()
 	s := &FinancialLookupsSync{}
 
 	// API allows nullable name
@@ -188,6 +197,7 @@ func TestTransformPaymentMethodToPB_NullName(t *testing.T) {
 }
 
 func TestTransformPaymentMethodToPB_MissingName(t *testing.T) {
+	t.Parallel()
 	s := &FinancialLookupsSync{}
 
 	// No name key at all
@@ -207,6 +217,7 @@ func TestTransformPaymentMethodToPB_MissingName(t *testing.T) {
 }
 
 func TestTransformPaymentMethodToPB_MissingID(t *testing.T) {
+	t.Parallel()
 	s := &FinancialLookupsSync{}
 
 	data := map[string]any{
@@ -220,6 +231,7 @@ func TestTransformPaymentMethodToPB_MissingID(t *testing.T) {
 }
 
 func TestTransformPaymentMethodToPB_ZeroID(t *testing.T) {
+	t.Parallel()
 	s := &FinancialLookupsSync{}
 
 	data := map[string]any{

--- a/pocketbase/sync/financial_transactions_test.go
+++ b/pocketbase/sync/financial_transactions_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestFinancialTransactionsSync_Name(t *testing.T) {
+	t.Parallel()
 	s := &FinancialTransactionsSync{}
 
 	got := s.Name()
@@ -20,6 +21,7 @@ func TestFinancialTransactionsSync_Name(t *testing.T) {
 // =============================================================================
 
 func TestTransformTransactionToPB(t *testing.T) {
+	t.Parallel()
 	s := &FinancialTransactionsSync{}
 
 	// Build lookup maps for relation resolution
@@ -175,6 +177,7 @@ func verifyFieldEmpty(t *testing.T, data map[string]any, field string) {
 }
 
 func TestTransformTransactionToPB_Reversed(t *testing.T) {
+	t.Parallel()
 	s := &FinancialTransactionsSync{}
 	lookupMaps := TransactionLookupMaps{}
 
@@ -201,6 +204,7 @@ func TestTransformTransactionToPB_Reversed(t *testing.T) {
 }
 
 func TestTransformTransactionToPB_MissingTransactionID(t *testing.T) {
+	t.Parallel()
 	s := &FinancialTransactionsSync{}
 	lookupMaps := TransactionLookupMaps{}
 
@@ -217,6 +221,7 @@ func TestTransformTransactionToPB_MissingTransactionID(t *testing.T) {
 }
 
 func TestTransformTransactionToPB_ZeroTransactionID(t *testing.T) {
+	t.Parallel()
 	s := &FinancialTransactionsSync{}
 	lookupMaps := TransactionLookupMaps{}
 
@@ -234,6 +239,7 @@ func TestTransformTransactionToPB_ZeroTransactionID(t *testing.T) {
 }
 
 func TestTransformTransactionToPB_NullOptionalFields(t *testing.T) {
+	t.Parallel()
 	s := &FinancialTransactionsSync{}
 	lookupMaps := TransactionLookupMaps{}
 
@@ -287,6 +293,7 @@ func TestTransformTransactionToPB_NullOptionalFields(t *testing.T) {
 }
 
 func TestTransformTransactionToPB_UnknownRelations(t *testing.T) {
+	t.Parallel()
 	s := &FinancialTransactionsSync{}
 
 	// Empty lookup maps - relations won't be resolvable
@@ -323,6 +330,7 @@ func TestTransformTransactionToPB_UnknownRelations(t *testing.T) {
 }
 
 func TestTransformTransactionToPB_NegativeAmount(t *testing.T) {
+	t.Parallel()
 	s := &FinancialTransactionsSync{}
 	lookupMaps := TransactionLookupMaps{}
 

--- a/pocketbase/sync/google_sheets_test.go
+++ b/pocketbase/sync/google_sheets_test.go
@@ -147,6 +147,7 @@ func (m *MockSheetsWriter) DeleteSheet(_ context.Context, _, sheetTab string) er
 }
 
 func TestMockSheetsWriter_EnsureSheetIsIdempotent(t *testing.T) {
+	t.Parallel()
 	// Test that calling EnsureSheet multiple times works (idempotent)
 	mock := NewMockSheetsWriter()
 	ctx := context.Background()
@@ -178,6 +179,7 @@ func TestMockSheetsWriter_EnsureSheetIsIdempotent(t *testing.T) {
 // =============================================================================
 
 func TestGetTabColor_GlobalTabs(t *testing.T) {
+	t.Parallel()
 	// Global tabs (g-*) should get light blue color
 	tests := []string{
 		"g-tag-def",
@@ -197,6 +199,7 @@ func TestGetTabColor_GlobalTabs(t *testing.T) {
 }
 
 func TestGetTabColor_YearTabs(t *testing.T) {
+	t.Parallel()
 	// Year tabs should get year-specific colors
 	tests := []struct {
 		tab      string
@@ -220,6 +223,7 @@ func TestGetTabColor_YearTabs(t *testing.T) {
 }
 
 func TestGetTabColor_FutureYears(t *testing.T) {
+	t.Parallel()
 	// Future years (2027+) should cycle through palette
 	color2027 := GetTabColor("2027-attendees")
 	color2028 := GetTabColor("2028-attendees")
@@ -234,6 +238,7 @@ func TestGetTabColor_FutureYears(t *testing.T) {
 }
 
 func TestGetTabColor_UnknownTabs(t *testing.T) {
+	t.Parallel()
 	// Tabs that don't match g-* or YYYY-* should get default color
 	color := GetTabColor("random-sheet")
 	if color != TabColorDefault {
@@ -242,6 +247,7 @@ func TestGetTabColor_UnknownTabs(t *testing.T) {
 }
 
 func TestTabColorConstants(t *testing.T) {
+	t.Parallel()
 	// Verify color constants are defined with valid RGB values
 	colors := map[string]TabColor{
 		"TabColorGlobal":  TabColorGlobal,
@@ -272,6 +278,7 @@ func TestTabColorConstants(t *testing.T) {
 // =============================================================================
 
 func TestBatchUpdateTabProperties_CombinesAllUpdates(t *testing.T) {
+	t.Parallel()
 	// Test that BatchUpdateTabProperties accepts multiple tab updates
 	// and applies them all in a single call
 	mock := NewMockSheetsWriter()
@@ -320,6 +327,7 @@ func TestBatchUpdateTabProperties_CombinesAllUpdates(t *testing.T) {
 }
 
 func TestBatchUpdateTabProperties_PartialUpdates(t *testing.T) {
+	t.Parallel()
 	// Test that we can update only color or only index for individual tabs
 	mock := NewMockSheetsWriter()
 	ctx := context.Background()
@@ -355,6 +363,7 @@ func TestBatchUpdateTabProperties_PartialUpdates(t *testing.T) {
 }
 
 func TestBatchUpdateTabProperties_EmptyUpdates(t *testing.T) {
+	t.Parallel()
 	// Test that empty updates list doesn't cause errors
 	mock := NewMockSheetsWriter()
 	ctx := context.Background()
@@ -370,6 +379,7 @@ func TestBatchUpdateTabProperties_EmptyUpdates(t *testing.T) {
 }
 
 func TestBatchUpdateTabProperties_PreservesSheetID(t *testing.T) {
+	t.Parallel()
 	// Verify that SheetID is correctly passed through for each update
 	mock := NewMockSheetsWriter()
 	ctx := context.Background()
@@ -397,6 +407,7 @@ func TestBatchUpdateTabProperties_PreservesSheetID(t *testing.T) {
 }
 
 func TestBatchUpdateTabProperties_ErrorHandling(t *testing.T) {
+	t.Parallel()
 	// Test that errors are properly propagated
 	mock := NewMockSheetsWriter()
 	mock.BatchUpdateError = context.DeadlineExceeded
@@ -416,6 +427,7 @@ func TestBatchUpdateTabProperties_ErrorHandling(t *testing.T) {
 }
 
 func TestBatchUpdateTabProperties_LargeBatch(t *testing.T) {
+	t.Parallel()
 	// Test that a large batch (similar to real 16+ tabs) works correctly
 	mock := NewMockSheetsWriter()
 	ctx := context.Background()
@@ -472,6 +484,7 @@ func TestBatchUpdateTabProperties_LargeBatch(t *testing.T) {
 // =============================================================================
 
 func TestDeleteSheet_TracksDeletedSheets(t *testing.T) {
+	t.Parallel()
 	// Test that DeleteSheet tracks which sheets were deleted
 	mock := NewMockSheetsWriter()
 	ctx := context.Background()
@@ -503,6 +516,7 @@ func TestDeleteSheet_TracksDeletedSheets(t *testing.T) {
 }
 
 func TestDeleteSheet_Idempotent(t *testing.T) {
+	t.Parallel()
 	// Test that DeleteSheet is idempotent - can be called for non-existent sheets
 	mock := NewMockSheetsWriter()
 	ctx := context.Background()
@@ -520,6 +534,7 @@ func TestDeleteSheet_Idempotent(t *testing.T) {
 }
 
 func TestDeleteSheet_MultipleDeletes(t *testing.T) {
+	t.Parallel()
 	// Test deleting multiple sheets
 	mock := NewMockSheetsWriter()
 	ctx := context.Background()
@@ -537,6 +552,7 @@ func TestDeleteSheet_MultipleDeletes(t *testing.T) {
 }
 
 func TestDeleteSheet_ErrorHandling(t *testing.T) {
+	t.Parallel()
 	// Test that errors are properly propagated
 	mock := NewMockSheetsWriter()
 	mock.DeleteError = context.DeadlineExceeded

--- a/pocketbase/sync/household_custom_field_values_test.go
+++ b/pocketbase/sync/household_custom_field_values_test.go
@@ -10,6 +10,7 @@ const testFieldDefPBID = "pb_field_100"
 const testHouseholdPBID = "pb_household_123"
 
 func TestHouseholdCustomFieldValuesSync_Name(t *testing.T) {
+	t.Parallel()
 	s := &HouseholdCustomFieldValuesSync{}
 
 	got := s.Name()
@@ -22,6 +23,7 @@ func TestHouseholdCustomFieldValuesSync_Name(t *testing.T) {
 
 // TestTransformHouseholdCustomFieldValueToPB tests transformation to PocketBase format
 func TestTransformHouseholdCustomFieldValueToPB(t *testing.T) {
+	t.Parallel()
 	s := &HouseholdCustomFieldValuesSync{}
 
 	// Mock CampMinder API response for a custom field value
@@ -68,6 +70,7 @@ func TestTransformHouseholdCustomFieldValueToPB(t *testing.T) {
 
 // TestTransformHouseholdCustomFieldValueEmptyValue tests that empty values are allowed
 func TestTransformHouseholdCustomFieldValueEmptyValue(t *testing.T) {
+	t.Parallel()
 	s := &HouseholdCustomFieldValuesSync{}
 
 	data := map[string]any{
@@ -84,6 +87,7 @@ func TestTransformHouseholdCustomFieldValueEmptyValue(t *testing.T) {
 
 // TestTransformHouseholdCustomFieldValueNilValue tests handling of nil Value
 func TestTransformHouseholdCustomFieldValueNilValue(t *testing.T) {
+	t.Parallel()
 	s := &HouseholdCustomFieldValuesSync{}
 
 	data := map[string]any{
@@ -104,6 +108,7 @@ func TestTransformHouseholdCustomFieldValueNilValue(t *testing.T) {
 // The PreloadCompositeRecords function appends "|year" to the keyBuilder result,
 // so the keyBuilder must NOT include year, and all lookups must use "key|year" format.
 func TestHouseholdCustomFieldValuesCompositeKeyFormat(t *testing.T) {
+	t.Parallel()
 	householdPBId := testHouseholdPBID
 	fieldDefPBId := testFieldDefPBID
 	year := 2025
@@ -143,6 +148,7 @@ func TestHouseholdCustomFieldValuesCompositeKeyFormat(t *testing.T) {
 // the keyBuilder closure should return identity only (no year),
 // because PreloadCompositeRecords will append "|year" to it.
 func TestHouseholdCustomFieldValuesKeyBuilderShouldNotIncludeYear(t *testing.T) {
+	t.Parallel()
 	// Simulate what the keyBuilder closure does
 	householdPBId := "abc123"
 	fieldDefPBId := "def456"
@@ -187,6 +193,7 @@ func TestHouseholdCustomFieldValuesKeyBuilderShouldNotIncludeYear(t *testing.T) 
 // This is the actual bug: TrackProcessedKey(yearScopedKey, 0) creates "key|0" but
 // orphan deletion looks for "key" without the trailing "|0".
 func TestHouseholdCustomFieldValuesTrackingMatchesOrphanLookup(t *testing.T) {
+	t.Parallel()
 	s := &HouseholdCustomFieldValuesSync{
 		BaseSyncService: BaseSyncService{
 			ProcessedKeys: make(map[string]bool),

--- a/pocketbase/sync/household_demographics_test.go
+++ b/pocketbase/sync/household_demographics_test.go
@@ -37,6 +37,7 @@ const testAffiliation = "Reform"
 // untrimmed name there would fail admission itself. No untrimmed name exists
 // in this table today; this pins the fix against a future one.
 func TestHouseholdDemographicsLoadFieldDefinitionsTrimsNames(t *testing.T) {
+	t.Parallel()
 	app := newFieldDefsTestApp(t, map[int]string{
 		1: "HH-Family Description ", // trailing space
 		2: "Board ",                 // trailing space, exact-match admission
@@ -80,6 +81,7 @@ func TestHouseholdDemographicsLoadFieldDefinitionsTrimsNames(t *testing.T) {
 
 // TestHouseholdDemographicsSync_Name verifies the service name is correct
 func TestHouseholdDemographicsSync_Name(t *testing.T) {
+	t.Parallel()
 	// The orchestrator registers and looks this service up by name; a rename
 	// that missed one of the two registration paths would strand the job.
 	if got := NewHouseholdDemographicsSync(nil).Name(); got != "household_demographics" {
@@ -89,6 +91,7 @@ func TestHouseholdDemographicsSync_Name(t *testing.T) {
 
 // TestHouseholdDemographicsSync_YearValidation tests year parameter validation
 func TestHouseholdDemographicsSync_YearValidation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		year      int
@@ -120,6 +123,7 @@ func TestHouseholdDemographicsSync_YearValidation(t *testing.T) {
 
 // TestHouseholdDemographicsFieldMapping tests mapping from HH- fields to demographic columns
 func TestHouseholdDemographicsFieldMapping(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		fieldName      string
 		expectedColumn string
@@ -171,6 +175,7 @@ func TestHouseholdDemographicsFieldMapping(t *testing.T) {
 
 // TestHouseholdCustomFieldMapping tests mapping from household custom fields
 func TestHouseholdCustomFieldMapping(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		fieldName      string
 		expectedColumn string
@@ -205,6 +210,7 @@ func TestHouseholdCustomFieldMapping(t *testing.T) {
 
 // TestHouseholdDemographicsBooleanParsing tests parsing of boolean custom field values
 func TestHouseholdDemographicsBooleanParsing(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		value    string
 		expected bool
@@ -249,6 +255,7 @@ func TestHouseholdDemographicsBooleanParsing(t *testing.T) {
 
 // TestIsHHField tests detection of HH- prefixed fields
 func TestIsHHField(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		fieldName string
 		isHHField bool
@@ -370,6 +377,7 @@ func rowKeys(rows map[string]*householdDemographicsRecord) []string {
 // answer was discarded with no log line and no counter. Both answers must now
 // survive, on their own row.
 func TestAggregateKeepsEveryPersonAnswer(t *testing.T) {
+	t.Parallel()
 	s := NewHouseholdDemographicsSync(nil)
 
 	values := []hhCustomValueEntry{
@@ -403,6 +411,7 @@ func TestAggregateKeepsEveryPersonAnswer(t *testing.T) {
 // artifact of whichever index the planner picked; the same input supplied in a
 // different order must produce byte-identical rows.
 func TestAggregateIsOrderIndependent(t *testing.T) {
+	t.Parallel()
 	s := NewHouseholdDemographicsSync(nil)
 
 	values := []hhCustomValueEntry{
@@ -440,6 +449,7 @@ func TestAggregateIsOrderIndependent(t *testing.T) {
 // still order-independent within one camper's answers, and one camper's "No"
 // no longer speaks for a sibling who said "Yes".
 func TestAggregateBooleanArmsStillOR(t *testing.T) {
+	t.Parallel()
 	s := NewHouseholdDemographicsSync(nil)
 
 	// Same camper, two contributing values -- the OR must win either way round.
@@ -478,6 +488,7 @@ func TestAggregateBooleanArmsStillOR(t *testing.T) {
 // camper's row. They land on the person-less row (person_id 0), which coexists
 // with the camper rows for the same household-year.
 func TestAggregateHouseholdValuesGetTheirOwnRow(t *testing.T) {
+	t.Parallel()
 	s := NewHouseholdDemographicsSync(nil)
 
 	personValues := []hhCustomValueEntry{
@@ -542,6 +553,7 @@ func TestAggregateHouseholdValuesGetTheirOwnRow(t *testing.T) {
 // single camper, so a case arm dropped or mis-wired during the re-grain shows
 // up as a wrong column rather than as a missing test.
 func TestAggregateFullRecord(t *testing.T) {
+	t.Parallel()
 	s := NewHouseholdDemographicsSync(nil)
 
 	personValues := []hhCustomValueEntry{
@@ -629,6 +641,7 @@ func TestAggregateFullRecord(t *testing.T) {
 // affiliation cannot be unioned coherently. Each camper's string is stored as
 // given, untouched.
 func TestAggregatePreservesMultiSelectVerbatim(t *testing.T) {
+	t.Parallel()
 	s := NewHouseholdDemographicsSync(nil)
 
 	rows := s.aggregateToRows([]hhCustomValueEntry{
@@ -660,6 +673,7 @@ func TestAggregatePreservesMultiSelectVerbatim(t *testing.T) {
 // key. A key that omits the person collapses siblings back together no matter
 // what the index says.
 func TestMakeCompositeKeyCarriesPerson(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		household string
 		personCM  int
@@ -694,6 +708,7 @@ func TestMakeCompositeKeyCarriesPerson(t *testing.T) {
 // against a fixture carrying the real unique index, so a key that disagrees
 // with either of the other two legs fails here rather than in production.
 func TestUpsertAndOrphanSweepAgreeOnGrain(t *testing.T) {
+	t.Parallel()
 	app, households, persons := newHouseholdDemographicsTestApp(t)
 	ctx := context.Background()
 
@@ -780,6 +795,7 @@ func TestUpsertAndOrphanSweepAgreeOnGrain(t *testing.T) {
 // to be a failed read than a year in which nobody answered anything -- and the
 // sweep is the one step of this sync that a re-run cannot undo.
 func TestDeleteOrphansRefusesToEmptyTheTable(t *testing.T) {
+	t.Parallel()
 	app, households, persons := newHouseholdDemographicsTestApp(t)
 	ctx := context.Background()
 
@@ -843,6 +859,7 @@ func countDemographicsRows(t *testing.T, app core.App) int {
 // The three arms are pinned separately because only the third one distinguishes
 // the new rule from the old one.
 func TestSetColumnIsMustBeUniqueNotFirstWins(t *testing.T) {
+	t.Parallel()
 	t.Run("writes into an empty column", func(t *testing.T) {
 		s := &HouseholdDemographicsSync{}
 		rec := &householdDemographicsRecord{householdPBID: "hh1", personCMID: 11, year: 2026}

--- a/pocketbase/sync/households_test.go
+++ b/pocketbase/sync/households_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestHouseholdsSync_Name(t *testing.T) {
+	t.Parallel()
 	s := &HouseholdsSync{}
 
 	got := s.Name()
@@ -17,6 +18,7 @@ func TestHouseholdsSync_Name(t *testing.T) {
 
 // TestTransformHouseholdToPB tests that all CampMinder household fields are extracted
 func TestTransformHouseholdToPB(t *testing.T) {
+	t.Parallel()
 	s := &HouseholdsSync{}
 
 	// Mock CampMinder API response (based on HouseholdDetails schema in persons.yaml)
@@ -86,6 +88,7 @@ func TestTransformHouseholdToPB(t *testing.T) {
 
 // TestTransformHouseholdHandlesMissingFields tests that nil/missing fields don't cause errors
 func TestTransformHouseholdHandlesMissingFields(t *testing.T) {
+	t.Parallel()
 	s := &HouseholdsSync{}
 
 	// Minimal data with only required fields
@@ -122,6 +125,7 @@ func TestTransformHouseholdHandlesMissingFields(t *testing.T) {
 
 // TestTransformHouseholdRequiredIDError tests that missing ID returns error
 func TestTransformHouseholdRequiredIDError(t *testing.T) {
+	t.Parallel()
 	s := &HouseholdsSync{}
 
 	// Missing ID field
@@ -137,6 +141,7 @@ func TestTransformHouseholdRequiredIDError(t *testing.T) {
 
 // TestTransformHouseholdZeroIDError tests that ID=0 returns error
 func TestTransformHouseholdZeroIDError(t *testing.T) {
+	t.Parallel()
 	s := &HouseholdsSync{}
 
 	// ID=0 (invalid)
@@ -152,6 +157,7 @@ func TestTransformHouseholdZeroIDError(t *testing.T) {
 
 // TestExtractHouseholdsFromPersons tests extraction of unique households from persons data
 func TestExtractHouseholdsFromPersons(t *testing.T) {
+	t.Parallel()
 	s := &HouseholdsSync{}
 
 	// Mock persons data with households
@@ -217,6 +223,7 @@ func TestExtractHouseholdsFromPersons(t *testing.T) {
 
 // TestTransformHouseholdToPB_BillingAddressFields tests extraction of individual billing address fields
 func TestTransformHouseholdToPB_BillingAddressFields(t *testing.T) {
+	t.Parallel()
 	s := &HouseholdsSync{}
 
 	householdData := map[string]any{
@@ -261,6 +268,7 @@ func TestTransformHouseholdToPB_BillingAddressFields(t *testing.T) {
 
 // TestTransformHouseholdToPB_BillingAddressFields_StateFieldFallback tests State field when StateProvince is missing
 func TestTransformHouseholdToPB_BillingAddressFields_StateFieldFallback(t *testing.T) {
+	t.Parallel()
 	s := &HouseholdsSync{}
 
 	householdData := map[string]any{
@@ -288,6 +296,7 @@ func TestTransformHouseholdToPB_BillingAddressFields_StateFieldFallback(t *testi
 
 // TestTransformHouseholdToPB_BillingAddressFields_ZipFieldFallback tests Zip field when PostalCode is missing
 func TestTransformHouseholdToPB_BillingAddressFields_ZipFieldFallback(t *testing.T) {
+	t.Parallel()
 	s := &HouseholdsSync{}
 
 	householdData := map[string]any{
@@ -315,6 +324,7 @@ func TestTransformHouseholdToPB_BillingAddressFields_ZipFieldFallback(t *testing
 
 // TestTransformHouseholdToPB_BillingAddressFields_MissingAddress tests graceful handling when no billing address
 func TestTransformHouseholdToPB_BillingAddressFields_MissingAddress(t *testing.T) {
+	t.Parallel()
 	s := &HouseholdsSync{}
 
 	householdData := map[string]any{
@@ -343,6 +353,7 @@ func TestTransformHouseholdToPB_BillingAddressFields_MissingAddress(t *testing.T
 
 // TestTransformHouseholdToPB_BillingAddressFields_CountryDefault tests country is empty when not specified
 func TestTransformHouseholdToPB_BillingAddressFields_CountryDefault(t *testing.T) {
+	t.Parallel()
 	s := &HouseholdsSync{}
 
 	householdData := map[string]any{

--- a/pocketbase/sync/lodging_alias_resolver_test.go
+++ b/pocketbase/sync/lodging_alias_resolver_test.go
@@ -15,6 +15,7 @@ import (
 // stays unbounded throughout: this test is about the ALIAS STRING resolving at
 // any year, not about one unit id surviving across years.
 func TestAliasResolverUnboundedWindows(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	years := []int{2017, 2022, 2025, 2026, 2030}
 	ridgeAByYear := make(map[int]string, len(years))
@@ -47,6 +48,7 @@ func TestAliasResolverUnboundedWindows(t *testing.T) {
 // in 2025. Resolving either side into the other silently relocates a household
 // across camp, and nothing downstream would notice.
 func TestAliasResolverRespectsRenameWindows(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	// Every building here gets a row in EVERY year the test resolves against,
 	// including the years its own alias window excludes. A rename retires the
@@ -136,6 +138,7 @@ func TestAliasResolverRespectsRenameWindows(t *testing.T) {
 // TestAliasResolverMergeDenotingAlias: 2+ members means the string denotes a
 // merge of that many rooms (spec 3.4). Six seeded aliases are of this shape.
 func TestAliasResolverMergeDenotingAlias(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	tioga1 := addUnit(t, app, "gt-tioga-1", 2025)
 	tioga2 := addUnit(t, app, "gt-tioga-2", 2025)
@@ -166,6 +169,7 @@ func TestAliasResolverMergeDenotingAlias(t *testing.T) {
 // "Tuolumne 7". They must come back unresolved, with the raw string preserved,
 // and must not panic or error.
 func TestAliasResolverUnresolvedIsNotAnError(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	addUnit(t, app, "ridge-a", 2022)
 
@@ -193,6 +197,7 @@ func TestAliasResolverUnresolvedIsNotAnError(t *testing.T) {
 // CampMinder values are hand-entered. Lookup normalises case and outer
 // whitespace; inner spacing stays significant because the seed relies on it.
 func TestAliasResolverToleratesWhitespaceAndCase(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	dsA := addUnit(t, app, "hc-downstairs-a", 2025)
 	addAlias(t, app, "Health Center Downstairs  - Room A", []string{dsA}, 0, 0)
@@ -223,6 +228,7 @@ func TestAliasResolverToleratesWhitespaceAndCase(t *testing.T) {
 // is on (alias_string, valid_from_year), not alias_string alone. Overlapping
 // windows are a data problem for staff, not something to resolve arbitrarily.
 func TestAliasResolverFlagsOverlappingWindows(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	a := addUnit(t, app, "ridge-a", 2025)
 	b := addUnit(t, app, "ridge-b", 2025)
@@ -249,6 +255,7 @@ func TestAliasResolverFlagsOverlappingWindows(t *testing.T) {
 // UnitIDs straight into a placement's relation, so resolving 2027 must not
 // hand back 2026's ids.
 func TestResolveReturnsTheRequestedYearsUnitIDs(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	id2026 := addUnit(t, app, "test-unit-a", 2026)
 	id2027 := addUnit(t, app, "test-unit-a", 2027)
@@ -276,6 +283,7 @@ func TestResolveReturnsTheRequestedYearsUnitIDs(t *testing.T) {
 // alias is unresolved. A partial member set would silently shrink a family's
 // rooms, which is worse than a name that does not resolve.
 func TestResolveIsUnresolvedWhenAMemberIsMissingThatYear(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	a2026 := addUnit(t, app, "test-unit-a", 2026)
 	b2026 := addUnit(t, app, "test-unit-b", 2026)
@@ -308,6 +316,7 @@ func TestResolveIsUnresolvedWhenAMemberIsMissingThatYear(t *testing.T) {
 // RelationField.ValidateValue cannot resolve; skipping the dangling member
 // here means only real ids ever reach that write, and the failure vanishes.
 func TestResolveIsUnresolvedWhenAMemberIsDangling(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	a2027 := addUnit(t, app, "test-unit-a", 2027)
 	addAliasWithDanglingMember(t, app, "Test Pair", []string{a2027, "missingunit0001"}, 0, 0)

--- a/pocketbase/sync/lodging_assignments_sync_test.go
+++ b/pocketbase/sync/lodging_assignments_sync_test.go
@@ -32,6 +32,7 @@ func seedOneWeekendHousehold(t *testing.T, app core.App) (sessionID, unitID stri
 }
 
 func TestLodgingAssignmentsSyncName(t *testing.T) {
+	t.Parallel()
 	s := NewLodgingAssignmentsSync(nil)
 	if s.Name() != serviceNameLodgingAssignments {
 		t.Errorf("Name() = %q, want %q", s.Name(), serviceNameLodgingAssignments)
@@ -40,6 +41,7 @@ func TestLodgingAssignmentsSyncName(t *testing.T) {
 
 // TestLodgingAssignmentsSyncHouseholdGrain: the whole happy path end to end.
 func TestLodgingAssignmentsSyncHouseholdGrain(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	sessionID, unitID := seedOneWeekendHousehold(t, app)
 
@@ -116,6 +118,7 @@ func TestLodgingAssignmentsSyncHouseholdGrain(t *testing.T) {
 // "units" relation must hold the 2027 row, never the 2026 one the alias
 // happens to store.
 func TestLodgingAssignmentsSyncWritesTheSyncedYearsUnitIDs(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	id2026 := addUnit(t, app, "test-unit-a", 2026)
 	id2027 := addUnit(t, app, "test-unit-a", 2027)
@@ -154,6 +157,7 @@ func TestLodgingAssignmentsSyncWritesTheSyncedYearsUnitIDs(t *testing.T) {
 // TestLodgingAssignmentsSyncIsIdempotent: a second run must not duplicate the
 // assignment or append a spurious history row.
 func TestLodgingAssignmentsSyncIsIdempotent(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	seedOneWeekendHousehold(t, app)
 
@@ -179,6 +183,7 @@ func TestLodgingAssignmentsSyncIsIdempotent(t *testing.T) {
 // 3.6 relies on to recover multi-weekend households whose earlier assignment
 // CampMinder overwrote.
 func TestLodgingAssignmentsSyncAppendsHistoryOnChange(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	seedOneWeekendHousehold(t, app)
 	ridgeB := addUnit(t, app, "ridge-b", 2025)
@@ -230,6 +235,7 @@ func TestLodgingAssignmentsSyncAppendsHistoryOnChange(t *testing.T) {
 // TestLodgingAssignmentsSyncRespectsStaffTouched: a placement a human moved on
 // the board is not reverted by the next CampMinder sync.
 func TestLodgingAssignmentsSyncRespectsStaffTouched(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	seedOneWeekendHousehold(t, app)
 	ridgeB := addUnit(t, app, "ridge-b", 2025)
@@ -267,6 +273,7 @@ func TestLodgingAssignmentsSyncRespectsStaffTouched(t *testing.T) {
 // -- one of four such strings in the real 2022/2023 data. It must become a work
 // queue item and must not be dropped, and must not stop the run.
 func TestLodgingAssignmentsSyncQueuesUnresolvedAlias(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
@@ -314,6 +321,7 @@ func TestLodgingAssignmentsSyncQueuesUnresolvedAlias(t *testing.T) {
 // attend more than one weekend against one CampMinder value. Spec 3.6 says flag
 // them for manual entry.
 func TestLodgingAssignmentsSyncQueuesAmbiguousSession(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	fc1 := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
@@ -357,6 +365,7 @@ func TestLodgingAssignmentsSyncQueuesAmbiguousSession(t *testing.T) {
 // so a two-room alias lands as one assignment naming both -- see placementFor.
 // A merged slot is the alias's own member set, not a row pointing at it.
 func TestIngestWritesAMultiRoomPlacementAsOneRow(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
@@ -404,6 +413,7 @@ const testAdultSessionEnd = "2025-10-19 07:00:00.000Z"
 // TestLodgingAssignmentsSyncPersonGrain: adult weekends enroll real persons, so
 // the placement keys on person_cm_id and household_cm_id stays 0.
 func TestLodgingAssignmentsSyncPersonGrain(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	womens := addSession(t, app, cmIDWomensWeekend, "Women's Weekend", "adult",
 		testAdultSessionStart, testAdultSessionEnd, 2025)
@@ -447,6 +457,7 @@ func TestLodgingAssignmentsSyncPersonGrain(t *testing.T) {
 // `> 0`, every person row (household_cm_id = 0) would have collided and only
 // ONE could exist.
 func TestLodgingAssignmentsSyncPersonGrainManyPerSession(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	womens := addSession(t, app, cmIDWomensWeekend, "Women's Weekend", "adult",
 		testAdultSessionStart, testAdultSessionEnd, 2025)
@@ -477,6 +488,7 @@ func TestLodgingAssignmentsSyncPersonGrainManyPerSession(t *testing.T) {
 // Reportable Family Camp Cabin values belong to persons with no active
 // enrollment. Queue them; never drop them.
 func TestLodgingAssignmentsSyncPersonGrainNoEnrolment(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	addSession(t, app, cmIDWomensWeekend, "Women's Weekend", "adult",
 		testAdultSessionStart, testAdultSessionEnd, 2025)
@@ -513,6 +525,7 @@ func TestLodgingAssignmentsSyncPersonGrainNoEnrolment(t *testing.T) {
 // (docs/architecture/sync-layer.md's own "Common Mistakes" table). Each miss is
 // silent -- the job simply never runs, or the GUI shows "idle" forever.
 func TestLodgingAssignmentsRegisteredEverywhere(t *testing.T) {
+	t.Parallel()
 	var inMeta bool
 	for _, m := range syncJobMeta {
 		if m.ID == serviceNameLodgingAssignments {
@@ -552,6 +565,7 @@ func TestLodgingAssignmentsRegisteredEverywhere(t *testing.T) {
 // the pass-through: still just the alias's own set, which is why it needs no
 // App on the struct above.
 func TestPlacementForPassesASingleRoomStraightThrough(t *testing.T) {
+	t.Parallel()
 	s := &LodgingAssignmentsSync{}
 	res := AliasResolution{Raw: "Room 1", UnitIDs: []string{"r1"}, Resolved: true}
 
@@ -564,6 +578,7 @@ func TestPlacementForPassesASingleRoomStraightThrough(t *testing.T) {
 // TestPlacementForPassesTheAliasSetThrough pins the collapse: a multi-room
 // alias no longer materializes a row, it simply IS the placement.
 func TestPlacementForPassesTheAliasSetThrough(t *testing.T) {
+	t.Parallel()
 	s := &LodgingAssignmentsSync{}
 	got := s.placementFor(AliasResolution{UnitIDs: []string{"u1", "u2"}, Resolved: true})
 	if len(got) != 2 || got[0] != "u1" || got[1] != "u2" {
@@ -577,6 +592,7 @@ func TestPlacementForPassesTheAliasSetThrough(t *testing.T) {
 // placed just before upsertAssignment would leave rows behind in that table
 // even though it never mentions it.
 func TestLodgingAssignmentsSyncDryRunWritesNothing(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
@@ -622,6 +638,7 @@ func TestLodgingAssignmentsSyncDryRunWritesNothing(t *testing.T) {
 // cabin must still have the new count persisted. The label is the MOVE
 // detector; it is not the change detector.
 func TestLodgingAssignmentsSyncUpdatesPartySizeInSameCabin(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	seedOneWeekendHousehold(t, app)
 
@@ -671,6 +688,7 @@ func TestLodgingAssignmentsSyncUpdatesPartySizeInSameCabin(t *testing.T) {
 // observation entirely -- and because the value is counted before the skip, even
 // the field_zero_values warning stays quiet.
 func TestLodgingAssignmentsSyncQueuesUnknownHousehold(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
@@ -703,6 +721,7 @@ func TestLodgingAssignmentsSyncQueuesUnknownHousehold(t *testing.T) {
 // TestLodgingAssignmentsSyncQueuesUnknownPerson: the person-grain twin of
 // TestLodgingAssignmentsSyncQueuesUnknownHousehold.
 func TestLodgingAssignmentsSyncQueuesUnknownPerson(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	addSession(t, app, cmIDWomensWeekend, "Women's Weekend", "adult",
 		testAdultSessionStart, testAdultSessionEnd, 2025)
@@ -740,6 +759,7 @@ func TestLodgingAssignmentsSyncQueuesUnknownPerson(t *testing.T) {
 // read as a move on every run: a re-save and a history row for a household
 // that never left its cabin.
 func TestLodgingAssignmentsSyncMergeLabelIgnoresMemberOrder(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
@@ -811,6 +831,7 @@ func TestLodgingAssignmentsSyncMergeLabelIgnoresMemberOrder(t *testing.T) {
 // audit trail is a record of MOVES, and dropping an id the database was
 // already entitled to hold is not one.
 func TestLodgingAssignmentsSyncLabelDropsUnresolvableUnits(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
@@ -1232,6 +1253,7 @@ func TestLodgingAssignmentsSyncWritesHistoryOnOrphanDelete(t *testing.T) {
 // production the stale row is gone and the placement's relation dangles; here
 // it stands in for the record the placement was written against.
 func TestFindAssignmentMatchesOnTheCampMinderSessionID(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	sessOld := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
@@ -1266,6 +1288,7 @@ func TestFindAssignmentMatchesOnTheCampMinderSessionID(t *testing.T) {
 // not widen the lookup. Two weekends in the same year hold a placement for the
 // same household, and asking for one must never return the other's row.
 func TestFindAssignmentStillSeparatesWeekends(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	sessA := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)

--- a/pocketbase/sync/lodging_fields_test.go
+++ b/pocketbase/sync/lodging_fields_test.go
@@ -10,6 +10,7 @@ import (
 // lodging_field_mappings has a UNIQUE index on field_cm_id that would reject the
 // second row at sync time rather than at review time.
 func TestLodgingSourceFieldsAreUnique(t *testing.T) {
+	t.Parallel()
 	seenCMID := map[int]string{}
 	for _, f := range lodgingSourceFields {
 		if prev, dup := seenCMID[f.CMID]; dup {
@@ -35,6 +36,7 @@ func TestLodgingSourceFieldsAreUnique(t *testing.T) {
 // -- so a request field appearing in that slice would file a work-queue issue
 // every single run, for a field that is being read correctly by somebody else.
 func TestLodgingRequestFieldsAreWellFormed(t *testing.T) {
+	t.Parallel()
 	assignment := map[int]string{}
 	for _, f := range lodgingSourceFields {
 		assignment[f.CMID] = f.Name
@@ -67,6 +69,7 @@ func TestLodgingRequestFieldsAreWellFormed(t *testing.T) {
 // display name. Resolving the name back from the cm_id is what stops a rename
 // from silently disconnecting an answer from its column.
 func TestLodgingRequestFieldNamesResolveThroughCMID(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 
 	renamed := addFieldDef(t, app, cmIDShareCabinsRegistration, "FC Cabin Sharing 2027")
@@ -93,6 +96,7 @@ func TestLodgingRequestFieldNamesResolveThroughCMID(t *testing.T) {
 // display name (spec 4.4). The fixture renames a field to something the name
 // would never match; the mapping must still be found.
 func TestLodgingFieldDefIDsMapsByCMID(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 
 	cabinDefID := addFieldDef(t, app, cmIDFamilyCampCabin, "Renamed By Staff In 2027")
@@ -119,6 +123,7 @@ func TestLodgingFieldDefIDsMapsByCMID(t *testing.T) {
 // a mapping stays active until a person turns it off, and once off the sync must
 // stop reading that field.
 func TestLodgingFieldDefIDsHonoursDisabledMapping(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	cabinDefID := addFieldDef(t, app, cmIDFamilyCampCabin, "Family Camp Cabin")
 
@@ -141,6 +146,7 @@ func TestLodgingFieldDefIDsHonoursDisabledMapping(t *testing.T) {
 // half of spec 4.4: "Retirement is never auto-inferred. A field with zero values
 // this year may simply have a form that hasn't been sent yet."
 func TestUpsertFieldMappingStatusIsIdempotentAndNeverAutoDisables(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	addFieldDef(t, app, cmIDFamilyCampCabin, "Family Camp Cabin")
 
@@ -182,6 +188,7 @@ func TestUpsertFieldMappingStatusIsIdempotentAndNeverAutoDisables(t *testing.T) 
 // wrong season -- "0 values in 2024" where staff expect "0 values in 2026, 171
 // in 2025". last_seen_* means MOST RECENT, so an older run must leave it alone.
 func TestUpsertFieldMappingStatusDoesNotRegressOnOlderYearBackfill(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	addFieldDef(t, app, cmIDFamilyCampCabin, "Family Camp Cabin")
 
@@ -224,6 +231,7 @@ func TestUpsertFieldMappingStatusDoesNotRegressOnOlderYearBackfill(t *testing.T)
 // year must still move the counters, or the warning freezes at whatever season
 // happened to run first.
 func TestUpsertFieldMappingStatusAdvancesOnNewerYear(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	addFieldDef(t, app, cmIDFamilyCampCabin, "Family Camp Cabin")
 

--- a/pocketbase/sync/lodging_grain_test.go
+++ b/pocketbase/sync/lodging_grain_test.go
@@ -11,6 +11,7 @@ import (
 // numbers, so all three illegal shapes save with a 200. This function is the
 // only place the invariant exists.
 func TestValidateAssignmentGrain(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		in   AssignmentGrain
@@ -58,6 +59,7 @@ func TestValidateAssignmentGrain(t *testing.T) {
 }
 
 func TestValidateAssignmentGrainAcceptsMultipleUnits(t *testing.T) {
+	t.Parallel()
 	err := ValidateAssignmentGrain(AssignmentGrain{
 		HouseholdCMID: 1001, UnitIDs: []string{"u1", "u2"},
 	})
@@ -67,6 +69,7 @@ func TestValidateAssignmentGrainAcceptsMultipleUnits(t *testing.T) {
 }
 
 func TestValidateAssignmentGrainRejectsEmptyUnits(t *testing.T) {
+	t.Parallel()
 	err := ValidateAssignmentGrain(AssignmentGrain{HouseholdCMID: 1001, UnitIDs: nil})
 	if !errors.Is(err, ErrGrainNoPlacement) {
 		t.Fatalf("want ErrGrainNoPlacement, got %v", err)
@@ -78,6 +81,7 @@ func TestValidateAssignmentGrainRejectsEmptyUnits(t *testing.T) {
 // these, this test fails and the guard can be reconsidered -- but until then the
 // invariant has no database backing.
 func TestAssignmentGrainIllegalStatesReallySaveInPocketBase(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)

--- a/pocketbase/sync/lodging_issues_test.go
+++ b/pocketbase/sync/lodging_issues_test.go
@@ -14,6 +14,7 @@ var testNow = time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
 // golangci-lint runs with `unused` enabled and would otherwise flag the ones no
 // code path has reached yet.
 func TestIssueKindsMatchTheMigration(t *testing.T) {
+	t.Parallel()
 	want := []string{
 		"unresolved_alias",
 		"ambiguous_alias",
@@ -40,6 +41,7 @@ func TestIssueKindsMatchTheMigration(t *testing.T) {
 // row. That is ONE thing for staff to fix, so it must be one queue item with an
 // occurrence count -- not five rows to wade through.
 func TestIssueRecorderCollapsesRepeats(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	r := NewIssueRecorder(app, 2022)
 
@@ -86,6 +88,7 @@ func TestIssueRecorderCollapsesRepeats(t *testing.T) {
 // TestIssueRecorderFlushIsIdempotent: re-running the sync must not double the
 // counts or add rows. occurrences is SET to what this run observed, not added to.
 func TestIssueRecorderFlushIsIdempotent(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 
 	for pass := 0; pass < 2; pass++ {
@@ -126,6 +129,7 @@ func TestIssueRecorderFlushIsIdempotent(t *testing.T) {
 // per-household problem, so two households must produce two rows even though the
 // raw value and source field are identical.
 func TestIssueRecorderKeepsPerHouseholdIssuesSeparate(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	r := NewIssueRecorder(app, 2025)
 
@@ -151,6 +155,7 @@ func TestIssueRecorderKeepsPerHouseholdIssuesSeparate(t *testing.T) {
 // re-run whose last_updated stops parsing produces no suggestion; writing that
 // emptiness over an open queue item takes its one-click confirmation with it.
 func TestIssueRecorderFlushKeepsAnEarlierSuggestion(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	sess := addSession(t, app, 1309514, "Family Camp 1", "family",
 		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
@@ -192,6 +197,7 @@ func TestIssueRecorderFlushKeepsAnEarlierSuggestion(t *testing.T) {
 // filter built by string concatenation would be a syntax error here, which is
 // exactly the class of bug that made Plan 1's alias verifier unable to pass.
 func TestIssueRecorderHandlesApostrophes(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	r := NewIssueRecorder(app, 2024)
 	r.Record(Issue{Kind: issueUnresolvedAlias, RawValue: "Golden Triangle - Doctor's House",

--- a/pocketbase/sync/lodging_phi_test.go
+++ b/pocketbase/sync/lodging_phi_test.go
@@ -37,6 +37,7 @@ var phiColumns = []string{
 
 // TestPHICollectionsAreNotExported is the assertion spec 5.4 asks for.
 func TestPHICollectionsAreNotExported(t *testing.T) {
+	t.Parallel()
 	configs := append(GetReadableYearExports(), GetReadableGlobalExports()...)
 
 	// Without this the test passes by looking at nothing: every assertion below
@@ -87,6 +88,7 @@ func TestPHICollectionsAreNotExported(t *testing.T) {
 // so the prefix scan below covers every lodging collection including ones not
 // yet written, and the manifest half is live rather than inert.
 func TestLodgingCollectionsAreNeverExported(t *testing.T) {
+	t.Parallel()
 	exported := map[string]string{}
 	for _, cfg := range GetReadableYearExports() {
 		exported[cfg.Collection] = "GetReadableYearExports"
@@ -130,6 +132,7 @@ func TestLodgingCollectionsAreNeverExported(t *testing.T) {
 // Kept as a separate test rather than folded into the merge from #1880: that one
 // is scoped to serviceNameLodgingAssignments and would not notice this.
 func TestFamilyCampDerivedManifestIsNotAnExportList(t *testing.T) {
+	t.Parallel()
 	exported := map[string]string{}
 	for _, cfg := range GetReadableYearExports() {
 		exported[cfg.Collection] = "GetReadableYearExports"
@@ -173,6 +176,7 @@ func TestFamilyCampDerivedManifestIsNotAnExportList(t *testing.T) {
 // stream, which on this deployment goes to the container log and from there
 // wherever logs go.
 func TestPHINarrativeIsNeverLogged(t *testing.T) {
+	t.Parallel()
 	for _, file := range []string{"family_camp_derived.go", "lodging_requests.go"} {
 		for _, v := range phiLogViolations(readSourceFile(t, file)) {
 			t.Errorf("%s: %s", file, v)
@@ -239,6 +243,7 @@ func parenDepth(s string) int {
 // covers is not hypothetical: the line-anchored version passed on every input
 // below except the first.
 func TestPHILogScannerCatchesWrappedCalls(t *testing.T) {
+	t.Parallel()
 	cases := map[string]bool{
 		`slog.Info("x", "v", med.bathroomExplain)`:                                      true,
 		"slog.Info(\"x\",\n\t\"v\", med.bathroomExplain,\n)":                            true,

--- a/pocketbase/sync/lodging_replay_test.go
+++ b/pocketbase/sync/lodging_replay_test.go
@@ -21,6 +21,7 @@ func seedIssue(t *testing.T, app core.App, values map[string]any) string {
 // would re-run the same failing resolution and bump occurrences, making the
 // queue look busier while nothing was repaired.
 func TestReplayIssueRefusesAnUnresolvedRow(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	id := seedIssue(t, app, map[string]any{
 		"kind":            issueWriteFailed,
@@ -39,6 +40,7 @@ func TestReplayIssueRefusesAnUnresolvedRow(t *testing.T) {
 // The grain guard: a row carrying neither a household nor a person cannot be
 // replayed, because ingestValue has nothing to attribute the placement to.
 func TestReplayIssueRefusesARowWithNoParty(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	id := seedIssue(t, app, map[string]any{
 		"kind":            issueWriteFailed,
@@ -58,6 +60,7 @@ func TestReplayIssueRefusesARowWithNoParty(t *testing.T) {
 // scoped to one season, and year 0 would silently build empty ones and then
 // queue a no_session item -- a repair that reports itself as a fresh problem.
 func TestReplayIssueRefusesARowWithNoYear(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	id := seedIssue(t, app, map[string]any{
 		"kind":            issueWriteFailed,
@@ -77,6 +80,7 @@ func TestReplayIssueRefusesARowWithNoYear(t *testing.T) {
 // per run -- resolver, unit tree, party-size indexes, session windows -- is
 // rebuilt here for one household.
 func TestReplayIssuePlacesAHouseholdWithoutASync(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	sessionID, unitID := seedOneWeekendHousehold(t, app)
 
@@ -133,6 +137,7 @@ func TestReplayIssuePlacesAHouseholdWithoutASync(t *testing.T) {
 // asked for family weekends would find no candidate for an adult-weekend person
 // and queue a no_session item -- the repair reporting itself as a new problem.
 func TestReplayIssuePlacesAPersonOnAnAdultWeekend(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	womens := addSession(t, app, cmIDWomensWeekend, "Women's Weekend", "adult",
 		testAdultSessionStart, testAdultSessionEnd, 2025)
@@ -181,6 +186,7 @@ func TestReplayIssuePlacesAPersonOnAnAdultWeekend(t *testing.T) {
 // docs/architecture/lodging-occupancy.md -- so this covers the mechanics:
 // resolver, unit tree and placementFor all reached from a replay.
 func TestReplayIssuePlacesAMultiRoomAliasAsOneRow(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
@@ -230,6 +236,7 @@ func TestReplayIssuePlacesAMultiRoomAliasAsOneRow(t *testing.T) {
 // conditional on failure; a blanket un-tick would bounce every repaired item
 // straight back into the queue.
 func TestReplayIssueLeavesAPlacedRowResolved(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	seedOneWeekendHousehold(t, app)
 
@@ -295,6 +302,7 @@ func seedThreeWeekendHousehold(
 // correct guess with the final weekend of the year. This asserts replay
 // reproduces the sync's answer: the weekend the real last_updated points at.
 func TestReplayIssueKeepsTheSuggestionTheSyncWouldHaveMade(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	// Edited between the first and second weekends, so the sync suggests the
 	// second. Now would suggest the third; a zero timestamp would suggest none.
@@ -336,6 +344,7 @@ func TestReplayIssueKeepsTheSuggestionTheSyncWouldHaveMade(t *testing.T) {
 // rather than blanking it, which is the same contract a re-run of the sync has
 // when last_updated stops parsing.
 func TestReplayIssuePreservesTheSuggestionWhenTheObservationIsGone(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	first, _, _ := seedThreeWeekendHousehold(t, app,
 		"Ridge A", "2025-06-10T09:00:00.0000000+00:00")
@@ -375,6 +384,7 @@ func TestReplayIssuePreservesTheSuggestionWhenTheObservationIsGone(t *testing.T)
 // row carries the remaining work, and Placed still tells the caller the click
 // did not finish the job.
 func TestReplayIssueTicksARowWhoseBlockerIsGoneAndOpensTheNewOne(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	fc1 := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
@@ -462,6 +472,7 @@ func TestReplayIssueTicksARowWhoseBlockerIsGoneAndOpensTheNewOne(t *testing.T) {
 // all, so the party-less fan-out that will replay those can. This pins the rule
 // directly rather than waiting for that caller to discover it.
 func TestFindExistingMatchesOnTheWholeDedupTuple(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	stored := Issue{
 		Kind: issueWriteFailed, RawValue: "Ridge 1and2",
@@ -531,6 +542,7 @@ func TestFindExistingMatchesOnTheWholeDedupTuple(t *testing.T) {
 // no placement, no open row anywhere, and a nil error: the work item vanishes,
 // which is the invariant this whole wave exists to establish.
 func TestReplayIssueReopensAnotherTickedRowItRehit(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	fc1 := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
@@ -669,6 +681,7 @@ func seedFanOutWithOneAmbiguousHousehold(
 // placements, so without an error a caller cannot tell "there was nothing to
 // place" from "this row was never replayable in the first place".
 func TestReplayPartylessIssueRefusesRowsItCannotFanOut(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 
 	cases := []struct {
@@ -757,6 +770,7 @@ func TestReplayPartylessIssueRefusesRowsItCannotFanOut(t *testing.T) {
 // stopping the replay. Reporting a quiet zero would tick the row on the
 // strength of a mapping nobody restored.
 func TestReplayPartylessIssueRefusesARowWhoseSourceFieldIsDisabled(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	seedTwoHouseholdsSharingACabinString(t, app, "Ridge Cabin 9", 2026)
 	addAlias(t, app, "Ridge Cabin 9", []string{addUnit(t, app, "ridge-9", 2026)}, 0, 0)
@@ -790,6 +804,7 @@ func TestReplayPartylessIssueRefusesARowWhoseSourceFieldIsDisabled(t *testing.T)
 // to one placement per household that wrote the string. This is the assertion
 // that fails if the function silently does nothing.
 func TestReplayPartylessIssueFansOutToEveryPartyThatWroteTheString(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	sessionID, parties := seedTwoHouseholdsSharingACabinString(t, app, "Ridge Cabin 9", 2026)
 	// The staff repair this replay follows: the string now has an alias.
@@ -852,6 +867,7 @@ func TestReplayPartylessIssueFansOutToEveryPartyThatWroteTheString(t *testing.T)
 // only the first party would silently rewrite a 2-household string as a
 // 1-household one.
 func TestReplayPartylessIssueReopensARowWhoseStringStillDoesNotResolve(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	seedTwoHouseholdsSharingACabinString(t, app, "Nowhere Cabin", 2026)
 	// A REAL mapping exists -- resolved_alias is set, as production always
@@ -909,6 +925,7 @@ func TestReplayPartylessIssueReopensARowWhoseStringStillDoesNotResolve(t *testin
 // cabin name" -- and a fan-out that re-fails identically for every party who
 // wrote the string must not undo that decision.
 func TestReplayPartylessIssueDoesNotReopenAnIgnoredRow(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	seedTwoHouseholdsSharingACabinString(t, app, "Not A Cabin", 2026)
 	// No alias, and none is coming: staff said this string is not a cabin
@@ -945,6 +962,7 @@ func TestReplayPartylessIssueDoesNotReopenAnIgnoredRow(t *testing.T) {
 // could not tell that collision apart from a genuine re-observation of the
 // row it was meant to touch.
 func TestReopenRecordedDoesNotReopenAnUnrelatedIgnoredRowDuringAPartyScopedReplay(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	_, parties := seedTwoHouseholdsSharingACabinString(t, app, "Not A Cabin", 2026)
 	// Nobody ever mapped "Not A Cabin" -- staff ignored it once, and it is
@@ -991,6 +1009,7 @@ func TestReopenRecordedDoesNotReopenAnUnrelatedIgnoredRowDuringAPartyScopedRepla
 // would report "placed 2" for a click that wrote one assignment and left a
 // household in the queue.
 func TestReplayPartylessIssueCountsOnlyThePartiesItPlaced(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	_, _, _, parties := seedFanOutWithOneAmbiguousHousehold(t, app, "Ridge Cabin 9")
 	addAlias(t, app, "Ridge Cabin 9", []string{addUnit(t, app, "ridge-9", 2025)}, 0, 0)
@@ -1059,6 +1078,7 @@ func TestReplayPartylessIssueCountsOnlyThePartiesItPlaced(t *testing.T) {
 // is the case that does discriminate, and
 // TestFindExistingMatchesOnTheWholeDedupTuple pins the lookup itself.
 func TestReplayPartylessIssueLeavesAnotherHouseholdsTickedRowAlone(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	_, _, _, parties := seedFanOutWithOneAmbiguousHousehold(t, app, "Ridge Cabin 9")
 	addAlias(t, app, "Ridge Cabin 9", []string{addUnit(t, app, "ridge-9", 2025)}, 0, 0)
@@ -1123,6 +1143,7 @@ func TestReplayPartylessIssueLeavesAnotherHouseholdsTickedRowAlone(t *testing.T)
 // holds whichever of the two the scan returns first, which is what makes this
 // order-independent where a stranger row is not.
 func TestReplayPartylessIssueReopensEveryBlockedPartysRow(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	_, parties := seedTwoHouseholdsSharingACabinString(t, app, "Ridge Cabin 9", 2025)
 	// The string resolves, so the alias row's own blocker is genuinely gone and
@@ -1198,6 +1219,7 @@ func TestReplayPartylessIssueReopensEveryBlockedPartysRow(t *testing.T) {
 // the final weekend of the year. Flush overwrites a non-empty suggestion, so
 // the damage lands in the database.
 func TestReplayPartylessIssueAttributesWithTheObservationTimestamp(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	_, second, third, _ := seedFanOutWithOneAmbiguousHousehold(t, app, "Ridge Cabin 9")
 	addAlias(t, app, "Ridge Cabin 9", []string{addUnit(t, app, "ridge-9", 2025)}, 0, 0)
@@ -1238,6 +1260,7 @@ func TestReplayPartylessIssueAttributesWithTheObservationTimestamp(t *testing.T)
 // always read household_custom_values would find nobody here and report a
 // successful replay of nothing.
 func TestReplayPartylessIssueFansOutAcrossThePersonGrain(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	womens := addSession(t, app, cmIDWomensWeekend, "Women's Weekend", "adult",
 		testAdultSessionStart, testAdultSessionEnd, 2025)

--- a/pocketbase/sync/lodging_requests_test.go
+++ b/pocketbase/sync/lodging_requests_test.go
@@ -22,6 +22,7 @@ const (
 // sharing-sentence guard, because that is the only thing separating a gate
 // answer from a mode option that happens to start with "No".
 func TestNormalizeShareGate(t *testing.T) {
+	t.Parallel()
 	cases := map[string]string{
 		"No, we would prefer not to share a camper cabin.": gateNoShare,
 		"Maybe, I am open to sharing a large camper cabin if a specific family that I know " +
@@ -51,6 +52,7 @@ func TestNormalizeShareGate(t *testing.T) {
 // requests" on it overwrote a genuine "Yes, I would like to share" with a hard
 // decline. 269 of 2025's rows carry that exact value.
 func TestCollapseNoRequestsDoesNotVetoTheGate(t *testing.T) {
+	t.Parallel()
 	const yesShare = "Yes, I would like to share a large camper cabin with a family that I " +
 		"request or with a family with similarly aged kid(s) that I can meet at Camp."
 	registration := time.Date(2025, 1, 10, 0, 0, 0, 0, time.UTC)
@@ -93,6 +95,7 @@ func TestCollapseNoRequestsDoesNotVetoTheGate(t *testing.T) {
 // observed "No requests + real request" combinations exist at all (design
 // doc §10).
 func TestCollapseSiblingDisagreementSurvivesANoRequestsSibling(t *testing.T) {
+	t.Parallel()
 	ts := time.Date(2025, 4, 21, 17, 51, 0, 0, time.UTC)
 	const withNamed = "Share a cabin WITH a specific family that I know (please include names " +
 		"below and ensure that the request is mutual)."
@@ -121,6 +124,7 @@ func TestCollapseSiblingDisagreementSurvivesANoRequestsSibling(t *testing.T) {
 // unrelated question was getting a fresh-looking request timestamp beside an
 // empty gate and empty text.
 func TestCollapseDoesNotStampUnrelatedFields(t *testing.T) {
+	t.Parallel()
 	ts := time.Date(2025, 6, 2, 11, 0, 0, 0, time.UTC)
 
 	got := CollapseToHouseholdGrain([]PersonRequestValue{
@@ -149,6 +153,7 @@ func TestCollapseDoesNotStampUnrelatedFields(t *testing.T) {
 // and WITH are different edge types. Note the sixth case: "No requests"
 // co-occurs with a real request in six rows, so it must not veto.
 func TestParseSharedCabinModes(t *testing.T) {
+	t.Parallel()
 	const near = "House my family NEAR a specific family that I know (please include names below)"
 	const with = "Share a cabin WITH a specific family that I know (please include names below " +
 		"and ensure that the request is mutual)."
@@ -203,6 +208,7 @@ func TestParseSharedCabinModes(t *testing.T) {
 // to survive the person-to-household collapse like the other two modes, or the
 // staff-matchable pool is empty on the board no matter what families answered.
 func TestCollapseCarriesSimilarAgesToHouseholdGrain(t *testing.T) {
+	t.Parallel()
 	ts := time.Date(2025, 4, 21, 17, 51, 0, 0, time.UTC)
 	const withOpen = "Share a cabin WITH a family with similarly aged kid(s) that I can meet at " +
 		"Camp (we will make this happen if we have others interested as well)."
@@ -228,6 +234,7 @@ func TestCollapseCarriesSimilarAgesToHouseholdGrain(t *testing.T) {
 // the SAME text twice. Without collapsing first, every request is
 // double-counted.
 func TestCollapseToHouseholdGrainDedupes(t *testing.T) {
+	t.Parallel()
 	ts := time.Date(2025, 4, 21, 17, 51, 0, 0, time.UTC)
 	// Emma and Liam Garcia are siblings; the parent answered once and CampMinder
 	// wrote the answer onto both children's records.
@@ -248,6 +255,7 @@ func TestCollapseToHouseholdGrainDedupes(t *testing.T) {
 
 // TestCollapseToHouseholdGrainThreeChildren: observed at n=3 too.
 func TestCollapseToHouseholdGrainThreeChildren(t *testing.T) {
+	t.Parallel()
 	ts := time.Date(2025, 4, 21, 17, 51, 0, 0, time.UTC)
 	var values []PersonRequestValue
 	for i := 0; i < 3; i++ {
@@ -267,6 +275,7 @@ func TestCollapseToHouseholdGrainThreeChildren(t *testing.T) {
 // genuinely DIFFERENT answers is not a duplicate. Both survive, joined, because
 // dropping one would lose a real request.
 func TestCollapseKeepsDistinctTextFromDifferentChildren(t *testing.T) {
+	t.Parallel()
 	ts := time.Date(2025, 4, 21, 17, 51, 0, 0, time.UTC)
 	values := []PersonRequestValue{
 		{HouseholdKey: hhA, FieldName: "Shared-request", Value: "the Johnson family", LastUpdated: ts},
@@ -286,6 +295,7 @@ func TestCollapseKeepsDistinctTextFromDifferentChildren(t *testing.T) {
 // answers disagree, take the form's -- it is updated more often. Resolve by
 // comparing last_updated, not by field name precedence alone."
 func TestCollapsePrefersMoreRecentGate(t *testing.T) {
+	t.Parallel()
 	older := time.Date(2025, 1, 10, 0, 0, 0, 0, time.UTC)
 	newer := time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC)
 
@@ -319,6 +329,7 @@ func TestCollapsePrefersMoreRecentGate(t *testing.T) {
 // registration answers disagree", and a rule with no test is a rule that breaks
 // silently the first time the form is rewritten.
 func TestCollapseFormWinsOnTimestampTie(t *testing.T) {
+	t.Parallel()
 	ts := time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC)
 	values := []PersonRequestValue{
 		{HouseholdKey: hhA, FieldName: "FAM CAMP-Share Cabins",
@@ -340,6 +351,7 @@ func TestCollapseFormWinsOnTimestampTie(t *testing.T) {
 // as the field auto-inferred retirement would have dropped -- 0 values in 2023,
 // 112 in 2024, 171 in 2025, 0 in 2026, and still live.
 func TestCollapseKeepsShareCommentsActive(t *testing.T) {
+	t.Parallel()
 	ts := time.Date(2025, 4, 21, 0, 0, 0, 0, time.UTC)
 	values := []PersonRequestValue{
 		{HouseholdKey: hhA, FieldName: "FAM CAMP-Share Comments",
@@ -353,6 +365,7 @@ func TestCollapseKeepsShareCommentsActive(t *testing.T) {
 
 // TestCollapseSeparatesHouseholds: no cross-household bleed.
 func TestCollapseSeparatesHouseholds(t *testing.T) {
+	t.Parallel()
 	ts := time.Date(2025, 4, 21, 0, 0, 0, 0, time.UTC)
 	values := []PersonRequestValue{
 		{HouseholdKey: hhA, FieldName: "Shared-request", Value: "the Johnson family", LastUpdated: ts},
@@ -387,6 +400,7 @@ func TestCollapseSeparatesHouseholds(t *testing.T) {
 // unknown -- which places as no-share but is a different fact from declining,
 // exactly as partyAttention separates "unverified" from "unmet".
 func TestDeriveShareEligibility(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name         string
 		gate         string
@@ -463,6 +477,7 @@ func TestDeriveShareEligibility(t *testing.T) {
 // NEAR is a SEPARATE AXIS, so it is expressible alongside a real share request
 // and must not suppress one either -- 29 households selected both.
 func TestDeriveShareEligibilityIgnoresNearOnly(t *testing.T) {
+	t.Parallel()
 	// NEAR alone reaches this function as "form answered, wants_with false".
 	got, source, conflict := DeriveShareEligibility(gateMaybeMutual, true, false, false, false)
 	if got != shareEligibilityDeclined {
@@ -487,6 +502,7 @@ func TestDeriveShareEligibilityIgnoresNearOnly(t *testing.T) {
 // nothing calls. formAnswered is the presence of the modes field, which is
 // what separates "declined" from "never answered".
 func TestCollapseCarriesShareEligibility(t *testing.T) {
+	t.Parallel()
 	const withNamed = "Share a cabin WITH a specific family that I know (please include names " +
 		"below and ensure that the request is mutual)."
 	const noShare = "No, we would prefer not to share a camper cabin."
@@ -539,6 +555,7 @@ func TestCollapseCarriesShareEligibility(t *testing.T) {
 // 35 households. Every consumer already reads "" as unknown, which is exactly
 // what makes this latent rather than visible -- the same shape as kindred#1921.
 func TestNormalizeShareEligibilityGivesUnknownOneSpelling(t *testing.T) {
+	t.Parallel()
 	eligibility, source := NormalizeShareEligibility("", "")
 	if eligibility != shareEligibilityUnknown || source != shareSourceNone {
 		t.Errorf("unwritten verdict = (%q, %q), want (%q, %q)",
@@ -573,6 +590,7 @@ func TestNormalizeShareEligibilityGivesUnknownOneSpelling(t *testing.T) {
 // against a form answer of open would report conflict=false, hiding exactly
 // the disagreement staff need to see.
 func TestDeriveShareEligibilityConflictTracksTheVerdict(t *testing.T) {
+	t.Parallel()
 	// similarAges WITHOUT with -- the state ParseSharedCabinModes prevents.
 	// Reached directly, the verdict is open, so a no_share gate conflicts.
 	_, _, conflict := DeriveShareEligibility(gateNoShare, true, false, true, false)
@@ -602,6 +620,7 @@ func TestDeriveShareEligibilityConflictTracksTheVerdict(t *testing.T) {
 // scoped to the FALLBACK only -- when the authoritative form answered, it wins,
 // which is the whole precedence rule.
 func TestDeriveShareEligibilityFallbackFailsSafeOnASiblingDecline(t *testing.T) {
+	t.Parallel()
 	for _, gate := range []string{gateYesShare, gateMaybeMutual} {
 		eligibility, source, conflict := DeriveShareEligibility(gate, false, false, false, true)
 		if eligibility != shareEligibilityDeclined {
@@ -629,6 +648,7 @@ func TestDeriveShareEligibilityFallbackFailsSafeOnASiblingDecline(t *testing.T) 
 // actually computed from the household's values rather than being a parameter
 // nothing supplies.
 func TestCollapseCarriesASiblingDeclineIntoTheFallback(t *testing.T) {
+	t.Parallel()
 	const noShare = "No, we would prefer not to share a camper cabin."
 	const yesShare = "Yes, I would like to share a large camper cabin with a family that I " +
 		"request or with a family with similarly aged kid(s) that I can meet at Camp."

--- a/pocketbase/sync/lodging_session_attribution_test.go
+++ b/pocketbase/sync/lodging_session_attribution_test.go
@@ -13,6 +13,7 @@ import (
 // back a time.Time. It returns a whole-second string, and AttributeSession
 // compares against session start dates, so the typed parse is the point.
 func TestParseCampMinderTimestamp(t *testing.T) {
+	t.Parallel()
 	got, ok := ParseCampMinderTimestamp("2025-04-21T17:51:11.5964281+00:00")
 	if !ok {
 		t.Fatal("failed to parse the CampMinder last_updated format")
@@ -34,6 +35,7 @@ func TestParseCampMinderTimestamp(t *testing.T) {
 // matches none of date_utils.go's DateFormats -- verified by running all eight
 // against it -- so it must be read via GetDateTime, not ParseDate.
 func TestLoadSessionWindowsReadsDateFields(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	addSession(t, app, 1309514, "Family Camp 1", "family",
 		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
@@ -66,6 +68,7 @@ func TestLoadSessionWindowsReadsDateFields(t *testing.T) {
 // "active enrolled". Any other status is not attending, and counting them would
 // manufacture ambiguity where there is none.
 func TestBuildHouseholdSessionIndexUsesActiveEnrolmentOnly(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	fc1 := addSession(t, app, 1309514, "Family Camp 1", "family",
 		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
@@ -92,6 +95,7 @@ func TestBuildHouseholdSessionIndexUsesActiveEnrolmentOnly(t *testing.T) {
 // TestBuildHouseholdSessionIndexDedupesSiblings: two enrolled children in one
 // household attending the same weekend is ONE household-weekend, not two.
 func TestBuildHouseholdSessionIndexDedupesSiblings(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	fc1 := addSession(t, app, 1309514, "Family Camp 1", "family",
 		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
@@ -116,6 +120,7 @@ func TestBuildHouseholdSessionIndexDedupesSiblings(t *testing.T) {
 // agree, so this asserts the filtered result is exactly the slice the full
 // index holds for that party -- not merely non-empty.
 func TestBuildSessionIndexFilteredToOnePartyMatchesTheFullIndex(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	fc1 := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
@@ -162,6 +167,7 @@ func TestBuildSessionIndexFilteredToOnePartyMatchesTheFullIndex(t *testing.T) {
 
 // TestAttributeSessionSingle: the 98% case.
 func TestAttributeSessionSingle(t *testing.T) {
+	t.Parallel()
 	only := SessionWindow{ID: "s1", CMID: 1309514, Name: "Family Camp 1",
 		Start: time.Date(2025, 5, 23, 7, 0, 0, 0, time.UTC),
 		End:   time.Date(2025, 5, 26, 7, 0, 0, 0, time.UTC)}
@@ -178,6 +184,7 @@ func TestAttributeSessionSingle(t *testing.T) {
 // TestAttributeSessionNone: 53 cabin values in 2025 belong to households with no
 // active family enrolment. They are queue items, not drops and not errors.
 func TestAttributeSessionNone(t *testing.T) {
+	t.Parallel()
 	got := AttributeSession(nil, time.Time{})
 	if got.Reason != attrNoSession {
 		t.Errorf("Reason = %q, want %q", got.Reason, attrNoSession)
@@ -195,6 +202,7 @@ func TestAttributeSessionNone(t *testing.T) {
 // Spec 3.6 says flag these for manual entry rather than guess, so SessionID
 // stays empty and only BestGuess carries the heuristic.
 func TestAttributeSessionAmbiguousSuggestsButDoesNotAssign(t *testing.T) {
+	t.Parallel()
 	mk := func(id string, cmID int, month, day int) SessionWindow {
 		return SessionWindow{ID: id, CMID: cmID,
 			Start: time.Date(2025, time.Month(month), day, 7, 0, 0, 0, time.UTC),
@@ -227,6 +235,7 @@ func TestAttributeSessionAmbiguousSuggestsButDoesNotAssign(t *testing.T) {
 // weekend has ended -- staff tidying records at season close -- suggests the
 // LAST weekend, since that is the one the value most plausibly describes.
 func TestAttributeSessionAmbiguousAfterAllSessions(t *testing.T) {
+	t.Parallel()
 	candidates := []SessionWindow{
 		{ID: "s1", CMID: 1309514, Start: time.Date(2025, 5, 23, 7, 0, 0, 0, time.UTC)},
 		{ID: "s3", CMID: 1356527, Start: time.Date(2025, 8, 28, 7, 0, 0, 0, time.UTC)},
@@ -243,6 +252,7 @@ func TestAttributeSessionAmbiguousAfterAllSessions(t *testing.T) {
 // TestAttributeSessionAmbiguousWithoutTimestamp: no timestamp, no suggestion --
 // but still a queue item rather than a drop.
 func TestAttributeSessionAmbiguousWithoutTimestamp(t *testing.T) {
+	t.Parallel()
 	candidates := []SessionWindow{
 		{ID: "s1", CMID: 1309514, Start: time.Date(2025, 5, 23, 7, 0, 0, 0, time.UTC)},
 		{ID: "s3", CMID: 1356527, Start: time.Date(2025, 8, 28, 7, 0, 0, 0, time.UTC)},

--- a/pocketbase/sync/lodging_session_cascade_test.go
+++ b/pocketbase/sync/lodging_session_cascade_test.go
@@ -65,6 +65,7 @@ func newCascadeProbeApp(t *testing.T, cascade bool) (app core.App, sessionID, as
 // PocketBase refuse the parent delete instead -- the sync reports an error and
 // no lodging row is lost.
 func TestSessionDeleteIsBlockedWhileAssignmentsExist(t *testing.T) {
+	t.Parallel()
 	app, sessionID, assignID := newCascadeProbeApp(t, false)
 
 	sess, err := app.FindRecordById("camp_sessions", sessionID)
@@ -93,6 +94,7 @@ func TestSessionDeleteIsBlockedWhileAssignmentsExist(t *testing.T) {
 // moves away from. If this ever stops passing, PocketBase changed its cascade
 // semantics and the reasoning behind 1500000124 needs revisiting.
 func TestSessionDeleteCascadesWhenCascadeIsOn(t *testing.T) {
+	t.Parallel()
 	app, sessionID, assignID := newCascadeProbeApp(t, true)
 
 	sess, err := app.FindRecordById("camp_sessions", sessionID)
@@ -116,6 +118,7 @@ func TestSessionDeleteCascadesWhenCascadeIsOn(t *testing.T) {
 // question -- "same cabin as last year" -- can only be joined on the CampMinder
 // id, which is why session_cm_id sits beside the relation instead of replacing it.
 func TestSessionCMIDSurvivesAcrossYears(t *testing.T) {
+	t.Parallel()
 	app, _, _ := newCascadeProbeApp(t, false)
 
 	sessions, err := app.FindCollectionByNameOrId("camp_sessions")

--- a/pocketbase/sync/lodging_session_status_test.go
+++ b/pocketbase/sync/lodging_session_status_test.go
@@ -34,6 +34,7 @@ const statusCollection = "lodging_session_status"
 // lodging_phi_test.go: cheap, and it fails at the moment someone adds the
 // reference rather than in production.
 func TestSyncNeverWritesTheStaffOwnedWeekendStatus(t *testing.T) {
+	t.Parallel()
 	entries, err := os.ReadDir(".")
 	if err != nil {
 		t.Fatalf("reading the sync package directory: %v", err)

--- a/pocketbase/sync/lodging_testsupport_fixture_test.go
+++ b/pocketbase/sync/lodging_testsupport_fixture_test.go
@@ -19,6 +19,7 @@ import (
 // surfaced because lodging/registry_test.go's twin fixture carries the index;
 // this package's did not.
 func TestLodgingUnitsFixtureRejectsDuplicateCodeYear(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	addUnit(t, app, "dup-code", 2026)
 
@@ -44,6 +45,7 @@ func TestLodgingUnitsFixtureRejectsDuplicateCodeYear(t *testing.T) {
 // the range too, a test can store year: 1 or year: 2025.5 and pass on data
 // the real database would reject.
 func TestLodgingUnitsFixtureRejectsYearOutsideProductionRange(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	col, err := app.FindCollectionByNameOrId("lodging_units")
 	if err != nil {
@@ -159,6 +161,7 @@ func loadProductionSchema(path string) (map[string]map[string]bool, error) {
 // contract itself, separate from TestLodgingTestsupportFixtureFieldsExist...
 // below, which needs the full CI boot to exercise the comparison it guards.
 func TestLoadProductionSchema(t *testing.T) {
+	t.Parallel()
 	write := func(t *testing.T, body string) string {
 		t.Helper()
 		path := filepath.Join(t.TempDir(), "collections.json")
@@ -231,6 +234,7 @@ func TestLoadProductionSchema(t *testing.T) {
 // produces that today, so this test SKIPS everywhere else -- including a
 // plain `go test ./...` -- rather than reimplementing the boot a second time.
 func TestLodgingTestsupportFixtureFieldsExistInProductionSchema(t *testing.T) {
+	t.Parallel()
 	schemaPath := os.Getenv("KINDRED_PROD_SCHEMA_JSON")
 	if schemaPath == "" {
 		t.Skip("KINDRED_PROD_SCHEMA_JSON not set -- this check runs in CI's " +

--- a/pocketbase/sync/lodging_testsupport_test.go
+++ b/pocketbase/sync/lodging_testsupport_test.go
@@ -403,6 +403,7 @@ func assertLodgingCollectionsEmpty(t *testing.T, app core.App) {
 // season nobody has loaded a registry for at all. Sync must skip the lodging
 // portion and return nil, not fail the whole run.
 func TestLodgingAssignmentsSyncSkipsWhenRegistryNeverLoaded(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	// No addUnit call anywhere: lodging_units is empty for every year.
 
@@ -433,6 +434,7 @@ func TestLodgingAssignmentsSyncSkipsWhenRegistryNeverLoaded(t *testing.T) {
 // for the new year and every cabin unresolves unless the guard catches it
 // first.
 func TestLodgingAssignmentsSyncSkipsWhenSeasonNotRolledForward(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	priorYearUnit := addUnit(t, app, "ridge-a", 2026)
 	addAlias(t, app, "Ridge A", []string{priorYearUnit}, 0, 0)
@@ -457,6 +459,7 @@ func TestLodgingAssignmentsSyncSkipsWhenSeasonNotRolledForward(t *testing.T) {
 // TestAliasResolverHasUnitsForYear exercises the two lookups Sync's year guard
 // depends on, distinguishing "never loaded" from "not this year".
 func TestAliasResolverHasUnitsForYear(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 	addUnit(t, app, "ridge-a", 2026)
 
@@ -478,6 +481,7 @@ func TestAliasResolverHasUnitsForYear(t *testing.T) {
 // TestAliasResolverHasAnyUnitsFalseWhenEmpty covers the other guard branch:
 // no registry loaded for any season at all.
 func TestAliasResolverHasAnyUnitsFalseWhenEmpty(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
 
 	r, err := NewAliasResolver(app)

--- a/pocketbase/sync/lodging_unit_tree_test.go
+++ b/pocketbase/sync/lodging_unit_tree_test.go
@@ -20,6 +20,7 @@ func testTree() map[string]UnitNode {
 // The two shapes a cycle takes: a unit pointing at itself, and a unit adopting
 // something already beneath it.
 func TestHasParentCycleDetectsSelfAndDescendants(t *testing.T) {
+	t.Parallel()
 	tree := testTree()
 	if !HasParentCycle(tree, "up", "up") {
 		t.Error("a unit cannot be its own parent")
@@ -37,6 +38,7 @@ func TestHasParentCycleDetectsSelfAndDescendants(t *testing.T) {
 // so it closes no loop for r1 -- the tree may already be corrupt, but that
 // is a separate problem from the one this function answers.
 func TestHasParentCycleIgnoresAnUnrelatedPreExistingCycle(t *testing.T) {
+	t.Parallel()
 	tree := map[string]UnitNode{
 		"a": {ID: "a", ParentID: "b"}, "b": {ID: "b", ParentID: "a"}, // loop, unrelated to r1
 		"bldg": {ID: "bldg", IsContainer: true},

--- a/pocketbase/sync/multi_workbook_export_test.go
+++ b/pocketbase/sync/multi_workbook_export_test.go
@@ -85,6 +85,7 @@ func (m *MockWorkbookManager) UpdateMasterIndex(_ context.Context) error {
 // =============================================================================
 
 func TestGetReadableGlobalExports_HasIndexSheet(t *testing.T) {
+	t.Parallel()
 	// The globals workbook should include an Index sheet as the first tab
 	configs := GetReadableGlobalExports()
 
@@ -109,6 +110,7 @@ func TestGetReadableGlobalExports_HasIndexSheet(t *testing.T) {
 }
 
 func TestGetReadableYearExports_HasCustomValues(t *testing.T) {
+	t.Parallel()
 	// Year exports should now include custom values (person + household)
 	configs := GetReadableYearExports()
 
@@ -133,6 +135,7 @@ func TestGetReadableYearExports_HasCustomValues(t *testing.T) {
 }
 
 func TestGetReadableExports_NoYearPrefixes(t *testing.T) {
+	t.Parallel()
 	// Readable exports should NOT have year prefixes - they go to separate workbooks
 	yearConfigs := GetReadableYearExports()
 
@@ -148,6 +151,7 @@ func TestGetReadableExports_NoYearPrefixes(t *testing.T) {
 }
 
 func TestGetReadableGlobalExports_NoGPrefix(t *testing.T) {
+	t.Parallel()
 	// Readable global exports should NOT have "g-" prefix - they go to separate workbook
 	configs := GetReadableGlobalExports()
 
@@ -163,6 +167,7 @@ func TestGetReadableGlobalExports_NoGPrefix(t *testing.T) {
 // =============================================================================
 
 func TestReadableYearExportSheetNames(t *testing.T) {
+	t.Parallel()
 	// Verify all expected year-specific sheets are included
 	names := GetReadableYearExportSheetNames()
 
@@ -194,6 +199,7 @@ func TestReadableYearExportSheetNames(t *testing.T) {
 }
 
 func TestReadableGlobalExportSheetNames(t *testing.T) {
+	t.Parallel()
 	// Verify all expected global sheets are included
 	names := GetReadableGlobalExportSheetNames()
 
@@ -224,6 +230,7 @@ func TestReadableGlobalExportSheetNames(t *testing.T) {
 var _ WorkbookManagerInterface = (*MockWorkbookManager)(nil)
 
 func TestMockWorkbookManager_GetOrCreateGlobalsWorkbook(t *testing.T) {
+	t.Parallel()
 	mock := NewMockWorkbookManager()
 	mock.GlobalsWorkbookID = "test-globals-id"
 
@@ -237,6 +244,7 @@ func TestMockWorkbookManager_GetOrCreateGlobalsWorkbook(t *testing.T) {
 }
 
 func TestMockWorkbookManager_GetOrCreateYearWorkbook(t *testing.T) {
+	t.Parallel()
 	mock := NewMockWorkbookManager()
 	mock.YearWorkbookIDs[2025] = "test-2025-id"
 
@@ -250,6 +258,7 @@ func TestMockWorkbookManager_GetOrCreateYearWorkbook(t *testing.T) {
 }
 
 func TestMockWorkbookManager_UpdateMasterIndex(t *testing.T) {
+	t.Parallel()
 	mock := NewMockWorkbookManager()
 
 	err := mock.UpdateMasterIndex(context.Background())
@@ -266,6 +275,7 @@ func TestMockWorkbookManager_UpdateMasterIndex(t *testing.T) {
 // =============================================================================
 
 func TestMultiWorkbookExport_GlobalsToGlobalsWorkbook(t *testing.T) {
+	t.Parallel()
 	// Test that global exports go to the globals workbook (not year workbooks)
 	mockWriter := NewMockSheetsWriter()
 	mockManager := NewMockWorkbookManager()
@@ -299,6 +309,7 @@ func TestMultiWorkbookExport_GlobalsToGlobalsWorkbook(t *testing.T) {
 }
 
 func TestMultiWorkbookExport_YearDataToYearWorkbook(t *testing.T) {
+	t.Parallel()
 	// Test that year data goes to the year workbook (not globals)
 	mockWriter := NewMockSheetsWriter()
 	mockManager := NewMockWorkbookManager()
@@ -331,6 +342,7 @@ func TestMultiWorkbookExport_YearDataToYearWorkbook(t *testing.T) {
 }
 
 func TestMultiWorkbookExport_IndexUpdatedAfterSync(t *testing.T) {
+	t.Parallel()
 	// Test that master index is updated after sync completes
 	mockManager := NewMockWorkbookManager()
 
@@ -348,6 +360,7 @@ func TestMultiWorkbookExport_IndexUpdatedAfterSync(t *testing.T) {
 }
 
 func TestMultiWorkbookExport_DifferentYearsGoToDifferentWorkbooks(t *testing.T) {
+	t.Parallel()
 	// Test that different years go to different workbooks
 	mockManager := NewMockWorkbookManager()
 	mockManager.YearWorkbookIDs[2024] = "year-2024-spreadsheet-id"
@@ -380,6 +393,7 @@ func TestMultiWorkbookExport_DifferentYearsGoToDifferentWorkbooks(t *testing.T) 
 }
 
 func TestReadableExportsExist(t *testing.T) {
+	t.Parallel()
 	// Verify readable exports exist and are non-empty
 	readableYear := GetReadableYearExports()
 	readableGlobal := GetReadableGlobalExports()
@@ -412,6 +426,7 @@ func TestReadableExportsExist(t *testing.T) {
 // =============================================================================
 
 func TestMultiWorkbookExport_StructHasWorkbookManager(t *testing.T) {
+	t.Parallel()
 	// MultiWorkbookExport should have a workbookManager field
 	// This replaces the single spreadsheetID in GoogleSheetsExport
 	mockWriter := NewMockSheetsWriter()
@@ -434,6 +449,7 @@ func TestMultiWorkbookExport_StructHasWorkbookManager(t *testing.T) {
 }
 
 func TestMultiWorkbookExport_Name(t *testing.T) {
+	t.Parallel()
 	// MultiWorkbookExport should have a Name() method
 	mockWriter := NewMockSheetsWriter()
 	mockManager := NewMockWorkbookManager()
@@ -450,6 +466,7 @@ func TestMultiWorkbookExport_Name(t *testing.T) {
 }
 
 func TestMultiWorkbookExport_SyncGlobalsToGlobalsWorkbook(t *testing.T) {
+	t.Parallel()
 	// SyncGlobalsOnly should:
 	// 1. Get/create globals workbook via WorkbookManager
 	// 2. Export to globals workbook using readable names
@@ -485,6 +502,7 @@ func TestMultiWorkbookExport_SyncGlobalsToGlobalsWorkbook(t *testing.T) {
 }
 
 func TestMultiWorkbookExport_SyncYearDataToYearWorkbook(t *testing.T) {
+	t.Parallel()
 	// SyncYearData should:
 	// 1. Get/create year workbook via WorkbookManager
 	// 2. Export to year workbook using readable names
@@ -512,6 +530,7 @@ func TestMultiWorkbookExport_SyncYearDataToYearWorkbook(t *testing.T) {
 }
 
 func TestMultiWorkbookExport_SyncUpdatesIndex(t *testing.T) {
+	t.Parallel()
 	// Full Sync should:
 	// 1. Export globals
 	// 2. Export year data
@@ -538,6 +557,7 @@ func TestMultiWorkbookExport_SyncUpdatesIndex(t *testing.T) {
 }
 
 func TestMultiWorkbookExport_SyncForYearsUsesMultipleWorkbooks(t *testing.T) {
+	t.Parallel()
 	// SyncForYears should use different workbooks for different years
 	mockWriter := NewMockSheetsWriter()
 	mockManager := NewMockWorkbookManager()
@@ -566,6 +586,7 @@ func TestMultiWorkbookExport_SyncForYearsUsesMultipleWorkbooks(t *testing.T) {
 // =============================================================================
 
 func TestSyncJobToCollections_HasExpectedMappings(t *testing.T) {
+	t.Parallel()
 	// Verify the SyncJobToCollections map has all expected mappings
 	expectedMappings := map[string][]string{
 		// Year-scoped
@@ -611,6 +632,7 @@ func TestSyncJobToCollections_HasExpectedMappings(t *testing.T) {
 }
 
 func TestSyncJobToCollections_PersonsMapsToMultipleCollections(t *testing.T) {
+	t.Parallel()
 	// persons sync populates both persons and households tables
 	collections, ok := SyncJobToCollections["persons"]
 	if !ok {
@@ -638,6 +660,7 @@ func TestSyncJobToCollections_PersonsMapsToMultipleCollections(t *testing.T) {
 }
 
 func TestSyncYearData_SkipsUnchangedCollections(t *testing.T) {
+	t.Parallel()
 	// This test verifies that SyncYearData skips collections that had no changes
 	// when changedCollections map is provided
 
@@ -658,6 +681,7 @@ func TestSyncYearData_SkipsUnchangedCollections(t *testing.T) {
 }
 
 func TestSyncGlobalsOnly_SkipsUnchangedCollections(t *testing.T) {
+	t.Parallel()
 	// Similar to year data, globals should also support skip optimization
 	t.Run("documents skip behavior for global exports", func(t *testing.T) {
 		// When changedCollections is provided:
@@ -667,6 +691,7 @@ func TestSyncGlobalsOnly_SkipsUnchangedCollections(t *testing.T) {
 }
 
 func TestSyncForYears_PassesChangedCollections(t *testing.T) {
+	t.Parallel()
 	// SyncForYears should accept and pass changedCollections to SyncYearData
 	t.Run("documents changedCollections parameter", func(t *testing.T) {
 		// SyncForYears(ctx, years, includeGlobals, changedCollections)

--- a/pocketbase/sync/multi_workbook_ordering_test.go
+++ b/pocketbase/sync/multi_workbook_ordering_test.go
@@ -13,6 +13,7 @@ const testTabNameAttendees = "Attendees"
 // =============================================================================
 
 func TestSortGlobalsWorkbookTabs_IndexFirst(t *testing.T) {
+	t.Parallel()
 	// Index sheet should always be first in globals workbook
 	tabs := []string{
 		"Tag Definitions",
@@ -29,6 +30,7 @@ func TestSortGlobalsWorkbookTabs_IndexFirst(t *testing.T) {
 }
 
 func TestSortGlobalsWorkbookTabs_AlphabetizedAfterIndex(t *testing.T) {
+	t.Parallel()
 	// After Index, other tabs should be alphabetized
 	tabs := []string{
 		"Tag Definitions",
@@ -60,6 +62,7 @@ func TestSortGlobalsWorkbookTabs_AlphabetizedAfterIndex(t *testing.T) {
 }
 
 func TestSortGlobalsWorkbookTabs_NoIndex(t *testing.T) {
+	t.Parallel()
 	// If Index is not present, should just alphabetize
 	tabs := []string{
 		"Tag Definitions",
@@ -83,6 +86,7 @@ func TestSortGlobalsWorkbookTabs_NoIndex(t *testing.T) {
 }
 
 func TestSortYearWorkbookTabs_Alphabetized(t *testing.T) {
+	t.Parallel()
 	// Year workbook tabs should be alphabetized
 	tabs := []string{
 		"Staff",
@@ -113,6 +117,7 @@ func TestSortYearWorkbookTabs_Alphabetized(t *testing.T) {
 // =============================================================================
 
 func TestGetMultiWorkbookTabColor_Index(t *testing.T) {
+	t.Parallel()
 	// Index tab should be gold
 	color := GetMultiWorkbookTabColor("Index")
 
@@ -122,6 +127,7 @@ func TestGetMultiWorkbookTabColor_Index(t *testing.T) {
 }
 
 func TestGetMultiWorkbookTabColor_CMSourcedTables(t *testing.T) {
+	t.Parallel()
 	// CampMinder-sourced tables should be orange
 	cmTabs := []string{
 		testTabNameAttendees, "Persons", "Households",
@@ -141,6 +147,7 @@ func TestGetMultiWorkbookTabColor_CMSourcedTables(t *testing.T) {
 }
 
 func TestGetMultiWorkbookTabColor_GlobalTables(t *testing.T) {
+	t.Parallel()
 	// Global tables should be grey
 	globalTabsList := []string{"Tag Definitions", "Custom Field Definitions", "Divisions", "Financial Categories"}
 
@@ -155,6 +162,7 @@ func TestGetMultiWorkbookTabColor_GlobalTables(t *testing.T) {
 }
 
 func TestGetMultiWorkbookTabColor_DerivedTables(t *testing.T) {
+	t.Parallel()
 	// Derived/computed tables should be grey
 	derivedTabsList := []string{"Camper History"}
 
@@ -169,6 +177,7 @@ func TestGetMultiWorkbookTabColor_DerivedTables(t *testing.T) {
 }
 
 func TestGetMultiWorkbookTabColor_Unknown(t *testing.T) {
+	t.Parallel()
 	// Unknown tabs in year workbook default to CM-sourced (orange)
 	color := GetMultiWorkbookTabColor("New CM Table")
 
@@ -182,6 +191,7 @@ func TestGetMultiWorkbookTabColor_Unknown(t *testing.T) {
 // =============================================================================
 
 func TestReorderGlobalsWorkbookTabs_AppliesColorsAndOrder(t *testing.T) {
+	t.Parallel()
 	// Test that reordering applies correct colors and positions
 	mockWriter := NewMockSheetsWriter()
 
@@ -205,6 +215,7 @@ func TestReorderGlobalsWorkbookTabs_AppliesColorsAndOrder(t *testing.T) {
 }
 
 func TestReorderYearWorkbookTabs_AppliesColorsAndOrder(t *testing.T) {
+	t.Parallel()
 	// Test that year workbook tabs are alphabetized
 	mockWriter := NewMockSheetsWriter()
 

--- a/pocketbase/sync/normalize_geographic_test.go
+++ b/pocketbase/sync/normalize_geographic_test.go
@@ -18,6 +18,7 @@ import (
 
 // TestNormalizeGeographicSync_Name verifies the service name is correct
 func TestNormalizeGeographicSync_Name(t *testing.T) {
+	t.Parallel()
 	// The service name must be "normalize_geographic" for orchestrator integration
 	expectedName := "normalize_geographic"
 
@@ -34,6 +35,7 @@ func TestNormalizeGeographicSync_Name(t *testing.T) {
 
 // TestNormalizeGeographicYearValidation tests year parameter validation
 func TestNormalizeGeographicYearValidation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		year      int
@@ -65,6 +67,7 @@ func TestNormalizeGeographicYearValidation(t *testing.T) {
 
 // TestNormalizedMappingCompositeKey tests the composite key format for normalized_mappings
 func TestNormalizedMappingCompositeKey(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		category      string
@@ -136,6 +139,7 @@ type testNormStats struct {
 // TestConfidenceEpsilonComparison tests that float64 confidence values are compared
 // with epsilon tolerance to ensure idempotent updates
 func TestConfidenceEpsilonComparison(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		existing    float64
@@ -199,6 +203,7 @@ func TestConfidenceEpsilonComparison(t *testing.T) {
 
 // TestMappingNeedsUpdateWithEpsilon tests the full update detection with epsilon comparison
 func TestMappingNeedsUpdateWithEpsilon(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		existingConf  float64
@@ -274,6 +279,7 @@ func TestMappingNeedsUpdateWithEpsilon(t *testing.T) {
 
 // TestIdempotentSyncRuns tests that running sync twice produces 0 updates on second run
 func TestIdempotentSyncRuns(t *testing.T) {
+	t.Parallel()
 	// Simulate first run creating records
 	mappings := []*testNormalizedMapping{
 		{
@@ -359,6 +365,7 @@ func simulateUpsertWithEpsilon(
 
 // TestUpsertNormalizedMappingsIdempotency verifies idempotent upsert behavior
 func TestUpsertNormalizedMappingsIdempotency(t *testing.T) {
+	t.Parallel()
 	// Simulate computed mappings from source data
 	mappings := []*testNormalizedMapping{
 		{
@@ -402,6 +409,7 @@ func TestUpsertNormalizedMappingsIdempotency(t *testing.T) {
 
 // TestUpsertNormalizedMappingsUpdateDetection verifies update detection
 func TestUpsertNormalizedMappingsUpdateDetection(t *testing.T) {
+	t.Parallel()
 	// Existing records in database
 	existingMappings := []*testNormalizedMapping{
 		{Category: "city", OriginalValue: "Oakland", NormalizedValue: "Oakland", OccurrenceCount: 10, Year: 2025},
@@ -428,6 +436,7 @@ func TestUpsertNormalizedMappingsUpdateDetection(t *testing.T) {
 
 // TestUpsertNormalizedMappingsOrphanDeletion verifies orphan cleanup
 func TestUpsertNormalizedMappingsOrphanDeletion(t *testing.T) {
+	t.Parallel()
 	// Existing records in database
 	existingMappings := []*testNormalizedMapping{
 		{
@@ -474,6 +483,7 @@ func TestUpsertNormalizedMappingsOrphanDeletion(t *testing.T) {
 
 // TestNormalizationCategories verifies category constants are correct
 func TestNormalizationCategories(t *testing.T) {
+	t.Parallel()
 	expected := []string{"city", "school", "congregation"}
 	categories := getNormalizationCategories()
 
@@ -658,6 +668,7 @@ func buildPersonSessionMappingKey(personPBID, sessionPBID, category string) stri
 
 // TestPersonSessionMappingKey tests the composite key format for person+session mappings
 func TestPersonSessionMappingKey(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		personPBID  string
@@ -702,6 +713,7 @@ func TestPersonSessionMappingKey(t *testing.T) {
 // TestPersonSessionMappingUniquePerPersonSession tests that each person+session+category
 // combination produces exactly one mapping record
 func TestPersonSessionMappingUniquePerPersonSession(t *testing.T) {
+	t.Parallel()
 	// Simulate attendee geo data for two campers in different sessions
 	attendeeData := []testAttendeeGeoData{
 		{
@@ -789,6 +801,7 @@ func TestPersonSessionMappingUniquePerPersonSession(t *testing.T) {
 // TestSessionFilterCountsMatchMainList tests that filtering by session returns
 // counts that match the main registration list (fixes the "show sources" mismatch bug)
 func TestSessionFilterCountsMatchMainList(t *testing.T) {
+	t.Parallel()
 	// Create mappings for 2 persons in session 2001, 1 person in session 2002
 	mappings := []*testPersonSessionMapping{
 		// Person 101 in session 2001: school = "Riverside Elementary"
@@ -849,6 +862,7 @@ func countByNormalizedValue(mappings []*testPersonSessionMapping) map[string]int
 // TestCongregationUsesPersonLevelData verifies that congregation comes from
 // person_custom_values (HH-Name of Congregation) not household_custom_values (Synagogue)
 func TestCongregationUsesPersonLevelData(t *testing.T) {
+	t.Parallel()
 	// Simulate person_custom_values data (person-level congregation)
 	personCongregations := map[int]string{
 		101: "Temple Beth El - Oakland",         // Person 101
@@ -888,6 +902,7 @@ func TestCongregationUsesPersonLevelData(t *testing.T) {
 // TestPersonSessionUpsertIdempotency tests that upserting the same person+session
 // mapping twice results in skip (not update or create)
 func TestPersonSessionUpsertIdempotency(t *testing.T) {
+	t.Parallel()
 	// First run: create mappings
 	mappings := []*testPersonSessionMapping{
 		{
@@ -977,6 +992,7 @@ func personSessionMappingNeedsUpdate(existing, newMapping *testPersonSessionMapp
 // - Waitlisted campers get clean data for review and seamless enrollment transitions
 // - More data points improve canonical value selection via frequency-based clustering
 func TestAllAttendeesForYearInNormalizedMappings(t *testing.T) {
+	t.Parallel()
 	type testAttendee struct {
 		PersonID int
 		StatusID int
@@ -1030,6 +1046,7 @@ func TestAllAttendeesForYearInNormalizedMappings(t *testing.T) {
 // The JSON address field was removed in the Phase 3 migration (PR #208).
 // loadAttendeeGeoData must use personRecord.GetString("address_city").
 func TestCityUsesDiscreteColumn(t *testing.T) {
+	t.Parallel()
 	// This test verifies the expected data flow:
 	// persons.address_city (text column) → attendeeGeoData.City
 	//
@@ -1065,6 +1082,7 @@ func TestCityUsesDiscreteColumn(t *testing.T) {
 // helper is no longer needed. The normalize_geographic.go loadAttendeeGeoData
 // function should read address_city directly, not parse JSON.
 func TestExtractCityFromAddressNotUsed(t *testing.T) {
+	t.Parallel()
 	// After the fix, extractCityFromAddress should not exist on NormalizeGeographicSync.
 	// This test serves as documentation that city comes from a discrete column.
 	//
@@ -1078,6 +1096,7 @@ func TestExtractCityFromAddressNotUsed(t *testing.T) {
 // ============================================================================
 
 func TestCallGeoNormalizeAPI(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		responseStatus int
@@ -1153,6 +1172,7 @@ const testCityOakland = "Oakland"
 // take priority over fuzzy match results. When a raw value has an alias
 // override, it should return the alias canonical with confidence 1.0.
 func TestResolveValueAliasOverrideTakesPriority(t *testing.T) {
+	t.Parallel()
 	// Fuzzy match lookup maps a raw value to a normalized entry
 	fuzzyLookup := map[string]normalizedEntry{
 		"Oaklnd": {Canonical: testCityOakland, Confidence: 0.9}, // fuzzy match would normalize to "Oakland"
@@ -1187,6 +1207,7 @@ func TestResolveValueAliasOverrideTakesPriority(t *testing.T) {
 // TestResolveValueAliasIsCaseInsensitive verifies that alias lookup is
 // case-insensitive (raw values are lowercased before lookup).
 func TestResolveValueAliasIsCaseInsensitive(t *testing.T) {
+	t.Parallel()
 	fuzzyLookup := map[string]normalizedEntry{}
 
 	aliasOverrides := map[string]map[string]string{
@@ -1218,6 +1239,7 @@ func TestResolveValueAliasIsCaseInsensitive(t *testing.T) {
 // are followed after fuzzy match resolution. If fuzzy matches "A" and a merge
 // says A -> B, the final result should be B.
 func TestResolveValueMergeRedirectAfterFuzzyMatch(t *testing.T) {
+	t.Parallel()
 	// Fuzzy match normalizes "Temple Beth-El" -> "Temple Beth El"
 	fuzzyLookup := map[string]normalizedEntry{
 		"Temple Beth-El": {Canonical: "Temple Beth El", Confidence: 0.9},
@@ -1255,6 +1277,7 @@ func TestResolveValueMergeRedirectAfterFuzzyMatch(t *testing.T) {
 // raw -> A, then merge redirects A -> B. Final result should be B with
 // confidence 1.0 (because the alias itself is a manual override).
 func TestResolveValueAliasPlusMerge(t *testing.T) {
+	t.Parallel()
 	fuzzyLookup := map[string]normalizedEntry{} // empty, alias should handle it
 
 	aliasOverrides := map[string]map[string]string{
@@ -1286,6 +1309,7 @@ func TestResolveValueAliasPlusMerge(t *testing.T) {
 // TestResolveValueEmptyOverridesFallBackToFuzzy verifies that when alias/merge
 // overrides are empty, the function falls back to fuzzy match as before.
 func TestResolveValueEmptyOverridesFallBackToFuzzy(t *testing.T) {
+	t.Parallel()
 	fuzzyLookup := map[string]normalizedEntry{
 		"San Fran": {Canonical: "San Francisco", Confidence: 0.9},
 	}
@@ -1316,6 +1340,7 @@ func TestResolveValueEmptyOverridesFallBackToFuzzy(t *testing.T) {
 // TestResolveValueFuzzyMatchExactCaseConfidence verifies that when fuzzy match
 // returns a case-equal result, confidence is 1.0.
 func TestResolveValueFuzzyMatchExactCaseConfidence(t *testing.T) {
+	t.Parallel()
 	fuzzyLookup := map[string]normalizedEntry{
 		testCityOakland: {Canonical: testCityOakland, Confidence: 1.0}, // exact match
 	}
@@ -1345,6 +1370,7 @@ func TestResolveValueFuzzyMatchExactCaseConfidence(t *testing.T) {
 // TestResolveValueNoMatchReturnsEmpty verifies that when no alias override
 // and no fuzzy match exist, resolveValue returns empty string and 0 confidence.
 func TestResolveValueNoMatchReturnsEmpty(t *testing.T) {
+	t.Parallel()
 	fuzzyLookup := map[string]normalizedEntry{} // no matches
 
 	aliasOverrides := map[string]map[string]string{
@@ -1372,6 +1398,7 @@ func TestResolveValueNoMatchReturnsEmpty(t *testing.T) {
 // TestResolveValueNilOverrideMapsDoNotPanic verifies that nil maps in the
 // overrides don't cause panics (defensive coding).
 func TestResolveValueNilOverrideMapsDoNotPanic(t *testing.T) {
+	t.Parallel()
 	fuzzyLookup := map[string]normalizedEntry{
 		testCityOakland: {Canonical: testCityOakland, Confidence: 1.0},
 	}
@@ -1395,6 +1422,7 @@ func TestResolveValueNilOverrideMapsDoNotPanic(t *testing.T) {
 // even when there are no alias overrides for a category. The fuzzy match
 // result is redirected by the merge.
 func TestResolveValueMergeOnlyNoAlias(t *testing.T) {
+	t.Parallel()
 	fuzzyLookup := map[string]normalizedEntry{
 		"Oak Valley Middle School": {Canonical: "Oak Valley Middle School", Confidence: 1.0},
 	}
@@ -1429,6 +1457,7 @@ func TestResolveValueMergeOnlyNoAlias(t *testing.T) {
 // TestResolveValueCategoryIsolation verifies that overrides for one category
 // do not affect resolution in another category.
 func TestResolveValueCategoryIsolation(t *testing.T) {
+	t.Parallel()
 	fuzzyLookup := map[string]normalizedEntry{
 		testCityOakland: {Canonical: testCityOakland, Confidence: 1.0},
 	}
@@ -1469,6 +1498,7 @@ func TestResolveValueCategoryIsolation(t *testing.T) {
 // TestAttendeeGeoDataHasAddressFields verifies the attendeeGeoData struct
 // carries address_state and address_country fields from the household join.
 func TestAttendeeGeoDataHasAddressFields(t *testing.T) {
+	t.Parallel()
 	data := attendeeGeoData{
 		PersonPBID:     "person_101",
 		PersonCMID:     101,
@@ -1492,6 +1522,7 @@ func TestAttendeeGeoDataHasAddressFields(t *testing.T) {
 // TestAttendeeGeoDataEmptyHousehold verifies that address fields default to
 // empty strings when no household is linked (nil expanded record).
 func TestAttendeeGeoDataEmptyHousehold(t *testing.T) {
+	t.Parallel()
 	data := attendeeGeoData{
 		PersonPBID:  "person_102",
 		PersonCMID:  102,
@@ -1513,6 +1544,7 @@ func TestAttendeeGeoDataEmptyHousehold(t *testing.T) {
 // TestPersonSessionMappingCarriesAddressFields verifies the personSessionMapping
 // struct carries address_state and address_country through the mapping pipeline.
 func TestPersonSessionMappingCarriesAddressFields(t *testing.T) {
+	t.Parallel()
 	m := personSessionMapping{
 		personPBID:      "person_101",
 		sessionPBID:     "session_2001",
@@ -1536,6 +1568,7 @@ func TestPersonSessionMappingCarriesAddressFields(t *testing.T) {
 // TestPersonSessionMappingNeedsUpdateDetectsAddressStateChange verifies that
 // a change to address_state triggers an update.
 func TestPersonSessionMappingNeedsUpdateDetectsAddressStateChange(t *testing.T) {
+	t.Parallel()
 	existing := &testPersonSessionMapping{
 		PersonPBID: "p101", SessionPBID: "s2001", Category: "city",
 		OriginalValue: "Oakland", NormalizedValue: "Oakland",
@@ -1558,6 +1591,7 @@ func TestPersonSessionMappingNeedsUpdateDetectsAddressStateChange(t *testing.T) 
 // TestPersonSessionMappingNeedsUpdateDetectsAddressCountryChange verifies that
 // a change to address_country triggers an update.
 func TestPersonSessionMappingNeedsUpdateDetectsAddressCountryChange(t *testing.T) {
+	t.Parallel()
 	existing := &testPersonSessionMapping{
 		PersonPBID: "p101", SessionPBID: "s2001", Category: "school",
 		OriginalValue: "Riverside Elementary", NormalizedValue: "Riverside Elementary",
@@ -1580,6 +1614,7 @@ func TestPersonSessionMappingNeedsUpdateDetectsAddressCountryChange(t *testing.T
 // TestPersonSessionMappingNeedsUpdateNoChangeWithAddress verifies that
 // identical address fields do not trigger a spurious update.
 func TestPersonSessionMappingNeedsUpdateNoChangeWithAddress(t *testing.T) {
+	t.Parallel()
 	existing := &testPersonSessionMapping{
 		PersonPBID: "p101", SessionPBID: "s2001", Category: "city",
 		OriginalValue: "Oakland", NormalizedValue: "Oakland",
@@ -1603,6 +1638,7 @@ func TestPersonSessionMappingNeedsUpdateNoChangeWithAddress(t *testing.T) {
 // address_country from attendeeGeoData flow through to personSessionMapping
 // for all three categories (school, city, congregation).
 func TestAddressFieldsPropagateToMappings(t *testing.T) {
+	t.Parallel()
 	attendeeData := []testAttendeeGeoData{
 		{
 			PersonPBID: "p101", PersonCMID: 101,
@@ -1665,6 +1701,7 @@ func TestAddressFieldsPropagateToMappings(t *testing.T) {
 // TestValueWithContextJSON verifies that valueWithContext serializes to the
 // JSON format expected by the Python normalizer: {"value": "x", "state": "CA", "country": "US"}
 func TestValueWithContextJSON(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    valueWithContext
@@ -1703,6 +1740,7 @@ func TestValueWithContextJSON(t *testing.T) {
 // TestValueWithContextSliceJSON verifies that a slice of valueWithContext
 // serializes to the array format sent to Python normalizer.
 func TestValueWithContextSliceJSON(t *testing.T) {
+	t.Parallel()
 	values := []valueWithContext{
 		{Value: "Oakland", State: "CA", Country: "US"},
 		{Value: "London", State: "", Country: "GB"},
@@ -1738,6 +1776,7 @@ func TestValueWithContextSliceJSON(t *testing.T) {
 
 // TestGeoContextStruct verifies geoContext stores state and country.
 func TestGeoContextStruct(t *testing.T) {
+	t.Parallel()
 	ctx := geoContext{State: "CA", Country: "US"}
 	if ctx.State != "CA" {
 		t.Errorf("State = %q, want %q", ctx.State, "CA")
@@ -1755,6 +1794,7 @@ func TestGeoContextStruct(t *testing.T) {
 // collects the first-seen state/country context for each unique value, and passes
 // context tuples (not bare strings) to the normalizer.
 func TestBuildNormalizationLookupCollectsContext(t *testing.T) {
+	t.Parallel()
 	// This test verifies the internal collection logic without calling Python.
 	// We test that unique values are collected with first-seen context.
 
@@ -1823,6 +1863,7 @@ func TestBuildNormalizationLookupCollectsContext(t *testing.T) {
 // TestBuildContextValuesFromMap verifies that converting a map[string]geoContext
 // to []valueWithContext produces the expected entries.
 func TestBuildContextValuesFromMap(t *testing.T) {
+	t.Parallel()
 	valuesWithContext := map[string]geoContext{
 		"Oakland": {State: "CA", Country: "US"},
 		"London":  {State: "", Country: "GB"},
@@ -1973,6 +2014,7 @@ func TestBuildNormalizationLookupCompositeKeyDedup(t *testing.T) {
 // TestGeoLookupKeyCompositeEquality verifies that geoLookupKey uses
 // all three fields (Value, State, Country) for equality comparison.
 func TestGeoLookupKeyCompositeEquality(t *testing.T) {
+	t.Parallel()
 	k1 := geoLookupKey{Value: "Springfield", State: "IL", Country: "US"}
 	k2 := geoLookupKey{Value: "Springfield", State: "MO", Country: "US"}
 	k3 := geoLookupKey{Value: "Springfield", State: "IL", Country: "US"}
@@ -2000,6 +2042,7 @@ func TestGeoLookupKeyCompositeEquality(t *testing.T) {
 // TestRejectedOverridesSkipsMappings verifies that canonicals in the rejected
 // blocklist are silently skipped during upsert.
 func TestRejectedOverridesSkipsMappings(t *testing.T) {
+	t.Parallel()
 	rejectedOverrides := map[string]map[string]bool{
 		categoryCity:         {"springfield": true},
 		categorySchool:       {},
@@ -2048,6 +2091,7 @@ func TestRejectedOverridesSkipsMappings(t *testing.T) {
 // TestRejectedOverridesCaseInsensitive verifies that rejection matching
 // is case-insensitive.
 func TestRejectedOverridesCaseInsensitive(t *testing.T) {
+	t.Parallel()
 	rejectedOverrides := map[string]map[string]bool{
 		categoryCity: {"springfield": true},
 	}
@@ -2076,6 +2120,7 @@ func TestRejectedOverridesCaseInsensitive(t *testing.T) {
 // TestAddressCityPopulatedInMappings verifies that address_city is populated
 // from the attendee's City field for all category mappings.
 func TestAddressCityPopulatedInMappings(t *testing.T) {
+	t.Parallel()
 	data := []attendeeGeoData{
 		{
 			PersonPBID: "p1", PersonCMID: 1001, SessionPBID: "s1", SessionCMID: 2001,
@@ -2122,6 +2167,7 @@ func TestAddressCityPopulatedInMappings(t *testing.T) {
 // TestOverrideMapDedup_AliasNewestYearWins verifies that when the same alias key
 // is assigned from records sorted by year ASC, the newest year's value wins.
 func TestOverrideMapDedup_AliasNewestYearWins(t *testing.T) {
+	t.Parallel()
 	aliasOverrides := map[string]map[string]string{
 		categoryCity: {}, categorySchool: {}, categoryCongregation: {},
 	}
@@ -2138,6 +2184,7 @@ func TestOverrideMapDedup_AliasNewestYearWins(t *testing.T) {
 
 // TestOverrideMapDedup_MergeNewestYearWins verifies merge override dedup.
 func TestOverrideMapDedup_MergeNewestYearWins(t *testing.T) {
+	t.Parallel()
 	mergeOverrides := map[string]map[string]string{
 		categoryCity: {}, categorySchool: {}, categoryCongregation: {},
 	}
@@ -2155,6 +2202,7 @@ func TestOverrideMapDedup_MergeNewestYearWins(t *testing.T) {
 
 // TestOverrideMapDedup_RejectedCarriesForward verifies rejected overrides persist across years.
 func TestOverrideMapDedup_RejectedCarriesForward(t *testing.T) {
+	t.Parallel()
 	rejectedOverrides := map[string]map[string]bool{
 		categoryCity: {}, categorySchool: {}, categoryCongregation: {},
 	}

--- a/pocketbase/sync/orchestrator_test.go
+++ b/pocketbase/sync/orchestrator_test.go
@@ -86,6 +86,7 @@ func (m *MockService) GetCallCount() int {
 
 // TestOrchestratorCreation tests orchestrator initialization
 func TestOrchestratorCreation(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	if o == nil {
@@ -112,6 +113,7 @@ func TestOrchestratorCreation(t *testing.T) {
 
 // TestRegisterService tests service registration
 func TestRegisterService(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	mock := &MockService{name: "test_service"}
@@ -128,6 +130,7 @@ func TestRegisterService(t *testing.T) {
 
 // TestRegisterMultipleServices tests registering multiple services
 func TestRegisterMultipleServices(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	services := []string{"sessions", "attendees", "persons", "bunks"}
@@ -144,6 +147,7 @@ func TestRegisterMultipleServices(t *testing.T) {
 
 // TestIsRunning tests running status checks
 func TestIsRunning(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Initially nothing should be running
@@ -171,6 +175,7 @@ func TestIsRunning(t *testing.T) {
 
 // TestGetStatus tests status retrieval
 func TestGetStatus(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Get status for non-existent job
@@ -211,6 +216,7 @@ func TestGetStatus(t *testing.T) {
 
 // TestIsAnyJobRunning tests checking if any sync job is currently running
 func TestIsAnyJobRunning(t *testing.T) {
+	t.Parallel()
 	t.Run("returns false when no jobs", func(t *testing.T) {
 		o := NewOrchestrator(nil)
 		if o.IsAnyJobRunning() {
@@ -265,6 +271,7 @@ func TestIsAnyJobRunning(t *testing.T) {
 
 // TestGetRunningJobs tests getting list of running jobs
 func TestGetRunningJobs(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Initially no jobs running
@@ -296,6 +303,7 @@ func TestGetRunningJobs(t *testing.T) {
 
 // TestIsDailySyncRunning tests daily sync running check
 func TestIsDailySyncRunning(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	if o.IsDailySyncRunning() {
@@ -313,6 +321,7 @@ func TestIsDailySyncRunning(t *testing.T) {
 
 // TestIsHistoricalSyncRunning tests historical sync running check
 func TestIsHistoricalSyncRunning(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	if o.IsHistoricalSyncRunning() {
@@ -335,6 +344,7 @@ func TestIsHistoricalSyncRunning(t *testing.T) {
 
 // TestSyncOrder tests that services are registered in correct dependency order
 func TestSyncOrder(t *testing.T) {
+	t.Parallel()
 	// Expected sync order for daily sync
 	expectedOrder := []string{
 		"sessions",
@@ -390,7 +400,9 @@ func TestSyncOrder(t *testing.T) {
 }
 
 // TestConcurrentAccess tests thread safety of orchestrator operations
-func TestConcurrentAccess(_ *testing.T) {
+func TestConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
 	o := NewOrchestrator(nil)
 
 	// Register a service
@@ -427,6 +439,7 @@ func TestConcurrentAccess(_ *testing.T) {
 
 // TestIsWeeklySyncRunning tests weekly sync running check
 func TestIsWeeklySyncRunning(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	if o.IsWeeklySyncRunning() {
@@ -444,6 +457,7 @@ func TestIsWeeklySyncRunning(t *testing.T) {
 
 // TestWeeklySyncServices tests that weekly sync includes expected global services
 func TestWeeklySyncServices(t *testing.T) {
+	t.Parallel()
 	// Weekly sync should include global definition tables that rarely change
 	// Divisions is included here since it's a global table (no year field)
 	expectedServices := []string{
@@ -476,6 +490,7 @@ func TestWeeklySyncServices(t *testing.T) {
 
 // TestWeeklySyncNotInDailySync verifies weekly services are NOT in daily sync
 func TestWeeklySyncNotInDailySync(t *testing.T) {
+	t.Parallel()
 	// Daily sync jobs - these should NOT include weekly sync services
 	// (person_tag_defs, custom_field_defs, staff_lookups, financial_lookups, divisions are weekly)
 	dailyJobs := []string{
@@ -507,6 +522,7 @@ func TestWeeklySyncNotInDailySync(t *testing.T) {
 
 // TestStatsWithSubStats tests Stats struct with SubStats for combined syncs
 func TestStatsWithSubStats(t *testing.T) {
+	t.Parallel()
 	stats := Stats{
 		Created:  10,
 		Updated:  5,
@@ -573,6 +589,7 @@ func TestStatsWithSubStats(t *testing.T) {
 
 // TestStatsWithoutSubStats tests Stats struct backwards compatibility without SubStats
 func TestStatsWithoutSubStats(t *testing.T) {
+	t.Parallel()
 	stats := Stats{
 		Created:  10,
 		Updated:  5,
@@ -594,6 +611,7 @@ func TestStatsWithoutSubStats(t *testing.T) {
 
 // TestMarkSyncRunning tests the MarkSyncRunning method
 func TestMarkSyncRunning(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Register a mock service
@@ -636,6 +654,7 @@ func TestMarkSyncRunning(t *testing.T) {
 
 // TestMarkSyncRunningPreservesStatus tests that MarkSyncRunning sets correct status fields
 func TestMarkSyncRunningPreservesStatus(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Register a mock service
@@ -683,6 +702,7 @@ func TestMarkSyncRunningPreservesStatus(t *testing.T) {
 // TestRunSingleSyncRespectsPreMarkedStatus tests that RunSingleSync uses existing status
 // if MarkSyncRunning was called first
 func TestRunSingleSyncRespectsPreMarkedStatus(t *testing.T) {
+	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {
 		o := NewOrchestrator(nil)
 
@@ -735,6 +755,7 @@ func TestRunSingleSyncRespectsPreMarkedStatus(t *testing.T) {
 // TestHistoricalSyncIncludesCustomValueServices verifies custom value services are
 // re-registered with year-specific client during historical syncs
 func TestHistoricalSyncIncludesCustomValueServices(t *testing.T) {
+	t.Parallel()
 	// This test verifies the historical sync services list includes custom value services
 	// The actual services list in RunSyncWithOptions should include:
 	// - person_custom_values
@@ -783,6 +804,7 @@ func TestHistoricalSyncIncludesCustomValueServices(t *testing.T) {
 
 // TestCustomValuesSyncServicesCount verifies the count of custom value services
 func TestCustomValuesSyncServicesCount(t *testing.T) {
+	t.Parallel()
 	jobs := GetCustomValuesSyncJobs()
 
 	if len(jobs) != 2 {
@@ -803,6 +825,7 @@ func TestCustomValuesSyncServicesCount(t *testing.T) {
 
 // TestWeeklySyncIncludesDivisions verifies divisions is in weekly sync (global table)
 func TestWeeklySyncIncludesDivisions(t *testing.T) {
+	t.Parallel()
 	jobs := GetWeeklySyncJobs()
 
 	found := false
@@ -824,6 +847,7 @@ func TestWeeklySyncIncludesDivisions(t *testing.T) {
 // stranded drafts, so a regression that drops it or moves it earlier must fail
 // this test.
 func TestGetDailySyncJobsStrandedAssignmentCleanupOrdering(t *testing.T) {
+	t.Parallel()
 	jobs := getDailySyncJobs()
 
 	pos := make(map[string]int, len(jobs))
@@ -850,6 +874,7 @@ func TestGetDailySyncJobsStrandedAssignmentCleanupOrdering(t *testing.T) {
 
 // TestDailySyncExcludesDivisions verifies divisions is NOT in daily sync
 func TestDailySyncExcludesDivisions(t *testing.T) {
+	t.Parallel()
 	// Daily sync jobs that would be in orderedJobs (excluding divisions)
 	// Note: This tests the expected behavior - divisions should NOT be here
 	dailyJobs := []string{
@@ -876,6 +901,7 @@ func TestDailySyncExcludesDivisions(t *testing.T) {
 
 // TestDailySyncIncludesFamilyCampDerived verifies family_camp_derived is in daily sync
 func TestDailySyncIncludesFamilyCampDerived(t *testing.T) {
+	t.Parallel()
 	// This test verifies family_camp_derived is part of expected daily sync jobs
 	expectedDailyJobs := []string{
 		"session_groups",
@@ -907,6 +933,7 @@ func TestDailySyncIncludesFamilyCampDerived(t *testing.T) {
 
 // TestHistoricalSyncIncludesFamilyCampDerived verifies family_camp_derived is in historical syncs
 func TestHistoricalSyncIncludesFamilyCampDerived(t *testing.T) {
+	t.Parallel()
 	// Get the list of services that SHOULD be re-registered for historical syncs
 	// These are the services registered in RunSyncWithOptions when opts.Year > 0
 	expectedHistoricalServices := []string{
@@ -943,6 +970,7 @@ func TestHistoricalSyncIncludesFamilyCampDerived(t *testing.T) {
 // TestHistoricalSyncExcludesDivisions verifies divisions is NOT in historical sync
 // (divisions is global - not year-specific)
 func TestHistoricalSyncExcludesDivisions(t *testing.T) {
+	t.Parallel()
 	// The list of services re-registered for historical syncs should NOT include divisions
 	// since divisions is a global table (no year field)
 	historicalServices := []string{
@@ -972,6 +1000,7 @@ func TestHistoricalSyncExcludesDivisions(t *testing.T) {
 
 // TestWeeklySyncJobsCount verifies the expected count of weekly sync jobs
 func TestWeeklySyncJobsCount(t *testing.T) {
+	t.Parallel()
 	jobs := GetWeeklySyncJobs()
 
 	// Weekly sync should have: person_tag_defs, custom_field_defs, staff_lookups,
@@ -985,6 +1014,7 @@ func TestWeeklySyncJobsCount(t *testing.T) {
 // TestRunSingleSyncContextDeadlineHandling verifies RunSingleSync respects parent context
 // deadlines appropriately, fixing the "rate limiter wait: context deadline exceeded" issue.
 func TestRunSingleSyncContextDeadlineHandling(t *testing.T) {
+	t.Parallel()
 	t.Run("uses parent context when deadline is generous", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			o := NewOrchestrator(nil)
@@ -1163,6 +1193,7 @@ func (c *contextCaptureMockService) Sync(ctx context.Context) error {
 // This ensures fresh DB setups triggered via API (not just RunDailySync)
 // get required global definitions before any year-specific syncs.
 func TestRunSyncWithOptionsChecksGlobalTables(t *testing.T) {
+	t.Parallel()
 	t.Run("documents that global check should run for API-triggered syncs", func(t *testing.T) {
 		// This test verifies the expected behavior: RunSyncWithOptions should
 		// call checkGlobalTablesEmpty() at the start, just like RunDailySync does.
@@ -1192,6 +1223,7 @@ func TestRunSyncWithOptionsChecksGlobalTables(t *testing.T) {
 
 // TestGetStatusWeeklySyncPending tests that queued weekly sync jobs show pending status
 func TestGetStatusWeeklySyncPending(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Set up weekly sync as running with jobs queued
@@ -1222,6 +1254,7 @@ func TestGetStatusWeeklySyncPending(t *testing.T) {
 
 // TestGetStatusWeeklySyncCompleted tests that completed weekly sync jobs show completed status
 func TestGetStatusWeeklySyncCompleted(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Set up weekly sync as running with jobs queued
@@ -1261,6 +1294,7 @@ func TestGetStatusWeeklySyncCompleted(t *testing.T) {
 
 // TestGetStatusCustomValuesSyncPending tests that queued custom values sync jobs show pending status
 func TestGetStatusCustomValuesSyncPending(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Set up custom values sync as running with jobs queued
@@ -1292,6 +1326,7 @@ func TestGetStatusCustomValuesSyncPending(t *testing.T) {
 
 // TestGetStatusCustomValuesSyncCompleted tests that completed custom values sync jobs show completed status
 func TestGetStatusCustomValuesSyncCompleted(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Set up custom values sync as running with jobs queued
@@ -1332,6 +1367,7 @@ func TestGetStatusCustomValuesSyncCompleted(t *testing.T) {
 
 // TestGlobalTablesCheckBehavior documents the expected behavior of checkGlobalTablesEmpty
 func TestGlobalTablesCheckBehavior(t *testing.T) {
+	t.Parallel()
 	// The checkGlobalTablesEmpty method:
 	// 1. Queries person_tag_defs table with limit 1
 	// 2. Returns true if no records found (global tables empty)
@@ -1371,6 +1407,7 @@ func TestGlobalTablesCheckBehavior(t *testing.T) {
 
 // TestEnqueueUnifiedSync tests basic enqueueing functionality
 func TestEnqueueUnifiedSync(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Enqueue first item
@@ -1401,6 +1438,7 @@ func TestEnqueueUnifiedSync(t *testing.T) {
 
 // TestEnqueueUnifiedSyncPosition tests queue position assignment
 func TestEnqueueUnifiedSyncPosition(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Enqueue multiple items
@@ -1427,6 +1465,7 @@ func TestEnqueueUnifiedSyncPosition(t *testing.T) {
 
 // TestEnqueueUnifiedSyncDuplicateDetection tests that duplicate requests return existing queue item
 func TestEnqueueUnifiedSyncDuplicateDetection(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Enqueue first item (without custom values)
@@ -1472,6 +1511,7 @@ func TestEnqueueUnifiedSyncDuplicateDetection(t *testing.T) {
 
 // TestDequeueUnifiedSync tests basic dequeue functionality
 func TestDequeueUnifiedSync(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Enqueue items
@@ -1497,6 +1537,7 @@ func TestDequeueUnifiedSync(t *testing.T) {
 
 // TestDequeueUnifiedSyncEmpty tests dequeue on empty queue
 func TestDequeueUnifiedSyncEmpty(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Dequeue from empty queue should return nil
@@ -1508,6 +1549,7 @@ func TestDequeueUnifiedSyncEmpty(t *testing.T) {
 
 // TestCancelQueuedSync tests canceling a queued sync
 func TestCancelQueuedSync(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Enqueue items
@@ -1538,6 +1580,7 @@ func TestCancelQueuedSync(t *testing.T) {
 
 // TestCancelQueuedSyncNotFound tests canceling a non-existent sync
 func TestCancelQueuedSyncNotFound(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Enqueue an item
@@ -1558,6 +1601,7 @@ func TestCancelQueuedSyncNotFound(t *testing.T) {
 
 // TestGetQueuedSyncsReturnsCopy tests that GetQueuedSyncs returns a copy
 func TestGetQueuedSyncsReturnsCopy(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	_, _ = o.EnqueueUnifiedSync(2025, "all", false, false, "user1")
@@ -1580,6 +1624,7 @@ func TestGetQueuedSyncsReturnsCopy(t *testing.T) {
 
 // TestGetQueuePositionByID tests getting position of a queued item
 func TestGetQueuePositionByID(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	qs1, _ := o.EnqueueUnifiedSync(2025, "all", false, false, "user1")
@@ -1611,6 +1656,7 @@ func TestGetQueuePositionByID(t *testing.T) {
 
 // TestQueueConcurrentAccess tests thread safety of queue operations
 func TestQueueConcurrentAccess(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	done := make(chan bool)
@@ -1658,6 +1704,7 @@ func TestQueueConcurrentAccess(t *testing.T) {
 
 // TestIsUnifiedSyncQueued tests checking if a unified sync is already queued
 func TestIsUnifiedSyncQueued(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Nothing queued initially
@@ -1687,6 +1734,7 @@ func TestIsUnifiedSyncQueued(t *testing.T) {
 
 // TestQueueLengthMethod tests the GetQueueLength method
 func TestQueueLengthMethod(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Empty queue
@@ -1718,6 +1766,7 @@ func TestQueueLengthMethod(t *testing.T) {
 
 // TestStats_IsNoOp tests the IsNoOp method on Stats
 func TestStats_IsNoOp(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		stats    Stats
@@ -1785,6 +1834,7 @@ func TestStats_IsNoOp(t *testing.T) {
 
 // TestJobMeta_AllJobsHavePhase tests that all sync jobs have a phase assigned
 func TestJobMeta_AllJobsHavePhase(t *testing.T) {
+	t.Parallel()
 	meta := GetJobMeta()
 
 	if len(meta) == 0 {
@@ -1818,6 +1868,7 @@ func TestJobMeta_AllJobsHavePhase(t *testing.T) {
 
 // TestJobMeta_SourcePhaseJobs tests that expected source jobs are in source phase
 func TestJobMeta_SourcePhaseJobs(t *testing.T) {
+	t.Parallel()
 	expectedSourceJobs := []string{
 		"session_groups",
 		"sessions",
@@ -1850,6 +1901,7 @@ func TestJobMeta_SourcePhaseJobs(t *testing.T) {
 
 // TestJobMeta_ExpensivePhaseJobs tests that custom values jobs are in expensive phase
 func TestJobMeta_ExpensivePhaseJobs(t *testing.T) {
+	t.Parallel()
 	expectedExpensiveJobs := []string{
 		"person_custom_values",
 		"household_custom_values",
@@ -1875,6 +1927,7 @@ func TestJobMeta_ExpensivePhaseJobs(t *testing.T) {
 
 // TestJobMeta_TransformPhaseJobs tests that derived tables are in transform phase
 func TestJobMeta_TransformPhaseJobs(t *testing.T) {
+	t.Parallel()
 	expectedTransformJobs := []string{
 		"camper_history",
 		"family_camp_derived",
@@ -1905,6 +1958,7 @@ func TestJobMeta_TransformPhaseJobs(t *testing.T) {
 // reconcile_request_lifecycle is registered there; stranded_assignment_cleanup
 // must be too.
 func TestJobMeta_IncludesStrandedAssignmentCleanup(t *testing.T) {
+	t.Parallel()
 	if got := GetPhaseForJob("stranded_assignment_cleanup"); got != PhaseTransform {
 		t.Errorf("GetPhaseForJob(\"stranded_assignment_cleanup\") = %q, want %q", got, PhaseTransform)
 	}
@@ -1924,6 +1978,7 @@ func TestJobMeta_IncludesStrandedAssignmentCleanup(t *testing.T) {
 
 // TestJobMeta_ProcessPhaseJobs tests that CSV/AI jobs are in process phase
 func TestJobMeta_ProcessPhaseJobs(t *testing.T) {
+	t.Parallel()
 	expectedProcessJobs := []string{
 		"bunk_requests",
 		"process_requests",
@@ -1949,6 +2004,7 @@ func TestJobMeta_ProcessPhaseJobs(t *testing.T) {
 
 // TestJobMeta_ExportPhaseJobs tests that export jobs are in export phase
 func TestJobMeta_ExportPhaseJobs(t *testing.T) {
+	t.Parallel()
 	expectedExportJobs := []string{
 		"multi_workbook_export",
 	}
@@ -1973,6 +2029,7 @@ func TestJobMeta_ExportPhaseJobs(t *testing.T) {
 
 // TestGetJobsForPhase_ReturnsCorrectJobs tests that GetJobsForPhase returns jobs for specified phase
 func TestGetJobsForPhase_ReturnsCorrectJobs(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		phase         Phase
 		expectedCount int // Minimum expected count
@@ -2030,6 +2087,7 @@ func TestGetJobsForPhase_ReturnsCorrectJobs(t *testing.T) {
 
 // TestGetJobsForPhase_InvalidPhase tests that GetJobsForPhase returns empty for invalid phase
 func TestGetJobsForPhase_InvalidPhase(t *testing.T) {
+	t.Parallel()
 	jobs := GetJobsForPhase("invalid_phase")
 	if len(jobs) != 0 {
 		t.Errorf("expected empty slice for invalid phase, got %v", jobs)
@@ -2038,6 +2096,7 @@ func TestGetJobsForPhase_InvalidPhase(t *testing.T) {
 
 // TestGetJobsForPhase_PreservesOrder tests that GetJobsForPhase returns jobs in definition order
 func TestGetJobsForPhase_PreservesOrder(t *testing.T) {
+	t.Parallel()
 	// Source jobs should be in a sensible order (sessions before attendees, etc.)
 	sourceJobs := GetJobsForPhase(PhaseSource)
 
@@ -2068,6 +2127,7 @@ func TestGetJobsForPhase_PreservesOrder(t *testing.T) {
 
 // TestGetAllPhases tests that GetAllPhases returns all valid phases
 func TestGetAllPhases(t *testing.T) {
+	t.Parallel()
 	phases := GetAllPhases()
 
 	if len(phases) != 5 {
@@ -2096,6 +2156,7 @@ func TestGetAllPhases(t *testing.T) {
 
 // TestGetPhaseForJob tests that GetPhaseForJob returns correct phase for each job
 func TestGetPhaseForJob(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		jobID    string
 		expected Phase
@@ -2124,6 +2185,7 @@ func TestGetPhaseForJob(t *testing.T) {
 
 // TestGetPhaseForJob_UnknownJob tests that GetPhaseForJob returns empty for unknown job
 func TestGetPhaseForJob_UnknownJob(t *testing.T) {
+	t.Parallel()
 	phase := GetPhaseForJob("unknown_job")
 	if phase != "" {
 		t.Errorf("expected empty phase for unknown job, got %q", phase)
@@ -2132,6 +2194,7 @@ func TestGetPhaseForJob_UnknownJob(t *testing.T) {
 
 // TestPhaseExecutionOrder tests that phases follow correct execution order
 func TestPhaseExecutionOrder(t *testing.T) {
+	t.Parallel()
 	// Expected order: source -> expensive -> transform -> process -> export
 	phases := GetAllPhases()
 
@@ -2156,6 +2219,7 @@ func TestPhaseExecutionOrder(t *testing.T) {
 
 // TestJobMeta_HouseholdDemographicsIncluded tests that household_demographics is in metadata
 func TestJobMeta_HouseholdDemographicsIncluded(t *testing.T) {
+	t.Parallel()
 	meta := GetJobMeta()
 
 	found := false
@@ -2179,6 +2243,7 @@ func TestJobMeta_HouseholdDemographicsIncluded(t *testing.T) {
 
 // TestJobMeta_NoDuplicateIDs tests that all job IDs are unique
 func TestJobMeta_NoDuplicateIDs(t *testing.T) {
+	t.Parallel()
 	meta := GetJobMeta()
 
 	seen := make(map[string]bool)
@@ -2196,6 +2261,7 @@ func TestJobMeta_NoDuplicateIDs(t *testing.T) {
 
 // TestOrchestrator_GetChangedCollections tests the GetChangedCollections method
 func TestOrchestrator_GetChangedCollections(t *testing.T) {
+	t.Parallel()
 	t.Run("empty when no completed syncs", func(t *testing.T) {
 		o := NewOrchestrator(nil)
 
@@ -2342,6 +2408,7 @@ func TestOrchestrator_GetChangedCollections(t *testing.T) {
 
 // TestDailySyncDoesNotIncludeTransformPhase tests that daily sync excludes all transform jobs
 func TestUnifiedSyncAlwaysIncludesTransformPhase(t *testing.T) {
+	t.Parallel()
 	// Transform jobs should ALWAYS be included in unified sync,
 	// regardless of IncludeCustomValues setting.
 	// They run against existing custom values data (same as daily sync).
@@ -2378,6 +2445,7 @@ func TestUnifiedSyncAlwaysIncludesTransformPhase(t *testing.T) {
 
 // TestRunSyncWithOptionsPhaseOrdering tests that phase ordering is correct
 func TestRunSyncWithOptionsPhaseOrdering(t *testing.T) {
+	t.Parallel()
 	t.Run("with custom values - CV before transform", func(t *testing.T) {
 		// When IncludeCustomValues=true, phases should be:
 		// Source → Expensive (CV) → Transform → (Process added separately)
@@ -2460,6 +2528,7 @@ func TestRunSyncWithOptionsPhaseOrdering(t *testing.T) {
 // only controls whether person_custom_values and household_custom_values run,
 // not whether transform phase runs.
 func TestUnifiedSyncCustomValuesOnlyAffectsCVJobs(t *testing.T) {
+	t.Parallel()
 	withCV := GetDefaultUnifiedSyncJobs(true)
 	withoutCV := GetDefaultUnifiedSyncJobs(false)
 
@@ -2507,6 +2576,7 @@ func TestUnifiedSyncCustomValuesOnlyAffectsCVJobs(t *testing.T) {
 // Historical syncs always include transform phase (same as current year).
 // They skip process phase (bunk_requests, process_requests) since those are current-year only.
 func TestRunSyncWithOptionsHistoricalMode(t *testing.T) {
+	t.Parallel()
 	t.Run("transform phase runs regardless of CV flag", func(t *testing.T) {
 		// Both with and without CV, transform jobs should be present
 		withCV := GetDefaultUnifiedSyncJobs(true)
@@ -2542,6 +2612,7 @@ func TestRunSyncWithOptionsHistoricalMode(t *testing.T) {
 
 // TestEnqueuePhaseSyncWithDebug tests that EnqueuePhaseSync accepts and stores debug flag
 func TestEnqueuePhaseSyncWithDebug(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	t.Run("debug flag is stored in queued sync", func(t *testing.T) {
@@ -2582,6 +2653,7 @@ func TestEnqueuePhaseSyncWithDebug(t *testing.T) {
 
 // TestEnqueueIndividualSyncWithDebug tests that EnqueueIndividualSync accepts and stores debug flag
 func TestEnqueueIndividualSyncWithDebug(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	t.Run("debug flag is stored in queued sync", func(t *testing.T) {
@@ -2633,6 +2705,7 @@ func (d *DebuggableMockService) IsDebugEnabled() bool {
 // TestProcessQueuedSyncsPhaseDebugPropagation tests that processQueuedSyncs
 // propagates the debug flag to services when processing phase syncs
 func TestProcessQueuedSyncsPhaseDebugPropagation(t *testing.T) {
+	t.Parallel()
 	// This test verifies the fix for the bug where debug flag was not
 	// being set on services when processing queued phase syncs
 
@@ -2677,6 +2750,7 @@ func TestProcessQueuedSyncsPhaseDebugPropagation(t *testing.T) {
 // TestProcessQueuedSyncsIndividualDebugPropagation tests that processQueuedSyncs
 // propagates the debug flag to services when processing individual syncs
 func TestProcessQueuedSyncsIndividualDebugPropagation(t *testing.T) {
+	t.Parallel()
 	t.Run("debug flag should be set on services for queued individual sync", func(t *testing.T) {
 		o := NewOrchestrator(nil)
 
@@ -2713,6 +2787,7 @@ func TestProcessQueuedSyncsIndividualDebugPropagation(t *testing.T) {
 
 // TestQueuedSyncDebugFieldSerialization tests that Debug field serializes correctly
 func TestQueuedSyncDebugFieldSerialization(t *testing.T) {
+	t.Parallel()
 	qs := QueuedSync{
 		ID:      "test-123",
 		Year:    2025,
@@ -2733,6 +2808,7 @@ func TestQueuedSyncDebugFieldSerialization(t *testing.T) {
 
 // TestGetCurrentRunProgress_NoSyncRunning tests that no progress is returned when nothing runs
 func TestGetCurrentRunProgress_NoSyncRunning(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	runType, remaining, total, completed := o.GetCurrentRunProgress()
@@ -2753,6 +2829,7 @@ func TestGetCurrentRunProgress_NoSyncRunning(t *testing.T) {
 
 // TestGetCurrentRunProgress_DailySyncRunning tests progress tracking during daily sync
 func TestGetCurrentRunProgress_DailySyncRunning(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Simulate daily sync in progress with 5 jobs, currently on job 2 (index 1)
@@ -2787,6 +2864,7 @@ func TestGetCurrentRunProgress_DailySyncRunning(t *testing.T) {
 
 // TestGetCurrentRunProgress_HistoricalSyncRunning tests progress tracking during historical sync
 func TestGetCurrentRunProgress_HistoricalSyncRunning(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Simulate historical sync in progress
@@ -2818,6 +2896,7 @@ func TestGetCurrentRunProgress_HistoricalSyncRunning(t *testing.T) {
 
 // TestGetCurrentRunProgress_WeeklySyncRunning tests progress tracking during weekly sync
 func TestGetCurrentRunProgress_WeeklySyncRunning(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Simulate weekly sync in progress
@@ -2846,6 +2925,7 @@ func TestGetCurrentRunProgress_WeeklySyncRunning(t *testing.T) {
 
 // TestGetCurrentRunProgress_CustomValuesSyncRunning tests progress tracking during CV sync
 func TestGetCurrentRunProgress_CustomValuesSyncRunning(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Simulate custom values sync in progress
@@ -2877,6 +2957,7 @@ func TestGetCurrentRunProgress_CustomValuesSyncRunning(t *testing.T) {
 
 // TestGetCurrentRunProgress_IndexOutOfBounds tests handling when index exceeds queue
 func TestGetCurrentRunProgress_IndexOutOfBounds(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Simulate edge case where index is at queue length
@@ -2908,6 +2989,7 @@ func TestGetCurrentRunProgress_IndexOutOfBounds(t *testing.T) {
 
 // TestGetCurrentRunProgress_PriorityOrder tests which sync type takes precedence
 func TestGetCurrentRunProgress_PriorityOrder(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Set multiple sync flags (shouldn't happen in practice, but tests priority)
@@ -2928,6 +3010,7 @@ func TestGetCurrentRunProgress_PriorityOrder(t *testing.T) {
 }
 
 func TestFinalizeSyncStatusSuccess(t *testing.T) {
+	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {
 		o := NewOrchestrator(nil)
 		mock := &MockService{name: "test", delay: 0}
@@ -2975,6 +3058,7 @@ func TestFinalizeSyncStatusSuccess(t *testing.T) {
 }
 
 func TestFinalizeSyncStatusError(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 	mock := &MockService{name: "test", delay: 0}
 	o.RegisterService("test", mock)
@@ -3008,6 +3092,7 @@ func TestFinalizeSyncStatusError(t *testing.T) {
 }
 
 func TestFinalizeSyncStatusNoopWhenNotTracked(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 	mock := &MockService{name: "test", delay: 0}
 	o.RegisterService("test", mock)
@@ -3028,6 +3113,7 @@ func TestFinalizeSyncStatusNoopWhenNotTracked(t *testing.T) {
 }
 
 func TestFinalizeSyncStatusCalledFromPanicRecovery(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 	mock := &MockService{name: "test", delay: 0}
 	o.RegisterService("test", mock)
@@ -3063,6 +3149,7 @@ func TestFinalizeSyncStatusCalledFromPanicRecovery(t *testing.T) {
 // TestFinalizeSyncStatusAtomicTransition tests that concurrent readers never see
 // a partially-written status during FinalizeSyncStatus.
 func TestFinalizeSyncStatusAtomicTransition(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 	mock := &MockService{name: "test", delay: 0}
 	o.RegisterService("test", mock)
@@ -3112,6 +3199,7 @@ func TestFinalizeSyncStatusAtomicTransition(t *testing.T) {
 // TestRunSingleSyncAtomicStatusTransition tests that RunSingleSync's goroutine
 // produces consistent status — no partial writes visible to concurrent readers.
 func TestRunSingleSyncAtomicStatusTransition(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 	mock := &MockService{name: "test", delay: 10 * time.Millisecond}
 	o.RegisterService("test", mock)
@@ -3154,6 +3242,7 @@ func TestRunSingleSyncAtomicStatusTransition(t *testing.T) {
 
 // TestRunTokenPopulated tests that RunSingleSync populates RunToken on the status
 func TestRunTokenPopulated(t *testing.T) {
+	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {
 		o := NewOrchestrator(nil)
 
@@ -3208,6 +3297,7 @@ func TestRunTokenPopulated(t *testing.T) {
 // TestRunTokenPreservedByFinalizeSyncStatus tests that FinalizeSyncStatus preserves
 // the RunToken from the running status
 func TestRunTokenPreservedByFinalizeSyncStatus(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	mock := &MockService{name: "test_service"}
@@ -3251,6 +3341,7 @@ func TestRunTokenPreservedByFinalizeSyncStatus(t *testing.T) {
 // runSyncAndWait should only unblock when the completed status has a matching token,
 // not when a different run of the same syncType completes.
 func TestRunSyncAndWaitMatchesToken(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	// Register a slow service
@@ -3307,6 +3398,7 @@ func TestRunSyncAndWaitMatchesToken(t *testing.T) {
 // The goroutine may complete before the token is captured from runningJobs,
 // leaving expectedToken="" which never matches — causing an infinite loop.
 func TestRunSyncAndWaitZeroDelayNoDeadlock(t *testing.T) {
+	t.Parallel()
 	// Run multiple iterations to increase race likelihood
 	for i := range 5 {
 		t.Run(fmt.Sprintf("iteration_%d", i), func(t *testing.T) {
@@ -3334,6 +3426,7 @@ func TestRunSyncAndWaitZeroDelayNoDeadlock(t *testing.T) {
 // with a random hex suffix. Regression test for #853 — same collision vulnerability
 // as #833 fixed in generateRunToken.
 func TestGenerateQueueID(t *testing.T) {
+	t.Parallel()
 	t.Run("returns non-empty string", func(t *testing.T) {
 		id := generateQueueID()
 		if id == "" {
@@ -3375,6 +3468,7 @@ func TestGenerateQueueID(t *testing.T) {
 // Regression test for #791 — two inline fmt.Sprintf("%d", time.Now().UnixNano()) calls
 // are consolidated into this single helper.
 func TestGenerateRunToken(t *testing.T) {
+	t.Parallel()
 	t.Run("returns non-empty string", func(t *testing.T) {
 		token := generateRunToken()
 		if token == "" {
@@ -3423,6 +3517,7 @@ func TestGenerateRunToken(t *testing.T) {
 // RunSingleSyncWithService, which must run *that* instance and never touch (or even require)
 // a registered singleton.
 func TestRunSingleSyncWithServiceIgnoresRegisteredSingleton(t *testing.T) {
+	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {
 		o := NewOrchestrator(nil)
 
@@ -3475,6 +3570,7 @@ func TestRunSingleSyncWithServiceIgnoresRegisteredSingleton(t *testing.T) {
 // case: once a run for syncType has been reserved, a later call for the same syncType is
 // rejected outright and its service instance is never executed.
 func TestRunSingleSyncWithServiceRejectsConcurrentRunForSameType(t *testing.T) {
+	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {
 		o := NewOrchestrator(nil)
 
@@ -3508,6 +3604,7 @@ func TestRunSingleSyncWithServiceRejectsConcurrentRunForSameType(t *testing.T) {
 // many goroutines race to start the same syncType at once, exactly one may win and execute —
 // everyone else must be rejected before their service instance ever runs.
 func TestRunSingleSyncWithServiceConcurrentCallsExactlyOneWins(t *testing.T) {
+	t.Parallel()
 	o := NewOrchestrator(nil)
 
 	const attempts = 50
@@ -3569,6 +3666,7 @@ func TestRunSingleSyncWithServiceConcurrentCallsExactlyOneWins(t *testing.T) {
 // asserts the registered singleton's Session field is untouched by B, no matter how B is
 // rejected.
 func TestCustomFieldValuesHandlersReserveBeforeMutatingSharedState(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name     string
 		syncType string

--- a/pocketbase/sync/orphan_guard_test.go
+++ b/pocketbase/sync/orphan_guard_test.go
@@ -13,6 +13,7 @@ import (
 // ---------------------------------------------------------------------------
 
 func TestOrphanSweepGuardCheck(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		computed   int
@@ -57,6 +58,7 @@ func TestOrphanSweepGuardCheck(t *testing.T) {
 // TestOrphanSweepGuardCheckCarriesTheHint proves a service can point the
 // operator at its own upstream, which is what the two shipped guards do.
 func TestOrphanSweepGuardCheckCarriesTheHint(t *testing.T) {
+	t.Parallel()
 	g := OrphanSweepGuard{
 		Entity:   "staff_vehicle_info",
 		Year:     2026,
@@ -82,6 +84,7 @@ func TestOrphanSweepGuardCheckCarriesTheHint(t *testing.T) {
 // entries when hundreds were expected, and the unwidened guard -- which only
 // asked "is it empty?" -- waved it through and deleted the rest.
 func TestBaseDeleteOrphansGuardedRefusesPartialCollapse(t *testing.T) {
+	t.Parallel()
 	const (
 		seeded   = 300
 		computed = 5
@@ -133,6 +136,7 @@ func TestBaseDeleteOrphansGuardedRefusesPartialCollapse(t *testing.T) {
 // TestBaseDeleteOrphansGuardedStillSweepsNormalChurn proves the widened guard
 // did not turn ordinary attrition into a failed sync.
 func TestBaseDeleteOrphansGuardedStillSweepsNormalChurn(t *testing.T) {
+	t.Parallel()
 	const (
 		seeded   = 300
 		computed = 290
@@ -181,6 +185,7 @@ func TestBaseDeleteOrphansGuardedStillSweepsNormalChurn(t *testing.T) {
 }
 
 func TestPersonCustomFieldValuesDeleteOrphansRefusesPartialCollapse(t *testing.T) {
+	t.Parallel()
 	const seeded = 300
 
 	app := newOrphanSweepTestApp(t, "person_custom_values", "person", "field_definition", "value")
@@ -214,6 +219,7 @@ func TestPersonCustomFieldValuesDeleteOrphansRefusesPartialCollapse(t *testing.T
 // the sweep's own filter is the whole year. Reading the whole year and judging
 // it against one session's keys would delete every other session's values.
 func TestPersonCustomFieldValuesDeleteOrphansIgnoresPersonsThisRunDidNotFetch(t *testing.T) {
+	t.Parallel()
 	// Person 2 holds far fewer rows than person 1 on purpose: dropping the
 	// scoping has to fail THIS test on the surviving-row count, not by tripping
 	// the collapse guard, or the test would not be pinning the scoping at all.
@@ -257,6 +263,7 @@ func TestPersonCustomFieldValuesDeleteOrphansIgnoresPersonsThisRunDidNotFetch(t 
 }
 
 func TestHouseholdCustomFieldValuesDeleteOrphansRefusesPartialCollapse(t *testing.T) {
+	t.Parallel()
 	const seeded = 300
 
 	app := newOrphanSweepTestApp(t, "household_custom_values", "household", "field_definition", "value")
@@ -284,6 +291,7 @@ func TestHouseholdCustomFieldValuesDeleteOrphansRefusesPartialCollapse(t *testin
 // mirrors the person case: getHouseholdIDsToSync takes the same ?session=
 // filter.
 func TestHouseholdCustomFieldValuesDeleteOrphansIgnoresHouseholdsThisRunDidNotFetch(t *testing.T) {
+	t.Parallel()
 	const (
 		household1Rows = 40
 		household2Rows = 10

--- a/pocketbase/sync/orphan_sweep_test.go
+++ b/pocketbase/sync/orphan_sweep_test.go
@@ -98,6 +98,7 @@ func countRows(t *testing.T, app core.App, collection, filter string) int {
 // keeps 1. The offset implementation deletes the first page, then asks for
 // offset 100 of a 50-row table, gets nothing back, and stops.
 func TestBaseDeleteOrphansInspectsEveryRecordWhileDeleting(t *testing.T) {
+	t.Parallel()
 	const seeded = 150
 
 	app := newOrphanSweepTestApp(t, "widgets", "name")
@@ -166,6 +167,7 @@ func TestBaseDeleteOrphansInspectsEveryRecordWhileDeleting(t *testing.T) {
 // The fixture is 10,050 rows for one person: the first 10,000 are still
 // computed, the last 50 are orphans that only a paginated sweep can reach.
 func TestPersonCustomFieldValuesDeleteOrphansSweepsPastTheTenThousandCap(t *testing.T) {
+	t.Parallel()
 	const (
 		seeded   = 10050
 		computed = 10000
@@ -199,6 +201,7 @@ func TestPersonCustomFieldValuesDeleteOrphansSweepsPastTheTenThousandCap(t *test
 // latent twin from kindred#2266: identical statement, identical cap, smaller
 // table today.
 func TestHouseholdCustomFieldValuesDeleteOrphansSweepsPastTheTenThousandCap(t *testing.T) {
+	t.Parallel()
 	const (
 		seeded   = 10050
 		computed = 10000
@@ -234,6 +237,7 @@ func TestHouseholdCustomFieldValuesDeleteOrphansSweepsPastTheTenThousandCap(t *t
 // orphaned. Unkeyable is not orphaned: nothing may be deleted, and the guard
 // never sees these rows because they were never deletion candidates.
 func TestBaseDeleteOrphansDeletesNothingWhenNoRecordCanBeKeyed(t *testing.T) {
+	t.Parallel()
 	const seeded = 50
 
 	app := newOrphanSweepTestApp(t, "widgets", "name")
@@ -296,6 +300,7 @@ func captureSweepLogs(t *testing.T) *strings.Builder {
 // (attendees, bunk_assignments, bunk_plans) tell the reader to look for an
 // unkeyable-record warning, so one has to exist.
 func TestBaseDeleteOrphansWarnsWhenNothingCanBeKeyed(t *testing.T) {
+	t.Parallel()
 	const seeded = 30
 
 	app := newOrphanSweepTestApp(t, "widgets", "name")
@@ -345,6 +350,7 @@ func TestBaseDeleteOrphansWarnsWhenNothingCanBeKeyed(t *testing.T) {
 // told the opposite of the truth. A blocking relation is the cheapest way to
 // make App.Delete fail for real rather than mocking it.
 func TestBaseDeleteOrphansCountsOnlyCompletedDeletes(t *testing.T) {
+	t.Parallel()
 	app := newOrphanSweepTestApp(t, "widgets", "name")
 	widgets, err := app.FindCollectionByNameOrId("widgets")
 	if err != nil {
@@ -431,6 +437,7 @@ func (a *filterSpyApp) FindRecordsByFilter(
 //
 // The paging cursor therefore must not travel in the filter string.
 func TestSweepDoesNotMintAFilterStringPerPage(t *testing.T) {
+	t.Parallel()
 	const seeded = 1200
 
 	base := newOrphanSweepTestApp(t, "person_custom_values", "person", "field_definition", "value")

--- a/pocketbase/sync/person_custom_field_values_test.go
+++ b/pocketbase/sync/person_custom_field_values_test.go
@@ -10,6 +10,7 @@ const testPersonPBID = "pb_person_123"
 const testFieldDefPBIDPerson = "pb_field_100"
 
 func TestPersonCustomFieldValuesSync_Name(t *testing.T) {
+	t.Parallel()
 	s := &PersonCustomFieldValuesSync{}
 
 	got := s.Name()
@@ -22,6 +23,7 @@ func TestPersonCustomFieldValuesSync_Name(t *testing.T) {
 
 // TestTransformPersonCustomFieldValueToPB tests transformation to PocketBase format
 func TestTransformPersonCustomFieldValueToPB(t *testing.T) {
+	t.Parallel()
 	s := &PersonCustomFieldValuesSync{}
 
 	// Mock CampMinder API response for a custom field value
@@ -68,6 +70,7 @@ func TestTransformPersonCustomFieldValueToPB(t *testing.T) {
 
 // TestTransformPersonCustomFieldValueEmptyValue tests that empty values are allowed
 func TestTransformPersonCustomFieldValueEmptyValue(t *testing.T) {
+	t.Parallel()
 	s := &PersonCustomFieldValuesSync{}
 
 	// Empty value is valid (field might be cleared)
@@ -85,6 +88,7 @@ func TestTransformPersonCustomFieldValueEmptyValue(t *testing.T) {
 
 // TestTransformPersonCustomFieldValueNilValue tests handling of nil Value
 func TestTransformPersonCustomFieldValueNilValue(t *testing.T) {
+	t.Parallel()
 	s := &PersonCustomFieldValuesSync{}
 
 	// Nil value (field has no value set)
@@ -106,6 +110,7 @@ func TestTransformPersonCustomFieldValueNilValue(t *testing.T) {
 // The PreloadCompositeRecords function appends "|year" to the keyBuilder result,
 // so the keyBuilder must NOT include year, and all lookups must use "key|year" format.
 func TestPersonCustomFieldValuesCompositeKeyFormat(t *testing.T) {
+	t.Parallel()
 	personPBId := testPersonPBID
 	fieldDefPBId := testFieldDefPBIDPerson
 	year := 2025
@@ -145,6 +150,7 @@ func TestPersonCustomFieldValuesCompositeKeyFormat(t *testing.T) {
 // the keyBuilder closure should return identity only (no year),
 // because PreloadCompositeRecords will append "|year" to it.
 func TestPersonCustomFieldValuesKeyBuilderShouldNotIncludeYear(t *testing.T) {
+	t.Parallel()
 	// Simulate what the keyBuilder closure does
 	personPBId := "abc123"
 	fieldDefPBId := "def456"
@@ -189,6 +195,7 @@ func TestPersonCustomFieldValuesKeyBuilderShouldNotIncludeYear(t *testing.T) {
 // This is the actual bug: TrackProcessedKey(yearScopedKey, 0) creates "key|0" but
 // orphan deletion looks for "key" without the trailing "|0".
 func TestPersonCustomFieldValuesTrackingMatchesOrphanLookup(t *testing.T) {
+	t.Parallel()
 	s := &PersonCustomFieldValuesSync{
 		BaseSyncService: BaseSyncService{
 			ProcessedKeys: make(map[string]bool),

--- a/pocketbase/sync/person_tag_definitions_test.go
+++ b/pocketbase/sync/person_tag_definitions_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestPersonTagDefinitionsSync_Name(t *testing.T) {
+	t.Parallel()
 	s := &PersonTagDefinitionsSync{}
 
 	got := s.Name()
@@ -17,6 +18,7 @@ func TestPersonTagDefinitionsSync_Name(t *testing.T) {
 
 // TestTransformPersonTagDefinitionToPB tests that all CampMinder tag definition fields are extracted
 func TestTransformPersonTagDefinitionToPB(t *testing.T) {
+	t.Parallel()
 	s := &PersonTagDefinitionsSync{}
 
 	// Mock CampMinder API response (based on TagDef schema in persons.yaml)
@@ -54,6 +56,7 @@ func TestTransformPersonTagDefinitionToPB(t *testing.T) {
 
 // TestTransformPersonTagDefinitionHandlesMissingFields tests that nil/missing fields don't cause errors
 func TestTransformPersonTagDefinitionHandlesMissingFields(t *testing.T) {
+	t.Parallel()
 	s := &PersonTagDefinitionsSync{}
 
 	// Minimal data with only required fields
@@ -82,6 +85,7 @@ func TestTransformPersonTagDefinitionHandlesMissingFields(t *testing.T) {
 
 // TestTransformPersonTagDefinitionRequiredNameError tests that missing Name returns error
 func TestTransformPersonTagDefinitionRequiredNameError(t *testing.T) {
+	t.Parallel()
 	s := &PersonTagDefinitionsSync{}
 
 	// Missing Name field
@@ -97,6 +101,7 @@ func TestTransformPersonTagDefinitionRequiredNameError(t *testing.T) {
 
 // TestTransformPersonTagDefinitionEmptyNameError tests that empty Name returns error
 func TestTransformPersonTagDefinitionEmptyNameError(t *testing.T) {
+	t.Parallel()
 	s := &PersonTagDefinitionsSync{}
 
 	// Empty Name field

--- a/pocketbase/sync/persons_test.go
+++ b/pocketbase/sync/persons_test.go
@@ -9,6 +9,7 @@ const testAlumniTagID = "rec_alumni_001"
 const testFirstName = "Emma"
 
 func TestPersonsSync_Name(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{}
 
 	got := s.Name()
@@ -21,6 +22,7 @@ func TestPersonsSync_Name(t *testing.T) {
 
 // TestTransformPersonToPB_CamperDetailsExpanded tests that all CamperDetails fields are extracted
 func TestTransformPersonToPB_CamperDetailsExpanded(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{
 		missingDataStats: make(map[string]int),
 	}
@@ -92,6 +94,7 @@ func TestTransformPersonToPB_CamperDetailsExpanded(t *testing.T) {
 
 // TestTransformPersonToPB_MissingCamperDetailsFields tests graceful handling of missing CamperDetails fields
 func TestTransformPersonToPB_MissingCamperDetailsFields(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{
 		missingDataStats: make(map[string]int),
 	}
@@ -136,6 +139,7 @@ func TestTransformPersonToPB_MissingCamperDetailsFields(t *testing.T) {
 
 // TestExtractHouseholdsFromPersonData tests household extraction during combined sync
 func TestExtractHouseholdsFromPersonData(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{
 		missingDataStats: make(map[string]int),
 	}
@@ -169,6 +173,7 @@ func TestExtractHouseholdsFromPersonData(t *testing.T) {
 
 // TestExtractHouseholdsFromPersonData_NoHouseholds tests handling when Households is missing
 func TestExtractHouseholdsFromPersonData_NoHouseholds(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{
 		missingDataStats: make(map[string]int),
 	}
@@ -187,6 +192,7 @@ func TestExtractHouseholdsFromPersonData_NoHouseholds(t *testing.T) {
 
 // TestPersonsSync_TransformHouseholdToPB tests household transformation for combined sync
 func TestPersonsSync_TransformHouseholdToPB(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{
 		missingDataStats: make(map[string]int),
 	}
@@ -229,6 +235,7 @@ func TestPersonsSync_TransformHouseholdToPB(t *testing.T) {
 
 // TestPersonsCompareFields tests that compareFields includes new CamperDetails fields and household relations
 func TestPersonsCompareFields(t *testing.T) {
+	t.Parallel()
 	// This verifies that the fields used in processPerson include the discrete address
 	// and email columns (added in Phase 2) and don't include removed JSON fields.
 	expectedNewFields := []string{
@@ -267,6 +274,7 @@ func TestPersonsCompareFields(t *testing.T) {
 
 // TestExtractHouseholdIDsFromPerson tests extraction of household CampMinder IDs
 func TestExtractHouseholdIDsFromPerson(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{}
 
 	personData := map[string]any{
@@ -302,6 +310,7 @@ func TestExtractHouseholdIDsFromPerson(t *testing.T) {
 
 // TestExtractHouseholdIDsFromPerson_Partial tests with only some households present
 func TestExtractHouseholdIDsFromPerson_Partial(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{}
 
 	// Child with only primary childhood household
@@ -330,6 +339,7 @@ func TestExtractHouseholdIDsFromPerson_Partial(t *testing.T) {
 
 // TestAllCapsNameFix tests ALL CAPS name conversion
 func TestAllCapsNameFix(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{}
 
 	tests := []struct {
@@ -356,6 +366,7 @@ func TestAllCapsNameFix(t *testing.T) {
 // including households sub-entity stats from combined sync
 // Note: person_tags stats removed - tags are now a multi-select relation on persons
 func TestPersonsSync_GetStats_WithSubStats(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{
 		missingDataStats: make(map[string]int),
 	}
@@ -411,6 +422,7 @@ func TestPersonsSync_GetStats_WithSubStats(t *testing.T) {
 // TestPersonsSync_GetStats_WithoutSubStats tests backwards compatibility
 // when sub-entity stats are not set (not a combined sync)
 func TestPersonsSync_GetStats_WithoutSubStats(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{
 		missingDataStats: make(map[string]int),
 	}
@@ -439,6 +451,7 @@ func TestPersonsSync_GetStats_WithoutSubStats(t *testing.T) {
 
 // TestPersonsSync_GetStats_PartialSubStats tests when only some sub-entity stats are set
 func TestPersonsSync_GetStats_PartialSubStats(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{
 		missingDataStats: make(map[string]int),
 	}
@@ -486,6 +499,7 @@ func TestPersonsSync_GetStats_PartialSubStats(t *testing.T) {
 
 // TestExtractTagIDs tests extracting PocketBase tag definition IDs from person data
 func TestExtractTagIDs(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{}
 
 	// Mock tag definitions map (name -> PocketBase ID)
@@ -537,6 +551,7 @@ func TestExtractTagIDs(t *testing.T) {
 
 // TestExtractTagIDs_NoTags tests handling when Tags is missing
 func TestExtractTagIDs_NoTags(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{}
 
 	tagDefsByName := map[string]string{
@@ -556,6 +571,7 @@ func TestExtractTagIDs_NoTags(t *testing.T) {
 
 // TestExtractTagIDs_EmptyTags tests handling when Tags is empty array
 func TestExtractTagIDs_EmptyTags(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{}
 
 	tagDefsByName := map[string]string{
@@ -576,6 +592,7 @@ func TestExtractTagIDs_EmptyTags(t *testing.T) {
 
 // TestExtractTagIDs_NilTags tests handling when Tags is nil
 func TestExtractTagIDs_NilTags(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{}
 
 	tagDefsByName := map[string]string{
@@ -596,6 +613,7 @@ func TestExtractTagIDs_NilTags(t *testing.T) {
 
 // TestExtractTagIDs_UnknownTag tests handling when tag name not in definitions
 func TestExtractTagIDs_UnknownTag(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{}
 
 	tagDefsByName := map[string]string{
@@ -627,6 +645,7 @@ func TestExtractTagIDs_UnknownTag(t *testing.T) {
 
 // TestExtractTagIDs_EmptyTagName tests handling when tag Name is empty
 func TestExtractTagIDs_EmptyTagName(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{}
 
 	tagDefsByName := map[string]string{
@@ -662,6 +681,7 @@ func TestExtractTagIDs_EmptyTagName(t *testing.T) {
 
 // TestExtractPersonIDsFromStaffRecords tests extraction of person IDs from staff records
 func TestExtractPersonIDsFromStaffRecords(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{}
 
 	staffRecords := []map[string]any{
@@ -692,6 +712,7 @@ func TestExtractPersonIDsFromStaffRecords(t *testing.T) {
 
 // TestExtractPersonIDsFromStaffRecords_SkipsInvalidIDs tests that invalid person IDs are skipped
 func TestExtractPersonIDsFromStaffRecords_SkipsInvalidIDs(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{}
 
 	staffRecords := []map[string]any{
@@ -722,6 +743,7 @@ func TestExtractPersonIDsFromStaffRecords_SkipsInvalidIDs(t *testing.T) {
 
 // TestExtractPersonIDsFromStaffRecords_EmptyInput tests handling of empty input
 func TestExtractPersonIDsFromStaffRecords_EmptyInput(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{}
 
 	personIDs := s.extractPersonIDsFromStaffRecords(nil)
@@ -737,6 +759,7 @@ func TestExtractPersonIDsFromStaffRecords_EmptyInput(t *testing.T) {
 
 // TestExtractPersonIDsFromStaffRecords_Deduplicates tests that duplicate IDs are removed
 func TestExtractPersonIDsFromStaffRecords_Deduplicates(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{}
 
 	// Staff member appears in multiple records (e.g., different status pages)
@@ -760,6 +783,7 @@ func TestExtractPersonIDsFromStaffRecords_Deduplicates(t *testing.T) {
 
 // TestMergePersonIDs tests merging of attendee and staff person IDs
 func TestMergePersonIDs(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{}
 
 	attendeeIDs := []int{1001, 1002, 1003}
@@ -787,6 +811,7 @@ func TestMergePersonIDs(t *testing.T) {
 
 // TestMergePersonIDs_WithOverlap tests merging when some IDs appear in both lists
 func TestMergePersonIDs_WithOverlap(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{}
 
 	// Former campers who are now staff (appear in both lists)
@@ -818,6 +843,7 @@ func TestMergePersonIDs_WithOverlap(t *testing.T) {
 
 // TestMergePersonIDs_EmptyInputs tests merging with empty or nil inputs
 func TestMergePersonIDs_EmptyInputs(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{}
 
 	// Both empty
@@ -851,6 +877,7 @@ func TestMergePersonIDs_EmptyInputs(t *testing.T) {
 
 // TestShouldExcludeTag_FutureYear tests that tags with future years are excluded
 func TestShouldExcludeTag_FutureYear(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{}
 	syncYear := 2025
 
@@ -895,6 +922,7 @@ func TestShouldExcludeTag_FutureYear(t *testing.T) {
 
 // TestShouldExcludeTag_DifferentSyncYears tests tag filtering with different sync years
 func TestShouldExcludeTag_DifferentSyncYears(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{}
 
 	// When syncing 2024, 2025 tags should be excluded
@@ -913,6 +941,7 @@ func TestShouldExcludeTag_DifferentSyncYears(t *testing.T) {
 
 // TestExtractTagIDs_FiltersFutureTags tests that extractTagIDs filters out future-year tags
 func TestExtractTagIDs_FiltersFutureTags(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{}
 
 	// Tag definitions - pretend these are in the database
@@ -971,6 +1000,7 @@ func TestExtractTagIDs_FiltersFutureTags(t *testing.T) {
 // TestTransformPersonToPB_CMLeadDateExtracted tests that cm_lead_date is extracted from CamperDetails
 // Note: cm_years_at_camp and cm_last_year_attended were removed (they duplicated years_at_camp/last_year_attended)
 func TestTransformPersonToPB_CMLeadDateExtracted(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{
 		missingDataStats: make(map[string]int),
 	}
@@ -1017,6 +1047,7 @@ func TestTransformPersonToPB_CMLeadDateExtracted(t *testing.T) {
 // TestTransformPersonToPB_CMLeadDateMissing tests graceful handling of missing cm_lead_date
 // Note: cm_years_at_camp and cm_last_year_attended were removed (they duplicated years_at_camp/last_year_attended)
 func TestTransformPersonToPB_CMLeadDateMissing(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{
 		missingDataStats: make(map[string]int),
 	}
@@ -1065,6 +1096,7 @@ func TestTransformPersonToPB_CMLeadDateMissing(t *testing.T) {
 // relation is populated from household_id when principal household is not available
 // This tests the fix for the bug where persons have household_id but empty household relation
 func TestUpdatePersonHouseholdRelations_UsesHouseholdID(t *testing.T) {
+	t.Parallel()
 	// This test verifies the expected behavior:
 	// When a person has household_id (CM ID) but no principal household in Households object,
 	// the household relation should still be populated by looking up the household by CM ID
@@ -1104,6 +1136,7 @@ func TestUpdatePersonHouseholdRelations_UsesHouseholdID(t *testing.T) {
 // TestTransformPersonToPB_IsCamperFlag tests that is_camper is set based on the isCamper parameter
 // Previously this was hardcoded to true, which incorrectly marked staff-only persons as campers
 func TestTransformPersonToPB_IsCamperFlag(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{
 		missingDataStats: make(map[string]int),
 	}
@@ -1144,6 +1177,7 @@ func TestTransformPersonToPB_IsCamperFlag(t *testing.T) {
 
 // TestGatherPersonIDs_TracksCamperStatus tests that gatherPersonIDs returns camper status info
 func TestGatherPersonIDs_TracksCamperStatus(t *testing.T) {
+	t.Parallel()
 	// This test documents the expected behavior:
 	// gatherPersonIDs should return both the list of person IDs AND a set indicating
 	// which IDs are campers (from attendees) vs staff-only
@@ -1159,6 +1193,7 @@ func TestGatherPersonIDs_TracksCamperStatus(t *testing.T) {
 // TestMergePersonIDs_PreservesCamperInfo tests that merging preserves camper identification
 // When staff and attendee IDs overlap, the person should still be marked as a camper
 func TestMergePersonIDs_PreservesCamperInfo(t *testing.T) {
+	t.Parallel()
 	// Former campers who are now staff should still be marked as campers
 	// because they appear in the attendees list
 
@@ -1191,6 +1226,7 @@ func TestMergePersonIDs_PreservesCamperInfo(t *testing.T) {
 
 // TestExtractAddressCity tests extraction of city from address for the new address_city field
 func TestExtractAddressCity(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{
 		missingDataStats: make(map[string]int),
 	}
@@ -1239,6 +1275,7 @@ func TestExtractAddressCity(t *testing.T) {
 
 // TestExtractAddressCity_StateField tests extraction when State field is used instead of StateProvince
 func TestExtractAddressCity_StateField(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{
 		missingDataStats: make(map[string]int),
 	}
@@ -1285,6 +1322,7 @@ func TestExtractAddressCity_StateField(t *testing.T) {
 
 // TestExtractAddressCity_NoHouseholds tests graceful handling when no household data
 func TestExtractAddressCity_NoHouseholds(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{
 		missingDataStats: make(map[string]int),
 	}
@@ -1327,6 +1365,7 @@ func TestExtractAddressCity_NoHouseholds(t *testing.T) {
 
 // TestExtractPrimaryEmail tests extraction of primary email (IsLogin: true)
 func TestExtractPrimaryEmail(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{
 		missingDataStats: make(map[string]int),
 	}
@@ -1376,6 +1415,7 @@ func TestExtractPrimaryEmail(t *testing.T) {
 
 // TestExtractPrimaryEmail_FirstEntryFallback tests that first entry is used when no IsLogin
 func TestExtractPrimaryEmail_FirstEntryFallback(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{
 		missingDataStats: make(map[string]int),
 	}
@@ -1423,6 +1463,7 @@ func TestExtractPrimaryEmail_FirstEntryFallback(t *testing.T) {
 
 // TestExtractPrimaryEmail_SingleEmail tests handling when only one email exists
 func TestExtractPrimaryEmail_SingleEmail(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{
 		missingDataStats: make(map[string]int),
 	}
@@ -1467,6 +1508,7 @@ func TestExtractPrimaryEmail_SingleEmail(t *testing.T) {
 
 // TestExtractPrimaryEmail_NoEmails tests handling when no emails exist
 func TestExtractPrimaryEmail_NoEmails(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{
 		missingDataStats: make(map[string]int),
 	}
@@ -1509,6 +1551,7 @@ func TestExtractPrimaryEmail_NoEmails(t *testing.T) {
 
 // TestPhoneNumbersRemoved tests that phone_numbers field is no longer populated
 func TestPhoneNumbersRemoved(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{
 		missingDataStats: make(map[string]int),
 	}
@@ -1548,6 +1591,7 @@ func TestPhoneNumbersRemoved(t *testing.T) {
 }
 
 func TestParseHouseholdSalutation(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{}
 
 	type want struct {
@@ -1681,6 +1725,7 @@ func TestParseHouseholdSalutation(t *testing.T) {
 // Relatives array (which only carries IDs) and produced parent_names=null for
 // every record — see #1393.
 func TestTransformPersonToPB_ParentNamesFromMailingTitle(t *testing.T) {
+	t.Parallel()
 	s := &PersonsSync{missingDataStats: make(map[string]int)}
 
 	personData := map[string]any{
@@ -1728,6 +1773,7 @@ func contains(haystack, needle string) bool {
 // this, the upsert path skips the field (only fields present in pbData are
 // compared/written), and stale guardian data persists indefinitely.
 func TestTransformPersonToPB_ParentNamesClearedOnParseFail(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name        string
 		households  any

--- a/pocketbase/sync/process_requests_test.go
+++ b/pocketbase/sync/process_requests_test.go
@@ -12,6 +12,7 @@ import (
 
 // TestCallAPIProcessor tests the HTTP-based process-requests API call
 func TestCallAPIProcessor(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		responseStatus int
@@ -103,6 +104,7 @@ func TestCallAPIProcessor(t *testing.T) {
 
 // TestCallAPIProcessor_ForceField verifies the force field is serialized in the request body
 func TestCallAPIProcessor_ForceField(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var reqBody map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
@@ -140,6 +142,7 @@ func TestCallAPIProcessor_ForceField(t *testing.T) {
 
 // TestCallAPIProcessor_CollectTracesField verifies collect_traces is serialized in the request body
 func TestCallAPIProcessor_CollectTracesField(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var reqBody map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
@@ -221,6 +224,7 @@ func TestGetProcessRequestsTimeout(t *testing.T) {
 
 // TestApiProcessorRequestSerializesTrigger verifies that the trigger field is serialized in the JSON body
 func TestApiProcessorRequestSerializesTrigger(t *testing.T) {
+	t.Parallel()
 	b, err := json.Marshal(apiProcessorRequest{Year: 2026, Session: "all", Trigger: "upload"})
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
@@ -232,6 +236,7 @@ func TestApiProcessorRequestSerializesTrigger(t *testing.T) {
 
 // TestApiProcessorRequestOmitsEmptyTrigger verifies that an empty trigger is omitted from the JSON body
 func TestApiProcessorRequestOmitsEmptyTrigger(t *testing.T) {
+	t.Parallel()
 	b, err := json.Marshal(apiProcessorRequest{Year: 2026, Session: "all"})
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
@@ -245,6 +250,7 @@ func TestApiProcessorRequestOmitsEmptyTrigger(t *testing.T) {
 // non-numeric strings after the migration from friendly session names.
 // Regression test for #807.
 func TestIsValidSessionWithCMIDs(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		session string

--- a/pocketbase/sync/quest_registrations_test.go
+++ b/pocketbase/sync/quest_registrations_test.go
@@ -14,6 +14,7 @@ import (
 // into the map and then silently fail to route. No untrimmed name exists in
 // this table today; this pins the fix against a future one.
 func TestQuestRegistrationsLoadFieldDefinitionsTrimsNames(t *testing.T) {
+	t.Parallel()
 	app := newFieldDefsTestApp(t, map[int]string{
 		1: "Q-Why come? ",           // trailing space
 		2: "Quest-Parent Signature", // already clean, must be unaffected
@@ -46,6 +47,7 @@ func TestQuestRegistrationsLoadFieldDefinitionsTrimsNames(t *testing.T) {
 
 // TestQuestRegistrationsSync_Name verifies the service name is correct
 func TestQuestRegistrationsSync_Name(t *testing.T) {
+	t.Parallel()
 	expectedName := "quest_registrations"
 	if serviceNameQuestRegistrations != expectedName {
 		t.Errorf("expected service name %q, got %q", expectedName, serviceNameQuestRegistrations)
@@ -54,6 +56,7 @@ func TestQuestRegistrationsSync_Name(t *testing.T) {
 
 // TestQuestRegistrationsYearValidation tests year parameter validation
 func TestQuestRegistrationsYearValidation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		year      int
@@ -81,6 +84,7 @@ func TestQuestRegistrationsYearValidation(t *testing.T) {
 
 // TestQuestFieldMapping tests CampMinder field to column mapping
 func TestQuestFieldMapping(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		fieldName  string
 		wantColumn string
@@ -153,6 +157,7 @@ func TestQuestFieldMapping(t *testing.T) {
 
 // TestQuestCompositeKeyFormat tests composite key generation
 func TestQuestCompositeKeyFormat(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		personID int
@@ -176,6 +181,7 @@ func TestQuestCompositeKeyFormat(t *testing.T) {
 
 // TestIsQuestField tests identification of Quest fields
 func TestIsQuestField(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		fieldName   string
 		wantIsQuest bool
@@ -203,6 +209,7 @@ func TestIsQuestField(t *testing.T) {
 
 // TestQuestBooleanParsing tests parsing Bar/Bat Mitzvah year field
 func TestQuestBooleanParsing(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		rawValue string
@@ -228,6 +235,7 @@ func TestQuestBooleanParsing(t *testing.T) {
 
 // TestQuestRecordBuilding tests building quest records from source data
 func TestQuestRecordBuilding(t *testing.T) {
+	t.Parallel()
 	fieldValues := []testQuestFieldValue{
 		{PersonID: 12345, FieldName: "Quest-Parent Signature", Value: "John Smith", Year: 2025},
 		{PersonID: 12345, FieldName: "Quest-biggest hope", Value: "Make new friends", Year: 2025},
@@ -265,6 +273,7 @@ func TestQuestRecordBuilding(t *testing.T) {
 
 // TestQuestEmptyDataHandling tests graceful handling of empty input
 func TestQuestEmptyDataHandling(t *testing.T) {
+	t.Parallel()
 	fieldValues := []testQuestFieldValue{}
 
 	records := buildQuestRecords(fieldValues)
@@ -276,6 +285,7 @@ func TestQuestEmptyDataHandling(t *testing.T) {
 
 // TestQuestFieldCount tests that we map all expected fields
 func TestQuestFieldCount(t *testing.T) {
+	t.Parallel()
 	// From the plan: 45 Quest-/Q- fields total
 	// We should map at least the key ones
 	knownFields := []string{

--- a/pocketbase/sync/rate_limit_integration_test.go
+++ b/pocketbase/sync/rate_limit_integration_test.go
@@ -12,6 +12,7 @@ import (
 // TestPersonCustomFieldValuesSync_HasRateLimiter verifies that the sync service
 // initializes with a rate limiter for API calls
 func TestPersonCustomFieldValuesSync_HasRateLimiter(t *testing.T) {
+	t.Parallel()
 	s := &PersonCustomFieldValuesSync{}
 
 	// Rate limiter should be nil by default on zero-value struct
@@ -26,6 +27,7 @@ func TestPersonCustomFieldValuesSync_HasRateLimiter(t *testing.T) {
 // TestPersonCustomFieldValuesSync_RateLimiterConfig verifies the rate limiter is configured
 // with appropriate settings for CampMinder's aggressive rate limits
 func TestPersonCustomFieldValuesSync_RateLimiterConfig(t *testing.T) {
+	t.Parallel()
 	// Create a rate limiter with our expected config
 	cfg := &ratelimit.Config{
 		APIDelay:          300 * time.Millisecond, // ~3 req/sec
@@ -51,6 +53,7 @@ func TestPersonCustomFieldValuesSync_RateLimiterConfig(t *testing.T) {
 
 // TestRateLimiterRetryOn429 verifies that rate limit errors (429) trigger retry behavior
 func TestRateLimiterRetryOn429(t *testing.T) {
+	t.Parallel()
 	cfg := &ratelimit.Config{
 		APIDelay:          10 * time.Millisecond, // Fast for testing
 		BackoffMultiplier: 2.0,
@@ -83,6 +86,7 @@ func TestRateLimiterRetryOn429(t *testing.T) {
 
 // TestRateLimiterMaxAttemptsExceeded verifies that persistent rate limits eventually fail
 func TestRateLimiterMaxAttemptsExceeded(t *testing.T) {
+	t.Parallel()
 	cfg := &ratelimit.Config{
 		APIDelay:          10 * time.Millisecond,
 		BackoffMultiplier: 2.0,
@@ -112,6 +116,7 @@ func TestRateLimiterMaxAttemptsExceeded(t *testing.T) {
 
 // TestRateLimiterSuccessfulRecovery verifies that the rate limiter resets after success
 func TestRateLimiterSuccessfulRecovery(t *testing.T) {
+	t.Parallel()
 	cfg := &ratelimit.Config{
 		APIDelay:          10 * time.Millisecond,
 		BackoffMultiplier: 2.0,
@@ -156,6 +161,7 @@ func TestRateLimiterSuccessfulRecovery(t *testing.T) {
 
 // TestRateLimiterNon429ErrorNotRetried verifies that non-rate-limit errors fail immediately
 func TestRateLimiterNon429ErrorNotRetried(t *testing.T) {
+	t.Parallel()
 	cfg := &ratelimit.Config{
 		APIDelay:          10 * time.Millisecond,
 		BackoffMultiplier: 2.0,
@@ -186,6 +192,7 @@ func TestRateLimiterNon429ErrorNotRetried(t *testing.T) {
 
 // TestRateLimiterContextCancellation verifies that context cancellation stops retries
 func TestRateLimiterContextCancellation(t *testing.T) {
+	t.Parallel()
 	cfg := &ratelimit.Config{
 		APIDelay:          10 * time.Millisecond,
 		BackoffMultiplier: 2.0,
@@ -240,6 +247,7 @@ func (m *MockCustomFieldFetcher) GetPersonCustomFieldValuesPage(
 // TestSyncWithRateLimiter_Integration tests that the sync logic properly wraps API calls
 // This tests the integration pattern we expect to implement
 func TestSyncWithRateLimiter_Integration(t *testing.T) {
+	t.Parallel()
 	cfg := &ratelimit.Config{
 		APIDelay:          10 * time.Millisecond,
 		BackoffMultiplier: 2.0,
@@ -286,6 +294,7 @@ func TestSyncWithRateLimiter_Integration(t *testing.T) {
 
 // TestSyncWithRateLimiter_PersistentFailure tests behavior when API keeps failing
 func TestSyncWithRateLimiter_PersistentFailure(t *testing.T) {
+	t.Parallel()
 	cfg := &ratelimit.Config{
 		APIDelay:          10 * time.Millisecond,
 		BackoffMultiplier: 2.0,
@@ -331,6 +340,7 @@ func TestSyncWithRateLimiter_PersistentFailure(t *testing.T) {
 // TestHouseholdCustomFieldValuesSync_HasRateLimiter verifies that the household sync service
 // also has a rate limiter field
 func TestHouseholdCustomFieldValuesSync_HasRateLimiter(t *testing.T) {
+	t.Parallel()
 	s := &HouseholdCustomFieldValuesSync{}
 
 	// Rate limiter should be nil by default on zero-value struct
@@ -362,6 +372,7 @@ func (m *MockHouseholdCustomFieldFetcher) GetHouseholdCustomFieldValuesPage(
 
 // TestHouseholdSyncWithRateLimiter_Integration tests household sync rate limiting
 func TestHouseholdSyncWithRateLimiter_Integration(t *testing.T) {
+	t.Parallel()
 	cfg := &ratelimit.Config{
 		APIDelay:          10 * time.Millisecond,
 		BackoffMultiplier: 2.0,

--- a/pocketbase/sync/rate_limited_sheets_writer_test.go
+++ b/pocketbase/sync/rate_limited_sheets_writer_test.go
@@ -151,6 +151,7 @@ func testConfig() *SheetsRateLimitConfig {
 // =============================================================================
 
 func TestRateLimitedWriter_DelegatesAllMethods(t *testing.T) {
+	t.Parallel()
 	mock := newTrackingMock()
 	writer := NewRateLimitedSheetsWriter(mock, testConfig())
 	ctx := context.Background()
@@ -226,6 +227,7 @@ func TestRateLimitedWriter_DelegatesAllMethods(t *testing.T) {
 // =============================================================================
 
 func TestRateLimitedWriter_RetriesWriteOn429(t *testing.T) {
+	t.Parallel()
 	mock := newTrackingMock()
 	mock.writeErrFn = failNTimes(2) // fail twice then succeed
 	writer := NewRateLimitedSheetsWriter(mock, testConfig())
@@ -240,6 +242,7 @@ func TestRateLimitedWriter_RetriesWriteOn429(t *testing.T) {
 }
 
 func TestRateLimitedWriter_RetriesClearOn429(t *testing.T) {
+	t.Parallel()
 	mock := newTrackingMock()
 	mock.clearErrFn = failNTimes(1)
 	writer := NewRateLimitedSheetsWriter(mock, testConfig())
@@ -254,6 +257,7 @@ func TestRateLimitedWriter_RetriesClearOn429(t *testing.T) {
 }
 
 func TestRateLimitedWriter_RetriesBatchUpdateOn429(t *testing.T) {
+	t.Parallel()
 	mock := newTrackingMock()
 	mock.batchUpdateErrFn = failNTimes(1)
 	writer := NewRateLimitedSheetsWriter(mock, testConfig())
@@ -272,6 +276,7 @@ func TestRateLimitedWriter_RetriesBatchUpdateOn429(t *testing.T) {
 // =============================================================================
 
 func TestRateLimitedWriter_RetriesGetMetadataOn429(t *testing.T) {
+	t.Parallel()
 	mock := newTrackingMock()
 	mock.getMetadataErrFn = failNTimes(2)
 	writer := NewRateLimitedSheetsWriter(mock, testConfig())
@@ -286,6 +291,7 @@ func TestRateLimitedWriter_RetriesGetMetadataOn429(t *testing.T) {
 }
 
 func TestRateLimitedWriter_RetriesEnsureSheetOn429(t *testing.T) {
+	t.Parallel()
 	mock := newTrackingMock()
 	mock.ensureErrFn = failNTimes(1)
 	writer := NewRateLimitedSheetsWriter(mock, testConfig())
@@ -304,6 +310,7 @@ func TestRateLimitedWriter_RetriesEnsureSheetOn429(t *testing.T) {
 // =============================================================================
 
 func TestRateLimitedWriter_GivesUpAfterMaxRetries(t *testing.T) {
+	t.Parallel()
 	mock := newTrackingMock()
 	// fail more times than max retries (config has MaxRetries=3)
 	mock.writeErrFn = failNTimes(10)
@@ -332,6 +339,7 @@ func TestRateLimitedWriter_GivesUpAfterMaxRetries(t *testing.T) {
 // =============================================================================
 
 func TestRateLimitedWriter_DoesNotRetryNon429Errors(t *testing.T) {
+	t.Parallel()
 	mock := newTrackingMock()
 	permErr := fmt.Errorf("permission denied")
 	mock.writeErrFn = func() error { return permErr }
@@ -353,6 +361,7 @@ func TestRateLimitedWriter_DoesNotRetryNon429Errors(t *testing.T) {
 }
 
 func TestRateLimitedWriter_DoesNotRetryGoogleAPINon429(t *testing.T) {
+	t.Parallel()
 	mock := newTrackingMock()
 	mock.writeErrFn = func() error {
 		return &googleapi.Error{Code: 403, Message: "forbidden"}
@@ -375,6 +384,7 @@ func TestRateLimitedWriter_DoesNotRetryGoogleAPINon429(t *testing.T) {
 // =============================================================================
 
 func TestRateLimitedWriter_RespectsContextCancellation(t *testing.T) {
+	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {
 		mock := newTrackingMock()
 		mock.writeErrFn = failNTimes(10) // always fail
@@ -408,6 +418,7 @@ func TestRateLimitedWriter_RespectsContextCancellation(t *testing.T) {
 // =============================================================================
 
 func TestRateLimitedWriter_UsesSeparateReadWriteLimiters(t *testing.T) {
+	t.Parallel()
 	// Verify that the rate limited writer has separate read and write limiters
 	// by checking it's structurally different (not nil, not same pointer)
 	mock := newTrackingMock()
@@ -437,6 +448,7 @@ func TestRateLimitedWriter_UsesSeparateReadWriteLimiters(t *testing.T) {
 // =============================================================================
 
 func TestDefaultSheetsRateLimitConfig(t *testing.T) {
+	t.Parallel()
 	cfg := DefaultSheetsRateLimitConfig()
 
 	if cfg.ReadsPerMinute != 50 {
@@ -467,6 +479,7 @@ func TestDefaultSheetsRateLimitConfig(t *testing.T) {
 // =============================================================================
 
 func TestRateLimitedWriter_NilConfigUsesDefaults(t *testing.T) {
+	t.Parallel()
 	mock := newTrackingMock()
 	writer := NewRateLimitedSheetsWriter(mock, nil)
 
@@ -486,6 +499,7 @@ func TestRateLimitedWriter_NilConfigUsesDefaults(t *testing.T) {
 // =============================================================================
 
 func TestRateLimitedWriter_Retries429WrappedInFmtErrorf(t *testing.T) {
+	t.Parallel()
 	mock := newTrackingMock()
 	var count atomic.Int32
 	mock.writeErrFn = func() error {
@@ -511,6 +525,7 @@ func TestRateLimitedWriter_Retries429WrappedInFmtErrorf(t *testing.T) {
 // =============================================================================
 
 func TestRateLimitedWriter_RetriesSetTabColorOn429(t *testing.T) {
+	t.Parallel()
 	mock := newTrackingMock()
 	mock.setColorErrFn = failNTimes(1)
 	writer := NewRateLimitedSheetsWriter(mock, testConfig())
@@ -525,6 +540,7 @@ func TestRateLimitedWriter_RetriesSetTabColorOn429(t *testing.T) {
 }
 
 func TestRateLimitedWriter_RetriesSetTabIndexOn429(t *testing.T) {
+	t.Parallel()
 	mock := newTrackingMock()
 	mock.setIndexErrFn = failNTimes(1)
 	writer := NewRateLimitedSheetsWriter(mock, testConfig())
@@ -539,6 +555,7 @@ func TestRateLimitedWriter_RetriesSetTabIndexOn429(t *testing.T) {
 }
 
 func TestRateLimitedWriter_RetriesDeleteSheetOn429(t *testing.T) {
+	t.Parallel()
 	mock := newTrackingMock()
 	mock.deleteErrFn = failNTimes(1)
 	writer := NewRateLimitedSheetsWriter(mock, testConfig())

--- a/pocketbase/sync/reconcile_request_lifecycle_test.go
+++ b/pocketbase/sync/reconcile_request_lifecycle_test.go
@@ -18,6 +18,7 @@ const (
 // whose current attendees.session differs from the session_id stored on any
 // of their existing bunk_requests rows.
 func TestFindMovedRequesters(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name             string
 		currentSessions  map[int]int
@@ -266,6 +267,7 @@ func saveBR(t *testing.T, app core.App, requesterCMID, requesteeCMID, sessionCMI
 // session_id stored on their bunk_requests rows has all their OBRs flipped to
 // processed=” so process_requests will re-build them.
 func TestReconcileRequestLifecycle_MarksMovedRequestersOBRsUnprocessed(t *testing.T) {
+	t.Parallel()
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -317,6 +319,7 @@ func TestReconcileRequestLifecycle_MarksMovedRequestersOBRsUnprocessed(t *testin
 // requesters whose status_id != 2 are NOT touched here — the orphan purge
 // in bunk_requests sync handles their cleanup by deleting OBRs entirely.
 func TestReconcileRequestLifecycle_IgnoresInactiveRequesters(t *testing.T) {
+	t.Parallel()
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -353,6 +356,7 @@ func TestReconcileRequestLifecycle_IgnoresInactiveRequesters(t *testing.T) {
 // TestReconcileRequestLifecycle_NoOpWhenNoStaleRows verifies that the function
 // is a no-op when no requesters have moved.
 func TestReconcileRequestLifecycle_NoOpWhenNoStaleRows(t *testing.T) {
+	t.Parallel()
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -385,6 +389,7 @@ func TestReconcileRequestLifecycle_NoOpWhenNoStaleRows(t *testing.T) {
 // TestReconcileRequestLifecycle_YearScoped verifies that the function only
 // touches OBRs in the requested year, not other years.
 func TestReconcileRequestLifecycle_YearScoped(t *testing.T) {
+	t.Parallel()
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -476,6 +481,7 @@ func TestReconcileLifecycleSync_RejectsMissingYearEnv(t *testing.T) {
 // fails, markErrors gets incremented (covered by code-path correctness; the
 // PB test harness does not have a clean way to force a per-record save error).
 func TestReconcileRequestLifecycle_SuccessPathReturnsZeroMarkErrors(t *testing.T) {
+	t.Parallel()
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)

--- a/pocketbase/sync/scheduler_test.go
+++ b/pocketbase/sync/scheduler_test.go
@@ -11,6 +11,7 @@ import (
 
 // TestSchedulerCreation tests scheduler initialization
 func TestSchedulerCreation(t *testing.T) {
+	t.Parallel()
 	s := NewScheduler(nil)
 
 	if s == nil {
@@ -29,6 +30,7 @@ func TestSchedulerCreation(t *testing.T) {
 
 // TestSchedulerTriggerSyncTypes tests that TriggerSync handles all expected types
 func TestSchedulerTriggerSyncTypes(t *testing.T) {
+	t.Parallel()
 	// Valid sync types that should be handled
 	validTypes := []string{
 		"refresh-bunking",
@@ -60,6 +62,7 @@ func TestSchedulerTriggerSyncTypes(t *testing.T) {
 
 // TestSchedulerUnknownSyncType tests that unknown sync types return an error
 func TestSchedulerUnknownSyncType(t *testing.T) {
+	t.Parallel()
 	s := NewScheduler(nil)
 
 	err := s.TriggerSync(context.Background(), "invalid-type")
@@ -74,6 +77,7 @@ func TestSchedulerUnknownSyncType(t *testing.T) {
 
 // TestIsWeeklySyncRunning tests weekly sync status check via scheduler
 func TestSchedulerIsWeeklySyncRunning(t *testing.T) {
+	t.Parallel()
 	s := NewScheduler(nil)
 
 	if s.IsWeeklySyncRunning() {
@@ -83,6 +87,7 @@ func TestSchedulerIsWeeklySyncRunning(t *testing.T) {
 
 // TestIsCustomValuesSyncRunning tests custom values sync status check via scheduler
 func TestSchedulerIsCustomValuesSyncRunning(t *testing.T) {
+	t.Parallel()
 	s := NewScheduler(nil)
 
 	if s.IsCustomValuesSyncRunning() {
@@ -92,6 +97,7 @@ func TestSchedulerIsCustomValuesSyncRunning(t *testing.T) {
 
 // TestTriggerSyncCustomValues tests that TriggerSync handles custom-values type
 func TestSchedulerTriggerSyncCustomValues(t *testing.T) {
+	t.Parallel()
 	s := NewScheduler(nil)
 
 	// Register mock services for custom values sync
@@ -109,6 +115,7 @@ func TestSchedulerTriggerSyncCustomValues(t *testing.T) {
 
 // TestGetCustomValuesSyncJobs tests that custom values sync jobs are returned correctly
 func TestGetCustomValuesSyncJobs(t *testing.T) {
+	t.Parallel()
 	jobs := GetCustomValuesSyncJobs()
 
 	expected := []string{"person_custom_values", "household_custom_values"}
@@ -128,6 +135,7 @@ func TestGetCustomValuesSyncJobs(t *testing.T) {
 // This is a regression test for the "rate limiter wait: context deadline exceeded" issue
 // that occurred when both custom values syncs ran concurrently, doubling API pressure.
 func TestCustomValuesSyncRunsSequentially(t *testing.T) {
+	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {
 		s := NewScheduler(nil)
 
@@ -205,6 +213,7 @@ func TestCustomValuesSyncRunsSequentially(t *testing.T) {
 
 // TestGetRefreshBunkingJobs tests that refresh bunking returns the correct services in order
 func TestGetRefreshBunkingJobs(t *testing.T) {
+	t.Parallel()
 	jobs := GetRefreshBunkingJobs()
 
 	// stranded_assignment_cleanup runs last: refresh-bunking rewrites bunk_plans,
@@ -226,6 +235,7 @@ func TestGetRefreshBunkingJobs(t *testing.T) {
 // bunks, bunk_plans, bunk_assignments, and stranded_assignment_cleanup in
 // sequence (not just bunk_assignments)
 func TestRefreshBunkingRunsAllServices(t *testing.T) {
+	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {
 		s := NewScheduler(nil)
 
@@ -277,6 +287,7 @@ func TestRefreshBunkingRunsAllServices(t *testing.T) {
 // TestRefreshBunkingRegistersRequiredServices verifies that TriggerSync for
 // refresh-bunking requires every bunking sync job to be registered
 func TestRefreshBunkingRegistersRequiredServices(t *testing.T) {
+	t.Parallel()
 	s := NewScheduler(nil)
 
 	// Only register bunk_assignments (old behavior) — should fail with new code

--- a/pocketbase/sync/session_groups_test.go
+++ b/pocketbase/sync/session_groups_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestSessionGroupsSync_Name(t *testing.T) {
+	t.Parallel()
 	s := &SessionGroupsSync{}
 
 	got := s.Name()
@@ -17,6 +18,7 @@ func TestSessionGroupsSync_Name(t *testing.T) {
 
 // TestTransformSessionGroupToPB tests that all CampMinder session group fields are extracted
 func TestTransformSessionGroupToPB(t *testing.T) {
+	t.Parallel()
 	s := &SessionGroupsSync{}
 
 	// Mock CampMinder API response
@@ -58,6 +60,7 @@ func TestTransformSessionGroupToPB(t *testing.T) {
 
 // TestTransformSessionGroupHandlesMissingFields tests that nil/missing fields don't cause errors
 func TestTransformSessionGroupHandlesMissingFields(t *testing.T) {
+	t.Parallel()
 	s := &SessionGroupsSync{}
 
 	// Minimal data with only required fields
@@ -92,6 +95,7 @@ func TestTransformSessionGroupHandlesMissingFields(t *testing.T) {
 
 // TestTransformSessionGroupRequiredIDError tests that missing ID returns error
 func TestTransformSessionGroupRequiredIDError(t *testing.T) {
+	t.Parallel()
 	s := &SessionGroupsSync{}
 
 	// Missing ID field

--- a/pocketbase/sync/sessions_test.go
+++ b/pocketbase/sync/sessions_test.go
@@ -7,6 +7,7 @@ import (
 const testSessionName = "Session 2"
 
 func TestSessionsSync_Name(t *testing.T) {
+	t.Parallel()
 	// Create a SessionsSync without dependencies for this simple test
 	s := &SessionsSync{}
 
@@ -20,6 +21,7 @@ func TestSessionsSync_Name(t *testing.T) {
 
 // TestTransformSessionExtractsAllFields tests that all CampMinder fields are extracted to PocketBase format
 func TestTransformSessionExtractsAllFields(t *testing.T) {
+	t.Parallel()
 	// Create SessionsSync with groupIDMap populated for session_group relation
 	s := &SessionsSync{
 		groupIDMap: map[int]string{
@@ -111,6 +113,7 @@ func TestTransformSessionExtractsAllFields(t *testing.T) {
 
 // TestTransformSessionHandlesMissingFields tests that nil/missing fields don't cause errors
 func TestTransformSessionHandlesMissingFields(t *testing.T) {
+	t.Parallel()
 	s := &SessionsSync{}
 
 	// Minimal session data with only required fields
@@ -159,6 +162,7 @@ func TestTransformSessionHandlesMissingFields(t *testing.T) {
 
 // TestTransformSessionHandlesNullFields tests that explicit null values are handled
 func TestTransformSessionHandlesNullFields(t *testing.T) {
+	t.Parallel()
 	s := &SessionsSync{}
 
 	// Session data with explicit nil values (as might come from JSON null)
@@ -204,6 +208,7 @@ func TestTransformSessionHandlesNullFields(t *testing.T) {
 // TestReclassifyOverlappingSessions_SharedStartDate tests that sessions sharing a start date
 // are reclassified so the longer session stays "main" and shorter ones become "embedded"
 func TestReclassifyOverlappingSessions_SharedStartDate(t *testing.T) {
+	t.Parallel()
 	s := &SessionsSync{}
 
 	// Session 2 (June 15 - July 13) and Taste of Camp 2 (June 15 - June 20)
@@ -255,6 +260,7 @@ func TestReclassifyOverlappingSessions_SharedStartDate(t *testing.T) {
 // TestReclassifyOverlappingSessions_SharedEndDate tests that sessions sharing an end date
 // are reclassified correctly
 func TestReclassifyOverlappingSessions_SharedEndDate(t *testing.T) {
+	t.Parallel()
 	s := &SessionsSync{}
 
 	// Session 3 (July 14 - Aug 10) and Session 3a (Aug 1 - Aug 10)
@@ -300,6 +306,7 @@ func TestReclassifyOverlappingSessions_SharedEndDate(t *testing.T) {
 
 // TestReclassifyOverlappingSessions_AGSessionsExempt tests that AG sessions are never reclassified
 func TestReclassifyOverlappingSessions_AGSessionsExempt(t *testing.T) {
+	t.Parallel()
 	s := &SessionsSync{}
 
 	// AG session with same dates as main session
@@ -345,6 +352,7 @@ func TestReclassifyOverlappingSessions_AGSessionsExempt(t *testing.T) {
 // TestReclassifyOverlappingSessions_EqualDurationAlphabetical tests that sessions with
 // equal duration are decided by alphabetical name (first stays main)
 func TestReclassifyOverlappingSessions_EqualDurationAlphabetical(t *testing.T) {
+	t.Parallel()
 	s := &SessionsSync{}
 
 	// "Session A" and "Session B" with identical dates
@@ -389,6 +397,7 @@ func TestReclassifyOverlappingSessions_EqualDurationAlphabetical(t *testing.T) {
 // TestReclassifyOverlappingSessions_MultipleOverlaps tests that multiple sessions sharing
 // a start date are all reclassified correctly
 func TestReclassifyOverlappingSessions_MultipleOverlaps(t *testing.T) {
+	t.Parallel()
 	s := &SessionsSync{}
 
 	// Session 2, ToC2, and Session 2b all share June 15 start
@@ -448,6 +457,7 @@ func TestReclassifyOverlappingSessions_MultipleOverlaps(t *testing.T) {
 // TestReclassifyOverlappingSessions_NoOverlap tests that sessions with unique dates
 // retain their original types
 func TestReclassifyOverlappingSessions_NoOverlap(t *testing.T) {
+	t.Parallel()
 	s := &SessionsSync{}
 
 	sessions := []map[string]any{
@@ -489,6 +499,7 @@ func TestReclassifyOverlappingSessions_NoOverlap(t *testing.T) {
 // TestReclassifyOverlappingSessions_NonMainUnchanged tests that non-main types
 // (family, tli, etc.) are not reclassified even if dates overlap
 func TestReclassifyOverlappingSessions_NonMainUnchanged(t *testing.T) {
+	t.Parallel()
 	s := &SessionsSync{}
 
 	// Family camp with same dates as a main session
@@ -533,6 +544,7 @@ func TestReclassifyOverlappingSessions_NonMainUnchanged(t *testing.T) {
 // TestReclassifyOverlappingSessions_MissingDates tests that sessions without dates
 // are skipped in reclassification
 func TestReclassifyOverlappingSessions_MissingDates(t *testing.T) {
+	t.Parallel()
 	s := &SessionsSync{}
 
 	sessions := []map[string]any{
@@ -573,6 +585,7 @@ func TestReclassifyOverlappingSessions_MissingDates(t *testing.T) {
 }
 
 func TestGetSessionTypeFromName(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string
@@ -666,6 +679,7 @@ func TestGetSessionTypeFromName(t *testing.T) {
 // TestGetSessionTypeFromGroupID tests that session group cm_ids map to correct session types
 // Session groups are stable across all years, making this classification reliable for historical data
 func TestGetSessionTypeFromGroupID(t *testing.T) {
+	t.Parallel()
 	s := &SessionsSync{}
 
 	tests := []struct {
@@ -788,6 +802,7 @@ func TestGetSessionTypeFromGroupID(t *testing.T) {
 // accepted as-is. A *mapped* group's result is never overridden - it only equals
 // sessionTypeOther when the switch actually hit its default arm.
 func TestClassifySessionType_UnmappedGroupFallsThroughToNameRules(t *testing.T) {
+	t.Parallel()
 	s := &SessionsSync{}
 
 	// cm_id 3062 ("Camp Sessions") is the real, historically stable unmapped group ID
@@ -922,6 +937,7 @@ func TestClassifySessionType_UnmappedGroupFallsThroughToNameRules(t *testing.T) 
 // TestRefineSummerSessionType tests that summer camp sessions are correctly classified
 // as main, ag, or embedded based on name and date patterns
 func TestRefineSummerSessionType(t *testing.T) {
+	t.Parallel()
 	s := &SessionsSync{}
 
 	// Build a list of all sessions for AG detection (AG needs matching dates with another session)
@@ -1027,6 +1043,7 @@ func TestRefineSummerSessionType(t *testing.T) {
 
 // TestIsAGSession tests the AG session detection logic using date matching + "gender" keyword
 func TestIsAGSession(t *testing.T) {
+	t.Parallel()
 	s := &SessionsSync{}
 
 	// Sessions for date matching

--- a/pocketbase/sync/sheets_config_test.go
+++ b/pocketbase/sync/sheets_config_test.go
@@ -11,6 +11,7 @@ import (
 // =============================================================================
 
 func TestSheetsConfig_DefaultSheetName(t *testing.T) {
+	t.Parallel()
 	// Test that default sheet names use lowercase with hyphens
 	tests := []struct {
 		collection string
@@ -34,6 +35,7 @@ func TestSheetsConfig_DefaultSheetName(t *testing.T) {
 }
 
 func TestSheetsConfig_GetSheetName_YearPrefixed(t *testing.T) {
+	t.Parallel()
 	// Test that year-specific tables get year prefix
 	config := &SheetsConfig{
 		Tables: map[string]*TableConfig{
@@ -71,6 +73,7 @@ func TestSheetsConfig_GetSheetName_YearPrefixed(t *testing.T) {
 }
 
 func TestSheetsConfig_GetSheetName_GlobalPrefixed(t *testing.T) {
+	t.Parallel()
 	// Test that global tables get short "g-" prefix (not "globals-")
 	config := &SheetsConfig{
 		Tables: map[string]*TableConfig{
@@ -107,6 +110,7 @@ func TestSheetsConfig_GetSheetName_GlobalPrefixed(t *testing.T) {
 }
 
 func TestSheetsConfig_GetSheetName_FallbackToDefault(t *testing.T) {
+	t.Parallel()
 	// Test that unknown collections fall back to default naming
 	config := &SheetsConfig{
 		Tables: map[string]*TableConfig{},
@@ -121,6 +125,7 @@ func TestSheetsConfig_GetSheetName_FallbackToDefault(t *testing.T) {
 }
 
 func TestSheetsConfig_LoadConfig_AutoGeneratesDefaults(t *testing.T) {
+	t.Parallel()
 	// Test that loading a missing config file auto-generates defaults
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "sheets_export.json")
@@ -148,6 +153,7 @@ func TestSheetsConfig_LoadConfig_AutoGeneratesDefaults(t *testing.T) {
 }
 
 func TestSheetsConfig_LoadConfig_ReadsExistingFile(t *testing.T) {
+	t.Parallel()
 	// Test that loading an existing config file works
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "sheets_export.json")
@@ -183,6 +189,7 @@ func TestSheetsConfig_LoadConfig_ReadsExistingFile(t *testing.T) {
 }
 
 func TestSheetsConfig_IsTableEnabled(t *testing.T) {
+	t.Parallel()
 	// Test enabled/disabled table checks
 	config := &SheetsConfig{
 		Tables: map[string]*TableConfig{
@@ -212,6 +219,7 @@ func TestSheetsConfig_IsTableEnabled(t *testing.T) {
 }
 
 func TestSheetsConfig_GetGlobalTables(t *testing.T) {
+	t.Parallel()
 	// Test getting only global tables
 	config := &SheetsConfig{
 		Tables: map[string]*TableConfig{
@@ -265,6 +273,7 @@ func TestSheetsConfig_GetGlobalTables(t *testing.T) {
 }
 
 func TestSheetsConfig_GetYearTables(t *testing.T) {
+	t.Parallel()
 	// Test getting only year-specific tables
 	config := &SheetsConfig{
 		Tables: map[string]*TableConfig{

--- a/pocketbase/sync/sheets_scheduling_test.go
+++ b/pocketbase/sync/sheets_scheduling_test.go
@@ -9,6 +9,7 @@ import (
 // =============================================================================
 
 func TestGoogleSheetsExportOptions_DefaultValues(t *testing.T) {
+	t.Parallel()
 	// Test default export options
 	opts := NewGoogleSheetsExportOptions()
 
@@ -24,6 +25,7 @@ func TestGoogleSheetsExportOptions_DefaultValues(t *testing.T) {
 }
 
 func TestGoogleSheetsExportOptions_WithYears(t *testing.T) {
+	t.Parallel()
 	// Test setting specific years
 	opts := NewGoogleSheetsExportOptions()
 	opts.Years = []int{2024, 2023, 2022}
@@ -37,6 +39,7 @@ func TestGoogleSheetsExportOptions_WithYears(t *testing.T) {
 }
 
 func TestGoogleSheetsExportOptions_GlobalsOnlyMode(t *testing.T) {
+	t.Parallel()
 	// Test globals-only export mode
 	opts := NewGoogleSheetsExportOptions()
 	opts.IncludeGlobals = true
@@ -51,6 +54,7 @@ func TestGoogleSheetsExportOptions_GlobalsOnlyMode(t *testing.T) {
 }
 
 func TestGoogleSheetsExportOptions_DailyOnlyMode(t *testing.T) {
+	t.Parallel()
 	// Test daily-only export mode (year data only)
 	opts := NewGoogleSheetsExportOptions()
 	opts.IncludeGlobals = false
@@ -65,6 +69,7 @@ func TestGoogleSheetsExportOptions_DailyOnlyMode(t *testing.T) {
 }
 
 func TestParseExportYearsParam(t *testing.T) {
+	t.Parallel()
 	// Test parsing years parameter from API request
 	tests := []struct {
 		input   string
@@ -96,6 +101,7 @@ func TestParseExportYearsParam(t *testing.T) {
 }
 
 func TestValidateExportYears(t *testing.T) {
+	t.Parallel()
 	// Test year validation (reasonable range)
 	tests := []struct {
 		years   []int

--- a/pocketbase/sync/staff_applications_test.go
+++ b/pocketbase/sync/staff_applications_test.go
@@ -16,6 +16,7 @@ import (
 // fix, loadFieldDefinitions stored the untrimmed name, so the switch never
 // matched and 3,492 answers across the three columns were silently dropped.
 func TestStaffApplicationsLoadFieldDefinitionsTrimsNames(t *testing.T) {
+	t.Parallel()
 	app := newFieldDefsTestApp(t, map[int]string{
 		1: "App-I responded to my stress ",  // trailing space, verbatim from CampMinder
 		2: "App-Someone whose work I ",      // trailing space, verbatim from CampMinder
@@ -61,6 +62,7 @@ func TestStaffApplicationsLoadFieldDefinitionsTrimsNames(t *testing.T) {
 
 // TestStaffApplicationsServiceName verifies the service name constant
 func TestStaffApplicationsServiceName(t *testing.T) {
+	t.Parallel()
 	expected := "staff_applications"
 	if serviceNameStaffApplications != expected {
 		t.Errorf("serviceNameStaffApplications = %q, want %q", serviceNameStaffApplications, expected)
@@ -70,6 +72,7 @@ func TestStaffApplicationsServiceName(t *testing.T) {
 // TestMapAppFieldToColumn tests the CampMinder field name to column mapping
 // for the 39 App- fields used in staff applications
 func TestMapAppFieldToColumn(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		cmField  string
 		expected string
@@ -144,6 +147,7 @@ func TestMapAppFieldToColumn(t *testing.T) {
 
 // TestParseAppBool tests boolean parsing for staff application fields
 func TestParseAppBool(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input    string
 		expected bool
@@ -172,6 +176,7 @@ func TestParseAppBool(t *testing.T) {
 // TestStaffApplicationsCompositeKey tests the unique key generation
 // Key format: personID|year
 func TestStaffApplicationsCompositeKey(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		personID int
 		year     int
@@ -195,6 +200,7 @@ func TestStaffApplicationsCompositeKey(t *testing.T) {
 
 // TestStaffApplicationsFieldMapping tests that all expected fields are present
 func TestStaffApplicationsFieldMapping(t *testing.T) {
+	t.Parallel()
 	expectedFields := []string{
 		// Work availability
 		"can_work_dates",
@@ -390,6 +396,7 @@ func seedStaffApplication(t *testing.T, app core.App, cmID, year int) string {
 // gate, the computed set comes back empty, and the unguarded sweep deletes the
 // whole year and then sets SyncSuccessful = true.
 func TestStaffApplicationsDeleteOrphansRefusesEmptyComputedSet(t *testing.T) {
+	t.Parallel()
 	app := newStaffApplicationsTestApp(t)
 	recID := seedStaffApplication(t, app, 1001, 2026)
 
@@ -422,6 +429,7 @@ func TestStaffApplicationsDeleteOrphansRefusesEmptyComputedSet(t *testing.T) {
 // TestStaffApplicationsDeleteOrphansStillSweepsGenuineOrphans proves the guard
 // did not disable orphan deletion for the normal case.
 func TestStaffApplicationsDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
+	t.Parallel()
 	app := newStaffApplicationsTestApp(t)
 	keepID := seedStaffApplication(t, app, 1001, 2026)
 	orphanID := seedStaffApplication(t, app, 1002, 2026)

--- a/pocketbase/sync/staff_lookups_test.go
+++ b/pocketbase/sync/staff_lookups_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestStaffLookupsSync_Name(t *testing.T) {
+	t.Parallel()
 	s := &StaffLookupsSync{}
 
 	got := s.Name()
@@ -20,6 +21,7 @@ func TestStaffLookupsSync_Name(t *testing.T) {
 // =============================================================================
 
 func TestTransformProgramAreaToPB(t *testing.T) {
+	t.Parallel()
 	s := &StaffLookupsSync{}
 
 	// Mock CampMinder API response
@@ -48,6 +50,7 @@ func TestTransformProgramAreaToPB(t *testing.T) {
 }
 
 func TestTransformProgramAreaToPB_MissingID(t *testing.T) {
+	t.Parallel()
 	s := &StaffLookupsSync{}
 
 	data := map[string]any{
@@ -61,6 +64,7 @@ func TestTransformProgramAreaToPB_MissingID(t *testing.T) {
 }
 
 func TestTransformProgramAreaToPB_ZeroID(t *testing.T) {
+	t.Parallel()
 	s := &StaffLookupsSync{}
 
 	data := map[string]any{
@@ -75,6 +79,7 @@ func TestTransformProgramAreaToPB_ZeroID(t *testing.T) {
 }
 
 func TestTransformProgramAreaToPB_MissingName(t *testing.T) {
+	t.Parallel()
 	s := &StaffLookupsSync{}
 
 	data := map[string]any{
@@ -88,6 +93,7 @@ func TestTransformProgramAreaToPB_MissingName(t *testing.T) {
 }
 
 func TestTransformProgramAreaToPB_EmptyName(t *testing.T) {
+	t.Parallel()
 	s := &StaffLookupsSync{}
 
 	data := map[string]any{
@@ -106,6 +112,7 @@ func TestTransformProgramAreaToPB_EmptyName(t *testing.T) {
 // =============================================================================
 
 func TestTransformOrgCategoryToPB(t *testing.T) {
+	t.Parallel()
 	s := &StaffLookupsSync{}
 
 	// Mock CampMinder API response
@@ -134,6 +141,7 @@ func TestTransformOrgCategoryToPB(t *testing.T) {
 }
 
 func TestTransformOrgCategoryToPB_MissingID(t *testing.T) {
+	t.Parallel()
 	s := &StaffLookupsSync{}
 
 	data := map[string]any{
@@ -147,6 +155,7 @@ func TestTransformOrgCategoryToPB_MissingID(t *testing.T) {
 }
 
 func TestTransformOrgCategoryToPB_ZeroID(t *testing.T) {
+	t.Parallel()
 	s := &StaffLookupsSync{}
 
 	data := map[string]any{
@@ -161,6 +170,7 @@ func TestTransformOrgCategoryToPB_ZeroID(t *testing.T) {
 }
 
 func TestTransformOrgCategoryToPB_MissingName(t *testing.T) {
+	t.Parallel()
 	s := &StaffLookupsSync{}
 
 	data := map[string]any{
@@ -174,6 +184,7 @@ func TestTransformOrgCategoryToPB_MissingName(t *testing.T) {
 }
 
 func TestTransformOrgCategoryToPB_EmptyName(t *testing.T) {
+	t.Parallel()
 	s := &StaffLookupsSync{}
 
 	data := map[string]any{
@@ -192,6 +203,7 @@ func TestTransformOrgCategoryToPB_EmptyName(t *testing.T) {
 // =============================================================================
 
 func TestTransformPositionToPB(t *testing.T) {
+	t.Parallel()
 	s := &StaffLookupsSync{}
 
 	// Program area lookup map
@@ -224,6 +236,7 @@ func TestTransformPositionToPB(t *testing.T) {
 }
 
 func TestTransformPositionToPB_NoProgramArea(t *testing.T) {
+	t.Parallel()
 	s := &StaffLookupsSync{}
 
 	programAreaMap := map[int]string{}
@@ -254,6 +267,7 @@ func TestTransformPositionToPB_NoProgramArea(t *testing.T) {
 }
 
 func TestTransformPositionToPB_UnknownProgramArea(t *testing.T) {
+	t.Parallel()
 	s := &StaffLookupsSync{}
 
 	// Program area map doesn't include the referenced ID
@@ -283,6 +297,7 @@ func TestTransformPositionToPB_UnknownProgramArea(t *testing.T) {
 }
 
 func TestTransformPositionToPB_MissingID(t *testing.T) {
+	t.Parallel()
 	s := &StaffLookupsSync{}
 
 	programAreaMap := map[int]string{}
@@ -298,6 +313,7 @@ func TestTransformPositionToPB_MissingID(t *testing.T) {
 }
 
 func TestTransformPositionToPB_ZeroID(t *testing.T) {
+	t.Parallel()
 	s := &StaffLookupsSync{}
 
 	programAreaMap := map[int]string{}
@@ -314,6 +330,7 @@ func TestTransformPositionToPB_ZeroID(t *testing.T) {
 }
 
 func TestTransformPositionToPB_MissingName(t *testing.T) {
+	t.Parallel()
 	s := &StaffLookupsSync{}
 
 	programAreaMap := map[int]string{}
@@ -329,6 +346,7 @@ func TestTransformPositionToPB_MissingName(t *testing.T) {
 }
 
 func TestTransformPositionToPB_EmptyName(t *testing.T) {
+	t.Parallel()
 	s := &StaffLookupsSync{}
 
 	programAreaMap := map[int]string{}

--- a/pocketbase/sync/staff_skills_test.go
+++ b/pocketbase/sync/staff_skills_test.go
@@ -57,6 +57,7 @@ func newSkillDefsTestApp(t *testing.T, defs map[int]string) core.App {
 // that column. No untrimmed name exists in this table today; this pins the
 // fix against a future one.
 func TestStaffSkillsLoadSkillDefinitionsTrimsNames(t *testing.T) {
+	t.Parallel()
 	app := newSkillDefsTestApp(t, map[int]string{
 		1: "Skills-Archery ", // trailing space
 		2: "Skills-Riflery",  // already clean, must be unaffected
@@ -90,6 +91,7 @@ func TestStaffSkillsLoadSkillDefinitionsTrimsNames(t *testing.T) {
 
 // TestStaffSkillsSync_Name verifies the service name is correct
 func TestStaffSkillsSync_Name(t *testing.T) {
+	t.Parallel()
 	// The service name must be "staff_skills" for orchestrator integration
 	expectedName := serviceNameStaffSkills
 
@@ -101,6 +103,7 @@ func TestStaffSkillsSync_Name(t *testing.T) {
 
 // TestStaffSkillsYearValidation tests year parameter validation
 func TestStaffSkillsYearValidation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		year      int
@@ -128,6 +131,7 @@ func TestStaffSkillsYearValidation(t *testing.T) {
 
 // TestParseProficiency tests parsing of pipe-delimited proficiency values
 func TestParseProficiency(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name             string
 		rawValue         string
@@ -223,6 +227,7 @@ func TestParseProficiency(t *testing.T) {
 
 // TestExtractSkillName tests stripping "Skills-" prefix from field names
 func TestExtractSkillName(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		fieldName     string
 		wantSkillName string
@@ -253,6 +258,7 @@ func TestExtractSkillName(t *testing.T) {
 
 // TestIsSkillsField tests identification of Skills- fields
 func TestIsSkillsField(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		fieldName    string
 		wantIsSkills bool
@@ -280,6 +286,7 @@ func TestIsSkillsField(t *testing.T) {
 
 // TestIsStaffPartition tests identification of Staff partition
 func TestIsStaffPartition(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		partition   string
 		wantIsStaff bool
@@ -309,6 +316,7 @@ func TestIsStaffPartition(t *testing.T) {
 // PocketBase stores select fields as JSON arrays, but GetString returns ""
 // or a stringified JSON like ["Staff"]. The fix should handle this correctly.
 func TestContainsStaffPartitionWithJSONArray(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		rawValue    any
@@ -402,6 +410,7 @@ func containsStaffPartitionFromRaw(rawValue any) bool {
 
 // TestStaffSkillsCompositeKeyFormat tests the composite key format used for upsert
 func TestStaffSkillsCompositeKeyFormat(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		personCMID int
@@ -444,6 +453,7 @@ func TestStaffSkillsCompositeKeyFormat(t *testing.T) {
 
 // TestStaffSkillsCompositeKeyDeterministic tests that the same input produces the same key
 func TestStaffSkillsCompositeKeyDeterministic(t *testing.T) {
+	t.Parallel()
 	keys := make([]string, 10)
 	for i := range 10 {
 		keys[i] = formatStaffSkillsCompositeKey(12345, 100, 2025)
@@ -458,6 +468,7 @@ func TestStaffSkillsCompositeKeyDeterministic(t *testing.T) {
 
 // TestStaffSkillsOrphanDetection tests that records not in processed keys are identified as orphans
 func TestStaffSkillsOrphanDetection(t *testing.T) {
+	t.Parallel()
 	existingKeys := map[string]bool{
 		"12345:100|2025": true,
 		"12345:101|2025": true,
@@ -484,6 +495,7 @@ func TestStaffSkillsOrphanDetection(t *testing.T) {
 
 // TestStaffSkillsUpsertDecision tests the create vs update decision logic
 func TestStaffSkillsUpsertDecision(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		existingKeys map[string]bool
@@ -556,6 +568,7 @@ type testStaffSkillRecord struct {
 
 // TestStaffSkillsRecordBuilding tests that records are correctly built from source data
 func TestStaffSkillsRecordBuilding(t *testing.T) {
+	t.Parallel()
 	// Simulate person custom value data
 	personValues := []testPersonSkillValue{
 		{PersonCMID: 12345, SkillCMID: 100, SkillName: "Archery", Value: "Int.|Exp.", Year: 2025},
@@ -607,6 +620,7 @@ func TestStaffSkillsRecordBuilding(t *testing.T) {
 
 // TestStaffSkillsDeduplication tests that duplicate records are handled correctly
 func TestStaffSkillsDeduplication(t *testing.T) {
+	t.Parallel()
 	personValues := []testPersonSkillValue{
 		// Duplicate entries for same person-skill-year (should deduplicate)
 		{PersonCMID: 12345, SkillCMID: 100, SkillName: "Archery", Value: "Int.", Year: 2025},
@@ -638,6 +652,7 @@ func TestStaffSkillsDeduplication(t *testing.T) {
 
 // TestStaffSkillsNotesFieldHandling tests that notes fields (non-structured) are handled correctly
 func TestStaffSkillsNotesFieldHandling(t *testing.T) {
+	t.Parallel()
 	// Notes fields should have booleans set to false and raw_value containing the text
 	personValues := []testPersonSkillValue{
 		{
@@ -676,6 +691,7 @@ func TestStaffSkillsNotesFieldHandling(t *testing.T) {
 
 // TestStaffSkillsEmptyDataHandling tests graceful handling of empty input
 func TestStaffSkillsEmptyDataHandling(t *testing.T) {
+	t.Parallel()
 	personValues := []testPersonSkillValue{}
 	personDemographics := map[int]testStaffDemographics{}
 
@@ -688,6 +704,7 @@ func TestStaffSkillsEmptyDataHandling(t *testing.T) {
 
 // TestStaffSkillsEmptyValueSkipped tests that empty values are skipped
 func TestStaffSkillsEmptyValueSkipped(t *testing.T) {
+	t.Parallel()
 	personValues := []testPersonSkillValue{
 		{PersonCMID: 12345, SkillCMID: 100, SkillName: "Archery", Value: "", Year: 2025},
 		{PersonCMID: 12345, SkillCMID: 101, SkillName: "Backpacking", Value: "Int.", Year: 2025},
@@ -711,6 +728,7 @@ func TestStaffSkillsEmptyValueSkipped(t *testing.T) {
 
 // TestStaffSkillsMissingDemographics tests handling when person demographics are missing
 func TestStaffSkillsMissingDemographics(t *testing.T) {
+	t.Parallel()
 	personValues := []testPersonSkillValue{
 		{PersonCMID: 12345, SkillCMID: 100, SkillName: "Archery", Value: "Int.", Year: 2025},
 	}
@@ -868,6 +886,7 @@ func findStaffSkillRecord(records []*testStaffSkillRecord, personCMID, skillCMID
 // TestStaffSkillsCompareFields verifies that the compareFields list for staff_skills
 // contains exactly the expected fields (inclusion list pattern, not skipFields exclusion).
 func TestStaffSkillsCompareFields(t *testing.T) {
+	t.Parallel()
 	// staffSkillsCompareFields should list all fields that matter for idempotency checks,
 	// excluding PocketBase-managed fields (id, created, updated, collectionId, collectionName)
 	// and the unique key fields (person_id, skill_cm_id, year) which don't change.
@@ -914,6 +933,7 @@ func TestStaffSkillsCompareFields(t *testing.T) {
 // TestStaffSkillsRecordNeedsUpdateUsesCompareFields verifies that recordNeedsUpdate
 // correctly detects when fields match (no update) and when they differ (needs update).
 func TestStaffSkillsRecordNeedsUpdateUsesCompareFields(t *testing.T) {
+	t.Parallel()
 	s := &StaffSkillsSync{}
 
 	// Create a minimal collection with the fields used in comparison

--- a/pocketbase/sync/staff_test.go
+++ b/pocketbase/sync/staff_test.go
@@ -8,6 +8,7 @@ import (
 
 // TestStaffServiceName verifies the service name constant
 func TestStaffServiceName(t *testing.T) {
+	t.Parallel()
 	expected := "staff"
 	if serviceNameStaff != expected {
 		t.Errorf("serviceNameStaff = %q, want %q", serviceNameStaff, expected)
@@ -18,6 +19,7 @@ func TestStaffServiceName(t *testing.T) {
 // This is a critical fix - the person_id field was missing, causing staff_applications
 // and staff_vehicle_info syncs to fail to match records.
 func TestTransformStaffToPB_PersonID(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		personID       float64
@@ -116,6 +118,7 @@ func testTransformStaffPersonID(data map[string]any, personMap map[int]string) (
 
 // TestAllStaffStatuses verifies the allStaffStatuses constant includes all 4 CampMinder statuses
 func TestAllStaffStatuses(t *testing.T) {
+	t.Parallel()
 	expected := []int{1, 2, 3, 4} // Active, Resigned, Dismissed, Cancelled
 	if !reflect.DeepEqual(allStaffStatuses, expected) {
 		t.Errorf("allStaffStatuses = %v, want %v", allStaffStatuses, expected)
@@ -124,6 +127,7 @@ func TestAllStaffStatuses(t *testing.T) {
 
 // TestSetStatusFields_AllStatuses verifies setStatusFields handles all 4 CampMinder staff statuses
 func TestSetStatusFields_AllStatuses(t *testing.T) {
+	t.Parallel()
 	s := &StaffSync{}
 
 	tests := []struct {
@@ -198,6 +202,7 @@ func TestSetStatusFields_AllStatuses(t *testing.T) {
 // CampMinder clears BunkAssignments from dismissed/resigned staff API responses,
 // but we want to keep the last-known bunk assignments in PocketBase.
 func TestShouldPreserveBunkData(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name              string
 		statusID          int
@@ -271,6 +276,7 @@ func TestShouldPreserveBunkData(t *testing.T) {
 // the bunks and bunk_staff fields are removed from pbData so ProcessSimpleRecord
 // skips comparing them (preserving the existing values).
 func TestPreserveBunkDataDeletesFields(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		statusID       int
@@ -339,6 +345,7 @@ func TestPreserveBunkDataDeletesFields(t *testing.T) {
 
 // TestTransformStaffToPB_MissingPersonID tests error handling for missing PersonID
 func TestTransformStaffToPB_MissingPersonID(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		data    map[string]any

--- a/pocketbase/sync/staff_vehicle_info_test.go
+++ b/pocketbase/sync/staff_vehicle_info_test.go
@@ -19,6 +19,7 @@ import (
 // into the map and then silently fail to route. No untrimmed name exists in
 // this table today; this pins the fix against a future one.
 func TestStaffVehicleInfoLoadFieldDefinitionsTrimsNames(t *testing.T) {
+	t.Parallel()
 	app := newFieldDefsTestApp(t, map[int]string{
 		1: "SVI-are you driving to camp ", // trailing space
 		2: "SVI-which friend",             // already clean, must be unaffected
@@ -51,6 +52,7 @@ func TestStaffVehicleInfoLoadFieldDefinitionsTrimsNames(t *testing.T) {
 
 // TestStaffVehicleInfoServiceName verifies the service name constant
 func TestStaffVehicleInfoServiceName(t *testing.T) {
+	t.Parallel()
 	expected := "staff_vehicle_info"
 	if serviceNameStaffVehicleInfo != expected {
 		t.Errorf("serviceNameStaffVehicleInfo = %q, want %q", serviceNameStaffVehicleInfo, expected)
@@ -61,6 +63,7 @@ func TestStaffVehicleInfoServiceName(t *testing.T) {
 // for the 10 SVI- fields used in staff vehicle info, plus the two literals that
 // must NOT route: the American plate spelling and an unknown field.
 func TestMapSVIFieldToColumn(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		cmField  string
 		expected string
@@ -114,6 +117,7 @@ func TestMapSVIFieldToColumn(t *testing.T) {
 // emitting 1/0 must not silently read as all-false. Narrowing this set is a
 // behavior change, not a cleanup.
 func TestParseSVIBoolImpl(t *testing.T) {
+	t.Parallel()
 	cases := map[string]bool{
 		// The only two values the live field actually contains.
 		"Yes": true,
@@ -145,6 +149,7 @@ func TestParseSVIBoolImpl(t *testing.T) {
 // TestStaffVehicleInfoCompositeKey tests the unique key generation
 // Key format: personID|year
 func TestStaffVehicleInfoCompositeKey(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		personID int
 		year     int
@@ -173,6 +178,7 @@ func TestStaffVehicleInfoCompositeKey(t *testing.T) {
 // Prefix rules do not rescue it: 34% of real answers begin with neither "yes"
 // nor "no", so the sentence itself is the only honest storage.
 func TestMapSVIFieldToRecordKeepsBringOthersVerbatim(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name  string
 		value string
@@ -199,6 +205,7 @@ func TestMapSVIFieldToRecordKeepsBringOthersVerbatim(t *testing.T) {
 // (1,780 answers, exactly 2 distinct values, 793 rows true). Nothing in
 // kindred#2262 may change it.
 func TestMapSVIFieldToRecordLeavesDrivingToCampABool(t *testing.T) {
+	t.Parallel()
 	for value, want := range map[string]bool{"Yes": true, "No": false, "yes": true} {
 		rec := &staffVehicleInfoRecord{}
 		mapSVIFieldToRecord(rec, "SVI-are you driving to camp", value)
@@ -357,6 +364,7 @@ func seedSVI(t *testing.T, app core.App, cmID, year int, hasStaff bool, values m
 // required relation, so the row cannot be written -- but a partial extraction
 // and a complete one currently produce identical output.
 func TestLoadPersonCustomValuesCountsStaffGateDrops(t *testing.T) {
+	t.Parallel()
 	app := newStaffVehicleTestApp(t)
 	seedSVI(t, app, 1001, 2026, true, map[string]string{
 		"SVI-are you driving to camp": "Yes",
@@ -397,6 +405,7 @@ func TestLoadPersonCustomValuesCountsStaffGateDrops(t *testing.T) {
 // site. A field admitted by the SVI- prefix but routed to no column is
 // discarded with no counter and no log line.
 func TestLoadPersonCustomValuesCountsUnmappedFields(t *testing.T) {
+	t.Parallel()
 	app := newStaffVehicleTestApp(t)
 	seedSVI(t, app, 1001, 2026, true, map[string]string{
 		"SVI-are you driving to camp": "Yes",
@@ -428,6 +437,7 @@ func TestLoadPersonCustomValuesCountsUnmappedFields(t *testing.T) {
 // always a broken input, never a legitimate "everything was removed" -- and
 // the current code deletes the year and reports success.
 func TestDeleteOrphansRefusesEmptyComputedSet(t *testing.T) {
+	t.Parallel()
 	app := newStaffVehicleTestApp(t)
 	col, err := app.FindCollectionByNameOrId("staff_vehicle_info")
 	if err != nil {
@@ -478,6 +488,7 @@ func TestDeleteOrphansRefusesEmptyComputedSet(t *testing.T) {
 // TestDeleteOrphansStillSweepsGenuineOrphans proves the guard did not disable
 // orphan deletion for the normal case.
 func TestDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
+	t.Parallel()
 	app := newStaffVehicleTestApp(t)
 	col, err := app.FindCollectionByNameOrId("staff_vehicle_info")
 	if err != nil {
@@ -518,6 +529,7 @@ func TestDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
 // fails by design: "SVI- who are you driving to camp" and
 // "SVI-Unit Head Training" are deliberately unrouted and carry no rows.
 func TestSVIRoutingReportAgainstRealFieldNames(t *testing.T) {
+	t.Parallel()
 	raw, err := os.ReadFile(filepath.Join("testdata", "svi_field_names.txt"))
 	if err != nil {
 		t.Fatalf("read testdata: %v", err)

--- a/pocketbase/sync/stranded_assignment_cleanup_test.go
+++ b/pocketbase/sync/stranded_assignment_cleanup_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestFindStrandedAssignments(t *testing.T) {
+	t.Parallel()
 	validPairs := map[string]bool{
 		strandedPairKey("sess1", "bunkA"): true,
 		strandedPairKey("sess1", "bunkB"): true,
@@ -33,6 +34,7 @@ func TestFindStrandedAssignments(t *testing.T) {
 }
 
 func TestFindEnrollmentOrphans(t *testing.T) {
+	t.Parallel()
 	enrolledPairs := map[string]bool{
 		strandedPairKey("sess1", "p1"): true,
 	}
@@ -60,6 +62,7 @@ func TestFindEnrollmentOrphans(t *testing.T) {
 // -- so that a camp_sessions record recreated rather than updated cannot turn
 // the whole sweep into a silent no-op.
 func TestFindLodgingEnrollmentOrphans(t *testing.T) {
+	t.Parallel()
 	householdIndex := map[int][]SessionWindow{
 		9001: {{ID: "pb1", CMID: 101}}, // still enrolled in weekend 101
 	}
@@ -87,6 +90,7 @@ func TestFindLodgingEnrollmentOrphans(t *testing.T) {
 }
 
 func TestReliableEnrolledSessions(t *testing.T) {
+	t.Parallel()
 	index := map[int][]SessionWindow{
 		9001: {{ID: "pb1", CMID: 101}, {ID: "pb2", CMID: 102}},
 		9002: {{ID: "pb1", CMID: 101}},
@@ -108,6 +112,7 @@ func TestReliableEnrolledSessions(t *testing.T) {
 }
 
 func TestSessionIndexHasWindow(t *testing.T) {
+	t.Parallel()
 	windows := []SessionWindow{{ID: "pb-a", CMID: 101}, {ID: "pb-b", CMID: 102}}
 	if !sessionIndexHasWindow(windows, 101) {
 		t.Error("want true for a present window CampMinder id")
@@ -273,6 +278,7 @@ func saveRec(t *testing.T, app core.App, collection string, data map[string]any)
 }
 
 func TestStrandedAssignmentCleanup_SweepsStrandedDraft(t *testing.T) {
+	t.Parallel()
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -312,6 +318,7 @@ func TestStrandedAssignmentCleanup_SweepsStrandedDraft(t *testing.T) {
 }
 
 func TestStrandedAssignmentCleanup_GateSkipsWhenNoBunkPlans(t *testing.T) {
+	t.Parallel()
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -346,6 +353,7 @@ func TestStrandedAssignmentCleanup_GateSkipsWhenNoBunkPlans(t *testing.T) {
 }
 
 func TestStrandedAssignmentCleanup_GateSkipsPerSession(t *testing.T) {
+	t.Parallel()
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -387,6 +395,7 @@ func TestStrandedAssignmentCleanup_GateSkipsPerSession(t *testing.T) {
 }
 
 func TestStrandedAssignmentCleanup_LeavesValidDraftUntouched(t *testing.T) {
+	t.Parallel()
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -423,6 +432,7 @@ func TestStrandedAssignmentCleanup_LeavesValidDraftUntouched(t *testing.T) {
 }
 
 func TestStrandedAssignmentCleanup_ProdAuditDoesNotDelete(t *testing.T) {
+	t.Parallel()
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -457,6 +467,7 @@ func TestStrandedAssignmentCleanup_ProdAuditDoesNotDelete(t *testing.T) {
 }
 
 func TestStrandedAssignmentCleanup_Idempotent(t *testing.T) {
+	t.Parallel()
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -496,6 +507,7 @@ func TestStrandedAssignmentCleanup_Idempotent(t *testing.T) {
 }
 
 func TestStrandedAssignmentCleanup_ProdAuditWarnings(t *testing.T) {
+	t.Parallel()
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -538,6 +550,7 @@ func TestStrandedAssignmentCleanup_ProdAuditWarnings(t *testing.T) {
 // WasSuccessful() reports false — but does NOT abort the run: the draft sweep
 // that already succeeded must still stand.
 func TestStrandedAssignmentCleanup_ProdQueryErrorIsCountedNotFatal(t *testing.T) {
+	t.Parallel()
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -592,6 +605,7 @@ func TestStrandedAssignmentCleanup_ProdQueryErrorIsCountedNotFatal(t *testing.T)
 }
 
 func TestStrandedAssignmentCleanup_SweepsEnrollmentOrphanDraft(t *testing.T) {
+	t.Parallel()
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -635,6 +649,7 @@ func TestStrandedAssignmentCleanup_SweepsEnrollmentOrphanDraft(t *testing.T) {
 }
 
 func TestStrandedAssignmentCleanup_EnrollmentGateSkipsPerSession(t *testing.T) {
+	t.Parallel()
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -681,6 +696,7 @@ func TestStrandedAssignmentCleanup_EnrollmentGateSkipsPerSession(t *testing.T) {
 }
 
 func TestStrandedAssignmentCleanup_EnrollmentOrphanProdAudit(t *testing.T) {
+	t.Parallel()
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -726,6 +742,7 @@ func TestStrandedAssignmentCleanup_EnrollmentOrphanProdAudit(t *testing.T) {
 // attendees query (see #2028's insistence on reuse over re-derivation).
 
 func TestStrandedAssignmentCleanup_SweepsLodgingEnrollmentOrphanDraftHousehold(t *testing.T) {
+	t.Parallel()
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -773,6 +790,7 @@ func TestStrandedAssignmentCleanup_SweepsLodgingEnrollmentOrphanDraftHousehold(t
 // and source survive, exactly like bunk+bunk_plan nulling leaves everything
 // else on the row alone.
 func TestStrandedAssignmentCleanup_LodgingDraftPreservesStaffTouchedAndSource(t *testing.T) {
+	t.Parallel()
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -820,6 +838,7 @@ func TestStrandedAssignmentCleanup_LodgingDraftPreservesStaffTouchedAndSource(t 
 }
 
 func TestStrandedAssignmentCleanup_LodgingEnrollmentGateSkipsPerSession(t *testing.T) {
+	t.Parallel()
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -864,6 +883,7 @@ func TestStrandedAssignmentCleanup_LodgingEnrollmentGateSkipsPerSession(t *testi
 // responsibility: this pass only audits lodging_assignments (the mirror) --
 // deletion is LodgingAssignmentsSync.deleteLodgingOrphans' job (#2028).
 func TestStrandedAssignmentCleanup_LodgingProdAuditDoesNotDelete(t *testing.T) {
+	t.Parallel()
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -909,6 +929,7 @@ func TestStrandedAssignmentCleanup_LodgingProdAuditDoesNotDelete(t *testing.T) {
 // TestStrandedAssignmentCleanup_LodgingPersonGrainOrphanDraft is the adult
 // weekend twin of the household-grain sweep.
 func TestStrandedAssignmentCleanup_LodgingPersonGrainOrphanDraft(t *testing.T) {
+	t.Parallel()
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -952,6 +973,7 @@ func TestStrandedAssignmentCleanup_LodgingPersonGrainOrphanDraft(t *testing.T) {
 // TestStrandedAssignmentCleanup_LeavesEnrolledLodgingDraftUntouched is the
 // obvious regression: a household still enrolled keeps its draft placement.
 func TestStrandedAssignmentCleanup_LeavesEnrolledLodgingDraftUntouched(t *testing.T) {
+	t.Parallel()
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -997,6 +1019,7 @@ func TestStrandedAssignmentCleanup_LeavesEnrolledLodgingDraftUntouched(t *testin
 // prod row; run 2 has nothing left to sweep, so Updated must be 0, and the
 // still-present prod row must warn exactly once again — not twice.
 func TestStrandedAssignmentCleanup_StatsResetBetweenRuns(t *testing.T) {
+	t.Parallel()
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -1048,6 +1071,7 @@ func TestStrandedAssignmentCleanup_StatsResetBetweenRuns(t *testing.T) {
 // audits nothing at all; without a per-run reset it keeps reporting run 1's
 // warning count, describing an audit that never happened.
 func TestStrandedAssignmentCleanup_ProdAuditWarningsClearWhenRunGatesOut(t *testing.T) {
+	t.Parallel()
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -1105,6 +1129,7 @@ func TestStrandedAssignmentCleanup_ProdAuditWarningsClearWhenRunGatesOut(t *test
 // reaches is this: two records, same CampMinder id, different PocketBase id --
 // the attendees on the new one, the placement still on the old.
 func TestStrandedAssignmentCleanup_LodgingOrphanPassKeysOnTheCampMinderSessionID(t *testing.T) {
+	t.Parallel()
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)

--- a/pocketbase/sync/table_exporter_test.go
+++ b/pocketbase/sync/table_exporter_test.go
@@ -14,6 +14,7 @@ const testCollectionAttendees = "attendees"
 // =============================================================================
 
 func TestFieldType_Constants(t *testing.T) {
+	t.Parallel()
 	// Test that field type constants are defined
 	tests := []struct {
 		name     string
@@ -39,6 +40,7 @@ func TestFieldType_Constants(t *testing.T) {
 }
 
 func TestColumnConfig_BasicFields(t *testing.T) {
+	t.Parallel()
 	// Test ColumnConfig struct fields
 	col := ColumnConfig{
 		Field:        "person",
@@ -60,6 +62,7 @@ func TestColumnConfig_BasicFields(t *testing.T) {
 }
 
 func TestExportConfig_YearPlaceholder(t *testing.T) {
+	t.Parallel()
 	// Test that sheet name supports {year} placeholder
 	config := ExportConfig{
 		Collection: testCollectionAttendees,
@@ -77,6 +80,7 @@ func TestExportConfig_YearPlaceholder(t *testing.T) {
 }
 
 func TestExportConfig_GlobalSheetName(t *testing.T) {
+	t.Parallel()
 	// Test that global exports don't use year prefix
 	config := ExportConfig{
 		Collection: "person_tag_defs",
@@ -94,6 +98,7 @@ func TestExportConfig_GlobalSheetName(t *testing.T) {
 }
 
 func TestFieldResolver_ResolveValue_Text(t *testing.T) {
+	t.Parallel()
 	// Test resolving a simple text field
 	resolver := NewFieldResolver()
 
@@ -111,6 +116,7 @@ func TestFieldResolver_ResolveValue_Text(t *testing.T) {
 }
 
 func TestFieldResolver_ResolveValue_Number(t *testing.T) {
+	t.Parallel()
 	// Test resolving a number field
 	resolver := NewFieldResolver()
 
@@ -128,6 +134,7 @@ func TestFieldResolver_ResolveValue_Number(t *testing.T) {
 }
 
 func TestFieldResolver_ResolveValue_NilValue(t *testing.T) {
+	t.Parallel()
 	// Test resolving nil values
 	resolver := NewFieldResolver()
 
@@ -144,6 +151,7 @@ func TestFieldResolver_ResolveValue_NilValue(t *testing.T) {
 }
 
 func TestFieldResolver_PreloadLookup(t *testing.T) {
+	t.Parallel()
 	// Test preloading lookup data
 	resolver := NewFieldResolver()
 
@@ -167,6 +175,7 @@ func TestFieldResolver_PreloadLookup(t *testing.T) {
 }
 
 func TestFieldResolver_ResolveMultiRelation(t *testing.T) {
+	t.Parallel()
 	// Test resolving multi-relation fields to comma-separated values
 	resolver := NewFieldResolver()
 
@@ -201,6 +210,7 @@ func TestFieldResolver_ResolveMultiRelation(t *testing.T) {
 }
 
 func TestFieldResolver_ResolveMultiRelation_Empty(t *testing.T) {
+	t.Parallel()
 	// Test resolving empty multi-relation
 	resolver := NewFieldResolver()
 	resolver.SetLookupData("bunks", map[string]string{})
@@ -227,6 +237,7 @@ func TestFieldResolver_ResolveMultiRelation_Empty(t *testing.T) {
 }
 
 func TestFieldResolver_ResolveSingleRelation(t *testing.T) {
+	t.Parallel()
 	// Test resolving single relation field
 	resolver := NewFieldResolver()
 
@@ -250,6 +261,7 @@ func TestFieldResolver_ResolveSingleRelation(t *testing.T) {
 }
 
 func TestBuildDataMatrix_Headers(t *testing.T) {
+	t.Parallel()
 	// Test that headers are correctly generated from column configs
 	columns := []ColumnConfig{
 		{Field: "first_name", Header: "First Name", Type: FieldTypeText},
@@ -282,6 +294,7 @@ func TestBuildDataMatrix_Headers(t *testing.T) {
 }
 
 func TestBuildDataMatrix_DataRows(t *testing.T) {
+	t.Parallel()
 	// Test that data rows are correctly built
 	columns := []ColumnConfig{
 		{Field: "first_name", Header: "First Name", Type: FieldTypeText},
@@ -316,6 +329,7 @@ func TestBuildDataMatrix_DataRows(t *testing.T) {
 }
 
 func TestGetReadableYearExports(t *testing.T) {
+	t.Parallel()
 	// Test that readable year export configs are defined
 	configs := GetReadableYearExports()
 
@@ -348,6 +362,7 @@ func TestGetReadableYearExports(t *testing.T) {
 }
 
 func TestGetReadableGlobalExports(t *testing.T) {
+	t.Parallel()
 	// Test that readable global export configs are defined
 	configs := GetReadableGlobalExports()
 
@@ -365,6 +380,7 @@ func TestGetReadableGlobalExports(t *testing.T) {
 }
 
 func TestTableExporter_ExportCallsEnsureSheet(t *testing.T) {
+	t.Parallel()
 	// Test that TableExporter calls EnsureSheet before writing
 	mock := NewMockSheetsWriter()
 	resolver := NewFieldResolver()
@@ -413,6 +429,7 @@ func TestTableExporter_ExportCallsEnsureSheet(t *testing.T) {
 // =============================================================================
 
 func TestFieldType_NewConstants(t *testing.T) {
+	t.Parallel()
 	// Test that new field type constants are defined and unique
 	types := []struct {
 		name string
@@ -444,6 +461,7 @@ func TestFieldType_NewConstants(t *testing.T) {
 }
 
 func TestFieldResolver_ResolveForeignKeyID(t *testing.T) {
+	t.Parallel()
 	// Test resolving a relation field to its cm_id (not display name)
 	resolver := NewFieldResolver()
 
@@ -474,6 +492,7 @@ func TestFieldResolver_ResolveForeignKeyID(t *testing.T) {
 }
 
 func TestFieldResolver_ResolveNestedField(t *testing.T) {
+	t.Parallel()
 	// Test resolving a relation field to a specific nested property (e.g., person → first_name)
 	resolver := NewFieldResolver()
 
@@ -516,6 +535,7 @@ func TestFieldResolver_ResolveNestedField(t *testing.T) {
 }
 
 func TestFieldResolver_ResolveWriteInOverride(t *testing.T) {
+	t.Parallel()
 	// Test resolving write-in override fields (write_in takes precedence over standard)
 	resolver := NewFieldResolver()
 
@@ -569,6 +589,7 @@ func TestFieldResolver_ResolveWriteInOverride(t *testing.T) {
 }
 
 func TestFieldResolver_ResolveDoubleFKResolve(t *testing.T) {
+	t.Parallel()
 	// Test resolving through two relations (staff.position1 → position.program_area → name)
 	resolver := NewFieldResolver()
 
@@ -613,6 +634,7 @@ func TestFieldResolver_ResolveDoubleFKResolve(t *testing.T) {
 }
 
 func TestFieldResolver_ResolveCMIDLookup(t *testing.T) {
+	t.Parallel()
 	// Test looking up by CM ID rather than PB ID (for session parent_id)
 	resolver := NewFieldResolver()
 
@@ -656,6 +678,7 @@ func TestFieldResolver_ResolveCMIDLookup(t *testing.T) {
 }
 
 func TestColumnConfig_NewFields(t *testing.T) {
+	t.Parallel()
 	// Test that ColumnConfig has new fields for advanced resolution
 	col := ColumnConfig{
 		Field:            "position1",
@@ -684,6 +707,7 @@ func TestColumnConfig_NewFields(t *testing.T) {
 }
 
 func TestGetReadableGlobalExports_DivisionsIncluded(t *testing.T) {
+	t.Parallel()
 	// Test that globals include divisions and NOT staff_positions
 	// staff_positions data is already inlined in staff export
 	configs := GetReadableGlobalExports()
@@ -707,6 +731,7 @@ func TestGetReadableGlobalExports_DivisionsIncluded(t *testing.T) {
 }
 
 func TestGetReadableGlobalExports_Count(t *testing.T) {
+	t.Parallel()
 	// Test that we have exactly 4 global exports (staff_positions removed)
 	configs := GetReadableGlobalExports()
 
@@ -719,6 +744,7 @@ func TestGetReadableGlobalExports_Count(t *testing.T) {
 }
 
 func TestFieldResolver_ResolveBool(t *testing.T) {
+	t.Parallel()
 	// Test resolving boolean fields
 	resolver := NewFieldResolver()
 
@@ -748,6 +774,7 @@ func TestFieldResolver_ResolveBool(t *testing.T) {
 }
 
 func TestBuildDataMatrix_WriteInOverride(t *testing.T) {
+	t.Parallel()
 	// Test that BuildDataMatrix handles WriteInOverride correctly
 	resolver := NewFieldResolver()
 
@@ -793,6 +820,7 @@ func TestBuildDataMatrix_WriteInOverride(t *testing.T) {
 // =============================================================================
 
 func TestGetReadableYearExports_HasReadableNames(t *testing.T) {
+	t.Parallel()
 	// Test that readable year exports use human-readable tab names (no year prefix)
 	configs := GetReadableYearExports()
 
@@ -810,6 +838,7 @@ func TestGetReadableYearExports_HasReadableNames(t *testing.T) {
 }
 
 func TestGetReadableYearExports_AttendeesHasReadableName(t *testing.T) {
+	t.Parallel()
 	// Test attendees config has readable name
 	configs := GetReadableYearExports()
 
@@ -832,6 +861,7 @@ func TestGetReadableYearExports_AttendeesHasReadableName(t *testing.T) {
 }
 
 func TestGetReadableYearExports_IncludesCustomValues(t *testing.T) {
+	t.Parallel()
 	// Test that readable exports include person_custom_values and household_custom_values
 	configs := GetReadableYearExports()
 
@@ -860,6 +890,7 @@ func TestGetReadableYearExports_IncludesCustomValues(t *testing.T) {
 }
 
 func TestGetReadableGlobalExports_HasReadableNames(t *testing.T) {
+	t.Parallel()
 	// Test that readable global exports use human-readable tab names (no g- prefix)
 	configs := GetReadableGlobalExports()
 
@@ -877,6 +908,7 @@ func TestGetReadableGlobalExports_HasReadableNames(t *testing.T) {
 }
 
 func TestGetReadableGlobalExports_TagDefsHasReadableName(t *testing.T) {
+	t.Parallel()
 	// Test person_tag_defs config has readable name
 	configs := GetReadableGlobalExports()
 
@@ -899,6 +931,7 @@ func TestGetReadableGlobalExports_TagDefsHasReadableName(t *testing.T) {
 }
 
 func TestGetReadableExportSheetNames(t *testing.T) {
+	t.Parallel()
 	// Test getting all readable sheet names (no year needed since names are static)
 	yearNames := GetReadableYearExportSheetNames()
 	globalNames := GetReadableGlobalExportSheetNames()

--- a/pocketbase/sync/upload_metadata_test.go
+++ b/pocketbase/sync/upload_metadata_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestReadBunkRequestsUploadMetadata_Missing(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	got, err := readBunkRequestsUploadMetadata(tmp)
 	if err != nil {
@@ -18,6 +19,7 @@ func TestReadBunkRequestsUploadMetadata_Missing(t *testing.T) {
 }
 
 func TestReadBunkRequestsUploadMetadata_Valid(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	csvDir := filepath.Join(tmp, "bunk_requests")
 	if err := os.MkdirAll(csvDir, 0750); err != nil {
@@ -51,6 +53,7 @@ func TestReadBunkRequestsUploadMetadata_Valid(t *testing.T) {
 }
 
 func TestReadBunkRequestsUploadMetadata_InvalidJSON(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	csvDir := filepath.Join(tmp, "bunk_requests")
 	if err := os.MkdirAll(csvDir, 0750); err != nil {

--- a/pocketbase/sync/workbook_manager_test.go
+++ b/pocketbase/sync/workbook_manager_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestWorkbookManager_GetOrCreateGlobalsWorkbook_NewWorkbook(t *testing.T) {
+	t.Parallel()
 	// Test that GetOrCreateGlobalsWorkbook creates a new workbook when none exists
 	// This tests the database interaction and workbook creation flow
 
@@ -36,6 +37,7 @@ func TestWorkbookManager_GetOrCreateGlobalsWorkbook_NewWorkbook(t *testing.T) {
 }
 
 func TestWorkbookManager_GetOrCreateYearWorkbook_NewWorkbook(t *testing.T) {
+	t.Parallel()
 	// Test that GetOrCreateYearWorkbook creates a new workbook when none exists
 
 	app, err := tests.NewTestApp()
@@ -58,6 +60,7 @@ func TestWorkbookManager_GetOrCreateYearWorkbook_NewWorkbook(t *testing.T) {
 }
 
 func TestWorkbookManager_SaveWorkbookRecord(t *testing.T) {
+	t.Parallel()
 	// Test saving a workbook record to the database
 	// This is an integration test that requires the sheets_workbooks collection
 
@@ -111,6 +114,7 @@ func TestWorkbookManager_SaveWorkbookRecord(t *testing.T) {
 }
 
 func TestWorkbookManager_SaveWorkbookRecord_YearWorkbook(t *testing.T) {
+	t.Parallel()
 	// Test saving a year-specific workbook record
 	// This is an integration test that requires the sheets_workbooks collection
 
@@ -159,6 +163,7 @@ func TestWorkbookManager_SaveWorkbookRecord_YearWorkbook(t *testing.T) {
 }
 
 func TestWorkbookManager_UpdateWorkbookStats(t *testing.T) {
+	t.Parallel()
 	// Test updating stats for an existing workbook
 	// This is an integration test that requires the sheets_workbooks collection
 
@@ -214,6 +219,7 @@ func TestWorkbookManager_UpdateWorkbookStats(t *testing.T) {
 }
 
 func TestWorkbookManager_ListAllWorkbooks(t *testing.T) {
+	t.Parallel()
 	// Test listing all workbooks
 	// This is an integration test that requires the sheets_workbooks collection
 
@@ -279,6 +285,7 @@ func TestWorkbookManager_ListAllWorkbooks(t *testing.T) {
 }
 
 func TestBuildIndexSheetData(t *testing.T) {
+	t.Parallel()
 	// Test building the index sheet data matrix
 
 	workbooks := []WorkbookRecord{
@@ -377,6 +384,7 @@ func (m *MockDriveSearcher) FindSpreadsheetByName(_ context.Context, name string
 // =============================================================================
 
 func TestGetOrCreateGlobalsWorkbook_RecoverFromDrive(t *testing.T) {
+	t.Parallel()
 	// Test that when DB is empty but Drive has the workbook,
 	// we recover by linking the existing Drive workbook to the DB
 
@@ -443,6 +451,7 @@ func TestGetOrCreateGlobalsWorkbook_RecoverFromDrive(t *testing.T) {
 }
 
 func TestGetOrCreateGlobalsWorkbook_DriveSearchFails_ContinuesToCreate(t *testing.T) {
+	t.Parallel()
 	// Test that when Drive search fails, we log a warning and continue to create new
 	// This ensures resilience - Drive API failures don't block the sync
 
@@ -484,6 +493,7 @@ func TestGetOrCreateGlobalsWorkbook_DriveSearchFails_ContinuesToCreate(t *testin
 }
 
 func TestGetOrCreateGlobalsWorkbook_DriveSearcherNil_SkipsSearch(t *testing.T) {
+	t.Parallel()
 	// Test backward compatibility - when driveSearcher is nil, skip Drive search entirely
 
 	app, err := tests.NewTestApp()
@@ -517,6 +527,7 @@ func TestGetOrCreateGlobalsWorkbook_DriveSearcherNil_SkipsSearch(t *testing.T) {
 }
 
 func TestGetOrCreateYearWorkbook_RecoverFromDrive(t *testing.T) {
+	t.Parallel()
 	// Same pattern for year workbook recovery
 
 	app, err := tests.NewTestApp()
@@ -573,6 +584,7 @@ func TestGetOrCreateYearWorkbook_RecoverFromDrive(t *testing.T) {
 }
 
 func TestGetOrCreateGlobalsWorkbook_NotInDrive_CreatesNew(t *testing.T) {
+	t.Parallel()
 	// Test that when neither DB nor Drive has the workbook, we create new
 
 	app, err := tests.NewTestApp()

--- a/scripts/ci/go_test_shard.py
+++ b/scripts/ci/go_test_shard.py
@@ -4,17 +4,25 @@
 `go test -race ./...` was the longest job in CI by a wide margin -- ~390s of a
 ~400s critical path, against ~156s for the next-slowest job. Almost none of that
 is test volume. The race detector costs about **4.5x** -- measured back-to-back on
-one machine, `sync` goes 60.8s -> 298.2s and `lodging` 35.1s -> 136.6s -- and it
-pays that serially: the Go tree has exactly one `t.Parallel()` in it, and it sits
-inside a subtest (`sync/orchestrator_test.go`), so no two top-level tests ever
-overlap. (A ~10x figure appears in earlier notes on this work; that was the
+one machine, `sync` goes 60.8s -> 298.2s and `lodging` 35.1s -> 136.6s. (A ~10x
+figure appears in earlier notes on this work; that was the
 `TestLodgingAssignmentsSync*` slice, which is schema-build heavy and not
 representative of the suite.) Two packages carry it all -- `sync` at 297s and
 `lodging` at 143s, with the other nine adding up to ~15s.
 
-This script splits that serial run across a CI matrix. It deliberately does NOT
-shard by package: `sync` alone would still be a 297s shard. It shards at the
-individual test-function level, so the two heavy packages get cut up too.
+It used to pay that 4.5x entirely serially: the Go tree had exactly one
+`t.Parallel()` in it, inside a subtest, so no two top-level tests ever
+overlapped. That is no longer true -- `sync` and `lodging` are parallel now
+(kindred#2281), which took them to ~110s and ~55s locally. The matrix below
+went from four shards to three as a result: with the tests parallelised, most
+of a shard is the ~100s compile-and-setup floor that does not shard at all, so
+a fourth job buys ~14s of wall clock for ~90 runner-seconds. The measured
+table is in ci.yml next to the matrix. `pocketbase/main_test_parallelism_test.go`
+is what keeps them that way.
+
+This script splits what remains across a CI matrix. It deliberately does NOT
+shard by package: `sync` alone would still be the longest shard. It shards at
+the individual test-function level, so the two heavy packages get cut up too.
 
 The whole design is shaped by one failure mode. A partition that quietly stops
 covering some tests still reports green, which is the paths-filter incident of


### PR DESCRIPTION
Closes #2281.

`go test -race ./...` was the longest job in CI. #2282 sharded it four ways to get it off the critical path; this is the durable half. The race detector costs ~4.5x and the tree paid it **entirely serially** — there was exactly one `t.Parallel()` in it, and it sat inside a subtest, so no two top-level tests ever overlapped.

## What changed

`t.Parallel()` on **1018 top-level tests** across `sync` and `lodging`, the two packages carrying ~430s of the ~470s. Measured locally at `GOMAXPROCS=4` under `-race`:

| package | before | after |
|---|---|---|
| `sync` | 298.4s | 110.5s |
| `lodging` | 126.8s | 55.5s |

## What blocked it — two causes, 34 tests

Both are named in `serialGroups` with their reason rather than worked around:

- **18 sync tests call `t.Setenv`.** The testing package panics outright on `Setenv` + `Parallel`, since the environment is process-global.
- **16 lodging tests swap a package-level variable** — `registryBasePath` / `registryAbsoluteRoots`, `os.Stdout` via `captureStdout`, slog's default handler via `captureLogs`. The registry pair were the **only true data races** the detector found. Leaving the writers serial costs nothing: Go runs every non-parallel test to completion before releasing the parallel ones, so they restore the globals before any reader starts.

## The guard

`pocketbase/main_test_parallelism_test.go` is what keeps this from eroding. A newly added serial test fails nothing and shows up in no review, but costs a few seconds forever — a hundred of them put the job back where it started. The guard walks both packages' ASTs and requires either a top-level `t.Parallel()` or an entry in `serialGroups` with a reason. A second test fails on any exemption that has been renamed, deleted, or since parallelised, so the list cannot rot into a list of excuses.

It counts only `t.Parallel()` in the function's own statement list — a call inside a `t.Run` closure does not count, which is exactly what the tree already had and what parallelised nothing.

It earned its keep during this PR: a rebase onto a moved `main` was re-applied with a sloppy script that found only 18 of the 34 exemptions, and the guard named all 16 it had missed.

`TestConcurrentAccess` took its parameter as `_`, which is why it was the one test in 1036 that could not be patched mechanically. It is self-contained and asserts through `-race`, so it just needed the parameter named.

## Four shards → three

Each shard pays a **~100s floor that does not shard** — ~88s of `-race` compile plus ~12s of checkout and setup-go. The compile is never cached: the setup-go key derives from `go.sum` alone, so it holds whichever variant saved it first (a non-race one), and Actions cache entries are immutable. With the tests parallelised, that floor is most of a shard, so returns collapse fast.

All four configurations measured on the runner, same tree:

| shards | shard times (s) | wall | runner-seconds |
|---|---|---|---|
| 4, serial (pre-change) | — | ~191s | ~764 |
| 2 | 199, 199 | 199s | 398 |
| **3** | **176, 173, 167** | **176s** | **516** |
| 4 | 158, 162, 131, 152 | 162s | 603 |

2 → 3 buys 23s; 3 → 4 buys only 14s, which is inside the spread a single 4-shard run already shows (131–162s, from uneven splits). Three is the knee: **~191s → ~176s wall, ~764 → ~516 runner-seconds.**

The bigger prize is local: `go test` in `pocketbase/` goes ~300s → ~124s, which sharding never gave anyone.

## Corrections to #2281's body

Measured while building this, worth recording since the issue closes here:

- **`globalScheduler` is listed as hazard #1 but is a non-issue.** `GetScheduler` has zero test call sites — only `sync/api.go:119` and `scheduler.go:307`, neither reached by a test.
- **The two real blockers were not mentioned** — `t.Setenv` and the registry path globals.
- **`orchestrator_test.go`, `api_test.go`, `rate_limited_sheets_writer_test.go`** were flagged "audit before parallelising"; their goroutines are all test-local and clean. Only `lodging/hooks_test.go` mattered, and only for the `os.Stdout` swap.
- **"297s to roughly 90s"** — measured 110s locally, and 12 cores was no faster than 4 (the workload is SQLite-write-bound, not core-bound).
- **"likely more than an afternoon"** — no genuine races in shared helpers surfaced.

## Deliberately not here

The eight `TestLodgingAssignmentsSync*` orphan-sweep tests are the most expensive left serial — ~22s of the ~25s serial prefix. Injecting the active season into `activeSeasonYear()` instead of reading the env would recover most of it, but that is an edit to a **deletion gate**, and it should not ride inside a thousand-line mechanical diff. Filed as #2289.

## Verification

13 local `-race` runs including five with `-shuffle=on`: no failures, no races, no flakes. Peak combined RSS 889 MiB against a 16 GB runner. `golangci-lint` clean; `scripts/pre-push-verify.sh` all green; full CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled parallel execution across extensive synchronization and lodging test coverage.
  * Added safeguards to ensure new tests remain parallelized and documented exceptions remain valid.
* **Chores**
  * Reduced continuous-integration test sharding from four shards to three.
  * Updated test-run documentation with timing and resource guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->