### PR TITLE
docs(sync): correct the family-camp grain docs and three stale code comments

### DIFF
--- a/docs/reference/family-camp-field-provenance.md
+++ b/docs/reference/family-camp-field-provenance.md
@@ -158,6 +158,55 @@ Two corrections that have both bitten already:
 
 ---
 
+> ## ⚠️ SUPERSEDED IN PART, 2026-08-13 — the Registration form has now been read
+>
+> Camp staff read the live Camper Registration form on 2026-08-13. Four things in §3 and §3b
+> above are now settled or corrected, and one mechanism is new:
+>
+> **1. A field can live on BOTH forms.** A CampMinder custom form can point at a backend field
+> and allow *update*, so the same stored field is offered on the Registration form and again on
+> the Family Camp Information form. This resolves the P1/P2 puzzle — the adult block appears on
+> both while writing **one** stored field — and it means §3b's *"**Not** the adult block"* is
+> **wrong**. It is on the Registration form, and also on the Information form.
+>
+> **2. This gives §3c a second drift mechanism it does not have.** §3c attributes sibling
+> divergence to the Information form being re-submittable. With the same fields exposed on two
+> forms, drift also arises from *two different forms writing one field at different times* —
+> which fits the bimodal timestamps at least as well and requires nobody to have filled one form
+> twice. Treat §3c's mechanism as **one of two**, not the explanation.
+>
+> **3. The four fields §3 lists as "inferred from stored values only" are now confirmed**, with
+> question text and gating:
+> - `FAM CAMP-bathroom` (274056) — *"Does your family require access to a bathroom that doesn't
+>   require you to leave your cabin for a medical or accessibility-related reason?"*, boolean
+> - `Housing-Bathroom` (274059) — *"If yes, please explain the medical condition or accessibility
+>   need:"*, conditional free text
+> - `Housing Accommodation` (274057) — *"Does your family need another housing accommodation for
+>   a medical or accessibility-related reason?"*, boolean
+> - `Housing Accommodation-Yes` (274058) — *"Please explain the medical condition or
+>   accessibility need:"*, conditional free text
+> - `FAM CAMP-Opt Out VIP` (256927) — *"If there is a waitlist for cabins with bathrooms and/or
+>   electricity, and a cabin is available that does not meet your needs … do you still want to
+>   register for this program?"* → *"Yes, please register regardless of cabin type"* /
+>   *"No, I am only able to attend with this accommodation in place"*. **Gated on the
+>   ACCOMMODATION boolean (274057)**, not the bathroom one.
+>
+> **4. The share gate's three options, verbatim** — `FAM CAMP-Share Cabins` (240877) is a
+> pick-one radio, not the four-checkbox `FAM CAMP-Shared Cabin` (263379):
+> - *"Yes, I would like to share a large camper cabin with a family that I request or with a
+>   family with similarly aged kid(s) that I can meet at Camp."*
+> - *"Maybe, I am open to sharing a large camper cabin if a specific family that I know wants to
+>   share a cabin with my family."*
+> - *"No, we would prefer not to share a camper cabin."*
+>
+> The "Maybe" wording is narrower than the word suggests — it means *only with a family I already
+> know*. `NormalizeShareGate` already encodes this correctly (`lodging_requests.go:214`,
+> `gateMaybeMutual` → `share_eligibility = "named"`).
+>
+> **5. Not a form, but recorded here because nothing else says it:** the *"family/adult
+> registration form"* is a misnomer — it is used only for individuals attending Women's and
+> Men's weekend.
+
 ## 3b. The Camper Registration form — housing block
 
 Recovered 2026-08-13 from a single camper's registration **confirmation PDF** (one real
@@ -392,7 +441,23 @@ re-derived when a form changes. Counts are lifetime unless noted.
 > question" and uses that to justify a `break` letting 171577 win the `cpap_info`
 > narrative slot.
 >
