### PR TITLE
feat(sync,frontend): count and log staff duplicate-status drops

### DIFF
--- a/frontend/src/components/admin/SyncTab.test.tsx
+++ b/frontend/src/components/admin/SyncTab.test.tsx
@@ -29,6 +29,10 @@ let strandedAssignmentCleanupStatus: unknown = idleStatus
 let personsStatus: unknown = idleStatus
 let staffLookupsStatus: unknown = idleStatus
 
+// #2267 needs its own injectable status: `staff` is a year sync (renderSyncCard) and is not
+// covered by any existing entry above. Reset in afterEach.
+let staffStatus: unknown = idleStatus
+
 vi.mock('../../hooks/useSyncCompletionToasts', () => ({
   useSyncCompletionToasts: () => ({
     camper_history: idleStatus,
@@ -50,6 +54,9 @@ vi.mock('../../hooks/useSyncCompletionToasts', () => ({
     },
     get staff_lookups() {
       return staffLookupsStatus
+    },
+    get staff() {
+      return staffStatus
     },
   }),
 }))
@@ -313,5 +320,51 @@ describe('SyncTab nested rejected records (#2295)', () => {
     fireEvent.click(screen.getByText('Global Definitions'))
 
     expect(within(cardByTitle('Staff Lookups', 'span')).getByText('7 rejected')).toBeInTheDocument()
+  })
+})
+
+// Regression test for #2267: Stats.DuplicateStaffStatus (pocketbase/sync/orchestrator.go) is
+// the new counter for staff records dropped because the same person appeared under more than
+// one CampMinder status in one run. Before the fix there was no counter at all and the only
+// trace was a slog.Debug line invisible at the default LOG_LEVEL=INFO — a counter nobody can
+// see on the Sync tab is the same class of bug #2284's rejected badge fixed, one field over.
+describe('SyncTab duplicate staff status badge (#2267)', () => {
+  afterEach(() => {
+    staffStatus = idleStatus
+  })
+
+  function staffCard() {
+    const heading = screen.getByText('Staff', { selector: 'div' })
+    const card = heading.closest('.flex.flex-col')
+    if (!card) throw new Error('could not find Staff card')
+    return card as HTMLElement
+  }
+
+  it('renders a duplicate-status badge when duplicate_staff_status is positive', () => {
+    staffStatus = {
+      status: 'success',
+      summary: {
+        created: 5,
+        updated: 0,
+        skipped: 0,
+        errors: 0,
+        duplicate_staff_status: 2,
+      },
+    }
+
+    renderSyncTab()
+
+    expect(within(staffCard()).getByText('2 dup status')).toBeInTheDocument()
+  })
+
+  it('renders no duplicate-status badge when duplicate_staff_status is zero or absent', () => {
+    staffStatus = {
+      status: 'success',
+      summary: { created: 5, updated: 0, skipped: 0, errors: 0 },
+    }
+
+    renderSyncTab()
+
+    expect(within(staffCard()).queryByText(/dup status/)).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/admin/SyncTab.tsx
+++ b/frontend/src/components/admin/SyncTab.tsx
@@ -299,6 +299,11 @@ export function SyncTab() {
                     {rejected} rejected
                   </span>
                 )}
+                {(status.summary.duplicate_staff_status ?? 0) > 0 && (
+                  <span className="font-medium text-amber-600 dark:text-amber-400">
+                    {status.summary.duplicate_staff_status} dup status
+                  </span>
+                )}
                 {(status.summary.prod_audit_warnings ?? 0) > 0 && (
                   <span className="font-medium text-amber-600 dark:text-amber-400">
                     {status.summary.prod_audit_warnings} prod⚠
@@ -870,6 +875,11 @@ export function SyncTab() {
                           {rejected > 0 && (
                             <span className="font-medium text-amber-600 dark:text-amber-400">
                               {rejected} rejected
+                            </span>
+                          )}
+                          {(status.summary.duplicate_staff_status ?? 0) > 0 && (
+                            <span className="font-medium text-amber-600 dark:text-amber-400">
+                              {status.summary.duplicate_staff_status} dup status
                             </span>
                           )}
                         </div>

--- a/frontend/src/hooks/useSyncStatusAPI.ts
+++ b/frontend/src/hooks/useSyncStatusAPI.ts
@@ -48,6 +48,11 @@ export interface SyncStatus {
     // Per-record transform failures: an upstream record could not be turned into a row.
     // Warn-only for its first season (#2284) — surfaced here, never failing a run.
     rejected?: number
+    // Staff records dropped because the same person appeared under more than one
+    // CampMinder status in one run (#2267). Only ever set by the `staff` service — the
+    // first status seen wins (see pocketbase/sync/staff.go's allStaffStatuses), and this
+    // is the count of every later status that lost that collapse.
+    duplicate_staff_status?: number
     already_processed?: number // For process_requests: records already processed
     prod_audit_warnings?: number // For stranded_assignment_cleanup: stranded prod assignments (observe-only)
     lodging_prod_audit_warnings?: number // For stranded_assignment_cleanup: stranded lodging prod assignments (observe-only)

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -306,6 +306,19 @@ type Stats struct {
 	// guess, and the season exists to accumulate the distribution to set one from. Until the
 	// #2295 sites land the column records honest zeroes (kindred#2284).
 	Rejected int `json:"rejected,omitempty"`
+	// DuplicateStaffStatus counts staff records dropped because the same person appeared
+	// under more than one CampMinder status in one sync run (kindred#2267). staff.go's
+	// allStaffStatuses is iterated in a fixed order and the first status seen for a
+	// person-year wins that collapse; this counts every later duplicate it drops. Nothing
+	// but staff.go increments this.
+	//
+	// Deliberately its own field rather than folded into Skipped: base_sync.go's
+	// ProcessSimpleRecord no-change branch already increments Skipped for every unchanged
+	// row, so on a steady-state run Skipped is roughly the whole roster and a duplicate
+	// drop would be invisible inside it. Not persisted to the sync_runs table (sync_runs.go)
+	// -- that would need a new migration column, which is out of scope here; the counter
+	// still reaches the live Sync tab via this JSON field.
+	DuplicateStaffStatus int `json:"duplicate_staff_status,omitempty"`
 	// Expanded tracks many-to-many expansions (e.g., bunk plans)
 	Expanded int `json:"expanded,omitempty"`
 	// AlreadyProcessed tracks records already processed (for process_requests)

--- a/pocketbase/sync/orchestrator_test.go
+++ b/pocketbase/sync/orchestrator_test.go
@@ -1822,6 +1822,13 @@ func TestStats_IsNoOp(t *testing.T) {
 			stats:    Stats{Created: 0, Updated: 0, Deleted: 0, Errors: 0, Duration: 60, Expanded: 50},
 			expected: true,
 		},
+		{
+			// kindred#2267: a run that only dropped duplicate-status staff records made
+			// no data change and must still report as a no-op.
+			name:     "duplicate staff status only is still no-op",
+			stats:    Stats{Created: 0, Updated: 0, Deleted: 0, Errors: 0, DuplicateStaffStatus: 3},
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pocketbase/sync/staff.go
+++ b/pocketbase/sync/staff.go
@@ -16,6 +16,17 @@ const serviceNameStaff = "staff"
 
 // allStaffStatuses defines all CampMinder staff statuses to sync.
 // 1=Active, 2=Resigned, 3=Dismissed, 4=Cancelled
+//
+// Precedence policy (kindred#2267): a person can come back from CampMinder under more than
+// one status in a single run (e.g. active this season, still returned as a resigned record
+// from a prior one). syncStaff writes at most one `staff` row per person per year, so when
+// that happens the FIRST status seen wins -- and "first" is exactly this slice's iteration
+// order. That makes Active > Resigned > Dismissed > Cancelled the effective precedence, and
+// it is a deliberate, stated policy now, not an accident of slice order. It is provisional:
+// nothing has evaluated whether Active-wins is the right call, only that it must be legible
+// and every collapse it causes counted (isDuplicateStaffStatus, Stats.DuplicateStaffStatus)
+// rather than silent. Do not reorder this slice to change precedence without updating this
+// comment and TestAllStaffStatuses, which pins the order.
 var allStaffStatuses = []int{1, 2, 3, 4}
 
 // StaffSync handles syncing year-scoped staff records from CampMinder
@@ -130,13 +141,13 @@ func (s *StaffSync) syncStaff(ctx context.Context) error {
 					continue
 				}
 
-				// Skip duplicates (same person appearing multiple times across statuses)
-				if s.IsKeyProcessed(personPBID, year) {
-					slog.Debug("Skipping duplicate staff record in API response", "person_pb_id", personPBID)
+				// Skip duplicates: see allStaffStatuses above for the precedence policy this
+				// implements (first status seen this run wins). isDuplicateStaffStatus does
+				// the bookkeeping for both outcomes -- tracking a first sighting, or counting
+				// and logging a later one dropped.
+				if s.isDuplicateStaffStatus(personPBID, year, status) {
 					continue
 				}
-
-				s.TrackProcessedKey(personPBID, year)
 
 				// Preserve bunk data for non-active staff — CampMinder clears
 				// BunkAssignments on dismissal, but we keep last-known assignments.
@@ -175,7 +186,8 @@ func (s *StaffSync) syncStaff(ctx context.Context) error {
 
 	slog.Info("Processed staff records", "total", totalProcessed,
 		"active", statusCounts[1], "resigned", statusCounts[2],
-		"dismissed", statusCounts[3], "cancelled", statusCounts[4])
+		"dismissed", statusCounts[3], "cancelled", statusCounts[4],
+		"duplicate_status_dropped", s.Stats.DuplicateStaffStatus)
 
 	// Mark sync as successful before orphan deletion (DeleteOrphans checks this flag)
 	s.SyncSuccessful = true
@@ -381,6 +393,23 @@ func (s *StaffSync) setStaffFloatField(pbData, data map[string]any, srcKey, dstK
 	if val, ok := data[srcKey].(float64); ok {
 		pbData[dstKey] = val
 	}
+}
+
+// isDuplicateStaffStatus reports whether personPBID has already been synced this run under a
+// higher-precedence status (see allStaffStatuses for the policy) and does the bookkeeping for
+// either outcome. A first sighting is tracked so a later status for the same person this run
+// is recognized as the duplicate. A duplicate is counted (Stats.DuplicateStaffStatus) and
+// logged at Warn -- visible at the default LOG_LEVEL=INFO -- mirroring the "no matching
+// person" branch immediately above its call site, which already does both (kindred#2267).
+func (s *StaffSync) isDuplicateStaffStatus(personPBID string, year, status int) bool {
+	if s.IsKeyProcessed(personPBID, year) {
+		s.Stats.DuplicateStaffStatus++
+		slog.Warn("Dropping duplicate staff record: person already synced this run under a higher-precedence status",
+			"person_pb_id", personPBID, "year", year, "dropped_status_id", status)
+		return true
+	}
+	s.TrackProcessedKey(personPBID, year)
+	return false
 }
 
 // shouldPreserveBunkData returns true when existing bunk data should be kept

--- a/pocketbase/sync/staff_test.go
+++ b/pocketbase/sync/staff_test.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -116,12 +117,73 @@ func testTransformStaffPersonID(data map[string]any, personMap map[int]string) (
 	return pbData, nil
 }
 
-// TestAllStaffStatuses verifies the allStaffStatuses constant includes all 4 CampMinder statuses
+// TestAllStaffStatuses verifies the allStaffStatuses constant includes all 4 CampMinder statuses.
+//
+// This is also, less obviously, an ORDER check, not just a membership check (kindred#2267):
+// syncStaff iterates allStaffStatuses in slice order and the first status seen for a
+// person-year wins when the same person appears under more than one status in one run
+// (isDuplicateStaffStatus below). Reordering this slice silently changes which status wins
+// a collapse -- Active(1) beats Resigned(2) beats Dismissed(3) beats Cancelled(4) -- and this
+// DeepEqual is what would catch that. Do not "tidy" it into a sorted or set-like comparison.
 func TestAllStaffStatuses(t *testing.T) {
 	t.Parallel()
-	expected := []int{1, 2, 3, 4} // Active, Resigned, Dismissed, Cancelled
+	expected := []int{1, 2, 3, 4} // Active, Resigned, Dismissed, Cancelled -- order is precedence
 	if !reflect.DeepEqual(allStaffStatuses, expected) {
 		t.Errorf("allStaffStatuses = %v, want %v", allStaffStatuses, expected)
+	}
+}
+
+// TestIsDuplicateStaffStatus pins kindred#2267: when the same person appears under more than
+// one CampMinder status in a single sync run, the first status seen (Active, per
+// allStaffStatuses' order) must win, and every later duplicate must be counted
+// (Stats.DuplicateStaffStatus) and logged at a level visible at the default LOG_LEVEL=INFO.
+//
+// Before the fix, the duplicate branch did neither: no counter existed at all, and the only
+// trace was a slog.Debug line invisible at INFO. Contrast the branch immediately above it in
+// syncStaff ("no matching person"), which already does both -- this test is the mirror of
+// that precedent.
+func TestIsDuplicateStaffStatus(t *testing.T) {
+	t.Parallel()
+	s := &StaffSync{BaseSyncService: BaseSyncService{ProcessedKeys: map[string]bool{}}}
+	buf := captureSweepLogs(t)
+
+	// Active (status 1) is the first sighting for this person-year -- allStaffStatuses
+	// processes it first, so it must NOT be treated as a duplicate.
+	if dup := s.isDuplicateStaffStatus("pb_person_1", 2026, 1); dup {
+		t.Fatalf("first sighting under Active reported as a duplicate")
+	}
+	if s.Stats.DuplicateStaffStatus != 0 {
+		t.Fatalf("Stats.DuplicateStaffStatus = %d after first sighting, want 0", s.Stats.DuplicateStaffStatus)
+	}
+
+	// Resigned (status 2) arrives later in the same run for the same person-year -- this
+	// is the duplicate that must be counted and logged, and Active must still be the
+	// record that survives (the caller's `continue` on a true return is what enforces
+	// that; this test only pins the reporting half).
+	if dup := s.isDuplicateStaffStatus("pb_person_1", 2026, 2); !dup {
+		t.Fatalf("second sighting under Resigned was not reported as a duplicate")
+	}
+	if s.Stats.DuplicateStaffStatus != 1 {
+		t.Fatalf("Stats.DuplicateStaffStatus = %d after duplicate, want 1", s.Stats.DuplicateStaffStatus)
+	}
+
+	// A different person-year must be unaffected by the first person's dedup state.
+	if dup := s.isDuplicateStaffStatus("pb_person_2", 2026, 1); dup {
+		t.Fatalf("unrelated person reported as a duplicate")
+	}
+	if s.Stats.DuplicateStaffStatus != 1 {
+		t.Fatalf("Stats.DuplicateStaffStatus = %d after unrelated person, want unchanged at 1", s.Stats.DuplicateStaffStatus)
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "level=WARN") {
+		t.Fatalf("expected a WARN-level log line for the dropped duplicate, got: %s", logged)
+	}
+	if !strings.Contains(logged, "pb_person_1") {
+		t.Fatalf("expected the log line to name the dropped person, got: %s", logged)
+	}
+	if strings.Contains(logged, "level=DEBUG") {
+		t.Fatalf("must not log the drop at Debug (invisible at default LOG_LEVEL=INFO), got: %s", logged)
 	}
 }
 


### PR DESCRIPTION
## What changed

`pocketbase/sync/staff.go`'s duplicate-status skip branch had no counter and logged at
`slog.Debug` (invisible at the default `LOG_LEVEL=INFO`), while the "no matching person"
branch immediately above it already counted (`Stats.Skipped++`) and logged at `Warn`. This PR
mirrors that precedent for the duplicate branch, and writes the precedence policy down as a
comment instead of leaving it an accident of `allStaffStatuses`' slice order.

**Does not change which status wins.** Active still wins a collapse, exactly as before — that
is a product call nobody has made, and this PR does not make it. It only makes the collapse
legible and countable.

1. `allStaffStatuses` gains a comment stating the precedence explicitly: first status seen this
   run wins, so Active(1) > Resigned(2) > Dismissed(3) > Cancelled(4) by slice order.
2. The skip branch (`staff.go:134` in the pre-fix tree, verified against `7b591a9c` per the
   issue) is extracted into `isDuplicateStaffStatus`, which does the same bookkeeping the
   "no matching person" branch above it does: counts the drop and logs at `Warn`.
3. New `Stats.DuplicateStaffStatus` field (`pocketbase/sync/orchestrator.go`) — see "Skipped
   vs. a new counter" below for why it isn't folded into `Skipped`.
4. `staff.go`'s existing per-run summary `slog.Info` line gains a
   `duplicate_status_dropped` field so the aggregate is visible even without Warn-level logs.
5. `frontend/src/hooks/useSyncStatusAPI.ts` + `SyncTab.tsx`: the new field is typed and
   rendered as a `"N dup status"` amber badge, at both card-render sites (mirrors how
   `rejected`/`skipped` are rendered at both), on the "Staff" card only (nothing else ever
   sets it).

## Skipped vs. a new counter — decided explicitly, not by default

The issue names this as the tradeoff to make deliberately. Reusing `Stats.Skipped` was cheaper
but wrong: `base_sync.go`'s `ProcessSimpleRecord` no-change branch already increments `Skipped`
for every unchanged row, and `staff.go` calls `ProcessSimpleRecord` for every record it writes.
On a steady-state run `Skipped` is therefore already roughly the whole roster (~279 for 2026),
and a handful of duplicate-status drops would be invisible inside that number. `Stats` gets its
own `DuplicateStaffStatus` field instead, `omitempty`, excluded from `IsNoOp()` (verified by a
new test case), and never touched outside `staff.go`.

**Not persisted to `sync_runs`.** `sync_runs.go` mirrors every `Stats` field to its own
migration-backed column, and adding one would mean a new PocketBase migration — out of scope
for this job. The counter still reaches the live Sync tab via the JSON status field; historical
persistence is a follow-up if the distribution turns out to matter.

## Out of scope, on purpose

- **Which status wins.** Unchanged. Active still wins every collapse.
- **`pocketbase/sync/bunk_assignments.go`.** `protectNonActiveStaffAssignments` reads whichever
  status survives the collapse and is unmodified by this PR — it belongs to a different,
  not-running item per the campaign's scope split.
- **A new PocketBase migration** for `sync_runs` (see above).

## Verification

```
cd pocketbase && go build ./...                                   # exit 0
cd pocketbase && go test ./sync/... -run 'TestIsDuplicateStaffStatus|TestAllStaffStatuses'  # exit 0, PASS
cd pocketbase && go test ./sync/...                                # exit 0, ok (57.9s)
cd pocketbase && golangci-lint run ./sync/...                      # 0 issues
cd frontend && npx tsc --noEmit -p .                               # exit 0, no output
cd frontend && ./node_modules/.bin/vitest run src/components/admin/SyncTab.test.tsx src/hooks/useSyncStatusAPI.test.ts
                                                                     # 2 files, 21 tests passed
bash scripts/pre-push-verify.sh                                    # exit 0 (see PR comment for full output)
```

## TDD

Both new tests were written first and run to a genuine failure before any implementation
existed:

- Go: `TestIsDuplicateStaffStatus` first failed to **compile** (`s.isDuplicateStaffStatus
  undefined`, `Stats.DuplicateStaffStatus undefined`) before `isDuplicateStaffStatus` or the
  `Stats` field existed.
- Frontend: `SyncTab duplicate staff status badge (#2267)` first failed with
  `TestingLibraryElementError: Unable to find an element with the text: 2 dup status` before
  the badge markup was added — the sibling "renders no badge" case passed throughout, confirming
  the failure was specific to the missing markup, not a broken test harness.

### Mutation check

Reverted `isDuplicateStaffStatus` to the pre-fix body (no counter, `slog.Debug`) and reran:

```
--- FAIL: TestIsDuplicateStaffStatus (0.00s)
    staff_test.go:167: Stats.DuplicateStaffStatus = 0 after duplicate, want 1
```

Reverted the frontend badge markup and reran:

```
Tests  1 failed | 10 passed (11)
 ❯ …Unable to find an element with the text: 2 dup status
```

Both restored to the real implementation afterward and reconfirmed green.

Closes #2267.

## Testing scope note

The issue's acceptance list asks for a test that "drives the skip branch ... and asserts both
that exactly one row is written **and** that the counter incremented." `TestIsDuplicateStaffStatus`
covers the counter/log half directly, and covers the "one row written" half only indirectly: it
proves the duplicate path returns `true` and the caller's `continue` is what skips
`ProcessSimpleRecord` for that record, so a duplicate can never reach the write path. It does not
drive a real `*core.Record` write through a live PocketBase app.

That's a deliberate scope call, not an oversight: `staff.go`'s `Sync()` talks to CampMinder
through a concrete `*campminder.Client` whose base URL is a package-level constant
(`https://api.campminder.com`), not overridable per-instance, so a full `Sync()` integration
test would need to fake that fixed host. No test in this file (or, as far as I found, in
`pocketbase/sync/*_test.go` generally) does that for a CampMinder-backed sync — every existing
staff.go test (`TestShouldPreserveBunkData`, `testTransformStaffPersonID`, etc.) tests an
extracted, DB-free helper the same way this PR's test does. I followed that established pattern
rather than building a new integration harness for this one PR. If DB-level coverage of the
"exactly one row" claim is wanted, it's a separate, larger piece of work.
