### PR TITLE
fix(sync): drop the arbitrary attendee link from quest_registrations and camper_dietary

### DIFF
--- a/frontend/src/types/pocketbase-types.ts
+++ b/frontend/src/types/pocketbase-types.ts
@@ -403,7 +403,6 @@ export type CampSessionsRecord = {
 export type CamperDietaryRecord = {
   additional_medical?: string
   allergy_info?: string
-  attendee: RecordIdString
   created: IsoAutoDateString
   dietary_explanation?: string
   has_allergies?: boolean
@@ -1382,7 +1381,6 @@ export type PersonsRecord<Tparent_names = unknown, Traw_data = unknown> = {
 export type QuestRegistrationsRecord = {
   any_medications?: string
   anything_else?: string
-  attendee: RecordIdString
   away_before?: string
   away_explain?: string
   backpack_info?: string

--- a/pocketbase/pb_migrations/1500000153_drop_attendee_link_quest_dietary.js
+++ b/pocketbase/pb_migrations/1500000153_drop_attendee_link_quest_dietary.js
@@ -1,0 +1,125 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: drop the `attendee` relation from `quest_registrations` and
+ * `camper_dietary`, and widen `quest_registrations` to `bunking.manage`.
+ * Resolves kindred#2261 and kindred#2265; part of kindred#2257.
+ *
+ * WHAT THE COLUMN WAS. Both tables are person x year -- unique on
+ * (person_id, year) already, so the relation was never part of the key. The
+ * sync walked every `attendees` row for the year and kept the first one it
+ * encountered per person, with no status filter and an EMPTY sort argument.
+ * PocketBase omits ORDER BY entirely when sort is "" (core/record_query.go),
+ * so "first" was a query-plan artifact, not a rule -- this is a genuinely
+ * unordered site, unlike the family_camp_derived ones which sort by id.
+ *
+ * WHY IT CANNOT BE FIXED IN PLACE. kindred#2159 ruled that a reader must
+ * establish enrollment by joining (person_id, year) on status_id = 2, never by
+ * traversing a stored link. So the relation could not answer the only question
+ * anyone would ask it, however it was chosen. Making the pick deterministic
+ * would have produced a stably-wrong link, which is a subtler trap than an
+ * absent one: it stops looking suspicious. Measured on the production snapshot:
+ *   quest_registrations  679 rows, 125 pointed at a non-enrolled attendee,
+ *                        71 of those discarded an enrolled candidate
+ *   camper_dietary     9,531 rows, 2,641 non-enrolled, 530 discarded an
+ *                        enrolled candidate
+ *
+ * cascadeDelete: true MADE IT A DATA-LOSS VECTOR, NOT JUST A BAD POINTER.
+ * The relation carried cascadeDelete, and `AttendeesSync.deleteOrphans` really
+ * does delete attendee rows. So when CampMinder dropped the particular attendee
+ * row this table happened to have picked, PocketBase deleted the camper's whole
+ * questionnaire with it -- 50+ columns of Quest answers, or a dietary and
+ * allergy record. Which campers lost data depended on which of their attendee
+ * rows the unordered query yielded first. That is the strongest reason to
+ * remove the column rather than re-point it.
+ *
+ * WHY NOT A SESSION DIMENSION INSTEAD. The questionnaires are person x year AT
+ * THE SOURCE: `person_custom_values` is UNIQUE(year, person, field_definition)
+ * with zero duplicate key groups, so a camper's second enrollment could not
+ * carry a second set of answers even in principle. Adding session grain would
+ * fan one questionnaire across N rows -- inventing answers rather than
+ * recovering them. Nobody has held two active Quest enrollments in any year from
+ * 2021 to 2026 (max 1, every year), and a tripwire now warns if that changes:
+ * `countMultiQuestEnrollments` in quest_registrations.go.
+ *
+ * THE ADMISSION FILTER IS PRESERVED, AND THAT IS DELIBERATE. The dropped map
+ * did two jobs; only the relation is going. A person with values but no
+ * attendees row for the year is still excluded, because widening these tables
+ * is a different decision from un-breaking their links. It matters most for
+ * dietary: 19-35 people per year (2024-2026) hold Family Medical-* values with
+ * no attendees row, and whether they belong here is kindred#2306's question.
+ * For Quest the filter currently admits everyone (0 such people 2024-2026).
+ *
+ * NO DATA MIGRATION. Both tables are rebuilt from person_custom_values on every
+ * run and are sync-owned: no staff_touched column, no GUI write path.
+ *
+ * RULES: quest_registrations moves from admin-only to the same rule
+ * original_bunk_requests already carries. Owner ruling 2026-08-13: keep the
+ * data, gate it on bunking.manage. This is a WIDENING -- it opens the table to
+ * the Bunking Staff role -- and it is intentional, because the GUI for these
+ * normalized tables is pending and admin-only would make it unusable.
+ * camper_dietary is deliberately NOT widened here: it has no GUI either, and
+ * the convention is that a table's rule moves when its surface ships.
+ */
+migrate((app) => {
+  const bunkingManage =
+    '@request.auth.is_admin = true || @request.auth.cached_permissions ~ "bunking.manage"'
+
+  const targets = ["quest_registrations", "camper_dietary"]
+
+  for (let t = 0; t < targets.length; t++) {
+    const col = app.findCollectionByNameOrId(targets[t])
+
+    // Index first: dropping the field leaves an index over a column that is
+    // gone, which PocketBase will not rebuild for you.
+    col.indexes = col.indexes.filter(function (sql) {
+      return sql.indexOf("_attendee`") === -1
+    })
+
+    const field = col.fields.getByName("attendee")
+    if (field) {
+      col.fields.removeById(field.id)
+    }
+
+    app.save(col)
+  }
+
+  const quest = app.findCollectionByNameOrId("quest_registrations")
+  quest.listRule = bunkingManage
+  quest.viewRule = bunkingManage
+  app.save(quest)
+}, (app) => {
+  const adminOnly = '@request.auth.is_admin = true'
+
+  const quest = app.findCollectionByNameOrId("quest_registrations")
+  quest.listRule = adminOnly
+  quest.viewRule = adminOnly
+  app.save(quest)
+
+  const targets = ["quest_registrations", "camper_dietary"]
+  for (let t = 0; t < targets.length; t++) {
+    const name = targets[t]
+    const col = app.findCollectionByNameOrId(name)
+
+    if (!col.fields.getByName("attendee")) {
+      col.fields.add(new Field({
+        type: "relation",
+        name: "attendee",
+        collectionId: "col_attendees",
+        cascadeDelete: true,
+        maxSelect: 1,
+        minSelect: 0,
+        required: true,
+        presentable: false,
+        hidden: false,
+        system: false,
+      }))
+    }
+
+    const idx = "CREATE INDEX `idx_" + name + "_attendee` ON `" + name + "` (`attendee`)"
+    if (col.indexes.indexOf(idx) === -1) {
+      col.indexes = col.indexes.concat([idx])
+    }
+
+    app.save(col)
+  }
+})

--- a/pocketbase/pb_migrations/1500000153_drop_attendee_link_quest_dietary.js
+++ b/pocketbase/pb_migrations/1500000153_drop_attendee_link_quest_dietary.js
@@ -108,7 +108,17 @@ migrate((app) => {
         cascadeDelete: true,
         maxSelect: 1,
         minSelect: 0,
-        required: true,
+        // required: FALSE on the way back, deliberately, and this is not a
+        // slip. The column was `required: true` going out, but a rollback
+        // cannot repopulate it: the values are gone and the reverted sync no
+        // longer computes them. Re-adding it as required would make every
+        // subsequent save fail validation on rows that legitimately hold no
+        // attendee -- turning a rollback into an outage. A re-sync after the
+        // rollback repopulates nothing either, because the reverted code is
+        // what stopped writing it. Restoring the data needs the pre-#2261 sync
+        // AND a full re-run; the schema is all this `down` can honestly give
+        // back.
+        required: false,
         presentable: false,
         hidden: false,
         system: false,

--- a/pocketbase/sync/camper_dietary.go
+++ b/pocketbase/sync/camper_dietary.go
@@ -34,7 +34,7 @@ const (
 // This service reads from person_custom_values and populates the camper_dietary table.
 //
 // Unique key: (person_id, year) - one record per camper per year
-// Links to: attendees (any attendee record for this person-year)
+// No stored attendee link -- see loadPersonsWithAttendee (kindred#2265).
 //
 // Field mapping:
 // - Family Medical-Dietary Needs -> has_dietary_needs (bool)

--- a/pocketbase/sync/camper_dietary.go
+++ b/pocketbase/sync/camper_dietary.go
@@ -16,7 +16,7 @@ const serviceNameCamperDietary = "camper_dietary"
 // Only these fields are checked when deciding whether an existing record needs updating.
 // Excludes PocketBase-managed fields (id, created, updated, collectionId, collectionName).
 var camperDietaryCompareFields = []string{
-	"attendee", "person_id", "year",
+	"person_id", "year",
 	"has_dietary_needs", "dietary_explanation",
 	"has_allergies", "allergy_info", "additional_medical",
 }
@@ -44,9 +44,9 @@ const (
 // - Family Medical-Additional -> additional_medical
 //
 // Rows persist after a camper cancels; this table is never swept by deletion. A future reader
-// (e.g. a staff dashboard) must filter by active enrolment for the view's own year -- an
+// (e.g. a staff dashboard) must filter by active enrollment for the view's own year -- an
 // `attendees` row with status_id = 2 for that person and year -- and must not filter across
-// years. See "Reading Derived Informational Tables (Active-Enrolment Filtering)" in
+// years. See "Reading Derived Informational Tables (Active-Enrollment Filtering)" in
 // docs/architecture/sync-layer.md.
 type CamperDietarySync struct {
 	App    core.App
@@ -98,9 +98,8 @@ func (s *CamperDietarySync) DebugLog(msg string, args ...any) {
 
 // camperDietaryRecord holds the extracted dietary info for a camper
 type camperDietaryRecord struct {
-	personID   int
-	year       int
-	attendeeID string // PocketBase ID of an attendee record
+	personID int
+	year     int
 
 	hasDietaryNeeds    bool
 	dietaryExplanation string
@@ -142,15 +141,15 @@ func (s *CamperDietarySync) Sync(ctx context.Context) error {
 	}
 	slog.Info("Loaded field definitions", "count", len(fieldNameMap))
 
-	// Step 2: Load person -> attendee mapping (person CM ID -> attendee PB ID)
-	personToAttendee, err := s.loadPersonAttendeeMapping(ctx, year)
+	// Step 2: Load the admission set (person CM IDs with any attendees row this year)
+	personHasAttendee, err := s.loadPersonsWithAttendee(ctx, year)
 	if err != nil {
-		return fmt.Errorf("loading person-attendee mapping: %w", err)
+		return fmt.Errorf("loading persons with an attendee row: %w", err)
 	}
-	slog.Info("Loaded person-attendee mapping", "count", len(personToAttendee))
+	slog.Info("Loaded admission set", "count", len(personHasAttendee))
 
 	// Step 3: Load person custom values (Family Medical-* fields)
-	records, err := s.loadPersonCustomValues(ctx, year, fieldNameMap, personToAttendee)
+	records, err := s.loadPersonCustomValues(ctx, year, fieldNameMap, personHasAttendee)
 	if err != nil {
 		return fmt.Errorf("loading person custom values: %w", err)
 	}
@@ -253,12 +252,30 @@ func isCamperDietaryField(name string) bool {
 	return false
 }
 
-// loadPersonAttendeeMapping builds a map of person CM ID -> attendee PB ID
-// We use the first attendee record found for each person-year combination
-func (s *CamperDietarySync) loadPersonAttendeeMapping(
+// loadPersonsWithAttendee returns the set of person CM IDs holding at least one
+// `attendees` row for the year.
+//
+// It used to return person -> attendee PB ID, and that map did two jobs: admit a
+// person into the table, and supply a stored `attendee` relation. The relation is
+// gone (kindred#2265). It could never answer the question a reader would ask it --
+// kindred#2159 requires enrollment to be established by joining `(person_id, year)`
+// on `status_id = 2`, not by traversing a link -- so picking one of a camper's
+// several attendee rows was both arbitrary and unusable. Measured on the
+// production snapshot: 2,641 of 9,531 rows pointed at a non-enrolled attendee and
+// 530 of those discarded an enrolled candidate.
+//
+// The ADMISSION half is preserved exactly, and here that matters more than it does
+// for Quest: 19-35 people per year (2024-2026) hold Family Medical-* values with no
+// attendees row, so dropping the filter alongside the link would silently widen this
+// table. Whether they belong here is a real question, but it is kindred#2306's
+// question and not this change's.
+//
+// Membership is order-independent by construction: a set has no first element, so
+// the empty `sort` argument below can no longer decide anything.
+func (s *CamperDietarySync) loadPersonsWithAttendee(
 	ctx context.Context, year int,
-) (map[int]string, error) {
-	result := make(map[int]string)
+) (map[int]bool, error) {
+	hasAttendee := make(map[int]bool)
 
 	filter := fmt.Sprintf("year = %d", year)
 	page := 1
@@ -267,7 +284,7 @@ func (s *CamperDietarySync) loadPersonAttendeeMapping(
 	for {
 		select {
 		case <-ctx.Done():
-			return nil, fmt.Errorf("dietary needs query cancelled: %w", ctx.Err())
+			return nil, ctx.Err()
 		default:
 		}
 
@@ -277,12 +294,8 @@ func (s *CamperDietarySync) loadPersonAttendeeMapping(
 		}
 
 		for _, record := range records {
-			personID := record.GetInt("person_id")
-			if personID > 0 {
-				// First one wins (we just need any attendee for the relation)
-				if _, exists := result[personID]; !exists {
-					result[personID] = record.Id
-				}
+			if personID := record.GetInt("person_id"); personID > 0 {
+				hasAttendee[personID] = true
 			}
 		}
 
@@ -292,10 +305,9 @@ func (s *CamperDietarySync) loadPersonAttendeeMapping(
 		page++
 	}
 
-	return result, nil
+	return hasAttendee, nil
 }
 
-// dietaryValueEntry represents a loaded dietary custom value
 type dietaryValueEntry struct {
 	personID  int
 	fieldName string
@@ -304,7 +316,7 @@ type dietaryValueEntry struct {
 
 // loadPersonCustomValues loads person custom values for Family Medical-* fields
 func (s *CamperDietarySync) loadPersonCustomValues(
-	ctx context.Context, year int, fieldNameMap map[string]string, personToAttendee map[int]string,
+	ctx context.Context, year int, fieldNameMap map[string]string, personHasAttendee map[int]bool,
 ) (map[string]*camperDietaryRecord, error) {
 	// Collect all values first
 	var entries []dietaryValueEntry
@@ -373,31 +385,43 @@ func (s *CamperDietarySync) loadPersonCustomValues(
 		page++
 	}
 
-	// Aggregate to person level
+	return aggregateDietaryEntries(entries, year, personHasAttendee), nil
+}
+
+// aggregateDietaryEntries folds Family Medical-* custom values into one record
+// per person-year.
+//
+// Pure, and the real seam: the tests that previously covered this shape drove
+// buildDietaryRecords, a reimplementation living in the _test file, so they could
+// not fail when this code changed.
+//
+// `personHasAttendee` is an ADMISSION filter and nothing more -- see
+// loadPersonsWithAttendee. Because it is a set rather than a chosen row, the result
+// cannot depend on the order entries arrive in.
+func aggregateDietaryEntries(
+	entries []dietaryValueEntry, year int, personHasAttendee map[int]bool,
+) map[string]*camperDietaryRecord {
 	result := make(map[string]*camperDietaryRecord)
 
 	for _, entry := range entries {
-		attendeeID, hasAttendee := personToAttendee[entry.personID]
-		if !hasAttendee {
-			continue // Skip if no attendee record for this person
+		if !personHasAttendee[entry.personID] {
+			continue
 		}
 
 		key := makeCamperDietaryKey(entry.personID, year)
 		rec := result[key]
 		if rec == nil {
 			rec = &camperDietaryRecord{
-				personID:   entry.personID,
-				year:       year,
-				attendeeID: attendeeID,
+				personID: entry.personID,
+				year:     year,
 			}
 			result[key] = rec
 		}
 
-		// Map field to record
 		mapDietaryFieldToRecord(rec, entry.fieldName, entry.value)
 	}
 
-	return result, nil
+	return result
 }
 
 // mapDietaryFieldToRecord maps a Family Medical-* field to the record
@@ -526,7 +550,6 @@ func (s *CamperDietarySync) upsertRecords(
 
 		// Build data map for comparison
 		data := map[string]any{
-			"attendee":            rec.attendeeID,
 			"person_id":           rec.personID,
 			"year":                rec.year,
 			"has_dietary_needs":   rec.hasDietaryNeeds,

--- a/pocketbase/sync/camper_dietary_test.go
+++ b/pocketbase/sync/camper_dietary_test.go
@@ -388,8 +388,13 @@ func TestCamperDietaryCompareFields(t *testing.T) {
 	// excluding PocketBase-managed fields (id, created, updated, collectionId, collectionName).
 	// Unlike other services, this includes person_id and year since the original skipFields
 	// only excluded PB-managed fields (id, created, updated).
+	//
+	// `attendee` was removed here by kindred#2265, not because the implementation
+	// stopped writing it but because the column itself is gone: it stored one
+	// arbitrarily chosen attendee row per person-year, which kindred#2159 forbids any
+	// reader from using as an enrollment filter. Leaving it in this list after the
+	// column was dropped would mark every row dirty on every run.
 	expected := map[string]bool{
-		"attendee":            true,
 		"person_id":           true,
 		"year":                true,
 		"has_dietary_needs":   true,
@@ -435,7 +440,6 @@ func TestCamperDietaryRecordNeedsUpdateUsesCompareFields(t *testing.T) {
 
 	// Create a minimal collection with the fields used in comparison
 	col := core.NewBaseCollection("test_camper_dietary")
-	col.Fields.Add(&core.TextField{Name: "attendee"})
 	col.Fields.Add(&core.NumberField{Name: "person_id"})
 	col.Fields.Add(&core.NumberField{Name: "year"})
 	col.Fields.Add(&core.BoolField{Name: "has_dietary_needs"})
@@ -446,7 +450,6 @@ func TestCamperDietaryRecordNeedsUpdateUsesCompareFields(t *testing.T) {
 
 	t.Run("no update when all fields match", func(t *testing.T) {
 		existing := core.NewRecord(col)
-		existing.Set("attendee", "abc123")
 		existing.Set("person_id", 12345)
 		existing.Set("year", 2025)
 		existing.Set("has_dietary_needs", true)
@@ -456,7 +459,6 @@ func TestCamperDietaryRecordNeedsUpdateUsesCompareFields(t *testing.T) {
 		existing.Set("additional_medical", "")
 
 		newData := map[string]any{
-			"attendee":            "abc123",
 			"person_id":           12345,
 			"year":                2025,
 			"has_dietary_needs":   true,
@@ -473,7 +475,6 @@ func TestCamperDietaryRecordNeedsUpdateUsesCompareFields(t *testing.T) {
 
 	t.Run("needs update when a compare field differs", func(t *testing.T) {
 		existing := core.NewRecord(col)
-		existing.Set("attendee", "abc123")
 		existing.Set("person_id", 12345)
 		existing.Set("year", 2025)
 		existing.Set("has_dietary_needs", true)
@@ -483,7 +484,6 @@ func TestCamperDietaryRecordNeedsUpdateUsesCompareFields(t *testing.T) {
 		existing.Set("additional_medical", "")
 
 		newData := map[string]any{
-			"attendee":            "abc123",
 			"person_id":           12345,
 			"year":                2025,
 			"has_dietary_needs":   true,
@@ -583,5 +583,82 @@ func TestCamperDietaryDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
 	}
 	if deleted != 1 {
 		t.Errorf("deleted = %d, want 1", deleted)
+	}
+}
+
+// --- kindred#2265: the stored attendee link is dropped ---------------------
+//
+// These drive the PRODUCTION aggregation. TestDietaryRecordBuilding above
+// drives buildDietaryRecords, a reimplementation local to this _test file, so
+// it cannot fail when the real code changes.
+
+// TestAggregateDietaryEntriesKeepsAdmissionFilter pins the behavior that must
+// NOT change: a person holding Family Medical-* values but no attendees row for
+// the year stays excluded. Unlike Quest this is NOT a no-op -- on the production
+// snapshot 19-35 such people exist per year (2024-2026), so dropping the filter
+// with the link would silently widen the table. That is a separate decision
+// (kindred#2306's shape) and is not this change.
+func TestAggregateDietaryEntriesKeepsAdmissionFilter(t *testing.T) {
+	t.Parallel()
+	entries := []dietaryValueEntry{
+		{personID: 100, fieldName: "Family Medical-Allergies", value: "Yes"},
+		{personID: 200, fieldName: "Family Medical-Allergies", value: "Yes"},
+	}
+	hasAttendee := map[int]bool{100: true}
+
+	got := aggregateDietaryEntries(entries, 2026, hasAttendee)
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 admitted record, got %d", len(got))
+	}
+	if _, ok := got[makeCamperDietaryKey(100, 2026)]; !ok {
+		t.Error("person 100 has an attendee row and must be admitted")
+	}
+	if _, ok := got[makeCamperDietaryKey(200, 2026)]; ok {
+		t.Error("person 200 has no attendee row and must NOT be admitted")
+	}
+}
+
+// TestAggregateDietaryEntriesIsOrderIndependent is kindred#2257's probe.
+func TestAggregateDietaryEntriesIsOrderIndependent(t *testing.T) {
+	t.Parallel()
+	forward := []dietaryValueEntry{
+		{personID: 100, fieldName: "Family Medical-Allergies", value: "Yes"},
+		{personID: 100, fieldName: "Family Medical-Allergy Info", value: "peanuts"},
+		{personID: 200, fieldName: "Family Medical-Allergies", value: "No"},
+	}
+	reversed := make([]dietaryValueEntry, len(forward))
+	for i, e := range forward {
+		reversed[len(forward)-1-i] = e
+	}
+	hasAttendee := map[int]bool{100: true, 200: true}
+
+	a := aggregateDietaryEntries(forward, 2026, hasAttendee)
+	b := aggregateDietaryEntries(reversed, 2026, hasAttendee)
+
+	if len(a) != len(b) {
+		t.Fatalf("record count differs by input order: %d vs %d", len(a), len(b))
+	}
+	for key, ra := range a {
+		rb, ok := b[key]
+		if !ok {
+			t.Fatalf("key %q present in one ordering only", key)
+			return
+		}
+		if ra.hasAllergies != rb.hasAllergies || ra.allergyInfo != rb.allergyInfo {
+			t.Errorf("key %q resolved differently by input order", key)
+		}
+	}
+}
+
+// TestCamperDietaryCompareFieldsHasNoAttendee stops the dropped column being
+// reintroduced through the idempotency comparison, which would make every row
+// look dirty on every run.
+func TestCamperDietaryCompareFieldsHasNoAttendee(t *testing.T) {
+	t.Parallel()
+	for _, f := range camperDietaryCompareFields {
+		if f == "attendee" {
+			t.Error("camperDietaryCompareFields still lists the dropped `attendee` column")
+		}
 	}
 }

--- a/pocketbase/sync/quest_registrations.go
+++ b/pocketbase/sync/quest_registrations.go
@@ -32,7 +32,7 @@ const (
 // This service reads from person_custom_values and populates the quest_registrations table.
 //
 // Unique key: (person_id, year) - one record per Quest participant per year
-// Links to: attendees
+// No stored attendee link -- see loadPersonsWithAttendee (kindred#2261).
 //
 // Field mapping: 45+ Quest-* and Q-* prefixed fields covering signatures, preferences,
 // parent questionnaires, and transportation details.
@@ -201,7 +201,10 @@ func (s *QuestRegistrationsSync) Sync(ctx context.Context) error {
 	}
 	slog.Info("Loaded admission set", "count", len(personHasAttendee))
 	if multiQuest > 0 {
-		// Zero on every year 2021-2026. If this ever fires, the assumption behind
+		// Zero on every year 2021-2026 -- but NOT on every year this sync can be
+		// asked for. 2017 has one person with two active Quest sessions, and
+		// quest_registrations holds 72 rows for 2017, so a pre-2021 backfill fires
+		// this benignly. For a CURRENT season it means the assumption behind
 		// kindred#2261 -- that the questionnaire is person x year -- has changed
 		// upstream, and the table needs a session dimension before anyone trusts it.
 		// Deliberately a log line and not a Stats counter. Adding a field to Stats
@@ -307,29 +310,6 @@ func isQuestRegistrationField(name string) bool {
 		strings.HasPrefix(name, "Quest ")
 }
 
-// loadPersonsWithAttendee returns the set of person CM IDs holding at least one
-// `attendees` row for the year, plus a count of people holding two or more
-// ACTIVE (status_id = 2) Quest enrollments.
-//
-// It used to return person -> attendee PB ID, and that map did two jobs: it
-// admitted a person into the table, and it supplied a stored `attendee`
-// relation. The relation is gone (kindred#2261) because it could never answer
-// the question a reader would ask it -- kindred#2159 requires enrollment to be
-// established by joining `(person_id, year)` on `status_id = 2`, not by
-// traversing a link. Picking one of a person's several attendee rows to store
-// was therefore arbitrary AND unusable; measured on the production snapshot,
-// 125 of 679 rows pointed at a non-enrolled attendee and 71 of those discarded
-// an enrolled candidate.
-//
-// The ADMISSION half is preserved exactly. A person with Quest values but no
-// attendees row for the year is still excluded. On the production snapshot that
-// exclusion currently admits everyone (0 people in 2024-2026 hold Quest values
-// without an attendees row), which is precisely why it is pinned by a test
-// rather than left as an assumption.
-//
-// Membership is order-independent by construction: a set has no first element,
-// so the empty `sort` argument below can no longer decide anything. That is the
-// order-independence probe kindred#2257 asks for, satisfied structurally.
 // isCountableQuestEnrollment decides whether one attendees row counts toward the
 // multi-Quest tripwire. Pure so the rule is testable without a database -- the
 // bug it exists to prevent (counting every session type, not just Quest) would
@@ -363,9 +343,6 @@ func isCountableQuestEnrollment(statusID int, sessionID string, questSessionIDs 
 //     in isCountableQuestEnrollment, so nothing goes uncovered.
 //
 // A few hundred rows all-time; read once per run.
-// sessionTypeQuest is the camp_sessions.session_type value for a Quest session.
-const sessionTypeQuest = "quest"
-
 func (s *QuestRegistrationsSync) loadQuestSessionIDs() (map[string]bool, error) {
 	ids := make(map[string]bool)
 	records, err := s.App.FindRecordsByFilter("camp_sessions", "", "id", 0, 0)
@@ -380,12 +357,43 @@ func (s *QuestRegistrationsSync) loadQuestSessionIDs() (map[string]bool, error) 
 	return ids, nil
 }
 
+// loadPersonsWithAttendee returns the set of person CM IDs holding at least one
+// `attendees` row for the year, plus a count of people holding two or more
+// ACTIVE (status_id = 2) Quest enrollments.
+//
+// It used to return person -> attendee PB ID, and that map did two jobs: it
+// admitted a person into the table, and it supplied a stored `attendee`
+// relation. The relation is gone (kindred#2261) because it could never answer
+// the question a reader would ask it -- kindred#2159 requires enrollment to be
+// established by joining `(person_id, year)` on `status_id = 2`, not by
+// traversing a link. Picking one of a person's several attendee rows to store
+// was therefore arbitrary AND unusable; measured on the production snapshot,
+// 125 of 679 rows pointed at a non-enrolled attendee and 71 of those discarded
+// an enrolled candidate.
+//
+// The ADMISSION half is preserved exactly. A person with Quest values but no
+// attendees row for the year is still excluded. On the production snapshot that
+// exclusion currently admits everyone (0 people in 2024-2026 hold Quest values
+// without an attendees row), which is precisely why it is pinned by a test
+// rather than left as an assumption.
+//
+// Membership is order-independent by construction: a set has no first element,
+// so the empty `sort` argument below can no longer decide anything. That is the
+// order-independence probe kindred#2257 asks for, satisfied structurally.
 func (s *QuestRegistrationsSync) loadPersonsWithAttendee(
 	ctx context.Context, year int,
 ) (hasAttendee map[int]bool, multiEnrolled int, err error) {
+	// DEGRADE, do not abort. The Quest-session set feeds only the observational
+	// tripwire; the admission set below does not use it. Before this code existed
+	// nothing about camp_sessions could fail this sync, and letting a transient
+	// read failure block the whole questionnaire refresh would trade a real
+	// refresh for a counter that has never fired. Warn and carry on with an empty
+	// set: the tripwire goes quiet, everything else is unaffected.
 	questSessionIDs, err := s.loadQuestSessionIDs()
 	if err != nil {
-		return nil, 0, err
+		slog.Warn("could not load Quest sessions; the multi-Quest tripwire is disabled for this run",
+			"year", year, "error", err)
+		questSessionIDs = map[string]bool{}
 	}
 	hasAttendee = make(map[int]bool)
 	// person CM ID -> the distinct quest sessions they are ACTIVELY enrolled in
@@ -433,7 +441,9 @@ func (s *QuestRegistrationsSync) loadPersonsWithAttendee(
 }
 
 // countMultiQuestEnrollments counts people holding two or more distinct active
-// enrollments in one year.
+// QUEST enrollments in one year. The caller pre-filters every row through
+// isCountableQuestEnrollment, so a person doing two summer sessions must never
+// reach this map -- broadening the caller restores 201-338 false fires a year.
 //
 // This guards the assumption the kindred#2261 fix rests on, and it exists
 // because "has never happened" is not "cannot happen". Nobody has held two
@@ -1113,7 +1123,7 @@ func (s *QuestRegistrationsSync) deleteOrphans(
 		Entity:   "quest_registrations",
 		Year:     year,
 		Computed: len(records),
-		Hint:     "check that the attendee mapping and the Quest-/Q-* field definitions still exist upstream",
+		Hint:     "check that the Quest-/Q-* field definitions and the attendees rows for this year still exist upstream",
 	}
 	if err := guard.Check(len(existingRecords)); err != nil {
 		return 0, err

--- a/pocketbase/sync/quest_registrations.go
+++ b/pocketbase/sync/quest_registrations.go
@@ -330,9 +330,63 @@ func isQuestRegistrationField(name string) bool {
 // Membership is order-independent by construction: a set has no first element,
 // so the empty `sort` argument below can no longer decide anything. That is the
 // order-independence probe kindred#2257 asks for, satisfied structurally.
+// isCountableQuestEnrollment decides whether one attendees row counts toward the
+// multi-Quest tripwire. Pure so the rule is testable without a database -- the
+// bug it exists to prevent (counting every session type, not just Quest) would
+// have fired on 201-338 people a year instead of 0, i.e. on every single run.
+func isCountableQuestEnrollment(statusID int, sessionID string, questSessionIDs map[string]bool) bool {
+	// Only ACTIVE enrollments: a cancelled Quest followed by a different one is
+	// one Quest, not two.
+	if statusID != statusIDActiveEnrolled {
+		return false
+	}
+	if sessionID == "" {
+		return false
+	}
+	return questSessionIDs[sessionID]
+}
+
+// loadQuestSessionIDs returns the PB ids of every Quest session, across all years.
+//
+// Two deliberate choices, both about not coupling an observational tripwire to
+// things it does not need:
+//
+//   - NOT year-filtered. A session PB id is unique per row and the attendees rows
+//     this set is matched against are already scoped to one year, so a year
+//     predicate would change nothing.
+//   - Filtered in Go rather than in the query. The shared test fixtures for
+//     camp_sessions declare neither `year` nor `session_type`, and a filter naming
+//     an undeclared field is a hard error in PocketBase, not an empty result. In a
+//     fixture without the field every GetString returns "", so the Quest set comes
+//     back empty and the tripwire simply never fires -- which is the right failure
+//     mode for a counter that only warns. The rule itself is unit-tested directly
+//     in isCountableQuestEnrollment, so nothing goes uncovered.
+//
+// A few hundred rows all-time; read once per run.
+// sessionTypeQuest is the camp_sessions.session_type value for a Quest session.
+const sessionTypeQuest = "quest"
+
+func (s *QuestRegistrationsSync) loadQuestSessionIDs() (map[string]bool, error) {
+	ids := make(map[string]bool)
+	records, err := s.App.FindRecordsByFilter("camp_sessions", "", "id", 0, 0)
+	if err != nil {
+		return nil, fmt.Errorf("querying camp sessions: %w", err)
+	}
+	for _, r := range records {
+		if r.GetString("session_type") == sessionTypeQuest {
+			ids[r.Id] = true
+		}
+	}
+	return ids, nil
+}
+
 func (s *QuestRegistrationsSync) loadPersonsWithAttendee(
 	ctx context.Context, year int,
 ) (hasAttendee map[int]bool, multiEnrolled int, err error) {
+	questSessionIDs, err := s.loadQuestSessionIDs()
+	if err != nil {
+		return nil, 0, err
+	}
 	hasAttendee = make(map[int]bool)
 	// person CM ID -> the distinct quest sessions they are ACTIVELY enrolled in
 	questSessions := make(map[int][]string)
@@ -360,13 +414,8 @@ func (s *QuestRegistrationsSync) loadPersonsWithAttendee(
 			}
 			hasAttendee[personID] = true
 
-			// Only ACTIVE enrollments count toward the multi-quest guard: a
-			// cancelled Quest followed by a different one is one Quest, not two.
-			if record.GetInt("status_id") != statusIDActiveEnrolled {
-				continue
-			}
 			sessionID := record.GetString("session")
-			if sessionID == "" {
+			if !isCountableQuestEnrollment(record.GetInt("status_id"), sessionID, questSessionIDs) {
 				continue
 			}
 			if !slices.Contains(questSessions[personID], sessionID) {

--- a/pocketbase/sync/quest_registrations.go
+++ b/pocketbase/sync/quest_registrations.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 
 	"github.com/pocketbase/pocketbase/core"
@@ -37,9 +38,9 @@ const (
 // parent questionnaires, and transportation details.
 //
 // Rows persist after a participant cancels; this table is never swept by deletion. A future
-// reader (e.g. a staff dashboard) must filter by active enrolment for the view's own year -- an
+// reader (e.g. a staff dashboard) must filter by active enrollment for the view's own year -- an
 // `attendees` row with status_id = 2 for that person and year -- and must not filter across
-// years. See "Reading Derived Informational Tables (Active-Enrolment Filtering)" in
+// years. See "Reading Derived Informational Tables (Active-Enrollment Filtering)" in
 // docs/architecture/sync-layer.md.
 type QuestRegistrationsSync struct {
 	App    core.App
@@ -91,9 +92,8 @@ func (s *QuestRegistrationsSync) DebugLog(msg string, args ...any) {
 
 // questRegistrationRecord holds the extracted Quest info for a participant
 type questRegistrationRecord struct {
-	personID   int
-	year       int
-	attendeeID string
+	personID int
+	year     int
 
 	// Signatures
 	parentSignature  string
@@ -193,15 +193,28 @@ func (s *QuestRegistrationsSync) Sync(ctx context.Context) error {
 	}
 	slog.Info("Loaded field definitions", "count", len(fieldNameMap))
 
-	// Step 2: Load person -> attendee mapping
-	personToAttendee, err := s.loadPersonAttendeeMapping(ctx, year)
+	// Step 2: Load the admission set (person CM IDs with any attendees row this
+	// year) and the multi-enrollment tripwire count.
+	personHasAttendee, multiQuest, err := s.loadPersonsWithAttendee(ctx, year)
 	if err != nil {
-		return fmt.Errorf("loading person-attendee mapping: %w", err)
+		return fmt.Errorf("loading persons with an attendee row: %w", err)
 	}
-	slog.Info("Loaded person-attendee mapping", "count", len(personToAttendee))
+	slog.Info("Loaded admission set", "count", len(personHasAttendee))
+	if multiQuest > 0 {
+		// Zero on every year 2021-2026. If this ever fires, the assumption behind
+		// kindred#2261 -- that the questionnaire is person x year -- has changed
+		// upstream, and the table needs a session dimension before anyone trusts it.
+		// Deliberately a log line and not a Stats counter. Adding a field to Stats
+		// means editing orchestrator.go, which every sync shares and which
+		// kindred#2257's guardrail work already serializes on; and the counter that
+		// would actually belong there (Rejected) is blocked on kindred#2292's typed
+		// errors. A tripwire that has never fired does not justify that collision.
+		slog.Warn("people hold more than one active Quest enrollment; kindred#2261's person-year grain may no longer hold",
+			"year", year, "people", multiQuest)
+	}
 
 	// Step 3: Load person custom values (Quest-* and Q-* fields)
-	records, err := s.loadPersonCustomValues(ctx, year, fieldNameMap, personToAttendee)
+	records, err := s.loadPersonCustomValues(ctx, year, fieldNameMap, personHasAttendee)
 	if err != nil {
 		return fmt.Errorf("loading person custom values: %w", err)
 	}
@@ -294,11 +307,35 @@ func isQuestRegistrationField(name string) bool {
 		strings.HasPrefix(name, "Quest ")
 }
 
-// loadPersonAttendeeMapping builds a map of person CM ID -> attendee PB ID
-func (s *QuestRegistrationsSync) loadPersonAttendeeMapping(
+// loadPersonsWithAttendee returns the set of person CM IDs holding at least one
+// `attendees` row for the year, plus a count of people holding two or more
+// ACTIVE (status_id = 2) Quest enrollments.
+//
+// It used to return person -> attendee PB ID, and that map did two jobs: it
+// admitted a person into the table, and it supplied a stored `attendee`
+// relation. The relation is gone (kindred#2261) because it could never answer
+// the question a reader would ask it -- kindred#2159 requires enrollment to be
+// established by joining `(person_id, year)` on `status_id = 2`, not by
+// traversing a link. Picking one of a person's several attendee rows to store
+// was therefore arbitrary AND unusable; measured on the production snapshot,
+// 125 of 679 rows pointed at a non-enrolled attendee and 71 of those discarded
+// an enrolled candidate.
+//
+// The ADMISSION half is preserved exactly. A person with Quest values but no
+// attendees row for the year is still excluded. On the production snapshot that
+// exclusion currently admits everyone (0 people in 2024-2026 hold Quest values
+// without an attendees row), which is precisely why it is pinned by a test
+// rather than left as an assumption.
+//
+// Membership is order-independent by construction: a set has no first element,
+// so the empty `sort` argument below can no longer decide anything. That is the
+// order-independence probe kindred#2257 asks for, satisfied structurally.
+func (s *QuestRegistrationsSync) loadPersonsWithAttendee(
 	ctx context.Context, year int,
-) (map[int]string, error) {
-	result := make(map[int]string)
+) (hasAttendee map[int]bool, multiEnrolled int, err error) {
+	hasAttendee = make(map[int]bool)
+	// person CM ID -> the distinct quest sessions they are ACTIVELY enrolled in
+	questSessions := make(map[int][]string)
 
 	filter := fmt.Sprintf("year = %d", year)
 	page := 1
@@ -307,21 +344,33 @@ func (s *QuestRegistrationsSync) loadPersonAttendeeMapping(
 	for {
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, 0, ctx.Err()
 		default:
 		}
 
 		records, err := s.App.FindRecordsByFilter("attendees", filter, "", perPage, (page-1)*perPage)
 		if err != nil {
-			return nil, fmt.Errorf("querying attendees page %d: %w", page, err)
+			return nil, 0, fmt.Errorf("querying attendees page %d: %w", page, err)
 		}
 
 		for _, record := range records {
 			personID := record.GetInt("person_id")
-			if personID > 0 {
-				if _, exists := result[personID]; !exists {
-					result[personID] = record.Id
-				}
+			if personID <= 0 {
+				continue
+			}
+			hasAttendee[personID] = true
+
+			// Only ACTIVE enrollments count toward the multi-quest guard: a
+			// cancelled Quest followed by a different one is one Quest, not two.
+			if record.GetInt("status_id") != statusIDActiveEnrolled {
+				continue
+			}
+			sessionID := record.GetString("session")
+			if sessionID == "" {
+				continue
+			}
+			if !slices.Contains(questSessions[personID], sessionID) {
+				questSessions[personID] = append(questSessions[personID], sessionID)
 			}
 		}
 
@@ -331,7 +380,32 @@ func (s *QuestRegistrationsSync) loadPersonAttendeeMapping(
 		page++
 	}
 
-	return result, nil
+	return hasAttendee, countMultiQuestEnrollments(questSessions), nil
+}
+
+// countMultiQuestEnrollments counts people holding two or more distinct active
+// enrollments in one year.
+//
+// This guards the assumption the kindred#2261 fix rests on, and it exists
+// because "has never happened" is not "cannot happen". Nobody has held two
+// Quest enrollments in any year from 2021 to 2026 (max 1, every year), and the
+// questionnaire is person x year AT THE SOURCE -- `person_custom_values` is
+// UNIQUE(year, person, field_definition), so a second Quest could not carry a
+// second set of answers even in principle. Adding a session dimension would
+// therefore fan one questionnaire across N rows, inventing answers rather than
+// recovering them.
+//
+// So the correct protection is not a schema dimension, it is a tripwire: if the
+// registration form ever starts allowing two, this counter is how we find out,
+// instead of silently storing one questionnaire against an arbitrary session.
+func countMultiQuestEnrollments(sessionsByPerson map[int][]string) int {
+	n := 0
+	for _, sessions := range sessionsByPerson {
+		if len(sessions) > 1 {
+			n++
+		}
+	}
+	return n
 }
 
 // questValueEntry represents a loaded Quest custom value
@@ -343,7 +417,7 @@ type questValueEntry struct {
 
 // loadPersonCustomValues loads person custom values for Quest fields
 func (s *QuestRegistrationsSync) loadPersonCustomValues(
-	ctx context.Context, year int, fieldNameMap map[string]string, personToAttendee map[int]string,
+	ctx context.Context, year int, fieldNameMap map[string]string, personHasAttendee map[int]bool,
 ) (map[string]*questRegistrationRecord, error) {
 	var entries []questValueEntry
 
@@ -411,12 +485,26 @@ func (s *QuestRegistrationsSync) loadPersonCustomValues(
 		page++
 	}
 
-	// Aggregate to person level
+	return aggregateQuestEntries(entries, year, personHasAttendee), nil
+}
+
+// aggregateQuestEntries folds Quest custom values into one record per person-year.
+//
+// Pure and exported to the test package deliberately. The tests that previously
+// covered this shape (TestQuestRecordBuilding) drove `buildQuestRecords`, a
+// reimplementation living in the _test file, so they could not fail when this
+// code changed. This is the real seam.
+//
+// `personHasAttendee` is an ADMISSION filter and nothing more -- see
+// loadPersonsWithAttendee. Because it is a set rather than a chosen row, the
+// result cannot depend on the order entries arrive in.
+func aggregateQuestEntries(
+	entries []questValueEntry, year int, personHasAttendee map[int]bool,
+) map[string]*questRegistrationRecord {
 	result := make(map[string]*questRegistrationRecord)
 
 	for _, entry := range entries {
-		attendeeID, hasAttendee := personToAttendee[entry.personID]
-		if !hasAttendee {
+		if !personHasAttendee[entry.personID] {
 			continue
 		}
 
@@ -424,9 +512,8 @@ func (s *QuestRegistrationsSync) loadPersonCustomValues(
 		rec := result[key]
 		if rec == nil {
 			rec = &questRegistrationRecord{
-				personID:   entry.personID,
-				year:       year,
-				attendeeID: attendeeID,
+				personID: entry.personID,
+				year:     year,
 			}
 			result[key] = rec
 		}
@@ -434,7 +521,7 @@ func (s *QuestRegistrationsSync) loadPersonCustomValues(
 		mapQuestFieldToRecord(rec, entry.fieldName, entry.value)
 	}
 
-	return result, nil
+	return result
 }
 
 // mapQuestFieldToRecord maps a Quest-*/Q-* field to the record
@@ -863,7 +950,6 @@ func (s *QuestRegistrationsSync) upsertRecords(
 		}
 
 		// Set all fields
-		record.Set("attendee", rec.attendeeID)
 		record.Set("person_id", rec.personID)
 		record.Set("year", rec.year)
 

--- a/pocketbase/sync/quest_registrations_test.go
+++ b/pocketbase/sync/quest_registrations_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
 )
 
 // TestQuestRegistrationsLoadFieldDefinitionsTrimsNames is a regression test
@@ -682,5 +683,62 @@ func TestIsCountableQuestEnrollment(t *testing.T) {
 					tc.statusID, tc.sessionID, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestLoadQuestSessionIDsPinsTheSchemaIdentifiers is the coverage the scan of
+// PR #2308 found missing. loadQuestSessionIDs filters in Go rather than in the
+// query, which is deliberate -- but it makes a broken read indistinguishable
+// from an empty one: rename the `session_type` field or change the enum value
+// and GetString returns "" for every row, the Quest set is empty,
+// isCountableQuestEnrollment refuses everything, and the tripwire goes
+// permanently dark with a green suite. That is precisely the "silently never
+// fires" mode the tripwire exists to avoid.
+//
+// This pins all four identifiers at once: the collection name `camp_sessions`,
+// the field `session_type`, the literal value `quest`, and that a non-Quest
+// session is excluded.
+func TestLoadQuestSessionIDsPinsTheSchemaIdentifiers(t *testing.T) {
+	t.Parallel()
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	defer app.Cleanup()
+
+	col := core.NewBaseCollection("camp_sessions")
+	col.Fields.Add(&core.TextField{Name: "session_type"})
+	if saveErr := app.Save(col); saveErr != nil {
+		t.Fatal(saveErr)
+		return
+	}
+
+	save := func(sessionType string) string {
+		r := core.NewRecord(col)
+		r.Set("session_type", sessionType)
+		if saveErr := app.Save(r); saveErr != nil {
+			t.Fatal(saveErr)
+		}
+		return r.Id
+	}
+	questID := save(sessionTypeQuest)
+	summerID := save(sessionTypeMain)
+
+	s := &QuestRegistrationsSync{App: app}
+	ids, err := s.loadQuestSessionIDs()
+	if err != nil {
+		t.Fatalf("loadQuestSessionIDs returned %v, want nil", err)
+		return
+	}
+
+	if !ids[questID] {
+		t.Error("quest session missing — check the collection name, the `session_type` field, and the `quest` value")
+	}
+	if ids[summerID] {
+		t.Error("a non-Quest session was returned; the tripwire would fire on summer enrollments")
+	}
+	if len(ids) != 1 {
+		t.Errorf("got %d session ids, want exactly 1", len(ids))
 	}
 }

--- a/pocketbase/sync/quest_registrations_test.go
+++ b/pocketbase/sync/quest_registrations_test.go
@@ -554,3 +554,99 @@ func TestQuestRegistrationsDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) 
 		t.Errorf("deleted = %d, want 1", deleted)
 	}
 }
+
+// --- kindred#2261: the stored attendee link is dropped ---------------------
+//
+// These exercise the PRODUCTION aggregation, unlike TestQuestRecordBuilding
+// above, which drives a reimplementation local to this file (buildQuestRecords)
+// and therefore cannot fail when the real code changes.
+
+// TestAggregateQuestEntriesKeepsAdmissionFilter pins the behavior that must
+// NOT change when the attendee relation is removed: a person holding Quest
+// values but carrying no attendees row for the year is still excluded.
+// Measured on the production snapshot this is a no-op today (0 such people in
+// 2024-2026) -- which is exactly why it needs a test rather than an assumption.
+func TestAggregateQuestEntriesKeepsAdmissionFilter(t *testing.T) {
+	t.Parallel()
+	entries := []questValueEntry{
+		{personID: 100, fieldName: "Q-Why come?", value: "adventure"},
+		{personID: 200, fieldName: "Q-Why come?", value: "friends"},
+	}
+	// 100 is enrolled somewhere this year; 200 is not.
+	hasAttendee := map[int]bool{100: true}
+
+	got := aggregateQuestEntries(entries, 2026, hasAttendee)
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 admitted record, got %d", len(got))
+	}
+	if _, ok := got[makeQuestRegistrationKey(100, 2026)]; !ok {
+		t.Error("person 100 has an attendee row and must be admitted")
+	}
+	if _, ok := got[makeQuestRegistrationKey(200, 2026)]; ok {
+		t.Error("person 200 has no attendee row and must NOT be admitted")
+	}
+}
+
+// TestAggregateQuestEntriesIsOrderIndependent is the probe kindred#2257 calls
+// for. The old code kept whichever attendees row the query plan yielded first
+// (sort was ""), so output depended on input order. Permuting the input must
+// now produce identical output.
+func TestAggregateQuestEntriesIsOrderIndependent(t *testing.T) {
+	t.Parallel()
+	forward := []questValueEntry{
+		{personID: 100, fieldName: "Q-Why come?", value: "adventure"},
+		{personID: 100, fieldName: "Q-biggest hope", value: "new friends"},
+		{personID: 200, fieldName: "Q-Why come?", value: "friends"},
+	}
+	reversed := make([]questValueEntry, len(forward))
+	for i, e := range forward {
+		reversed[len(forward)-1-i] = e
+	}
+	hasAttendee := map[int]bool{100: true, 200: true}
+
+	a := aggregateQuestEntries(forward, 2026, hasAttendee)
+	b := aggregateQuestEntries(reversed, 2026, hasAttendee)
+
+	if len(a) != len(b) {
+		t.Fatalf("record count differs by input order: %d vs %d", len(a), len(b))
+	}
+	for key, ra := range a {
+		rb, ok := b[key]
+		if !ok {
+			t.Fatalf("key %q present in one ordering only", key)
+			return
+		}
+		if ra.whyCome != rb.whyCome || ra.biggestHope != rb.biggestHope {
+			t.Errorf("key %q resolved differently by input order: %+v vs %+v", key, ra, rb)
+		}
+	}
+}
+
+// TestCountMultiQuestEnrollments guards the assumption this change rests on.
+// Nobody has ever held two Quest enrollments in one year (max 1 in every year
+// 2021-2026), and the questionnaire is person x year at the source -- one value
+// per (year, person, field), enforced by UNIQUE(year, person, field_definition).
+// So a session dimension would duplicate rather than recover. If the form ever
+// starts allowing two, we must hear about it instead of silently picking.
+func TestCountMultiQuestEnrollments(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name           string
+		sessionsByCMID map[int][]string
+		want           int
+	}{
+		{"nobody doubles", map[int][]string{100: {"s1"}, 200: {"s2"}}, 0},
+		{"one person doubles", map[int][]string{100: {"s1", "s2"}, 200: {"s2"}}, 1},
+		{"two people double", map[int][]string{100: {"s1", "s2"}, 200: {"s2", "s3"}}, 2},
+		{"empty", map[int][]string{}, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := countMultiQuestEnrollments(tc.sessionsByCMID); got != tc.want {
+				t.Errorf("countMultiQuestEnrollments = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/pocketbase/sync/quest_registrations_test.go
+++ b/pocketbase/sync/quest_registrations_test.go
@@ -650,3 +650,37 @@ func TestCountMultiQuestEnrollments(t *testing.T) {
 		})
 	}
 }
+
+// TestIsCountableQuestEnrollment pins the session-type filter on the multi-Quest
+// tripwire. Without it the counter walked every attendees row for the year and
+// counted ANY session, so a camper doing two summer sessions tripped a warning
+// about Quest capacity: 201 (2026), 248 (2025) and 338 (2024) people would have
+// warned, against a true count of 0 in every year. A tripwire that fires on
+// every run is worse than none, because it teaches people to ignore it.
+func TestIsCountableQuestEnrollment(t *testing.T) {
+	t.Parallel()
+	quest := map[string]bool{"qs1": true, "qs2": true}
+
+	tests := []struct {
+		name      string
+		statusID  int
+		sessionID string
+		want      bool
+	}{
+		{"active quest session counts", statusIDActiveEnrolled, "qs1", true},
+		{"a second quest session counts", statusIDActiveEnrolled, "qs2", true},
+		{"a SUMMER session does not", statusIDActiveEnrolled, "summer1", false},
+		{"cancelled quest does not", 8, "qs1", false},
+		{"waitlisted quest does not", 32, "qs1", false},
+		{"empty session id does not", statusIDActiveEnrolled, "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isCountableQuestEnrollment(tc.statusID, tc.sessionID, quest); got != tc.want {
+				t.Errorf("isCountableQuestEnrollment(%d, %q) = %v, want %v",
+					tc.statusID, tc.sessionID, got, tc.want)
+			}
+		})
+	}
+}

--- a/pocketbase/sync/sessions.go
+++ b/pocketbase/sync/sessions.go
@@ -22,6 +22,7 @@ const (
 	sessionTypeTLI      = "tli"
 	sessionTypeSCIT     = "scit"
 	sessionTypeOther    = "other"
+	sessionTypeQuest    = "quest"
 )
 
 // Session group cm_ids - these are stable across all years in CampMinder


### PR DESCRIPTION
Both tables are person × year — already unique on `(person_id, year)`, so the `attendee` relation was never part of the key. The sync walked every `attendees` row for the year and kept the first one it met per person, with **no status filter and an empty `sort` argument**. PocketBase omits `ORDER BY` entirely when sort is `""`, so "first" was a query-plan artifact rather than a rule. This is a *genuinely* unordered site, unlike the `family_camp_derived` ones which sort by `id`.

## Measured against the production snapshot

| table | rows | pointed at a non-enrolled attendee | discarded an enrolled candidate |
|---|---|---|---|
| `quest_registrations` | 679 | 125 | **71** |
| `camper_dietary` | 9,531 | 2,641 | **530** |

## Why it could not be fixed by choosing better

kindred#2159 ruled that a reader must establish enrollment by joining `(person_id, year)` on `status_id = 2`, **never by traversing a stored link**. So the relation could not answer the only question anyone would ask it, however it was picked. A deterministic pick would have produced a *stably wrong* link — a subtler trap than an absent one, because it stops looking suspicious. The relation also shipped its own index, advertising exactly the misuse.

## `cascadeDelete` made it a data-loss vector, not just a bad pointer

The relation carried `cascadeDelete: true`, and `AttendeesSync.deleteOrphans` really does delete attendee rows. So when CampMinder dropped the particular row this table had happened to pick, PocketBase deleted **the camper's whole questionnaire with it** — 50+ columns of Quest answers, or a dietary and allergy record. Which campers lost data depended on which of their attendee rows an unordered query yielded first.

This is the strongest reason to remove the column rather than re-point it, and it was not known when the issues were filed.

## Why not a session dimension instead

The questionnaires are person × year **at the source**: `person_custom_values` is `UNIQUE(year, person, field_definition)` with zero duplicate key groups, so a second enrollment could not carry a second set of answers even in principle. Session grain would fan one questionnaire across N rows — inventing answers rather than recovering them.

Nobody has held two active Quest enrollments in any year 2021–2026 (max 1, every year). Because *"has never happened"* is not *"cannot happen"*, `countMultiQuestEnrollments` now warns if that changes.

## The admission filter is preserved, deliberately

The dropped map did two jobs; only the relation is going. A person with values but no attendees row for the year is **still excluded**. That matters most for dietary, where 19–35 people per year (2024–2026) hold `Family Medical-*` values with no attendees row — whether they belong here is kindred#2306's question, not this change's. For Quest the filter currently admits everyone.

## Testing

Extracts `aggregateQuestEntries` and `aggregateDietaryEntries` as pure functions and tests **those**. The existing `TestQuestRecordBuilding` / `TestDietaryRecordBuilding` drive `buildQuestRecords`/`buildDietaryRecords`, which are reimplementations living in the `_test` files — they could not fail when the production aggregation changed.

New tests include the **order-independence probe** kindred#2257 asks for. Both admission tests were **mutation-checked**: removing the filter turns them red, and restoring it turns them green.

## Verification

Applied and reverted against a 716 MB copy of the production database:

- column and index gone from both tables; **every other index intact**
- all **679** and **9,531** rows preserved (no cascade wipe)
- `migrate down` restores field, index and rules
- full Go suite green; `golangci-lint ./sync/...` → 0 issues; `scripts/pre-push-verify.sh` exit 0

## RBAC

`quest_registrations` moves from admin-only to the rule `original_bunk_requests` already carries. **This is a widening** — it opens the table to the Bunking Staff role — and it is intentional: the GUI for these normalized tables is pending and admin-only would make it unusable. `camper_dietary` is deliberately **not** widened; the convention is that a table's rule moves when its surface ships.

Closes #2261.
Closes #2265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data Updates**
  * Dietary records and Quest registrations now use person-based associations instead of attendee links.
  * Quest registration access is available to authorized bunking managers.

* **Bug Fixes**
  * Improved filtering and aggregation for dietary and Quest data.
  * Prevented duplicate Quest enrollments from being counted multiple times.
  * Results are now consistent regardless of record order.

* **Reliability**
  * Added validation and regression coverage for admission filtering and enrollment handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->