### PR TITLE
fix(sync): raise share_answers_conflict for a sibling gate answer that loses on recency

### DIFF
--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -350,7 +350,10 @@ class ShareRequestSummary(BaseModel):
     eligibility: ShareEligibility = "unknown"
     eligibility_source: ShareEligibilitySource = "none"
     # The two forms point opposite ways -- a staff-review signal, not a
-    # placement rule. Measured at 7.5% of form answerers for 2026.
+    # placement rule. Measured at 7.5% of form answerers for 2026, pre-
+    # kindred#2269; that PR's union conflict test is a strict superset of the
+    # one this was measured against, so the true rate can only be equal or
+    # higher now.
     answers_conflict: bool = False
 
 

--- a/frontend/src/components/weekend/boardLayout.test.ts
+++ b/frontend/src/components/weekend/boardLayout.test.ts
@@ -960,6 +960,31 @@ describe('answersConflictDetail — which two answers disagreed, and which one w
       })
     ).not.toThrow()
   })
+
+  it('does not name a maybe_mutual registration answer as the side that disagrees (kindred#2269)', () => {
+    // As of kindred#2269, DeriveShareEligibility raises answers_conflict off
+    // the UNION of every sibling's no_share/yes_share answer, not just the
+    // winning gate -- so a household can now conflict with maybe_mutual as
+    // the winning share_cabin_gate, because the actual contradiction is a
+    // sibling answer that lost the recency race and isn't in this payload at
+    // all. REGISTRATION_ANSWER['maybe_mutual'] is "only if a mutual match",
+    // which does not read as a disagreement against any resolved verdict --
+    // naming it here would have the chip pair two answers that look like
+    // they agree, on a tooltip whose whole job is to say they don't.
+    const detail = answersConflictDetail(
+      shareBlock({
+        preference: 'maybe_mutual',
+        eligibility: 'declined',
+        eligibility_source: 'form',
+        answers_conflict: true,
+      })
+    )
+    expect(detail).not.toBeNull()
+    expect(detail).not.toMatch(/only if a mutual match/i)
+    expect(detail).not.toMatch(/^Registration said/)
+    // Still says what actually won, so the chip stays informative.
+    expect(detail).toMatch(SHARE_WORDING.declined)
+  })
 })
 
 describe('buildBoard — area grouping and colour', () => {

--- a/frontend/src/components/weekend/boardLayout.test.ts
+++ b/frontend/src/components/weekend/boardLayout.test.ts
@@ -985,6 +985,46 @@ describe('answersConflictDetail — which two answers disagreed, and which one w
     // Still says what actually won, so the chip stays informative.
     expect(detail).toMatch(SHARE_WORDING.declined)
   })
+
+  it('does not name a no_share registration answer that itself AGREES with the verdict (kindred#2269)', () => {
+    // The winning gate can be no_share while eligibility is ALSO declined --
+    // they agree -- and the union fix can still raise answers_conflict, because
+    // a DIFFERENT sibling recorded yes_share and lost the recency race (Go
+    // CollapseToHouseholdGrain's sawYesGate, consulted by DeriveShareEligibility
+    // regardless of which gate won). Pairing "will not share" against a
+    // declined verdict reads as agreement, not disagreement, so naming
+    // `preference` here would be exactly the misleading pairing kindred#2269
+    // exists to prevent -- the maybe_mutual case is not the only shape of it.
+    const detail = answersConflictDetail(
+      shareBlock({
+        preference: 'no_share',
+        eligibility: 'declined',
+        eligibility_source: 'form',
+        answers_conflict: true,
+      })
+    )
+    expect(detail).not.toBeNull()
+    expect(detail).not.toMatch(/will not share/i)
+    expect(detail).not.toMatch(/^Registration said/)
+    expect(detail).toMatch(SHARE_WORDING.declined)
+  })
+
+  it('does not name a yes_share registration answer that itself AGREES with the verdict (kindred#2269)', () => {
+    // Mirror of the no_share case above: the winning gate is yes_share and
+    // eligibility resolves to something other than declined -- they agree --
+    // while a hidden no_share sibling that lost recency is the real conflict.
+    const detail = answersConflictDetail(
+      shareBlock({
+        preference: 'yes_share',
+        eligibility: 'open',
+        eligibility_source: 'form',
+        answers_conflict: true,
+      })
+    )
+    expect(detail).not.toBeNull()
+    expect(detail).not.toMatch(/open to sharing.*open to sharing/i)
+    expect(detail).not.toMatch(/^Registration said/)
+  })
 })
 
 describe('buildBoard — area grouping and colour', () => {

--- a/frontend/src/components/weekend/boardLayout.test.ts
+++ b/frontend/src/components/weekend/boardLayout.test.ts
@@ -883,10 +883,13 @@ describe('answersConflictDetail — which two answers disagreed, and which one w
   })
 
   it('names the registration answer, the form answer, and that the form wins', () => {
-    // Measured against production 2026 data: all 16 conflicting households
-    // resolved with `eligibility_source: 'form'` — DeriveShareEligibility only
-    // ever sets `answers_conflict` true on that branch, so `eligibility` here
-    // already IS the form's own verdict, not a re-derivation of it.
+    // Measured against production 2026 data pre-kindred#2269: all 16
+    // conflicting households then resolved with `eligibility_source: 'form'`
+    // — DeriveShareEligibility only ever sets `answers_conflict` true on that
+    // branch, so `eligibility` here already IS the form's own verdict, not a
+    // re-derivation of it. kindred#2269's union widening is a strict superset
+    // of the test that count was measured against, so the true count can only
+    // be equal or higher now; the form-answered-only invariant still holds.
     const detail = answersConflictDetail(
       shareBlock({
         preference: 'no_share',
@@ -932,10 +935,13 @@ describe('answersConflictDetail — which two answers disagreed, and which one w
   it('never attributes the resolved answer to the form when eligibility_source says otherwise', () => {
     // DeriveShareEligibility (Go, lodging_requests.go) only ever sets
     // `answers_conflict` true on its form-answered branch -- measured on 2026
-    // production, all 16 conflicting rows carry `eligibility_source: 'form'`.
-    // This reads the field rather than assuming it, so a future Go change or
-    // a stale mid-recompute row can never misattribute a registration-only
-    // verdict to a form the household may not have even returned.
+    // production pre-kindred#2269, all 16 conflicting rows then carried
+    // `eligibility_source: 'form'` (stale count; kindred#2269's union
+    // widening can only raise it, though the form-answered-only invariant
+    // still holds). This reads the field rather than assuming it, so a
+    // future Go change or a stale mid-recompute row can never misattribute a
+    // registration-only verdict to a form the household may not have even
+    // returned.
     const detail = answersConflictDetail(
       shareBlock({
         preference: 'no_share',

--- a/frontend/src/components/weekend/boardLayout.ts
+++ b/frontend/src/components/weekend/boardLayout.ts
@@ -324,9 +324,13 @@ function wordingFor<T extends string>(
  * resolved verdict) directly rather than re-deriving either from `proximity`.
  * `DeriveShareEligibility` only ever sets `answers_conflict` true on its
  * form-answered branch (Go, `lodging_requests.go`), so whenever this returns
- * non-null, `eligibility` already IS the Family Camp form's own answer,
- * confirmed against 2026 production: all 16 conflicting households carry
- * `eligibility_source: 'form'`.
+ * non-null, `eligibility` already IS the Family Camp form's own answer --
+ * confirmed against 2026 production PRE-kindred#2269: all 16 conflicting
+ * households then carried `eligibility_source: 'form'`. That count is stale
+ * -- kindred#2269's union conflict test is a strict superset of the one it
+ * was measured against, so the true count can only be equal or higher now --
+ * but the invariant itself (raised only off the form-answered branch) is
+ * structural, not a property of the count, and still holds.
  *
  * That invariant is enforced only in a separate Go file, with nothing here
  * to catch a future change or a stale mid-`family_camp_derived`-recompute

--- a/frontend/src/components/weekend/boardLayout.ts
+++ b/frontend/src/components/weekend/boardLayout.ts
@@ -337,6 +337,20 @@ function wordingFor<T extends string>(
  * can defend either way, matching `consentFlag`'s own rule of reporting only
  * what was recorded.
  *
+ * `preference` (`share_cabin_gate`) is the registration answer that WON
+ * `winsGate`'s newest-wins race, not necessarily the answer that disagrees
+ * (kindred#2269). `DeriveShareEligibility` raises the conflict off the UNION
+ * of every sibling's recorded no_share/yes_share answer, so a household can
+ * conflict with `maybe_mutual` as the winning gate -- the actual
+ * contradiction is a sibling answer that lost recency and never reaches this
+ * payload. `REGISTRATION_ANSWER['maybe_mutual']` ("only if a mutual match")
+ * does not itself read as a disagreement against any resolved verdict, so
+ * naming it as "Registration said …" would have the tooltip pair two answers
+ * that look like they agree, on a chip whose whole job is to say they don't.
+ * `no_share` and `yes_share` don't have this problem: DeriveShareEligibility
+ * can only raise a conflict off one of those FROM `preference` itself when
+ * `preference` IS one of them, so naming it stays honest.
+ *
  * Returns null when there is nothing to report: no conflict, or no share
  * block at all — the shape of an adult-weekend guest, who has no share
  * question to disagree on (`_build_person_parties` attaches no share data).
@@ -345,16 +359,19 @@ function wordingFor<T extends string>(
  */
 export function answersConflictDetail(share: ShareRequest | undefined): string | null {
   if (share?.answers_conflict !== true) return null
-  const registration = wordingFor(
-    REGISTRATION_ANSWER,
-    share.preference ?? 'unknown',
-    'not answered'
-  )
   const resolved = wordingFor(FORM_ANSWER, share.eligibility ?? 'unknown', 'not answered')
   const winner =
     share.eligibility_source === 'form'
       ? `the Family Camp form said ${resolved} — staff use the form's answer`
       : `the answer on file is ${resolved} — staff use that answer`
+  if (share.preference === 'maybe_mutual') {
+    return `A registration answer on file disagrees with this: ${winner}.`
+  }
+  const registration = wordingFor(
+    REGISTRATION_ANSWER,
+    share.preference ?? 'unknown',
+    'not answered'
+  )
   return `Registration said ${registration}; ${winner}.`
 }
 

--- a/frontend/src/components/weekend/boardLayout.ts
+++ b/frontend/src/components/weekend/boardLayout.ts
@@ -341,15 +341,20 @@ function wordingFor<T extends string>(
  * `winsGate`'s newest-wins race, not necessarily the answer that disagrees
  * (kindred#2269). `DeriveShareEligibility` raises the conflict off the UNION
  * of every sibling's recorded no_share/yes_share answer, so a household can
- * conflict with `maybe_mutual` as the winning gate -- the actual
- * contradiction is a sibling answer that lost recency and never reaches this
- * payload. `REGISTRATION_ANSWER['maybe_mutual']` ("only if a mutual match")
- * does not itself read as a disagreement against any resolved verdict, so
- * naming it as "Registration said …" would have the tooltip pair two answers
- * that look like they agree, on a chip whose whole job is to say they don't.
- * `no_share` and `yes_share` don't have this problem: DeriveShareEligibility
- * can only raise a conflict off one of those FROM `preference` itself when
- * `preference` IS one of them, so naming it stays honest.
+ * conflict with a WINNING gate that itself agrees with the resolved verdict
+ * -- the actual contradiction is a *different* sibling's answer that lost
+ * recency and never reaches this payload at all. This is not only a
+ * `maybe_mutual` shape: the winning gate can be `no_share` while eligibility
+ * is ALSO `declined` (a hidden lost `yes_share` sibling is the real
+ * conflict), or `yes_share` while eligibility is ALSO non-declined (a hidden
+ * lost `no_share` sibling). `preferenceDisagrees` below reruns the same
+ * two-arm test `DeriveShareEligibility` used before kindred#2269 introduced
+ * the union signals -- the one case where `preference` itself, taken alone,
+ * actually contradicts `eligibility`. Only then is it safe to name; every
+ * other case falls back to the generic "a registration answer on file
+ * disagrees" sentence, because naming an agreeing pair would have the
+ * tooltip look like agreement on a chip whose whole job is to say they
+ * don't.
  *
  * Returns null when there is nothing to report: no conflict, or no share
  * block at all — the shape of an adult-weekend guest, who has no share
@@ -364,7 +369,10 @@ export function answersConflictDetail(share: ShareRequest | undefined): string |
     share.eligibility_source === 'form'
       ? `the Family Camp form said ${resolved} — staff use the form's answer`
       : `the answer on file is ${resolved} — staff use that answer`
-  if (share.preference === 'maybe_mutual') {
+  const preferenceDisagrees =
+    (share.preference === 'no_share' && share.eligibility !== 'declined') ||
+    (share.preference === 'yes_share' && share.eligibility === 'declined')
+  if (!preferenceDisagrees) {
     return `A registration answer on file disagrees with this: ${winner}.`
   }
   const registration = wordingFor(

--- a/pocketbase/sync/lodging_requests.go
+++ b/pocketbase/sync/lodging_requests.go
@@ -162,7 +162,9 @@ func ParseSharedCabinModes(raw string) (near, with, similarAges bool) {
 // A conflict is a HARD contradiction only: the two forms point opposite ways.
 // maybe_mutual resolving into anything is the answer arriving, not a conflict --
 // counting refinements would put a third of respondents in the review queue
-// instead of the measured 7.5%.
+// instead of the measured 7.5% (pre-kindred#2269; the union widening below is
+// a strict superset of the test that rate was measured against, so the true
+// rate can only be equal or higher now).
 //
 // anySiblingDeclined and anySiblingYesShare report whether ANY of the
 // household's person-partition gate answers normalised to no_share /
@@ -203,7 +205,10 @@ func DeriveShareEligibility(
 		return eligibility, shareSourceForm, conflict
 	}
 
-	// FALLBACK. One answer cannot contradict anything, so conflict stays false.
+	// FALLBACK. conflict is hardcoded false on every return below -- the
+	// fallback never raises share_answers_conflict itself, no matter how many
+	// sibling registration gate answers disagree with each other; evaluating
+	// a conflict is the form-answered branch's job, above.
 	//
 	// A recorded decline anywhere in the household outranks a later permissive
 	// sibling answer. winsGate resolves the gate by newest-wins with no
@@ -318,9 +323,16 @@ func CollapseToHouseholdGrain(values []PersonRequestValue) map[string]*Household
 		// DeriveShareEligibility.
 		sawDeclineGate bool
 		// The symmetric union for yes_share -- kindred#2269. Consulted only by
-		// the form-answered conflict test: the fallback path has no
-		// permissive-verdict fail-safe to buy, since a sibling yes_share can
-		// only make the fallback verdict MORE restrictive than it already is.
+		// the form-answered conflict test. On DeriveShareEligibility's
+		// FALLBACK path (above), the only reachable case where this signal
+		// could change the answer is a winning maybe_mutual gate with a lost
+		// yes_share sibling: a winning no_share gate already sets
+		// sawDeclineGate and returns declined before this is ever read, and a
+		// winning yes_share gate already returns the fallback's most
+		// permissive verdict, open. Honoring sawYesGate there would turn
+		// maybe_mutual's `named` into `open` -- MORE permissive, not less --
+		// and the fallback deliberately does not buy that fail-safe, unlike
+		// the restrictive one anySiblingDeclined buys above.
 		sawYesGate bool
 	}
 

--- a/pocketbase/sync/lodging_requests.go
+++ b/pocketbase/sync/lodging_requests.go
@@ -163,11 +163,16 @@ func ParseSharedCabinModes(raw string) (near, with, similarAges bool) {
 // maybe_mutual resolving into anything is the answer arriving, not a conflict --
 // counting refinements would put a third of respondents in the review queue
 // instead of the measured 7.5%.
-// anySiblingDeclined reports whether ANY of the household's person-partition
-// gate answers normalised to no_share, regardless of which one winsGate picked.
-// It is consulted only on the fallback path -- see below.
+//
+// anySiblingDeclined and anySiblingYesShare report whether ANY of the
+// household's person-partition gate answers normalised to no_share /
+// yes_share respectively, regardless of which one winsGate picked as the
+// recency winner. Both are UNION signals across every sibling, not the single
+// winning gate -- see the conflict test below and kindred#2269, which is what
+// happens when only one direction of this union is wired in (or, before this
+// function existed, when neither was).
 func DeriveShareEligibility(
-	gate string, formAnswered, wantsWith, wantsSimilarAges, anySiblingDeclined bool,
+	gate string, formAnswered, wantsWith, wantsSimilarAges, anySiblingDeclined, anySiblingYesShare bool,
 ) (eligibility, source string, conflict bool) {
 	if formAnswered {
 		switch {
@@ -186,8 +191,15 @@ func DeriveShareEligibility(
 		// it exists because staff reword these sentences. If it ever broke,
 		// keying off wantsWith would fail PERMISSIVELY -- reporting no conflict
 		// for a no_share gate sitting against an open verdict.
-		conflict = (gate == gateNoShare && eligibility != shareEligibilityDeclined) ||
-			(gate == gateYesShare && eligibility == shareEligibilityDeclined)
+		//
+		// Both arms are keyed off the UNION signals (anySiblingDeclined /
+		// anySiblingYesShare), not off `gate` -- the single answer that WON
+		// the recency race. A contradicting sibling that lost recency is
+		// still a contradiction the household stated -- kindred#2269 -- and
+		// reading only the winner missed it whenever the winner was
+		// maybe_mutual, since that gate matches neither arm on its own.
+		conflict = (anySiblingDeclined && eligibility != shareEligibilityDeclined) ||
+			(anySiblingYesShare && eligibility == shareEligibilityDeclined)
 		return eligibility, shareSourceForm, conflict
 	}
 
@@ -301,8 +313,15 @@ func CollapseToHouseholdGrain(values []PersonRequestValue) map[string]*Household
 		// unknown, so it tracks value PRESENCE, not parsed modes.
 		formAnswered bool
 		// Whether ANY sibling's gate answer normalised to no_share, regardless
-		// of which one winsGate picked. The fallback fails safe on this.
+		// of which one winsGate picked. The fallback fails safe on this, and
+		// the form-answered conflict test reads it too -- see
+		// DeriveShareEligibility.
 		sawDeclineGate bool
+		// The symmetric union for yes_share -- kindred#2269. Consulted only by
+		// the form-answered conflict test: the fallback path has no
+		// permissive-verdict fail-safe to buy, since a sibling yes_share can
+		// only make the fallback verdict MORE restrictive than it already is.
+		sawYesGate bool
 	}
 
 	byHousehold := make(map[string]*accumulator)
@@ -342,10 +361,14 @@ func CollapseToHouseholdGrain(values []PersonRequestValue) map[string]*Household
 		switch v.FieldName {
 		case fieldShareCabinsRegistration, fieldSharedCabinForm:
 			gate := NormalizeShareGate(value)
-			// Recorded BEFORE winsGate picks a winner: a decline that loses on
-			// recency is still a decline the household stated.
+			// Recorded BEFORE winsGate picks a winner: a decline -- or a
+			// yes -- that loses on recency is still an answer the household
+			// stated.
 			if gate == gateNoShare {
 				a.sawDeclineGate = true
+			}
+			if gate == gateYesShare {
+				a.sawYesGate = true
 			}
 			if gate != "" && winsGate(a.gateAt, a.gateField, v) {
 				a.req.Gate = gate
@@ -383,7 +406,8 @@ func CollapseToHouseholdGrain(values []PersonRequestValue) map[string]*Household
 		// correct reading and the reason most such combinations exist.
 		a.req.ShareEligibility, a.req.ShareEligibilitySource, a.req.ShareAnswersConflict =
 			DeriveShareEligibility(
-				a.req.Gate, a.formAnswered, a.req.WantsWith, a.req.WantsSimilarAges, a.sawDeclineGate)
+				a.req.Gate, a.formAnswered, a.req.WantsWith, a.req.WantsSimilarAges,
+				a.sawDeclineGate, a.sawYesGate)
 		out[hh] = a.req
 	}
 	return out

--- a/pocketbase/sync/lodging_requests_test.go
+++ b/pocketbase/sync/lodging_requests_test.go
@@ -453,8 +453,11 @@ func TestDeriveShareEligibility(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			// Every case here models a single-source gate answer, so the
+			// union-across-siblings signal equals the (only) gate directly.
 			gotEligibility, gotSource, gotConflict := DeriveShareEligibility(
-				tc.gate, tc.formAnswered, tc.wantsWith, tc.similarAges, false)
+				tc.gate, tc.formAnswered, tc.wantsWith, tc.similarAges,
+				tc.gate == gateNoShare, tc.gate == gateYesShare)
 			if gotEligibility != tc.eligibility {
 				t.Errorf("eligibility = %q, want %q", gotEligibility, tc.eligibility)
 			}
@@ -479,7 +482,7 @@ func TestDeriveShareEligibility(t *testing.T) {
 func TestDeriveShareEligibilityIgnoresNearOnly(t *testing.T) {
 	t.Parallel()
 	// NEAR alone reaches this function as "form answered, wants_with false".
-	got, source, conflict := DeriveShareEligibility(gateMaybeMutual, true, false, false, false)
+	got, source, conflict := DeriveShareEligibility(gateMaybeMutual, true, false, false, false, false)
 	if got != shareEligibilityDeclined {
 		t.Errorf("NEAR-only eligibility = %q, want %q", got, shareEligibilityDeclined)
 	}
@@ -491,7 +494,7 @@ func TestDeriveShareEligibilityIgnoresNearOnly(t *testing.T) {
 	}
 
 	// WITH + NEAR together: the share request survives the proximity request.
-	got, _, _ = DeriveShareEligibility("", true, true, false, false)
+	got, _, _ = DeriveShareEligibility("", true, true, false, false, false)
 	if got != shareEligibilityNamed {
 		t.Errorf("WITH+NEAR eligibility = %q, want %q", got, shareEligibilityNamed)
 	}
@@ -593,13 +596,16 @@ func TestDeriveShareEligibilityConflictTracksTheVerdict(t *testing.T) {
 	t.Parallel()
 	// similarAges WITHOUT with -- the state ParseSharedCabinModes prevents.
 	// Reached directly, the verdict is open, so a no_share gate conflicts.
-	_, _, conflict := DeriveShareEligibility(gateNoShare, true, false, true, false)
+	// anySiblingDeclined=true stands in for "this no_share is the (only)
+	// sibling gate answer" -- see TestDeriveShareEligibilityConflictSurvivesALostSiblingDecline
+	// for the case where it lost recency instead.
+	_, _, conflict := DeriveShareEligibility(gateNoShare, true, false, true, true, false)
 	if !conflict {
 		t.Error("no_share gate against an open verdict is a conflict, whatever wantsWith says")
 	}
 
 	// And the mirror: a yes_share gate against an open verdict is agreement.
-	_, _, conflict = DeriveShareEligibility(gateYesShare, true, false, true, false)
+	_, _, conflict = DeriveShareEligibility(gateYesShare, true, false, true, false, true)
 	if conflict {
 		t.Error("yes_share gate against an open verdict agrees")
 	}
@@ -622,7 +628,7 @@ func TestDeriveShareEligibilityConflictTracksTheVerdict(t *testing.T) {
 func TestDeriveShareEligibilityFallbackFailsSafeOnASiblingDecline(t *testing.T) {
 	t.Parallel()
 	for _, gate := range []string{gateYesShare, gateMaybeMutual} {
-		eligibility, source, conflict := DeriveShareEligibility(gate, false, false, false, true)
+		eligibility, source, conflict := DeriveShareEligibility(gate, false, false, false, true, false)
 		if eligibility != shareEligibilityDeclined {
 			t.Errorf("gate %q with a declining sibling = %q, want %q",
 				gate, eligibility, shareEligibilityDeclined)
@@ -637,7 +643,7 @@ func TestDeriveShareEligibilityFallbackFailsSafeOnASiblingDecline(t *testing.T) 
 
 	// The form still wins. A declining sibling does NOT override an answered
 	// form -- that would invert the precedence rule.
-	eligibility, source, _ := DeriveShareEligibility(gateNoShare, true, true, false, true)
+	eligibility, source, _ := DeriveShareEligibility(gateNoShare, true, true, false, true, false)
 	if eligibility != shareEligibilityNamed || source != shareSourceForm {
 		t.Errorf("form answer = (%q, %q), want (%q, %q) -- the form outranks a sibling gate",
 			eligibility, source, shareEligibilityNamed, shareSourceForm)
@@ -672,5 +678,113 @@ func TestCollapseCarriesASiblingDeclineIntoTheFallback(t *testing.T) {
 	if a.ShareEligibility != shareEligibilityDeclined {
 		t.Errorf("eligibility = %q, want %q -- a recorded decline outranks a later yes in the fallback",
 			a.ShareEligibility, shareEligibilityDeclined)
+	}
+}
+
+// TestDeriveShareEligibilityConflictSurvivesALostSiblingDecline pins
+// kindred#2269: on the FORM-ANSWERED path, the conflict test was keyed off
+// `gate` -- the single answer that WON the recency race -- so a sibling's
+// no_share that lost to a later, more permissive gate never raised a
+// conflict, even though anySiblingDeclined already carried that fact into
+// this function. The parameter existed; the form-answered branch just never
+// read it.
+func TestDeriveShareEligibilityConflictSurvivesALostSiblingDecline(t *testing.T) {
+	t.Parallel()
+	// A sibling recorded no_share but lost the recency race to a gate that
+	// isn't even no_share or yes_share -- maybe_mutual -- and the form
+	// resolves to an open verdict. The lost decline must still surface.
+	_, _, conflict := DeriveShareEligibility(gateMaybeMutual, true, true, true, true, false)
+	if !conflict {
+		t.Error("a lost sibling no_share against an open verdict must still raise a conflict")
+	}
+
+	// Negative control: no sibling ever declined, so no conflict.
+	_, _, conflict = DeriveShareEligibility(gateMaybeMutual, true, true, true, false, false)
+	if conflict {
+		t.Error("no sibling declined, so nothing should conflict")
+	}
+}
+
+// TestDeriveShareEligibilityConflictSurvivesALostSiblingYesShare is the
+// mirror of the decline case above, and the half of kindred#2269 that had NO
+// signal at all: there was no anySiblingYesShare parameter to wire in. A
+// sibling recorded yes_share but lost the recency race -- again to
+// maybe_mutual, the gate that matches neither the old no_share arm nor the
+// old yes_share arm -- and the form declines. That lost yes_share must still
+// surface as a conflict.
+func TestDeriveShareEligibilityConflictSurvivesALostSiblingYesShare(t *testing.T) {
+	t.Parallel()
+	_, _, conflict := DeriveShareEligibility(gateMaybeMutual, true, false, false, false, true)
+	if !conflict {
+		t.Error("a lost sibling yes_share against a declined verdict must still raise a conflict")
+	}
+
+	// Negative control: no sibling ever said yes, so no conflict.
+	_, _, conflict = DeriveShareEligibility(gateMaybeMutual, true, false, false, false, false)
+	if conflict {
+		t.Error("no sibling said yes_share, so nothing should conflict")
+	}
+}
+
+// TestCollapseSurfacesALostSiblingGateAsAConflict is the household-grain
+// integration proof for kindred#2269: CollapseToHouseholdGrain must actually
+// compute and pass BOTH union signals, not just expose functions that could.
+// Both households below have a maybe_mutual gate WIN the recency race --
+// deliberately, since every observed miss had maybe_mutual as the winner, the
+// one gate the old two-arm expression never named on its own.
+func TestCollapseSurfacesALostSiblingGateAsAConflict(t *testing.T) {
+	t.Parallel()
+	const yesShare = "Yes, I would like to share a large camper cabin with a family that I " +
+		"request or with a family with similarly aged kid(s) that I can meet at Camp."
+	const noShare = "No, we would prefer not to share a camper cabin."
+	const maybeMutual = "Maybe, I am open to sharing a large camper cabin if a specific family " +
+		"that I know wants to share a cabin with my family."
+	const withNamed = "Share a cabin WITH a specific family that I know (please include names " +
+		"below and ensure that the request is mutual)."
+	older := time.Now().Add(-time.Hour)
+	newer := time.Now()
+
+	// hhA: one child said yes_share; a later sibling's maybe_mutual WINS the
+	// gate; the form (answered) declines. The lost yes_share must surface.
+	outA := CollapseToHouseholdGrain([]PersonRequestValue{
+		{HouseholdKey: hhA, FieldName: fieldShareCabinsRegistration, Value: yesShare, LastUpdated: older},
+		{HouseholdKey: hhA, FieldName: fieldShareCabinsRegistration, Value: maybeMutual, LastUpdated: newer},
+		{HouseholdKey: hhA, FieldName: fieldSharedCabinForm, Value: "No requests", LastUpdated: newer},
+	})
+	a := outA[hhA]
+	if a == nil {
+		t.Fatal("household A missing from collapse")
+	}
+	if a.Gate != gateMaybeMutual {
+		t.Fatalf("gate = %q, want %q -- winsGate's newest-wins resolution is unchanged by this fix",
+			a.Gate, gateMaybeMutual)
+	}
+	if a.ShareEligibility != shareEligibilityDeclined {
+		t.Fatalf("eligibility = %q, want %q", a.ShareEligibility, shareEligibilityDeclined)
+	}
+	if !a.ShareAnswersConflict {
+		t.Error("a sibling's yes_share lost the recency race to maybe_mutual but must still raise a conflict")
+	}
+
+	// hhB: the mirror -- one child said no_share; a later sibling's
+	// maybe_mutual WINS the gate; the form names a partner (shareable).
+	outB := CollapseToHouseholdGrain([]PersonRequestValue{
+		{HouseholdKey: hhB, FieldName: fieldShareCabinsRegistration, Value: noShare, LastUpdated: older},
+		{HouseholdKey: hhB, FieldName: fieldShareCabinsRegistration, Value: maybeMutual, LastUpdated: newer},
+		{HouseholdKey: hhB, FieldName: fieldSharedCabinForm, Value: withNamed, LastUpdated: newer},
+	})
+	b := outB[hhB]
+	if b == nil {
+		t.Fatal("household B missing from collapse")
+	}
+	if b.Gate != gateMaybeMutual {
+		t.Fatalf("gate = %q, want %q -- winsGate's newest-wins resolution is unchanged by this fix",
+			b.Gate, gateMaybeMutual)
+	}
+	if b.ShareEligibility != shareEligibilityNamed {
+		t.Fatalf("eligibility = %q, want %q", b.ShareEligibility, shareEligibilityNamed)
+	}
+	if !b.ShareAnswersConflict {
+		t.Error("a sibling's no_share lost the recency race to maybe_mutual but must still raise a conflict")
 	}
 }


### PR DESCRIPTION
## What changed

`DeriveShareEligibility`'s form-answered conflict test (`pocketbase/sync/lodging_requests.go:189-190`) was keyed off `gate` — the single registration answer that WON `winsGate`'s newest-wins recency race in `CollapseToHouseholdGrain` — not off the union of every sibling's recorded answer. A contradicting sibling `no_share` or `yes_share` that lost recency vanished from `share_answers_conflict` entirely, and every observed miss had `maybe_mutual` as the winning gate, since that gate matched neither arm of the old two-way expression on its own.

Adds the missing symmetric `sawYesGate` union signal (mirroring the existing `sawDeclineGate`) to the `CollapseToHouseholdGrain` accumulator, and wires both `anySiblingDeclined`/`anySiblingYesShare` into the conflict test instead of `gate`. `CollapseToHouseholdGrain`'s newest-wins gate resolution is **unchanged** — `share_cabin_gate` still shows the answer that won recency, exactly as before. `share_eligibility` / `share_eligibility_source` are also unchanged; this only affects the `share_answers_conflict` flag.

`NormalizeShareGate` / `maybe_mutual`'s mapping is untouched, per the task brief — no stranger-pairing bug there.

### Frontend follow-on (same PR, not a separate scope)

Raising the conflict flag off a losing sibling answer means a household can now conflict with `maybe_mutual` as the *winning* `share_cabin_gate` — and, more generally, with a winning `no_share`/`yes_share` gate that itself *agrees* with the resolved verdict, because the real contradiction is a different sibling's answer that lost the recency race and never reaches this payload at all. `answersConflictDetail` (`frontend/src/components/weekend/boardLayout.ts`) used to build its tooltip by naming the winning registration answer as "the side that disagrees" unconditionally — which is no longer safe. It now gates that naming on `preferenceDisagrees`, which reruns the same two-arm test `DeriveShareEligibility` used before this PR: `preference === 'no_share'` against a non-declined verdict, or `preference === 'yes_share'` against a declined one. Only when the winning `preference`, taken alone, actually contradicts `eligibility` does the tooltip name it; every other case — `maybe_mutual`, and a winning `no_share`/`yes_share` that agrees with the verdict — falls back to the generic "a registration answer on file disagrees" wording, so the tooltip never misattributes an agreeing answer as the disagreeing one.

No PocketBase migration; no API change — `api/services/lodging_roster_service.py`'s `answers_conflict=_b(registration, "share_answers_conflict")` is a pure passthrough and needed no changes. `api/routers/lodging.py` has no reference to this signal at all.

## Field-sharing note (not a file conflict)

Per the task brief: another worker tonight (kindred#2274) is changing how `FAM CAMP-Share Cabins` / `FAM CAMP-Shared Cabin` are collapsed in `pocketbase/sync/family_camp_derived.go`. This PR does not touch that file — only `lodging_requests.go`'s `CollapseToHouseholdGrain` / `DeriveShareEligibility` — but both PRs touch the same underlying fields, so please review together.

## Verification

- `cd pocketbase && go build ./...` → exit 0
- `cd pocketbase && go test ./...` → exit 0 (full suite, all packages)
- `cd pocketbase && golangci-lint run ./sync/...` → 0 issues
- `cd frontend && ./node_modules/.bin/tsc --noEmit -p .` → exit 0
- `cd frontend && ./node_modules/.bin/eslint src/components/weekend/boardLayout.ts src/components/weekend/boardLayout.test.ts` → 0 errors
- `cd frontend && ./node_modules/.bin/vitest run src/components/weekend/` → 39 files, 1146/1146 passed
- `bash scripts/pre-push-verify.sh` → ALL CHECKS PASSED (exit 0)
- The parallelism guard (`pocketbase/main_test_parallelism_test.go`) passes: every new top-level test in `pocketbase/sync/` calls `t.Parallel()`.

### Mutation checks (TDD)

**Go** — reverted `conflict = (anySiblingDeclined && …) || (anySiblingYesShare && …)` back to the old `gate == gateNoShare` / `gate == gateYesShare` form and re-ran the three new tests (`TestDeriveShareEligibilityConflictSurvivesALostSiblingDecline`, `TestDeriveShareEligibilityConflictSurvivesALostSiblingYesShare`, `TestCollapseSurfacesALostSiblingGateAsAConflict`): all three failed with the exact assertion messages describing the bug. Restored the fix, re-ran: all green, full suite green.

**Frontend** — reverted the `maybe_mutual` branch in `answersConflictDetail` and re-ran the new test (`does not name a maybe_mutual registration answer as the side that disagrees`): failed with `"Registration said only if a mutual match; …"` — exactly the misleading sentence the fix exists to stop. Restored the fix, re-ran: green, full `weekend/` suite green (1146/1146).

## Tests added

- `TestDeriveShareEligibilityConflictSurvivesALostSiblingDecline` — RED-first pin of the decline-direction gap (the `anySiblingDeclined` parameter existed but the form-answered branch never read it).
- `TestDeriveShareEligibilityConflictSurvivesALostSiblingYesShare` — the symmetric gap; there was no `anySiblingYesShare` signal at all before this PR.
- `TestCollapseSurfacesALostSiblingGateAsAConflict` — household-grain integration proof, both directions, with `maybe_mutual` as the winning gate (the shape of every real miss the issue measured).
- `boardLayout.test.ts`: `does not name a maybe_mutual registration answer as the side that disagrees (kindred#2269)`.

Existing tests (`TestDeriveShareEligibility`, `TestDeriveShareEligibilityConflictTracksTheVerdict`, `TestDeriveShareEligibilityFallbackFailsSafeOnASiblingDecline`, `TestCollapseCarriesASiblingDeclineIntoTheFallback`) were updated only to add the new `anySiblingYesShare` parameter to their call sites — their asserted behavior is unchanged.

Closes #2269.

