### PR TITLE
fix(sync): protect non-active staff bunk assignments, abort sweep on failure

### DIFF
--- a/docs/reference/sync-id-conventions.md
+++ b/docs/reference/sync-id-conventions.md
@@ -16,13 +16,46 @@ Every record synced from CampMinder has two IDs:
 | Field | Type | Purpose |
 |-------|------|---------|
 | `cm_id` | int | The CampMinder ID for this record's primary entity |
-| `person_id` | int | CampMinder person ID (on attendees, bunk_assignments, etc.) |
+| `person_id` | int | CampMinder person ID. On most person-scoped tables (`attendees`, `staff`, `camper_history`, `quest_registrations`, …) but **not all** — notably **not** on `bunk_assignments`. Check that collection's migration before filtering on it |
 | `person` | relation | PocketBase relation field pointing to persons table (resolved from CM ID) |
 | `session` | relation | PocketBase relation field pointing to camp_sessions table |
 | `bunk` | relation | PocketBase relation field pointing to bunks table |
 | `year` | int | Season/year identifier (from `CAMPMINDER_SEASON_ID`) |
 
 **Pattern:** Data fields store CM IDs (`person_id = 12345`). Relation fields store PB IDs (`person = "abc123def456789"`). The relation fields are populated by resolving CM IDs at write time.
+
+### ⚠️ `person_id` is not universal — `bunk_assignments` does not have it
+
+**`bunk_assignments` links to a person only through the `person` relation.** There is no
+`person_id` column on that collection; its fields are `cm_id`, `person`, `session`, `bunk`,
+`bunk_plan`, `year`, `created`, `updated` (`pb_migrations/1500000019_bunk_assignments.js`).
+`cm_id` there is the **assignment's** own CampMinder id, not the person's.
+
+This row of the table previously read "on attendees, bunk_assignments, etc.", and that sentence
+is the likely origin of kindred#2287: `protectNonActiveStaffAssignments` filtered
+`bunk_assignments` on `person_id = %d` for its entire life, `FindRecordsByFilter` errored on every
+iteration, and a `slog.Warn` swallowed it — so the function reported success while protecting
+nothing, for months.
+
+**A second trap corroborates the first, so check the field list rather than the index list.** That
+migration declares:
+
+```js
+"CREATE INDEX `idx_bunk_assignments_person_id` ON `bunk_assignments` (`cm_id`)"
+```
+
+The index is *named* `person_id` but is actually **on `cm_id`**. Anyone verifying the column's
+existence by grepping the migration for `person_id` finds this line and concludes the column is
+real. It is not.
+
+To filter `bunk_assignments` by person, resolve the CampMinder id to a PocketBase id first and
+filter on the relation:
+
+```go
+people, err := s.App.FindRecordsByFilter("persons",
+    fmt.Sprintf("cm_id = %d && year = %d", personCMID, year), "", 1, 0)
+// ...then: fmt.Sprintf("year = %d && person = '%s'", year, people[0].Id)
+```
 
 ## How Relations Are Resolved
 

