### PR TITLE
fix(sync): count and log discarded BUS-* transportation fields

### DIFF
--- a/pocketbase/sync/camper_transportation.go
+++ b/pocketbase/sync/camper_transportation.go
@@ -587,6 +587,14 @@ var retiredBusFieldReasons = map[string]string{
 	"BUS-phone number of person dropping off":  "abandoned predecessor of the routed \"-correct\" field; zero rows ever",
 }
 
+// Separate from the above: alt_pickup_2_name, alt_pickup_2_phone and
+// alt_pickup_1_relationship ARE routed (colAltPickup2Name, colAltPickup2Phone,
+// colAltPickup1Relationship all have switch cases below) but have never held
+// a value in any year 2017-2026. kindred#2272 decided KEEP AS-IS: dropping
+// them needs a migration and is only worth it inside a wider
+// camper_transportation cleanup, none of which is in flight. Do not touch
+// these three columns on their own.
+
 // classifyUnmappedBusFields splits per-field discard counts (fields
 // MapTransportationFieldToColumn returned "" for) into the eleven names
 // retiredBusFieldReasons already explains, and everything else. The second

--- a/pocketbase/sync/camper_transportation.go
+++ b/pocketbase/sync/camper_transportation.go
@@ -33,7 +33,6 @@ const (
 	colAltPickup1Relationship = "alt_pickup_1_relationship"
 	colAltPickup2Name         = "alt_pickup_2_name"
 	colAltPickup2Phone        = "alt_pickup_2_phone"
-	colAltPickup2Relationship = "alt_pickup_2_relationship"
 )
 
 // CamperTransportationSync extracts BUS-* custom fields for camper transportation.
@@ -224,6 +223,7 @@ func (s *CamperTransportationSync) Sync(ctx context.Context) error {
 		"created", s.Stats.Created,
 		"updated", s.Stats.Updated,
 		"deleted", s.Stats.Deleted,
+		"skipped", s.Stats.Skipped,
 		"errors", s.Stats.Errors,
 	)
 
@@ -416,6 +416,14 @@ func (s *CamperTransportationSync) loadPersonCustomValues(
 
 	// Aggregate to person-session level
 	result := make(map[string]*camperTransportationRecord)
+	// unmappedCounts tracks discard events: a "BUS-*" field accepted by
+	// isCamperTransportationField (the prefix test) that has no case in
+	// MapTransportationFieldToColumn. Keyed by field name so the eventual log
+	// line names what was dropped, not just how much (kindred#2272). This
+	// counts per (person, session) entry -- i.e. discard EVENTS, not source
+	// values: a value on a person enrolled in two sessions fans out to two
+	// entries here, same as it does for a routed field.
+	unmappedCounts := make(map[string]int)
 
 	for _, entry := range entries {
 		key := attendeeKey{personID: entry.personID, sessionID: entry.sessionID}
@@ -436,18 +444,50 @@ func (s *CamperTransportationSync) loadPersonCustomValues(
 			result[compositeKey] = rec
 		}
 
-		// Map field to record
-		mapTransportFieldToRecord(rec, entry.fieldName, entry.value)
+		// Map field to record. A field with no case in
+		// MapTransportationFieldToColumn used to be dropped here with no
+		// counter and no log line -- the sync reported success either way.
+		if column := mapTransportFieldToRecord(rec, entry.fieldName, entry.value); column == "" {
+			unmappedCounts[entry.fieldName]++
+		}
+	}
+
+	if len(unmappedCounts) > 0 {
+		known, unexpected := classifyUnmappedBusFields(unmappedCounts)
+		total := 0
+		for _, n := range unmappedCounts {
+			total += n
+		}
+		s.Stats.Skipped += total
+
+		// One aggregated warning per run, not one per discarded value -- a
+		// historical backfill over 2017-2020 would otherwise log 1,628 lines.
+		// unexpected is the bucket that actually needs a human: a name not in
+		// retiredBusFieldReasons is either a new CampMinder "BUS-*" field with
+		// no routing case yet, or a retired field this list has not been told
+		// about.
+		slog.Warn("Camper transportation: discarding values for unmapped BUS-* fields",
+			"year", year,
+			"discard_events", total,
+			"known_retired_fields", known,
+			"unrecognized_fields", unexpected,
+		)
 	}
 
 	return result, nil
 }
 
