### PR TITLE
docs(sync): family camp field provenance and the grain-collapse work-list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ See `/docs`:
 - `architecture/` — sync-layer, bunk-request-pipeline, session-types, metrics-module, data-model, solver-internals
 - `guides/` — solver-configuration, csv-preparation, dev-database-seeding, troubleshooting, docker-deployment
 - `api/` — solver-api
-- `reference/` — cli-commands, configuration, tables, commit-conventions, git-workflow, oauth2-setup, pocketbase-migrations, go-sync-patterns, sync-id-conventions, family-camp-field-provenance, issue-triage, lodging-registry, lodging-board-vs-summer, lodging-inventory-sheet, objective-sensitivity, weekend-go-live-sequence
+- `reference/` — cli-commands, configuration, tables, commit-conventions, git-workflow, oauth2-setup, pocketbase-migrations, go-sync-patterns, sync-id-conventions, family-camp-field-provenance, family-camp-grain-collapse, issue-triage, lodging-registry, lodging-board-vs-summer, lodging-inventory-sheet, objective-sensitivity, weekend-go-live-sequence
 
 `docs/reference/` also holds four large working documents that churn — read them for current
 state, not as stable reference: `solver-roadmap.md`, `solver-config-decisions.md`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ See `/docs`:
 - `architecture/` — sync-layer, bunk-request-pipeline, session-types, metrics-module, data-model, solver-internals
 - `guides/` — solver-configuration, csv-preparation, dev-database-seeding, troubleshooting, docker-deployment
 - `api/` — solver-api
-- `reference/` — cli-commands, configuration, tables, commit-conventions, git-workflow, oauth2-setup, pocketbase-migrations, go-sync-patterns, sync-id-conventions, issue-triage, lodging-registry, lodging-board-vs-summer, lodging-inventory-sheet, objective-sensitivity, weekend-go-live-sequence
+- `reference/` — cli-commands, configuration, tables, commit-conventions, git-workflow, oauth2-setup, pocketbase-migrations, go-sync-patterns, sync-id-conventions, family-camp-field-provenance, issue-triage, lodging-registry, lodging-board-vs-summer, lodging-inventory-sheet, objective-sensitivity, weekend-go-live-sequence
 
 `docs/reference/` also holds four large working documents that churn — read them for current
 state, not as stable reference: `solver-roadmap.md`, `solver-config-decisions.md`,

