### PR TITLE
refactor(sync): seven deleteOrphans implementations return (int, error)

### DIFF
--- a/pocketbase/sync/camper_dietary.go
+++ b/pocketbase/sync/camper_dietary.go
@@ -177,14 +177,21 @@ func (s *CamperDietarySync) Sync(ctx context.Context) error {
 	s.Stats.Errors = errors
 
 	// Step 6: Delete orphans
-	deleted := s.deleteOrphans(ctx, records, existingRecords)
+	deleted, orphanErr := s.deleteOrphans(ctx, records, existingRecords, year)
 	s.Stats.Deleted = deleted
 
-	// WAL checkpoint
+	// WAL checkpoint BEFORE the error return below -- upsertRecords has already
+	// written by this point, and the refusal path can fire on a non-empty
+	// computed set (a PARTIAL collapse), which is exactly the case where writes
+	// already happened.
 	if s.Stats.Created > 0 || s.Stats.Updated > 0 || s.Stats.Deleted > 0 {
 		if err := s.forceWALCheckpoint(); err != nil {
 			slog.Warn("WAL checkpoint failed", "error", err)
 		}
+	}
+
+	if orphanErr != nil {
+		return fmt.Errorf("orphan sweep refused: %w", orphanErr)
 	}
 
 	s.SyncSuccessful = true
@@ -561,18 +568,34 @@ func (s *CamperDietarySync) upsertRecords(
 	return created, updated, skipped, errors
 }
 
-// deleteOrphans removes records that exist in DB but not in computed set
+// deleteOrphans removes records that exist in DB but not in computed set.
+//
+// Refuses when the computed set is too small to be believed against the rows
+// on disk: that combination is always a broken input, and sweeping on it
+// deletes the year and reports success (kindred#2257, kindred#2283). The rule
+// lives in OrphanSweepGuard so there is one implementation, not an eighth copy.
 func (s *CamperDietarySync) deleteOrphans(
 	ctx context.Context,
 	records map[string]*camperDietaryRecord,
 	existingRecords map[string]string,
-) int {
+	year int,
+) (int, error) {
+	guard := OrphanSweepGuard{
+		Entity:   "camper_dietary",
+		Year:     year,
+		Computed: len(records),
+		Hint:     "check that the attendee mapping and the dietary field definitions still exist upstream",
+	}
+	if err := guard.Check(len(existingRecords)); err != nil {
+		return 0, err
+	}
+
 	deleted := 0
 
 	for key, recordID := range existingRecords {
 		select {
 		case <-ctx.Done():
-			return deleted
+			return deleted, ctx.Err()
 		default:
 		}
 
@@ -591,7 +614,7 @@ func (s *CamperDietarySync) deleteOrphans(
 		}
 	}
 
-	return deleted
+	return deleted, nil
 }
 
 // forceWALCheckpoint forces a SQLite WAL checkpoint

--- a/pocketbase/sync/camper_dietary.go
+++ b/pocketbase/sync/camper_dietary.go
@@ -49,11 +49,14 @@ const (
 // years. See "Reading Derived Informational Tables (Active-Enrolment Filtering)" in
 // docs/architecture/sync-layer.md.
 type CamperDietarySync struct {
-	App            core.App
-	Year           int
-	DryRun         bool
-	Debug          bool
-	Stats          Stats
+	App    core.App
+	Year   int
+	DryRun bool
+	Debug  bool
+	Stats  Stats
+	// SyncSuccessful reports whether this run's extraction produced any rows.
+	// Set immediately after extraction, NOT at the end of Sync(), because its
+	// one consumer is the orphan sweep, which runs before Sync() returns.
 	SyncSuccessful bool
 }
 
@@ -153,12 +156,23 @@ func (s *CamperDietarySync) Sync(ctx context.Context) error {
 	}
 	slog.Info("Extracted camper dietary records", "count", len(records))
 
+	// The extraction finished without error, so len(records) is now a fact about
+	// the SOURCE rather than about whether this run worked. Gate the sweep on it:
+	// a year in which nobody answered is a legitimately empty upstream, not a
+	// collapse, and refusing there wedged the table -- a refused sweep never
+	// clears the rows, so `existing` stayed high and every later run refused
+	// again. This is the policy BaseSyncService.DeleteOrphans already applies
+	// ("Only delete orphans if the sync was successful", with SyncSuccessful set
+	// mid-fetch and gated on rows arriving); these four declared their own
+	// SyncSuccessful at the END of Sync(), where it was always false during
+	// their own sweep and nothing ever read it (kindred#2283).
+	s.SyncSuccessful = len(records) > 0
+
 	if s.DryRun {
 		slog.Info("Dry run mode - extracted but not writing",
 			"records", len(records),
 		)
 		s.Stats.Created = len(records)
-		s.SyncSuccessful = true
 		return nil
 	}
 
@@ -194,7 +208,6 @@ func (s *CamperDietarySync) Sync(ctx context.Context) error {
 		return wrapOrphanSweepError(orphanErr)
 	}
 
-	s.SyncSuccessful = true
 	slog.Info("Camper dietary extraction completed",
 		"year", year,
 		"created", s.Stats.Created,
@@ -580,6 +593,16 @@ func (s *CamperDietarySync) deleteOrphans(
 	existingRecords map[string]string,
 	year int,
 ) (int, error) {
+	// An empty source is not a collapse. Sync() sets SyncSuccessful from the
+	// size of this run's extraction, so a year nobody answered skips the sweep
+	// and succeeds rather than refusing forever (kindred#2283). The guard below
+	// still owns the case that matters: a source that came back SHORT.
+	if !s.SyncSuccessful {
+		slog.Info("Skipping orphan deletion: the source returned no rows for this year",
+			"entity", "camper_dietary", "year", year)
+		return 0, nil
+	}
+
 	guard := OrphanSweepGuard{
 		Entity:   "camper_dietary",
 		Year:     year,

--- a/pocketbase/sync/camper_dietary.go
+++ b/pocketbase/sync/camper_dietary.go
@@ -191,7 +191,7 @@ func (s *CamperDietarySync) Sync(ctx context.Context) error {
 	}
 
 	if orphanErr != nil {
-		return fmt.Errorf("orphan sweep refused: %w", orphanErr)
+		return wrapOrphanSweepError(orphanErr)
 	}
 
 	s.SyncSuccessful = true

--- a/pocketbase/sync/camper_dietary_test.go
+++ b/pocketbase/sync/camper_dietary_test.go
@@ -503,6 +503,12 @@ func TestCamperDietaryRecordNeedsUpdateUsesCompareFields(t *testing.T) {
 // kindred#2283 adds. Before this fix deleteOrphans returned a bare int and had
 // no channel to refuse a sweep at all -- an empty computed set against a
 // populated year deleted the whole year and reported success.
+//
+// NOTE since kindred#2283 rows 3+4: this pins the guard's CONTRACT, not a state
+// Sync() can now produce. Sync() sets SyncSuccessful from len(records), so an
+// empty computed set skips the sweep before the guard is consulted. The arm
+// that stays live on this path is the ratio one -- a source that came back
+// short rather than empty.
 func TestCamperDietaryDeleteOrphansRefusesCollapsedComputedSet(t *testing.T) {
 	t.Parallel()
 	app := newOrphanSweepTestApp(t, "camper_dietary", "person_id")
@@ -518,6 +524,11 @@ func TestCamperDietaryDeleteOrphansRefusesCollapsedComputedSet(t *testing.T) {
 	}
 
 	s := NewCamperDietarySync(app)
+	// Set explicitly because this drives deleteOrphans directly rather than
+	// through Sync(), which is what normally sets it from the size of the
+	// extraction (kindred#2283 rows 3+4). The three ProcessedKeys-based syncs
+	// have always required this of their tests; these four now match.
+	s.SyncSuccessful = true
 	existing := map[string]string{makeCamperDietaryKey(8001, 2026): rec.Id}
 
 	deleted, err := s.deleteOrphans(context.Background(),
@@ -556,6 +567,11 @@ func TestCamperDietaryDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
 	}
 
 	s := NewCamperDietarySync(app)
+	// Set explicitly because this drives deleteOrphans directly rather than
+	// through Sync(), which is what normally sets it from the size of the
+	// extraction (kindred#2283 rows 3+4). The three ProcessedKeys-based syncs
+	// have always required this of their tests; these four now match.
+	s.SyncSuccessful = true
 	records := map[string]*camperDietaryRecord{
 		makeCamperDietaryKey(8001, 2026): {personID: 8001, year: 2026},
 	}

--- a/pocketbase/sync/camper_dietary_test.go
+++ b/pocketbase/sync/camper_dietary_test.go
@@ -486,3 +486,72 @@ func TestCamperDietaryRecordNeedsUpdateUsesCompareFields(t *testing.T) {
 		}
 	})
 }
+
+// TestCamperDietaryDeleteOrphansRefusesCollapsedComputedSet pins the guard
+// kindred#2283 adds. Before this fix deleteOrphans returned a bare int and had
+// no channel to refuse a sweep at all -- an empty computed set against a
+// populated year deleted the whole year and reported success.
+func TestCamperDietaryDeleteOrphansRefusesCollapsedComputedSet(t *testing.T) {
+	app := newOrphanSweepTestApp(t, "camper_dietary", "person_id")
+	col, err := app.FindCollectionByNameOrId("camper_dietary")
+	if err != nil {
+		t.Fatalf("find camper_dietary: %v", err)
+	}
+	rec := core.NewRecord(col)
+	rec.Set("person_id", 8001)
+	rec.Set("year", 2026)
+	if saveErr := app.Save(rec); saveErr != nil {
+		t.Fatalf("save existing row: %v", saveErr)
+	}
+
+	s := NewCamperDietarySync(app)
+	existing := map[string]string{makeCamperDietaryKey(8001, 2026): rec.Id}
+
+	deleted, err := s.deleteOrphans(context.Background(),
+		map[string]*camperDietaryRecord{}, existing, 2026)
+
+	if err == nil {
+		t.Fatal("expected an error when the computed set is empty and rows exist, got nil")
+	}
+	if deleted != 0 {
+		t.Errorf("deleted = %d, want 0 -- nothing may be removed on the refusal path", deleted)
+	}
+
+	remaining, err := app.FindRecordsByFilter("camper_dietary", "year = 2026", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query: %v", err)
+	}
+	if len(remaining) != 1 {
+		t.Errorf("%d rows survived, want 1 -- the guard must not delete", len(remaining))
+	}
+}
+
+// TestCamperDietaryDeleteOrphansStillSweepsGenuineOrphans proves the guard did
+// not disable orphan deletion for the normal case.
+func TestCamperDietaryDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
+	app := newOrphanSweepTestApp(t, "camper_dietary", "person_id")
+	col, err := app.FindCollectionByNameOrId("camper_dietary")
+	if err != nil {
+		t.Fatalf("find camper_dietary: %v", err)
+	}
+	orphan := core.NewRecord(col)
+	orphan.Set("person_id", 8002)
+	orphan.Set("year", 2026)
+	if saveErr := app.Save(orphan); saveErr != nil {
+		t.Fatalf("save orphan: %v", saveErr)
+	}
+
+	s := NewCamperDietarySync(app)
+	records := map[string]*camperDietaryRecord{
+		makeCamperDietaryKey(8001, 2026): {personID: 8001, year: 2026},
+	}
+	existing := map[string]string{makeCamperDietaryKey(8002, 2026): orphan.Id}
+
+	deleted, err := s.deleteOrphans(context.Background(), records, existing, 2026)
+	if err != nil {
+		t.Fatalf("deleteOrphans: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("deleted = %d, want 1", deleted)
+	}
+}

--- a/pocketbase/sync/camper_dietary_test.go
+++ b/pocketbase/sync/camper_dietary_test.go
@@ -504,6 +504,7 @@ func TestCamperDietaryRecordNeedsUpdateUsesCompareFields(t *testing.T) {
 // no channel to refuse a sweep at all -- an empty computed set against a
 // populated year deleted the whole year and reported success.
 func TestCamperDietaryDeleteOrphansRefusesCollapsedComputedSet(t *testing.T) {
+	t.Parallel()
 	app := newOrphanSweepTestApp(t, "camper_dietary", "person_id")
 	col, err := app.FindCollectionByNameOrId("camper_dietary")
 	if err != nil {
@@ -541,6 +542,7 @@ func TestCamperDietaryDeleteOrphansRefusesCollapsedComputedSet(t *testing.T) {
 // TestCamperDietaryDeleteOrphansStillSweepsGenuineOrphans proves the guard did
 // not disable orphan deletion for the normal case.
 func TestCamperDietaryDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
+	t.Parallel()
 	app := newOrphanSweepTestApp(t, "camper_dietary", "person_id")
 	col, err := app.FindCollectionByNameOrId("camper_dietary")
 	if err != nil {

--- a/pocketbase/sync/camper_history.go
+++ b/pocketbase/sync/camper_history.go
@@ -393,13 +393,21 @@ func (c *CamperHistorySync) Sync(ctx context.Context) error {
 	c.SyncSuccessful = true
 
 	// Delete orphaned records (campers unenrolled from sessions)
-	c.deleteOrphans(existingRecords)
+	deleted, orphanErr := c.deleteOrphans(existingRecords, year)
+	c.Stats.Deleted = deleted
 
-	// WAL checkpoint
+	// WAL checkpoint BEFORE the error return below -- the upsert loop above has
+	// already written by this point, and the refusal path can fire on a
+	// non-empty computed set (a PARTIAL collapse), which is exactly the case
+	// where writes already happened.
 	if c.Stats.Created > 0 || c.Stats.Updated > 0 || c.Stats.Deleted > 0 {
 		if err := c.forceWALCheckpoint(); err != nil {
 			slog.Warn("WAL checkpoint failed", "error", err)
 		}
+	}
+
+	if orphanErr != nil {
+		return fmt.Errorf("orphan sweep refused: %w", orphanErr)
 	}
 
 	slog.Info("Camper history v2 computation completed",
@@ -1118,10 +1126,20 @@ func (c *CamperHistorySync) recordNeedsUpdate(
 }
 
 // deleteOrphans removes records that weren't processed (campers unenrolled from sessions)
-func (c *CamperHistorySync) deleteOrphans(existingRecords map[string]*core.Record) int {
+func (c *CamperHistorySync) deleteOrphans(existingRecords map[string]*core.Record, year int) (int, error) {
 	if !c.SyncSuccessful {
 		slog.Info("Skipping orphan deletion due to sync failure")
-		return 0
+		return 0, nil
+	}
+
+	guard := OrphanSweepGuard{
+		Entity:   "camper_history",
+		Year:     year,
+		Computed: len(c.ProcessedKeys),
+		Hint:     "check that the CampMinder attendee feed returned this season",
+	}
+	if err := guard.Check(len(existingRecords)); err != nil {
+		return 0, err
 	}
 
 	orphanCount := 0
@@ -1145,9 +1163,8 @@ func (c *CamperHistorySync) deleteOrphans(existingRecords map[string]*core.Recor
 	}
 
 	if orphanCount > 0 {
-		c.Stats.Deleted = orphanCount
 		slog.Info("Deleted orphaned camper_history records", "count", orphanCount)
 	}
 
-	return orphanCount
+	return orphanCount, nil
 }

--- a/pocketbase/sync/camper_history.go
+++ b/pocketbase/sync/camper_history.go
@@ -407,7 +407,7 @@ func (c *CamperHistorySync) Sync(ctx context.Context) error {
 	}
 
 	if orphanErr != nil {
-		return fmt.Errorf("orphan sweep refused: %w", orphanErr)
+		return wrapOrphanSweepError(orphanErr)
 	}
 
 	slog.Info("Camper history v2 computation completed",
@@ -1125,7 +1125,13 @@ func (c *CamperHistorySync) recordNeedsUpdate(
 	return compareRecordNeedsUpdate(existing, newData, compareFields)
 }
 
-// deleteOrphans removes records that weren't processed (campers unenrolled from sessions)
+// deleteOrphans removes records that weren't processed (campers unenrolled from
+// sessions).
+//
+// Refuses when the computed set is too small to be believed against the rows
+// on disk: that combination is always a broken input, and sweeping on it
+// deletes the year and reports success (kindred#2257, kindred#2283). The rule
+// lives in OrphanSweepGuard so there is one implementation, not an eighth copy.
 func (c *CamperHistorySync) deleteOrphans(existingRecords map[string]*core.Record, year int) (int, error) {
 	if !c.SyncSuccessful {
 		slog.Info("Skipping orphan deletion due to sync failure")

--- a/pocketbase/sync/camper_history.go
+++ b/pocketbase/sync/camper_history.go
@@ -171,6 +171,14 @@ func (c *CamperHistorySync) Sync(ctx context.Context) error {
 		return fmt.Errorf("loading attendees: %w", err)
 	}
 
+	// An empty source is not a collapse, so this returns BEFORE loading existing
+	// rows and before the sweep: nothing is deleted and the run succeeds. That is
+	// the same policy the four records-map syncs got in kindred#2283 rows 3+4 and
+	// the one BaseSyncService.DeleteOrphans applies -- expressed here as an early
+	// return rather than a SyncSuccessful gate, because this file has nothing
+	// left to do once there are no attendees. Leaving the sweep to refuse instead
+	// would wedge the table: a refused sweep never clears the rows it refused
+	// over, so the condition would not resolve on its own.
 	if len(attendees) == 0 {
 		slog.Info("No attendees found for year", "year", year)
 		c.SyncSuccessful = true

--- a/pocketbase/sync/camper_history_test.go
+++ b/pocketbase/sync/camper_history_test.go
@@ -2478,3 +2478,75 @@ func TestCamperHistoryRecordNeedsUpdateUsesCompareFields(t *testing.T) {
 		}
 	})
 }
+
+// TestCamperHistoryDeleteOrphansRefusesCollapsedComputedSet pins the guard
+// kindred#2283 adds. Before this fix deleteOrphans returned a bare int and had
+// no channel to refuse a sweep at all -- an empty ProcessedKeys map against a
+// populated year deleted the whole year and reported success.
+func TestCamperHistoryDeleteOrphansRefusesCollapsedComputedSet(t *testing.T) {
+	app := newOrphanSweepTestApp(t, "camper_history", "person_id", "session_cm_id")
+	col, err := app.FindCollectionByNameOrId("camper_history")
+	if err != nil {
+		t.Fatalf("find camper_history: %v", err)
+	}
+	rec := core.NewRecord(col)
+	rec.Set("person_id", 5001)
+	rec.Set("session_cm_id", 200)
+	rec.Set("year", 2026)
+	if saveErr := app.Save(rec); saveErr != nil {
+		t.Fatalf("save existing row: %v", saveErr)
+	}
+
+	c := NewCamperHistorySync(app)
+	c.SyncSuccessful = true
+	c.ProcessedKeys = make(map[string]bool) // nothing processed this run
+
+	existing := map[string]*core.Record{"5001:200|2026": rec}
+	deleted, err := c.deleteOrphans(existing, 2026)
+
+	if err == nil {
+		t.Fatal("expected an error when nothing was processed and rows exist, got nil")
+	}
+	if deleted != 0 {
+		t.Errorf("deleted = %d, want 0 -- nothing may be removed on the refusal path", deleted)
+	}
+
+	remaining, err := app.FindRecordsByFilter("camper_history", "year = 2026", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query: %v", err)
+	}
+	if len(remaining) != 1 {
+		t.Errorf("%d rows survived, want 1 -- the guard must not delete", len(remaining))
+	}
+}
+
+// TestCamperHistoryDeleteOrphansStillSweepsGenuineOrphans proves the guard did
+// not disable orphan deletion for the normal case (a camper unenrolled from a
+// session).
+func TestCamperHistoryDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
+	app := newOrphanSweepTestApp(t, "camper_history", "person_id", "session_cm_id")
+	col, err := app.FindCollectionByNameOrId("camper_history")
+	if err != nil {
+		t.Fatalf("find camper_history: %v", err)
+	}
+	orphan := core.NewRecord(col)
+	orphan.Set("person_id", 5002)
+	orphan.Set("session_cm_id", 200)
+	orphan.Set("year", 2026)
+	if saveErr := app.Save(orphan); saveErr != nil {
+		t.Fatalf("save orphan: %v", saveErr)
+	}
+
+	c := NewCamperHistorySync(app)
+	c.SyncSuccessful = true
+	c.ProcessedKeys = map[string]bool{"5001:200|2026": true}
+
+	existing := map[string]*core.Record{"5002:200|2026": orphan}
+	deleted, err := c.deleteOrphans(existing, 2026)
+	if err != nil {
+		t.Fatalf("deleteOrphans: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("deleted = %d, want 1", deleted)
+	}
+}

--- a/pocketbase/sync/camper_history_test.go
+++ b/pocketbase/sync/camper_history_test.go
@@ -2668,8 +2668,8 @@ func TestCamperHistorySyncPropagatesSweepRefusal(t *testing.T) {
 		a := core.NewRecord(attendees)
 		a.Set("person_id", cmID)
 		a.Set("year", 2026)
-		if err := app.Save(a); err != nil {
-			t.Fatalf("save attendee %d: %v", cmID, err)
+		if saveErr := app.Save(a); saveErr != nil {
+			t.Fatalf("save attendee %d: %v", cmID, saveErr)
 		}
 	}
 
@@ -2682,8 +2682,8 @@ func TestCamperHistorySyncPropagatesSweepRefusal(t *testing.T) {
 		rec.Set("person_id", 900+i)
 		rec.Set("session_cm_id", 200)
 		rec.Set("year", 2026)
-		if err := app.Save(rec); err != nil {
-			t.Fatalf("save existing row %d: %v", i, err)
+		if saveErr := app.Save(rec); saveErr != nil {
+			t.Fatalf("save existing row %d: %v", i, saveErr)
 		}
 	}
 

--- a/pocketbase/sync/camper_history_test.go
+++ b/pocketbase/sync/camper_history_test.go
@@ -1,12 +1,14 @@
 package sync
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strings"
 	"testing"
 
 	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
 )
 
 // Test constants for fictional data
@@ -2587,5 +2589,121 @@ func TestCamperHistoryDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
 	}
 	if deleted != 1 {
 		t.Errorf("deleted = %d, want 1", deleted)
+	}
+}
+
+// newCamperHistorySyncTestApp builds the collections CamperHistorySync.Sync()
+// reads on its way to the orphan sweep. Most are empty -- the loaders tolerate
+// that -- but they must exist, because a query against a missing collection is
+// an error that would abort Sync() long before the sweep.
+func newCamperHistorySyncTestApp(t *testing.T) core.App {
+	t.Helper()
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	simple := map[string][]string{
+		"camp_sessions":           {"name", "session_type"},
+		"bunks":                   {"name"},
+		"divisions":               {"name"},
+		"custom_field_defs":       {"name"},
+		"households":              {},
+		"persons":                 {"first_name", "last_name", "gender"},
+		"person_custom_values":    {"person", "field_definition", "value"},
+		"household_custom_values": {"household", "field_definition", "value"},
+		"bunk_assignments":        {"person", "session", "bunk"},
+		"attendees":               {"person", "session", "status", "session_type"},
+	}
+	for name, textFields := range simple {
+		col := core.NewBaseCollection(name)
+		for _, f := range textFields {
+			col.Fields.Add(&core.TextField{Name: f})
+		}
+		col.Fields.Add(&core.NumberField{Name: "cm_id"})
+		col.Fields.Add(&core.NumberField{Name: "person_id"})
+		col.Fields.Add(&core.NumberField{Name: "status_id"})
+		col.Fields.Add(&core.NumberField{Name: "year"})
+		// The loaders page with a "-created" sort; the field has to exist.
+		col.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
+		if err := app.Save(col); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	hist := core.NewBaseCollection("camper_history")
+	hist.Fields.Add(&core.NumberField{Name: "person_id"})
+	hist.Fields.Add(&core.NumberField{Name: "session_cm_id"})
+	hist.Fields.Add(&core.NumberField{Name: "year"})
+	for _, f := range []string{"name", "session_name", "session_type", "gender", "status"} {
+		hist.Fields.Add(&core.TextField{Name: f})
+	}
+	hist.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
+	if err := app.Save(hist); err != nil {
+		t.Fatalf("create camper_history: %v", err)
+	}
+	return app
+}
+
+// TestCamperHistorySyncPropagatesSweepRefusal is the caller-propagation test for
+// kindred#2283. camper_history.go is one of the two files that previously called
+// deleteOrphans without even capturing its return value, so "the caller now uses
+// the error" is the whole point of the change here -- and the guard tests alone
+// prove nothing about it. Sibling PR kindred#2294 shipped exactly this gap.
+//
+// Deleting the `if orphanErr != nil` return in camper_history.go makes this test
+// fail; without it the whole sync suite stays green.
+func TestCamperHistorySyncPropagatesSweepRefusal(t *testing.T) {
+	t.Parallel()
+	app := newCamperHistorySyncTestApp(t)
+
+	attendees, err := app.FindCollectionByNameOrId("attendees")
+	if err != nil {
+		t.Fatalf("find attendees: %v", err)
+	}
+	// Three attendees this run -- believable on its own, a collapse against
+	// what is already stored.
+	for _, cmID := range []int{101, 102, 103} {
+		a := core.NewRecord(attendees)
+		a.Set("person_id", cmID)
+		a.Set("year", 2026)
+		if err := app.Save(a); err != nil {
+			t.Fatalf("save attendee %d: %v", cmID, err)
+		}
+	}
+
+	hist, err := app.FindCollectionByNameOrId("camper_history")
+	if err != nil {
+		t.Fatalf("find camper_history: %v", err)
+	}
+	for i := range OrphanSweepMinRows + 5 {
+		rec := core.NewRecord(hist)
+		rec.Set("person_id", 900+i)
+		rec.Set("session_cm_id", 200)
+		rec.Set("year", 2026)
+		if err := app.Save(rec); err != nil {
+			t.Fatalf("save existing row %d: %v", i, err)
+		}
+	}
+
+	c := NewCamperHistorySync(app)
+	c.Year = 2026
+	syncErr := c.Sync(context.Background())
+
+	if syncErr == nil {
+		t.Fatal("Sync returned nil on a refused sweep -- the refusal never reached the caller")
+	}
+	if !strings.Contains(syncErr.Error(), "orphan sweep refused") {
+		t.Errorf("Sync error = %q, want it to carry the sweep refusal", syncErr.Error())
+	}
+
+	remaining, err := app.FindRecordsByFilter("camper_history", "year = 2026 && person_id >= 900", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query: %v", err)
+	}
+	if len(remaining) != OrphanSweepMinRows+5 {
+		t.Errorf("%d seeded rows survived, want %d -- a refused sweep must delete nothing",
+			len(remaining), OrphanSweepMinRows+5)
 	}
 }

--- a/pocketbase/sync/camper_history_test.go
+++ b/pocketbase/sync/camper_history_test.go
@@ -2521,6 +2521,7 @@ func TestCamperHistoryRecordNeedsUpdateUsesCompareFields(t *testing.T) {
 // no channel to refuse a sweep at all -- an empty ProcessedKeys map against a
 // populated year deleted the whole year and reported success.
 func TestCamperHistoryDeleteOrphansRefusesCollapsedComputedSet(t *testing.T) {
+	t.Parallel()
 	app := newOrphanSweepTestApp(t, "camper_history", "person_id", "session_cm_id")
 	col, err := app.FindCollectionByNameOrId("camper_history")
 	if err != nil {
@@ -2561,6 +2562,7 @@ func TestCamperHistoryDeleteOrphansRefusesCollapsedComputedSet(t *testing.T) {
 // not disable orphan deletion for the normal case (a camper unenrolled from a
 // session).
 func TestCamperHistoryDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
+	t.Parallel()
 	app := newOrphanSweepTestApp(t, "camper_history", "person_id", "session_cm_id")
 	col, err := app.FindCollectionByNameOrId("camper_history")
 	if err != nil {

--- a/pocketbase/sync/camper_transportation.go
+++ b/pocketbase/sync/camper_transportation.go
@@ -202,7 +202,7 @@ func (s *CamperTransportationSync) Sync(ctx context.Context) error {
 	}
 
 	if orphanErr != nil {
-		return fmt.Errorf("orphan sweep refused: %w", orphanErr)
+		return wrapOrphanSweepError(orphanErr)
 	}
 
 	s.SyncSuccessful = true

--- a/pocketbase/sync/camper_transportation.go
+++ b/pocketbase/sync/camper_transportation.go
@@ -51,11 +51,14 @@ const (
 // years. See "Reading Derived Informational Tables (Active-Enrolment Filtering)" in
 // docs/architecture/sync-layer.md.
 type CamperTransportationSync struct {
-	App            core.App
-	Year           int
-	DryRun         bool
-	Debug          bool
-	Stats          Stats
+	App    core.App
+	Year   int
+	DryRun bool
+	Debug  bool
+	Stats  Stats
+	// SyncSuccessful reports whether this run's extraction produced any rows.
+	// Set immediately after extraction, NOT at the end of Sync(), because its
+	// one consumer is the orphan sweep, which runs before Sync() returns.
 	SyncSuccessful bool
 }
 
@@ -165,12 +168,23 @@ func (s *CamperTransportationSync) Sync(ctx context.Context) error {
 	}
 	slog.Info("Extracted camper transportation records", "count", len(records))
 
+	// The extraction finished without error, so len(records) is now a fact about
+	// the SOURCE rather than about whether this run worked. Gate the sweep on it:
+	// a year in which nobody answered is a legitimately empty upstream, not a
+	// collapse, and refusing there wedged the table -- a refused sweep never
+	// clears the rows, so `existing` stayed high and every later run refused
+	// again. This is the policy BaseSyncService.DeleteOrphans already applies
+	// ("Only delete orphans if the sync was successful", with SyncSuccessful set
+	// mid-fetch and gated on rows arriving); these four declared their own
+	// SyncSuccessful at the END of Sync(), where it was always false during
+	// their own sweep and nothing ever read it (kindred#2283).
+	s.SyncSuccessful = len(records) > 0
+
 	if s.DryRun {
 		slog.Info("Dry run mode - extracted but not writing",
 			"records", len(records),
 		)
 		s.Stats.Created = len(records)
-		s.SyncSuccessful = true
 		return nil
 	}
 
@@ -205,7 +219,6 @@ func (s *CamperTransportationSync) Sync(ctx context.Context) error {
 		return wrapOrphanSweepError(orphanErr)
 	}
 
-	s.SyncSuccessful = true
 	slog.Info("Camper transportation extraction completed",
 		"year", year,
 		"created", s.Stats.Created,
@@ -672,6 +685,16 @@ func (s *CamperTransportationSync) deleteOrphans(
 	existingRecords map[string]string,
 	year int,
 ) (int, error) {
+	// An empty source is not a collapse. Sync() sets SyncSuccessful from the
+	// size of this run's extraction, so a year nobody answered skips the sweep
+	// and succeeds rather than refusing forever (kindred#2283). The guard below
+	// still owns the case that matters: a source that came back SHORT.
+	if !s.SyncSuccessful {
+		slog.Info("Skipping orphan deletion: the source returned no rows for this year",
+			"entity", "camper_transportation", "year", year)
+		return 0, nil
+	}
+
 	guard := OrphanSweepGuard{
 		Entity:   "camper_transportation",
 		Year:     year,

--- a/pocketbase/sync/camper_transportation.go
+++ b/pocketbase/sync/camper_transportation.go
@@ -188,14 +188,21 @@ func (s *CamperTransportationSync) Sync(ctx context.Context) error {
 	s.Stats.Errors = errors
 
 	// Step 6: Delete orphans
-	deleted := s.deleteOrphans(ctx, records, existingRecords)
+	deleted, orphanErr := s.deleteOrphans(ctx, records, existingRecords, year)
 	s.Stats.Deleted = deleted
 
-	// WAL checkpoint
+	// WAL checkpoint BEFORE the error return below -- upsertRecords has already
+	// written by this point, and the refusal path can fire on a non-empty
+	// computed set (a PARTIAL collapse), which is exactly the case where writes
+	// already happened.
 	if s.Stats.Created > 0 || s.Stats.Updated > 0 || s.Stats.Deleted > 0 {
 		if err := s.forceWALCheckpoint(); err != nil {
 			slog.Warn("WAL checkpoint failed", "error", err)
 		}
+	}
+
+	if orphanErr != nil {
+		return fmt.Errorf("orphan sweep refused: %w", orphanErr)
 	}
 
 	s.SyncSuccessful = true
@@ -653,18 +660,34 @@ func (s *CamperTransportationSync) upsertRecords(
 	return created, updated, errors
 }
 
-// deleteOrphans removes records that exist in DB but not in computed set
+// deleteOrphans removes records that exist in DB but not in computed set.
+//
+// Refuses when the computed set is too small to be believed against the rows
+// on disk: that combination is always a broken input, and sweeping on it
+// deletes the year and reports success (kindred#2257, kindred#2283). The rule
+// lives in OrphanSweepGuard so there is one implementation, not an eighth copy.
 func (s *CamperTransportationSync) deleteOrphans(
 	ctx context.Context,
 	records map[string]*camperTransportationRecord,
 	existingRecords map[string]string,
-) int {
+	year int,
+) (int, error) {
+	guard := OrphanSweepGuard{
+		Entity:   "camper_transportation",
+		Year:     year,
+		Computed: len(records),
+		Hint:     "check that the attendee mapping and the BUS-* field definitions still exist upstream",
+	}
+	if err := guard.Check(len(existingRecords)); err != nil {
+		return 0, err
+	}
+
 	deleted := 0
 
 	for key, recordID := range existingRecords {
 		select {
 		case <-ctx.Done():
-			return deleted
+			return deleted, ctx.Err()
 		default:
 		}
 
@@ -683,7 +706,7 @@ func (s *CamperTransportationSync) deleteOrphans(
 		}
 	}
 
-	return deleted
+	return deleted, nil
 }
 
 // forceWALCheckpoint forces a SQLite WAL checkpoint

--- a/pocketbase/sync/camper_transportation_test.go
+++ b/pocketbase/sync/camper_transportation_test.go
@@ -514,6 +514,7 @@ func TestAttendeeKeyRequiresValidSessionID(t *testing.T) {
 // and had no channel to refuse a sweep at all -- an empty computed set against
 // a populated year deleted the whole year and reported success.
 func TestCamperTransportationDeleteOrphansRefusesCollapsedComputedSet(t *testing.T) {
+	t.Parallel()
 	app := newOrphanSweepTestApp(t, "camper_transportation", "person_id", "session_id")
 	col, err := app.FindCollectionByNameOrId("camper_transportation")
 	if err != nil {
@@ -552,6 +553,7 @@ func TestCamperTransportationDeleteOrphansRefusesCollapsedComputedSet(t *testing
 // TestCamperTransportationDeleteOrphansStillSweepsGenuineOrphans proves the
 // guard did not disable orphan deletion for the normal case.
 func TestCamperTransportationDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
+	t.Parallel()
 	app := newOrphanSweepTestApp(t, "camper_transportation", "person_id", "session_id")
 	col, err := app.FindCollectionByNameOrId("camper_transportation")
 	if err != nil {

--- a/pocketbase/sync/camper_transportation_test.go
+++ b/pocketbase/sync/camper_transportation_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
 )
 
 // TestCamperTransportationLoadFieldDefinitionsTrimsNames is a regression test
@@ -492,5 +494,76 @@ func TestAttendeeKeyRequiresValidSessionID(t *testing.T) {
 					tt.personID, tt.sessionID, shouldAdd, tt.shouldAdd)
 			}
 		})
+	}
+}
+
+// TestCamperTransportationDeleteOrphansRefusesCollapsedComputedSet pins the
+// guard kindred#2283 adds. Before this fix deleteOrphans returned a bare int
+// and had no channel to refuse a sweep at all -- an empty computed set against
+// a populated year deleted the whole year and reported success.
+func TestCamperTransportationDeleteOrphansRefusesCollapsedComputedSet(t *testing.T) {
+	app := newOrphanSweepTestApp(t, "camper_transportation", "person_id", "session_id")
+	col, err := app.FindCollectionByNameOrId("camper_transportation")
+	if err != nil {
+		t.Fatalf("find camper_transportation: %v", err)
+	}
+	rec := core.NewRecord(col)
+	rec.Set("person_id", 7001)
+	rec.Set("session_id", 300)
+	rec.Set("year", 2026)
+	if saveErr := app.Save(rec); saveErr != nil {
+		t.Fatalf("save existing row: %v", saveErr)
+	}
+
+	s := NewCamperTransportationSync(app)
+	existing := map[string]string{makeTransportationKey(7001, 300, 2026): rec.Id}
+
+	deleted, err := s.deleteOrphans(context.Background(),
+		map[string]*camperTransportationRecord{}, existing, 2026)
+
+	if err == nil {
+		t.Fatal("expected an error when the computed set is empty and rows exist, got nil")
+	}
+	if deleted != 0 {
+		t.Errorf("deleted = %d, want 0 -- nothing may be removed on the refusal path", deleted)
+	}
+
+	remaining, err := app.FindRecordsByFilter("camper_transportation", "year = 2026", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query: %v", err)
+	}
+	if len(remaining) != 1 {
+		t.Errorf("%d rows survived, want 1 -- the guard must not delete", len(remaining))
+	}
+}
+
+// TestCamperTransportationDeleteOrphansStillSweepsGenuineOrphans proves the
+// guard did not disable orphan deletion for the normal case.
+func TestCamperTransportationDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
+	app := newOrphanSweepTestApp(t, "camper_transportation", "person_id", "session_id")
+	col, err := app.FindCollectionByNameOrId("camper_transportation")
+	if err != nil {
+		t.Fatalf("find camper_transportation: %v", err)
+	}
+	orphan := core.NewRecord(col)
+	orphan.Set("person_id", 7002)
+	orphan.Set("session_id", 300)
+	orphan.Set("year", 2026)
+	if saveErr := app.Save(orphan); saveErr != nil {
+		t.Fatalf("save orphan: %v", saveErr)
+	}
+
+	s := NewCamperTransportationSync(app)
+	records := map[string]*camperTransportationRecord{
+		makeTransportationKey(7001, 300, 2026): {personID: 7001, sessionID: 300, year: 2026},
+	}
+	existing := map[string]string{makeTransportationKey(7002, 300, 2026): orphan.Id}
+
+	deleted, err := s.deleteOrphans(context.Background(), records, existing, 2026)
+	if err != nil {
+		t.Fatalf("deleteOrphans: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("deleted = %d, want 1", deleted)
 	}
 }

--- a/pocketbase/sync/camper_transportation_test.go
+++ b/pocketbase/sync/camper_transportation_test.go
@@ -513,6 +513,12 @@ func TestAttendeeKeyRequiresValidSessionID(t *testing.T) {
 // guard kindred#2283 adds. Before this fix deleteOrphans returned a bare int
 // and had no channel to refuse a sweep at all -- an empty computed set against
 // a populated year deleted the whole year and reported success.
+//
+// NOTE since kindred#2283 rows 3+4: this pins the guard's CONTRACT, not a state
+// Sync() can now produce. Sync() sets SyncSuccessful from len(records), so an
+// empty computed set skips the sweep before the guard is consulted. The arm
+// that stays live on this path is the ratio one -- a source that came back
+// short rather than empty.
 func TestCamperTransportationDeleteOrphansRefusesCollapsedComputedSet(t *testing.T) {
 	t.Parallel()
 	app := newOrphanSweepTestApp(t, "camper_transportation", "person_id", "session_id")
@@ -529,6 +535,11 @@ func TestCamperTransportationDeleteOrphansRefusesCollapsedComputedSet(t *testing
 	}
 
 	s := NewCamperTransportationSync(app)
+	// Set explicitly because this drives deleteOrphans directly rather than
+	// through Sync(), which is what normally sets it from the size of the
+	// extraction (kindred#2283 rows 3+4). The three ProcessedKeys-based syncs
+	// have always required this of their tests; these four now match.
+	s.SyncSuccessful = true
 	existing := map[string]string{makeTransportationKey(7001, 300, 2026): rec.Id}
 
 	deleted, err := s.deleteOrphans(context.Background(),
@@ -568,6 +579,11 @@ func TestCamperTransportationDeleteOrphansStillSweepsGenuineOrphans(t *testing.T
 	}
 
 	s := NewCamperTransportationSync(app)
+	// Set explicitly because this drives deleteOrphans directly rather than
+	// through Sync(), which is what normally sets it from the size of the
+	// extraction (kindred#2283 rows 3+4). The three ProcessedKeys-based syncs
+	// have always required this of their tests; these four now match.
+	s.SyncSuccessful = true
 	records := map[string]*camperTransportationRecord{
 		makeTransportationKey(7001, 300, 2026): {personID: 7001, sessionID: 300, year: 2026},
 	}

--- a/pocketbase/sync/household_demographics.go
+++ b/pocketbase/sync/household_demographics.go
@@ -46,11 +46,14 @@ const sortByID = "id"
 //     land on a person-less row (person_id 0) rather than being copied onto
 //     every camper.
 type HouseholdDemographicsSync struct {
-	App            core.App
-	Year           int  // Year to compute for (0 = current year from env)
-	DryRun         bool // Dry run mode (compute but don't write)
-	Debug          bool // Enable verbose debug logging
-	Stats          Stats
+	App    core.App
+	Year   int  // Year to compute for (0 = current year from env)
+	DryRun bool // Dry run mode (compute but don't write)
+	Debug  bool // Enable verbose debug logging
+	Stats  Stats
+	// SyncSuccessful reports whether this run's extraction produced any rows.
+	// Set immediately after extraction, NOT at the end of Sync(), because its
+	// one consumer is the orphan sweep, which runs before Sync() returns.
 	SyncSuccessful bool
 
 	// columnConflicts counts values setColumn refused to overwrite. Zero on
@@ -248,12 +251,23 @@ func (s *HouseholdDemographicsSync) Sync(ctx context.Context) error {
 	records := s.aggregateToRows(personValues, householdValues, year)
 	slog.Info("Aggregated to person grain", "rows", len(records), "conflicts", s.columnConflicts)
 
+	// The extraction finished without error, so len(records) is now a fact about
+	// the SOURCE rather than about whether this run worked. Gate the sweep on it:
+	// a year in which nobody answered is a legitimately empty upstream, not a
+	// collapse, and refusing there wedged the table -- a refused sweep never
+	// clears the rows, so `existing` stayed high and every later run refused
+	// again. This is the policy BaseSyncService.DeleteOrphans already applies
+	// ("Only delete orphans if the sync was successful", with SyncSuccessful set
+	// mid-fetch and gated on rows arriving); these four declared their own
+	// SyncSuccessful at the END of Sync(), where it was always false during
+	// their own sweep and nothing ever read it (kindred#2283).
+	s.SyncSuccessful = len(records) > 0
+
 	if s.DryRun {
 		slog.Info("Dry run mode - computed but not writing",
 			"rows", len(records),
 		)
 		s.Stats.Created = len(records)
-		s.SyncSuccessful = true
 		return nil
 	}
 
@@ -289,7 +303,6 @@ func (s *HouseholdDemographicsSync) Sync(ctx context.Context) error {
 		return wrapOrphanSweepError(orphanErr)
 	}
 
-	s.SyncSuccessful = true
 	slog.Info("Household demographics computation completed",
 		"year", year,
 		"column_conflicts", s.columnConflicts,
@@ -954,6 +967,16 @@ func (s *HouseholdDemographicsSync) deleteOrphans(
 	existingRecords map[string]string,
 	year int,
 ) (int, error) {
+	// An empty source is not a collapse. Sync() sets SyncSuccessful from the
+	// size of this run's extraction, so a year nobody answered skips the sweep
+	// and succeeds rather than refusing forever (kindred#2283). The guard below
+	// still owns the case that matters: a source that came back SHORT.
+	if !s.SyncSuccessful {
+		slog.Info("Skipping orphan deletion: the source returned no rows for this year",
+			"entity", "household_demographics", "year", year)
+		return 0, nil
+	}
+
 	guard := OrphanSweepGuard{
 		Entity:   "household_demographics",
 		Year:     year,

--- a/pocketbase/sync/household_demographics.go
+++ b/pocketbase/sync/household_demographics.go
@@ -286,7 +286,7 @@ func (s *HouseholdDemographicsSync) Sync(ctx context.Context) error {
 	}
 
 	if orphanErr != nil {
-		return fmt.Errorf("orphan sweep refused: %w", orphanErr)
+		return wrapOrphanSweepError(orphanErr)
 	}
 
 	s.SyncSuccessful = true
@@ -940,6 +940,14 @@ func (s *HouseholdDemographicsSync) upsertRecords(
 // (kindred#2283). The rule now lives in the shared OrphanSweepGuard, which
 // widens "empty" to "suspiciously small" and is the one implementation behind
 // every guarded sweep in this package rather than an eighth local copy.
+//
+// The old check also did `s.Stats.Errors++` on refusal, and that increment was
+// deliberately NOT carried over. Stats.Errors counts infrastructure failures --
+// a save that did not land, a query that broke -- and kindred#2293 makes a
+// non-zero count fail the run outright. A refusal is not an infrastructure
+// failure: it is this guard working, and it already reaches the operator as
+// the error Sync() returns. Counting it as well would report one event twice
+// and make a healthy refusal indistinguishable from a broken database.
 func (s *HouseholdDemographicsSync) deleteOrphans(
 	ctx context.Context,
 	records map[string]*householdDemographicsRecord,

--- a/pocketbase/sync/household_demographics.go
+++ b/pocketbase/sync/household_demographics.go
@@ -272,14 +272,21 @@ func (s *HouseholdDemographicsSync) Sync(ctx context.Context) error {
 	s.Stats.Errors = errors
 
 	// Step 8: Delete orphans (records in DB but not in computed set)
-	deleted := s.deleteOrphans(ctx, records, existingRecords)
+	deleted, orphanErr := s.deleteOrphans(ctx, records, existingRecords, year)
 	s.Stats.Deleted = deleted
 
-	// WAL checkpoint
+	// WAL checkpoint BEFORE the error return below -- upsertRecords has already
+	// written by this point, and the refusal path can fire on a non-empty
+	// computed set (a PARTIAL collapse), which is exactly the case where writes
+	// already happened.
 	if s.Stats.Created > 0 || s.Stats.Updated > 0 || s.Stats.Deleted > 0 {
 		if err := s.forceWALCheckpoint(); err != nil {
 			slog.Warn("WAL checkpoint failed", "error", err)
 		}
+	}
+
+	if orphanErr != nil {
+		return fmt.Errorf("orphan sweep refused: %w", orphanErr)
 	}
 
 	s.SyncSuccessful = true
@@ -925,25 +932,31 @@ func (s *HouseholdDemographicsSync) upsertRecords(
 // upsertRecords exactly. Widen one without the other and the next run sweeps
 // away the rows the other just wrote, reporting success as it goes
 // (kindred#2257).
+//
+// Refuses when the computed set is too small to be believed against the rows
+// on disk. This USED to be a hand-rolled `len(records) == 0` check that caught
+// only a TOTAL collapse -- a load that returned a handful of rows against
+// hundreds on disk sailed straight past it and the sweep deleted the rest
+// (kindred#2283). The rule now lives in the shared OrphanSweepGuard, which
+// widens "empty" to "suspiciously small" and is the one implementation behind
+// every guarded sweep in this package rather than an eighth local copy.
 func (s *HouseholdDemographicsSync) deleteOrphans(
 	ctx context.Context,
 	records map[string]*householdDemographicsRecord,
 	existingRecords map[string]string,
-) int {
-	deleted := 0
-
-	// Refuse to empty the table. Every row is recomputed from
-	// person_custom_values on each run, so an empty computed set standing
-	// against a populated table is far more likely to be a load that came back
-	// empty than a year in which nobody answered anything -- and this sweep is
-	// the one step of this sync a re-run cannot undo.
-	if len(records) == 0 && len(existingRecords) > 0 {
-		slog.Error("Refusing to delete household_demographics orphans: nothing was computed",
-			"existing_records", len(existingRecords),
-		)
-		s.Stats.Errors++
-		return 0
+	year int,
+) (int, error) {
+	guard := OrphanSweepGuard{
+		Entity:   "household_demographics",
+		Year:     year,
+		Computed: len(records),
+		Hint:     "check that the persons sync ran for that year and that person_custom_values loaded",
 	}
+	if err := guard.Check(len(existingRecords)); err != nil {
+		return 0, err
+	}
+
+	deleted := 0
 
 	// Build set of computed keys
 	computedKeys := make(map[string]bool)
@@ -956,7 +969,7 @@ func (s *HouseholdDemographicsSync) deleteOrphans(
 	for key, recordID := range existingRecords {
 		select {
 		case <-ctx.Done():
-			return deleted
+			return deleted, ctx.Err()
 		default:
 		}
 
@@ -975,7 +988,7 @@ func (s *HouseholdDemographicsSync) deleteOrphans(
 		}
 	}
 
-	return deleted
+	return deleted, nil
 }
 
 // forceWALCheckpoint forces a SQLite WAL checkpoint

--- a/pocketbase/sync/household_demographics_test.go
+++ b/pocketbase/sync/household_demographics_test.go
@@ -977,9 +977,9 @@ func TestHouseholdDemographicsDeleteOrphansRefusesPartialCollapse(t *testing.T) 
 // newHouseholdDemographicsSyncTestApp extends newHouseholdDemographicsTestApp
 // with the three collections Sync() reads on its way to the sweep, so a test
 // can drive the whole run rather than calling deleteOrphans directly.
-func newHouseholdDemographicsSyncTestApp(t *testing.T) (core.App, *core.Collection, *core.Collection) {
+func newHouseholdDemographicsSyncTestApp(t *testing.T) (app core.App, households, persons *core.Collection) {
 	t.Helper()
-	app, households, persons := newHouseholdDemographicsTestApp(t)
+	app, households, persons = newHouseholdDemographicsTestApp(t)
 
 	defs := core.NewBaseCollection("custom_field_defs")
 	defs.Fields.Add(&core.TextField{Name: "name"})
@@ -1034,8 +1034,8 @@ func TestHouseholdDemographicsSyncPropagatesSweepRefusal(t *testing.T) {
 	}
 	def := core.NewRecord(defs)
 	def.Set("name", "HH-Jewish Affiliation")
-	if err := app.Save(def); err != nil {
-		t.Fatalf("save field def: %v", err)
+	if saveErr := app.Save(def); saveErr != nil {
+		t.Fatalf("save field def: %v", saveErr)
 	}
 
 	pcvCol, err := app.FindCollectionByNameOrId("person_custom_values")
@@ -1049,16 +1049,16 @@ func TestHouseholdDemographicsSyncPropagatesSweepRefusal(t *testing.T) {
 		p.Set("cm_id", cmID)
 		p.Set("household", hh.Id)
 		p.Set("year", 2026)
-		if err := app.Save(p); err != nil {
-			t.Fatalf("save person %d: %v", cmID, err)
+		if saveErr := app.Save(p); saveErr != nil {
+			t.Fatalf("save person %d: %v", cmID, saveErr)
 		}
 		v := core.NewRecord(pcvCol)
 		v.Set("person", p.Id)
 		v.Set("field_definition", def.Id)
 		v.Set("value", testAffiliation)
 		v.Set("year", 2026)
-		if err := app.Save(v); err != nil {
-			t.Fatalf("save custom value for %d: %v", cmID, err)
+		if saveErr := app.Save(v); saveErr != nil {
+			t.Fatalf("save custom value for %d: %v", cmID, saveErr)
 		}
 	}
 
@@ -1072,8 +1072,8 @@ func TestHouseholdDemographicsSyncPropagatesSweepRefusal(t *testing.T) {
 		rec.Set("household", hh.Id)
 		rec.Set("person_id", 900+i)
 		rec.Set("year", 2026)
-		if err := app.Save(rec); err != nil {
-			t.Fatalf("save existing row %d: %v", i, err)
+		if saveErr := app.Save(rec); saveErr != nil {
+			t.Fatalf("save existing row %d: %v", i, saveErr)
 		}
 	}
 

--- a/pocketbase/sync/household_demographics_test.go
+++ b/pocketbase/sync/household_demographics_test.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"context"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/pocketbase/pocketbase/core"
@@ -970,5 +971,133 @@ func TestHouseholdDemographicsDeleteOrphansRefusesPartialCollapse(t *testing.T) 
 	}
 	if len(remaining) != OrphanSweepMinRows+5 {
 		t.Errorf("%d rows survived, want %d -- the guard must not delete", len(remaining), OrphanSweepMinRows+5)
+	}
+}
+
+// newHouseholdDemographicsSyncTestApp extends newHouseholdDemographicsTestApp
+// with the three collections Sync() reads on its way to the sweep, so a test
+// can drive the whole run rather than calling deleteOrphans directly.
+func newHouseholdDemographicsSyncTestApp(t *testing.T) (core.App, *core.Collection, *core.Collection) {
+	t.Helper()
+	app, households, persons := newHouseholdDemographicsTestApp(t)
+
+	defs := core.NewBaseCollection("custom_field_defs")
+	defs.Fields.Add(&core.TextField{Name: "name"})
+	if err := app.Save(defs); err != nil {
+		t.Fatalf("create custom_field_defs: %v", err)
+	}
+
+	pcv := core.NewBaseCollection("person_custom_values")
+	pcv.Fields.Add(&core.TextField{Name: "person"})
+	pcv.Fields.Add(&core.TextField{Name: "field_definition"})
+	pcv.Fields.Add(&core.TextField{Name: "value"})
+	pcv.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(pcv); err != nil {
+		t.Fatalf("create person_custom_values: %v", err)
+	}
+
+	hcv := core.NewBaseCollection("household_custom_values")
+	hcv.Fields.Add(&core.TextField{Name: "household"})
+	hcv.Fields.Add(&core.TextField{Name: "field_definition"})
+	hcv.Fields.Add(&core.TextField{Name: "value"})
+	hcv.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(hcv); err != nil {
+		t.Fatalf("create household_custom_values: %v", err)
+	}
+
+	return app, households, persons
+}
+
+// TestHouseholdDemographicsSyncPropagatesSweepRefusal is the caller-propagation
+// test for kindred#2283. The guard tests above prove deleteOrphans REFUSES; on
+// their own they prove nothing about whether anyone listens. Sibling PR
+// kindred#2294 shipped exactly that gap -- a counted failure that never reached
+// the returned error, so the run went green on a broken sweep.
+//
+// This drives the real Sync() and asserts the refusal comes back out of it.
+// Deleting the `if orphanErr != nil` return in household_demographics.go makes
+// this test fail; without it the whole sync suite stays green.
+func TestHouseholdDemographicsSyncPropagatesSweepRefusal(t *testing.T) {
+	t.Parallel()
+	app, households, persons := newHouseholdDemographicsSyncTestApp(t)
+
+	hh := core.NewRecord(households)
+	hh.Set("cm_id", 9001)
+	hh.Set("year", 2026)
+	if err := app.Save(hh); err != nil {
+		t.Fatalf("save household: %v", err)
+	}
+
+	defs, err := app.FindCollectionByNameOrId("custom_field_defs")
+	if err != nil {
+		t.Fatalf("find custom_field_defs: %v", err)
+	}
+	def := core.NewRecord(defs)
+	def.Set("name", "HH-Jewish Affiliation")
+	if err := app.Save(def); err != nil {
+		t.Fatalf("save field def: %v", err)
+	}
+
+	pcvCol, err := app.FindCollectionByNameOrId("person_custom_values")
+	if err != nil {
+		t.Fatalf("find person_custom_values: %v", err)
+	}
+	// Three campers answered this year -- a believable computed set on its own,
+	// but a collapse against what is already stored.
+	for _, cmID := range []int{101, 102, 103} {
+		p := core.NewRecord(persons)
+		p.Set("cm_id", cmID)
+		p.Set("household", hh.Id)
+		p.Set("year", 2026)
+		if err := app.Save(p); err != nil {
+			t.Fatalf("save person %d: %v", cmID, err)
+		}
+		v := core.NewRecord(pcvCol)
+		v.Set("person", p.Id)
+		v.Set("field_definition", def.Id)
+		v.Set("value", testAffiliation)
+		v.Set("year", 2026)
+		if err := app.Save(v); err != nil {
+			t.Fatalf("save custom value for %d: %v", cmID, err)
+		}
+	}
+
+	// OrphanSweepMinRows+5 rows already on disk that this run does not compute.
+	demoCol, err := app.FindCollectionByNameOrId("household_demographics")
+	if err != nil {
+		t.Fatalf("find household_demographics: %v", err)
+	}
+	for i := range OrphanSweepMinRows + 5 {
+		rec := core.NewRecord(demoCol)
+		rec.Set("household", hh.Id)
+		rec.Set("person_id", 900+i)
+		rec.Set("year", 2026)
+		if err := app.Save(rec); err != nil {
+			t.Fatalf("save existing row %d: %v", i, err)
+		}
+	}
+
+	s := NewHouseholdDemographicsSync(app)
+	s.Year = 2026
+	syncErr := s.Sync(context.Background())
+
+	if syncErr == nil {
+		t.Fatal("Sync returned nil on a refused sweep -- the refusal never reached the caller")
+	}
+	if !strings.Contains(syncErr.Error(), "orphan sweep refused") {
+		t.Errorf("Sync error = %q, want it to carry the sweep refusal", syncErr.Error())
+	}
+	if s.SyncSuccessful {
+		t.Error("SyncSuccessful is true after a refused sweep")
+	}
+
+	// The refusal must not have deleted: the seeded rows plus the three this
+	// run wrote before the sweep.
+	remaining, err := app.FindRecordsByFilter("household_demographics", "year = 2026", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query: %v", err)
+	}
+	if want := OrphanSweepMinRows + 5 + 3; len(remaining) != want {
+		t.Errorf("%d rows survived, want %d -- a refused sweep must delete nothing", len(remaining), want)
 	}
 }

--- a/pocketbase/sync/household_demographics_test.go
+++ b/pocketbase/sync/household_demographics_test.go
@@ -743,8 +743,8 @@ func TestUpsertAndOrphanSweepAgreeOnGrain(t *testing.T) {
 	if len(existing) != 2 {
 		t.Fatalf("loadExistingRecords keyed %d rows, want 2 -- a household-grain key hides a sibling", len(existing))
 	}
-	if deleted := s.deleteOrphans(ctx, rows, existing); deleted != 0 {
-		t.Fatalf("deleteOrphans removed %d of the rows the write path just created", deleted)
+	if deleted, sweepErr := s.deleteOrphans(ctx, rows, existing, 2026); sweepErr != nil || deleted != 0 {
+		t.Fatalf("deleteOrphans removed %d of the rows the write path just created (err=%v)", deleted, sweepErr)
 	}
 	if n := countDemographicsRows(t, app); n != 2 {
 		t.Fatalf("household_demographics holds %d rows after a no-op sweep, want 2", n)
@@ -756,8 +756,8 @@ func TestUpsertAndOrphanSweepAgreeOnGrain(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loadExistingRecords before sweep: %v", err)
 	}
-	if deleted := s.deleteOrphans(ctx, onlyFirst, existing); deleted != 1 {
-		t.Fatalf("deleteOrphans removed %d rows, want 1", deleted)
+	if deleted, sweepErr := s.deleteOrphans(ctx, onlyFirst, existing, 2026); sweepErr != nil || deleted != 1 {
+		t.Fatalf("deleteOrphans removed %d rows, want 1 (err=%v)", deleted, sweepErr)
 	}
 	if n := countDemographicsRows(t, app); n != 1 {
 		t.Fatalf("household_demographics holds %d rows, want 1", n)
@@ -813,15 +813,15 @@ func TestDeleteOrphansRefusesToEmptyTheTable(t *testing.T) {
 		t.Fatalf("loadExistingRecords after upsert: %v", err)
 	}
 
-	deleted := s.deleteOrphans(ctx, map[string]*householdDemographicsRecord{}, existing)
+	deleted, err := s.deleteOrphans(ctx, map[string]*householdDemographicsRecord{}, existing, 2026)
+	if err == nil {
+		t.Error("deleteOrphans against an empty computed set returned nil; want a refusal error")
+	}
 	if deleted != 0 {
 		t.Errorf("deleteOrphans removed %d rows against an empty computed set; want a refusal", deleted)
 	}
 	if n := countDemographicsRows(t, app); n != 1 {
 		t.Errorf("household_demographics holds %d rows, want 1 (nothing swept)", n)
-	}
-	if s.Stats.Errors == 0 {
-		t.Error("a refused sweep must be audible in Stats.Errors, got 0")
 	}
 }
 
@@ -901,4 +901,56 @@ func TestSetColumnIsMustBeUniqueNotFirstWins(t *testing.T) {
 			t.Errorf("conflicts = %d, want 2", s.columnConflicts)
 		}
 	})
+}
+
+// TestHouseholdDemographicsDeleteOrphansRefusesPartialCollapse is the point of
+// kindred#2283: this file carried its OWN hand-rolled guard that caught only a
+// TOTAL collapse (computed set empty). A PARTIAL collapse -- a handful of rows
+// computed against hundreds on disk -- sailed straight past it and swept
+// everything else. The shared OrphanSweepGuard widens "empty" to "suspiciously
+// small"; this test only passes once that guard is wired in, because the old
+// local check (`len(records) == 0`) does not fire when records has 3 entries.
+func TestHouseholdDemographicsDeleteOrphansRefusesPartialCollapse(t *testing.T) {
+	app := newOrphanSweepTestApp(t, "household_demographics", "household", "person_id")
+	col, err := app.FindCollectionByNameOrId("household_demographics")
+	if err != nil {
+		t.Fatalf("find household_demographics: %v", err)
+	}
+
+	existing := make(map[string]string, OrphanSweepMinRows+5)
+	for i := range OrphanSweepMinRows + 5 {
+		rec := core.NewRecord(col)
+		rec.Set("household", "hh_fixed")
+		rec.Set("person_id", i+1)
+		rec.Set("year", 2026)
+		if saveErr := app.Save(rec); saveErr != nil {
+			t.Fatalf("save existing row %d: %v", i, saveErr)
+		}
+		existing[MakeCompositeKey("hh_fixed", i+1, 2026)] = rec.Id
+	}
+
+	s := NewHouseholdDemographicsSync(app)
+	// Only 3 computed against 25 on disk -- well under the 50% floor, and well
+	// past the old hand-rolled guard's "== 0" check.
+	computed := map[string]*householdDemographicsRecord{
+		MakeCompositeKey("hh_fixed", 1, 2026): {householdPBID: "hh_fixed", personCMID: 1, year: 2026},
+		MakeCompositeKey("hh_fixed", 2, 2026): {householdPBID: "hh_fixed", personCMID: 2, year: 2026},
+		MakeCompositeKey("hh_fixed", 3, 2026): {householdPBID: "hh_fixed", personCMID: 3, year: 2026},
+	}
+
+	deleted, err := s.deleteOrphans(context.Background(), computed, existing, 2026)
+	if err == nil {
+		t.Fatal("expected an error when the computed set covers a fraction of what is on disk, got nil")
+	}
+	if deleted != 0 {
+		t.Errorf("deleted = %d, want 0 -- nothing may be removed on the refusal path", deleted)
+	}
+
+	remaining, err := app.FindRecordsByFilter("household_demographics", "year = 2026", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query: %v", err)
+	}
+	if len(remaining) != OrphanSweepMinRows+5 {
+		t.Errorf("%d rows survived, want %d -- the guard must not delete", len(remaining), OrphanSweepMinRows+5)
+	}
 }

--- a/pocketbase/sync/household_demographics_test.go
+++ b/pocketbase/sync/household_demographics_test.go
@@ -732,6 +732,11 @@ func TestUpsertAndOrphanSweepAgreeOnGrain(t *testing.T) {
 	}
 
 	s := NewHouseholdDemographicsSync(app)
+	// Set explicitly because this drives deleteOrphans directly rather than
+	// through Sync(), which is what normally sets it from the size of the
+	// extraction (kindred#2283 rows 3+4). The three ProcessedKeys-based syncs
+	// have always required this of their tests; these four now match.
+	s.SyncSuccessful = true
 	both := []hhCustomValueEntry{
 		hhPersonEntry(hh.Id, personPBIDs[101], 101, "HH-Jewish Affiliation", testAffiliation),
 		hhPersonEntry(hh.Id, personPBIDs[102], 102, "HH-Jewish Affiliation", "Prefer not to answer"),
@@ -795,6 +800,12 @@ func TestUpsertAndOrphanSweepAgreeOnGrain(t *testing.T) {
 // person_custom_values on each run, so an empty computed set is far more likely
 // to be a failed read than a year in which nobody answered anything -- and the
 // sweep is the one step of this sync that a re-run cannot undo.
+//
+// NOTE since kindred#2283 rows 3+4: this pins the guard's CONTRACT, not a state
+// Sync() can now produce. Sync() sets SyncSuccessful from len(records), so an
+// empty computed set skips the sweep before the guard is consulted. The arm
+// that stays live on this path is the ratio one -- a source that came back
+// short rather than empty.
 func TestDeleteOrphansRefusesToEmptyTheTable(t *testing.T) {
 	t.Parallel()
 	app, households, persons := newHouseholdDemographicsTestApp(t)
@@ -815,6 +826,11 @@ func TestDeleteOrphansRefusesToEmptyTheTable(t *testing.T) {
 	}
 
 	s := NewHouseholdDemographicsSync(app)
+	// Set explicitly because this drives deleteOrphans directly rather than
+	// through Sync(), which is what normally sets it from the size of the
+	// extraction (kindred#2283 rows 3+4). The three ProcessedKeys-based syncs
+	// have always required this of their tests; these four now match.
+	s.SyncSuccessful = true
 	rows := s.aggregateToRows([]hhCustomValueEntry{
 		hhPersonEntry(hh.Id, p.Id, 101, "HH-Jewish Affiliation", testAffiliation),
 	}, nil, 2026)
@@ -949,6 +965,11 @@ func TestHouseholdDemographicsDeleteOrphansRefusesPartialCollapse(t *testing.T) 
 	}
 
 	s := NewHouseholdDemographicsSync(app)
+	// Set explicitly because this drives deleteOrphans directly rather than
+	// through Sync(), which is what normally sets it from the size of the
+	// extraction (kindred#2283 rows 3+4). The three ProcessedKeys-based syncs
+	// have always required this of their tests; these four now match.
+	s.SyncSuccessful = true
 	// Only 3 computed against 25 on disk -- well under the 50% floor, and well
 	// past the old hand-rolled guard's "== 0" check.
 	computed := map[string]*householdDemographicsRecord{
@@ -1087,9 +1108,11 @@ func TestHouseholdDemographicsSyncPropagatesSweepRefusal(t *testing.T) {
 	if !strings.Contains(syncErr.Error(), "orphan sweep refused") {
 		t.Errorf("Sync error = %q, want it to carry the sweep refusal", syncErr.Error())
 	}
-	if s.SyncSuccessful {
-		t.Error("SyncSuccessful is true after a refused sweep")
-	}
+	// Deliberately NOT asserting anything about s.SyncSuccessful here. Since
+	// kindred#2283 rows 3+4 it reports whether the EXTRACTION produced rows, not
+	// whether the run succeeded, so it is true on this path -- the extraction
+	// did produce three rows; it was the sweep that refused. The returned error
+	// is the signal, and it is asserted above.
 
 	// The refusal must not have deleted: the seeded rows plus the three this
 	// run wrote before the sweep.
@@ -1099,5 +1122,133 @@ func TestHouseholdDemographicsSyncPropagatesSweepRefusal(t *testing.T) {
 	}
 	if want := OrphanSweepMinRows + 5 + 3; len(remaining) != want {
 		t.Errorf("%d rows survived, want %d -- a refused sweep must delete nothing", len(remaining), want)
+	}
+}
+
+// seedHouseholdDemographicsRun writes `computed` campers who answered an HH-
+// field this year plus `existing` stored rows this run does not account for.
+func seedHouseholdDemographicsRun(
+	t *testing.T, app core.App, households, persons *core.Collection, computed, existing int,
+) {
+	t.Helper()
+
+	hh := core.NewRecord(households)
+	hh.Set("cm_id", 9001)
+	hh.Set("year", 2026)
+	if err := app.Save(hh); err != nil {
+		t.Fatalf("save household: %v", err)
+	}
+
+	defs, err := app.FindCollectionByNameOrId("custom_field_defs")
+	if err != nil {
+		t.Fatalf("find custom_field_defs: %v", err)
+	}
+	def := core.NewRecord(defs)
+	def.Set("name", "HH-Jewish Affiliation")
+	if saveErr := app.Save(def); saveErr != nil {
+		t.Fatalf("save field def: %v", saveErr)
+	}
+
+	pcvCol, err := app.FindCollectionByNameOrId("person_custom_values")
+	if err != nil {
+		t.Fatalf("find person_custom_values: %v", err)
+	}
+	for i := range computed {
+		p := core.NewRecord(persons)
+		p.Set("cm_id", 101+i)
+		p.Set("household", hh.Id)
+		p.Set("year", 2026)
+		if saveErr := app.Save(p); saveErr != nil {
+			t.Fatalf("save person %d: %v", 101+i, saveErr)
+		}
+		v := core.NewRecord(pcvCol)
+		v.Set("person", p.Id)
+		v.Set("field_definition", def.Id)
+		v.Set("value", testAffiliation)
+		v.Set("year", 2026)
+		if saveErr := app.Save(v); saveErr != nil {
+			t.Fatalf("save custom value %d: %v", 101+i, saveErr)
+		}
+	}
+
+	demoCol, err := app.FindCollectionByNameOrId("household_demographics")
+	if err != nil {
+		t.Fatalf("find household_demographics: %v", err)
+	}
+	for i := range existing {
+		rec := core.NewRecord(demoCol)
+		rec.Set("household", hh.Id)
+		rec.Set("person_id", 900+i)
+		rec.Set("year", 2026)
+		if saveErr := app.Save(rec); saveErr != nil {
+			t.Fatalf("save existing row %d: %v", i, saveErr)
+		}
+	}
+}
+
+// TestHouseholdDemographicsEmptyUpstreamSkipsSweep pins the kindred#2283
+// rows 3+4 policy for this file: a year in which nobody answered an HH- field
+// is a legitimately empty source, not a collapse. The sweep is skipped, the run
+// succeeds, and what is on disk is left alone. Refusing instead wedged the
+// table -- the rows were never cleared, so `existing` stayed high and every
+// later run refused again.
+func TestHouseholdDemographicsEmptyUpstreamSkipsSweep(t *testing.T) {
+	t.Parallel()
+	app, households, persons := newHouseholdDemographicsSyncTestApp(t)
+	seedHouseholdDemographicsRun(t, app, households, persons, 0, OrphanSweepMinRows+5)
+
+	s := NewHouseholdDemographicsSync(app)
+	s.Year = 2026
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync on an empty upstream returned %v, want nil -- an empty source is not a collapse", err)
+	}
+
+	remaining, err := app.FindRecordsByFilter("household_demographics", "year = 2026", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query: %v", err)
+	}
+	if len(remaining) != OrphanSweepMinRows+5 {
+		t.Errorf("%d rows survived, want %d -- an empty upstream must skip the sweep, not run it",
+			len(remaining), OrphanSweepMinRows+5)
+	}
+}
+
+// TestHouseholdDemographicsNonEmptyUpstreamStillSweeps is the negative control:
+// the skip must not become "never sweep".
+func TestHouseholdDemographicsNonEmptyUpstreamStillSweeps(t *testing.T) {
+	t.Parallel()
+	app, households, persons := newHouseholdDemographicsSyncTestApp(t)
+	seedHouseholdDemographicsRun(t, app, households, persons, 3, 0)
+
+	// One stored row this run does not compute, and few enough on disk that the
+	// ratio arm does not apply -- only the sweep itself is under test.
+	demoCol, err := app.FindCollectionByNameOrId("household_demographics")
+	if err != nil {
+		t.Fatalf("find household_demographics: %v", err)
+	}
+	hhs, err := app.FindRecordsByFilter("households", "cm_id = 9001", "", 1, 0)
+	if err != nil || len(hhs) == 0 {
+		t.Fatalf("find seeded household: %v", err)
+	}
+	orphan := core.NewRecord(demoCol)
+	orphan.Set("household", hhs[0].Id)
+	orphan.Set("person_id", 999)
+	orphan.Set("year", 2026)
+	if saveErr := app.Save(orphan); saveErr != nil {
+		t.Fatalf("save orphan: %v", saveErr)
+	}
+
+	s := NewHouseholdDemographicsSync(app)
+	s.Year = 2026
+	if syncErr := s.Sync(context.Background()); syncErr != nil {
+		t.Fatalf("Sync on a healthy run returned %v, want nil", syncErr)
+	}
+
+	survivors, err := app.FindRecordsByFilter("household_demographics", "year = 2026 && person_id = 999", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query: %v", err)
+	}
+	if len(survivors) != 0 {
+		t.Error("the genuine orphan survived -- a non-empty upstream must still sweep")
 	}
 }

--- a/pocketbase/sync/household_demographics_test.go
+++ b/pocketbase/sync/household_demographics_test.go
@@ -928,6 +928,7 @@ func TestSetColumnIsMustBeUniqueNotFirstWins(t *testing.T) {
 // small"; this test only passes once that guard is wired in, because the old
 // local check (`len(records) == 0`) does not fire when records has 3 entries.
 func TestHouseholdDemographicsDeleteOrphansRefusesPartialCollapse(t *testing.T) {
+	t.Parallel()
 	app := newOrphanSweepTestApp(t, "household_demographics", "household", "person_id")
 	col, err := app.FindCollectionByNameOrId("household_demographics")
 	if err != nil {

--- a/pocketbase/sync/normalize_geographic.go
+++ b/pocketbase/sync/normalize_geographic.go
@@ -217,13 +217,21 @@ func (n *NormalizeGeographicSync) Sync(ctx context.Context) error {
 	n.SyncSuccessful = true
 
 	// Step 7: Delete orphaned mappings
-	n.deleteOrphans(existingMappings)
+	deleted, orphanErr := n.deleteOrphans(existingMappings, year)
+	n.Stats.Deleted = deleted
 
-	// WAL checkpoint
+	// WAL checkpoint BEFORE the error return below -- the upserts above have
+	// already written by this point, and the refusal path can fire on a
+	// non-empty computed set (a PARTIAL collapse), which is exactly the case
+	// where writes already happened.
 	if n.Stats.Created > 0 || n.Stats.Updated > 0 || n.Stats.Deleted > 0 {
 		if err := n.forceWALCheckpoint(); err != nil {
 			slog.Warn("WAL checkpoint failed", "error", err)
 		}
+	}
+
+	if orphanErr != nil {
+		return fmt.Errorf("orphan sweep refused: %w", orphanErr)
 	}
 
 	slog.Info("Geographic normalization completed",
@@ -1145,11 +1153,27 @@ func (n *NormalizeGeographicSync) updatePersonsNormalized(
 	return nil
 }
 
-// deleteOrphans removes mappings that weren't processed (no longer in source data)
-func (n *NormalizeGeographicSync) deleteOrphans(existingMappings map[string]*core.Record) int {
+// deleteOrphans removes mappings that weren't processed (no longer in source data).
+//
+// Refuses when the computed set is too small to be believed against the rows
+// on disk: that combination is always a broken input, and sweeping on it
+// deletes the season's mappings and reports success (kindred#2257,
+// kindred#2283). The rule lives in OrphanSweepGuard so there is one
+// implementation, not an eighth copy.
+func (n *NormalizeGeographicSync) deleteOrphans(existingMappings map[string]*core.Record, year int) (int, error) {
 	if !n.SyncSuccessful {
 		slog.Info("Skipping orphan deletion due to sync failure")
-		return 0
+		return 0, nil
+	}
+
+	guard := OrphanSweepGuard{
+		Entity:   "normalized_mappings",
+		Year:     year,
+		Computed: len(n.ProcessedKeys),
+		Hint:     "check that the attendees sync returned this season",
+	}
+	if err := guard.Check(len(existingMappings)); err != nil {
+		return 0, err
 	}
 
 	orphanCount := 0
@@ -1176,11 +1200,10 @@ func (n *NormalizeGeographicSync) deleteOrphans(existingMappings map[string]*cor
 	}
 
 	if orphanCount > 0 {
-		n.Stats.Deleted = orphanCount
 		slog.Info("Deleted orphaned normalized_mappings", "count", orphanCount)
 	}
 
-	return orphanCount
+	return orphanCount, nil
 }
 
 // resolveValue checks alias overrides first, then fuzzy match, then merge redirects.

--- a/pocketbase/sync/normalize_geographic.go
+++ b/pocketbase/sync/normalize_geographic.go
@@ -231,7 +231,7 @@ func (n *NormalizeGeographicSync) Sync(ctx context.Context) error {
 	}
 
 	if orphanErr != nil {
-		return fmt.Errorf("orphan sweep refused: %w", orphanErr)
+		return wrapOrphanSweepError(orphanErr)
 	}
 
 	slog.Info("Geographic normalization completed",

--- a/pocketbase/sync/normalize_geographic_test.go
+++ b/pocketbase/sync/normalize_geographic_test.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -12,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
 )
 
 // ============================================================================
@@ -2294,5 +2296,201 @@ func TestNormalizeGeographicDeleteOrphansStillSweepsGenuineOrphans(t *testing.T)
 	}
 	if deleted != 1 {
 		t.Errorf("deleted = %d, want 1", deleted)
+	}
+}
+
+// newNormalizeGeographicSyncTestApp builds the collections
+// NormalizeGeographicSync.Sync() reads on its way to the orphan sweep.
+// `attendees.person` and `attendees.session` must be real relations because
+// Sync() expands them; the rest only have to exist.
+func newNormalizeGeographicSyncTestApp(t *testing.T) core.App {
+	t.Helper()
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	created := func(col *core.Collection) {
+		col.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
+	}
+
+	households := core.NewBaseCollection("households")
+	households.Fields.Add(&core.NumberField{Name: "cm_id"})
+	households.Fields.Add(&core.TextField{Name: "billing_state"})
+	households.Fields.Add(&core.TextField{Name: "billing_country"})
+	created(households)
+	if err := app.Save(households); err != nil {
+		t.Fatalf("create households: %v", err)
+	}
+
+	sessions := core.NewBaseCollection("camp_sessions")
+	sessions.Fields.Add(&core.NumberField{Name: "cm_id"})
+	sessions.Fields.Add(&core.TextField{Name: "name"})
+	created(sessions)
+	if err := app.Save(sessions); err != nil {
+		t.Fatalf("create camp_sessions: %v", err)
+	}
+
+	persons := core.NewBaseCollection("persons")
+	persons.Fields.Add(&core.NumberField{Name: "cm_id"})
+	persons.Fields.Add(&core.TextField{Name: "school"})
+	persons.Fields.Add(&core.TextField{Name: "address_city"})
+	persons.Fields.Add(&core.TextField{Name: "normalized_city"})
+	persons.Fields.Add(&core.TextField{Name: "normalized_school"})
+	persons.Fields.Add(&core.TextField{Name: "normalized_congregation"})
+	persons.Fields.Add(&core.NumberField{Name: "year"})
+	persons.Fields.Add(&core.RelationField{
+		Name: "primary_childhood_household", CollectionId: households.Id, MaxSelect: 1,
+	})
+	created(persons)
+	if err := app.Save(persons); err != nil {
+		t.Fatalf("create persons: %v", err)
+	}
+
+	attendees := core.NewBaseCollection("attendees")
+	attendees.Fields.Add(&core.RelationField{Name: "person", CollectionId: persons.Id, MaxSelect: 1})
+	attendees.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
+	attendees.Fields.Add(&core.NumberField{Name: "year"})
+	created(attendees)
+	if err := app.Save(attendees); err != nil {
+		t.Fatalf("create attendees: %v", err)
+	}
+
+	for _, name := range []string{"custom_field_defs", "person_custom_values", "geo_overrides"} {
+		col := core.NewBaseCollection(name)
+		for _, f := range []string{
+			"name", "person", "field_definition", "value",
+			"type", "category", "canonical_name", "merged_into", "raw_value",
+		} {
+			col.Fields.Add(&core.TextField{Name: f})
+		}
+		col.Fields.Add(&core.NumberField{Name: "year"})
+		created(col)
+		if err := app.Save(col); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	// Sync() also rewrites the *_normalized columns on camper_history before it
+	// reaches the sweep; the collection has to exist for that step to run.
+	hist := core.NewBaseCollection("camper_history")
+	for _, f := range []string{
+		"city", "school", "congregation",
+		"city_normalized", "school_normalized", "congregation_normalized",
+	} {
+		hist.Fields.Add(&core.TextField{Name: f})
+	}
+	hist.Fields.Add(&core.NumberField{Name: "person_id"})
+	hist.Fields.Add(&core.NumberField{Name: "year"})
+	created(hist)
+	if err := app.Save(hist); err != nil {
+		t.Fatalf("create camper_history: %v", err)
+	}
+
+	mappings := core.NewBaseCollection("normalized_mappings")
+	for _, f := range []string{
+		"person", "session", "category", "original_value", "normalized_value",
+		"address_state", "address_country", "address_city",
+	} {
+		mappings.Fields.Add(&core.TextField{Name: f})
+	}
+	mappings.Fields.Add(&core.NumberField{Name: "confidence"})
+	mappings.Fields.Add(&core.NumberField{Name: "year"})
+	created(mappings)
+	if err := app.Save(mappings); err != nil {
+		t.Fatalf("create normalized_mappings: %v", err)
+	}
+
+	return app
+}
+
+// TestNormalizeGeographicSyncPropagatesSweepRefusal is the caller-propagation
+// test for kindred#2283. normalize_geographic.go is the other file that
+// previously called deleteOrphans without capturing its return value at all, so
+// "the caller now uses the error" is the whole point of the change here, and the
+// guard tests alone prove nothing about it. Sibling PR kindred#2294 shipped
+// exactly this gap: a counted failure that never reached the returned error.
+//
+// The attendees here carry no city, school or congregation, which keeps the
+// fixture hermetic -- populating any of them sends buildNormalizationLookup to
+// the geo-normalize HTTP API, and pointing that at an httptest server needs
+// t.Setenv, which cannot coexist with the t.Parallel() kindred#2288 requires.
+// The refusal therefore comes from the empty-computed-set arm.
+//
+// Deleting the `if orphanErr != nil` return in normalize_geographic.go makes
+// this test fail; without it the whole sync suite stays green.
+func TestNormalizeGeographicSyncPropagatesSweepRefusal(t *testing.T) {
+	t.Parallel()
+	app := newNormalizeGeographicSyncTestApp(t)
+
+	sessions, err := app.FindCollectionByNameOrId("camp_sessions")
+	if err != nil {
+		t.Fatalf("find camp_sessions: %v", err)
+	}
+	sess := core.NewRecord(sessions)
+	sess.Set("cm_id", 200)
+	sess.Set("name", "Session A")
+	if err := app.Save(sess); err != nil {
+		t.Fatalf("save session: %v", err)
+	}
+
+	personsCol, err := app.FindCollectionByNameOrId("persons")
+	if err != nil {
+		t.Fatalf("find persons: %v", err)
+	}
+	attendeesCol, err := app.FindCollectionByNameOrId("attendees")
+	if err != nil {
+		t.Fatalf("find attendees: %v", err)
+	}
+	for _, cmID := range []int{101, 102, 103} {
+		p := core.NewRecord(personsCol)
+		p.Set("cm_id", cmID)
+		p.Set("year", 2026)
+		if err := app.Save(p); err != nil {
+			t.Fatalf("save person %d: %v", cmID, err)
+		}
+		a := core.NewRecord(attendeesCol)
+		a.Set("person", p.Id)
+		a.Set("session", sess.Id)
+		a.Set("year", 2026)
+		if err := app.Save(a); err != nil {
+			t.Fatalf("save attendee %d: %v", cmID, err)
+		}
+	}
+
+	mappingsCol, err := app.FindCollectionByNameOrId("normalized_mappings")
+	if err != nil {
+		t.Fatalf("find normalized_mappings: %v", err)
+	}
+	for i := range OrphanSweepMinRows + 5 {
+		rec := core.NewRecord(mappingsCol)
+		rec.Set("person", fmt.Sprintf("pers_%06d", i))
+		rec.Set("session", sess.Id)
+		rec.Set("category", categoryCity)
+		rec.Set("year", 2026)
+		if err := app.Save(rec); err != nil {
+			t.Fatalf("save existing mapping %d: %v", i, err)
+		}
+	}
+
+	n := NewNormalizeGeographicSync(app)
+	n.Year = 2026
+	syncErr := n.Sync(context.Background())
+
+	if syncErr == nil {
+		t.Fatal("Sync returned nil on a refused sweep -- the refusal never reached the caller")
+	}
+	if !strings.Contains(syncErr.Error(), "orphan sweep refused") {
+		t.Errorf("Sync error = %q, want it to carry the sweep refusal", syncErr.Error())
+	}
+
+	remaining, err := app.FindRecordsByFilter("normalized_mappings", "year = 2026", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query: %v", err)
+	}
+	if len(remaining) != OrphanSweepMinRows+5 {
+		t.Errorf("%d rows survived, want %d -- a refused sweep must delete nothing",
+			len(remaining), OrphanSweepMinRows+5)
 	}
 }

--- a/pocketbase/sync/normalize_geographic_test.go
+++ b/pocketbase/sync/normalize_geographic_test.go
@@ -2225,6 +2225,7 @@ func TestOverrideMapDedup_RejectedCarriesForward(t *testing.T) {
 // against a populated year deleted every normalized mapping and reported
 // success.
 func TestNormalizeGeographicDeleteOrphansRefusesCollapsedComputedSet(t *testing.T) {
+	t.Parallel()
 	app := newOrphanSweepTestApp(t, "normalized_mappings", "category", "person", "session")
 	col, err := app.FindCollectionByNameOrId("normalized_mappings")
 	if err != nil {
@@ -2266,6 +2267,7 @@ func TestNormalizeGeographicDeleteOrphansRefusesCollapsedComputedSet(t *testing.
 // TestNormalizeGeographicDeleteOrphansStillSweepsGenuineOrphans proves the
 // guard did not disable orphan deletion for the normal case.
 func TestNormalizeGeographicDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
+	t.Parallel()
 	app := newOrphanSweepTestApp(t, "normalized_mappings", "category", "person", "session")
 	col, err := app.FindCollectionByNameOrId("normalized_mappings")
 	if err != nil {

--- a/pocketbase/sync/normalize_geographic_test.go
+++ b/pocketbase/sync/normalize_geographic_test.go
@@ -2431,8 +2431,8 @@ func TestNormalizeGeographicSyncPropagatesSweepRefusal(t *testing.T) {
 	sess := core.NewRecord(sessions)
 	sess.Set("cm_id", 200)
 	sess.Set("name", "Session A")
-	if err := app.Save(sess); err != nil {
-		t.Fatalf("save session: %v", err)
+	if saveErr := app.Save(sess); saveErr != nil {
+		t.Fatalf("save session: %v", saveErr)
 	}
 
 	personsCol, err := app.FindCollectionByNameOrId("persons")
@@ -2447,15 +2447,15 @@ func TestNormalizeGeographicSyncPropagatesSweepRefusal(t *testing.T) {
 		p := core.NewRecord(personsCol)
 		p.Set("cm_id", cmID)
 		p.Set("year", 2026)
-		if err := app.Save(p); err != nil {
-			t.Fatalf("save person %d: %v", cmID, err)
+		if saveErr := app.Save(p); saveErr != nil {
+			t.Fatalf("save person %d: %v", cmID, saveErr)
 		}
 		a := core.NewRecord(attendeesCol)
 		a.Set("person", p.Id)
 		a.Set("session", sess.Id)
 		a.Set("year", 2026)
-		if err := app.Save(a); err != nil {
-			t.Fatalf("save attendee %d: %v", cmID, err)
+		if saveErr := app.Save(a); saveErr != nil {
+			t.Fatalf("save attendee %d: %v", cmID, saveErr)
 		}
 	}
 
@@ -2469,8 +2469,8 @@ func TestNormalizeGeographicSyncPropagatesSweepRefusal(t *testing.T) {
 		rec.Set("session", sess.Id)
 		rec.Set("category", categoryCity)
 		rec.Set("year", 2026)
-		if err := app.Save(rec); err != nil {
-			t.Fatalf("save existing mapping %d: %v", i, err)
+		if saveErr := app.Save(rec); saveErr != nil {
+			t.Fatalf("save existing mapping %d: %v", i, saveErr)
 		}
 	}
 

--- a/pocketbase/sync/normalize_geographic_test.go
+++ b/pocketbase/sync/normalize_geographic_test.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
 )
 
 // ============================================================================
@@ -2166,5 +2168,81 @@ func TestOverrideMapDedup_RejectedCarriesForward(t *testing.T) {
 
 	if !rejectedOverrides[categoryCity]["springfield"] {
 		t.Error("expected springfield to remain rejected")
+	}
+}
+
+// TestNormalizeGeographicDeleteOrphansRefusesCollapsedComputedSet pins the
+// guard kindred#2283 adds. Before this fix deleteOrphans returned a bare int
+// and had no channel to refuse a sweep at all -- an empty ProcessedKeys map
+// against a populated year deleted every normalized mapping and reported
+// success.
+func TestNormalizeGeographicDeleteOrphansRefusesCollapsedComputedSet(t *testing.T) {
+	app := newOrphanSweepTestApp(t, "normalized_mappings", "category", "person", "session")
+	col, err := app.FindCollectionByNameOrId("normalized_mappings")
+	if err != nil {
+		t.Fatalf("find normalized_mappings: %v", err)
+	}
+	rec := core.NewRecord(col)
+	rec.Set("category", categoryCity)
+	rec.Set("person", "pers_001")
+	rec.Set("session", "sess_001")
+	rec.Set("year", 2026)
+	if saveErr := app.Save(rec); saveErr != nil {
+		t.Fatalf("save existing row: %v", saveErr)
+	}
+
+	n := NewNormalizeGeographicSync(app)
+	n.SyncSuccessful = true
+	n.ProcessedKeys = make(map[string]bool) // nothing processed this run
+
+	key := "pers_001:sess_001:" + categoryCity
+	existing := map[string]*core.Record{key: rec}
+	deleted, err := n.deleteOrphans(existing, 2026)
+
+	if err == nil {
+		t.Fatal("expected an error when nothing was processed and rows exist, got nil")
+	}
+	if deleted != 0 {
+		t.Errorf("deleted = %d, want 0 -- nothing may be removed on the refusal path", deleted)
+	}
+
+	remaining, err := app.FindRecordsByFilter("normalized_mappings", "year = 2026", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query: %v", err)
+	}
+	if len(remaining) != 1 {
+		t.Errorf("%d rows survived, want 1 -- the guard must not delete", len(remaining))
+	}
+}
+
+// TestNormalizeGeographicDeleteOrphansStillSweepsGenuineOrphans proves the
+// guard did not disable orphan deletion for the normal case.
+func TestNormalizeGeographicDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
+	app := newOrphanSweepTestApp(t, "normalized_mappings", "category", "person", "session")
+	col, err := app.FindCollectionByNameOrId("normalized_mappings")
+	if err != nil {
+		t.Fatalf("find normalized_mappings: %v", err)
+	}
+	orphan := core.NewRecord(col)
+	orphan.Set("category", categoryCity)
+	orphan.Set("person", "pers_002")
+	orphan.Set("session", "sess_001")
+	orphan.Set("year", 2026)
+	if saveErr := app.Save(orphan); saveErr != nil {
+		t.Fatalf("save orphan: %v", saveErr)
+	}
+
+	n := NewNormalizeGeographicSync(app)
+	n.SyncSuccessful = true
+	n.ProcessedKeys = map[string]bool{"pers_001:sess_001:" + categoryCity: true}
+
+	orphanKey := "pers_002:sess_001:" + categoryCity
+	existing := map[string]*core.Record{orphanKey: orphan}
+	deleted, err := n.deleteOrphans(existing, 2026)
+	if err != nil {
+		t.Fatalf("deleteOrphans: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("deleted = %d, want 1", deleted)
 	}
 }

--- a/pocketbase/sync/orphan_guard.go
+++ b/pocketbase/sync/orphan_guard.go
@@ -1,6 +1,10 @@
 package sync
 
-import "fmt"
+import (
+	"context"
+	"errors"
+	"fmt"
+)
 
 // Orphan-sweep thresholds (kindred#2279).
 //
@@ -96,4 +100,27 @@ func (g OrphanSweepGuard) Check(existing int) error {
 	}
 
 	return fmt.Errorf("%s", msg)
+}
+
+// wrapOrphanSweepError classifies a failed orphan sweep for the caller's return.
+//
+// A guard refusal and a cancelled context are different operational facts and
+// must not share a message: "refused" says the computed set is not to be
+// trusted and points an operator at the CampMinder feed, while "interrupted"
+// says the run simply ran out of time and the data is probably fine. Reporting
+// the second as the first sends them to investigate something that is not
+// broken.
+//
+// kindred#2280 settled this wording on staff_vehicle_info.go and
+// staff_applications.go; it lives here so every guarded sweep in the package
+// reads the same rather than carrying its own copy. Returns nil for nil so it
+// is safe to call unconditionally.
+func wrapOrphanSweepError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("orphan sweep interrupted: %w", err)
+	}
+	return fmt.Errorf("orphan sweep refused: %w", err)
 }

--- a/pocketbase/sync/orphan_guard_test.go
+++ b/pocketbase/sync/orphan_guard_test.go
@@ -425,9 +425,20 @@ func newCustomValuesSyncTestApp(t *testing.T, target string, targetFields ...str
 		t.Fatalf("create persons: %v", err)
 	}
 
+	// camper_transportation reads the session CM ID by EXPANDING this relation,
+	// not from a session_id column, so the relation has to be real.
+	campSessions := core.NewBaseCollection("camp_sessions")
+	campSessions.Fields.Add(&core.NumberField{Name: "cm_id"})
+	campSessions.Fields.Add(&core.TextField{Name: "name"})
+	created(campSessions)
+	if err := app.Save(campSessions); err != nil {
+		t.Fatalf("create camp_sessions: %v", err)
+	}
+
 	attendees := core.NewBaseCollection("attendees")
 	attendees.Fields.Add(&core.NumberField{Name: "person_id"})
 	attendees.Fields.Add(&core.NumberField{Name: "session_id"})
+	attendees.Fields.Add(&core.RelationField{Name: "session", CollectionId: campSessions.Id, MaxSelect: 1})
 	attendees.Fields.Add(&core.NumberField{Name: "year"})
 	created(attendees)
 	if err := app.Save(attendees); err != nil {
@@ -497,6 +508,14 @@ func seedCustomValuesRun(t *testing.T, app core.App, target, fieldName, partitio
 	personsCol, _ := app.FindCollectionByNameOrId("persons")
 	attendeesCol, _ := app.FindCollectionByNameOrId("attendees")
 	valuesCol, _ := app.FindCollectionByNameOrId("person_custom_values")
+	sessionsCol, _ := app.FindCollectionByNameOrId("camp_sessions")
+
+	sess := core.NewRecord(sessionsCol)
+	sess.Set("cm_id", 200)
+	sess.Set("name", "Session A")
+	if saveErr := app.Save(sess); saveErr != nil {
+		t.Fatalf("save camp session: %v", saveErr)
+	}
 	for i := range computed {
 		cmID := 101 + i
 		p := core.NewRecord(personsCol)
@@ -508,6 +527,7 @@ func seedCustomValuesRun(t *testing.T, app core.App, target, fieldName, partitio
 		a := core.NewRecord(attendeesCol)
 		a.Set("person_id", cmID)
 		a.Set("session_id", 200)
+		a.Set("session", sess.Id)
 		a.Set("year", 2026)
 		if saveErr := app.Save(a); saveErr != nil {
 			t.Fatalf("save attendee %d: %v", cmID, saveErr)
@@ -633,6 +653,11 @@ func TestDeleteOrphansReturnsContextErrorOnCancellation(t *testing.T) {
 	cancel()
 
 	s := NewCamperDietarySync(app)
+	// Set explicitly because this drives deleteOrphans directly rather than
+	// through Sync(), which is what normally sets it from the size of the
+	// extraction (kindred#2283 rows 3+4). The three ProcessedKeys-based syncs
+	// have always required this of their tests; these four now match.
+	s.SyncSuccessful = true
 	deleted, err := s.deleteOrphans(ctx, computed, existing, 2026)
 
 	if !errors.Is(err, context.Canceled) {
@@ -645,4 +670,138 @@ func TestDeleteOrphansReturnsContextErrorOnCancellation(t *testing.T) {
 	if got := wrapOrphanSweepError(err).Error(); !strings.HasPrefix(got, "orphan sweep interrupted: ") {
 		t.Errorf("a cancelled sweep is reported as %q, want it classified as interrupted", got)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// kindred#2283 rows 3+4 -- a genuinely empty upstream must not wedge the sweep
+// ---------------------------------------------------------------------------
+
+// assertEmptyUpstreamSkipsSweep pins the policy BaseSyncService.DeleteOrphans
+// already implements (base_sync.go: "Only delete orphans if the sync was
+// successful", with SyncSuccessful gated on rows actually arriving): a source
+// that legitimately returns nothing is not a collapse, so the sweep is SKIPPED
+// and the run succeeds, leaving what is on disk alone.
+//
+// Before this, these four refused instead -- and because a refused sweep never
+// clears the rows, `existing` stayed high and the refusal repeated on every
+// subsequent run. The table could not drain and the sync could not go green.
+//
+// Asserted against the database, not the return value: "reported success" and
+// "deleted nothing" are separate claims and the interesting failure satisfies
+// only the first.
+func assertEmptyUpstreamSkipsSweep(t *testing.T, app core.App, target string, wantRows int, syncErr error) {
+	t.Helper()
+
+	if syncErr != nil {
+		t.Fatalf("Sync on an empty upstream returned %v, want nil -- an empty source is not a collapse", syncErr)
+	}
+	remaining, err := app.FindRecordsByFilter(target, "year = 2026", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query %s: %v", target, err)
+	}
+	if len(remaining) != wantRows {
+		t.Errorf("%d rows survived, want %d -- an empty upstream must skip the sweep, not run it",
+			len(remaining), wantRows)
+	}
+}
+
+func TestCamperDietaryEmptyUpstreamSkipsSweep(t *testing.T) {
+	t.Parallel()
+	app := newCustomValuesSyncTestApp(t, "camper_dietary", "allergy_info")
+	seedCustomValuesRun(t, app, "camper_dietary", "Family Medical-Allergy Info", "", 0, OrphanSweepMinRows+5)
+
+	s := NewCamperDietarySync(app)
+	s.Year = 2026
+	assertEmptyUpstreamSkipsSweep(t, app, "camper_dietary", OrphanSweepMinRows+5, s.Sync(context.Background()))
+}
+
+func TestCamperTransportationEmptyUpstreamSkipsSweep(t *testing.T) {
+	t.Parallel()
+	app := newCustomValuesSyncTestApp(t, "camper_transportation", "to_camp_method")
+	seedCustomValuesRun(t, app, "camper_transportation", "BUS-To Camp", "", 0, OrphanSweepMinRows+5)
+
+	s := NewCamperTransportationSync(app)
+	s.Year = 2026
+	assertEmptyUpstreamSkipsSweep(t, app, "camper_transportation", OrphanSweepMinRows+5, s.Sync(context.Background()))
+}
+
+func TestQuestRegistrationsEmptyUpstreamSkipsSweep(t *testing.T) {
+	t.Parallel()
+	app := newCustomValuesSyncTestApp(t, "quest_registrations", "quest_status")
+	seedCustomValuesRun(t, app, "quest_registrations", "Quest-Status", "", 0, OrphanSweepMinRows+5)
+
+	s := NewQuestRegistrationsSync(app)
+	s.Year = 2026
+	assertEmptyUpstreamSkipsSweep(t, app, "quest_registrations", OrphanSweepMinRows+5, s.Sync(context.Background()))
+}
+
+// --- negative controls: the gate must not disable orphan deletion ------------
+
+// assertNonEmptyUpstreamStillSweeps is the other half. A gate that skips the
+// sweep whenever it is unsure would pass every test above and quietly stop
+// deleting anything, which is the failure the guard exists to avoid in reverse.
+func assertNonEmptyUpstreamStillSweeps(t *testing.T, app core.App, target string, syncErr error) {
+	t.Helper()
+
+	if syncErr != nil {
+		t.Fatalf("Sync on a healthy run returned %v, want nil", syncErr)
+	}
+	orphans, err := app.FindRecordsByFilter(target, "year = 2026 && person_id = 999", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query %s: %v", target, err)
+	}
+	if len(orphans) != 0 {
+		t.Errorf("the genuine orphan survived -- a non-empty upstream must still sweep")
+	}
+}
+
+// seedOrphanOnly writes a single row this run will not account for, small enough
+// that the ratio arm does not apply and only the sweep itself is under test.
+func seedOrphanOnly(t *testing.T, app core.App, target string) {
+	t.Helper()
+	col, err := app.FindCollectionByNameOrId(target)
+	if err != nil {
+		t.Fatalf("find %s: %v", target, err)
+	}
+	rec := core.NewRecord(col)
+	rec.Set("person_id", 999)
+	rec.Set("session_id", 200)
+	rec.Set("skill_cm_id", 999)
+	rec.Set("year", 2026)
+	if saveErr := app.Save(rec); saveErr != nil {
+		t.Fatalf("save orphan: %v", saveErr)
+	}
+}
+
+func TestCamperDietaryNonEmptyUpstreamStillSweeps(t *testing.T) {
+	t.Parallel()
+	app := newCustomValuesSyncTestApp(t, "camper_dietary", "allergy_info")
+	seedCustomValuesRun(t, app, "camper_dietary", "Family Medical-Allergy Info", "", 3, 0)
+	seedOrphanOnly(t, app, "camper_dietary")
+
+	s := NewCamperDietarySync(app)
+	s.Year = 2026
+	assertNonEmptyUpstreamStillSweeps(t, app, "camper_dietary", s.Sync(context.Background()))
+}
+
+func TestCamperTransportationNonEmptyUpstreamStillSweeps(t *testing.T) {
+	t.Parallel()
+	app := newCustomValuesSyncTestApp(t, "camper_transportation", "to_camp_method")
+	seedCustomValuesRun(t, app, "camper_transportation", "BUS-To Camp", "", 3, 0)
+	seedOrphanOnly(t, app, "camper_transportation")
+
+	s := NewCamperTransportationSync(app)
+	s.Year = 2026
+	assertNonEmptyUpstreamStillSweeps(t, app, "camper_transportation", s.Sync(context.Background()))
+}
+
+func TestQuestRegistrationsNonEmptyUpstreamStillSweeps(t *testing.T) {
+	t.Parallel()
+	app := newCustomValuesSyncTestApp(t, "quest_registrations", "quest_status")
+	seedCustomValuesRun(t, app, "quest_registrations", "Quest-Status", "", 3, 0)
+	seedOrphanOnly(t, app, "quest_registrations")
+
+	s := NewQuestRegistrationsSync(app)
+	s.Year = 2026
+	assertNonEmptyUpstreamStillSweeps(t, app, "quest_registrations", s.Sync(context.Background()))
 }

--- a/pocketbase/sync/orphan_guard_test.go
+++ b/pocketbase/sync/orphan_guard_test.go
@@ -1,11 +1,14 @@
 package sync
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
 )
 
 // ---------------------------------------------------------------------------
@@ -324,5 +327,322 @@ func TestHouseholdCustomFieldValuesDeleteOrphansIgnoresHouseholdsThisRunDidNotFe
 	if swept != household1Rows-1 {
 		t.Fatalf("%d of household 1's rows survived, want %d -- the genuine orphan must still go",
 			swept, household1Rows-1)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// kindred#2283 row 2 -- classifying a sweep failure
+// ---------------------------------------------------------------------------
+
+// TestWrapOrphanSweepError pins the distinction kindred#2280 settled on
+// staff_vehicle_info.go and staff_applications.go: a guard refusal and a
+// cancelled context are different operational facts and must not share a
+// message. "Refused" tells an operator the CampMinder feed is not to be
+// trusted; "interrupted" tells them the run ran out of time. Reporting the
+// second as the first sends them to look at data that is fine.
+//
+// The wording here is copied from those two files deliberately -- the value is
+// that every guarded sweep in the package reads the same, so this helper is the
+// one place the phrasing lives rather than a seventh hand-written copy.
+func TestWrapOrphanSweepError(t *testing.T) {
+	t.Parallel()
+
+	guardErr := OrphanSweepGuard{Entity: "widgets", Year: 2026, Computed: 0}.Check(50)
+	if guardErr == nil {
+		t.Fatal("fixture is wrong: an empty computed set against 50 rows must refuse")
+	}
+
+	tests := []struct {
+		name       string
+		in         error
+		wantPrefix string
+	}{
+		{"a guard refusal is a refusal", guardErr, "orphan sweep refused: "},
+		{"a cancelled context is an interruption", context.Canceled, "orphan sweep interrupted: "},
+		{"an expired deadline is an interruption", context.DeadlineExceeded, "orphan sweep interrupted: "},
+		{
+			"a wrapped cancellation is still an interruption",
+			fmt.Errorf("deleting row 12: %w", context.Canceled),
+			"orphan sweep interrupted: ",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := wrapOrphanSweepError(tc.in)
+			if got == nil {
+				t.Fatalf("wrapOrphanSweepError(%v) = nil, want an error", tc.in)
+			}
+			if !strings.HasPrefix(got.Error(), tc.wantPrefix) {
+				t.Errorf("wrapOrphanSweepError(%v) = %q, want prefix %q", tc.in, got.Error(), tc.wantPrefix)
+			}
+			// The cause must survive wrapping, or callers upstream lose the
+			// ability to tell cancellation from refusal themselves.
+			if !errors.Is(got, tc.in) {
+				t.Errorf("wrapOrphanSweepError(%v) does not unwrap to its cause", tc.in)
+			}
+		})
+	}
+
+	t.Run("nil in, nil out", func(t *testing.T) {
+		t.Parallel()
+		if got := wrapOrphanSweepError(nil); got != nil {
+			t.Errorf("wrapOrphanSweepError(nil) = %v, want nil", got)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// kindred#2283 row 1 -- caller propagation for the person_custom_values syncs
+// ---------------------------------------------------------------------------
+
+// newCustomValuesSyncTestApp builds the collections the four
+// person_custom_values-driven syncs read on their way to the orphan sweep.
+// Shared because those four load the same shape: a field definition, the values
+// pointing at it, the persons those values belong to, and an attendee row per
+// person to hang the relation on.
+func newCustomValuesSyncTestApp(t *testing.T, target string, targetFields ...string) core.App {
+	t.Helper()
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	created := func(col *core.Collection) {
+		col.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
+	}
+
+	persons := core.NewBaseCollection("persons")
+	persons.Fields.Add(&core.NumberField{Name: "cm_id"})
+	persons.Fields.Add(&core.NumberField{Name: "year"})
+	for _, f := range []string{"first_name", "last_name"} {
+		persons.Fields.Add(&core.TextField{Name: f})
+	}
+	created(persons)
+	if err := app.Save(persons); err != nil {
+		t.Fatalf("create persons: %v", err)
+	}
+
+	attendees := core.NewBaseCollection("attendees")
+	attendees.Fields.Add(&core.NumberField{Name: "person_id"})
+	attendees.Fields.Add(&core.NumberField{Name: "session_id"})
+	attendees.Fields.Add(&core.NumberField{Name: "year"})
+	created(attendees)
+	if err := app.Save(attendees); err != nil {
+		t.Fatalf("create attendees: %v", err)
+	}
+
+	defs := core.NewBaseCollection("custom_field_defs")
+	defs.Fields.Add(&core.TextField{Name: "name"})
+	defs.Fields.Add(&core.TextField{Name: "partition"})
+	// staff_skills skips any definition whose cm_id is 0, so the fixture needs
+	// a real one or its Sync() bails before it ever reaches the sweep.
+	defs.Fields.Add(&core.NumberField{Name: "cm_id"})
+	defs.Fields.Add(&core.NumberField{Name: "year"})
+	created(defs)
+	if err := app.Save(defs); err != nil {
+		t.Fatalf("create custom_field_defs: %v", err)
+	}
+
+	values := core.NewBaseCollection("person_custom_values")
+	values.Fields.Add(&core.TextField{Name: "person"})
+	values.Fields.Add(&core.TextField{Name: "field_definition"})
+	values.Fields.Add(&core.TextField{Name: "value"})
+	values.Fields.Add(&core.NumberField{Name: "year"})
+	created(values)
+	if err := app.Save(values); err != nil {
+		t.Fatalf("create person_custom_values: %v", err)
+	}
+
+	col := core.NewBaseCollection(target)
+	col.Fields.Add(&core.NumberField{Name: "person_id"})
+	col.Fields.Add(&core.NumberField{Name: "session_id"})
+	col.Fields.Add(&core.NumberField{Name: "skill_cm_id"})
+	// Required, per the year invariant every CampMinder-derived table carries.
+	col.Fields.Add(&core.NumberField{Name: "year", Required: true})
+	for _, f := range targetFields {
+		col.Fields.Add(&core.TextField{Name: f})
+	}
+	col.Fields.Add(&core.TextField{Name: "person"})
+	col.Fields.Add(&core.TextField{Name: "attendee"})
+	created(col)
+	if err := app.Save(col); err != nil {
+		t.Fatalf("create %s: %v", target, err)
+	}
+
+	return app
+}
+
+// seedCustomValuesRun writes `computed` campers who each answered `fieldName`
+// this year, plus `existing` rows already stored in `target` that this run does
+// not account for. The ratio is what trips OrphanSweepGuard.
+func seedCustomValuesRun(t *testing.T, app core.App, target, fieldName, partition string, computed, existing int) {
+	t.Helper()
+
+	defs, err := app.FindCollectionByNameOrId("custom_field_defs")
+	if err != nil {
+		t.Fatalf("find custom_field_defs: %v", err)
+	}
+	def := core.NewRecord(defs)
+	def.Set("name", fieldName)
+	def.Set("partition", partition)
+	def.Set("cm_id", 77)
+	def.Set("year", 2026)
+	if err := app.Save(def); err != nil {
+		t.Fatalf("save field def: %v", err)
+	}
+
+	personsCol, _ := app.FindCollectionByNameOrId("persons")
+	attendeesCol, _ := app.FindCollectionByNameOrId("attendees")
+	valuesCol, _ := app.FindCollectionByNameOrId("person_custom_values")
+	for i := range computed {
+		cmID := 101 + i
+		p := core.NewRecord(personsCol)
+		p.Set("cm_id", cmID)
+		p.Set("year", 2026)
+		if err := app.Save(p); err != nil {
+			t.Fatalf("save person %d: %v", cmID, err)
+		}
+		a := core.NewRecord(attendeesCol)
+		a.Set("person_id", cmID)
+		a.Set("session_id", 200)
+		a.Set("year", 2026)
+		if err := app.Save(a); err != nil {
+			t.Fatalf("save attendee %d: %v", cmID, err)
+		}
+		v := core.NewRecord(valuesCol)
+		v.Set("person", p.Id)
+		v.Set("field_definition", def.Id)
+		v.Set("value", "Yes")
+		v.Set("year", 2026)
+		if err := app.Save(v); err != nil {
+			t.Fatalf("save custom value %d: %v", cmID, err)
+		}
+	}
+
+	targetCol, err := app.FindCollectionByNameOrId(target)
+	if err != nil {
+		t.Fatalf("find %s: %v", target, err)
+	}
+	for i := range existing {
+		rec := core.NewRecord(targetCol)
+		rec.Set("person_id", 900+i)
+		rec.Set("session_id", 200)
+		rec.Set("skill_cm_id", 300+i)
+		rec.Set("year", 2026)
+		if err := app.Save(rec); err != nil {
+			t.Fatalf("save existing row %d: %v", i, err)
+		}
+	}
+}
+
+// assertSweepRefusalReachesCaller runs syncFn and requires the sweep refusal to
+// come back out of it, with nothing deleted. This is the kindred#2294 gap: the
+// guard tests prove deleteOrphans REFUSES, and prove nothing about whether the
+// caller listens.
+func assertSweepRefusalReachesCaller(t *testing.T, app core.App, target string, wantRows int, syncErr error) {
+	t.Helper()
+
+	if syncErr == nil {
+		t.Fatal("Sync returned nil on a refused sweep -- the refusal never reached the caller")
+	}
+	if !strings.Contains(syncErr.Error(), "orphan sweep refused") {
+		t.Errorf("Sync error = %q, want it to carry the sweep refusal", syncErr.Error())
+	}
+	remaining, err := app.FindRecordsByFilter(target, "year = 2026 && person_id >= 900", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query %s: %v", target, err)
+	}
+	if len(remaining) != wantRows {
+		t.Errorf("%d seeded rows survived, want %d -- a refused sweep must delete nothing",
+			len(remaining), wantRows)
+	}
+}
+
+func TestCamperDietarySyncPropagatesSweepRefusal(t *testing.T) {
+	t.Parallel()
+	app := newCustomValuesSyncTestApp(t, "camper_dietary", "allergy_info")
+	seedCustomValuesRun(t, app, "camper_dietary", "Family Medical-Allergy Info", "", 3, OrphanSweepMinRows+5)
+
+	s := NewCamperDietarySync(app)
+	s.Year = 2026
+	assertSweepRefusalReachesCaller(t, app, "camper_dietary", OrphanSweepMinRows+5, s.Sync(context.Background()))
+}
+
+func TestCamperTransportationSyncPropagatesSweepRefusal(t *testing.T) {
+	t.Parallel()
+	app := newCustomValuesSyncTestApp(t, "camper_transportation", "to_camp_method")
+	seedCustomValuesRun(t, app, "camper_transportation", "BUS-To Camp", "", 3, OrphanSweepMinRows+5)
+
+	s := NewCamperTransportationSync(app)
+	s.Year = 2026
+	assertSweepRefusalReachesCaller(t, app, "camper_transportation", OrphanSweepMinRows+5, s.Sync(context.Background()))
+}
+
+func TestQuestRegistrationsSyncPropagatesSweepRefusal(t *testing.T) {
+	t.Parallel()
+	app := newCustomValuesSyncTestApp(t, "quest_registrations", "quest_status")
+	seedCustomValuesRun(t, app, "quest_registrations", "Quest-Status", "", 3, OrphanSweepMinRows+5)
+
+	s := NewQuestRegistrationsSync(app)
+	s.Year = 2026
+	assertSweepRefusalReachesCaller(t, app, "quest_registrations", OrphanSweepMinRows+5, s.Sync(context.Background()))
+}
+
+func TestStaffSkillsSyncPropagatesSweepRefusal(t *testing.T) {
+	t.Parallel()
+	app := newCustomValuesSyncTestApp(t, "staff_skills", "skill_name", "raw_value")
+	seedCustomValuesRun(t, app, "staff_skills", "Skills-Archery", partitionStaff, 3, OrphanSweepMinRows+5)
+
+	s := NewStaffSkillsSync(app)
+	s.Year = 2026
+	assertSweepRefusalReachesCaller(t, app, "staff_skills", OrphanSweepMinRows+5, s.Sync(context.Background()))
+}
+
+// TestDeleteOrphansReturnsContextErrorOnCancellation closes the loop on the
+// classification above. wrapOrphanSweepError only reports "interrupted" if what
+// reaches it is genuinely a context error, so this pins the other half: a
+// cancelled sweep returns ctx.Err() rather than a nil error and a short count.
+// Together the two mean a cancelled run cannot be reported as a data refusal.
+func TestDeleteOrphansReturnsContextErrorOnCancellation(t *testing.T) {
+	t.Parallel()
+	app := newCustomValuesSyncTestApp(t, "camper_dietary", "allergy_info")
+	col, err := app.FindCollectionByNameOrId("camper_dietary")
+	if err != nil {
+		t.Fatalf("find camper_dietary: %v", err)
+	}
+
+	// Enough rows on disk, and a computed set large enough to clear the guard,
+	// so the only thing that can stop the sweep is the cancellation.
+	existing := make(map[string]string, OrphanSweepMinRows+5)
+	computed := make(map[string]*camperDietaryRecord, OrphanSweepMinRows+5)
+	for i := range OrphanSweepMinRows + 5 {
+		rec := core.NewRecord(col)
+		rec.Set("person_id", 900+i)
+		rec.Set("year", 2026)
+		if saveErr := app.Save(rec); saveErr != nil {
+			t.Fatalf("save row %d: %v", i, saveErr)
+		}
+		existing[makeCamperDietaryKey(900+i, 2026)] = rec.Id
+		computed[makeCamperDietaryKey(900+i, 2026)] = &camperDietaryRecord{personID: 900 + i}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	s := NewCamperDietarySync(app)
+	deleted, err := s.deleteOrphans(ctx, computed, existing, 2026)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("deleteOrphans on a cancelled context returned %v, want context.Canceled", err)
+	}
+	if deleted != 0 {
+		t.Errorf("deleted = %d, want 0 -- a cancelled sweep should stop before deleting", deleted)
+	}
+	// And the caller's wrapping must call that an interruption, not a refusal.
+	if got := wrapOrphanSweepError(err).Error(); !strings.HasPrefix(got, "orphan sweep interrupted: ") {
+		t.Errorf("a cancelled sweep is reported as %q, want it classified as interrupted", got)
 	}
 }

--- a/pocketbase/sync/orphan_guard_test.go
+++ b/pocketbase/sync/orphan_guard_test.go
@@ -490,8 +490,8 @@ func seedCustomValuesRun(t *testing.T, app core.App, target, fieldName, partitio
 	def.Set("partition", partition)
 	def.Set("cm_id", 77)
 	def.Set("year", 2026)
-	if err := app.Save(def); err != nil {
-		t.Fatalf("save field def: %v", err)
+	if saveErr := app.Save(def); saveErr != nil {
+		t.Fatalf("save field def: %v", saveErr)
 	}
 
 	personsCol, _ := app.FindCollectionByNameOrId("persons")
@@ -502,23 +502,23 @@ func seedCustomValuesRun(t *testing.T, app core.App, target, fieldName, partitio
 		p := core.NewRecord(personsCol)
 		p.Set("cm_id", cmID)
 		p.Set("year", 2026)
-		if err := app.Save(p); err != nil {
-			t.Fatalf("save person %d: %v", cmID, err)
+		if saveErr := app.Save(p); saveErr != nil {
+			t.Fatalf("save person %d: %v", cmID, saveErr)
 		}
 		a := core.NewRecord(attendeesCol)
 		a.Set("person_id", cmID)
 		a.Set("session_id", 200)
 		a.Set("year", 2026)
-		if err := app.Save(a); err != nil {
-			t.Fatalf("save attendee %d: %v", cmID, err)
+		if saveErr := app.Save(a); saveErr != nil {
+			t.Fatalf("save attendee %d: %v", cmID, saveErr)
 		}
 		v := core.NewRecord(valuesCol)
 		v.Set("person", p.Id)
 		v.Set("field_definition", def.Id)
 		v.Set("value", "Yes")
 		v.Set("year", 2026)
-		if err := app.Save(v); err != nil {
-			t.Fatalf("save custom value %d: %v", cmID, err)
+		if saveErr := app.Save(v); saveErr != nil {
+			t.Fatalf("save custom value %d: %v", cmID, saveErr)
 		}
 	}
 

--- a/pocketbase/sync/quest_registrations.go
+++ b/pocketbase/sync/quest_registrations.go
@@ -241,7 +241,7 @@ func (s *QuestRegistrationsSync) Sync(ctx context.Context) error {
 	}
 
 	if orphanErr != nil {
-		return fmt.Errorf("orphan sweep refused: %w", orphanErr)
+		return wrapOrphanSweepError(orphanErr)
 	}
 
 	s.SyncSuccessful = true

--- a/pocketbase/sync/quest_registrations.go
+++ b/pocketbase/sync/quest_registrations.go
@@ -42,11 +42,14 @@ const (
 // years. See "Reading Derived Informational Tables (Active-Enrolment Filtering)" in
 // docs/architecture/sync-layer.md.
 type QuestRegistrationsSync struct {
-	App            core.App
-	Year           int
-	DryRun         bool
-	Debug          bool
-	Stats          Stats
+	App    core.App
+	Year   int
+	DryRun bool
+	Debug  bool
+	Stats  Stats
+	// SyncSuccessful reports whether this run's extraction produced any rows.
+	// Set immediately after extraction, NOT at the end of Sync(), because its
+	// one consumer is the orphan sweep, which runs before Sync() returns.
 	SyncSuccessful bool
 }
 
@@ -204,12 +207,23 @@ func (s *QuestRegistrationsSync) Sync(ctx context.Context) error {
 	}
 	slog.Info("Extracted Quest registration records", "count", len(records))
 
+	// The extraction finished without error, so len(records) is now a fact about
+	// the SOURCE rather than about whether this run worked. Gate the sweep on it:
+	// a year in which nobody answered is a legitimately empty upstream, not a
+	// collapse, and refusing there wedged the table -- a refused sweep never
+	// clears the rows, so `existing` stayed high and every later run refused
+	// again. This is the policy BaseSyncService.DeleteOrphans already applies
+	// ("Only delete orphans if the sync was successful", with SyncSuccessful set
+	// mid-fetch and gated on rows arriving); these four declared their own
+	// SyncSuccessful at the END of Sync(), where it was always false during
+	// their own sweep and nothing ever read it (kindred#2283).
+	s.SyncSuccessful = len(records) > 0
+
 	if s.DryRun {
 		slog.Info("Dry run mode - extracted but not writing",
 			"records", len(records),
 		)
 		s.Stats.Created = len(records)
-		s.SyncSuccessful = true
 		return nil
 	}
 
@@ -244,7 +258,6 @@ func (s *QuestRegistrationsSync) Sync(ctx context.Context) error {
 		return wrapOrphanSweepError(orphanErr)
 	}
 
-	s.SyncSuccessful = true
 	slog.Info("Quest registrations extraction completed",
 		"year", year,
 		"created", s.Stats.Created,
@@ -951,6 +964,16 @@ func (s *QuestRegistrationsSync) deleteOrphans(
 	existingRecords map[string]string,
 	year int,
 ) (int, error) {
+	// An empty source is not a collapse. Sync() sets SyncSuccessful from the
+	// size of this run's extraction, so a year nobody answered skips the sweep
+	// and succeeds rather than refusing forever (kindred#2283). The guard below
+	// still owns the case that matters: a source that came back SHORT.
+	if !s.SyncSuccessful {
+		slog.Info("Skipping orphan deletion: the source returned no rows for this year",
+			"entity", "quest_registrations", "year", year)
+		return 0, nil
+	}
+
 	guard := OrphanSweepGuard{
 		Entity:   "quest_registrations",
 		Year:     year,

--- a/pocketbase/sync/quest_registrations.go
+++ b/pocketbase/sync/quest_registrations.go
@@ -227,14 +227,21 @@ func (s *QuestRegistrationsSync) Sync(ctx context.Context) error {
 	s.Stats.Errors = errors
 
 	// Step 6: Delete orphans
-	deleted := s.deleteOrphans(ctx, records, existingRecords)
+	deleted, orphanErr := s.deleteOrphans(ctx, records, existingRecords, year)
 	s.Stats.Deleted = deleted
 
-	// WAL checkpoint
+	// WAL checkpoint BEFORE the error return below -- upsertRecords has already
+	// written by this point, and the refusal path can fire on a non-empty
+	// computed set (a PARTIAL collapse), which is exactly the case where writes
+	// already happened.
 	if s.Stats.Created > 0 || s.Stats.Updated > 0 || s.Stats.Deleted > 0 {
 		if err := s.forceWALCheckpoint(); err != nil {
 			slog.Warn("WAL checkpoint failed", "error", err)
 		}
+	}
+
+	if orphanErr != nil {
+		return fmt.Errorf("orphan sweep refused: %w", orphanErr)
 	}
 
 	s.SyncSuccessful = true
@@ -932,18 +939,34 @@ func (s *QuestRegistrationsSync) upsertRecords(
 	return created, updated, errors
 }
 
-// deleteOrphans removes records that exist in DB but not in computed set
+// deleteOrphans removes records that exist in DB but not in computed set.
+//
+// Refuses when the computed set is too small to be believed against the rows
+// on disk: that combination is always a broken input, and sweeping on it
+// deletes the year and reports success (kindred#2257, kindred#2283). The rule
+// lives in OrphanSweepGuard so there is one implementation, not an eighth copy.
 func (s *QuestRegistrationsSync) deleteOrphans(
 	ctx context.Context,
 	records map[string]*questRegistrationRecord,
 	existingRecords map[string]string,
-) int {
+	year int,
+) (int, error) {
+	guard := OrphanSweepGuard{
+		Entity:   "quest_registrations",
+		Year:     year,
+		Computed: len(records),
+		Hint:     "check that the attendee mapping and the Quest-/Q-* field definitions still exist upstream",
+	}
+	if err := guard.Check(len(existingRecords)); err != nil {
+		return 0, err
+	}
+
 	deleted := 0
 
 	for key, recordID := range existingRecords {
 		select {
 		case <-ctx.Done():
-			return deleted
+			return deleted, ctx.Err()
 		default:
 		}
 
@@ -962,7 +985,7 @@ func (s *QuestRegistrationsSync) deleteOrphans(
 		}
 	}
 
-	return deleted
+	return deleted, nil
 }
 
 // forceWALCheckpoint forces a SQLite WAL checkpoint

--- a/pocketbase/sync/quest_registrations_test.go
+++ b/pocketbase/sync/quest_registrations_test.go
@@ -472,6 +472,12 @@ func findQuestRecord(records []*testQuestRecord, personID, year int) *testQuestR
 // guard kindred#2283 adds. Before this fix deleteOrphans returned a bare int
 // and had no channel to refuse a sweep at all -- an empty computed set against
 // a populated year deleted the whole year and reported success.
+//
+// NOTE since kindred#2283 rows 3+4: this pins the guard's CONTRACT, not a state
+// Sync() can now produce. Sync() sets SyncSuccessful from len(records), so an
+// empty computed set skips the sweep before the guard is consulted. The arm
+// that stays live on this path is the ratio one -- a source that came back
+// short rather than empty.
 func TestQuestRegistrationsDeleteOrphansRefusesCollapsedComputedSet(t *testing.T) {
 	t.Parallel()
 	app := newOrphanSweepTestApp(t, "quest_registrations", "person_id")
@@ -487,6 +493,11 @@ func TestQuestRegistrationsDeleteOrphansRefusesCollapsedComputedSet(t *testing.T
 	}
 
 	s := NewQuestRegistrationsSync(app)
+	// Set explicitly because this drives deleteOrphans directly rather than
+	// through Sync(), which is what normally sets it from the size of the
+	// extraction (kindred#2283 rows 3+4). The three ProcessedKeys-based syncs
+	// have always required this of their tests; these four now match.
+	s.SyncSuccessful = true
 	existing := map[string]string{makeQuestRegistrationKey(9001, 2026): rec.Id}
 
 	deleted, err := s.deleteOrphans(context.Background(),
@@ -525,6 +536,11 @@ func TestQuestRegistrationsDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) 
 	}
 
 	s := NewQuestRegistrationsSync(app)
+	// Set explicitly because this drives deleteOrphans directly rather than
+	// through Sync(), which is what normally sets it from the size of the
+	// extraction (kindred#2283 rows 3+4). The three ProcessedKeys-based syncs
+	// have always required this of their tests; these four now match.
+	s.SyncSuccessful = true
 	records := map[string]*questRegistrationRecord{
 		makeQuestRegistrationKey(9001, 2026): {personID: 9001, year: 2026},
 	}

--- a/pocketbase/sync/quest_registrations_test.go
+++ b/pocketbase/sync/quest_registrations_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
 )
 
 // TestQuestRegistrationsLoadFieldDefinitionsTrimsNames is a regression test
@@ -454,4 +456,73 @@ func findQuestRecord(records []*testQuestRecord, personID, year int) *testQuestR
 		}
 	}
 	return nil
+}
+
+// TestQuestRegistrationsDeleteOrphansRefusesCollapsedComputedSet pins the
+// guard kindred#2283 adds. Before this fix deleteOrphans returned a bare int
+// and had no channel to refuse a sweep at all -- an empty computed set against
+// a populated year deleted the whole year and reported success.
+func TestQuestRegistrationsDeleteOrphansRefusesCollapsedComputedSet(t *testing.T) {
+	app := newOrphanSweepTestApp(t, "quest_registrations", "person_id")
+	col, err := app.FindCollectionByNameOrId("quest_registrations")
+	if err != nil {
+		t.Fatalf("find quest_registrations: %v", err)
+	}
+	rec := core.NewRecord(col)
+	rec.Set("person_id", 9001)
+	rec.Set("year", 2026)
+	if saveErr := app.Save(rec); saveErr != nil {
+		t.Fatalf("save existing row: %v", saveErr)
+	}
+
+	s := NewQuestRegistrationsSync(app)
+	existing := map[string]string{makeQuestRegistrationKey(9001, 2026): rec.Id}
+
+	deleted, err := s.deleteOrphans(context.Background(),
+		map[string]*questRegistrationRecord{}, existing, 2026)
+
+	if err == nil {
+		t.Fatal("expected an error when the computed set is empty and rows exist, got nil")
+	}
+	if deleted != 0 {
+		t.Errorf("deleted = %d, want 0 -- nothing may be removed on the refusal path", deleted)
+	}
+
+	remaining, err := app.FindRecordsByFilter("quest_registrations", "year = 2026", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query: %v", err)
+	}
+	if len(remaining) != 1 {
+		t.Errorf("%d rows survived, want 1 -- the guard must not delete", len(remaining))
+	}
+}
+
+// TestQuestRegistrationsDeleteOrphansStillSweepsGenuineOrphans proves the
+// guard did not disable orphan deletion for the normal case.
+func TestQuestRegistrationsDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
+	app := newOrphanSweepTestApp(t, "quest_registrations", "person_id")
+	col, err := app.FindCollectionByNameOrId("quest_registrations")
+	if err != nil {
+		t.Fatalf("find quest_registrations: %v", err)
+	}
+	orphan := core.NewRecord(col)
+	orphan.Set("person_id", 9002)
+	orphan.Set("year", 2026)
+	if saveErr := app.Save(orphan); saveErr != nil {
+		t.Fatalf("save orphan: %v", saveErr)
+	}
+
+	s := NewQuestRegistrationsSync(app)
+	records := map[string]*questRegistrationRecord{
+		makeQuestRegistrationKey(9001, 2026): {personID: 9001, year: 2026},
+	}
+	existing := map[string]string{makeQuestRegistrationKey(9002, 2026): orphan.Id}
+
+	deleted, err := s.deleteOrphans(context.Background(), records, existing, 2026)
+	if err != nil {
+		t.Fatalf("deleteOrphans: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("deleted = %d, want 1", deleted)
+	}
 }

--- a/pocketbase/sync/quest_registrations_test.go
+++ b/pocketbase/sync/quest_registrations_test.go
@@ -473,6 +473,7 @@ func findQuestRecord(records []*testQuestRecord, personID, year int) *testQuestR
 // and had no channel to refuse a sweep at all -- an empty computed set against
 // a populated year deleted the whole year and reported success.
 func TestQuestRegistrationsDeleteOrphansRefusesCollapsedComputedSet(t *testing.T) {
+	t.Parallel()
 	app := newOrphanSweepTestApp(t, "quest_registrations", "person_id")
 	col, err := app.FindCollectionByNameOrId("quest_registrations")
 	if err != nil {
@@ -510,6 +511,7 @@ func TestQuestRegistrationsDeleteOrphansRefusesCollapsedComputedSet(t *testing.T
 // TestQuestRegistrationsDeleteOrphansStillSweepsGenuineOrphans proves the
 // guard did not disable orphan deletion for the normal case.
 func TestQuestRegistrationsDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
+	t.Parallel()
 	app := newOrphanSweepTestApp(t, "quest_registrations", "person_id")
 	col, err := app.FindCollectionByNameOrId("quest_registrations")
 	if err != nil {

--- a/pocketbase/sync/staff_skills.go
+++ b/pocketbase/sync/staff_skills.go
@@ -150,6 +150,14 @@ func (s *StaffSkillsSync) Sync(ctx context.Context) error {
 		return fmt.Errorf("loading skill values: %w", err)
 	}
 
+	// An empty source is not a collapse, so this returns BEFORE loading existing
+	// rows and before the sweep: nothing is deleted and the run succeeds. That is
+	// the same policy the four records-map syncs got in kindred#2283 rows 3+4 and
+	// the one BaseSyncService.DeleteOrphans applies -- expressed here as an early
+	// return rather than a SyncSuccessful gate, because this file has nothing
+	// left to do once there are no values. Leaving the sweep to refuse instead
+	// would wedge the table: a refused sweep never clears the rows it refused
+	// over, so the condition would not resolve on its own.
 	if len(skillValues) == 0 {
 		slog.Info("No skill values found for year", "year", year)
 		s.SyncSuccessful = true

--- a/pocketbase/sync/staff_skills.go
+++ b/pocketbase/sync/staff_skills.go
@@ -272,13 +272,21 @@ func (s *StaffSkillsSync) Sync(ctx context.Context) error {
 	s.SyncSuccessful = true
 
 	// Delete orphans
-	s.deleteOrphans(existingRecords)
+	deleted, orphanErr := s.deleteOrphans(existingRecords, year)
+	s.Stats.Deleted = deleted
 
-	// WAL checkpoint
+	// WAL checkpoint BEFORE the error return below -- upsertRecords has already
+	// written by this point, and the refusal path can fire on a non-empty
+	// computed set (a PARTIAL collapse), which is exactly the case where writes
+	// already happened.
 	if s.Stats.Created > 0 || s.Stats.Updated > 0 || s.Stats.Deleted > 0 {
 		if err := s.forceWALCheckpoint(); err != nil {
 			slog.Warn("WAL checkpoint failed", "error", err)
 		}
+	}
+
+	if orphanErr != nil {
+		return fmt.Errorf("orphan sweep refused: %w", orphanErr)
 	}
 
 	slog.Info("Staff skills extraction completed",
@@ -637,10 +645,20 @@ func (s *StaffSkillsSync) recordNeedsUpdate(
 }
 
 // deleteOrphans removes records that weren't processed
-func (s *StaffSkillsSync) deleteOrphans(existingRecords map[string]*core.Record) int {
+func (s *StaffSkillsSync) deleteOrphans(existingRecords map[string]*core.Record, year int) (int, error) {
 	if !s.SyncSuccessful {
 		slog.Info("Skipping orphan deletion due to sync failure")
-		return 0
+		return 0, nil
+	}
+
+	guard := OrphanSweepGuard{
+		Entity:   "staff_skills",
+		Year:     year,
+		Computed: len(s.ProcessedKeys),
+		Hint:     "check that the CampMinder Skills- field feed returned this season",
+	}
+	if err := guard.Check(len(existingRecords)); err != nil {
+		return 0, err
 	}
 
 	orphanCount := 0
@@ -664,11 +682,10 @@ func (s *StaffSkillsSync) deleteOrphans(existingRecords map[string]*core.Record)
 	}
 
 	if orphanCount > 0 {
-		s.Stats.Deleted = orphanCount
 		slog.Info("Deleted orphaned staff_skills records", "count", orphanCount)
 	}
 
-	return orphanCount
+	return orphanCount, nil
 }
 
 // forceWALCheckpoint forces a SQLite WAL checkpoint

--- a/pocketbase/sync/staff_skills.go
+++ b/pocketbase/sync/staff_skills.go
@@ -275,8 +275,8 @@ func (s *StaffSkillsSync) Sync(ctx context.Context) error {
 	deleted, orphanErr := s.deleteOrphans(existingRecords, year)
 	s.Stats.Deleted = deleted
 
-	// WAL checkpoint BEFORE the error return below -- upsertRecords has already
-	// written by this point, and the refusal path can fire on a non-empty
+	// WAL checkpoint BEFORE the error return below -- the upsert loop above has
+	// already written by this point, and the refusal path can fire on a non-empty
 	// computed set (a PARTIAL collapse), which is exactly the case where writes
 	// already happened.
 	if s.Stats.Created > 0 || s.Stats.Updated > 0 || s.Stats.Deleted > 0 {
@@ -286,7 +286,7 @@ func (s *StaffSkillsSync) Sync(ctx context.Context) error {
 	}
 
 	if orphanErr != nil {
-		return fmt.Errorf("orphan sweep refused: %w", orphanErr)
+		return wrapOrphanSweepError(orphanErr)
 	}
 
 	slog.Info("Staff skills extraction completed",
@@ -644,7 +644,12 @@ func (s *StaffSkillsSync) recordNeedsUpdate(
 	return compareRecordNeedsUpdate(existing, newData, compareFields)
 }
 
-// deleteOrphans removes records that weren't processed
+// deleteOrphans removes records that weren't processed.
+//
+// Refuses when the computed set is too small to be believed against the rows
+// on disk: that combination is always a broken input, and sweeping on it
+// deletes the year and reports success (kindred#2257, kindred#2283). The rule
+// lives in OrphanSweepGuard so there is one implementation, not an eighth copy.
 func (s *StaffSkillsSync) deleteOrphans(existingRecords map[string]*core.Record, year int) (int, error) {
 	if !s.SyncSuccessful {
 		slog.Info("Skipping orphan deletion due to sync failure")

--- a/pocketbase/sync/staff_skills_test.go
+++ b/pocketbase/sync/staff_skills_test.go
@@ -1021,7 +1021,10 @@ func newStaffSkillsOrphanTestApp(t *testing.T) core.App {
 	col := core.NewBaseCollection("staff_skills")
 	col.Fields.Add(&core.NumberField{Name: "person_id"})
 	col.Fields.Add(&core.NumberField{Name: "skill_cm_id"})
-	col.Fields.Add(&core.NumberField{Name: "year"})
+	// Required, because every CampMinder-derived table carries a required year
+	// (CLAUDE.md) -- a fixture that accepts a yearless row lets a test pass
+	// against data production would reject.
+	col.Fields.Add(&core.NumberField{Name: "year", Required: true})
 	if err := app.Save(col); err != nil {
 		t.Fatalf("save staff_skills: %v", err)
 	}

--- a/pocketbase/sync/staff_skills_test.go
+++ b/pocketbase/sync/staff_skills_test.go
@@ -1033,6 +1033,7 @@ func newStaffSkillsOrphanTestApp(t *testing.T) core.App {
 // no channel to refuse a sweep at all -- an empty ProcessedKeys map against a
 // populated year deleted the whole year and reported success.
 func TestStaffSkillsDeleteOrphansRefusesCollapsedComputedSet(t *testing.T) {
+	t.Parallel()
 	app := newStaffSkillsOrphanTestApp(t)
 	col, err := app.FindCollectionByNameOrId("staff_skills")
 	if err != nil {
@@ -1072,6 +1073,7 @@ func TestStaffSkillsDeleteOrphansRefusesCollapsedComputedSet(t *testing.T) {
 // TestStaffSkillsDeleteOrphansStillSweepsGenuineOrphans proves the guard did
 // not disable orphan deletion for the normal case.
 func TestStaffSkillsDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
+	t.Parallel()
 	app := newStaffSkillsOrphanTestApp(t)
 	col, err := app.FindCollectionByNameOrId("staff_skills")
 	if err != nil {

--- a/pocketbase/sync/staff_skills_test.go
+++ b/pocketbase/sync/staff_skills_test.go
@@ -986,3 +986,95 @@ func TestStaffSkillsRecordNeedsUpdateUsesCompareFields(t *testing.T) {
 		}
 	})
 }
+
+// newStaffSkillsOrphanTestApp returns a throwaway app holding only the
+// staff_skills collection -- the minimum deleteOrphans touches (it looks up
+// by ID and deletes; it does not read any other collection).
+func newStaffSkillsOrphanTestApp(t *testing.T) core.App {
+	t.Helper()
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	col := core.NewBaseCollection("staff_skills")
+	col.Fields.Add(&core.NumberField{Name: "person_id"})
+	col.Fields.Add(&core.NumberField{Name: "skill_cm_id"})
+	col.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(col); err != nil {
+		t.Fatalf("save staff_skills: %v", err)
+	}
+	return app
+}
+
+// TestStaffSkillsDeleteOrphansRefusesCollapsedComputedSet pins the guard
+// kindred#2283 adds. Before this fix deleteOrphans returned a bare int and had
+// no channel to refuse a sweep at all -- an empty ProcessedKeys map against a
+// populated year deleted the whole year and reported success.
+func TestStaffSkillsDeleteOrphansRefusesCollapsedComputedSet(t *testing.T) {
+	app := newStaffSkillsOrphanTestApp(t)
+	col, err := app.FindCollectionByNameOrId("staff_skills")
+	if err != nil {
+		t.Fatalf("find staff_skills: %v", err)
+	}
+	rec := core.NewRecord(col)
+	rec.Set("person_id", 12345)
+	rec.Set("skill_cm_id", 100)
+	rec.Set("year", 2026)
+	if saveErr := app.Save(rec); saveErr != nil {
+		t.Fatalf("save existing row: %v", saveErr)
+	}
+
+	s := NewStaffSkillsSync(app)
+	s.SyncSuccessful = true
+	s.ProcessedKeys = make(map[string]bool) // nothing processed this run
+
+	existing := map[string]*core.Record{"12345:100|2026": rec}
+	deleted, err := s.deleteOrphans(existing, 2026)
+
+	if err == nil {
+		t.Fatal("expected an error when nothing was processed and rows exist, got nil")
+	}
+	if deleted != 0 {
+		t.Errorf("deleted = %d, want 0 -- nothing may be removed on the refusal path", deleted)
+	}
+
+	remaining, err := app.FindRecordsByFilter("staff_skills", "year = 2026", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query: %v", err)
+	}
+	if len(remaining) != 1 {
+		t.Errorf("%d rows survived, want 1 -- the guard must not delete", len(remaining))
+	}
+}
+
+// TestStaffSkillsDeleteOrphansStillSweepsGenuineOrphans proves the guard did
+// not disable orphan deletion for the normal case.
+func TestStaffSkillsDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
+	app := newStaffSkillsOrphanTestApp(t)
+	col, err := app.FindCollectionByNameOrId("staff_skills")
+	if err != nil {
+		t.Fatalf("find staff_skills: %v", err)
+	}
+	orphan := core.NewRecord(col)
+	orphan.Set("person_id", 12346)
+	orphan.Set("skill_cm_id", 100)
+	orphan.Set("year", 2026)
+	if saveErr := app.Save(orphan); saveErr != nil {
+		t.Fatalf("save orphan: %v", saveErr)
+	}
+
+	s := NewStaffSkillsSync(app)
+	s.SyncSuccessful = true
+	s.ProcessedKeys = map[string]bool{"12345:100|2026": true}
+
+	existing := map[string]*core.Record{"12346:100|2026": orphan}
+	deleted, err := s.deleteOrphans(existing, 2026)
+	if err != nil {
+		t.Fatalf("deleteOrphans: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("deleted = %d, want 1", deleted)
+	}
+}


### PR DESCRIPTION
## Summary

Seven `deleteOrphans` implementations in `pocketbase/sync/` returned a bare `int` and had no channel to refuse a sweep at all. This changes each to `(int, error)`, updates the caller to propagate the error (failing the sync run rather than silently succeeding), and routes every refusal through the shared `OrphanSweepGuard` from kindred#2279 — no new guard implementation.

Files: `staff_skills.go`, `camper_history.go`, `camper_transportation.go`, `household_demographics.go`, `camper_dietary.go`, `quest_registrations.go`, `normalize_geographic.go`.

Two of the seven (`camper_history.go`, `normalize_geographic.go`) previously called `deleteOrphans` without even capturing the return value — the deletion count was computed and discarded. Both now capture `(deleted, err)` and use both.

## household_demographics.go: guard REPLACED, not supplemented

This file carried its own hand-rolled refusal:

```go
if len(records) == 0 && len(existingRecords) > 0 {
    slog.Error("Refusing to delete household_demographics orphans: nothing was computed", ...)
    s.Stats.Errors++
    return 0
}
```

That block is fully **removed**, not left in place alongside the shared guard. Leaving both would have double-reported a single refusal, and the increment specifically had to go: `Stats.Errors++` on a legitimate refusal would otherwise be indistinguishable from a genuine infrastructure failure once other in-flight work makes `Stats.Errors > 0` fail the run.

The old check also only caught a **total** collapse (`len(records) == 0`). `TestHouseholdDemographicsDeleteOrphansRefusesPartialCollapse` pins the case it could never see: 3 computed rows against 25 on disk — well past `== 0`, and well under the shared guard's 50% floor. That gap is the actual reason this file was in scope for #2283, not just the signature change.

## WAL checkpoint ordering

In every one of the seven callers, the WAL checkpoint happens **before** the `if orphanErr != nil { return ... }` check, not after:

```go
deleted, orphanErr := s.deleteOrphans(ctx, records, existingRecords, year)
s.Stats.Deleted = deleted

// WAL checkpoint BEFORE the error return below -- upsertRecords has already
// written by this point, and the refusal path can fire on a non-empty
// computed set (a PARTIAL collapse), which is exactly the case where writes
// already happened.
if s.Stats.Created > 0 || s.Stats.Updated > 0 || s.Stats.Deleted > 0 {
    if err := s.forceWALCheckpoint(); err != nil { ... }
}

if orphanErr != nil {
    return fmt.Errorf("orphan sweep refused: %w", orphanErr)
}
```

This matters because the guard's ratio arm (kindred#2279) can refuse on a **non-empty** computed set — a partial collapse, not just an empty one. `upsertRecords` runs before the sweep and may have already written rows in that same call. If the checkpoint ran only on the non-error path, a refused sweep would leave those upsert writes sitting in the WAL rather than flushed, even though they are real and should persist. Checkpointing first, then returning the refusal error, keeps the upsert's writes durable regardless of whether the sweep itself proceeds.

## Caller propagation is now pinned (review finding)

Propagation was correct in all seven files but **untested**: swallowing `orphanErr` in every caller left the entire `pocketbase/sync` suite green. That is the shape sibling kindred#2294 shipped, where a counted failure never reached the returned error and the run went green on a broken sweep.

There is now **one `Sync()`-level test per file — all seven covered**, no partial coverage:

| File | Test |
|---|---|
| `camper_history.go` | `TestCamperHistorySyncPropagatesSweepRefusal` |
| `normalize_geographic.go` | `TestNormalizeGeographicSyncPropagatesSweepRefusal` |
| `household_demographics.go` | `TestHouseholdDemographicsSyncPropagatesSweepRefusal` |
| `camper_dietary.go` | `TestCamperDietarySyncPropagatesSweepRefusal` |
| `camper_transportation.go` | `TestCamperTransportationSyncPropagatesSweepRefusal` |
| `quest_registrations.go` | `TestQuestRegistrationsSyncPropagatesSweepRefusal` |
| `staff_skills.go` | `TestStaffSkillsSyncPropagatesSweepRefusal` |

Each drives the real `Sync()` against a fixture whose computed set collapses against what is on disk, and requires the refusal to come back out of `Sync()` with nothing deleted. Mutation-checked **individually**: with `return wrapOrphanSweepError(orphanErr)` replaced by a log in all seven callers, all seven tests fail (exit 1). Before this commit that same mutation left the suite green.

One caveat worth stating: `TestNormalizeGeographicSyncPropagatesSweepRefusal` refuses via the empty-computed-set arm rather than the ratio arm. Giving its attendees any city/school/congregation sends `buildNormalizationLookup` to the geo-normalize HTTP API, and pointing that at an `httptest` server needs `t.Setenv`, which cannot coexist with the `t.Parallel()` kindred#2288 requires.

## A cancelled context is no longer reported as a refusal (review finding)

The four ctx-taking sweeps return `ctx.Err()`, and the caller wrapped **every** error as `"orphan sweep refused"`. A run that simply timed out therefore told the operator its CampMinder feed was not to be trusted — the opposite of the truth, and a different response.

kindred#2280 already settled this on `staff_vehicle_info.go:200-205` and `staff_applications.go:213-218`: `context.Canceled` and `context.DeadlineExceeded` are an `"orphan sweep interrupted"`. Rather than write a sixth and seventh copy of that three-line classification, it now lives in `wrapOrphanSweepError` beside the guard, producing byte-identical messages, and all seven callers in this PR route through it. `TestWrapOrphanSweepError` pins the classification; `TestDeleteOrphansReturnsContextErrorOnCancellation` pins the other half, that a cancelled sweep really does return a context error rather than a nil error and a short count.

The two pre-existing inline copies in `staff_vehicle_info.go` and `staff_applications.go` were left alone as out of scope; converting them to the helper is a one-line change each if wanted.

## An empty upstream no longer wedges the sweep (review finding)

Four of the seven refused whenever the computed set was empty — including when the source legitimately had nothing for that year. That did not merely fail the run: **a refused sweep never clears the rows it refused over**, so `existing` stayed high, the next run refused again, and the table could not drain.

The repo already had a policy for this. `BaseSyncService.DeleteOrphans` skips the sweep unless `SyncSuccessful` is set, and sets it mid-fetch gated on rows actually arriving, so on the shared path a zero-row upstream skips and succeeds. These four declared their **own** `SyncSuccessful` at the *end* of `Sync()`, where it was always false during their own sweep and — verified per file — nothing ever read it. Write-only dead state.

So the set point moves to immediately after extraction, taking its value from whether the extraction produced rows, and each sweep is gated on it. `camper_dietary.go`, `camper_transportation.go`, `quest_registrations.go`, `household_demographics.go`.

**`staff_skills.go` and `camper_history.go` already did this by hand**, returning early on an empty source before loading existing rows. Their behaviour is unchanged; they gain a comment saying it is deliberate, so the seven read as one policy rather than an accident. Their apparent inconsistency was them being right.

**One consequence worth naming:** for the four gated files the guard's *empty-computed* arm is no longer reachable through `Sync()` — the gate intercepts first — so the **ratio arm is the live one**, which is the intended split (empty is legitimate, short is suspicious). The four tests that pin the empty arm now say so in their doc comments: they pin the guard's contract, not a reachable state.

Tests assert **against the database, not the return value** — "reported success" and "deleted nothing" are separate claims and the interesting failure satisfies only the first. Negative controls prove the gate did not become "never sweep". Both directions mutation-checked:

| Mutation | Result |
|---|---|
| Gate removed | 4 empty-upstream tests fail, **exit 1** |
| Gate forced to always skip | 4 negative controls fail, **exit 1** |

The tests that drive `deleteOrphans` directly now set `SyncSuccessful`, which is what the three `ProcessedKeys`-based syncs have always required of theirs.

## Mutation-checked

Each file has a guard-refusal test and a still-sweeps-genuine-orphans test. For every one, the guard block was deleted, the refusal test was re-run and confirmed to fail (exit code, not just log text), then the guard was restored and re-confirmed green.

Closes #2283.

## Other notes

- Branched before kindred#2288 (the sync/lodging `t.Parallel()` guard) landed on main. Merged current main in and added `t.Parallel()` as the first statement to all 22 new top-level tests (13 guard tests plus the 9 added for the review findings) — each builds its own throwaway `pbtests.NewTestApp()` with no shared state, so none needed a serial exemption. None calls `t.Setenv`, which would panic alongside `t.Parallel()`.
- Checked all seven files against the kindred#2295 shape (a rejected/errored record left untracked because the counter bump and its `continue` precede the tracking write, so the sweep deletes that record's still-valid existing row). None of the seven has it: in the three `ProcessedKeys`-based files (`staff_skills.go`, `camper_history.go`, `normalize_geographic.go`) the key is marked processed *before* the save attempt; in the four `records`-map-based files (`camper_transportation.go`, `camper_dietary.go`, `quest_registrations.go`, `household_demographics.go`) the computed set is built once during extraction and never mutated on a save failure, so a failed save doesn't drop the entry that keeps `deleteOrphans` from treating it as an orphan.

  A review pass briefly flagged `normalize_geographic.go`'s rejected-canonical `continue` as an instance of this shape; that was withdrawn. The kindred#2295 defect is a key going missing because a record **failed to transform**. A `geo_overrides` rejection is an operator saying "never produce this mapping again", so the sweep removing the previously-stored row is the override taking effect, not data loss.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented synchronization from deleting records when computed results are empty or suspiciously incomplete.
  * Sync operations now report orphan-cleanup failures instead of incorrectly completing successfully.
  * Improved handling of cancellation during cleanup.
  * Ensured database checkpoints occur even when cleanup encounters an error.
  * Genuine orphaned records continue to be removed correctly.

* **Tests**
  * Added regression coverage for protected and successful orphan cleanup scenarios across synchronization areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