-// mapTransportFieldToRecord maps a BUS-* field to the record
-func mapTransportFieldToRecord(rec *camperTransportationRecord, fieldName, value string) {
+// mapTransportFieldToRecord maps a BUS-* field to the record. It returns the
+// column the value was written to, or "" if MapTransportationFieldToColumn
+// has no case for fieldName. mapTransportFieldToRecord is a package-level
+// function with no receiver and no access to Stats, so the caller --
+// loadPersonCustomValues' aggregation loop, which does have the receiver --
+// is where an empty return gets counted and logged instead of silently
+// dropped (kindred#2272).
+func mapTransportFieldToRecord(rec *camperTransportationRecord, fieldName, value string) string {
 	column := MapTransportationFieldToColumn(fieldName)
 	if column == "" {
-		return
+		return ""
 	}
 
 	switch column {
@@ -512,9 +552,66 @@ func mapTransportFieldToRecord(rec *camperTransportationRecord, fieldName, value
 			rec.altPickup2Phone = value
 		}
 	}
+
+	return column
 }
 
-// MapTransportationFieldToColumn maps CampMinder field names to database column names
+// retiredBusFieldReasons documents the eleven CampMinder "BUS-*" custom field
+// definitions that MapTransportationFieldToColumn deliberately has no case
+// for. They belonged to an airport/flight-transfer form retired after the
+// 2020 season: kindred#2272 measured 1,299 discarded source values (1,628
+// discard events once fanned out per multi-session camper) across 188
+// people, every one of them dated 2017-2020, and zero in every year since
+// 2021 -- nothing has been lost since, and nothing is being lost today. A
+// name landing in this map is a closed question, not an oversight; do not
+// add a routing case for one without first checking whether CampMinder
+// actually resumed collecting it.
+//
+// "BUS-phone number of person dropping off" is the odd one out: it has zero
+// rows in person_custom_values in ANY year. It is the abandoned Integer-typed
+// predecessor of the routed, String-typed
+// "BUS-Phone number of person dropping off-correct" -- do not confuse the two
+// when reading a diff; they differ only by a capital P and the "-correct"
+// suffix.
+var retiredBusFieldReasons = map[string]string{
+	"BUS-From camp-traveling without grownup":  "retired flight-transfer form field, no values since 2020",
+	"BUS-Departure airport-from camp":          "retired flight-transfer form field, no values since 2020",
+	"BUS-Airport arriving to home from camp":   "retired flight-transfer form field, no values since 2020",
+	"BUS-Flight # from camp":                   "retired flight-transfer form field, no values since 2020",
+	"BUS-Departing time of return home flight": "retired flight-transfer form field, no values since 2020",
+	"BUS-To camp-traveling without adult":      "retired flight-transfer form field, no values since 2020",
+	"BUS-Departure airport to camp":            "retired flight-transfer form field, no values since 2020",
+	"BUS-Arriving airport to camp":             "retired flight-transfer form field, no values since 2020",
+	"BUS-Flight # to camp":                     "retired flight-transfer form field, no values since 2020",
+	"BUS-Arrival time to camp":                 "retired flight-transfer form field, no values since 2020",
+	"BUS-phone number of person dropping off":  "abandoned predecessor of the routed \"-correct\" field; zero rows ever",
+}
+
+// classifyUnmappedBusFields splits per-field discard counts (fields
+// MapTransportationFieldToColumn returned "" for) into the eleven names
+// retiredBusFieldReasons already explains, and everything else. The second
+// bucket is the one an operator needs to act on: it is either a brand-new
+// CampMinder "BUS-*" field with no routing case yet, or a retired field this
+// map has not been told about.
+func classifyUnmappedBusFields(counts map[string]int) (known, unexpected map[string]int) {
+	known = make(map[string]int, len(counts))
+	unexpected = make(map[string]int, len(counts))
+	for name, n := range counts {
+		if _, ok := retiredBusFieldReasons[name]; ok {
+			known[name] = n
+		} else {
+			unexpected[name] = n
+		}
+	}
+	return known, unexpected
+}
+
+// MapTransportationFieldToColumn maps CampMinder field names to database
+// column names. Eleven "BUS-*" definitions are deliberately absent from this
+// switch -- see retiredBusFieldReasons immediately above for which ones and
+// why. Adding a case here removes a field from that map's coverage too, so
+// keep them in sync (TestRetiredBusFieldReasonsCoversExactlyTheElevenUnroutedNames
+// checks this).
 func MapTransportationFieldToColumn(fieldName string) string {
 	switch fieldName {
 	// To/From camp method

--- a/pocketbase/sync/camper_transportation_test.go
+++ b/pocketbase/sync/camper_transportation_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
 )
 
 // TestCamperTransportationLoadFieldDefinitionsTrimsNames is a regression test
@@ -139,6 +140,21 @@ func TestTransportationFieldMapping(t *testing.T) {
 		{"Bus From Camp", "from_camp_method"},
 		// Unknown field
 		{"Unknown-Field", ""},
+		// The eleven retired airport/flight-transfer fields (kindred#2272) --
+		// deliberately unrouted, not an oversight. Before this addition nothing
+		// in this table asserted that a "BUS-*" name maps to "", so a case
+		// accidentally added for one of these would not have failed a test.
+		{"BUS-From camp-traveling without grownup", ""},
+		{"BUS-Departure airport-from camp", ""},
+		{"BUS-Airport arriving to home from camp", ""},
+		{"BUS-Flight # from camp", ""},
+		{"BUS-Departing time of return home flight", ""},
+		{"BUS-To camp-traveling without adult", ""},
+		{"BUS-Departure airport to camp", ""},
+		{"BUS-Arriving airport to camp", ""},
+		{"BUS-Flight # to camp", ""},
+		{"BUS-Arrival time to camp", ""},
+		{"BUS-phone number of person dropping off", ""},
 	}
 
 	for _, tt := range tests {
@@ -149,6 +165,118 @@ func TestTransportationFieldMapping(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRetiredBusFieldReasonsCoversExactlyTheElevenUnroutedNames pins
+// kindred#2272's inventory: 26 "BUS-*"/legacy definitions accepted, 15 names
+// routed to 13 columns, 11 names with no case at all. Every one of those
+// eleven must carry an explicit reason in retiredBusFieldReasons -- and
+// MapTransportationFieldToColumn must agree that none of them route anywhere,
+// or the "known-retired" bucket in classifyUnmappedBusFields would silently
+// swallow a field that actually needs a routing case added.
+func TestRetiredBusFieldReasonsCoversExactlyTheElevenUnroutedNames(t *testing.T) {
+	t.Parallel()
+	names := []string{
+		"BUS-From camp-traveling without grownup",
+		"BUS-Departure airport-from camp",
+		"BUS-Airport arriving to home from camp",
+		"BUS-Flight # from camp",
+		"BUS-Departing time of return home flight",
+		"BUS-To camp-traveling without adult",
+		"BUS-Departure airport to camp",
+		"BUS-Arriving airport to camp",
+		"BUS-Flight # to camp",
+		"BUS-Arrival time to camp",
+		"BUS-phone number of person dropping off",
+	}
+
+	if len(retiredBusFieldReasons) != len(names) {
+		t.Errorf("retiredBusFieldReasons has %d entries, want %d -- a name was added or dropped without updating this test",
+			len(retiredBusFieldReasons), len(names))
+	}
+
+	for _, name := range names {
+		reason, ok := retiredBusFieldReasons[name]
+		if !ok {
+			t.Errorf("retiredBusFieldReasons is missing %q", name)
+			continue
+		}
+		if strings.TrimSpace(reason) == "" {
+			t.Errorf("retiredBusFieldReasons[%q] has an empty reason", name)
+		}
+		if col := MapTransportationFieldToColumn(name); col != "" {
+			t.Errorf("%q is listed in retiredBusFieldReasons but MapTransportationFieldToColumn routes it to %q -- "+
+				"remove it from the retired list or the switch, not both", name, col)
+		}
+	}
+}
+
+// TestClassifyUnmappedBusFields pins the split classifyUnmappedBusFields makes
+// between discards the eleven-name retired list already explains and any name
+// that is not on that list -- the second bucket is the one that should worry
+// an operator, because it means either a new CampMinder "BUS-*" field showed
+// up with no routing case, or a retired field this list has not been told
+// about yet.
+func TestClassifyUnmappedBusFields(t *testing.T) {
+	t.Parallel()
+	counts := map[string]int{
+		"BUS-Departure airport-from camp": 3, // known-retired
+		"BUS-Space Rocket to Camp":        1, // not on any list
+	}
+
+	known, unexpected := classifyUnmappedBusFields(counts)
+
+	if got := known["BUS-Departure airport-from camp"]; got != 3 {
+		t.Errorf("known[%q] = %d, want 3", "BUS-Departure airport-from camp", got)
+	}
+	if _, leaked := unexpected["BUS-Departure airport-from camp"]; leaked {
+		t.Error("a known-retired field leaked into the unexpected bucket")
+	}
+	if got := unexpected["BUS-Space Rocket to Camp"]; got != 1 {
+		t.Errorf("unexpected[%q] = %d, want 1", "BUS-Space Rocket to Camp", got)
+	}
+	if _, leaked := known["BUS-Space Rocket to Camp"]; leaked {
+		t.Error("a field with no retired-field reason must not land in the known bucket")
+	}
+}
+
+// testRoutedBusValue is a routed transportation value reused across
+// kindred#2272's new tests below. Named to satisfy goconst (min-occurrences:
+// 3) without touching the table-driven tests elsewhere in this file that
+// already repeat "Bus-SF" as anonymous struct fields -- goconst does not
+// count those the same way, so they were never flagged.
+const testRoutedBusValue = "Bus-SF"
+
+// TestMapTransportFieldToRecordReturnsColumnWritten pins the return-value
+// contract kindred#2272 adds: mapTransportFieldToRecord now reports which
+// column (if any) it wrote to, so its caller -- the aggregation loop in
+// loadPersonCustomValues, the only place with access to the receiver and
+// therefore to Stats -- can count and log an unmapped field instead of
+// discarding it in silence.
+func TestMapTransportFieldToRecordReturnsColumnWritten(t *testing.T) {
+	t.Parallel()
+
+	t.Run("mapped field returns its column and writes the value", func(t *testing.T) {
+		rec := &camperTransportationRecord{}
+		column := mapTransportFieldToRecord(rec, "BUS-to camp", testRoutedBusValue)
+		if column != colToCampMethod {
+			t.Errorf("column = %q, want %q", column, colToCampMethod)
+		}
+		if rec.toCampMethod != testRoutedBusValue {
+			t.Errorf("rec.toCampMethod = %q, want %q", rec.toCampMethod, testRoutedBusValue)
+		}
+	})
+
+	t.Run("unmapped retired field returns empty and leaves the record untouched", func(t *testing.T) {
+		rec := &camperTransportationRecord{}
+		column := mapTransportFieldToRecord(rec, "BUS-Departure airport-from camp", "SFO")
+		if column != "" {
+			t.Errorf("column = %q, want \"\"", column)
+		}
+		if *rec != (camperTransportationRecord{}) {
+			t.Errorf("rec was mutated by an unmapped field: %+v", rec)
+		}
+	})
 }
 
 // TestTransportationCompositeKeyFormat tests composite key generation
@@ -595,5 +723,177 @@ func TestCamperTransportationDeleteOrphansStillSweepsGenuineOrphans(t *testing.T
 	}
 	if deleted != 1 {
 		t.Errorf("deleted = %d, want 1", deleted)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// kindred#2272: the silent-discard mechanism itself
+// ---------------------------------------------------------------------------
+
+// newTransportValuesTestApp returns a throwaway app holding just the two
+// collections loadPersonCustomValues actually queries: person_custom_values
+// (the source rows) and persons (person PB ID -> CampMinder person ID).
+// loadPersonCustomValues takes fieldNameMap and attendeeMap as plain Go map
+// parameters rather than loading them itself, so a fake custom_field_defs or
+// attendees collection would test plumbing this function does not use.
+func newTransportValuesTestApp(t *testing.T) core.App {
+	t.Helper()
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	pcv := core.NewBaseCollection("person_custom_values")
+	pcv.Fields.Add(&core.TextField{Name: "field_definition"})
+	pcv.Fields.Add(&core.TextField{Name: "person"})
+	pcv.Fields.Add(&core.TextField{Name: "value"})
+	pcv.Fields.Add(&core.NumberField{Name: "year"})
+	if saveErr := app.Save(pcv); saveErr != nil {
+		t.Fatalf("save person_custom_values: %v", saveErr)
+	}
+
+	persons := core.NewBaseCollection("persons")
+	persons.Fields.Add(&core.NumberField{Name: "cm_id"})
+	if saveErr := app.Save(persons); saveErr != nil {
+		t.Fatalf("save persons: %v", saveErr)
+	}
+
+	return app
+}
+
+// addPersonCustomValue writes one person_custom_values row.
+func addPersonCustomValue(t *testing.T, app core.App, fieldDefID, personPBID, value string, year int) {
+	t.Helper()
+	col, err := app.FindCollectionByNameOrId("person_custom_values")
+	if err != nil {
+		t.Fatalf("find person_custom_values: %v", err)
+	}
+	rec := core.NewRecord(col)
+	rec.Set("field_definition", fieldDefID)
+	rec.Set("person", personPBID)
+	rec.Set("value", value)
+	rec.Set("year", year)
+	if saveErr := app.Save(rec); saveErr != nil {
+		t.Fatalf("save person_custom_values row: %v", saveErr)
+	}
+}
+
+// TestLoadPersonCustomValuesCountsAndLogsUnmappedFields is the end-to-end pin
+// for kindred#2272's actual fix: before this, a "BUS-*" field accepted by
+// isCamperTransportationField but missing a case in
+// MapTransportationFieldToColumn was discarded with no counter and no log
+// line. It now must increment Stats.Skipped once per discard event and log
+// the field name, split into the known-retired bucket (documented in
+// retiredBusFieldReasons) and the unrecognized bucket (a name this run has
+// never been told about -- the signal that matters if CampMinder ever adds a
+// new "BUS-*" field).
+func TestLoadPersonCustomValuesCountsAndLogsUnmappedFields(t *testing.T) {
+	t.Parallel()
+	app := newTransportValuesTestApp(t)
+
+	personsCol, err := app.FindCollectionByNameOrId("persons")
+	if err != nil {
+		t.Fatalf("find persons: %v", err)
+	}
+	person := core.NewRecord(personsCol)
+	person.Set("cm_id", 7001)
+	if saveErr := app.Save(person); saveErr != nil {
+		t.Fatalf("save person: %v", saveErr)
+	}
+
+	const year = 2019
+	// One routed field (must still work), one known-retired unrouted field,
+	// and one field this run has never seen before (simulates a hypothetical
+	// new CampMinder "BUS-*" definition).
+	addPersonCustomValue(t, app, "fd_routed", person.Id, testRoutedBusValue, year)
+	addPersonCustomValue(t, app, "fd_retired", person.Id, "SFO", year)
+	addPersonCustomValue(t, app, "fd_novel", person.Id, "unexpected value", year)
+
+	fieldNameMap := map[string]string{
+		"fd_routed":  "BUS-to camp",
+		"fd_retired": "BUS-Departure airport-from camp",
+		"fd_novel":   "BUS-Space Rocket to Camp",
+	}
+	attendeeMap := map[attendeeKey]string{
+		{personID: 7001, sessionID: 9001}: "att1",
+	}
+
+	logs := captureSweepLogs(t)
+
+	s := NewCamperTransportationSync(app)
+	records, err := s.loadPersonCustomValues(context.Background(), year, fieldNameMap, attendeeMap)
+	if err != nil {
+		t.Fatalf("loadPersonCustomValues: %v", err)
+	}
+
+	compositeKey := makeTransportationKey(7001, 9001, year)
+	rec, ok := records[compositeKey]
+	if !ok {
+		t.Fatalf("no record for composite key %q; got %d records", compositeKey, len(records))
+	}
+	if rec.toCampMethod != testRoutedBusValue {
+		t.Errorf("routed field was not written: toCampMethod = %q, want %q", rec.toCampMethod, testRoutedBusValue)
+	}
+
+	if s.Stats.Skipped != 2 {
+		t.Errorf("Stats.Skipped = %d, want 2 -- one discard event each for the retired and the novel field",
+			s.Stats.Skipped)
+	}
+
+	logged := logs.String()
+	if !strings.Contains(logged, "BUS-Departure airport-from camp") {
+		t.Errorf("known-retired field name missing from logs:\n%s", logged)
+	}
+	if !strings.Contains(logged, "BUS-Space Rocket to Camp") {
+		t.Errorf("unrecognized field name missing from logs:\n%s", logged)
+	}
+	if !strings.Contains(logged, "level=WARN") {
+		t.Errorf("expected the discard to be logged at WARN level:\n%s", logged)
+	}
+	// The routed field must never appear as a discard.
+	if strings.Contains(logged, "BUS-to camp") {
+		t.Errorf("a successfully routed field was logged as a discard:\n%s", logged)
+	}
+}
+
+// TestLoadPersonCustomValuesNoDiscardsMeansNoWarnLog proves the fix does not
+// spam every ordinary sync run: a year with nothing unmapped must not log at
+// all and must leave Stats.Skipped at zero, matching the actual 2021+ data
+// (kindred#2272 measured zero discards in every year since 2021).
+func TestLoadPersonCustomValuesNoDiscardsMeansNoWarnLog(t *testing.T) {
+	t.Parallel()
+	app := newTransportValuesTestApp(t)
+
+	personsCol, err := app.FindCollectionByNameOrId("persons")
+	if err != nil {
+		t.Fatalf("find persons: %v", err)
+	}
+	person := core.NewRecord(personsCol)
+	person.Set("cm_id", 7002)
+	if saveErr := app.Save(person); saveErr != nil {
+		t.Fatalf("save person: %v", saveErr)
+	}
+
+	const year = 2026
+	addPersonCustomValue(t, app, "fd_routed", person.Id, testRoutedBusValue, year)
+
+	fieldNameMap := map[string]string{"fd_routed": "BUS-to camp"}
+	attendeeMap := map[attendeeKey]string{
+		{personID: 7002, sessionID: 9002}: "att2",
+	}
+
+	logs := captureSweepLogs(t)
+
+	s := NewCamperTransportationSync(app)
+	if _, err := s.loadPersonCustomValues(context.Background(), year, fieldNameMap, attendeeMap); err != nil {
+		t.Fatalf("loadPersonCustomValues: %v", err)
+	}
+
+	if s.Stats.Skipped != 0 {
+		t.Errorf("Stats.Skipped = %d, want 0", s.Stats.Skipped)
+	}
+	if logged := logs.String(); logged != "" {
+		t.Errorf("expected no log output when nothing was discarded, got:\n%s", logged)
 	}
 }


### PR DESCRIPTION
## What changed

`camper_transportation`'s field-accept filter (`isCamperTransportationField`, prefix match on
`BUS-*`) is broader than the routing switch (`MapTransportationFieldToColumn`, 15 exact names).
A field the switch does not recognise returned `""` and `mapTransportFieldToRecord` discarded it
with **no counter and no log line** — the sync reported success either way.

Re-derived against the current tree (`7b591a9c`'s anchors had already drifted by ~20 lines; this
PR is written against the tree, not the issue's line numbers): **26 definitions accepted, 15 names
routed to 13 columns, 11 names with no case at all.** All 1,299 discarded source values (1,628
discard events once fanned out per multi-session camper) are dated 2017-2020 — a retired
airport/flight-transfer form — and **zero since 2021**. Nothing has been lost since 2021 and
nothing is being lost today. This PR fixes the *mechanism*, not a data-loss backfill: what happens
if CampMinder ever adds a new `BUS-*` field.

- `mapTransportFieldToRecord` now returns the column it wrote to (`""` for an unmapped field), so
  its caller — `loadPersonCustomValues`' aggregation loop, the only place with the receiver and
  therefore `Stats` — can count the discard instead of silently dropping it.
- `retiredBusFieldReasons` documents the eleven known-dead field names with a reason each. A name
  landing there is a closed question, not an oversight.
- `classifyUnmappedBusFields` splits a run's discards into that known-retired bucket and an
  "unrecognized" bucket — the one that actually needs a human, because it means either a brand-new
  CampMinder field with no routing case, or a retired field this list hasn't been told about.
- One aggregated `slog.Warn` per sync run (not per discarded value — a historical 2017-2020
  backfill would otherwise log 1,628 lines) reports both buckets, and `Stats.Skipped` is
  incremented so the count survives into `sync_runs`.
- Removed `colAltPickup2Relationship`, a dead constant with no case in the switch and no other
  reference anywhere in the codebase (`grep -rn colAltPickup2Relationship pocketbase/` → only the
  declaration, confirmed before removal).
- Extended `TestTransportationFieldMapping`'s table with all eleven retired names → `""`. This
  closes the exact trap the issue calls out: nothing previously asserted that a `BUS-*` name maps
  to nothing, so an accidental routing case for a retired field would not have failed a test.

**Not done, deliberately:** no columns added, no migration, no backfill of the 1,299 historical
values. The issue's own fix-direction section calls that optional and separate ("only worth doing
if a wider `camper_transportation` cleanup is already in flight"), and the job scoping this PR
explicitly excluded it. The grain — `(person_id, session_id, year)` as the write key, the orphan
key, and the unique index — is untouched, matching the trap the issue calls out.

**Decision recorded on the three never-populated columns (acceptance box):** `alt_pickup_2_name`,
`alt_pickup_2_phone` and `alt_pickup_1_relationship` are **KEEP AS-IS**. All three are routed
columns — `MapTransportationFieldToColumn` has a case for each — that have simply never held a
value in any year 2017-2026; that's a different situation from the eleven fields above, which
have no routing case at all. The issue's own fix-direction section already made this call
(direction 4): dropping them needs a migration and is "only worth doing if a wider
`camper_transportation` cleanup is already in flight; on its own the churn exceeds the benefit,"
and if the columns stay, "leave them alone entirely — do not half-do this." No wider cleanup is in
flight, so this PR does not touch those three columns in any way. A short comment records the same
decision next to `retiredBusFieldReasons` in `camper_transportation.go` for the next reader who
doesn't come in through GitHub.

I also checked `Stats.Rejected` as a possibly-more-semantically-correct counter for a per-record
transform failure. Its doc comment in `orchestrator.go` explicitly says it is declared but
**not yet written by any site**, held back until kindred#2295 lands the orphan-sweep guard that
makes it safe. I did not activate it here — that would be scope creep on a deliberately-gated
field — and used `Stats.Skipped` instead, consistent with ~15 other sync services.

## Verification

```
go build ./...                          # exit 0
go vet ./sync/...                       # exit 0
golangci-lint run ./sync/...            # 0 issues
go test ./...                           # ok, all packages
gofmt -l ./sync/                        # no output
```

`main_test_parallelism_test.go`'s `TestSyncAndLodgingTestsRunInParallel` /
`TestSerialTestExemptionsAreAllStillNeeded` both pass — every new top-level test in
`pocketbase/sync/` calls `t.Parallel()`.

## TDD / mutation-check transcript

Tests were written first and confirmed to fail to compile against the pre-fix tree
(`retiredBusFieldReasons`, `classifyUnmappedBusFields` undefined; `mapTransportFieldToRecord`
had no return value) — see `go vet` output at that point:

```
sync/camper_transportation_test.go:193:9: undefined: retiredBusFieldReasons
sync/camper_transportation_test.go:227:23: undefined: classifyUnmappedBusFields
sync/camper_transportation_test.go:254:13: mapTransportFieldToRecord(...) (no value) used as value
```

After implementing, two mutation checks against the finished code:

1. **Reverted the counting/logging block** in `loadPersonCustomValues` (replaced it with a no-op).
   `TestLoadPersonCustomValuesCountsAndLogsUnmappedFields` failed as expected:
   `Stats.Skipped = 0, want 2`, log-content assertions failed (fields/level missing).
   `TestLoadPersonCustomValuesNoDiscardsMeansNoWarnLog` still passed (nothing to break there).
   Restored — suite green again.
2. **Added a routing case back for a retired field** (`"BUS-Departure airport-from camp"` →
   `colAltPickup2Phone`, simulating the exact "accidental case added" trap the issue names).
   `TestTransportationFieldMapping/BUS-Departure_airport-from_camp` and
   `TestRetiredBusFieldReasonsCoversExactlyTheElevenUnroutedNames` both failed as expected.
   Restored — suite green again.

## Notes for the reviewer

- The issue's body anchors (`:235`, `:498`, `:427-431`) were written against `7b591a9c` and have
  since drifted (current lines on this branch are `~255`, `~623`/`~487` respectively) — no
  correction needed to the issue body itself, since it already says "re-derive from the tree," but
  flagging it here so nobody chases the old line numbers.
- Design choice worth a second look: I split the warning into `known_retired_fields` /
  `unrecognized_fields` structured attrs on a single `slog.Warn` call, rather than the issue's
  literal phrasing of one flat list of names+counts. This was to satisfy the JOB's explicit ask
  for "an explicit ignore-list with a reason" while still keeping it to one aggregated line per
  run. Happy to flatten it if the split reads as over-engineered.

Closes #2272.

