### PR TITLE
feat(sync): duplicate-SessionID observation counter for attendees (#2263)

### DIFF
--- a/pocketbase/sync/attendees.go
+++ b/pocketbase/sync/attendees.go
@@ -19,6 +19,13 @@ type AttendeesSync struct {
 
 	// Caches for validation
 	sessionCMIDs map[string]bool
+
+	// DuplicateSessionEnrollments counts, across the whole run, how many "extra" entries
+	// appeared beyond the first for a given attendee's (person, session) pair — see
+	// duplicateSessionEnrollments below and kindred#2263. Zero over a real season answers
+	// the open question; non-zero gives it data. This is observation only: it does not
+	// change dedup behavior, the composite key, or idx_attendees_unique.
+	DuplicateSessionEnrollments int
 }
 
 // NewAttendeesSync creates a new attendees sync service
@@ -37,9 +44,10 @@ func (s *AttendeesSync) Name() string {
 // Sync performs the attendees sync
 func (s *AttendeesSync) Sync(ctx context.Context) error {
 	s.LogSyncStart("attendees")
-	s.Stats = Stats{}        // Reset stats
-	s.SyncSuccessful = false // Reset sync status
-	s.ClearProcessedKeys()   // Reset processed tracking
+	s.Stats = Stats{}                 // Reset stats
+	s.SyncSuccessful = false          // Reset sync status
+	s.ClearProcessedKeys()            // Reset processed tracking
+	s.DuplicateSessionEnrollments = 0 // Reset kindred#2263 observation counter
 
 	// Load session CampMinder IDs for validation
 	if err := s.loadSessionIDs(); err != nil {
@@ -180,6 +188,10 @@ func (s *AttendeesSync) processAttendee(
 		return nil
 	}
 
+	// kindred#2263 observation: does this attendee's own array ever repeat a SessionID? See
+	// duplicateSessionEnrollments below for what this catches and why it matters.
+	duplicateSessions := s.duplicateSessionEnrollments(personCMID, sessionStatuses)
+
 	// Process each enrollment
 	for _, enrollmentData := range sessionStatuses {
 		enrollment, ok := enrollmentData.(map[string]any)
@@ -188,12 +200,76 @@ func (s *AttendeesSync) processAttendee(
 		}
 
 		if err := s.processEnrollment(personCMID, enrollment, existingAttendees); err != nil {
-			slog.Error("Error processing enrollment", "person_cm_id", personCMID, "error", err)
+			// A duplicate SessionID in the source data makes the *second* entry's error
+			// attributable: it's the entry that loses the (person, session) key collision,
+			// either overwriting the first (idempotent upsert) or — on a first-ever sync,
+			// before existingAttendees has an entry for the key — taking the create branch
+			// and hitting idx_attendees_unique. Tag it so that failure mode is legible in
+			// the logs rather than reading as an unexplained local DB fault.
+			if sessionIDFloat, ok := enrollment["SessionID"].(float64); ok &&
+				duplicateSessions[int(sessionIDFloat)] != nil {
+				slog.Error("Error processing enrollment (duplicate SessionID within this "+
+					"attendee's SessionProgramStatus — see kindred#2263)",
+					"person_cm_id", personCMID, "session_cm_id", int(sessionIDFloat), "error", err)
+			} else {
+				slog.Error("Error processing enrollment", "person_cm_id", personCMID, "error", err)
+			}
 			s.Stats.Errors++
 		}
 	}
 
 	return nil
+}
+
+// duplicateSessionEnrollments scans a single attendee's SessionProgramStatus entries for
+// SessionIDs that appear more than once, and returns them keyed by SessionID with each
+// occurrence's ProgramID (or nil, if the entry has none) in encounter order.
+//
+// This is the identity question kindred#2263 asks, made observable. processEnrollment keys
+// an enrollment on (person, session) only — fmt.Sprintf("%d:%d", personCMID, sessionCMID) —
+// never reading ProgramID. If CampMinder's vendor API ever returns two SessionProgramStatus
+// entries for the same person+session (one per program, say), the second one collapses onto
+// the first: whichever is processed last wins the upsert. Nobody can currently see that
+// happen without inspecting a live API response, which needs credentials this sync doesn't
+// have reason to spend. This function only observes and logs; it changes no identity, no
+// key, and no schema — see the scope note on kindred#2263 for why that split is deliberate.
+//
+// Every duplicated SessionID found logs one slog.Warn naming every ProgramID seen (or its
+// absence), and s.DuplicateSessionEnrollments accumulates the "extra" entries (len-1 per
+// duplicated session) across the whole run, so a season's worth of runs can answer whether
+// this ever actually happens.
+func (s *AttendeesSync) duplicateSessionEnrollments(personCMID int, sessionStatuses []any) map[int][]any {
+	bySession := make(map[int][]any)
+	for _, raw := range sessionStatuses {
+		enrollment, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		sessionIDFloat, ok := enrollment["SessionID"].(float64)
+		if !ok {
+			continue
+		}
+		sessionCMID := int(sessionIDFloat)
+		// enrollment["ProgramID"] is nil when the key is absent, which is exactly the
+		// "or their absence" the counter needs to record.
+		bySession[sessionCMID] = append(bySession[sessionCMID], enrollment["ProgramID"])
+	}
+
+	duplicates := make(map[int][]any)
+	for sessionCMID, programIDs := range bySession {
+		if len(programIDs) < 2 {
+			continue
+		}
+		duplicates[sessionCMID] = programIDs
+		s.DuplicateSessionEnrollments += len(programIDs) - 1
+		slog.Warn("Duplicate SessionID within one attendee's SessionProgramStatus "+
+			"(kindred#2263 — observation only, no identity change)",
+			"person_cm_id", personCMID,
+			"session_cm_id", sessionCMID,
+			"count", len(programIDs),
+			"program_ids", programIDs)
+	}
+	return duplicates
 }
 
 // processEnrollment processes a single enrollment using pre-loaded existing attendees

--- a/pocketbase/sync/attendees.go
+++ b/pocketbase/sync/attendees.go
@@ -142,7 +142,8 @@ func (s *AttendeesSync) Sync(ctx context.Context) error {
 		// Don't fail the sync if checkpoint fails
 	}
 
-	s.LogSyncComplete("Attendees")
+	s.LogSyncComplete("Attendees",
+		fmt.Sprintf("duplicate_session_enrollments=%d", s.DuplicateSessionEnrollments))
 
 	return nil
 }

--- a/pocketbase/sync/attendees.go
+++ b/pocketbase/sync/attendees.go
@@ -201,16 +201,20 @@ func (s *AttendeesSync) processAttendee(
 		}
 
 		if err := s.processEnrollment(personCMID, enrollment, existingAttendees); err != nil {
-			// A duplicate SessionID in the source data makes the *second* entry's error
-			// attributable: it's the entry that loses the (person, session) key collision,
-			// either overwriting the first (idempotent upsert) or — on a first-ever sync,
-			// before existingAttendees has an entry for the key — taking the create branch
-			// and hitting idx_attendees_unique. Tag it so that failure mode is legible in
-			// the logs rather than reading as an unexplained local DB fault.
+			// duplicateSessions is keyed by SessionID and holds every entry that shares a
+			// SessionID with another entry in this attendee's array — first, second, or
+			// later; it doesn't identify which one is "the duplicate". So this only tells
+			// us the group fact: this SessionID appears more than once. A (person, session)
+			// key collision — overwriting the first entry on an idempotent upsert, or, on a
+			// first-ever sync before existingAttendees has an entry for the key, taking the
+			// create branch and hitting idx_attendees_unique — is one plausible cause of
+			// this failure, but not the only one; this entry could equally be failing for a
+			// reason unrelated to the collision. Tag it so the possible collision is legible
+			// in the logs rather than the error reading as an unexplained local DB fault.
 			if sessionIDFloat, ok := enrollment["SessionID"].(float64); ok &&
 				duplicateSessions[int(sessionIDFloat)] != nil {
-				slog.Error("Error processing enrollment (duplicate SessionID within this "+
-					"attendee's SessionProgramStatus — see kindred#2263)",
+				slog.Error("Error processing enrollment (this SessionID appears more than "+
+					"once in this attendee's SessionProgramStatus — see kindred#2263)",
 					"person_cm_id", personCMID, "session_cm_id", int(sessionIDFloat), "error", err)
 			} else {
 				slog.Error("Error processing enrollment", "person_cm_id", personCMID, "error", err)

--- a/pocketbase/sync/attendees_duplicate_session_test.go
+++ b/pocketbase/sync/attendees_duplicate_session_test.go
@@ -1,0 +1,144 @@
+package sync
+
+import "testing"
+
+// These tests cover kindred#2263: attendees.go's processEnrollment keys an enrollment on
+// (person, session) only — SessionProgramStatus's ProgramID is never read. If CampMinder ever
+// emits two SessionProgramStatus entries for the same person+session pair (one per program,
+// say), the second one silently collapses onto the first. Nobody can tell whether that
+// actually happens without a live API response — this counter is the observation instead.
+//
+// Scope is deliberately narrow (see the package comment above duplicateSessionEnrollments in
+// attendees.go): this only detects and logs the event. It does not add ProgramID to any key,
+// does not touch idx_attendees_unique, and does not change attendee_status_history.
+
+func TestAttendeesSync_DuplicateSessionEnrollments_NoDuplicates(t *testing.T) {
+	t.Parallel()
+
+	s := &AttendeesSync{}
+	sessionStatuses := []any{
+		map[string]any{"SessionID": float64(100), "ProgramID": float64(1), "StatusID": float64(2)},
+		map[string]any{"SessionID": float64(200), "ProgramID": float64(1), "StatusID": float64(2)},
+	}
+
+	dupes := s.duplicateSessionEnrollments(12345, sessionStatuses)
+
+	if len(dupes) != 0 {
+		t.Fatalf("expected no duplicates, got %v", dupes)
+	}
+	if s.DuplicateSessionEnrollments != 0 {
+		t.Fatalf("expected counter 0, got %d", s.DuplicateSessionEnrollments)
+	}
+}
+
+func TestAttendeesSync_DuplicateSessionEnrollments_DetectsDuplicate(t *testing.T) {
+	t.Parallel()
+
+	s := &AttendeesSync{}
+	sessionStatuses := []any{
+		map[string]any{"SessionID": float64(500), "ProgramID": float64(10), "StatusID": float64(2)},
+		map[string]any{"SessionID": float64(500), "ProgramID": float64(20), "StatusID": float64(2)},
+	}
+
+	dupes := s.duplicateSessionEnrollments(999, sessionStatuses)
+
+	entries, ok := dupes[500]
+	if !ok {
+		t.Fatalf("expected session 500 to be flagged as duplicate, got %v", dupes)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries recorded for the duplicated session, got %d", len(entries))
+	}
+	if s.DuplicateSessionEnrollments != 1 {
+		t.Fatalf("expected counter to record 1 extra entry, got %d", s.DuplicateSessionEnrollments)
+	}
+}
+
+func TestAttendeesSync_DuplicateSessionEnrollments_MissingProgramIDRecordedAsAbsent(t *testing.T) {
+	t.Parallel()
+
+	s := &AttendeesSync{}
+	sessionStatuses := []any{
+		map[string]any{"SessionID": float64(500), "ProgramID": float64(10), "StatusID": float64(2)},
+		// Second entry has no ProgramID key at all — the counter must still catch the
+		// duplicate SessionID and record the absence rather than dropping the entry.
+		map[string]any{"SessionID": float64(500), "StatusID": float64(2)},
+	}
+
+	dupes := s.duplicateSessionEnrollments(999, sessionStatuses)
+
+	entries, ok := dupes[500]
+	if !ok || len(entries) != 2 {
+		t.Fatalf("expected 2 entries for session 500, got %v", dupes)
+	}
+	if entries[0] != float64(10) {
+		t.Fatalf("expected first ProgramID to be 10, got %v", entries[0])
+	}
+	if entries[1] != nil {
+		t.Fatalf("expected second (missing) ProgramID to be recorded as nil, got %v", entries[1])
+	}
+}
+
+func TestAttendeesSync_DuplicateSessionEnrollments_ThreeEntriesCountsTwoExtra(t *testing.T) {
+	t.Parallel()
+
+	s := &AttendeesSync{}
+	sessionStatuses := []any{
+		map[string]any{"SessionID": float64(700), "ProgramID": float64(1)},
+		map[string]any{"SessionID": float64(700), "ProgramID": float64(2)},
+		map[string]any{"SessionID": float64(700), "ProgramID": float64(3)},
+	}
+
+	dupes := s.duplicateSessionEnrollments(1, sessionStatuses)
+
+	if len(dupes[700]) != 3 {
+		t.Fatalf("expected 3 entries for session 700, got %d", len(dupes[700]))
+	}
+	// Three entries for one (person, session) key means two entries are "extra" beyond the
+	// first — that is the count that matters for judging how often it happens over a season.
+	if s.DuplicateSessionEnrollments != 2 {
+		t.Fatalf("expected counter to record 2 extra entries, got %d", s.DuplicateSessionEnrollments)
+	}
+}
+
+func TestAttendeesSync_DuplicateSessionEnrollments_IgnoresMalformedEntries(t *testing.T) {
+	t.Parallel()
+
+	s := &AttendeesSync{}
+	sessionStatuses := []any{
+		"not a map",
+		map[string]any{"ProgramID": float64(1)}, // missing SessionID entirely
+		map[string]any{"SessionID": "not-a-number", "ProgramID": float64(1)},
+		map[string]any{"SessionID": float64(300), "ProgramID": float64(1)},
+	}
+
+	dupes := s.duplicateSessionEnrollments(1, sessionStatuses)
+
+	if len(dupes) != 0 {
+		t.Fatalf("expected no duplicates among malformed/singleton entries, got %v", dupes)
+	}
+	if s.DuplicateSessionEnrollments != 0 {
+		t.Fatalf("expected counter 0, got %d", s.DuplicateSessionEnrollments)
+	}
+}
+
+func TestAttendeesSync_DuplicateSessionEnrollments_AccumulatesAcrossCalls(t *testing.T) {
+	t.Parallel()
+
+	s := &AttendeesSync{}
+
+	// Simulates two different attendees in the same sync run, each with one duplicated
+	// session. A season-wide counter must accumulate rather than reset per attendee.
+	s.duplicateSessionEnrollments(1, []any{
+		map[string]any{"SessionID": float64(100), "ProgramID": float64(1)},
+		map[string]any{"SessionID": float64(100), "ProgramID": float64(2)},
+	})
+	s.duplicateSessionEnrollments(2, []any{
+		map[string]any{"SessionID": float64(200), "ProgramID": float64(1)},
+		map[string]any{"SessionID": float64(200), "ProgramID": float64(2)},
+	})
+
+	if s.DuplicateSessionEnrollments != 2 {
+		t.Fatalf("expected counter to accumulate to 2 across calls, got %d", s.DuplicateSessionEnrollments)
+	}
+}

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -286,7 +286,7 @@ type Stats struct {
 	// rejected record) and also the result of ProcessCompositeRecord's App.Save. Note this
 	// is processEnrollment, NOT its caller processAttendee — processAttendee returns only
 	// `invalid or missing PersonID` or nil, counting and swallowing processEnrollment's
-	// errors itself, so the outer site at attendees.go:113 is unambiguously a rejection.
+	// errors itself, so the outer site at attendees.go:121 is unambiguously a rejection.
 	// ProcessSimpleRecord is genuinely mixed too, returning `recordData missing required
 	// 'year' field` alongside its App.Save.
 	//


### PR DESCRIPTION
## What changed

Adds `AttendeesSync.duplicateSessionEnrollments`, a scan of a single attendee's
`SessionProgramStatus` array (already in hand from the CampMinder response — no live API
call, no credentials) that detects when two or more entries share the same `SessionID`.

- Logs one `slog.Warn` per duplicated `SessionID`, naming every `ProgramID` seen for that
  session (or its absence, when the entry has none) — so if the counter ever fires, the log
  line already carries the data needed to judge whether `ProgramID` is a real dimension.
- Accumulates the "extra" entries (`len(entries)-1` per duplicated session) on a new
  `AttendeesSync.DuplicateSessionEnrollments` field, reset each `Sync()` run, so the count is
  visible for a whole run rather than per-attendee.
- When a subsequent `processEnrollment` error lands on a `SessionID` that was flagged as
  duplicated, the error log line now says so explicitly — but only the group fact: this
  SessionID appears more than once in this attendee's `SessionProgramStatus` array. It does
  not (and cannot, from a map keyed by SessionID) identify which specific entry is "the"
  duplicate. A same-key collision is one plausible cause of the failure — the create branch
  hitting `idx_attendees_unique` on a first-ever sync, or an overwrite on the update branch —
  but any entry sharing that SessionID could equally be failing for a reason unrelated to the
  collision. The tag makes a possible collision legible in the logs; it doesn't assert one.

## Why this shape (measured justification)

This is the narrow option the campaign settled on for #2263 (§4 of the master plan): a
duplicate-`SessionID` counter rather than inspecting a live API response — self-answering, no
credentials, a few lines. It deliberately does **not**:

- add `ProgramID` (or any program dimension) to the composite key,
- touch `idx_attendees_unique`,
- write a migration, or
- change `attendee_status_history`.

Those are the schema/product decision the issue explicitly says the owner has not made, and
the issue itself says impact "cannot be quantified from the database, because the enrollment's
program is persisted nowhere." This PR is the plumbing that lets it be quantified going
forward, from logs, over a real season — without committing to a grain change first.

## Not closing #2263

Per the campaign's explicit instruction, this PR does **not** carry `Closes #2263`. The issue
closes only once this counter has reported zero (or non-zero) over a real season — that's the
issue's own stated acceptance path, not something a single PR can satisfy.

## What I deliberately left out (and why)

The job notes suggested that if attributing the first-run insert failure "cheaply" was
possible without touching schema, to do it too. I did the log-attribution half (see above:
duplicated-session errors get a distinguishing message). I did **not** go further and have
`processAttendee` return a different `Stats` classification for that case (e.g. routing it to
`Rejected` instead of `Errors`) — that reclassification is explicitly out of scope per
`Stats.Errors`'s own doc comment (kindred#2292/#2295 own that split), and doing it here would
mean touching shared `Stats` semantics for a single call site, which is a bigger blast radius
than this issue asked for.

## Verification

```
cd pocketbase && go build ./...                                        # exit 0
cd pocketbase && go test ./sync/... -run TestAttendeesSync_DuplicateSessionEnrollments -v
                                                                         # 6/6 PASS, exit 0
cd pocketbase && go test ./...                                         # exit 0 (all packages)
cd pocketbase && golangci-lint run ./sync/...                          # 0 issues, exit 0
cd pocketbase && go vet ./sync/...                                     # exit 0
gofmt -l pocketbase/sync/attendees.go pocketbase/sync/attendees_duplicate_session_test.go
                                                                         # empty output = clean
bash scripts/pre-push-verify.sh                                        # ALL CHECKS PASSED, exit 0
                                                                         # (includes `go test -race ./...`,
                                                                         # full sync package, 508s, all PASS)
```

Push verified by the remote ref moving, not by the push tool's verdict:
```
git fetch -q && git rev-list --count origin/feature/attendee-duplicate-session-counter..HEAD
# 0
```

## Mutation check (TDD requirement)

Before implementing, the 6 new tests were run against the unmodified tree and failed to
**compile** (`duplicateSessionEnrollments undefined`) — confirmed red.

After implementing, all 6 passed. To confirm the tests actually pin the duplicate-detection
logic (not just exercise it), I broke the threshold check (`len(programIDs) < 2` →
`len(programIDs) < 999`, i.e. every session — including singletons — gets flagged as a
"duplicate"):

```
--- FAIL: TestAttendeesSync_DuplicateSessionEnrollments_DetectsDuplicate
    attendees_duplicate_session_test.go:47: expected session 500 to be flagged as duplicate, got map[]
--- FAIL: TestAttendeesSync_DuplicateSessionEnrollments_AccumulatesAcrossCalls
    attendees_duplicate_session_test.go:142: expected counter to accumulate to 2 across calls, got 0
--- FAIL: TestAttendeesSync_DuplicateSessionEnrollments_ThreeEntriesCountsTwoExtra
    attendees_duplicate_session_test.go:95: expected 3 entries for session 700, got 0
--- FAIL: TestAttendeesSync_DuplicateSessionEnrollments_MissingProgramIDRecordedAsAbsent
    attendees_duplicate_session_test.go:72: expected 2 entries for session 500, got map[]
FAIL
```

4 of 6 went red on the mutation (the other 2 — `NoDuplicates` and `IgnoresMalformedEntries` —
correctly stayed green, since their inputs have no repeated `SessionID` for the mutated
threshold to catch differently). Reverted, re-confirmed green, then ran the full suite.

## New tests and `t.Parallel()`

All 6 new top-level tests in `pocketbase/sync/attendees_duplicate_session_test.go` call
`t.Parallel()` as their first statement — confirmed by
`go test . -run TestSyncAndLodgingTestsRunInParallel` (the repo's AST parallelism guard),
which passed.

## Anchors verified against the tree

The issue's anchors (`attendees.go:175-194` for the `SessionProgramStatus` loop,
`attendees.go:222-226` for the composite-key build, `attendees.go:190-192` for the swallowed
error) all matched `d6d5fd87` exactly — no correction needed here.
