### PR TITLE
fix(frontend): let the household journey card's names wrap, not truncate

### DIFF
--- a/frontend/src/components/weekend/HouseholdJourneyCard.test.tsx
+++ b/frontend/src/components/weekend/HouseholdJourneyCard.test.tsx
@@ -124,6 +124,29 @@ describe('the housing states', () => {
 
     expect(rowFor(2026).textContent).not.toEqual(rowFor(2019).textContent)
   })
+
+  it('lets a long lodging name wrap instead of clipping it with an ellipsis', () => {
+    // kindred#2253. A unit name with a wing or sub-unit suffix loses exactly
+    // that suffix to `truncate`'s ellipsis — the half that distinguishes it
+    // from a same-building sibling.
+    show([
+      _row({
+        year: 2025,
+        housing: 'placed',
+        cabin_name: 'Clouds Rest Lodge - West Wing Room 12B',
+      }),
+    ])
+
+    const housing = screen.getByTestId('household-journey-housing')
+    // `truncate` is Tailwind's `overflow-hidden` + ellipsis + `nowrap`
+    // combined into one class. `min-w-0` is the OTHER half of the mechanism
+    // — it is what lets this flex child shrink below its content width at
+    // all — and it stays: dropping only `truncate` is what lets the name
+    // wrap instead of overflowing its row.
+    expect(housing).toHaveClass('min-w-0')
+    expect(housing).not.toHaveClass('truncate')
+    expect(housing).toHaveTextContent('Clouds Rest Lodge - West Wing Room 12B')
+  })
 })
 
 describe('the enrolment states', () => {
@@ -239,6 +262,46 @@ describe('the family name', () => {
     expect(screen.getByTestId('household-journey-title').textContent).toBe(
       'The Garcia-Lopez Family'
     )
+  })
+
+  it('lets a long family name wrap instead of clipping it with an ellipsis', () => {
+    // kindred#2253's second anchor: the header carries the same `truncate`
+    // as the year row, and a multi-surname household is exactly as likely to
+    // overflow it as a long unit name is to overflow the row.
+    show([
+      _row({
+        year: 2025,
+        children: [
+          { person_cm_id: 1, display_name: 'Emma Johnson', last_name: 'Johnson', age: 9, grade: 4 },
+        ],
+      }),
+      _row({
+        year: 2023,
+        children: [
+          {
+            person_cm_id: 2,
+            display_name: 'Liam Garcia-Lopez',
+            last_name: 'Garcia-Lopez',
+            age: 7,
+            grade: 2,
+          },
+        ],
+      }),
+      _row({
+        year: 2021,
+        children: [
+          {
+            person_cm_id: 3,
+            display_name: 'Ava Martinez',
+            last_name: 'Martinez',
+            age: 6,
+            grade: 1,
+          },
+        ],
+      }),
+    ])
+
+    expect(screen.getByTestId('household-journey-title')).not.toHaveClass('truncate')
   })
 
   it('falls back to a neutral heading when no child on any year carries a surname', () => {

--- a/frontend/src/components/weekend/HouseholdJourneyCard.tsx
+++ b/frontend/src/components/weekend/HouseholdJourneyCard.tsx
@@ -143,8 +143,17 @@ function JourneyRows({
                 {year}
               </span>
 
+              {/* Wraps rather than truncates (kindred#2253): a unit name with
+                  a wing or sub-unit suffix lost exactly that suffix to
+                  `truncate`'s ellipsis — the half that distinguishes it from
+                  a same-building sibling. The card is a fixed-width panel and
+                  the rows are short, so a second line costs little. `min-w-0`
+                  stays: it is what lets this flex child shrink below its
+                  content width at all, which is what makes the wrap happen
+                  instead of the row overflowing its card. */}
               <span
-                className={`flex min-w-0 items-center gap-1 truncate text-sm ${
+                data-testid="household-journey-housing"
+                className={`flex min-w-0 items-center gap-1 text-sm ${
                   isPlaced ? 'text-foreground font-medium' : 'text-muted-foreground italic'
                 }`}
               >
@@ -217,9 +226,13 @@ export function HouseholdJourneyCard({ householdCmId, currentYear }: HouseholdJo
       className="bg-card border-border overflow-hidden rounded-2xl border shadow-sm"
     >
       <div className="from-forest-600 to-forest-700 bg-gradient-to-r px-5 py-4">
+        {/* Wraps rather than truncates, same reasoning as the housing name
+            below (kindred#2253): a multi-surname household is exactly as
+            likely to overflow this heading as a long unit name is to
+            overflow a year row, and the card has room to grow. */}
         <h2
           data-testid="household-journey-title"
-          className="font-display flex items-center gap-2 truncate text-lg font-bold text-white"
+          className="font-display flex items-center gap-2 text-lg font-bold text-white"
         >
           <TreePine className="h-5 w-5 flex-shrink-0" />
           {familyLabel.length > 0 ? familyLabel : NO_NAME_HEADING}

--- a/frontend/src/components/weekend/HouseholdJourneyCard.tsx
+++ b/frontend/src/components/weekend/HouseholdJourneyCard.tsx
@@ -150,7 +150,18 @@ function JourneyRows({
                   the rows are short, so a second line costs little. `min-w-0`
                   stays: it is what lets this flex child shrink below its
                   content width at all, which is what makes the wrap happen
-                  instead of the row overflowing its card. */}
+                  instead of the row overflowing its card.
+
+                  A DELIBERATE divergence from summer, per the root CLAUDE.md
+                  §4 rule: CampJourneyTimeline's own bunk span — this row's
+                  direct analog — still truncates
+                  (`camper/CampJourneyTimeline.tsx`, the `record.bunkName`
+                  span). That surface's cabin names are short, fixed-format
+                  callsigns with nothing meaningful to lose to an ellipsis.
+                  Family-camp lodging names are staff-typed strings that can
+                  carry a wing or sub-unit suffix — exactly the substring
+                  `truncate` chops — so summer's treatment does not transfer
+                  here and this row earns its own. */}
               <span
                 data-testid="household-journey-housing"
                 className={`flex min-w-0 items-center gap-1 text-sm ${


### PR DESCRIPTION
## What changed

`HouseholdJourneyCard.tsx` applied Tailwind's `truncate` (overflow-hidden + ellipsis + nowrap) to two spans:

- the prior-year housing/lodging name in each year row
- the family-name header (the household's surname label)

A lodging name wider than its column was clipped to an ellipsis with no way to see the rest — and the longer unit names, the ones carrying a wing or sub-unit suffix, are the ones that lose exactly that distinguishing tail. Same failure mode applies to a multi-surname household header.

Fix direction 1 from the issue ("let the row wrap instead of truncating"): both `truncate` classes are dropped, so the text wraps onto a second line instead of clipping. `min-w-0` stays on the housing span — it is the other half of the mechanism, letting that flex child shrink below its content width at all, which is what makes wrapping happen instead of the row overflowing its card.

No new visual channel, colour, token, or interaction was introduced — this only removes a class from two existing elements. A `data-testid="household-journey-housing"` was added to the housing span purely as a test query handle (matching the existing `family-card-last-year-cabin` precedent in `FamilyCard.tsx`); it renders nothing.

## Measured justification

Anchors from the issue, verified against the tree before editing — both line numbers matched exactly on `main` (d6d5fd87):
- `HouseholdJourneyCard.tsx:147` — the truncating year row
- `HouseholdJourneyCard.tsx:222` — the header, which also truncates

The header was in scope because the issue explicitly listed it as the second anchor "for whether the same treatment applies," and the failure mode generalizes: a household with several distinct child surnames overflows the header exactly as a long unit name overflows a row.

## How verified

```
cd frontend && ./node_modules/.bin/vitest run src/components/weekend/HouseholdJourneyCard.test.tsx
# Test Files  1 passed (1) / Tests  25 passed (25)

./node_modules/.bin/vitest run   # full frontend suite
# Test Files  445 passed (445) / Tests  6788 passed (6788)

./node_modules/.bin/tsc --noEmit -p .   # exit 0

bash scripts/pre-push-verify.sh
# PASS prettier / PASS eslint / PASS tsc / PASS vitest — ALL CHECKS PASSED
```

### TDD

Both new tests were written first, against the untouched component, and confirmed RED before any implementation change:

- `lets a long lodging name wrap instead of clipping it with an ellipsis` — failed because `household-journey-housing` testid did not exist yet (getByTestId threw)
- `lets a long family name wrap instead of clipping it with an ellipsis` — failed with `expect(element).not.toHaveClass("truncate")` / Received: `... truncate ...`

Implemented (dropped `truncate` from both spans, added the testid), reran: 25/25 GREEN.

### Mutation check

Reintroduced `truncate` on both spans via `sed` (leaving the testid and the rest of the fix in place), reran the file's suite:

```
❯ lets a long lodging name wrap instead of clipping it with an ellipsis
  Expected the element not to have class: truncate
  Received: flex min-w-0 items-center gap-1 truncate text-sm text-foreground font-medium

❯ lets a long family name wrap instead of clipping it with an ellipsis
  Expected the element not to have class: truncate
  Received: font-display flex items-center gap-2 truncate text-lg font-bold text-white

Tests  2 failed | 23 passed (25)
```

Both new tests went RED for the expected reason, the other 23 stayed GREEN. Reverted the mutation, reran, confirmed GREEN again (25/25).

Closes #2253.