### PR TITLE
build(deps): bump the Go toolchain to 1.26.6 for four stdlib CVEs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -85,7 +85,7 @@ reviews:
 
     - path: "pocketbase/**/*.go"
       instructions: |
-        Go 1.26+ codebase (pocketbase/go.mod declares `go 1.26.4`). Idiomatic baseline:
+        Go 1.26+ codebase (pocketbase/go.mod declares `go 1.26.6`). Idiomatic baseline:
         - `any` (not `interface{}`); `map[string]any` (not `map[string]interface{}`)
         - `slices`, `maps`, `cmp` packages over legacy `sort.*`
         - `min`/`max`/`clear` builtins; `cmp.Or` for first-non-zero

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,7 +319,16 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
-        go-version: '1.26.x'
+        # go-version-file, not a literal: setup-go pins GOTOOLCHAIN=local, so the
+        # runner CANNOT fetch a newer toolchain the way a developer's machine
+        # does. Whatever this step installs is the only toolchain the job has,
+        # and if go.mod declares a higher minimum every Go command hard-fails
+        # with "requires go >= X (running Y; GOTOOLCHAIN=local)". A floating
+        # '1.26.x' therefore silently breaks the build the moment go.mod is
+        # bumped ahead of the newest release the manifest happens to serve.
+        # Reading the version from go.mod keeps ONE source of truth and makes a
+        # future bump a one-line change there.
+        go-version-file: pocketbase/go.mod
         check-latest: true
         cache: true
         cache-dependency-path: pocketbase/go.sum
@@ -578,7 +587,16 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
-        go-version: '1.26.x'
+        # go-version-file, not a literal: setup-go pins GOTOOLCHAIN=local, so the
+        # runner CANNOT fetch a newer toolchain the way a developer's machine
+        # does. Whatever this step installs is the only toolchain the job has,
+        # and if go.mod declares a higher minimum every Go command hard-fails
+        # with "requires go >= X (running Y; GOTOOLCHAIN=local)". A floating
+        # '1.26.x' therefore silently breaks the build the moment go.mod is
+        # bumped ahead of the newest release the manifest happens to serve.
+        # Reading the version from go.mod keeps ONE source of truth and makes a
+        # future bump a one-line change there.
+        go-version-file: pocketbase/go.mod
         check-latest: true
         cache: true
         cache-dependency-path: pocketbase/go.sum
@@ -607,7 +625,16 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
-        go-version: '1.26.x'
+        # go-version-file, not a literal: setup-go pins GOTOOLCHAIN=local, so the
+        # runner CANNOT fetch a newer toolchain the way a developer's machine
+        # does. Whatever this step installs is the only toolchain the job has,
+        # and if go.mod declares a higher minimum every Go command hard-fails
+        # with "requires go >= X (running Y; GOTOOLCHAIN=local)". A floating
+        # '1.26.x' therefore silently breaks the build the moment go.mod is
+        # bumped ahead of the newest release the manifest happens to serve.
+        # Reading the version from go.mod keeps ONE source of truth and makes a
+        # future bump a one-line change there.
+        go-version-file: pocketbase/go.mod
         check-latest: true
         cache: true
         cache-dependency-path: pocketbase/go.sum

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.26.4
+go 1.26.6
 
 use (
 	./docker/healthcheck

--- a/pocketbase/go.mod
+++ b/pocketbase/go.mod
@@ -1,6 +1,6 @@
 module github.com/camp/kindred/pocketbase
 
-go 1.26.4
+go 1.26.6
 
 require (
 	github.com/pocketbase/dbx v1.12.0


### PR DESCRIPTION
`govulncheck` started failing CI on four Go standard-library vulnerabilities, all fixed in **go1.26.6**:

| ID | Package |
|---|---|
| GO-2026-6218 | `net/url` |
| GO-2026-6091 | `html/template` |
| GO-2026-6090 | `crypto/tls` |
| GO-2026-6089 | `net/http` |

**This is not caused by any code change — it blocks every open PR**, and it started the moment the advisories published against the 1.26.5 the runner had cached.

## The change

- `go.work` and `pocketbase/go.mod`: `go 1.26.4` → **`go 1.26.6`**. They must move together — Go refuses to build when `go.work` declares an older version than a module it uses.
- All three `setup-go` steps: `go-version: '1.26.x'` → **`go-version-file: pocketbase/go.mod`**.
- Corrects a stale `go 1.26.4` reference in the CodeRabbit config prompt.

## ⚠️ Correcting my own reasoning — the first push of this PR was wrong

The original version of this PR left CI alone, arguing that `check-latest: true` made the floating `'1.26.x'` self-healing. **That was wrong and it broke the run:**

```
go: ../go.work requires go >= 1.26.6 (running go 1.26.5; GOTOOLCHAIN=local)
```

**`actions/setup-go` sets `GOTOOLCHAIN=local` itself** — deliberately, so a build cannot silently download a different toolchain. That is a good default worth keeping. But it means **whatever setup-go installs is the only toolchain the job has.** A developer's machine transparently fetches 1.26.6 under `GOTOOLCHAIN=auto`; the runner cannot, so declaring a higher minimum in `go.mod` hard-fails every Go command rather than upgrading.

So a floating `'1.26.x'` is *not* self-healing here — it silently breaks the build the moment `go.mod` moves ahead of whatever the manifest happens to serve, which is exactly what happened.

`go-version-file` installs precisely the version `go.mod` declares, satisfies `GOTOOLCHAIN=local` by construction, keeps **one** source of truth, and makes the next CVE bump a one-line change in `go.mod` rather than four edits that have to agree.

## Verification, with the new toolchain

- `govulncheck ./...` → **No vulnerabilities found** (down from four)
- full Go suite green
- `golangci-lint run ./...` → 0 issues
- workflow YAML re-validated after the edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)