### PR TITLE
fix(api): scope family_camp_medical reads to households that touched a weekend session

### DIFF
--- a/api/services/lodging_repository.py
+++ b/api/services/lodging_repository.py
@@ -105,6 +105,16 @@ def _weekend_type_filter() -> str:
     return " || ".join(f'session_type = "{t}"' for t in WEEKEND_SESSION_TYPES)
 
 
+def _attendee_weekend_session_filter() -> str:
+    """Same weekend types as `_weekend_type_filter`, but through the relation.
+
+    This one filters `attendees` (via its `session` relation), which needs
+    the `session.` prefix; `_weekend_type_filter` filters `camp_sessions`
+    directly and would produce the wrong field name if reused here.
+    """
+    return " || ".join(f'session.session_type = "{t}"' for t in WEEKEND_SESSION_TYPES)
+
+
 class LodgingRepository:
     """PocketBase access layer for the weekend lodging surface."""
 
@@ -649,6 +659,72 @@ class LodgingRepository:
                 assignments[household_cm_id] = cabin
         return assignments
 
+    async def _fetch_weekend_touched_household_ids(self, year: int) -> set[str]:
+        """PB ids of households with ANY attendee on a family/adult session
+        this year (kindred#2306).
+
+        `processMedical` (`family_camp_derived.go:981-1095`) reads
+        `Family Medical-*` / `Family Camp-Physician*` custom values, and those
+        fields are answered by summer households too -- so `family_camp_medical`
+        holds rows for households with no family-camp connection at all: 310 of
+        886 in the 2026 production snapshot. Owner ruling 2026-08-13 (campaign
+        decision D3): filter at READ, leave `processMedical` and the write path
+        alone -- reversible, where narrowing the write plus an unguarded sweep
+        would not be.
+
+        ANY status, deliberately NOT `ACTIVE_ENROLLED_FILTER`: a cancelled or
+        waitlisted attendee still means the household touched a weekend
+        session. Narrowing to status_id = 2 would ALSO drop the 71-of-886
+        households that registered but had nobody actively enrolled -- that
+        population is kindred#2305's separate problem, not this one, and the
+        two issues are being kept apart deliberately.
+
+        `person.household`, the PocketBase relation -- NOT `person.household_id`
+        (the CampMinder int used elsewhere in this file for a cross-YEAR
+        bridge). `family_camp_medical.household` is that same relation,
+        already scoped to this year's `households` row, so no cm_id bridge is
+        needed the way a cross-year read needs one.
+        """
+        rows = await self._page(
+            ATTENDEES,
+            query_params={
+                "filter": (f"year = {year} && ({_attendee_weekend_session_filter()})"),
+                "expand": "person",
+                "sort": STABLE_SORT,
+            },
+        )
+        touched: set[str] = set()
+        for row in rows:
+            expand = getattr(row, "expand", None) or {}
+            person = expand.get("person") if isinstance(expand, dict) else None
+            household_pb_id = str(getattr(person, "household", "") or "") if person is not None else ""
+            if household_pb_id:
+                touched.add(household_pb_id)
+        return touched
+
+    async def _household_touched_weekend_session(self, year: int, household_pb_id: str) -> bool:
+        """One household's version of `_fetch_weekend_touched_household_ids`.
+
+        A targeted existence check rather than the bulk helper, so the single-
+        household PHI read below never has to pull the whole year's attendee
+        roster into memory to answer one household's question. Same predicate
+        (ANY status, family/adult session, this year) -- see that method's
+        docstring for why.
+        """
+        if not household_pb_id:
+            return False
+        rows = await self._page(
+            ATTENDEES,
+            query_params={
+                "filter": (
+                    f'year = {year} && person.household = "{pb_escape(household_pb_id)}" '
+                    f"&& ({_attendee_weekend_session_filter()})"
+                ),
+                "sort": STABLE_SORT,
+            },
+        )
+        return bool(rows)
+
     async def fetch_family_camp_medical(self, year: int) -> dict[str, Any]:
         """PHI, keyed by household PB id. NO PRODUCTION CALLER.
 
@@ -663,12 +739,19 @@ class LodgingRepository:
         household's disclosure into API memory is the cost that deletion
         bought back, and presence is not a signal. Two tests in
         test_lodging_roster_service.py assert this is never called.
+
+        Family-camp scoped (kindred#2306): rows for a household that never
+        touched a family or adult session this year are dropped. See
+        `_fetch_weekend_touched_household_ids` for the predicate.
         """
         rows = await self._page(
             FAMILY_CAMP_MEDICAL,
             query_params={"filter": f"year = {year}", "sort": STABLE_SORT},
         )