--- a/pocketbase/main_test_parallelism_test.go
+++ b/pocketbase/main_test_parallelism_test.go
@@ -104,6 +104,30 @@ var serialGroups = []struct {
 		tests:  []string{"TestBuildNormalizationLookupCompositeKeyDedup"},
 	},
 	{
+		// These four drive deleteOrphans, which reads the season through
+		// s.Client.GetSeasonID(). Client is a concrete *campminder.Client and
+		// campminder.NewClient reads CAMPMINDER_PRIMARY_KEY from the
+		// environment, so building one costs a t.Setenv.
+		//
+		// The guard's own advice applies here -- threading the key through
+		// NewClient instead of reading os.Getenv would parallelise all four --
+		// but that is an edit to the production CampMinder constructor, and it
+		// does not belong in a bunk-assignment protection fix. Tracked rather
+		// than smuggled in.
+		//
+		// The three tests in this file that do NOT sweep need no client and
+		// are parallel.
+		pkg:    "sync",
+		reason: "t.Setenv: campminder.NewClient reads CAMPMINDER_PRIMARY_KEY",
+		tests: []string{
+			"TestProtectThenSweepOrphans_DismissedStaffAssignmentSurvivesSweep",
+			"TestProtectThenSweepOrphans_ProtectionFailureAbortsSweep",
+			"TestProtectThenSweepOrphans_ProtectionSuccessStillSweeps",
+			"TestProtectThenSweepOrphans_SessionLookupFailureAbortsSweep",
+			"TestProtectThenSweepOrphans_SweepRefusalIsCountedAndReturned",
+		},
+	},
+	{
 		// registryBasePath / registryAbsoluteRoots (lodging/registry.go) are
 		// the only true data races the detector found when the whole tree was
 		// made parallel at once: withRegistryBasePath writes them, and every

--- a/pocketbase/sync/bunk_assignments.go
+++ b/pocketbase/sync/bunk_assignments.go
@@ -237,14 +237,10 @@ func (s *BunkAssignmentsSync) Sync(ctx context.Context) error {
 
 	slog.Info("Fetched bunk assignments from CampMinder", "count", totalAssignments)
 
-	// Protect bunk_assignments for non-active staff from orphan deletion.
-	// CampMinder removes assignments on dismissal, but we preserve them.
-	s.protectNonActiveStaffAssignments(year)
-
-	// Delete orphaned assignments
-	if err := s.deleteOrphans(); err != nil {
-		slog.Error("Error deleting orphans", "error", err)
-	}
+	// Protect bunk_assignments for non-active staff from orphan deletion, then
+	// sweep orphans -- in that order, and only if protection succeeded. See
+	// protectThenSweepOrphans.
+	s.protectThenSweepOrphans(year)
 
 	// Force WAL checkpoint to ensure data is flushed
 	if err := s.ForceWALCheckpoint(); err != nil {
@@ -498,10 +494,38 @@ func (s *BunkAssignmentsSync) processAssignment(
 	return s.ProcessCompositeRecord("bunk_assignments", key, recordData, existingAssignments, []string{"year"})
 }
 
+// protectThenSweepOrphans marks non-active staff assignments as protected
+// before running the orphan sweep, and only runs the sweep if protection
+// succeeded.
+//
+// The ordering is load-bearing, not cosmetic: deleteOrphans removes every
+// bunk_assignment this run did not mark as processed. If protection fails
+// partway through, the tracking it was building is incomplete -- so running
+// the sweep anyway would delete precisely the assignments protection exists
+// to save, and only afterward would the run report a failure. That reports
+// the damage instead of preventing it. Aborting here means a protection
+// failure costs a sync cycle, not the data. See kindred#2287.
+func (s *BunkAssignmentsSync) protectThenSweepOrphans(year int) {
+	if _, err := s.protectNonActiveStaffAssignments(year); err != nil {
+		slog.Error("Error protecting non-active staff bunk assignments", "error", err)
+		s.Stats.Errors++
+		return
+	}
+
+	if err := s.deleteOrphans(); err != nil {
+		slog.Error("Error deleting orphans", "error", err)
+	}
+}
+
 // protectNonActiveStaffAssignments marks existing bunk_assignments for non-active
 // bunk staff as processed so DeleteOrphans won't remove them. CampMinder strips
 // assignments from dismissed/resigned staff API responses, but we preserve them.
-func (s *BunkAssignmentsSync) protectNonActiveStaffAssignments(year int) {
+//
+// bunk_assignments has no person_id column -- the person link is the `person`
+// relation, resolved from the CampMinder id (docs/reference/sync-id-conventions.md).
+// It returns the number of assignments protected and any error encountered;
+// the caller decides how to surface a failure instead of it being swallowed.
+func (s *BunkAssignmentsSync) protectNonActiveStaffAssignments(year int) (int, error) {
 	nonActiveFilter := fmt.Sprintf("status != 'active' && bunk_staff = true && year = %d", year)
 	protectedCount := 0
 
@@ -512,8 +536,20 @@ func (s *BunkAssignmentsSync) protectNonActiveStaffAssignments(year int) {
 		}
 		personCMID := int(personID)
 
+		// Resolve the person's CampMinder id to their persons PB id so we can
+		// filter bunk_assignments on the `person` relation.
+		personFilter := fmt.Sprintf("cm_id = %d && year = %d", personCMID, year)
+		people, err := s.App.FindRecordsByFilter("persons", personFilter, "", 1, 0)
+		if err != nil {
+			return fmt.Errorf("resolving person %d: %w", personCMID, err)
+		}
+		if len(people) == 0 {
+			return nil
+		}
+		personPBID := people[0].Id
+
 		// Find this person's existing bunk_assignments and mark as processed
-		baFilter := fmt.Sprintf("year = %d && person_id = %d", year, personCMID)
+		baFilter := fmt.Sprintf("year = %d && person = '%s'", year, personPBID)
 		bas, err := s.App.FindRecordsByFilter("bunk_assignments", baFilter, "", 0, 0)
 		if err != nil {
 			return fmt.Errorf("finding bunk assignments for person %d: %w", personCMID, err)
@@ -542,12 +578,14 @@ func (s *BunkAssignmentsSync) protectNonActiveStaffAssignments(year int) {
 
 		return nil
 	}); err != nil {
-		slog.Warn("Error loading non-active staff for bunk assignment protection", "error", err)
+		return protectedCount, fmt.Errorf("loading non-active staff for bunk assignment protection: %w", err)
 	}
 
 	if protectedCount > 0 {
 		slog.Info("Protected bunk assignments for non-active staff", "count", protectedCount)
 	}
+
+	return protectedCount, nil
 }
 
 // deleteOrphans deletes assignments that exist in PocketBase but weren't in CampMinder

--- a/pocketbase/sync/bunk_assignments.go
+++ b/pocketbase/sync/bunk_assignments.go
@@ -240,12 +240,22 @@ func (s *BunkAssignmentsSync) Sync(ctx context.Context) error {
 	// Protect bunk_assignments for non-active staff from orphan deletion, then
 	// sweep orphans -- in that order, and only if protection succeeded. See
 	// protectThenSweepOrphans.
-	s.protectThenSweepOrphans(year)
+	sweepErr := s.protectThenSweepOrphans(year)
 
-	// Force WAL checkpoint to ensure data is flushed
+	// Force WAL checkpoint to ensure data is flushed.
+	//
+	// This precedes the sweepErr return deliberately: the fetch loop above has
+	// already written this run's assignments, and those writes are still in the
+	// WAL on the failure path too. Checkpointing after the return would strand
+	// them. staff_applications.go and staff_vehicle_info.go order it the same
+	// way, for the same reason.
 	if err := s.ForceWALCheckpoint(); err != nil {
 		slog.Warn("WAL checkpoint failed", "error", err)
 		// Don't fail the sync if checkpoint fails
+	}
+
+	if sweepErr != nil {
+		return sweepErr
 	}
 
 	// Use extra stats to show fetched count
@@ -498,23 +508,39 @@ func (s *BunkAssignmentsSync) processAssignment(
 // before running the orphan sweep, and only runs the sweep if protection
 // succeeded.
 //
-// The ordering is load-bearing, not cosmetic: deleteOrphans removes every
-// bunk_assignment this run did not mark as processed. If protection fails
-// partway through, the tracking it was building is incomplete -- so running
-// the sweep anyway would delete precisely the assignments protection exists
-// to save, and only afterward would the run report a failure. That reports
-// the damage instead of preventing it. Aborting here means a protection
-// failure costs a sync cycle, not the data. See kindred#2287.
-func (s *BunkAssignmentsSync) protectThenSweepOrphans(year int) {
+// The ordering is load-bearing, not cosmetic: deleteOrphans removes the
+// bunk_assignments this run did not mark as processed, unless OrphanSweepGuard
+// refuses the sweep outright for having too small a computed set to believe
+// (kindred#2279). If protection fails partway through, the tracking it was
+// building is incomplete -- so running the sweep anyway would delete precisely
+// the assignments protection exists to save, and only afterward would the run
+// report a failure. That reports the damage instead of preventing it. Aborting
+// here means a protection failure costs a sync cycle, not the data. See
+// kindred#2287.
+//
+// Both failure branches below are counted and returned, not logged and
+// dropped. They are the same event from an operator's point of view -- an
+// upstream step came back untrustworthy and rows were therefore not swept --
+// and a returned error is what makes Sync() report the run as failed. Counting
+// alone does not: the orchestrator derives a run's status from the returned
+// error, so a protection failure that only incremented Stats.Errors reported
+// success until kindred#2293 lands, and would silently depend on that PR's
+// merge order afterwards. staff_applications.go and staff_vehicle_info.go
+// return their sweep refusals the same way.
+func (s *BunkAssignmentsSync) protectThenSweepOrphans(year int) error {
 	if _, err := s.protectNonActiveStaffAssignments(year); err != nil {
 		slog.Error("Error protecting non-active staff bunk assignments", "error", err)
 		s.Stats.Errors++
-		return
+		return fmt.Errorf("protecting non-active staff bunk assignments: %w", err)
 	}
 
 	if err := s.deleteOrphans(); err != nil {
 		slog.Error("Error deleting orphans", "error", err)
+		s.Stats.Errors++
+		return fmt.Errorf("orphan sweep refused: %w", err)
 	}
+
+	return nil
 }
 
 // protectNonActiveStaffAssignments marks existing bunk_assignments for non-active
@@ -563,8 +589,18 @@ func (s *BunkAssignmentsSync) protectNonActiveStaffAssignments(year int) (int, e
 			if sessionPBID == "" {
 				continue
 			}
+			// A query failure and a genuinely absent session are not the same
+			// event and must not share a branch. Collapsing them is how this
+			// function silently dropped an assignment it was meant to protect:
+			// the key was never tracked, protection still reported success, and
+			// the sweep below then deleted the row. A missing session stays a
+			// non-destructive skip -- deleteOrphans cannot derive a composite
+			// key for such a record either, so it is not at risk.
 			sessions, err := s.App.FindRecordsByFilter("camp_sessions", fmt.Sprintf("id = '%s'", sessionPBID), "", 1, 0)
-			if err != nil || len(sessions) == 0 {
+			if err != nil {
+				return fmt.Errorf("resolving session %q for person %d: %w", sessionPBID, personCMID, err)
+			}
+			if len(sessions) == 0 {
 				continue
 			}
 			sessionCMID, ok := sessions[0].Get("cm_id").(float64)

--- a/pocketbase/sync/bunk_assignments_protection_test.go
+++ b/pocketbase/sync/bunk_assignments_protection_test.go
@@ -5,9 +5,48 @@ import (
 	"testing"
 
 	"github.com/camp/kindred/pocketbase/campminder"
+	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase/core"
 	pbtests "github.com/pocketbase/pocketbase/tests"
 )
+
+// flakyCollectionApp wraps a core.App and fails the first failuresLeft calls to
+// FindRecordsByFilter for one named collection, delegating everything else.
+//
+// It models a TRANSIENT database error, which is the only shape in which the
+// session-lookup hazard is observable. A permanent camp_sessions failure cannot
+// demonstrate it: deleteOrphans resolves session relations through the same
+// collection, so a still-failing lookup leaves the assignment unkeyable and the
+// sweep skips it anyway -- the row survives for the wrong reason and the test
+// would pass against the bug. Failing exactly the one lookup protection makes,
+// then healing, is what separates "protection dropped it" from "the sweep could
+// not see it". Deleting the session record instead would not work either: that
+// yields an empty result, not an error, which is the deliberate non-destructive
+// skip path.
+type flakyCollectionApp struct {
+	core.App
+	collection   string
+	failuresLeft int
+}
+
+func (a *flakyCollectionApp) FindRecordsByFilter(
+	collectionModelOrIdentifier any,
+	filter string,
+	sort string,
+	limit int,
+	offset int,
+	params ...dbx.Params,
+) ([]*core.Record, error) {
+	if name, ok := collectionModelOrIdentifier.(string); ok && name == a.collection && a.failuresLeft > 0 {
+		a.failuresLeft--
+		return nil, fmt.Errorf("simulated transient database failure querying %s", name)
+	}
+	records, err := a.App.FindRecordsByFilter(collectionModelOrIdentifier, filter, sort, limit, offset, params...)
+	if err != nil {
+		return nil, fmt.Errorf("delegating FindRecordsByFilter: %w", err)
+	}
+	return records, nil
+}
 
 // setupBunkAssignmentProtectionCollections builds the minimal schema needed
 // to exercise protectNonActiveStaffAssignments against a real PocketBase app:
@@ -19,14 +58,14 @@ func setupBunkAssignmentProtectionCollections(t *testing.T, app core.App) {
 
 	sessions := core.NewBaseCollection("camp_sessions")
 	sessions.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
-	sessions.Fields.Add(&core.NumberField{Name: "year"})
+	sessions.Fields.Add(&core.NumberField{Name: "year", Required: true})
 	if err := app.Save(sessions); err != nil {
 		t.Fatalf("create camp_sessions: %v", err)
 	}
 
 	persons := core.NewBaseCollection("persons")
 	persons.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
-	persons.Fields.Add(&core.NumberField{Name: "year"})
+	persons.Fields.Add(&core.NumberField{Name: "year", Required: true})
 	if err := app.Save(persons); err != nil {
 		t.Fatalf("create persons: %v", err)
 	}
@@ -34,7 +73,7 @@ func setupBunkAssignmentProtectionCollections(t *testing.T, app core.App) {
 	assignments := core.NewBaseCollection("bunk_assignments")
 	assignments.Fields.Add(&core.RelationField{Name: "person", CollectionId: persons.Id, MaxSelect: 1})
 	assignments.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
-	assignments.Fields.Add(&core.NumberField{Name: "year"})
+	assignments.Fields.Add(&core.NumberField{Name: "year", Required: true})
 	// PaginateRecords sorts by "-created" unconditionally, and deleteOrphans's
 	// call to BuildRecordCMIDMappings goes through it.
 	assignments.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
@@ -46,7 +85,7 @@ func setupBunkAssignmentProtectionCollections(t *testing.T, app core.App) {
 	staff.Fields.Add(&core.NumberField{Name: "person_id", Required: true})
 	staff.Fields.Add(&core.TextField{Name: "status"})
 	staff.Fields.Add(&core.BoolField{Name: "bunk_staff"})
-	staff.Fields.Add(&core.NumberField{Name: "year"})
+	staff.Fields.Add(&core.NumberField{Name: "year", Required: true})
 	// PaginateRecords sorts by "-created" unconditionally, so the staff
 	// collection needs it even though nothing else in this test reads it.
 	staff.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
@@ -65,6 +104,8 @@ func setupBunkAssignmentProtectionCollections(t *testing.T, app core.App) {
 // a live PocketBase app, unlike the local-logic simulation in
 // TestBunkAssignmentsSync_NonActiveStaffOrphanProtection above.
 func TestProtectNonActiveStaffAssignments_ProtectsDismissedStaff(t *testing.T) {
+	t.Parallel()
+
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -108,23 +149,24 @@ func TestProtectNonActiveStaffAssignments_ProtectsDismissedStaff(t *testing.T) {
 // legitimate way to force protectThenSweepOrphans down its failure path without
 // re-breaking production code to do it.
 //
-// bunk_assignments carries a `created` autodate field here (unlike
-// setupBunkAssignmentProtectionCollections' copy) because deleteOrphans's call
-// to BuildRecordCMIDMappings goes through PaginateRecords, which sorts by
-// "-created" unconditionally.
+// Everything else matches setupBunkAssignmentProtectionCollections, `created`
+// autodate field included -- deleteOrphans's call to BuildRecordCMIDMappings
+// goes through PaginateRecords, which sorts by "-created" unconditionally, so
+// both copies need it. The absent `staff` collection is the only difference,
+// and it is the whole point of this helper.
 func setupBunkAssignmentSweepCollections(t *testing.T, app core.App) {
 	t.Helper()
 
 	sessions := core.NewBaseCollection("camp_sessions")
 	sessions.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
-	sessions.Fields.Add(&core.NumberField{Name: "year"})
+	sessions.Fields.Add(&core.NumberField{Name: "year", Required: true})
 	if err := app.Save(sessions); err != nil {
 		t.Fatalf("create camp_sessions: %v", err)
 	}
 
 	persons := core.NewBaseCollection("persons")
 	persons.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
-	persons.Fields.Add(&core.NumberField{Name: "year"})
+	persons.Fields.Add(&core.NumberField{Name: "year", Required: true})
 	if err := app.Save(persons); err != nil {
 		t.Fatalf("create persons: %v", err)
 	}
@@ -132,7 +174,7 @@ func setupBunkAssignmentSweepCollections(t *testing.T, app core.App) {
 	assignments := core.NewBaseCollection("bunk_assignments")
 	assignments.Fields.Add(&core.RelationField{Name: "person", CollectionId: persons.Id, MaxSelect: 1})
 	assignments.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
-	assignments.Fields.Add(&core.NumberField{Name: "year"})
+	assignments.Fields.Add(&core.NumberField{Name: "year", Required: true})
 	assignments.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
 	if err := app.Save(assignments); err != nil {
 		t.Fatalf("create bunk_assignments: %v", err)
@@ -251,6 +293,8 @@ func TestProtectThenSweepOrphans_ProtectionSuccessStillSweeps(t *testing.T) {
 // bunk staff are left alone -- their assignments come fresh from the
 // CampMinder API each sync and must not be pre-tracked as processed.
 func TestProtectNonActiveStaffAssignments_ActiveStaffUntouched(t *testing.T) {
+	t.Parallel()
+
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -279,5 +323,245 @@ func TestProtectNonActiveStaffAssignments_ActiveStaffUntouched(t *testing.T) {
 	}
 	if protectedCount != 0 {
 		t.Errorf("protectedCount = %d, want 0 -- active staff assignments should not be pre-tracked", protectedCount)
+	}
+}
+
+// TestProtectThenSweepOrphans_DismissedStaffAssignmentSurvivesSweep is the
+// end-to-end guarantee kindred#2287 actually asked for, and the one the other
+// tests in this file each prove only half of: _ProtectsDismissedStaff shows
+// protection writes the key but never runs the sweep, and
+// _ProtectionSuccessStillSweeps runs the sweep but against an empty staff
+// collection, so nothing is ever protected in the same pass that deletes.
+//
+// Here one call to protectThenSweepOrphans must do both: keep the dismissed
+// staff member's assignment and delete a genuine orphan beside it. That is what
+// pins the composite-key format across the seam -- protection builds keys with
+// TrackProcessedCompositeKey and deleteOrphans rebuilds them from stored
+// records, and nothing but this test fails if the two formats drift apart.
+func TestProtectThenSweepOrphans_DismissedStaffAssignmentSurvivesSweep(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupBunkAssignmentProtectionCollections(t, app)
+
+	const year = 2025
+	const dismissedCMID = 3000004
+	const dismissedSessionCMID = 5004
+
+	// The dismissed staff member: CampMinder has stopped reporting the
+	// assignment, so nothing in this run marks it processed. Only protection
+	// can save it.
+	dismissedPerson := saveRec(t, app, "persons", map[string]any{"cm_id": dismissedCMID, "year": year})
+	dismissedSession := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": dismissedSessionCMID, "year": year})
+	dismissedAssignment := saveRec(t, app, "bunk_assignments", map[string]any{
+		"person": dismissedPerson.Id, "session": dismissedSession.Id, "year": year,
+	})
+	saveRec(t, app, "staff", map[string]any{
+		"person_id": dismissedCMID, "status": "dismissed", "bunk_staff": true, "year": year,
+	})
+
+	// A genuine orphan: nobody's staff record, never marked processed. The
+	// sweep must still delete this, or the test would pass simply because the
+	// sweep did nothing at all.
+	orphanPerson := saveRec(t, app, "persons", map[string]any{"cm_id": 4000005, "year": year})
+	orphanSession := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 6005, "year": year})
+	orphanAssignment := saveRec(t, app, "bunk_assignments", map[string]any{
+		"person": orphanPerson.Id, "session": orphanSession.Id, "year": year,
+	})
+
+	s := &BunkAssignmentsSync{BaseSyncService: BaseSyncService{
+		App: app, Client: newTestCampMinderClient(t, year), ProcessedKeys: make(map[string]bool),
+	}}
+	s.SyncSuccessful = true // arms deleteOrphans
+
+	if err := s.protectThenSweepOrphans(year); err != nil {
+		t.Fatalf("protectThenSweepOrphans: %v", err)
+	}
+
+	if s.Stats.Errors != 0 {
+		t.Errorf("Stats.Errors = %d, want 0 -- nothing failed on this path", s.Stats.Errors)
+	}
+
+	// protectedCount > 0, observed through the key protection wrote.
+	wantKey := fmt.Sprintf("%d:%d|%d", dismissedCMID, dismissedSessionCMID, year)
+	if !s.ProcessedKeys[wantKey] {
+		t.Errorf("ProcessedKeys[%q] missing -- protection did not run or used a different key format", wantKey)
+	}
+
+	if _, err := app.FindRecordById("bunk_assignments", dismissedAssignment.Id); err != nil {
+		t.Errorf("dismissed staff assignment was deleted by the sweep it was supposed to be protected from: %v", err)
+	}
+
+	if _, err := app.FindRecordById("bunk_assignments", orphanAssignment.Id); err == nil {
+		t.Error("genuine orphan still exists -- the sweep did not run, so this test proves nothing about protection")
+	}
+}
+
+// TestProtectThenSweepOrphans_SessionLookupFailureAbortsSweep covers the second
+// instance of the kindred#2295 class found inside this very function: the
+// per-assignment camp_sessions lookup treated a query error and a genuinely
+// missing session identically, with `if err != nil || len(sessions) == 0 {
+// continue }`.
+//
+// A transient failure there was silent and destructive in combination: the
+// assignment never reached TrackProcessedCompositeKey, protection still
+// returned nil, so protectThenSweepOrphans ran the sweep and deleted the very
+// row the dismissed-staff protection exists to keep. The abort-on-failure gate
+// added for #2287 did not help, because protection never reported a failure.
+//
+// A missing session record must remain a non-destructive skip -- that is a real
+// state, not an error, and the sweep cannot derive a composite key for such a
+// record anyway.
+func TestProtectThenSweepOrphans_SessionLookupFailureAbortsSweep(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupBunkAssignmentProtectionCollections(t, app)
+
+	const year = 2025
+	const dismissedCMID = 3000005
+	const dismissedSessionCMID = 5005
+
+	dismissedPerson := saveRec(t, app, "persons", map[string]any{"cm_id": dismissedCMID, "year": year})
+	dismissedSession := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": dismissedSessionCMID, "year": year})
+	dismissedAssignment := saveRec(t, app, "bunk_assignments", map[string]any{
+		"person": dismissedPerson.Id, "session": dismissedSession.Id, "year": year,
+	})
+	saveRec(t, app, "staff", map[string]any{
+		"person_id": dismissedCMID, "status": "dismissed", "bunk_staff": true, "year": year,
+	})
+
+	// A second assignment whose key IS tracked, so the computed set is
+	// non-empty and OrphanSweepGuard does not refuse the sweep as a total
+	// collapse -- which would make this test pass without proving anything.
+	keptPerson := saveRec(t, app, "persons", map[string]any{"cm_id": 4000006, "year": year})
+	keptSession := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 6006, "year": year})
+	saveRec(t, app, "bunk_assignments", map[string]any{
+		"person": keptPerson.Id, "session": keptSession.Id, "year": year,
+	})
+
+	// Fail exactly one camp_sessions lookup: the single one protection makes
+	// for the single dismissed staff member. Every later lookup -- including
+	// every one deleteOrphans makes to rebuild composite keys -- succeeds, so
+	// the dismissed assignment is fully keyable by the sweep and would be
+	// deleted if protection let it through.
+	flaky := &flakyCollectionApp{App: app, collection: "camp_sessions", failuresLeft: 1}
+
+	s := &BunkAssignmentsSync{BaseSyncService: BaseSyncService{
+		App: flaky, Client: newTestCampMinderClient(t, year), ProcessedKeys: make(map[string]bool),
+	}}
+	s.SyncSuccessful = true
+	s.TrackProcessedCompositeKey(fmt.Sprintf("%d:%d", 4000006, 6006), year)
+
+	err = s.protectThenSweepOrphans(year)
+	if err == nil {
+		t.Error("protectThenSweepOrphans returned nil -- a failed session lookup must be reported, not swallowed")
+	}
+
+	if s.Stats.Errors == 0 {
+		t.Error("Stats.Errors = 0, want > 0 -- a failed database query is an infrastructure failure and must be counted")
+	}
+
+	if flaky.failuresLeft != 0 {
+		t.Fatal("the injected camp_sessions failure never fired -- this test did not exercise the path it claims to")
+	}
+
+	if _, err := app.FindRecordById("bunk_assignments", dismissedAssignment.Id); err != nil {
+		t.Errorf("dismissed staff assignment was swept after a transient session-lookup failure -- "+
+			"protection dropped it silently and the sweep ran anyway: %v", err)
+	}
+}
+
+// TestProtectThenSweepOrphans_SweepRefusalIsCountedAndReturned pins the second
+// of protectThenSweepOrphans's two failure branches.
+//
+// Protection succeeding and the sweep then refusing is the same event to an
+// operator as protection failing outright -- an upstream step came back
+// untrustworthy and rows were not swept -- but the two branches sat side by
+// side treating it differently: one counted and returned, the other only
+// logged. A refusal that is merely logged leaves Sync() returning nil, so the
+// run reports success having swept nothing.
+//
+// The refusal here is a real OrphanSweepGuard total collapse (kindred#2279),
+// not a stub: an empty computed set against rows on disk.
+func TestProtectThenSweepOrphans_SweepRefusalIsCountedAndReturned(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupBunkAssignmentProtectionCollections(t, app) // empty staff -- protection succeeds with nothing to do
+
+	const year = 2025
+
+	person := saveRec(t, app, "persons", map[string]any{"cm_id": 4000007, "year": year})
+	session := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 6007, "year": year})
+	assignment := saveRec(t, app, "bunk_assignments", map[string]any{
+		"person": person.Id, "session": session.Id, "year": year,
+	})
+
+	s := &BunkAssignmentsSync{BaseSyncService: BaseSyncService{
+		App: app, Client: newTestCampMinderClient(t, year), ProcessedKeys: make(map[string]bool),
+	}}
+	s.SyncSuccessful = true
+	// ProcessedKeys deliberately left empty: rows on disk, nothing computed,
+	// which is exactly what OrphanSweepGuard refuses.
+
+	err = s.protectThenSweepOrphans(year)
+	if err == nil {
+		t.Error("protectThenSweepOrphans returned nil -- a refused sweep must be reported, not just logged")
+	}
+
+	if s.Stats.Errors == 0 {
+		t.Error("Stats.Errors = 0, want > 0 -- a refused sweep is counted like any other infrastructure failure")
+	}
+
+	if _, err := app.FindRecordById("bunk_assignments", assignment.Id); err != nil {
+		t.Errorf("the guard refused the sweep but records were deleted anyway: %v", err)
+	}
+}
+
+// TestProtectNonActiveStaffAssignments_MissingSessionIsNonDestructiveSkip is the
+// other half of the test above: a session record that is genuinely absent is not
+// an error, and must not abort protection or the sweep for everyone else.
+func TestProtectNonActiveStaffAssignments_MissingSessionIsNonDestructiveSkip(t *testing.T) {
+	t.Parallel()
+
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupBunkAssignmentProtectionCollections(t, app)
+
+	const year = 2025
+	const dismissedCMID = 3000006
+
+	dismissedPerson := saveRec(t, app, "persons", map[string]any{"cm_id": dismissedCMID, "year": year})
+	session := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 5006, "year": year})
+	saveRec(t, app, "bunk_assignments", map[string]any{
+		"person": dismissedPerson.Id, "session": session.Id, "year": year,
+	})
+	saveRec(t, app, "staff", map[string]any{
+		"person_id": dismissedCMID, "status": "resigned", "bunk_staff": true, "year": year,
+	})
+
+	// Remove the session the assignment points at, leaving a dangling relation.
+	if delErr := app.Delete(session); delErr != nil {
+		t.Fatalf("delete session: %v", delErr)
+	}
+
+	s := &BunkAssignmentsSync{BaseSyncService: BaseSyncService{App: app, ProcessedKeys: make(map[string]bool)}}
+
+	protectedCount, err := s.protectNonActiveStaffAssignments(year)
+	if err != nil {
+		t.Fatalf("a missing session must be a skip, not an error: %v", err)
+	}
+	if protectedCount != 0 {
+		t.Errorf("protectedCount = %d, want 0 -- there is no session to build a composite key from", protectedCount)
 	}
 }

--- a/pocketbase/sync/bunk_assignments_protection_test.go
+++ b/pocketbase/sync/bunk_assignments_protection_test.go
@@ -1,0 +1,283 @@
+package sync
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/camp/kindred/pocketbase/campminder"
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+)
+
+// setupBunkAssignmentProtectionCollections builds the minimal schema needed
+// to exercise protectNonActiveStaffAssignments against a real PocketBase app:
+// persons, camp_sessions, bunk_assignments (linked via the `person` relation,
+// not a person_id column -- see docs/reference/sync-id-conventions.md), and
+// staff.
+func setupBunkAssignmentProtectionCollections(t *testing.T, app core.App) {
+	t.Helper()
+
+	sessions := core.NewBaseCollection("camp_sessions")
+	sessions.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
+	sessions.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(sessions); err != nil {
+		t.Fatalf("create camp_sessions: %v", err)
+	}
+
+	persons := core.NewBaseCollection("persons")
+	persons.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
+	persons.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(persons); err != nil {
+		t.Fatalf("create persons: %v", err)
+	}
+
+	assignments := core.NewBaseCollection("bunk_assignments")
+	assignments.Fields.Add(&core.RelationField{Name: "person", CollectionId: persons.Id, MaxSelect: 1})
+	assignments.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
+	assignments.Fields.Add(&core.NumberField{Name: "year"})
+	// PaginateRecords sorts by "-created" unconditionally, and deleteOrphans's
+	// call to BuildRecordCMIDMappings goes through it.
+	assignments.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
+	if err := app.Save(assignments); err != nil {
+		t.Fatalf("create bunk_assignments: %v", err)
+	}
+
+	staff := core.NewBaseCollection("staff")
+	staff.Fields.Add(&core.NumberField{Name: "person_id", Required: true})
+	staff.Fields.Add(&core.TextField{Name: "status"})
+	staff.Fields.Add(&core.BoolField{Name: "bunk_staff"})
+	staff.Fields.Add(&core.NumberField{Name: "year"})
+	// PaginateRecords sorts by "-created" unconditionally, so the staff
+	// collection needs it even though nothing else in this test reads it.
+	staff.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
+	if err := app.Save(staff); err != nil {
+		t.Fatalf("create staff: %v", err)
+	}
+}
+
+// TestProtectNonActiveStaffAssignments_ProtectsDismissedStaff is a regression
+// test for kindred#2287: protectNonActiveStaffAssignments filtered
+// bunk_assignments on a "person_id" column that does not exist (the person
+// link is the `person` relation; bunk_assignments has no person_id field).
+// FindRecordsByFilter errored on every iteration, protectedCount stayed 0,
+// and the error was swallowed by a slog.Warn -- so the function reported
+// success while protecting nothing. This exercises the real function against
+// a live PocketBase app, unlike the local-logic simulation in
+// TestBunkAssignmentsSync_NonActiveStaffOrphanProtection above.
+func TestProtectNonActiveStaffAssignments_ProtectsDismissedStaff(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupBunkAssignmentProtectionCollections(t, app)
+
+	const year = 2025
+	const personCMID = 3000001
+	const sessionCMID = 5001
+
+	person := saveRec(t, app, "persons", map[string]any{"cm_id": personCMID, "year": year})
+	session := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": sessionCMID, "year": year})
+	saveRec(t, app, "bunk_assignments", map[string]any{
+		"person": person.Id, "session": session.Id, "year": year,
+	})
+	saveRec(t, app, "staff", map[string]any{
+		"person_id": personCMID, "status": "dismissed", "bunk_staff": true, "year": year,
+	})
+
+	s := &BunkAssignmentsSync{BaseSyncService: BaseSyncService{App: app, ProcessedKeys: make(map[string]bool)}}
+
+	protectedCount, err := s.protectNonActiveStaffAssignments(year)
+	if err != nil {
+		t.Fatalf("protectNonActiveStaffAssignments: %v", err)
+	}
+	if protectedCount == 0 {
+		t.Fatal("protectedCount = 0, want > 0 for a year with a known non-active bunk staff assignment")
+	}
+
+	wantKey := fmt.Sprintf("%d:%d|%d", personCMID, sessionCMID, year)
+	if !s.ProcessedKeys[wantKey] {
+		t.Errorf("ProcessedKeys[%q] missing -- assignment was not protected from orphan deletion", wantKey)
+	}
+}
+
+// setupBunkAssignmentSweepCollections builds persons/camp_sessions/bunk_assignments
+// only -- deliberately no "staff" collection. protectNonActiveStaffAssignments's
+// PaginateRecords("staff", ...) call then fails with a real "missing collection"
+// error, the same class of infrastructure failure a broken filter produces: a
+// legitimate way to force protectThenSweepOrphans down its failure path without
+// re-breaking production code to do it.
+//
+// bunk_assignments carries a `created` autodate field here (unlike
+// setupBunkAssignmentProtectionCollections' copy) because deleteOrphans's call
+// to BuildRecordCMIDMappings goes through PaginateRecords, which sorts by
+// "-created" unconditionally.
+func setupBunkAssignmentSweepCollections(t *testing.T, app core.App) {
+	t.Helper()
+
+	sessions := core.NewBaseCollection("camp_sessions")
+	sessions.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
+	sessions.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(sessions); err != nil {
+		t.Fatalf("create camp_sessions: %v", err)
+	}
+
+	persons := core.NewBaseCollection("persons")
+	persons.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
+	persons.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(persons); err != nil {
+		t.Fatalf("create persons: %v", err)
+	}
+
+	assignments := core.NewBaseCollection("bunk_assignments")
+	assignments.Fields.Add(&core.RelationField{Name: "person", CollectionId: persons.Id, MaxSelect: 1})
+	assignments.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
+	assignments.Fields.Add(&core.NumberField{Name: "year"})
+	assignments.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
+	if err := app.Save(assignments); err != nil {
+		t.Fatalf("create bunk_assignments: %v", err)
+	}
+}
+
+// newTestCampMinderClient builds a real *campminder.Client for tests that only
+// need GetSeasonID() -- a pure getter, no network call -- so deleteOrphans can
+// run against a live PocketBase app without mocking CampMinder's HTTP API.
+func newTestCampMinderClient(t *testing.T, year int) *campminder.Client {
+	t.Helper()
+	t.Setenv("CAMPMINDER_PRIMARY_KEY", "test-subscription-key")
+	client, err := campminder.NewClient(&campminder.Config{APIKey: "test-key", ClientID: "test-client", SeasonID: year})
+	if err != nil {
+		t.Fatalf("campminder.NewClient: %v", err)
+	}
+	return client
+}
+
+// TestProtectThenSweepOrphans_ProtectionFailureAbortsSweep is a regression test
+// for the ordering half of kindred#2287: protectNonActiveStaffAssignments used
+// to run, its error get counted, and then deleteOrphans run anyway in the same
+// Sync() call -- so a protection failure meant the sweep deleted precisely the
+// assignments protection existed to save, and only THEN did the run report a
+// failure. That reports the damage instead of preventing it. The fix is that a
+// protection failure must abort the sweep, not just get logged next to it.
+func TestProtectThenSweepOrphans_ProtectionFailureAbortsSweep(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupBunkAssignmentSweepCollections(t, app)
+
+	const year = 2025
+
+	// A "kept" assignment: its key will be marked processed, as the normal
+	// sync loop would have done for a live camper/staff record. Needed so the
+	// orphan-sweep guard sees a non-empty computed set and does not refuse the
+	// sweep as a total collapse (which would pass this test for the wrong
+	// reason).
+	keptPerson := saveRec(t, app, "persons", map[string]any{"cm_id": 4000001, "year": year})
+	keptSession := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 6001, "year": year})
+	saveRec(t, app, "bunk_assignments", map[string]any{
+		"person": keptPerson.Id, "session": keptSession.Id, "year": year,
+	})
+
+	// An orphan: NOT in ProcessedKeys. If the sweep runs, this gets deleted.
+	orphanPerson := saveRec(t, app, "persons", map[string]any{"cm_id": 4000002, "year": year})
+	orphanSession := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 6002, "year": year})
+	orphanAssignment := saveRec(t, app, "bunk_assignments", map[string]any{
+		"person": orphanPerson.Id, "session": orphanSession.Id, "year": year,
+	})
+
+	s := &BunkAssignmentsSync{BaseSyncService: BaseSyncService{
+		App: app, Client: newTestCampMinderClient(t, year), ProcessedKeys: make(map[string]bool),
+	}}
+	s.SyncSuccessful = true // arms deleteOrphans; otherwise it no-ops regardless of ordering
+	s.TrackProcessedCompositeKey(fmt.Sprintf("%d:%d", 4000001, 6001), year)
+
+	s.protectThenSweepOrphans(year)
+
+	if s.Stats.Errors == 0 {
+		t.Error("Stats.Errors = 0, want > 0 -- the missing staff collection is an infrastructure failure and must be counted")
+	}
+
+	if _, err := app.FindRecordById("bunk_assignments", orphanAssignment.Id); err != nil {
+		t.Errorf("orphan bunk_assignment was deleted despite a protection failure -- "+
+			"the sweep ran when it must not have: %v", err)
+	}
+}
+
+// TestProtectThenSweepOrphans_ProtectionSuccessStillSweeps is the mirror check:
+// the abort-on-failure guard above must not also block the sweep on a normal,
+// successful run.
+func TestProtectThenSweepOrphans_ProtectionSuccessStillSweeps(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupBunkAssignmentProtectionCollections(t, app) // includes an empty "staff" collection
+
+	const year = 2025
+
+	keptPerson := saveRec(t, app, "persons", map[string]any{"cm_id": 4000003, "year": year})
+	keptSession := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 6003, "year": year})
+	saveRec(t, app, "bunk_assignments", map[string]any{
+		"person": keptPerson.Id, "session": keptSession.Id, "year": year,
+	})
+
+	orphanPerson := saveRec(t, app, "persons", map[string]any{"cm_id": 4000004, "year": year})
+	orphanSession := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 6004, "year": year})
+	orphanAssignment := saveRec(t, app, "bunk_assignments", map[string]any{
+		"person": orphanPerson.Id, "session": orphanSession.Id, "year": year,
+	})
+
+	s := &BunkAssignmentsSync{BaseSyncService: BaseSyncService{
+		App: app, Client: newTestCampMinderClient(t, year), ProcessedKeys: make(map[string]bool),
+	}}
+	s.SyncSuccessful = true
+	s.TrackProcessedCompositeKey(fmt.Sprintf("%d:%d", 4000003, 6003), year)
+
+	s.protectThenSweepOrphans(year)
+
+	if s.Stats.Errors != 0 {
+		t.Errorf("Stats.Errors = %d, want 0 -- protection had nothing to fail on", s.Stats.Errors)
+	}
+
+	if _, err := app.FindRecordById("bunk_assignments", orphanAssignment.Id); err == nil {
+		t.Error("orphan bunk_assignment still exists -- the sweep did not run on a successful protection pass")
+	}
+}
+
+// TestProtectNonActiveStaffAssignments_ActiveStaffUntouched verifies active
+// bunk staff are left alone -- their assignments come fresh from the
+// CampMinder API each sync and must not be pre-tracked as processed.
+func TestProtectNonActiveStaffAssignments_ActiveStaffUntouched(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupBunkAssignmentProtectionCollections(t, app)
+
+	const year = 2025
+	const personCMID = 3000002
+	const sessionCMID = 5002
+
+	person := saveRec(t, app, "persons", map[string]any{"cm_id": personCMID, "year": year})
+	session := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": sessionCMID, "year": year})
+	saveRec(t, app, "bunk_assignments", map[string]any{
+		"person": person.Id, "session": session.Id, "year": year,
+	})
+	saveRec(t, app, "staff", map[string]any{
+		"person_id": personCMID, "status": "active", "bunk_staff": true, "year": year,
+	})
+
+	s := &BunkAssignmentsSync{BaseSyncService: BaseSyncService{App: app, ProcessedKeys: make(map[string]bool)}}
+
+	protectedCount, err := s.protectNonActiveStaffAssignments(year)
+	if err != nil {
+		t.Fatalf("protectNonActiveStaffAssignments: %v", err)
+	}
+	if protectedCount != 0 {
+		t.Errorf("protectedCount = %d, want 0 -- active staff assignments should not be pre-tracked", protectedCount)
+	}
+}

--- a/pocketbase/sync/bunk_assignments_test.go
+++ b/pocketbase/sync/bunk_assignments_test.go
@@ -152,6 +152,14 @@ func TestBunkAssignmentsSync_StaffSessionLookup(t *testing.T) {
 // bunk_assignments for non-active bunk staff are pre-tracked as processed,
 // so DeleteOrphans won't remove them. CampMinder strips assignments from
 // dismissed/resigned staff, but we preserve them in PocketBase.
+//
+// NOTE: this only replicates the tracking logic inline -- it never calls
+// protectNonActiveStaffAssignments, so it could not have caught kindred#2287
+// (the real function's bunk_assignments filter named a nonexistent column
+// and errored on every iteration). For a test that exercises the actual
+// function against a live PocketBase app, see
+// TestProtectNonActiveStaffAssignments_ProtectsDismissedStaff in
+// bunk_assignments_protection_test.go.
 func TestBunkAssignmentsSync_NonActiveStaffOrphanProtection(t *testing.T) {
 	tests := []struct {
 		name             string


### PR DESCRIPTION
## Summary

`protectNonActiveStaffAssignments` (`pocketbase/sync/bunk_assignments.go`) exists to stop `DeleteOrphans` from removing bunk assignments for staff CampMinder has stopped reporting (dismissed/resigned/cancelled). It has never actually protected anything: it filtered `bunk_assignments` on `person_id`, a column that does not exist on that collection (the person link is the `person` relation). `FindRecordsByFilter` errored on every iteration, and the error was swallowed by a `slog.Warn` -- so the sync reported success while protecting nothing. Re-ran the measurement against the current snapshot: 2026 has 7 non-active bunk staff (4 resigned, 2 dismissed, 1 cancelled), holding zero protected `bunk_assignments` between them -- unchanged from the issue.

#2287's body originally covered only the filter. It undersold the ordering defect below -- reworded the issue body and posted a comment explaining the change before opening this PR, so the two agree.

Two independent problems, both fixed:

**1. The filter itself.** Resolve `personCMID` to the `persons` PocketBase id first, then filter `bunk_assignments` on `person = '<pbid>'` instead of the nonexistent `person_id` column, per `docs/reference/sync-id-conventions.md` (cross-table relationships resolve CampMinder ids to PocketBase relation fields, not raw CM ids as filter columns). `protectNonActiveStaffAssignments` now returns `(int, error)` instead of silently swallowing failures.

**2. The ordering -- this one mattered more.** `DeleteOrphans` ran unconditionally right after the protection step, regardless of whether protection succeeded. So the failure sequence was: protection fails → the error gets counted → the sweep deletes precisely the assignments protection exists to save → the run reports failed *afterward*. That reports the damage instead of preventing it, for a fix whose entire purpose is preserving those rows. `protectThenSweepOrphans` now aborts the sweep the moment protection fails, and increments `s.Stats.Errors` (an existing field, already used elsewhere in this file) instead of a bare `slog.Warn`. Per kindred#2284 (open, error-escalation policy) no change was made to how the orchestrator treats `Stats.Errors` -- out of scope here.

## Tests (written first, confirmed failing before implementation)

- `TestProtectNonActiveStaffAssignments_ProtectsDismissedStaff` / `_ActiveStaffUntouched` -- exercise `protectNonActiveStaffAssignments` against a live PocketBase test app (not a simulation), asserting `protectedCount > 0` for a year with known non-active bunk staff.
- `TestProtectThenSweepOrphans_ProtectionFailureAbortsSweep` -- builds a live app with `persons`/`camp_sessions`/`bunk_assignments` but deliberately omits the `staff` collection (a real infrastructure failure, not a mock), seeds a "kept" assignment and an "orphan" assignment, arms the sweep (`SyncSuccessful = true`), and asserts the orphan record survives and `Stats.Errors > 0`.
- `TestProtectThenSweepOrphans_ProtectionSuccessStillSweeps` -- mirror check that the new abort-on-failure gate doesn't also block a normal successful sweep.
- Added a note on the pre-existing `TestBunkAssignmentsSync_NonActiveStaffOrphanProtection` pointing to the new integration tests -- the old test only replicated the tracking logic inline and never called the real function, which is why it could not have caught either bug.

## Mutation checks

- Filter fix: reverted `person = '%s'` back to the broken `person_id = %d`, confirmed `TestProtectNonActiveStaffAssignments_ProtectsDismissedStaff` goes RED (exit code 1), restored, confirmed GREEN.
- Ordering fix: removed the early `return` in `protectThenSweepOrphans`, confirmed `TestProtectThenSweepOrphans_ProtectionFailureAbortsSweep` goes RED (exit code 1) -- the log captured `Deleted orphaned records entity="bunk assignment" count=1` printed immediately after the protection error, the bug itself on tape -- restored, confirmed GREEN.

Closes #2287.

## Test plan
- [x] `cd pocketbase && go test ./sync/...` -- pass
- [x] `cd pocketbase && go test ./...` -- pass
- [x] `go build ./...` / `go vet ./...` / `gofmt -l` -- clean
- [x] `golangci-lint run --config ../.golangci.yml ./sync/...` -- 0 issues
- [x] `bash scripts/pre-push-verify.sh` (full `-race` suite included) -- ALL CHECKS PASSED


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bunk-assignment synchronization to protect assignments for non-active staff before removing orphaned records.
  * Prevented orphan cleanup when assignment protection encounters an error.
  * Improved staff lookup and assignment filtering reliability.

* **Tests**
  * Added integration coverage for dismissed staff protection, active staff handling, protection failures, and successful orphan cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->