--- a/docs/reference/family-camp-field-provenance.md
+++ b/docs/reference/family-camp-field-provenance.md
@@ -1,0 +1,465 @@
+# Family Camp Field Provenance
+
+What each family-camp housing field actually is: which form asks it, the question a
+family reads, what shape the answer takes, and which internal column it becomes.
+
+Companion to `docs/reference/sync-id-conventions.md` (ID conventions),
+`docs/architecture/sync-layer.md` (job order) and `docs/reference/lodging-registry.md`.
+
+**Why this file exists.** None of it is discoverable from the CampMinder API. See
+[The API ceiling](#the-api-ceiling) — the API returns a field's internal admin label and
+nothing else. Question text, answer options, conditional logic and form membership exist
+only here and in the heads of the staff who built the forms. Treat this file as the
+system of record for those, and correct it in place when it is wrong.
+
+---
+
+## 1. There are exactly two grains
+
+CampMinder stores a custom value against either a **person** or a **household**. That is
+the whole taxonomy, and it is the load-bearing fact, because grain decides whether
+collapsing a value to a household is safe.
+
+| Grain | `custom_field_defs.partition` | Stored in | One value per |
+|-------|-------------------------------|-----------|---------------|
+| **per-child** | `["Camper"]` | `person_custom_values` | person, per year |
+| **adult** | `["Adult"]` | `person_custom_values` | person, per year |
+| **household** | `["Family"]` | `household_custom_values` | household, per year |
+
+Two things that look like additional grains and are not:
+
+- **The vendor's adult list is a transform, not a source.** `Family Camp Adult 1-5`
+  (household partition) is populated by CampMinder *vendor* staff who read the per-child
+  `Family Camp-P1 First Name`, `P2 First Name` and `Family Camp-Additional Adults`
+  answers and retype them as household values, splitting names by hand. It is child data
+  promoted to household grain by a human. The per-child fields are the source of truth;
+  the slots are a hand-made copy. See [§6](#6-the-adult-transcription-chain).
+- **The bunking CSV upload is a transport, not a source.** `BunkingNotes Notes`,
+  `Share Bunk With` and `Internal Bunk Notes` are per-child data living in CampMinder's
+  Bunking module. They are not custom fields and have no API endpoint, so they reach
+  Kindred only via a hand-uploaded CSV export. The upload is how they travel, not what
+  they are.
+
+---
+
+## 2. The API ceiling
+
+Verified against the vendored OpenAPI specs in `docs/api/external/campminder/specs/` and
+against all 1,270 field definitions already synced into `custom_field_defs`.
+
+### What the API gives you
+
+`CustomFieldDefinition` has exactly **seven** properties:
+
+```text
+Id, Name, DataType, Partition, IsSeasonal, IsArray, IsActive
+```
+
+That is precisely what `custom_field_defs` already stores. There is nothing else to fetch.
+
+### What it does not give you
+
+- **No question text.** `Name` is the internal admin label (`FAM CAMP-Share Cabins`), not
+  the sentence a parent reads.
+- **No option list.** Nothing enumerates the choices of a select.
+- **No validation.** No required flag, no max length, no conditional/skip logic.
+- **No form membership.** Nothing says which form a field appears on, or in what order.
+
+### `DataType` does not even give you the answer type
+
+Across all 1,270 definitions: **1,259 are `String`**. Five `Boolean`, four `Integer`, two
+`Decimal`. Every family-camp housing field is `String` — the yes/no gates, the
+multi-option selects, the free text, and the adult *count* alike.
+
+**`IsArray` is the only structural signal the API provides.** Exactly one field in the
+housing set carries it: `FAM CAMP-Shared Cabin` (263379), which is why that one alone is
+pipe-delimited.
+
+> **Consequence.** Answer type, option vocabulary and conditional logic must be
+> **inferred from stored values**. This is the root cause of kindred#1875 — nothing in the
+> schema said the CPAP field was a multi-option select. When you need a field's real
+> shape, run `SELECT DISTINCT value ...`, never trust `DataType`.
+
+### The five bunking fields are not reachable at all
+
+Confirmed four independent ways:
+
+1. Absent from all 1,270 field definitions under any spelling of *bunk*, *socialize*,
+   *note*, *internal* or *request*.
+2. Not properties on `PersonResponse` (25 props) or `CamperDetails` (12).
+3. No note/request/comment property on any schema in `bunks.yaml`.
+4. No relevant operation among the **28 total operations** across the seven base URLs
+   (auth, sessions, persons, bunks, divisions, staff, financials).
+
+Near-miss, so nobody re-investigates: `Family Camp-Camper 1-7 Bunk With` / `Bunkmate`
+(36533-36552, 14 definitions) *are* per-camper custom fields and *would* be API-reachable,
+but hold **zero values in every year from 2023 on**. Dead legacy fields.
+
+The CSV export is the only route. The fixable part is the **report definition** — it is
+summer-scoped, which is why 73% of family-camp children with a staff bunking note are
+invisible to Kindred — not the transport.
+
+---
+
+## 3. The Family Camp Information form
+
+Question text as presented to families. Supplied by camp staff 2026-08-13; this is the
+authoritative record, since the API exposes none of it.
+
+The form opens with the shared-cabin question.
+
+> **Scope of what is validated.** This form has been read in full. The Registration form
+> is now **partly** recovered — its housing block only, from a confirmation PDF — see
+> [§3b](#3b-the-camper-registration-form--housing-block).
+>
+> Still **inferred from stored values only**, because they are conditional fields that did
+> not render on the single confirmation available: `Shared-request` (274133),
+> `Housing-Bathroom` (274059), `Housing Accommodation-Yes` (274058) and
+> `FAM CAMP-Opt Out VIP` (256927). Their absence is itself consistent with gating — that
+> camper answered "No" to both the bathroom and accommodation gates.
+>
+> Confirmed present on Registration, from its prose block: `FAM CAMP-Share Cabins`,
+> `FAM CAMP-CPAP`, `FAM CAMP-bathroom`, `Housing Accommodation`. **Not** the adult block —
+> `Total Adults-FC` and the per-child P1/P2 fields are on *this* form, and the
+> confirmation merely prints their values ([§3b](#3b-the-camper-registration-form--housing-block)).
+>
+> One caveat that has not changed: `custom_field_defs` has no form column, so form
+> membership is only ever established by reading a form, never from the database.
+
+| # | Field label | Question as families read it | Answer shape |
+|---|-------------|------------------------------|--------------|
+| 1 | `FAM CAMP-Shared Cabin` | Would you like to share a cabin with another family or be housed near another family? | **Multi-checkbox**, four options (see [§5](#5-inferred-option-vocabularies)). The only `IsArray=1` field in the set; stored pipe-delimited |
+| 2 | `COVID-19 Bunking Requests` | Housing request | Free text. **Not conditional** — see the note below |
+| 3 | `Family Camp-Special Needs` | Does anyone in your family have a developmental, physical, emotional, or social need that requires an accommodation? Please let us know so we can best support your family at Camp! | Select one, Yes / No |
+| 4 | `Family Camp-Special Needs Yes` | If yes, please explain: | Free text, gated on #3 = Yes |
+| 5 | `Family Camp-Anything else` | Anything else you'd like us to know about your children or family? | Free text |
+| 6 | `Family Medical-Additional` | Please list any additional health information on any member of your family (including current medications). List the family member and medication/condition. | Free text |
+| 7 | `Family Camp-CPAP` | Is anyone in your family bringing a CPAP machine to Camp? | Yes / No |
+| 8 | `Family Medical-CPAP Explain` | If yes, please explain: | Free text, gated on #7 = Yes |
+
+### `COVID-19 Bunking Requests` is not conditional, and the name is misleading
+
+Two corrections that have both bitten already:
+
+- **It is not about COVID.** It is the live housing-request free text. The name is legacy
+  residue and causes readers to skip it. The `cm_id` (206286) is the contract.
+- **It does not depend on the shared-cabin answer.** An internal working sheet annotated
+  it "If FAM CAMP-Shared Cabin is anything". That is wrong, and this one is **fully
+  settled** — both fields sit on the Family Camp Information form, the form that has been
+  read, and staff confirm no gating. The data agrees: people who answered the
+  housing-request box while leaving the shared-cabin question blank number **39 of 412
+  (9.5%) in 2025** and **38 of 249 (15.3%) in 2026**. Under a real gate that is
+  impossible. (2024 reads 356 of 356 because 263379 carries no values that year — ignore
+  it.)
+
+  **The transform correctly ignores the claimed dependency, and that is what preserves
+  those households' requests.** Anyone who "fixes" the code to honour that note will
+  delete real requests.
+
+---
+
+## 3b. The Camper Registration form — housing block
+
+Recovered 2026-08-13 from a single camper's registration **confirmation PDF** (one real
+record, gitignored, never committed).
+
+> **What this document can and cannot prove — read before citing it.** Its custom-field
+> section is headed `CUSTOM FIELDS` and dumps **the camper's values across every form**.
+> It therefore proves *a field holds a value for this camper*; it does **not** prove
+> *which form asked it*. Field adjacency in the dump is layout, not provenance — the
+> adult block prints beside the housing questions while living on a different form
+> entirely ([§3c](#3c-the-information-form-is-updatable--the-drift-engine)).
+>
+> What the PDF *does* establish is the **prose**: the housing description and the Shared
+> Cabin Incentive text are printed with the housing questions, and their content is
+> registration-time by construction — the discount is "off your Family Camp
+> registration", and the text forward-references a *later* form for naming families. That
+> prose is identical for every family and contains no personal data.
+
+### The housing block
+
+```text
+<housing description — see below>
+  FAM CAMP-CPAP (256582) · FAM CAMP-bathroom (274056) · Housing Accommodation (274057)
+
+"Shared Cabin Incentive: ..."
+  FAM CAMP-Share Cabins (240877)
+```
+
+The registration form **defers naming to the later form**: *"You will have an opportunity
+to request specific families closer to the time of the program, or can note your
+request(s) below in the comments."* That is the two-form sequence stated to families, and
+it is why the naming fields live on the Information form.
+
+One field-label note, unrelated to provenance: `Total Adults-FC` (209430) renders as
+**"Total # of Adults"**. Earlier searches missed it because the stored definition name
+differs from the label families read.
+
+### The housing description, verbatim
+
+> Our Family Camp cabin spaces include individual rooms in shared spaces, large camper
+> cabins, small cabins and yurts, and housing is spread all over the grounds. The majority
+> of our cabins have twin-sized beds, no overhead lighting and are a short walk to a
+> shared bathhouse. Smaller families with 2-3 participants will be assigned to smaller
+> living spaces, or they can opt into sharing a large camper cabin with another family.
+> **We have minimal housing with attached bathrooms — these spaces are set aside for
+> families with children under 2 years of age, seniors who need this accommodation, and
+> families in need of specific accommodations for medical or accessibility-related
+> reasons.** Camper Cabins (one large room) are a primary housing option we prioritize for
+> families with four or more people, including children ages 2 - 16.
+
+**This is the rationing rule for the scarcest housing, written down**, and it is useful
+for what it says about *contention* rather than as a taxonomy to model. Seniors are not a
+separate signal to capture — a senior who needs the accommodation answers the
+accommodation question like anyone else, and this is one prose sentence, not a field list.
+Defining camp's questions is camp's job, not the schema's.
+
+What the passage does establish is **who competes for the same scarce units**: infant
+families, and anyone answering the bathroom or accommodation gates. That contention is
+real and nothing models it today.
+
+Two allocation rules stated here are worth holding onto because they are ours to
+implement: **party size drives unit type** (four or more → Camper Cabin), and the under-2
+boundary in the prose is the same one `INFANT_BED_EXEMPT_MONTHS` encodes.
+
+### The share gate is financially incentivised
+
+> **Shared Cabin Incentive:** Due to historically increased demand for Family Camps, we are
+> offering a **20% discount** off your Family Camp registration to families who share large
+> camper cabins (one large room with bunk beds — no walls separating the space — and a
+> short walk to a shared bathhouse) at a Family Camp weekend. If you want to share a cabin
+> with another family, please check the box below. If you end up sharing a cabin, you will
+> receive the discount following the weekend. [...] Please note, we can not guarantee
+> specific requests but we will do our best.
+
+**A "yes" on `FAM CAMP-Share Cabins` is partly a price decision, not purely a social
+preference**, and the discount is contingent on actually being shared. Nothing downstream
+knows this. It is the most likely explanation for the large "Maybe" population, and it
+means a share request is weaker evidence of social intent than its wording suggests —
+while *declining* is correspondingly stronger, since the family is turning down money.
+
+---
+
+## 3c. The Information form is updatable — the drift engine
+
+Per camp staff, 2026-08-13. This is the single most explanatory fact in this file, because
+it accounts for several anomalies that otherwise look like separate defects.
+
+**The chain.** `Family Camp-P1 First Name` (34160), `Family Camp-P2 First Name` (34161),
+`Family Camp-Additional Adults` (36525) and the total-adults field live on the **Family
+Camp Information form**, and CampMinder vendor staff transpose *from there* into
+`Family Camp Adult 1-5`.
+
+**Two properties of that form break the chain:**
+
+1. **It can be updated after submission.** The vendor's transposition is therefore a
+   **point-in-time snapshot of a moving source**. A family that adds a grandparent, drops
+   an adult, or corrects a name after the transposition leaves the household slots stale,
+   and nothing re-reconciles them — 36525 has no reader in the codebase at all.
+2. **It says "You will only need to fill out this form once per family" — and it is a
+   family-level form landing on child records.** When a family fills it once, one child
+   carries the answers and the siblings are blank. **When a family fills it more than
+   once, two children carry *different* answers.**
+
+**What this explains, all at once:**
+
+| Symptom | Explanation |
+|---|---|
+| Stated vs listed adult counts disagree (18 of 380 households in 2026) | The count was stated at one moment; the slots were transposed at another |
+| ~45% of households naming additional adults have no slot 3-5 | Updates landing after transposition, plus 36525 having no reader |
+| Siblings disagree on family-level answers | The form was filled more than once, on different children |
+| Siblings are merely *sparse* rather than conflicting | The form was filled once — the intended behaviour |
+| `Total Adults-FC` sibling disagreement (52.2% in 2024, ~1% after) | See the 2024 caveat in [§7](#7-standing-traps) |
+
+**Consequences for design.** Three, and they are not obvious from the data alone:
+
+- **Sparsity and conflict are different events, not different amounts of the same event.**
+  Sparsity means *filled once, correctly*; conflict means *filled twice*. Any transform
+  that treats them on one scale is modelling the wrong thing. Coalescing across siblings
+  is right for sparsity and wrong for conflict.
+- **Recency is a defensible tie-break here, and only here.** Because the source is a
+  form that is legitimately re-submitted, `last_updated` carries real meaning for these
+  fields — unlike the first-non-empty-by-record-id rule, which correlates with nothing.
+  Any per-answer layer must retain `last_updated` per answer for this reason.
+- **The vendor slots are a cache, not a source.** Treat `Family Camp Adult 1-5` as a
+  derived snapshot that can go stale, and the per-child Information-form fields as the
+  source of truth. That is the opposite of how kindred#1943's body frames it.
+
+### Measured: the timestamps confirm it, and separate two distinct mechanisms
+
+Every child's copy is written separately — **zero** households share a `last_updated`
+across siblings, in any field or year. The *spread* between those writes is bimodal, and
+that is what distinguishes a single sitting from a genuine re-submission (2026):
+
+| Field | Siblings agree | Siblings differ |
+|---|---|---|
+| **Total Adults-FC** | n=192, median **0.00d**, 174 within a day | n=9, median **133 days**, **none** within a day |
+| Additional Adults | n=8, all within a day | n=12, median 2.05d, max 264d |
+| P1 First Name | n=199, median 0.01d, 120 within a day | n=28, median 0.01d, **19 within a day** |
+
+Read the top row first: when a household's adult counts agree, the writes are minutes or
+hours apart — one sitting, fanned across the children. When they **disagree**, they are a
+median of **four months** apart and *not one pair* was written on the same day. That is
+the drift, visible in the data exactly as staff describe it.
+
+**Two mechanisms, needing opposite fixes:**
+
+- **Re-submission** (`Total Adults-FC`, most of `Additional Adults`): months apart, a real
+  update. **The later answer is the right one** — recency is the correct rule.
+- **Same-sitting variance** (`P1 First Name`: 19 of 28 divergences within a day): the
+  family typed the same adult's name slightly differently on each child's page in one
+  sitting. Recency is meaningless here; these want **normalisation and dedup**, because
+  the two values denote one person.
+
+Treating these as one problem — which every current transform does — guarantees getting
+one of them wrong. Note the interaction with [§6](#6-the-adult-transcription-chain): the
+name-variance class is precisely what makes the vendor's hand-dedup hard, and the
+re-submission class is what makes their snapshot go stale.
+
+---
+
+## 4. The gate → explain pattern
+
+A form-authoring convention the camp uses on the Family Camp Information form, and on
+other camp forms such as the dietary and allergy questions. It is **not** a CampMinder
+platform construct — CampMinder neither enforces nor exposes the link. Every field in
+every such pair lands as an ordinary **per-child custom value**.
+
+```text
+<Gate>          Yes / No select
+<Gate> Yes      free text, shown only when the gate is Yes
+```
+
+Known pairs in the housing set:
+
+| Gate | Explain |
+|------|---------|
+| `Family Camp-Special Needs` (182696) | `Family Camp-Special Needs Yes` (182698) |
+| `Family Camp-CPAP` (171577) | `Family Medical-CPAP Explain` (171578) |
+| `Housing Accommodation` (274057) | `Housing Accommodation-Yes` (274058) |
+| `FAM CAMP-bathroom` (274056) | `Housing-Bathroom` (274059) |
+
+### The splice: a gate and its explanation can survive from different children
+
+`processRegistrations` and `processMedical` collapse each field to household grain
+**independently**, taking the first non-empty value over an id-sorted list of person
+values. Because the two halves of a pair are separate fields, their winners can be
+different children.
+
+Measured share of households (where both halves have a value) whose stored gate and
+stored explanation come from **different children**:
+
+| Pair | 2024 | 2025 | 2026 |
+|------|------|------|------|
+| Special Needs | 7 / 66 · 10.6% | 11 / 66 · 16.7% | 2 / 40 · 5.0% |
+| CPAP | 9 / 36 · 25.0% | 13 / 39 · 33.3% | 2 / 20 · 10.0% |
+| Housing Accommodation | — | — | 11 / 30 · 36.7% |
+| Bathroom | — | — | 17 / 45 · 37.8% |
+
+This is worse than losing a sibling's text: the two halves of one question get spliced
+across two children, so the explanation staff read does not necessarily describe the need
+that raised the flag. Housing Accommodation and Bathroom have 2026-only rows because their
+derived columns have only ever been computed for 2026.
+
+**Design rule that follows:** a gate and its explain must stay bound to the same person
+through any transform. In a per-answer layer that is automatic. In any household rollup it
+has to be explicit — collapse the *pair*, never the two fields independently.
+
+---
+
+## 5. Inferred option vocabularies
+
+The API supplies no option list, so these are observed from stored values and must be
+re-derived when a form changes. Counts are lifetime unless noted.
+
+**`Family Camp-Special Needs` (182696)** — pure binary, matching the stated type:
+`No` 5,379 · `Yes` 784.
+
+**`Family Camp-CPAP` (171577)** — pure binary: `No` 3,279 · `Yes` 223.
+
+**`FAM CAMP-CPAP` (256582), Registration form — a different question, multi-option:**
+
+| Option | Means |
+|--------|-------|
+| `No` | — |
+| `Yes` | power |
+| `Yes, outlet needed for CPAP machine` | power |
+| `Yes, bathroom or other housing accommodation for a medical (not CPAP related) or accessibility-related reason needed` | bathroom |
+| `Yes, we need an outlet for a CPAP machine AND need a bathroom or other housing accommodation ...` | power + bathroom |
+
+> **The two CPAP fields are concurrent, not sequential — so the `break` is wrong.**
+> A comment in `family_camp_derived.go` calls 171577 and 256582 "generations of the same
+> question" and uses that to justify a `break` letting 171577 win the `cpap_info`
+> narrative slot.
+>
+> **256582's question text is unknown** — it sits on the Registration form, which has not
+> been located (see [§3](#3-the-family-camp-information-form)). Two observations settle
+> the precedence anyway, without it:
+>
+> - **They co-occur at scale.** Same person, same year, both answered: 12 (2024), **619
+>   (2025)**, **343 (2026)**. Sequential generations would show ~0. 171577 also has values
+>   back to 2021 while 256582 starts in 2024, so they run concurrently, not in series.
+> - **Their scopes differ, provably.** One of 256582's options reads *"bathroom or other
+>   housing accommodation for a medical (**not CPAP related**) or accessibility-related
+>   reason needed"*. A question meaning *"is anyone bringing a CPAP machine?"* cannot have
+>   an answer meaning *"no CPAP, but I need a bathroom"*.
+>
+> Whatever 256582 asks, it is broader than 171577 and its options carry the need; 171577
+> stores only `Yes`/`No`. The `break` therefore lets an uninformative binary overwrite the
+> sentence that names the need. Fix the comment alongside the code — but correct it to
+> *"concurrent questions of differing scope"*, which is what the evidence supports, not to
+> a claim about the Registration form's wording, which nobody has read.
+
+**`FAM CAMP-Shared Cabin` (263379)** — four checkboxes, pipe-delimited when more than one
+is ticked: share *with* a specific family · share *with* a family with similarly aged kids
+· house *near* a specific family · no requests. NEAR and WITH are different edge types —
+proximity is satisfied by map distance, co-housing by sharing a slot — and a household can
+tick both.
+
+---
+
+## 6. The adult transcription chain
+
+```text
+per-child (Camper partition)                      household (Family partition)
+  Family Camp-P1 First Name   (34160)   ──┐
+  Family Camp-P2 First Name   (34161)   ──┼── hand-retyped by ──▶  Family Camp Adult 1-5
+  Family Camp-Additional Adults (36525) ──┘   CampMinder vendor      (219270-219272,
+                                                                      221653, 221654)
+```
+
+Facts worth not rediscovering:
+
+- `Family Camp-P1/P2 Last Name` (216785 / 216786) died after 2022 — 445 values that year,
+  then 1 / 3 / 2 / 0. Post-2022 the only camper-level source is the "First Name" field,
+  which in practice holds a **full typed name** (773 of 788 2026 values contain a space).
+- `Family Camp Name 3` (34162) has **zero values in every year**, so there is no
+  camper-level source for adults 3+ except the free-text `Additional Adults`.
+- `Family Camp-Additional Adults` (36525) is admitted into the field map and then routed
+  nowhere. Hand-transcription is the *only* path from it to the product, and nothing
+  compares source to target.
+- **Slot number is not an identity.** Roughly one adult in five occupies a different
+  `adult_number` between consecutive years, and slot 1 holds a different person in 25-34%
+  of returning households. Never join on `adult_number` across years.
+- Wrong *dedup* is essentially absent — one household-year in three years has the same
+  name in two slots. The defect is **under-transcription**: ~45% of households naming
+  additional adults end up with no slot 3-5 at all.
+
+---
+
+## 7. Standing traps
+
+- **Match on `cm_id`, never the display name.** Staff rename fields. One shipped field
+  (`Family Camp-Physician `, 39680) still carries a trailing space; `normalizeFieldName`
+  exists because of it. The adult pipeline currently violates this and routes on
+  display-name substrings.
+- **Two live fields differ by one letter.** `Housing Accommodation` (274057, Camper) and
+  `Housing Accomodation` (274055, Adult) are not a typo to correct.
+- **A field can be admitted and still routed nowhere.** "The value is in
+  `person_custom_values`" and "a transform routes it into a column something reads" are
+  different claims, and conflating them is the most common error in this area.
+- **The registration and information forms ask overlapping questions.** Where both are
+  answered, precedence must be deliberate and documented, not incidental to load order.
+- **Adult-partition answers have no child row**, so a per-child report structurally cannot
+  show them. 18 of 63 households flagged for a private bathroom in 2026 are flagged only
+  because of an adult.

--- a/docs/reference/family-camp-grain-collapse.md
+++ b/docs/reference/family-camp-grain-collapse.md
@@ -1,0 +1,299 @@
+# Family Camp Grain Collapse — the work-list
+
+Every site where the family-camp sync folds per-person answers into one household value,
+what rule each uses, how much it discards, and how the open issues map onto it.
+
+Companion to `docs/reference/family-camp-field-provenance.md`, which covers what the
+fields *mean*. This file covers what the code *does to them*. Read that one first —
+several decisions here only make sense once you know a value's grain and its form.
+
+Measured against the production snapshot at `pocketbase/pb_data/data.db`, tree `ffd5ee87`.
+2026 was mid-registration when measured, so 2026 counts are floors.
+
+---
+
+## 1. Read these three traps before measuring anything
+
+**1. It is not random, and three issue bodies say it is.** `#2255` (and text echoed into
+siblings) warns that the collapse is "random-wins" and implies a flaky test. It is not.
+Every map range on this path (`family_camp_derived.go:684`, `:838`, `:994`,
+`lodging_requests.go:377`) affects only *output slice order*, never which value wins. The
+winner is fixed by the input slice, and `loadPersonCustomValues` sorts by `id` (`:523`,
+with a comment saying why). So the sites are **deterministic against a given database** —
+arbitrary, uncorrelated with recency or completeness, unstable across a delete/recreate of
+a source row, but *not* a per-run coin flip. A flakiness test will chase a ghost. The
+correct probe is an **order-independence** test: permute the input slice, assert identical
+output.
+
+The one genuinely unordered site is elsewhere: `household_demographics.go` passes `""` for
+sort (`:369`), which is `#2260`'s summer-path defect and a different file.
+
+**2. Eight derived columns are zero for every year except 2026.** `share_eligibility` is
+empty on all 3,459 rows for 2017-2025 and populated on all 464 for 2026 — only 2026 has
+been through a current `family_camp_derived` run. Same for `needs_power`,
+`needs_private_bathroom`, `share_cabin_gate`, `request_text`, `wants_*`,
+`accommodation_is_mandatory`, `opt_out_vip`. **2025 currently reads as a year with no
+accommodation needs at all.** Any baseline drawn from it is wrong, and a re-derive is a
+prerequisite for measuring anything historical.
+
+**3. State your denominator.** This is the error the verification pass kept finding. Three
+populations give three different answers and none is wrong:
+
+| Population | 2024 | 2025 | 2026 |
+|---|---|---|---|
+| All households with any family-camp value | 612 | 566 | 428 |
+| Households with any FC adult signal | 469 | 418 | 382 |
+| **Rostered** — actively enrolled (`status_id = 2`) in a `family` or `adult` session | **696** | **619** | **516** |
+
+The rostered cut is the operational one. Use it, and say so.
+
+---
+
+## 2. The catalogue — 26 sites
+
+Rule key: **first-wins** = first non-empty in id order, later values fall through
+silently · **OR** = boolean or, fail-safe · **join** = dedup-and-join, lossless.
+No site anywhere counts its loss: no `Stats` field, no `slog.Warn`, no
+`lodging_ingest_issues` row, no conflict column, for any of the 20 lossy sites.
+
+### `processAdults` — `family_camp_derived.go:636-676`
+
+Group key `(household, adult_slot)`. All arms are `Contains(fieldName, X) && field == ""`.
+
+| # | Column | Source cm_id | Rule | Notes |
+|---|---|---|---|---|
+| A1 | `first_name` | 34160 / 34161 | first-wins | documented at `:603-635`; holds a full typed name |
+| A2 | `last_name` | 216785 / 216786 | first-wins | dead — 0 conflicts, unfilled after 2022 |
+| A3 | `email` | 224590 / 224591 | `preferEmail` `:716-726` then first-wins | only site with a validity tie-break |
+| A4 | `pronouns` | 241038 / 241039 | first-wins | |
+| A5 | `gender` | 34163 / 34164 | first-wins | |
+| A6 | `date_of_birth` | 34166 / 34167 | first-wins | **largest single loss in the file** |
+| A7 | `relationship_to_camper` | 36523 / 36524 | first-wins | **semantically void** once separated from the child it is relative to |
+| A8 | `name` | 219270-219272, 221653/221654 | none | household grain; `UNIQUE(year,household,field)` means no collapse occurs |
+
+### `processRegistrations` — `family_camp_derived.go:749-836`
+
+Exact-name switch, `if reg.X == ""` guards.
+
+| # | Column | cm_id | Line | Rule |
+|---|---|---|---|---|
+| R1 | `share_cabin_preference` | 240877 | `:760-763` | first-wins — **resolved by a different rule than `share_cabin_gate` on the same row** |
+| R2 | `shared_cabin_modes_raw` | 263379 | `:764-767` | first-wins (no readers) |
+| R3 | `arrival_eta` | 36529 | `:768-771` | first-wins |
+| R4 | `special_occasions` | 60413 | `:772-775` | first-wins |
+| R5 | `goals` | 36526 | `:781-784` | first-wins (retired after 2024) |
+| R6 | `notes` | 36528 | `:785-788` | first-wins |
+| R7 | `cabin_assignment` | 218072 | `:734-745` | household grain, no collapse |
+| B1 | `needs_private_bathroom` | 274056 / 274053 | `:815-816` | **OR — correct** |
+| B2 | `has_infant` | 257248 | `:823-830` | **OR — correct** |
+| B3 | `needs_accommodation` | 223999 / 274057 / 274055 | `:794-795` | **OR — correct** |
+| B4 | `opt_out_vip` + `accommodation_is_mandatory` | 256927 / 256935 | `:796-814` + `:838-853` | **OR plus an order-independent blocker override.** The best-designed site on this path and the model for what a conflict rule should look like |
+| B5 | `needs_power` + bathroom arm | 256582 / 171577 / 256933 | `:817-822` | OR of two independently-tested needs via `classifyCPAPAnswer` — correct |
+
+### `CollapseToHouseholdGrain` — `lodging_requests.go:291-390`
+
+The only site with a written-down, reviewed policy.
+
+| # | Column | Line | Rule |
+|---|---|---|---|
+| C1 | `share_cabin_gate` | `:344-357`, `winsGate` `:408-418` | **newest-wins by `last_updated`**, form field breaks an exact tie. `sawDeclineGate` `:347-349` preserves one direction of the discarded signal |
+| C2 | `request_text` | `:366-372` | **dedup-and-join — LOSSLESS.** The model to copy |
+| C3 | `wants_near/with/similar_ages` | `:358-364` | OR — correct |
+| C4 | `share_eligibility`, `share_answers_conflict` | `:377-386` | derived from the collapsed set; the conflict flag is computed against the **winner only**, which is `#2269` |
+
+### `processMedical` — `family_camp_derived.go:981-992`, then `:994-1095`
+
+| # | Column | Line | Rule |
+|---|---|---|---|
+| M0 | *the flatten itself* | `:986-988` | first-wins across **every** field name, before any per-field logic. **This one site is behind M1-M8** |
+| M1 | `cpap_info` | `:1010-1021` | first-wins, **plus a `break` at `:1015`** keeping the older camper generation (171577) over the newer (256582). Adult-CPAP (256933) is correctly additive |
+| M2-M5 | `physician_info`, `special_needs_info`, `allergy_info`, `dietary_info` | `:1024-1065` | each concatenates a **gate token with a narrative**, chosen independently by M0 — so the two halves can come from different people |
+| M6-M8 | `additional_info`, `bathroom_explain`, `accommodation_explain` | `:1068-1084` | first-wins |
+
+---
+
+## 3. How much is discarded
+
+Method: group by `(year, household, cm_id)`. A group with ≥2 non-empty person rows is
+**sparsity** if all values are equal, **conflict** if ≥2 distinct. Only conflict is loss.
+Sparsity outruns conflict roughly **5:1** — most of the flatten is legitimately collapsing
+one parent's answer copied onto several children's forms.
+
+| Cut | 2024 | 2025 | 2026 |
+|---|---|---|---|
+| Answers discarded, all households | 828 | 843 | 637 |
+| Answers discarded, **rostered** | **689** | **676** | **569** |
+| Rostered households losing ≥1 answer | 252 / 696 (36%) | 207 / 619 (33%) | 196 / 516 (38%) |
+
+Top sites by 2026 loss, rostered cut: DOB 92 · dietary narrative 75 · allergy narrative 67
+· email 60 · first name 57 · additional medical 44 · arrival ETA 38 · bathroom explain 22
+· gender 20 · relationship 17.
+
+Two sites are lossless and confirmed by measurement: **C2** (57-87 second answers *survive*
+per year that the other sites would discard) and the five OR sites **B1-B5** (0-6 conflicts
+a year, ORing to the fail-safe direction rather than discarding).
+
+### Reproducing it
+
+```sql
+CREATE TEMP VIEW pv AS
+SELECT pcv.year yr, p.household hh, d.cm_id cmid, TRIM(pcv.value) val
+FROM person_custom_values pcv
+JOIN persons p ON p.id = pcv.person AND p.year = pcv.year
+JOIN custom_field_defs d ON d.id = pcv.field_definition
+WHERE pcv.year IN (2024,2025,2026) AND p.household <> '' AND TRIM(pcv.value) <> '';
+
+-- answers discarded per year (exclude the lossless C2 cm_ids)
+SELECT yr, SUM(CASE WHEN nd >= 2 THEN nd - 1 ELSE 0 END)
+FROM (SELECT yr, hh, cmid, COUNT(*) nrows, COUNT(DISTINCT val) nd
+      FROM pv GROUP BY 1,2,3)
+WHERE cmid NOT IN (274133, 240598, 206286)
+GROUP BY yr;
+```
+
+For the rostered cut, inner-join:
+
+```sql
+JOIN (SELECT DISTINCT p.year, p.household
+      FROM attendees a
+      JOIN persons p ON p.id = a.person
+      JOIN camp_sessions s ON s.id = a.session
+      WHERE s.session_type IN ('family','adult') AND a.status_id = 2) r
+  ON r.year = pv.yr AND r.household = pv.hh
+```
+
+### Confirmed on the staff artifact
+
+The housing-request CSV has 98 child rows across 63 households; 31 have ≥2 children.
+**23 of those 31 (74%) carry at least one column where sibling rows hold different
+non-empty values** — 45 discarded answers on one weekend's report. Worst: `Share Bunk With`
+10 households (but see the provenance doc — that column is summer-scoped and not a lodging
+input), `FamilyMedical-Additional` 9, `Housing-Bathroom` 7, then `Shared-request`,
+`COVID-19BunkingRequests` and `FamilyCamp-SpecialNeedsYes` at 3 each.
+
+Columns 25-29 (`FamilyCampAdult1-5`) show **zero** conflicts and pure repetition across
+sibling rows — confirming they are household-partition values fanned onto child rows.
+
+---
+
+## 4. Issue map
+
+**None of the seven is a duplicate.** `#2255`, `#2274` and `#2275` are three siblings of
+one mechanism in one file, sharing one root loop shape, one prerequisite and one ~100-line
+region — they should ship as **one PR**, but merging the *issues* would lose three
+genuinely different collapse policies (narrative join vs free-text join vs per-attribute
+decision).
+
+| Issue | Sites | Status against the tree |
+|---|---|---|
+| `#2257` | tracking | Says "20 sites, three mechanisms". The catalogue finds **26 sites**; 20 lossy is right |
+| `#2255` | M0 + the M1 `break` | Anchors correct. Reproduced: 330 rows reading `"No; <narrative>"` (243 with 2+ answerers); 703 household-years hold both camper CPAP generations, **70 disagreeing** |
+| `#2274` | R1-R6 | **Every cell reproduced exactly:** Trans ETA 420/428/121 · Goals 240/247/0 · Anything else 73/75/29 · Share Cabins 30/30/24 · Shared Cabin 16/16/16 · Special occasions 14/14/5. One anchor wrong: "the person loop at `:757`" — it opens at **`:749`** |
+| `#2275` | A1-A7 | **Reproduced exactly:** DOB 1,124 colliding / **1,151 lost** · first name 791/801 · gender 511/513 · relationship 315/323 · email 326 colliding. Its latent-collision warning is real and confirmed: `FAM CAMP Adult 1/2 Gender-Other` (240871/240872) and `FAM Camp Adult 1/2-Pronouns other` (241040/241042) would funnel into the `gender`/`pronouns` arms and carry zero values in every year |
+| `#2269` | C4 | Not a data-loss site — C1's collapse is correct; the review flag is what is missing. Correctly scoped |
+| `#2270` | ingest upsert, not a transform | Latent — 0 duplicate key groups today. The household twin at `household_custom_field_values.go:319-320`/`:329` has the identical shape |
+| `#2260` | `household_demographics.go:494` | **Summer path, distinct file and loader.** Also the only genuinely unordered site |
+
+### Bodies to correct before implementing
+
+Repo convention is to fix the body in place with `gh issue edit`, and comment saying what
+changed. See `CLAUDE.md` §4.
+
+- **`#2255`** and the siblings echoing it — the "random-wins / flaky" framing. Replace with
+  deterministic-but-arbitrary, and swap the proposed flakiness test for an
+  order-independence probe.
+- **`#2274`** — anchor `:757` → `:749`; loss table omits the share fields.
+- **`#2275`** — add that slots 3-5 carry *no* attributes in any year, so the entire
+  attribute loss is a slots-1-and-2 phenomenon.
+- **`#2276`** — claims three unrouted questions; the live population is **35** admitted-
+  but-unrouted family-camp definitions, ~5,000 values in 2026 alone.
+- **`#2256`** — three factual errors and an unmentioned blocker; see the provenance doc's
+  bunking section. Someone implementing from it today ships something that looks correct
+  on 10 children and silently omits 27.
+
+---
+
+## 5. Recommended order
+
+**Step 0 is a hard prerequisite and nothing can start without it:** widen
+`customValueEntry` (`family_camp_derived.go:437-445`) to carry the person PB id and cm id.
+It currently discards the person id at load, which is the root architectural cause of
+every site above. Both `#2255` and `#2275` name it.
+
+1. **Step 0** — widen `customValueEntry`.
+2. **Build the per-answer tables, dual-write** alongside the existing ones. No consumer
+   changes. This is where the loss is provably recovered and where the order-independence
+   probe belongs.
+3. **Re-derive the three existing tables** from the new person tables rather than from
+   `personValues`, adding dedup-and-join plus a single `answer_conflicts` JSON array naming
+   which fields disagreed — one column, not four booleans, so adding a field later needs no
+   migration. `#2255`, `#2274`, `#2275` all close here.
+4. **Add `session_cm_id`** to `family_camp_registrations`. **The grain triple must move in
+   one PR:** the write key in `upsertRegistrations`, the orphan key `ProcessedRegKeys`
+   (`family_camp_derived.go:34`), and `idx_fc_reg_unique` (migration `1500000035:288`).
+   Then switch `fetch_family_camp_registrations(year)` → `(year, session_cm_id)`.
+5. **Point the weekend medical panel** at the per-answer table and wire
+   `original_bunk_requests` into the roster — the two things staff asked for directly.
+
+**No backfill, no data migration, no CampMinder re-fetch.** `person_custom_values` holds
+1,608,513 rows under `UNIQUE(year, person, field_definition)` with **zero** duplicate key
+groups; `household_custom_values` likewise. The three `family_camp_*` tables are
+sync-owned, have no `staff_touched` column and no GUI write path. Every value is recovered
+by re-running `family_camp_derived` against data already on disk.
+
+---
+
+## 6. Carry-forward warnings
+
+- **Person grain preserves *who answered*, not *who the answer is about*.** 31.5% of
+  allergy narratives name a household member other than the record holder. Any UI built on
+  the per-answer table must say **"reported by"**, never "about". This is the single
+  easiest way to turn a data fix into a clinical error.
+- **`family_camp_medical` has no enrolment filter** — 381 of 886 2026 rows are out of
+  family-camp scope, because `processMedical` reads `Family Medical-*` fields that summer
+  campers also answer. Narrowing it is a behaviour change; confirm with staff before
+  assuming it is a bug.
+- **`relationship_to_camper` is void at household-adult grain** and only becomes
+  well-defined keyed by the reporting person. Whether the household rollup should carry any
+  version of it is open.
+- **`date_of_birth` / `gender` / `pronouns` on adults** — kindred#1945's parked decision
+  (whether these columns are kept at all) now gates the single largest loss site (A6, 92
+  answers in 2026). Worth resolving before step 2, not after.
+- **Which years to replay** is a real decision, not a detail. Only 2026 has been through a
+  current run. A re-grain that also backfills 2024-2025 changes thousands of historical
+  rows written by three code generations. The only known reader of those years is the
+  year-over-year card, which reads `cabin_assignment` only.
+
+---
+
+## 7. Relationship to the wider transform-grain audit
+
+A broader audit ran first and produced this issue family. It covers **the whole sync
+layer** — 118 grain-reduction sites, 19 losing — and classifies loss into three
+mechanisms: **A** person→household first-wins, **B** coarse target grain on a relation key,
+**C** mapping gaps (the largest class, ~23,254 values). Its framing is still the right one
+and this file does not replace it: this file is the family-camp **depth** pass under its
+mechanism A.
+
+Three things in it to correct before relying on it:
+
+1. **"Random / SQLite paging order" over-generalises.** It is accurate for
+   `household_demographics.go:494`, which passes `""` for sort. It is **wrong** for
+   `family_camp_derived.go`, which sorts by `id` at `:523`. Deterministic-but-arbitrary,
+   as §1 above sets out. Its *remedy* — the order-independence probe — is right either way.
+2. **It counts `family_camp_derived.go:988` as one site.** That is site M0 here, and M0
+   alone is behind M1-M8. The family-camp path holds **26** sites, 20 of them lossy. Its
+   per-site figure and this file's path-wide figure are different measurements, not
+   competing ones.
+3. **Several of its items have shipped.** Closed since it was written: the licence-plate
+   spelling (`#2258`), the summer household first-wins (`#2260`), `can_bring_others`
+   (`#2262`), the person-custom-value orphan-sweep cap (`#2266`), and its **step 0** — a
+   counted database failure now fails the run (`#2284`, PR `#2293`). Its remaining
+   guardrail steps 1-5 are unshipped and still the recommended order.
+
+What this file adds that the wider audit could not see, because it predates reading the
+forms: the semantics in `family-camp-field-provenance.md`, and in particular that the
+Information form is **re-submittable**. That splits mechanism A into two populations
+needing opposite rules — genuine re-submission months apart, where recency is correct, and
+same-sitting name variance, where normalisation is. A single `NewestWins` policy applied
+across mechanism A would get the second population wrong.

--- a/pocketbase/CLAUDE.md
+++ b/pocketbase/CLAUDE.md
@@ -132,6 +132,7 @@ Read before touching sync code:
 | `docs/reference/go-sync-patterns.md` | Service structure, `BaseSyncService`, idempotent upserts, orphan-deletion safety, year-scoped vs global collections |
 | `docs/reference/sync-id-conventions.md` | `PopulateRelations`, composite keys, why data fields hold CampMinder IDs and relation fields hold PocketBase IDs |
 | `docs/reference/family-camp-field-provenance.md` | Which form asks each family-camp housing field, the question families read, what the CampMinder API can and cannot tell you, and why the adult slots drift |
+| `docs/reference/family-camp-grain-collapse.md` | The 26 sites where family-camp person answers collapse to household grain, what each discards, and how #2257 and its siblings map onto them |
 
 ## DB file access
 

--- a/pocketbase/CLAUDE.md
+++ b/pocketbase/CLAUDE.md
@@ -131,6 +131,7 @@ Read before touching sync code:
 | `docs/architecture/sync-layer.md` | Architecture, phase/job order, the add-a-new-sync-job checklist |
 | `docs/reference/go-sync-patterns.md` | Service structure, `BaseSyncService`, idempotent upserts, orphan-deletion safety, year-scoped vs global collections |
 | `docs/reference/sync-id-conventions.md` | `PopulateRelations`, composite keys, why data fields hold CampMinder IDs and relation fields hold PocketBase IDs |
+| `docs/reference/family-camp-field-provenance.md` | Which form asks each family-camp housing field, the question families read, what the CampMinder API can and cannot tell you, and why the adult slots drift |
 
 ## DB file access
 


### PR DESCRIPTION
Two reference docs. The first records what the family-camp housing fields **mean**; the second records what the code **does to them**. Together they are meant to be handed to an agent picking up #2257 and its siblings.

## 1. `family-camp-field-provenance.md` — the semantics

These fields carry meaning that exists in no code and no API response: which form asks a question, what a family actually reads, whether an answer is a select or free text, and which gate a follow-up depends on.

`CustomFieldDefinition` exposes seven properties — `Id, Name, DataType, Partition, IsSeasonal, IsArray, IsActive` — which is exactly what `custom_field_defs` already stores. No question text, no option list, no validation, no form membership. And `DataType` does not even give the answer type: **1,259 of 1,270 definitions are `String`**, so a yes/no gate, a multi-option select, free text and an integer count are indistinguishable by schema. `IsArray` is the only structural signal. That is the root cause of #1875.

Recorded: the two grains; what the API can and cannot answer (including four independent checks that the five bunking fields are unreachable, so the fixable part is the summer-scoped report definition, not the CSV transport); the Information form's question text; the gate → explain pattern, with the measurement that a gate and its explanation survive from **different children in 5–38%** of households; the Registration form's housing prose; and the adult transcription chain.

**The Information form is re-submittable**, which is the mechanism behind the adult-count drift. Timestamps separate two populations needing opposite fixes — genuine re-submission (median **133 days** apart, none same-day) versus same-sitting name variance (19 of 28 within a day).

## 2. `family-camp-grain-collapse.md` — the work-list

**26 sites** across `processAdults`, `processRegistrations`, `CollapseToHouseholdGrain` and `processMedical`. 20 are first-non-empty-wins, 5 are boolean OR (correct), 1 is dedup-and-join (lossless, and the model to copy). **None of the 20 counts its loss** — no `Stats` field, no `slog.Warn`, no ingest-issue row, no conflict column.

Rostered cut: **689 / 676 / 569** answers discarded for 2024 / 2025 / 2026, affecting **252 / 207 / 196** households (36% / 33% / 38%). Reproducing SQL included.

Three traps are called out first, because each invalidates a measurement:

1. **It is not random.** `family_camp_derived.go` sorts its paged read by `id` (`:523`), so it is deterministic-but-arbitrary. Several issue bodies say "random-wins" and propose a flakiness test; the correct probe is **order-independence**. The one genuinely unordered site is `household_demographics.go`, a different file.
2. **Eight derived columns are zero for every year except 2026** — 2025 reads as a year with no accommodation needs at all.
3. **Three household populations give three denominators.** The rostered cut is the operational one.

Also included: the issue map (none of the seven is a duplicate, though #2255/#2274/#2275 share one mechanism and should ship as one PR), the bodies needing correction before implementation, the prerequisite (`customValueEntry` discards the person id at load — nothing can start before it is widened), and a section reconciling this against the wider 118-site transform-grain audit, including which of its items have since shipped.

## Verification

- `npx markdownlint-cli2` clean; commitlint clean; push confirmed by remote ref.
- Scanned for PII: no camper, family, staff, camp, school or congregation names. Source material (a staff CSV export and one camper's registration confirmation PDF) is gitignored and uncommitted.
- Docs only — no code, schema or behaviour changes.

Indexed in `CLAUDE.md` and `pocketbase/CLAUDE.md`. Informs #2257, #2274, #2275, #2255, #2269, #2276, #2256. Closes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)