-        return {str(getattr(row, "household", "")): row for row in rows}
+        touched = await self._fetch_weekend_touched_household_ids(year)
+        return {
+            household_pb_id: row for row in rows if (household_pb_id := str(getattr(row, "household", ""))) in touched
+        }
 
     async def fetch_medical_for_household(self, year: int, household_pb_id: str) -> Any | None:
         """PHI for ONE household, or None.
@@ -676,6 +759,12 @@ class LodgingRepository:
         A blank id means the household did not resolve, and is never turned
         into a query: an unanchored filter is how one family's narrative
         reaches another family's request.
+
+        Family-camp scoped (kindred#2306), and checked BEFORE the PHI read
+        below: a household that never touched a family or adult session this
+        year gets None without `family_camp_medical` ever being queried, not
+        merely filtered out of a result that already carried its narrative.
+        See `_household_touched_weekend_session` for the predicate.
 
         `pb_escape` for the same reason, and it is the same anchor: a quote in
         the id closes the literal, and PocketBase binds `&&` tighter than
@@ -686,6 +775,8 @@ class LodgingRepository:
         last place to leave the odd one out.
         """
         if not household_pb_id:
+            return None
+        if not await self._household_touched_weekend_session(year, household_pb_id):
             return None
         rows = await self._page(
             FAMILY_CAMP_MEDICAL,

--- a/tests/unit/api/services/test_lodging_repository.py
+++ b/tests/unit/api/services/test_lodging_repository.py
@@ -176,6 +176,156 @@ class TestNarrowPhiReads:
         pb.collection.return_value.get_full_list.assert_not_called()
 
 
+class TestFamilyCampMedicalIsScopedToFamilyOrAdultAttendance:
+    """kindred#2306. `processMedical` reads `Family Medical-*` /
+    `Family Camp-Physician*` custom values, which summer households answer
+    too -- 310 of 886 2026 `family_camp_medical` rows belong to a household
+    that never touched a family or adult session at all. Owner ruling
+    2026-08-13 (campaign decision D3): filter at READ, leave `processMedical`
+    and the write path untouched -- reversible, where narrowing the write
+    plus an unguarded sweep would not be.
+
+    "Touched" is ANY attendee row on a family/adult session that year,
+    regardless of status -- deliberately NOT narrowed to
+    `ACTIVE_ENROLLED_FILTER`. The 71-of-886 households that registered but
+    had nobody actively enrolled are kindred#2305's separate problem;
+    narrowing to status_id = 2 here would silently do that fix too and
+    conflate the two issues the campaign is keeping apart.
+    """
+
+    @pytest.mark.asyncio
+    async def test_bulk_read_drops_a_household_that_never_touched_a_weekend_session(
+        self, repo: LodgingRepository, pb: MagicMock
+    ) -> None:
+        _route_by_collection(
+            pb,
+            {
+                "family_camp_medical": [_record(household="hh_untouched", cpap_info="Uses a CPAP nightly")],
+                "attendees": [],
+            },
+        )
+
+        result = await repo.fetch_family_camp_medical(2026)
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_bulk_read_keeps_a_household_that_touched_a_weekend_session(
+        self, repo: LodgingRepository, pb: MagicMock
+    ) -> None:
+        touched_attendee = _record()
+        touched_attendee.expand = {"person": _record(household="hh_touched")}
+        _route_by_collection(
+            pb,
+            {
+                "family_camp_medical": [_record(household="hh_touched", cpap_info="Uses a CPAP nightly")],
+                "attendees": [touched_attendee],
+            },
+        )
+
+        result = await repo.fetch_family_camp_medical(2026)
+
+        assert "hh_touched" in result
+        assert result["hh_touched"].cpap_info == "Uses a CPAP nightly"
+
+    @pytest.mark.asyncio
+    async def test_bulk_read_keeps_a_household_registered_but_never_actively_enrolled(
+        self, repo: LodgingRepository, pb: MagicMock
+    ) -> None:
+        """The kindred#2305 population -- registered, nobody enrolled -- must
+        stay in scope here. Only zero-connection households (kindred#2306)
+        are excluded.
+        """
+        not_enrolled_attendee = _record(status_id=7)
+        not_enrolled_attendee.expand = {"person": _record(household="hh_registered_only")}
+        _route_by_collection(
+            pb,
+            {
+                "family_camp_medical": [_record(household="hh_registered_only", cpap_info="Uses a CPAP nightly")],
+                "attendees": [not_enrolled_attendee],
+            },
+        )
+
+        result = await repo.fetch_family_camp_medical(2026)
+
+        assert "hh_registered_only" in result
+
+    @pytest.mark.asyncio
+    async def test_bulk_touched_check_is_scoped_to_family_and_adult_sessions_and_the_year(
+        self, repo: LodgingRepository, pb: MagicMock
+    ) -> None:
+        queries = _route_by_collection(pb, {"family_camp_medical": [], "attendees": []})
+
+        await repo.fetch_family_camp_medical(2026)
+
+        filter_str = queries["attendees"][0]["filter"]
+        assert "year = 2026" in filter_str
+        assert 'session.session_type = "family"' in filter_str
+        assert 'session.session_type = "adult"' in filter_str
+        assert "status_id" not in filter_str
+
+    @pytest.mark.asyncio
+    async def test_single_household_read_returns_none_for_an_untouched_household(
+        self, repo: LodgingRepository, pb: MagicMock
+    ) -> None:
+        _route_by_collection(
+            pb,
+            {
+                "family_camp_medical": [_record(household="hh_1", cpap_info="Uses a CPAP nightly")],
+                "attendees": [],
+            },
+        )
+
+        result = await repo.fetch_medical_for_household(2026, "hh_1")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_single_household_read_returns_the_row_for_a_touched_household(
+        self, repo: LodgingRepository, pb: MagicMock
+    ) -> None:
+        _route_by_collection(
+            pb,
+            {
+                "family_camp_medical": [_record(household="hh_1", cpap_info="Uses a CPAP nightly")],
+                "attendees": [_record()],
+            },
+        )
+
+        result = await repo.fetch_medical_for_household(2026, "hh_1")
+
+        assert result is not None
+        assert result.cpap_info == "Uses a CPAP nightly"
+
+    @pytest.mark.asyncio
+    async def test_single_household_touched_check_never_reads_family_camp_medical_when_untouched(
+        self, repo: LodgingRepository, pb: MagicMock
+    ) -> None:
+        """PHI minimization: an untouched household's medical row is never
+        read off PocketBase at all, not merely filtered out afterward.
+        """
+        queries = _route_by_collection(pb, {"family_camp_medical": [], "attendees": []})
+
+        await repo.fetch_medical_for_household(2026, "hh_1")
+
+        assert "family_camp_medical" not in queries
+
+    @pytest.mark.asyncio
+    async def test_single_household_touched_check_filters_on_the_person_household_relation(
+        self, repo: LodgingRepository, pb: MagicMock
+    ) -> None:
+        queries = _route_by_collection(pb, {"family_camp_medical": [], "attendees": []})
+
+        await repo.fetch_medical_for_household(2026, "hh_1")
+
+        filter_str = queries["attendees"][0]["filter"]
+        assert "year = 2026" in filter_str
+        assert 'person.household = "hh_1"' in filter_str
+        assert 'session.session_type = "family"' in filter_str
+        assert 'session.session_type = "adult"' in filter_str
+        assert "status_id" not in filter_str
+
+
 class TestLodgingReadsKeyOnTheCampMinderSessionId:
     """Every lodging read names the weekend by `session_cm_id` (kindred#2042).
 


### PR DESCRIPTION
## What changed

`family_camp_medical` holds PHI keyed by household, but `processMedical`
(`pocketbase/sync/family_camp_derived.go:981-1100`, **untouched by this PR**)
reads `Family Medical-*` / `Family Camp-Physician*` custom values that summer
households answer too — so the table carries rows for households with no
family-camp connection at all.

This PR adds a **read-side** scoping filter in `api/services/lodging_repository.py`
to both medical read paths:

- `fetch_family_camp_medical(year)` — the bulk read (currently no production
  caller) now drops rows for households that never touched a family/adult
  session that year.
- `fetch_medical_for_household(year, household_pb_id)` — the single-household
  PHI read used by the gated medical endpoint now checks touched-ness
  **before** querying `family_camp_medical` at all, so an out-of-scope
  household's narrative is never read off PocketBase, not merely filtered out
  afterward.

"Touched" = the household has ANY attendee row (any `status_id`, not narrowed
to `ACTIVE_ENROLLED_FILTER`) on a `family` or `adult` session that year.
Deliberately not narrowed to active-enrolled: doing so would also exclude the
71-of-886 households that registered but had nobody actively enrolled, which
is kindred#2305's separate problem, not this issue's.

**The write path is untouched.** `processMedical`, the Go sync, and the
`family_camp_medical` schema are unchanged — no migration, no data sweep, no
row deleted. This matches campaign decision D3 (owner ruling 2026-08-13,
recorded on the issue): filter at read, don't narrow the write — reversible,
where narrowing the write plus an unguarded sweep would not be. Matches
kindred#2159's precedent.

## Measured (from the issue, 2026 production snapshot)

Of 886 `family_camp_medical` rows:

| Household did that year | rows |
|---|---|
| Actively enrolled (`status_id = 2`) in a family or adult session | 505 |
| Registered for one but nobody enrolled (kindred#2305, stays visible) | 71 |
| **Never touched a family or adult session at all — what this PR drops** | **310** |

Corroborated from the source side: 663 households hold a value on those
fields in 2026; only 398 touched a family/adult session, 265 never did.

## Verification

```
cd /home/adam/kindred-worktrees/family-camp-medical-scope
uv run pytest tests/unit/api/services/test_lodging_repository.py -q
# 103 passed

SKIP_POCKETBASE_TESTS=true uv run pytest tests/ -n auto -q
# 6306 passed, 41 skipped (DB/server-coupled, expected), exit 0

bash scripts/pre-push-verify.sh
# ruff-check, mypy, api-types-freshness, pytest (6306 passed) — ALL CHECKS PASSED, exit 0
```

No Go files touched, so `go test`/`golangci-lint` are not applicable here.
No frontend files touched, so `vitest` is not applicable here.

### Mutation check

Reverted both filtering changes (bulk method: computed `touched` but ignored
it; single-household method: removed the touched guard) and reran the new
test class. 4 of 8 new tests — the ones that specifically assert the
filtering behavior — went RED as expected:

```
FAILED test_bulk_read_drops_a_household_that_never_touched_a_weekend_session
FAILED test_single_household_read_returns_none_for_an_untouched_household
FAILED test_single_household_touched_check_never_reads_family_camp_medical_when_untouched
FAILED test_single_household_touched_check_filters_on_the_person_household_relation
4 failed, 4 passed, 95 deselected
```

Restored the implementation and reran — 103/103 green again. The tests pin
the fix rather than passing vacuously.

## Doc correction — already shipped

The job also asked to correct `docs/reference/family-camp-grain-collapse.md`
§6's "381 of 886" figure (which silently merged this issue with kindred#2305).
**That correction already landed in PR #2309** (merged just before this PR's
branch point) — no doc changes are included here.

## Issue body correction

The issue body's closing "Open question for staff... Do not implement from
this body until that is settled" is now stale — the question was settled by
owner ruling 2026-08-13 (campaign decision D3). Corrected the issue body in
place (kept all original measurements and reasoning, added a ruling block at
top, struck the outdated instruction) and left an audit comment explaining
the edit.

Closes #2306.

