### PR TITLE
fix(frontend): wire a real tooltip for the "Answers disagree" chip

### DIFF
--- a/frontend/src/components/weekend/FamilyCard.test.tsx
+++ b/frontend/src/components/weekend/FamilyCard.test.tsx
@@ -17,7 +17,7 @@
  * Fictional data throughout.
  */
 import { DndContext } from '@dnd-kit/core'
-import { render, screen, within } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
 import { describe, expect, it, vi } from 'vitest'
@@ -434,7 +434,7 @@ describe('FamilyCard — what it shows', () => {
     expect(screen.queryByText('Declined sharing')).not.toBeInTheDocument()
   })
 
-  it('says which two answers disagreed, and that the form wins, on the "Answers disagree" chip (kindred#2083)', () => {
+  it('says which two answers disagreed, and that the form wins, on the "Answers disagree" chip\'s tooltip (kindred#2250)', () => {
     render(
       <FamilyCard
         party={party({
@@ -451,27 +451,26 @@ describe('FamilyCard — what it shows', () => {
         onOpen={vi.fn()}
       />
     )
-    // kindred#2177: the detail is real text now, not a bare `title` that
-    // fires on mouse hover and nothing else.
-    const chip = screen.getByText('Answers disagree').closest('span')
+    // kindred#2250: the detail is now a real, keyboard- and touch-reachable
+    // `ui/Tooltip` trigger, not the `sr-only` text kindred#2177 shipped as a
+    // stopgap while the card's outer `<button>` still forbade a nested
+    // interactive descendant (kindred#2222 lifted that wall; this chip is
+    // what actually uses the opening).
+    const chip = screen.getByText('Answers disagree').closest('button')
+    expect(chip).not.toBeNull()
     expect(chip).not.toHaveAttribute('title')
-    expect(chip?.textContent).toMatch(/will not share/)
-    expect(chip?.textContent).toMatch(/open to sharing/)
-    expect(chip?.textContent).toMatch(/form's answer/)
-    // kindred#2222: the sr-only sentence is still in the DOM (asserted above
-    // via `chip?.textContent`, and jsdom does not hide `sr-only` text any
-    // more than a screen reader's ordinary reading cursor does), but the
-    // card's open control no longer wraps the chip row at all — the whole
-    // point of this refactor is that the chip row is a SIBLING of the
-    // control, not its child, so a future interactive trigger there
-    // (kindred#2229) is never nested inside another one. That means the
-    // sentence is no longer folded into the control's accessible name the
-    // way it was when the card was one big `<button>`. Closing THAT gap —
-    // giving the sentence a real accessible relationship to a trigger a
-    // touch user can reach — is kindred#2229's job, not this one's.
-    expect(screen.getByRole('button', { name: /Johnson/ })).not.toHaveAccessibleName(
-      /form's answer/
-    )
+    // Closed by default — the detail sentence is not sitting on the page
+    // until a staff member actually summons it.
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+    fireEvent.focus(chip as HTMLElement)
+    const tooltip = screen.getByRole('tooltip')
+    expect(tooltip).toHaveTextContent(/will not share/)
+    expect(tooltip).toHaveTextContent(/open to sharing/)
+    expect(tooltip).toHaveTextContent(/form's answer/)
+    // Still a SIBLING of the card's own open control, never nested inside
+    // it (kindred#2222) — a nested interactive trigger would be invalid
+    // HTML and its tap would bubble into `onOpen` instead of the bubble.
+    expect(screen.getByRole('button', { name: /Johnson/ })).not.toContainElement(chip)
   })
 
   it('never nests an interactive control inside another one — checked by ROLE, not TAG (kindred#2222)', () => {

--- a/frontend/src/components/weekend/FamilyCard.tsx
+++ b/frontend/src/components/weekend/FamilyCard.tsx
@@ -59,6 +59,7 @@ import { Fragment } from 'react'
 
 import type { LodgingUnitRow, PartyChildRow, RosterPartyRow } from '../../types/lodging'
 import { displayCampMinderAge, displayTruncatedAge } from '../../utils/age'
+import { Tooltip } from '../ui/Tooltip'
 import { answersConflictDetail, SHARE_WORDING, shareWordingChip } from './boardLayout'
 import {
   attendingAdults as computeAttendingAdults,
@@ -135,40 +136,44 @@ function Chip({
    * The chip's per-party detail, e.g. "Answers disagree"'s account of which
    * two answers disagreed (kindred#2083).
    *
-   * ## Why this is still NOT `ui/Tooltip`, unlike every other chip on this surface
+   * ## Now a real `ui/Tooltip` trigger, not `sr-only` text (kindred#2250)
    *
    * kindred#2177 replaced the board's `title` attributes with a focusable
-   * tooltip, and this chip was named as the highest-leverage one. It
-   * couldn't have it: THE WHOLE CARD WAS A `<button>` (see `FamilyCard`
-   * below), and a `<button>`'s content model forbids interactive
-   * descendants. A nested trigger would have been invalid HTML and its tap
-   * would have bubbled straight into `onOpen`, opening the details panel
-   * instead of the bubble. `HouseholdRosterRow`'s in-button badges hit the
-   * identical wall and took the identical way out.
+   * tooltip everywhere except here: THE WHOLE CARD WAS A `<button>` at the
+   * time, and a `<button>`'s content model forbids interactive descendants
+   * — a nested trigger would have been invalid HTML and its tap would have
+   * bubbled straight into `onOpen`, opening the details panel instead of
+   * the bubble. `HouseholdRosterRow`'s in-button badges hit the identical
+   * wall and took the identical `sr-only` way out.
    *
    * kindred#2222 removed that wall — `FamilyCard`'s frame is a `<div>` now,
    * and this chip row is a SIBLING of the card's open control, not its
-   * child, so a real interactive trigger here would no longer be invalid
-   * HTML or steal the click. This chip still doesn't carry one: #2222 was
-   * the structural unblock, not the tooltip wiring — that's kindred#2229.
-   *
-   * So the detail is still REAL `sr-only` TEXT, exactly as kindred#2177
-   * shipped it. That is strictly more than the `title` it replaced gave —
-   * `title` on a `<span>` is not reliably announced at all — and it leaves
-   * one gap, honestly stated: a touch user still cannot summon this
-   * sentence. #2250 is what closes it -- #2229 was closed NOT_PLANNED, and
-   * the live issue is the desktop-visibility one staff actually reported.
+   * child — but left the trigger unwired. A real staff member could not
+   * read a real answer-conflict explanation because it was parked in
+   * `sr-only` text nothing on this desktop-only board ever announces
+   * (kindred#2250's field report). Same trigger primitive as
+   * `SharePreferenceChip`, the other chip on this surface with a per-party
+   * detail behind it: `Tooltip` when there's a `title` to show, a plain
+   * `<span>` when there isn't, so a chip with nothing to explain never
+   * becomes a dead stop in the tab order.
    */
   title?: string
 }) {
   const chipClassName = `inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-semibold whitespace-nowrap ${CHIP_TONE[tone]}`
-  return (
-    <span className={chipClassName}>
+  const content = (
+    <>
       {Icon && <Icon className="mr-0.5 h-3 w-3 flex-shrink-0" aria-hidden="true" />}
       {label}
-      {title !== undefined && title.length > 0 && <span className="sr-only"> — {title}</span>}
-    </span>
+    </>
   )
+  if (title !== undefined && title.length > 0) {
+    return (
+      <Tooltip content={title} className={chipClassName}>
+        {content}
+      </Tooltip>
+    )
+  }
+  return <span className={chipClassName}>{content}</span>
 }
 
 /**
@@ -240,7 +245,7 @@ function ChildList({
  * on purpose: a `<button>`'s content model forbids an interactive
  * descendant, and the chip row is exactly where kindred#2177 left a
  * `sr-only` detail sentence waiting for a real tooltip trigger
- * (kindred#2229). Swapping the card's outer frame to a `<div>` while still
+ * (kindred#2250). Swapping the card's outer frame to a `<div>` while still
  * wrapping the WHOLE body in one inner `<button>` would just move that wall
  * one level deeper — nothing would actually be unblocked. Keeping the chip
  * row OUT of the button is what does.
@@ -404,9 +409,10 @@ function FamilyCardIdentity({ party }: { party: RosterPartyRow }) {
  *
  * A SIBLING of `FamilyCardIdentity`'s `<button>` (kindred#2222), never its
  * child — see that component's doc for why. The one chip carrying a `title`
- * today (`Chip`'s "Answers disagree" detail, kindred#2083) still renders it
- * as `sr-only` text, exactly as kindred#2177 shipped: this refactor
- * unblocks a real `ui/Tooltip` trigger here, it does not wire one in.
+ * today (`Chip`'s "Answers disagree" detail, kindred#2083) is a real
+ * `ui/Tooltip` trigger now, not `sr-only` text (kindred#2250) — the sibling
+ * relationship this refactor set up is what makes that trigger valid HTML
+ * here at all.
  */
 function FamilyCardChips({
   party,
@@ -531,7 +537,7 @@ export function FamilyCard({
 
   return (
     // NOT a `<button>` (kindred#2222) — a `<div>` frame, so the chip row
-    // below can host a real interactive trigger (kindred#2229) as a SIBLING
+    // below can host a real interactive trigger (kindred#2250) as a SIBLING
     // instead of a forbidden nested descendant.
     //
     // `ref`/`listeners` stay HERE, not on the inner control below: dnd-kit's


### PR DESCRIPTION
## What changed

`FamilyCard`'s `Chip` carried its "Answers disagree" per-party detail (kindred#2083 — which two answers disagreed) as `sr-only` text. That was a deliberate stopgap: kindred#2177 converted every other `title` on the weekend board to a keyboard/touch-reachable `ui/Tooltip`, but this chip couldn't have one — the whole card was a `<button>` at the time, and a `<button>`'s content model forbids an interactive descendant. kindred#2222 later swapped the card's frame to a `<div>` with the chip row as a *sibling* of the open control, which unblocked a real trigger here — but nothing wired one in.

A staff member working the board could not read the detail because it was parked in `sr-only` text a desktop, mouse-and-keyboard board never announces (this codebase's accessibility posture is deliberately minimal — three users, desktop, no assistive tech — so `sr-only` buys nothing here; see `frontend/CLAUDE.md` § "Accessibility — deliberately minimal").

`Chip` now renders through `ui/Tooltip` when it carries a `title`, exactly the pattern `SharePreferenceChip` already uses for its own per-party detail on the same surface — falling back to a plain `<span>` when there's nothing to explain, so a chip with no detail never becomes a dead stop in the tab order.

## Comment repoint — already done on main

The campaign brief for this issue also asked to repoint `FamilyCard.tsx:159` and `HouseholdRosterRow.tsx:127`/`:138`, which pointed at kindred#2229 (closed NOT_PLANNED) as "what closes it." **Checked the tree first: this was already fixed** in #2309 (merged as part of `d6d5fd87`, current `main`). Nothing left to do there. I did additionally repoint two more `#2229` references this PR's own diff sits next to (`FamilyCard.tsx` lines ~248 and ~540, both describing the sibling-frame refactor as "unblocking a future trigger") to `#2250`, since that trigger now exists and those two were the only remaining stale mentions of `#2229` as *this* chip's closing issue.

One `#2229` reference intentionally left alone: `HouseholdRosterTable.test.tsx:512` and `HouseholdRosterRow.tsx`'s Returning/First-time badges are a *different* pair of chips, explicitly out of scope for #2250 (the issue's own body says "the fix direction is to replace the sr-only detail... not to add anything alongside it" for the *share-conflict* chip only) — those badges stay `sr-only` by design, per the comment already there.

## Verification

- `cd frontend && ./node_modules/.bin/vitest run src/components/weekend/FamilyCard.test.tsx` → 64/64 passed
- `cd frontend && ./node_modules/.bin/vitest run src/components/weekend/` → 39 files, 1145/1145 passed
- `cd frontend && ./node_modules/.bin/tsc --noEmit -p .` → exit 0
- `cd frontend && ./node_modules/.bin/eslint src/components/weekend/FamilyCard.tsx src/components/weekend/FamilyCard.test.tsx` → 0 errors (3 pre-existing warnings, none touched by this diff)
- `bash scripts/pre-push-verify.sh` → ALL CHECKS PASSED

**Mutation check** (TDD): the new test (`says which two answers disagreed... on the "Answers disagree" chip's tooltip (kindred#2250)`) was written first against the old `sr-only` implementation and confirmed RED (`expected null not to be null` — no `<button>` existed for the chip). After implementing, reverted the `Tooltip`-wrapping branch back to a bare `<span>` and re-ran: same test failed the same way, confirming it actually pins the new behavior rather than passing vacuously. Restored the real implementation and re-ran green (64/64).

Closes #2250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)