### PR TITLE
fix(sync): flag duplicate custom-field-value API entries instead of silently collapsing them

### DIFF
--- a/pocketbase/sync/custom_field_values_duplicate_guard_test.go
+++ b/pocketbase/sync/custom_field_values_duplicate_guard_test.go
@@ -198,6 +198,140 @@ func TestPersonCustomFieldValuesDuplicateInRunGuard_CrossPageDuplicate(t *testin
 	}
 }
 
+// TestPersonCustomFieldValuesDuplicateInRunGuard_DifferentYearsBothSucceed verifies the
+// guard is scoped by year too, not just by field definition: the same person and field
+// definition in two different years (e.g. a January re-run touching last season's data
+// alongside this season's) are not duplicates of each other, because year is part of the
+// composite key both here and in the orphan-sweep key it must stay consistent with.
+func TestPersonCustomFieldValuesDuplicateInRunGuard_DifferentYearsBothSucceed(t *testing.T) {
+	t.Parallel()
+
+	app := newOrphanSweepTestApp(t, "person_custom_values",
+		"person", "field_definition", "value", "last_updated")
+
+	s := &PersonCustomFieldValuesSync{
+		BaseSyncService: BaseSyncService{
+			App:           app,
+			ProcessedKeys: map[string]bool{},
+			Stats:         Stats{},
+		},
+	}
+
+	fieldDefMapping := map[int]string{100: testFieldDefPBIDPerson}
+	existingRecords := map[string]*core.Record{}
+
+	entry2025 := map[string]any{"id": float64(100), "value": "Vegetarian"}
+	entry2026 := map[string]any{"id": float64(100), "value": "Vegan"}
+
+	if err := s.processPersonCustomFieldValue(
+		entry2025, 12345, testPersonPBID, 2025, fieldDefMapping, existingRecords); err != nil {
+		t.Fatalf("2025 entry: %v", err)
+	}
+	if err := s.processPersonCustomFieldValue(
+		entry2026, 12345, testPersonPBID, 2026, fieldDefMapping, existingRecords); err != nil {
+		t.Fatalf("2026 entry: %v", err)
+	}
+
+	if s.Stats.Created != 2 {
+		t.Errorf("Stats.Created = %d, want 2 (different years are not duplicates)", s.Stats.Created)
+	}
+	if s.Stats.Rejected != 0 {
+		t.Errorf("Stats.Rejected = %d, want 0", s.Stats.Rejected)
+	}
+
+	recs, err := app.FindRecordsByFilter("person_custom_values", "", "", 0, 0)
+	if err != nil {
+		t.Fatalf("find records: %v", err)
+	}
+	if len(recs) != 2 {
+		t.Fatalf("found %d person_custom_values rows, want exactly 2 (one per year)", len(recs))
+	}
+}
+
+// TestHouseholdCustomFieldValuesDuplicateInRunGuard_DifferentFieldsBothSucceed mirrors
+// TestPersonCustomFieldValuesDuplicateInRunGuard_DifferentFieldsBothSucceed for the
+// household variant: two different field definitions in one run are not duplicates.
+func TestHouseholdCustomFieldValuesDuplicateInRunGuard_DifferentFieldsBothSucceed(t *testing.T) {
+	t.Parallel()
+
+	app := newOrphanSweepTestApp(t, "household_custom_values",
+		"household", "field_definition", "value", "last_updated")
+
+	s := &HouseholdCustomFieldValuesSync{
+		BaseSyncService: BaseSyncService{
+			App:           app,
+			ProcessedKeys: map[string]bool{},
+			Stats:         Stats{},
+		},
+	}
+
+	fieldDefMapping := map[int]string{100: testFieldDefPBID, 200: "pb_field_200"}
+	existingRecords := map[string]*core.Record{}
+
+	entryA := map[string]any{"id": float64(100), "value": "Premium"}
+	entryB := map[string]any{"id": float64(200), "value": "Wait-listed"}
+
+	if err := s.processHouseholdCustomFieldValue(
+		entryA, 54321, testHouseholdPBID, 2025, fieldDefMapping, existingRecords); err != nil {
+		t.Fatalf("entry A: %v", err)
+	}
+	if err := s.processHouseholdCustomFieldValue(
+		entryB, 54321, testHouseholdPBID, 2025, fieldDefMapping, existingRecords); err != nil {
+		t.Fatalf("entry B: %v", err)
+	}
+
+	if s.Stats.Created != 2 {
+		t.Errorf("Stats.Created = %d, want 2 (different field definitions are not duplicates)", s.Stats.Created)
+	}
+	if s.Stats.Rejected != 0 {
+		t.Errorf("Stats.Rejected = %d, want 0", s.Stats.Rejected)
+	}
+}
+
+// TestHouseholdCustomFieldValuesDuplicateInRunGuard_CrossPageDuplicate mirrors
+// TestPersonCustomFieldValuesDuplicateInRunGuard_CrossPageDuplicate for the household
+// variant: syncHouseholdCustomFieldValues's pagination loop threads the same
+// fieldDefMapping/existingRecords/ProcessedKeys across every page for one household, so a
+// duplicate straddling a page boundary is indistinguishable to the guard from a same-page
+// repeat.
+func TestHouseholdCustomFieldValuesDuplicateInRunGuard_CrossPageDuplicate(t *testing.T) {
+	t.Parallel()
+
+	app := newOrphanSweepTestApp(t, "household_custom_values",
+		"household", "field_definition", "value", "last_updated")
+
+	s := &HouseholdCustomFieldValuesSync{
+		BaseSyncService: BaseSyncService{
+			App:           app,
+			ProcessedKeys: map[string]bool{},
+			Stats:         Stats{},
+		},
+	}
+
+	fieldDefMapping := map[int]string{100: testFieldDefPBID}
+	existingRecords := map[string]*core.Record{}
+
+	page1Entry := map[string]any{"id": float64(100), "value": "Premium"}
+	page2Entry := map[string]any{"id": float64(100), "value": "Standard"}
+
+	if err := s.processHouseholdCustomFieldValue(
+		page1Entry, 54321, testHouseholdPBID, 2025, fieldDefMapping, existingRecords); err != nil {
+		t.Fatalf("page 1 entry: %v", err)
+	}
+	if err := s.processHouseholdCustomFieldValue(
+		page2Entry, 54321, testHouseholdPBID, 2025, fieldDefMapping, existingRecords); err != nil {
+		t.Fatalf("page 2 entry: %v", err)
+	}
+
+	if s.Stats.Created != 1 {
+		t.Errorf("Stats.Created = %d, want 1", s.Stats.Created)
+	}
+	if s.Stats.Rejected != 1 {
+		t.Errorf("Stats.Rejected = %d, want 1 (page 2's repeat must be caught too, not just same-page)",
+			s.Stats.Rejected)
+	}
+}
+
 // TestHouseholdCustomFieldValuesDuplicateInRunGuard mirrors the person-variant test above
 // for household_custom_field_values.go's identical shape.
 func TestHouseholdCustomFieldValuesDuplicateInRunGuard(t *testing.T) {

--- a/pocketbase/sync/custom_field_values_duplicate_guard_test.go
+++ b/pocketbase/sync/custom_field_values_duplicate_guard_test.go
@@ -1,0 +1,252 @@
+// This file pins kindred#2270: persons/{id}/custom-fields (and its household twin)
+// returns a flat list keyed only by field definition. Before this fix, a second API
+// entry for a (person, field_definition, year) already seen in this run silently
+// collapsed onto the first -- counted as Skipped, Updated, or (only on save failure)
+// Errors, with nothing logged and nothing flagged.
+//
+// The defect is latent: CampMinder packs multi-selects into one delimited string, so
+// the two-entries-per-field shape does not occur in production today. The fix is not a
+// storage-grain change -- still one row per (person, field_definition, year) -- it is a
+// guard so that if the shape ever changes, the loss is attributable (Stats.Rejected +
+// a log line) instead of invisible.
+//
+// processPersonCustomFieldValue / processHouseholdCustomFieldValue are split out of
+// their sync* loops (which need a live CampMinder HTTP round trip via s.Client) purely
+// so this guard is directly testable against the real implementation, without a mock
+// HTTP server. Everything else about the two functions is a verbatim move.
+package sync
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// TestPersonCustomFieldValuesDuplicateInRunGuard: the second entry for a field
+// definition already tracked this run must be rejected and counted, not silently
+// applied on top of the first.
+func TestPersonCustomFieldValuesDuplicateInRunGuard(t *testing.T) {
+	t.Parallel()
+
+	app := newOrphanSweepTestApp(t, "person_custom_values",
+		"person", "field_definition", "value", "last_updated")
+
+	s := &PersonCustomFieldValuesSync{
+		BaseSyncService: BaseSyncService{
+			App:           app,
+			ProcessedKeys: map[string]bool{},
+			Stats:         Stats{},
+		},
+	}
+
+	fieldDefMapping := map[int]string{100: testFieldDefPBIDPerson}
+	existingRecords := map[string]*core.Record{}
+
+	first := map[string]any{"id": float64(100), "value": "Vegetarian"}
+	second := map[string]any{"id": float64(100), "value": "Vegan"}
+
+	if err := s.processPersonCustomFieldValue(
+		first, 12345, testPersonPBID, 2025, fieldDefMapping, existingRecords); err != nil {
+		t.Fatalf("first entry: %v", err)
+	}
+	if err := s.processPersonCustomFieldValue(
+		second, 12345, testPersonPBID, 2025, fieldDefMapping, existingRecords); err != nil {
+		t.Fatalf("second (duplicate) entry: %v", err)
+	}
+
+	if s.Stats.Created != 1 {
+		t.Errorf("Stats.Created = %d, want 1 (only the first entry creates a row)", s.Stats.Created)
+	}
+	if s.Stats.Updated != 0 {
+		t.Errorf("Stats.Updated = %d, want 0 (the duplicate must not overwrite the first entry)", s.Stats.Updated)
+	}
+	if s.Stats.Rejected != 1 {
+		t.Errorf("Stats.Rejected = %d, want 1 (the duplicate must be counted, not silently swallowed)", s.Stats.Rejected)
+	}
+
+	recs, err := app.FindRecordsByFilter("person_custom_values", "", "", 0, 0)
+	if err != nil {
+		t.Fatalf("find records: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("found %d person_custom_values rows, want exactly 1", len(recs))
+	}
+	if got, want := recs[0].GetString("value"), "Vegetarian"; got != want {
+		t.Errorf("stored value = %q, want %q (first entry wins; the rejected duplicate must not land)", got, want)
+	}
+}
+
+// TestPersonCustomFieldValuesDuplicateInRunGuard_ThirdAndLaterEntriesAlsoCounted verifies
+// the guard counts every extra entry, not just the second.
+func TestPersonCustomFieldValuesDuplicateInRunGuard_ThirdAndLaterEntriesAlsoCounted(t *testing.T) {
+	t.Parallel()
+
+	app := newOrphanSweepTestApp(t, "person_custom_values",
+		"person", "field_definition", "value", "last_updated")
+
+	s := &PersonCustomFieldValuesSync{
+		BaseSyncService: BaseSyncService{
+			App:           app,
+			ProcessedKeys: map[string]bool{},
+			Stats:         Stats{},
+		},
+	}
+
+	fieldDefMapping := map[int]string{100: testFieldDefPBIDPerson}
+	existingRecords := map[string]*core.Record{}
+
+	for i, value := range []string{"Vegetarian", "Vegan", "Gluten-Free"} {
+		entry := map[string]any{"id": float64(100), "value": value}
+		if err := s.processPersonCustomFieldValue(
+			entry, 12345, testPersonPBID, 2025, fieldDefMapping, existingRecords); err != nil {
+			t.Fatalf("entry %d: %v", i, err)
+		}
+	}
+
+	if s.Stats.Created != 1 {
+		t.Errorf("Stats.Created = %d, want 1", s.Stats.Created)
+	}
+	if s.Stats.Rejected != 2 {
+		t.Errorf("Stats.Rejected = %d, want 2 (two duplicate entries beyond the first)", s.Stats.Rejected)
+	}
+}
+
+// TestPersonCustomFieldValuesDuplicateInRunGuard_DifferentFieldsBothSucceed verifies the
+// guard is scoped to the composite key -- two different field definitions for the same
+// person in the same run are NOT duplicates of each other.
+func TestPersonCustomFieldValuesDuplicateInRunGuard_DifferentFieldsBothSucceed(t *testing.T) {
+	t.Parallel()
+
+	app := newOrphanSweepTestApp(t, "person_custom_values",
+		"person", "field_definition", "value", "last_updated")
+
+	s := &PersonCustomFieldValuesSync{
+		BaseSyncService: BaseSyncService{
+			App:           app,
+			ProcessedKeys: map[string]bool{},
+			Stats:         Stats{},
+		},
+	}
+
+	fieldDefMapping := map[int]string{100: testFieldDefPBIDPerson, 200: "pb_field_200"}
+	existingRecords := map[string]*core.Record{}
+
+	entryA := map[string]any{"id": float64(100), "value": "Vegetarian"}
+	entryB := map[string]any{"id": float64(200), "value": "Loves camp"}
+
+	if err := s.processPersonCustomFieldValue(
+		entryA, 12345, testPersonPBID, 2025, fieldDefMapping, existingRecords); err != nil {
+		t.Fatalf("entry A: %v", err)
+	}
+	if err := s.processPersonCustomFieldValue(
+		entryB, 12345, testPersonPBID, 2025, fieldDefMapping, existingRecords); err != nil {
+		t.Fatalf("entry B: %v", err)
+	}
+
+	if s.Stats.Created != 2 {
+		t.Errorf("Stats.Created = %d, want 2 (different field definitions are not duplicates)", s.Stats.Created)
+	}
+	if s.Stats.Rejected != 0 {
+		t.Errorf("Stats.Rejected = %d, want 0", s.Stats.Rejected)
+	}
+}
+
+// TestPersonCustomFieldValuesDuplicateInRunGuard_CrossPageDuplicate is kindred#2270's
+// cross-page acceptance case: syncPersonCustomFieldValues's pagination loop calls
+// processPersonCustomFieldValue once per value across ALL pages for one person, threading
+// the same fieldDefMapping/existingRecords/ProcessedKeys through every page fetch (page is
+// not part of any reset). Simulating "page 1's entry" then "page 2's entry" as two
+// sequential calls against that same shared state is exactly that call sequence -- there
+// is no separate per-page bookkeeping to reset in between, which is precisely what makes a
+// same-run duplicate straddling a page boundary indistinguishable to the guard from one
+// repeated on a single page.
+func TestPersonCustomFieldValuesDuplicateInRunGuard_CrossPageDuplicate(t *testing.T) {
+	t.Parallel()
+
+	app := newOrphanSweepTestApp(t, "person_custom_values",
+		"person", "field_definition", "value", "last_updated")
+
+	s := &PersonCustomFieldValuesSync{
+		BaseSyncService: BaseSyncService{
+			App:           app,
+			ProcessedKeys: map[string]bool{},
+			Stats:         Stats{},
+		},
+	}
+
+	fieldDefMapping := map[int]string{100: testFieldDefPBIDPerson}
+	existingRecords := map[string]*core.Record{}
+
+	page1Entry := map[string]any{"id": float64(100), "value": "Vegetarian"}
+	page2Entry := map[string]any{"id": float64(100), "value": "Vegan"}
+
+	if err := s.processPersonCustomFieldValue(
+		page1Entry, 12345, testPersonPBID, 2025, fieldDefMapping, existingRecords); err != nil {
+		t.Fatalf("page 1 entry: %v", err)
+	}
+	if err := s.processPersonCustomFieldValue(
+		page2Entry, 12345, testPersonPBID, 2025, fieldDefMapping, existingRecords); err != nil {
+		t.Fatalf("page 2 entry: %v", err)
+	}
+
+	if s.Stats.Created != 1 {
+		t.Errorf("Stats.Created = %d, want 1", s.Stats.Created)
+	}
+	if s.Stats.Rejected != 1 {
+		t.Errorf("Stats.Rejected = %d, want 1 (page 2's repeat must be caught too, not just same-page)",
+			s.Stats.Rejected)
+	}
+}
+
+// TestHouseholdCustomFieldValuesDuplicateInRunGuard mirrors the person-variant test above
+// for household_custom_field_values.go's identical shape.
+func TestHouseholdCustomFieldValuesDuplicateInRunGuard(t *testing.T) {
+	t.Parallel()
+
+	app := newOrphanSweepTestApp(t, "household_custom_values",
+		"household", "field_definition", "value", "last_updated")
+
+	s := &HouseholdCustomFieldValuesSync{
+		BaseSyncService: BaseSyncService{
+			App:           app,
+			ProcessedKeys: map[string]bool{},
+			Stats:         Stats{},
+		},
+	}
+
+	fieldDefMapping := map[int]string{100: testFieldDefPBID}
+	existingRecords := map[string]*core.Record{}
+
+	first := map[string]any{"id": float64(100), "value": "Premium"}
+	second := map[string]any{"id": float64(100), "value": "Standard"}
+
+	if err := s.processHouseholdCustomFieldValue(
+		first, 54321, testHouseholdPBID, 2025, fieldDefMapping, existingRecords); err != nil {
+		t.Fatalf("first entry: %v", err)
+	}
+	if err := s.processHouseholdCustomFieldValue(
+		second, 54321, testHouseholdPBID, 2025, fieldDefMapping, existingRecords); err != nil {
+		t.Fatalf("second (duplicate) entry: %v", err)
+	}
+
+	if s.Stats.Created != 1 {
+		t.Errorf("Stats.Created = %d, want 1 (only the first entry creates a row)", s.Stats.Created)
+	}
+	if s.Stats.Updated != 0 {
+		t.Errorf("Stats.Updated = %d, want 0 (the duplicate must not overwrite the first entry)", s.Stats.Updated)
+	}
+	if s.Stats.Rejected != 1 {
+		t.Errorf("Stats.Rejected = %d, want 1 (the duplicate must be counted, not silently swallowed)", s.Stats.Rejected)
+	}
+
+	recs, err := app.FindRecordsByFilter("household_custom_values", "", "", 0, 0)
+	if err != nil {
+		t.Fatalf("find records: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("found %d household_custom_values rows, want exactly 1", len(recs))
+	}
+	if got, want := recs[0].GetString("value"), "Premium"; got != want {
+		t.Errorf("stored value = %q, want %q (first entry wins; the rejected duplicate must not land)", got, want)
+	}
+}

--- a/pocketbase/sync/household_custom_field_values.go
+++ b/pocketbase/sync/household_custom_field_values.go
@@ -318,96 +318,9 @@ func (s *HouseholdCustomFieldValuesSync) syncHouseholdCustomFieldValues(
 		}
 
 		for _, valueData := range values {
-			// Extract field ID from API response
-			fieldCMIDFloat, ok := valueData["id"].(float64)
-			if !ok || fieldCMIDFloat == 0 {
-				slog.Warn("Invalid or missing field id in custom field value",
-					"household_cm_id", householdCMID)
-				s.Stats.Rejected++
-				continue
-			}
-			fieldCMID := int(fieldCMIDFloat)
-
-			// Look up field definition PB ID
-			fieldDefPBId, found := fieldDefMapping[fieldCMID]
-			if !found {
-				// Field definition not synced, skip
-				s.DebugLog("Field definition not found, skipping",
-					"field_cm_id", fieldCMID,
-					"household_cm_id", householdCMID)
-				continue
-			}
-
-			// Transform to PB format (simplified: only value and year)
-			pbData := s.transformHouseholdCustomFieldValueToPB(valueData, householdPBId, fieldDefPBId, year)
-
-			// Build composite key: identity only (no year)
-			// yearScopedKey matches format from PreloadCompositeRecords
-			compositeKey := fmt.Sprintf("%s:%s", householdPBId, fieldDefPBId)
-			yearScopedKey := fmt.Sprintf("%s|%d", compositeKey, year)
-
-			// Track as processed using yearScopedKey format
-			// Use TrackProcessedCompositeKey to avoid double year suffix:
-			// TrackProcessedKey(yearScopedKey, 0) would create "key|year|0"
-			// but deleteOrphans looks for "key|year"
-			s.TrackProcessedCompositeKey(compositeKey, year)
-
-			// Check for existing record using yearScopedKey
-			if existing, found := existingRecords[yearScopedKey]; found {
-				// Fast path: if lastUpdated unchanged, skip entirely
-				existingLastUpdated := existing.GetString("last_updated")
-				newLastUpdated, hasNewLastUpdated := pbData["last_updated"].(string)
-
-				if existingLastUpdated != "" && hasNewLastUpdated && existingLastUpdated == newLastUpdated {
-					// lastUpdated matches - no changes, skip update
-					s.Stats.Skipped++
-					continue
-				}
-
-				// Value or lastUpdated changed - update record
-				newValue, _ := pbData["value"].(string)
-				if existing.GetString("value") != newValue || existingLastUpdated != newLastUpdated {
-					for key, val := range pbData {
-						existing.Set(key, val)
-					}
-					if err := s.App.Save(existing); err != nil {
-						valueStr, _ := pbData["value"].(string)
-						slog.Error("Error updating household custom field value",
-							"error", err,
-							"household_cm_id", householdCMID,
-							"field_cm_id", fieldCMID,
-							"value_length", len(valueStr))
-						s.Stats.Errors++
-					} else {
-						s.Stats.Updated++
-					}
-				} else {
-					s.Stats.Skipped++
-				}
-			} else {
-				collection, err := s.App.FindCollectionByNameOrId("household_custom_values")
-				if err != nil {
-					return fmt.Errorf("finding collection: %w", err)
-				}
-
-				record := core.NewRecord(collection)
-				for key, val := range pbData {
-					record.Set(key, val)
-				}
-
-				if err := s.App.Save(record); err != nil {
-					valueStr, _ := pbData["value"].(string)
-					slog.Error("Error creating household custom field value",
-						"error", err,
-						"household_cm_id", householdCMID,
-						"field_cm_id", fieldCMID,
-						"value_length", len(valueStr))
-					s.Stats.Errors++
-				} else {
-					s.Stats.Created++
-					// Add to existingRecords to prevent duplicate creation if API returns duplicates
-					existingRecords[yearScopedKey] = record
-				}
+			if err := s.processHouseholdCustomFieldValue(
+				valueData, householdCMID, householdPBId, year, fieldDefMapping, existingRecords); err != nil {
+				return err
 			}
 		}
 
@@ -415,6 +328,137 @@ func (s *HouseholdCustomFieldValuesSync) syncHouseholdCustomFieldValues(
 			break
 		}
 		page++
+	}
+
+	return nil
+}
+
+// processHouseholdCustomFieldValue handles one API-returned custom field value entry for
+// a household: resolves the field definition, applies the same-run duplicate guard, and
+// creates/updates/skips the row accordingly. Split out of syncHouseholdCustomFieldValues
+// (which needs a live CampMinder HTTP round trip via s.Client) purely so the guard below
+// can be exercised directly in tests.
+func (s *HouseholdCustomFieldValuesSync) processHouseholdCustomFieldValue(
+	valueData map[string]any,
+	householdCMID int,
+	householdPBId string,
+	year int,
+	fieldDefMapping map[int]string,
+	existingRecords map[string]*core.Record,
+) error {
+	// Extract field ID from API response
+	fieldCMIDFloat, ok := valueData["id"].(float64)
+	if !ok || fieldCMIDFloat == 0 {
+		slog.Warn("Invalid or missing field id in custom field value",
+			"household_cm_id", householdCMID)
+		s.Stats.Rejected++
+		return nil
+	}
+	fieldCMID := int(fieldCMIDFloat)
+
+	// Look up field definition PB ID
+	fieldDefPBId, found := fieldDefMapping[fieldCMID]
+	if !found {
+		// Field definition not synced, skip
+		s.DebugLog("Field definition not found, skipping",
+			"field_cm_id", fieldCMID,
+			"household_cm_id", householdCMID)
+		return nil
+	}
+
+	// Transform to PB format (simplified: only value and year)
+	pbData := s.transformHouseholdCustomFieldValueToPB(valueData, householdPBId, fieldDefPBId, year)
+
+	// Build composite key: identity only (no year)
+	// yearScopedKey matches format from PreloadCompositeRecords
+	compositeKey := fmt.Sprintf("%s:%s", householdPBId, fieldDefPBId)
+	yearScopedKey := fmt.Sprintf("%s|%d", compositeKey, year)
+
+	// Duplicate-in-run guard (kindred#2270). See the identical comment in
+	// person_custom_field_values.go's processPersonCustomFieldValue -- this is the
+	// household twin of the same defect and the same fix. persons/households/{id}/custom-
+	// fields is documented as one entry per field definition, and CampMinder packs
+	// multi-selects into a single delimited value string rather than repeating the field
+	// id, so a second entry for a key this run has already tracked is not today's shape.
+	// Before this guard it silently collapsed onto the first with no diagnostic. This does
+	// NOT change the storage grain -- still one row per (household, field_definition,
+	// year) -- it only makes that collapse loud.
+	if s.IsKeyProcessed(compositeKey, year) {
+		valueStr, _ := pbData["value"].(string)
+		slog.Warn("Duplicate custom field value entry in this sync run, discarding",
+			"household_cm_id", householdCMID,
+			"field_cm_id", fieldCMID,
+			"field_definition_pb_id", fieldDefPBId,
+			"year", year,
+			"value_length", len(valueStr))
+		s.Stats.Rejected++
+		return nil
+	}
+
+	// Track as processed using yearScopedKey format
+	// Use TrackProcessedCompositeKey to avoid double year suffix:
+	// TrackProcessedKey(yearScopedKey, 0) would create "key|year|0"
+	// but deleteOrphans looks for "key|year"
+	s.TrackProcessedCompositeKey(compositeKey, year)
+
+	// Check for existing record using yearScopedKey
+	if existing, found := existingRecords[yearScopedKey]; found {
+		// Fast path: if lastUpdated unchanged, skip entirely
+		existingLastUpdated := existing.GetString("last_updated")
+		newLastUpdated, hasNewLastUpdated := pbData["last_updated"].(string)
+
+		if existingLastUpdated != "" && hasNewLastUpdated && existingLastUpdated == newLastUpdated {
+			// lastUpdated matches - no changes, skip update
+			s.Stats.Skipped++
+			return nil
+		}
+
+		// Value or lastUpdated changed - update record
+		newValue, _ := pbData["value"].(string)
+		if existing.GetString("value") != newValue || existingLastUpdated != newLastUpdated {
+			for key, val := range pbData {
+				existing.Set(key, val)
+			}
+			if err := s.App.Save(existing); err != nil {
+				valueStr, _ := pbData["value"].(string)
+				slog.Error("Error updating household custom field value",
+					"error", err,
+					"household_cm_id", householdCMID,
+					"field_cm_id", fieldCMID,
+					"value_length", len(valueStr))
+				s.Stats.Errors++
+			} else {
+				s.Stats.Updated++
+			}
+		} else {
+			s.Stats.Skipped++
+		}
+	} else {
+		collection, err := s.App.FindCollectionByNameOrId("household_custom_values")
+		if err != nil {
+			return fmt.Errorf("finding collection: %w", err)
+		}
+
+		record := core.NewRecord(collection)
+		for key, val := range pbData {
+			record.Set(key, val)
+		}
+
+		if err := s.App.Save(record); err != nil {
+			valueStr, _ := pbData["value"].(string)
+			slog.Error("Error creating household custom field value",
+				"error", err,
+				"household_cm_id", householdCMID,
+				"field_cm_id", fieldCMID,
+				"value_length", len(valueStr))
+			s.Stats.Errors++
+		} else {
+			s.Stats.Created++
+			// Add to existingRecords so a later record within this same run for the
+			// same key hits the "existing" branch (which the guard above now also
+			// short-circuits before it can be reached by a true duplicate).
+			existingRecords[yearScopedKey] = record
+		}
 	}
 
 	return nil

--- a/pocketbase/sync/person_custom_field_values.go
+++ b/pocketbase/sync/person_custom_field_values.go
@@ -324,97 +324,9 @@ func (s *PersonCustomFieldValuesSync) syncPersonCustomFieldValues(
 
 		// Process each value
 		for _, valueData := range values {
-			// Extract field ID from API response
-			fieldCMIDFloat, ok := valueData["id"].(float64)
-			if !ok || fieldCMIDFloat == 0 {
-				slog.Warn("Invalid or missing field id in custom field value",
-					"person_cm_id", personCMID)
-				s.Stats.Rejected++
-				continue
-			}
-			fieldCMID := int(fieldCMIDFloat)
-
-			// Look up field definition PB ID
-			fieldDefPBId, found := fieldDefMapping[fieldCMID]
-			if !found {
-				// Field definition not synced, skip
-				s.DebugLog("Field definition not found, skipping",
-					"field_cm_id", fieldCMID,
-					"person_cm_id", personCMID)
-				continue
-			}
-
-			// Transform to PB format (simplified: only value and year)
-			pbData := s.transformPersonCustomFieldValueToPB(valueData, personPBId, fieldDefPBId, year)
-
-			// Build composite key: identity only (no year)
-			// yearScopedKey matches format from PreloadCompositeRecords
-			compositeKey := fmt.Sprintf("%s:%s", personPBId, fieldDefPBId)
-			yearScopedKey := fmt.Sprintf("%s|%d", compositeKey, year)
-
-			// Track as processed using yearScopedKey format
-			// Use TrackProcessedCompositeKey to avoid double year suffix:
-			// TrackProcessedKey(yearScopedKey, 0) would create "key|year|0"
-			// but deleteOrphans looks for "key|year"
-			s.TrackProcessedCompositeKey(compositeKey, year)
-
-			// Check for existing record using yearScopedKey
-			if existing, found := existingRecords[yearScopedKey]; found {
-				// Fast path: if lastUpdated unchanged, skip entirely
-				existingLastUpdated := existing.GetString("last_updated")
-				newLastUpdated, hasNewLastUpdated := pbData["last_updated"].(string)
-
-				if existingLastUpdated != "" && hasNewLastUpdated && existingLastUpdated == newLastUpdated {
-					// lastUpdated matches - no changes, skip update
-					s.Stats.Skipped++
-					continue
-				}
-
-				// Value or lastUpdated changed - update record
-				newValue, _ := pbData["value"].(string)
-				if existing.GetString("value") != newValue || existingLastUpdated != newLastUpdated {
-					for key, val := range pbData {
-						existing.Set(key, val)
-					}
-					if err := s.App.Save(existing); err != nil {
-						valueStr, _ := pbData["value"].(string)
-						slog.Error("Error updating custom field value",
-							"error", err,
-							"person_cm_id", personCMID,
-							"field_cm_id", fieldCMID,
-							"value_length", len(valueStr))
-						s.Stats.Errors++
-					} else {
-						s.Stats.Updated++
-					}
-				} else {
-					s.Stats.Skipped++
-				}
-			} else {
-				// Create new record
-				collection, err := s.App.FindCollectionByNameOrId("person_custom_values")
-				if err != nil {
-					return fmt.Errorf("finding collection: %w", err)
-				}
-
-				record := core.NewRecord(collection)
-				for key, val := range pbData {
-					record.Set(key, val)
-				}
-
-				if err := s.App.Save(record); err != nil {
-					valueStr, _ := pbData["value"].(string)
-					slog.Error("Error creating custom field value",
-						"error", err,
-						"person_cm_id", personCMID,
-						"field_cm_id", fieldCMID,
-						"value_length", len(valueStr))
-					s.Stats.Errors++
-				} else {
-					s.Stats.Created++
-					// Add to existingRecords to prevent duplicate creation if API returns duplicates
-					existingRecords[yearScopedKey] = record
-				}
+			if err := s.processPersonCustomFieldValue(
+				valueData, personCMID, personPBId, year, fieldDefMapping, existingRecords); err != nil {
+				return err
 			}
 		}
 
@@ -422,6 +334,141 @@ func (s *PersonCustomFieldValuesSync) syncPersonCustomFieldValues(
 			break
 		}
 		page++
+	}
+
+	return nil
+}
+
+// processPersonCustomFieldValue handles one API-returned custom field value entry for a
+// person: resolves the field definition, applies the same-run duplicate guard, and
+// creates/updates/skips the row accordingly. Split out of syncPersonCustomFieldValues
+// (which needs a live CampMinder HTTP round trip via s.Client) purely so the guard below
+// can be exercised directly in tests.
+func (s *PersonCustomFieldValuesSync) processPersonCustomFieldValue(
+	valueData map[string]any,
+	personCMID int,
+	personPBId string,
+	year int,
+	fieldDefMapping map[int]string,
+	existingRecords map[string]*core.Record,
+) error {
+	// Extract field ID from API response
+	fieldCMIDFloat, ok := valueData["id"].(float64)
+	if !ok || fieldCMIDFloat == 0 {
+		slog.Warn("Invalid or missing field id in custom field value",
+			"person_cm_id", personCMID)
+		s.Stats.Rejected++
+		return nil
+	}
+	fieldCMID := int(fieldCMIDFloat)
+
+	// Look up field definition PB ID
+	fieldDefPBId, found := fieldDefMapping[fieldCMID]
+	if !found {
+		// Field definition not synced, skip
+		s.DebugLog("Field definition not found, skipping",
+			"field_cm_id", fieldCMID,
+			"person_cm_id", personCMID)
+		return nil
+	}
+
+	// Transform to PB format (simplified: only value and year)
+	pbData := s.transformPersonCustomFieldValueToPB(valueData, personPBId, fieldDefPBId, year)
+
+	// Build composite key: identity only (no year)
+	// yearScopedKey matches format from PreloadCompositeRecords
+	compositeKey := fmt.Sprintf("%s:%s", personPBId, fieldDefPBId)
+	yearScopedKey := fmt.Sprintf("%s|%d", compositeKey, year)
+
+	// Duplicate-in-run guard (kindred#2270). persons/{id}/custom-fields is documented as
+	// one entry per field definition, and CampMinder packs multi-selects into a single
+	// delimited value string rather than repeating the field id -- so a second entry for
+	// a key this run has already tracked is not today's shape. Before this guard, that
+	// second entry silently landed on the "existing" branch below (populated either from
+	// the DB preload or from this same run's own `existingRecords[yearScopedKey] = record`
+	// a few lines down) and collapsed onto the first with no diagnostic: matching
+	// lastUpdated counted it as Skipped, a changed value counted it as Updated, and only an
+	// App.Save failure counted it as Errors. This does NOT change the storage grain --
+	// still exactly one row per (person, field_definition, year) -- it only makes that
+	// existing collapse loud: count it as Rejected (upstream data quality, not a local
+	// fault) and log it, so a future API shape change is attributable instead of invisible.
+	if s.IsKeyProcessed(compositeKey, year) {
+		valueStr, _ := pbData["value"].(string)
+		slog.Warn("Duplicate custom field value entry in this sync run, discarding",
+			"person_cm_id", personCMID,
+			"field_cm_id", fieldCMID,
+			"field_definition_pb_id", fieldDefPBId,
+			"year", year,
+			"value_length", len(valueStr))
+		s.Stats.Rejected++
+		return nil
+	}
+
+	// Track as processed using yearScopedKey format
+	// Use TrackProcessedCompositeKey to avoid double year suffix:
+	// TrackProcessedKey(yearScopedKey, 0) would create "key|year|0"
+	// but deleteOrphans looks for "key|year"
+	s.TrackProcessedCompositeKey(compositeKey, year)
+
+	// Check for existing record using yearScopedKey
+	if existing, found := existingRecords[yearScopedKey]; found {
+		// Fast path: if lastUpdated unchanged, skip entirely
+		existingLastUpdated := existing.GetString("last_updated")
+		newLastUpdated, hasNewLastUpdated := pbData["last_updated"].(string)
+
+		if existingLastUpdated != "" && hasNewLastUpdated && existingLastUpdated == newLastUpdated {
+			// lastUpdated matches - no changes, skip update
+			s.Stats.Skipped++
+			return nil
+		}
+
+		// Value or lastUpdated changed - update record
+		newValue, _ := pbData["value"].(string)
+		if existing.GetString("value") != newValue || existingLastUpdated != newLastUpdated {
+			for key, val := range pbData {
+				existing.Set(key, val)
+			}
+			if err := s.App.Save(existing); err != nil {
+				valueStr, _ := pbData["value"].(string)
+				slog.Error("Error updating custom field value",
+					"error", err,
+					"person_cm_id", personCMID,
+					"field_cm_id", fieldCMID,
+					"value_length", len(valueStr))
+				s.Stats.Errors++
+			} else {
+				s.Stats.Updated++
+			}
+		} else {
+			s.Stats.Skipped++
+		}
+	} else {
+		// Create new record
+		collection, err := s.App.FindCollectionByNameOrId("person_custom_values")
+		if err != nil {
+			return fmt.Errorf("finding collection: %w", err)
+		}
+
+		record := core.NewRecord(collection)
+		for key, val := range pbData {
+			record.Set(key, val)
+		}
+
+		if err := s.App.Save(record); err != nil {
+			valueStr, _ := pbData["value"].(string)
+			slog.Error("Error creating custom field value",
+				"error", err,
+				"person_cm_id", personCMID,
+				"field_cm_id", fieldCMID,
+				"value_length", len(valueStr))
+			s.Stats.Errors++
+		} else {
+			s.Stats.Created++
+			// Add to existingRecords so a later record within this same run for the
+			// same key hits the "existing" branch (which the guard above now also
+			// short-circuits before it can be reached by a true duplicate).
+			existingRecords[yearScopedKey] = record
+		}
 	}
 
 	return nil

--- a/pocketbase/sync/rejection_sites_test.go
+++ b/pocketbase/sync/rejection_sites_test.go
@@ -67,6 +67,14 @@ func expectedRejectSites() []rejectSite {
 		{"financial_transactions.go", "Invalid transaction cm_id"},
 		{"household_custom_field_values.go", "Invalid or missing field id in custom field value"},
 		{"person_custom_field_values.go", "Invalid or missing field id in custom field value"},
+		// kindred#2270: a second API entry for a (person|household, field_definition, year)
+		// already tracked this run. Today's API shape makes this latent -- CampMinder packs
+		// multi-selects into one delimited value string -- but before this guard the second
+		// entry silently collapsed onto the first (Skipped/Updated/Errors depending on
+		// timing) with nothing attributable. Same per-record upstream-shape rejection as the
+		// "Invalid or missing field id" pair directly above; belongs on the same counter.
+		{"household_custom_field_values.go", "Duplicate custom field value entry in this sync run, discarding"},
+		{"person_custom_field_values.go", "Duplicate custom field value entry in this sync run, discarding"},
 		{"person_tag_definitions.go", "Error transforming person tag definition"},
 		{"person_tag_definitions.go", "Invalid person tag definition name"},
 		{"persons.go", "Error transforming household"},


### PR DESCRIPTION
## What

`persons/{id}/custom-fields` (and its household twin) returns a flat list keyed only by
field definition. The sync tracked processed keys via `TrackProcessedCompositeKey`, but
never *checked* the tracker before writing — so a second API entry for a
`(person, field_definition, year)` already seen this run silently collapsed onto the
first, counted as `Skipped`, `Updated`, or (only on a save failure) `Errors`. Nothing
errored, nothing logged.

This is latent, not active: CampMinder packs multi-selects into one `|`-delimited value
string (46,505 of 181,274 array-typed person values contain one; 0 contain a semicolon),
so the N-entries-per-field shape does not occur in the current snapshot, and the unique
index has zero duplicate-key rows across the whole table. The defect is the **absence of
a guard**: if the API shape ever changes, the loss becomes silent and unattributable.

## Fix

Added a same-run duplicate guard to both `person_custom_field_values.go` and
`household_custom_field_values.go` (identical shape, fixed together per the issue). Before
tracking a composite key as processed, check whether this run has already tracked it
(`s.IsKeyProcessed`, pre-existing `BaseSyncService` infra — no new tracking map needed,
since the composite key already includes the person/household PB ID, so a single
run-scoped map behaves identically to a per-person set). A repeat:

- increments `Stats.Rejected` (upstream-data-quality counter, warn-only, distinct from
  `Stats.Errors` which fails the run) instead of silently landing on `Skipped`/`Updated`
- logs `slog.Warn` with `person_cm_id`/`household_cm_id`, `field_cm_id`,
  `field_definition_pb_id`, `year`, `value_length`
- does **not** overwrite the first entry's row

**No grain change.** Still exactly one row per `(person|household, field_definition,
year)`. The write key, orphan key, and unique index are all untouched — the guard only
makes the pre-existing collapse loud instead of invisible.

To make the guard directly testable against the real implementation (rather than a
simulated copy in the test file), the per-value processing body was extracted verbatim
out of `syncPersonCustomFieldValues` / `syncHouseholdCustomFieldValues`'s loop into
`processPersonCustomFieldValue` / `processHouseholdCustomFieldValue`. This was necessary
because `campminder.Client`'s base URL is a package-level constant with no test seam, so
the outer sync function can't be driven through a mock HTTP server without also touching
`client.go` (out of scope for this PR). The extraction is a pure move — every existing
branch, log line, and stat bump is unchanged — plus the new guard.

Also updates the `rejection_sites_test.go` census (`TestNoUnexpectedSiteUsesTheRejectedCounter`)
to allowlist the two new `Stats.Rejected++` sites with reasoning, since that test enumerates
every counter bump in the package by AST and fails on any unlisted one.

## Verification

```
$ go build ./...                                                          exit=0
$ go test ./sync/... -run 'DuplicateInRunGuard' -v                        exit=0 (8 tests, all PASS)
$ go test ./...                                                           exit=0
$ go vet ./sync/...                                                       exit=0
$ gofmt -l <changed files>                                                (empty — clean)
$ golangci-lint run ./sync/...                                            0 issues
$ bash scripts/pre-push-verify.sh                                         exit=0
```

### Mutation check (guard specifically, not just the extraction)

Broke only the new guard (`if s.IsKeyProcessed(...)` → `if false && s.IsKeyProcessed(...)`)
and reran the five `DuplicateInRunGuard` tests that assert an actual duplicate (the three
that assert two *different* keys both succeed are unaffected by this mutation and stayed
green):

```
--- FAIL: TestPersonCustomFieldValuesDuplicateInRunGuard_ThirdAndLaterEntriesAlsoCounted
    Stats.Rejected = 0, want 2 (two duplicate entries beyond the first)
--- FAIL: TestHouseholdCustomFieldValuesDuplicateInRunGuard
    Stats.Updated = 1, want 0 (the duplicate must not overwrite the first entry)
    Stats.Rejected = 0, want 1 (the duplicate must be counted, not silently swallowed)
    stored value = "Standard", want "Premium" (first entry wins; the rejected duplicate must not land)
--- FAIL: TestPersonCustomFieldValuesDuplicateInRunGuard
    Stats.Updated = 1, want 0 (the duplicate must not overwrite the first entry)
    Stats.Rejected = 0, want 1 (the duplicate must be counted, not silently swallowed)
    stored value = "Vegan", want "Vegetarian" (first entry wins; the rejected duplicate must not land)
--- FAIL: TestPersonCustomFieldValuesDuplicateInRunGuard_CrossPageDuplicate
    Stats.Rejected = 0, want 1 (page 2's repeat must be caught too, not just same-page)
--- FAIL: TestHouseholdCustomFieldValuesDuplicateInRunGuard_CrossPageDuplicate
    Stats.Rejected = 0, want 1 (page 2's repeat must be caught too, not just same-page)
FAIL (exit=1)
```

Reproduces exactly the pre-fix behavior the issue describes (last-write-wins, counted as
`Updated`, nothing flagged). Restored the guard; all tests green again (exit=0).

## Acceptance checklist (from the issue body)

- [x] A repeated field id within one person's sync (across pages) emits `slog.Warn`
      naming the field cm id — `TestPersonCustomFieldValuesDuplicateInRunGuard_CrossPageDuplicate`
      exercises exactly the cross-page call sequence (state threads through
      `syncPersonCustomFieldValues`'s page loop unchanged by page number).
- [x] A dedicated counter (`Stats.Rejected`) separates these from `Stats.Skipped`.
- [x] Regression test drives the loop with two entries sharing an `id`, asserts the
      warning fires and the counter increments; confirmed RED on the pre-fix code via the
      mutation check above (not `main` directly, since the guard didn't exist to remove —
      the mutation check disables the new `if` instead, which is the same code path).
- [x] Second regression test covers the cross-page case explicitly.
- [x] Household variant gets the identical treatment.
- [x] The three key-format tests (`TestPersonCustomFieldValuesCompositeKeyFormat`,
      `TestPersonCustomFieldValuesKeyBuilderShouldNotIncludeYear`,
      `TestPersonCustomFieldValuesTrackingMatchesOrphanLookup`) pass unchanged — verified
      directly, the fix never touches the key format.

One acceptance line I did *not* implement literally: "naming... **the occurrence count**"
in the log line. `Stats.Rejected` gives a run-wide count and the log fields
(`person_cm_id`/`household_cm_id` + `field_cm_id` + `year`) are enough to `grep` and count
occurrences per key by hand, but there's no per-key occurrence number in each log line.
Adding one would mean threading a new counts-map parameter through both sync functions
for a diagnostic-only nicety on a path that, today, never fires in production. Flagging
the tradeoff rather than silently dropping it — happy to add it if wanted.

Closes #2270.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate custom-field entries for the same person or household, field, and year from overwriting the original value.
  * Duplicate entries are now rejected, counted, and logged consistently, including duplicates across paginated sync results.
  * Different custom fields continue to be processed independently.

* **Tests**
  * Added comprehensive coverage for person and household duplicate-entry handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