-> **256582's question text is unknown** — it sits on the Registration form, which has not
+> **CORRECTED 2026-08-13 — 256582's question text is now known, and the real shape is a DATED
+> SPLIT.** The live Registration form asks *"Is anyone in your family bringing a CPAP machine to
+> Camp **that requires an outlet**?"* as a plain boolean. The multi-option vocabulary below is
+> **historical**: it ran in 2025, when 256582 was one combined question covering CPAP *and*
+> bathroom *and* accommodation. Measured by year — 2025: 56 "outlet needed", 51 "bathroom or
+> other housing accommodation", 12 "outlet AND bathroom", 757 `No`. 2026: 623 `No`, 44 plain
+> `Yes`, and one residual of each multi-option string. The bathroom and accommodation gates were
+> split out into `FAM CAMP-bathroom` (274056) and `Housing Accommodation` (274057), whose first
+> values are 2025, with their explain twins arriving in 2026.
+>
+> **Consequence for `classifyCPAPAnswer`: a 2026 `Yes` means outlet-only, while a 2025
+> "Yes, bathroom or other housing accommodation…" means no CPAP at all.** Code that treats 256582
+> uniformly across years is reading two different questions. The conclusion below — that the
+> `break` is wrong — still holds; the reasoning is now the split rather than "concurrent
+> questions of differing scope".
+>
+> *(Original note, retained because its evidence stands:)* 256582's question text was unknown — it sits on the Registration form, which had not
 > been located (see [§3](#3-the-family-camp-information-form)). Two observations settle
 > the precedence anyway, without it:
 >

--- a/docs/reference/family-camp-grain-collapse.md
+++ b/docs/reference/family-camp-grain-collapse.md
@@ -238,8 +238,15 @@ every site above. Both `#2255` and `#2275` name it.
 **No backfill, no data migration, no CampMinder re-fetch.** `person_custom_values` holds
 1,608,513 rows under `UNIQUE(year, person, field_definition)` with **zero** duplicate key
 groups; `household_custom_values` likewise. The three `family_camp_*` tables are
-sync-owned, have no `staff_touched` column and no GUI write path. Every value is recovered
-by re-running `family_camp_derived` against data already on disk.
+sync-owned and have no `staff_touched` column. Two caveats on the write path, added 2026-08-13:
+all three collections carry `@request.auth.is_admin = true` for create/update/delete, so a
+superuser *can* write through the admin UI or REST — that is the house norm rather than a
+GUI, and any such edit is silently overwritten by the next upsert. And "every value is
+recovered" is verified for **2026 only**: the 4,618 `family_camp_adults` rows for 2017-2021
+were written by an earlier code generation off person-level `Family Camp-P1/P2 *` fields
+(`name` empty, `first_name` populated), and whether today's `processAdults` reproduces them
+at all has **never been tested**. With the sweep unguarded, "does not reproduce" means
+"deletes".
 
 ---
 
@@ -249,20 +256,61 @@ by re-running `family_camp_derived` against data already on disk.
   allergy narratives name a household member other than the record holder. Any UI built on
   the per-answer table must say **"reported by"**, never "about". This is the single
   easiest way to turn a data fix into a clinical error.
-- **`family_camp_medical` has no enrolment filter** — 381 of 886 2026 rows are out of
-  family-camp scope, because `processMedical` reads `Family Medical-*` fields that summer
-  campers also answer. Narrowing it is a behaviour change; confirm with staff before
-  assuming it is a bug.
+- **`family_camp_medical` holds rows it should not, and "381 of 886" is TWO defects, not one.**
+  Corrected 2026-08-13 — the figure silently merged them, which would have produced one fix
+  for two problems:
+  - **310** rows belong to households that never touched a family or adult session at all,
+    because `processMedical` reads `Family Medical-*` fields that summer campers also answer.
+    That is **kindred#2306**. Corroborated from the source side: 663 households hold a value on
+    those fields in 2026, only 398 touched a family/adult session, so 265 never did.
+  - **71** rows belong to households that registered but had nobody actively enrolled — the
+    enrollment-status defect, which also affects `family_camp_registrations` (51) and
+    `family_camp_adults` (46). That is **kindred#2305**.
+  Owner ruling 2026-08-13 on the first: **filter at read, do not narrow the write.** It matches
+  kindred#2159's precedent — a read-side filter is scoped to the view's own year and leaves the
+  record intact — and it is reversible, where narrowing plus an unguarded sweep is not.
 - **`relationship_to_camper` is void at household-adult grain** and only becomes
-  well-defined keyed by the reporting person. Whether the household rollup should carry any
-  version of it is open.
-- **`date_of_birth` / `gender` / `pronouns` on adults** — kindred#1945's parked decision
-  (whether these columns are kept at all) now gates the single largest loss site (A6, 92
-  answers in 2026). Worth resolving before step 2, not after.
+  well-defined keyed by the reporting person. **Settled 2026-08-13: KEEP the column.** It is
+  not hypothetical — it is rendered in two live surfaces, `FamilyDetailsPanel.tsx:265-266` and
+  `HouseholdYearMembersModal.tsx:127-128`.
+- **`date_of_birth` / `gender` / `pronouns` / `email` on adults — the hold stands, and A6 is
+  NOT blocked.** Corrected 2026-08-13; this bullet previously said the decision was "parked"
+  and "gates" A6, and both were false. The 2026-08-07 ruling holds all four columns ("kept for
+  now. Not deleted, not deprecated"), and the 2026-08-09 ruling that **closed** kindred#1945
+  re-affirmed it: *"No deletion of the `gender` / `date_of_birth` / `email` / `pronouns`
+  columns — the 2026-08-07 hold stands."* #1945 closed `COMPLETED` via PR #2194, which shipped
+  a validity-preferring merge for **email only** and explicitly left `first_name`, `last_name`,
+  `pronouns`, `gender`, `date_of_birth` and `relationship` at first-non-empty-wins, because no
+  defensible validity notion exists for them. **A6 is live, unblocked, and squarely inside the
+  re-grain (kindred#2275) rather than gated by a column decision.** What #1945 left open is the
+  per-attribute *merge policy*, which is #2275's subject. Note the columns' state: zero readers
+  in `api/`, `bunking/` or `frontend/` — `PartyAdult` (`api/schemas/lodging.py:296-303`) exposes
+  only `adult_number`, `display_name` and `relationship`.
 - **Which years to replay** is a real decision, not a detail. Only 2026 has been through a
-  current run. A re-grain that also backfills 2024-2025 changes thousands of historical
-  rows written by three code generations. The only known reader of those years is the
-  year-over-year card, which reads `cabin_assignment` only.
+  current run. **Owner ruling 2026-08-13: 2026 only for now, re-evaluate later** — and the
+  re-evaluation is a live commitment, not a cancellation. Revisit once a real dry-run diff
+  exists (see below).
+
+  ⚠️ **This bullet previously claimed "the only known reader of those years is the
+  year-over-year card, which reads `cabin_assignment` only". That is false**, and it understated
+  the blast radius by two columns plus row-existence. `build_household_journey` makes **three**
+  cross-year reads:
+
+  | Read | Table | Year scope | Renders, 2017-2025 |
+  |---|---|---|---|
+  | `fetch_household_adults_by_year` (`lodging_repository.py:420-453`) | `family_camp_adults` | **all years, no bound** | **8,955** adult names, **5,214** relationship labels |
+  | `fetch_household_registration_years` (`:455-476`) | `family_camp_registrations` | **all years** | **3,459** rows whose mere *existence* puts a year on a family's timeline |
+  | `fetch_cabin_assignments_by_household_cm_id(year)` (`:597-650`) | `.cabin_assignment` | per traced year | 1,786 cabin strings — the only one this bullet named |
+
+  **Two hazards must be cleared before any replay wider than 2026:**
+  1. `family_camp_derived`'s three orphan sweeps are **unguarded**. `orphan_guard.go:54-58`
+     enumerates nine guarded services and this one is not among them;
+     `deleteOrphanedAdults`/`…Registrations`/`…Medical` (`:1606`, `:1640`, `:1672`) return a bare
+     `int`. It is the last unguarded sweep in the package, guarding exactly the three tables a
+     replay rewrites.
+  2. `DryRun` reports counts, not a diff. It fires at `:232` immediately after `processMedical`
+     and returns **before** any `preloadExisting*`, so a replay cannot be measured before it is
+     done — which is what makes the wider question unanswerable today rather than merely open.
 
 ---
 
@@ -285,11 +333,27 @@ Three things in it to correct before relying on it:
    alone is behind M1-M8. The family-camp path holds **26** sites, 20 of them lossy. Its
    per-site figure and this file's path-wide figure are different measurements, not
    competing ones.
-3. **Several of its items have shipped.** Closed since it was written: the licence-plate
-   spelling (`#2258`), the summer household first-wins (`#2260`), `can_bring_others`
-   (`#2262`), the person-custom-value orphan-sweep cap (`#2266`), and its **step 0** — a
-   counted database failure now fails the run (`#2284`, PR `#2293`). Its remaining
-   guardrail steps 1-5 are unshipped and still the recommended order.
+3. **Several of its items have shipped, and its step 0 only HALF shipped.** Closed since it was
+   written: the licence-plate spelling (`#2258`), the summer household first-wins (`#2260`),
+   `can_bring_others` (`#2262`), the person-custom-value orphan-sweep cap (`#2266`), and
+   `staff_vehicle_info`'s routing (`#2268`).
+
+   **Step 0 split.** `#2284` closed via PR `#2293`, but only the infrastructure half landed —
+   `totalInfrastructureErrors` now fails a run. The other half is **`#2292`, still open**:
+   wrapper sites return both classes of error through one value, so `Stats.Rejected` cannot be
+   populated without typed errors. `Stats.Rejected` is therefore **blocked, not declined**, and
+   `orchestrator.go:353` says so verbatim. **`#2292` is a hard predecessor of the audit's steps
+   2 and 3** — any per-site loss counter that must distinguish *rejected* from *errored* waits
+   on it. The escalation-policy question is separately filed as `#2298` (reviewed, deliberately
+   kept, to revisit on evidence); do not re-open it as a fresh question.
+
+4. **Its counts are superseded — do not size this campaign from it.** Re-measured 2026-08-13:
+   `quest_registrations` 358 → **430** discarded links; bunk_assignments' "23 lost" → **97
+   hazard pairs / 74 ceiling**; "1,213 map entries" → **1,146** (1,213 is *sessions discarded*,
+   a different quantity). Its inventory also still advertises `household_demographics.go:494`
+   — its largest mechanism-A site — and all four `staff_vehicle_info` sites as open. **All of
+   those shipped.** Where the audit and an issue body disagree on a number, the body has usually
+   been re-measured and the audit has not.
 
 What this file adds that the wider audit could not see, because it predates reading the
 forms: the semantics in `family-camp-field-provenance.md`, and in particular that the

--- a/frontend/src/components/weekend/FamilyCard.tsx
+++ b/frontend/src/components/weekend/FamilyCard.tsx
@@ -156,7 +156,8 @@ function Chip({
    * shipped it. That is strictly more than the `title` it replaced gave —
    * `title` on a `<span>` is not reliably announced at all — and it leaves
    * one gap, honestly stated: a touch user still cannot summon this
-   * sentence. #2229 is what closes it.
+   * sentence. #2250 is what closes it -- #2229 was closed NOT_PLANNED, and
+   * the live issue is the desktop-visibility one staff actually reported.
    */
   title?: string
 }) {

--- a/frontend/src/components/weekend/HouseholdRosterRow.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterRow.tsx
@@ -124,7 +124,8 @@ export function HouseholdRosterRow({ party, showRequests, unit, onOpen }: Househ
             First-time badges — a `<button>`'s content model forbids an
             interactive descendant, so those badges' `sr-only` detail
             (kindred#2177) could never become a real, touch-reachable
-            tooltip trigger (kindred#2229) without first breaking that wall.
+            tooltip trigger (kindred#2250; #2229 closed NOT_PLANNED) without
+            first breaking that wall.
             The badges are laid out here as siblings of the control rather
             than a shrunken click target, using the "stretched link" trick:
             `hover:bg-muted/30` lives on THIS `relative` wrapper (so the
@@ -135,7 +136,7 @@ export function HouseholdRosterRow({ party, showRequests, unit, onOpen }: Househ
             content below is a plain, non-positioned sibling — which a
             positioned `absolute` box always paints ABOVE regardless of DOM
             order. Nothing in the content is interactive today, so that
-            ordering is invisible; the day kindred#2229 wires a real tooltip
+            ordering is invisible; the day kindred#2250 wires a real tooltip
             trigger into a badge, that trigger needs its own `relative z-10`
             (or similar) to sit above this layer and receive its own clicks
             — the standard caveat of this pattern, not a defect on its own. */}

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -597,9 +597,13 @@ func (s *FamilyCampDerivedSync) loadPersonCustomValues(
 // stands, unchanged, because none of them has a validity notion as crisp as
 // "syntactically valid email" -- inventing one to feel consistent would be
 // guessing, not fixing. Which sibling should win there remains a product
-// decision, coupled to the still-open question of whether
-// gender/date_of_birth/pronouns are kept at all, so today's behavior for
-// those fields is pinned by test instead of changed on a guess.
+// decision. It is NOT coupled to whether the columns exist: kindred#1945
+// closed 2026-08-09 refusing deletion ("No deletion of the gender /
+// date_of_birth / email / pronouns columns -- the 2026-08-07 hold stands"),
+// so column existence blocks nothing here. What #1945 left open is exactly
+// this per-attribute merge policy, and that is kindred#2275's subject.
+// Today's behavior for those fields is pinned by test instead of changed on
+// a guess.
 func (s *FamilyCampDerivedSync) processAdults(
 	householdValues []customValueEntry, personValues []customValueEntry,
 ) []*adultData {

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -2135,10 +2135,11 @@ func TestRegistrationNeedsUpdateIgnoresTheUnknownSpelling(t *testing.T) {
 // first+last` coalesce, which fires for 5 of 382 households). gender,
 // date_of_birth, email and pronouns have zero readers anywhere.
 //
-// PENDING, deliberately (owner ruling on kindred#1945): which sibling should
-// win is a product decision, and it is coupled to the still-open question of
-// whether gender/date_of_birth/email/pronouns are kept. Do not "fix" this test
-// by changing the merge until that ruling lands.
+// PENDING, deliberately: which sibling should win is a product decision, and
+// it is kindred#2275's subject. It is NOT coupled to whether the columns are
+// kept -- kindred#1945 closed 2026-08-09 refusing deletion, so that half is
+// settled and A6 is unblocked. Do not "fix" this test by changing the merge
+// until kindred#2275 rules on the per-attribute policy.
 func TestProcessAdultsPersonFieldsTakeTheFirstLoadedSibling(t *testing.T) {
 	t.Parallel()
 	s := &FamilyCampDerivedSync{}


### PR DESCRIPTION
Part A artifact hygiene for the kindred#2257 triage pass. **No behaviour change** — docs and comments only.

Every correction was verified against the tree at `21154083` and the production snapshot. **Six agent-proposed corrections that failed verification were discarded rather than applied** (two ended mid-token, one would have overwritten the provenance doc, one asserted a splice that measurement shows cannot happen).

## `family-camp-grain-collapse.md`

| § | Was | Now |
|---|---|---|
| §6 #1945 | "parked decision … gates A6" | **Both false.** #1945 closed 2026-08-09 `COMPLETED` refusing deletion; A6 is live and unblocked. What it left open is the per-attribute merge policy = #2275 |
| §6 replay | "the only known reader is the year-over-year card, `cabin_assignment` only" | **False.** Three cross-year reads: **8,955** adult names, **5,214** relationship labels, **3,459** row-existences vs the 1,786 cabin strings named |
| §6 medical | "381 of 886 out of scope" | **Two defects fused.** 310 never touched a family session (#2306) + 71 registered-but-not-enrolled (#2305) |
| §6 relationship | presented as open | **KEEP** — renders in two live surfaces |
| §5 | "no GUI write path", "every value is recovered" | Both too strong. Adds the admin-rule caveat; narrows recovery to **2026 only** (2017-2021's 4,618 rows came from an earlier code generation, reproduction untested — and with an unguarded sweep, "does not reproduce" means "deletes") |
| §7 | "step 0 shipped" | **Half shipped.** #2292 is open, so `Stats.Rejected` is blocked not declined — and #2292 is a hard predecessor of steps 2-3. Adds that the audit's counts are superseded and it must not size the campaign |

Owner rulings recorded: replay **2026 only for now** (with the re-evaluation marked as a live commitment), and **filter `family_camp_medical` at read**.

## `family-camp-field-provenance.md`

Camp staff read the live Camper Registration form on 2026-08-13.

- **§3b's "Not the adult block" is wrong.** A CampMinder custom form can point at a backend field and allow *update*, so one stored field appears on both forms. **This also gives §3c a second drift mechanism it lacks** — two forms writing one field at different times, which fits the bimodal timestamps without anyone having filled one form twice.
- **The four "inferred from stored values only" fields are now confirmed**, with question text and gating — including that Opt Out VIP hangs off the **accommodation** boolean, not the bathroom one.
- **§5's "256582's question text is unknown" is superseded, and the real shape is a dated split.** 256582 was one combined multi-option question in 2025 and is a plain boolean in 2026; the bathroom and accommodation gates were broken out into 274056/274057 (first values 2025) with their explain twins in 2026.

  | | 2024 | 2025 | 2026 |
  |---|---|---|---|
  | plain `No` | 11 | 757 | 623 |
  | plain `Yes` | 4 | 1 | 44 |
  | "outlet needed for CPAP" | — | 56 | 1 |
  | "bathroom or other housing accommodation (not CPAP related)" | 2 | 51 | — |

  **So a 2026 `Yes` means outlet-only, while a 2025 `"Yes, bathroom…"` means no CPAP at all.** The conclusion that the `break` is wrong still holds; the reasoning changes.
- Records the three share-gate options verbatim, and that **"Maybe" means only with a family the household already knows** — which `NormalizeShareGate` already encodes correctly.
- Records that the *"family/adult registration form"* is a misnomer, used only for Women's and Men's weekend.

## Code comments

- `family_camp_derived.go` and its test claimed the merge policy is *"coupled to the still-open question of whether the columns are kept"*. #1945 settled that half.
- `FamilyCard.tsx` and `HouseholdRosterRow.tsx` pointed at #2229 as the issue closing the tooltip gap. **#2229 is CLOSED/NOT_PLANNED**; the live issue is #2250.

## Verification

markdownlint clean · Go sync suite green · `FamilyCard` + `HouseholdRosterTable` suites green (104 tests) · checked first that no source-grep test anchors on the edited comment literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)