### PR TITLE
fix(sync): guard family_camp_derived's three orphan sweeps and give DryRun a real diff

### DIFF
--- a/docs/reference/family-camp-grain-collapse.md
+++ b/docs/reference/family-camp-grain-collapse.md
@@ -245,8 +245,9 @@ GUI, and any such edit is silently overwritten by the next upsert. And "every va
 recovered" is verified for **2026 only**: the 4,618 `family_camp_adults` rows for 2017-2021
 were written by an earlier code generation off person-level `Family Camp-P1/P2 *` fields
 (`name` empty, `first_name` populated), and whether today's `processAdults` reproduces them
-at all has **never been tested**. With the sweep unguarded, "does not reproduce" means
-"deletes".
+at all has **never been tested**. Until 2026-08-13 the sweep was unguarded, which made "does
+not reproduce" mean "deletes"; it now refuses instead (see §6), and a `DryRun` diff will say
+which of the two it is before anything is written.
 
 ---
 
@@ -302,15 +303,26 @@ at all has **never been tested**. With the sweep unguarded, "does not reproduce"
   | `fetch_household_registration_years` (`:455-476`) | `family_camp_registrations` | **all years** | **3,459** rows whose mere *existence* puts a year on a family's timeline |
   | `fetch_cabin_assignments_by_household_cm_id(year)` (`:597-650`) | `.cabin_assignment` | per traced year | 1,786 cabin strings — the only one this bullet named |
 
-  **Two hazards must be cleared before any replay wider than 2026:**
-  1. `family_camp_derived`'s three orphan sweeps are **unguarded**. `orphan_guard.go:54-58`
-     enumerates nine guarded services and this one is not among them;
-     `deleteOrphanedAdults`/`…Registrations`/`…Medical` (`:1606`, `:1640`, `:1672`) return a bare
-     `int`. It is the last unguarded sweep in the package, guarding exactly the three tables a
-     replay rewrites.
-  2. `DryRun` reports counts, not a diff. It fires at `:232` immediately after `processMedical`
-     and returns **before** any `preloadExisting*`, so a replay cannot be measured before it is
-     done — which is what makes the wider question unanswerable today rather than merely open.
+  **Two hazards had to be cleared before any replay wider than 2026. Both are CLEARED as of
+  2026-08-13** — they were the whole content of the first family-camp grain PR, and the
+  re-evaluation above is what they unblock:
+  1. ~~`family_camp_derived`'s three orphan sweeps are **unguarded**.~~ **Fixed.**
+     `deleteOrphanedAdults`/`…Registrations`/`…Medical` (`family_camp_derived.go:1840`, `:1889`,
+     `:1934`) now each construct an `OrphanSweepGuard` and return `(int, error)`, and `Sync`
+     joins the three refusals and returns them through `wrapOrphanSweepError`. It was the last
+     unguarded sweep in the package; `orphan_guard.go` now enumerates **ten** services that build
+     their own guard. `Rejected` is left unset, as it is for the other nine — this service counts
+     no rejections.
+  2. ~~`DryRun` reports counts, not a diff.~~ **Fixed.** The dry-run return moved past the three
+     `preloadExisting*` calls (`family_camp_derived.go:301`), and `reportDryRun` (`:1292`) now
+     records a per-table `DryRunDiff` — would-create / would-update / unchanged / would-delete,
+     judged by the SAME `needsUpdate` comparisons the writing path uses — on `s.DryRunDiff`, logs
+     it, and mirrors it into `Stats`. It also reports `GuardWouldRefuse`, so a diff promising
+     3,000 deletions says whether hazard 1's guard would then block them. **A dry run still
+     writes nothing**, which is pinned by test.
+
+     What this does NOT do: it does not answer the replay question, it makes it answerable. Run
+     `family_camp_derived` with `DryRun` against 2017-2025 and read the diff before deciding.
 
 ---
 

--- a/docs/reference/family-camp-grain-collapse.md
+++ b/docs/reference/family-camp-grain-collapse.md
@@ -16,9 +16,9 @@ Measured against the production snapshot at `pocketbase/pb_data/data.db`, tree `
 
 **1. It is not random, and three issue bodies say it is.** `#2255` (and text echoed into
 siblings) warns that the collapse is "random-wins" and implies a flaky test. It is not.
-Every map range on this path (`family_camp_derived.go:684`, `:838`, `:994`,
+Every map range on this path (`family_camp_derived.go:811`, `:965`, `:1121`,
 `lodging_requests.go:377`) affects only *output slice order*, never which value wins. The
-winner is fixed by the input slice, and `loadPersonCustomValues` sorts by `id` (`:523`,
+winner is fixed by the input slice, and `loadPersonCustomValues` sorts by `id` (`:646`,
 with a comment saying why). So the sites are **deterministic against a given database** —
 arbitrary, uncorrelated with recency or completeness, unstable across a delete/recreate of
 a source row, but *not* a per-run coin flip. A flakiness test will chase a ghost. The
@@ -56,39 +56,39 @@ silently · **OR** = boolean or, fail-safe · **join** = dedup-and-join, lossles
 No site anywhere counts its loss: no `Stats` field, no `slog.Warn`, no
 `lodging_ingest_issues` row, no conflict column, for any of the 20 lossy sites.
 
-### `processAdults` — `family_camp_derived.go:636-676`
+### `processAdults` — `family_camp_derived.go:763-802`
 
 Group key `(household, adult_slot)`. All arms are `Contains(fieldName, X) && field == ""`.
 
 | # | Column | Source cm_id | Rule | Notes |
 |---|---|---|---|---|
-| A1 | `first_name` | 34160 / 34161 | first-wins | documented at `:603-635`; holds a full typed name |
+| A1 | `first_name` | 34160 / 34161 | first-wins | documented at `:682-729`; holds a full typed name |
 | A2 | `last_name` | 216785 / 216786 | first-wins | dead — 0 conflicts, unfilled after 2022 |
-| A3 | `email` | 224590 / 224591 | `preferEmail` `:716-726` then first-wins | only site with a validity tie-break |
+| A3 | `email` | 224590 / 224591 | `preferEmail` `:836-851` then first-wins | only site with a validity tie-break |
 | A4 | `pronouns` | 241038 / 241039 | first-wins | |
 | A5 | `gender` | 34163 / 34164 | first-wins | |
 | A6 | `date_of_birth` | 34166 / 34167 | first-wins | **largest single loss in the file** |
 | A7 | `relationship_to_camper` | 36523 / 36524 | first-wins | **semantically void** once separated from the child it is relative to |
 | A8 | `name` | 219270-219272, 221653/221654 | none | household grain; `UNIQUE(year,household,field)` means no collapse occurs |
 
-### `processRegistrations` — `family_camp_derived.go:749-836`
+### `processRegistrations` — `family_camp_derived.go:876-959`
 
 Exact-name switch, `if reg.X == ""` guards.
 
 | # | Column | cm_id | Line | Rule |
 |---|---|---|---|---|
-| R1 | `share_cabin_preference` | 240877 | `:760-763` | first-wins — **resolved by a different rule than `share_cabin_gate` on the same row** |
-| R2 | `shared_cabin_modes_raw` | 263379 | `:764-767` | first-wins (no readers) |
-| R3 | `arrival_eta` | 36529 | `:768-771` | first-wins |
-| R4 | `special_occasions` | 60413 | `:772-775` | first-wins |
-| R5 | `goals` | 36526 | `:781-784` | first-wins (retired after 2024) |
-| R6 | `notes` | 36528 | `:785-788` | first-wins |
-| R7 | `cabin_assignment` | 218072 | `:734-745` | household grain, no collapse |
-| B1 | `needs_private_bathroom` | 274056 / 274053 | `:815-816` | **OR — correct** |
-| B2 | `has_infant` | 257248 | `:823-830` | **OR — correct** |
-| B3 | `needs_accommodation` | 223999 / 274057 / 274055 | `:794-795` | **OR — correct** |
-| B4 | `opt_out_vip` + `accommodation_is_mandatory` | 256927 / 256935 | `:796-814` + `:838-853` | **OR plus an order-independent blocker override.** The best-designed site on this path and the model for what a conflict rule should look like |
-| B5 | `needs_power` + bathroom arm | 256582 / 171577 / 256933 | `:817-822` | OR of two independently-tested needs via `classifyCPAPAnswer` — correct |
+| R1 | `share_cabin_preference` | 240877 | `:887-890` | first-wins — **resolved by a different rule than `share_cabin_gate` on the same row** |
+| R2 | `shared_cabin_modes_raw` | 263379 | `:891-894` | first-wins (no readers) |
+| R3 | `arrival_eta` | 36529 | `:895-898` | first-wins |
+| R4 | `special_occasions` | 60413 | `:899-902` | first-wins |
+| R5 | `goals` | 36526 | `:908-911` | first-wins (retired after 2024) |
+| R6 | `notes` | 36528 | `:912-915` | first-wins |
+| R7 | `cabin_assignment` | 218072 | `:861-873` | household grain, no collapse |
+| B1 | `needs_private_bathroom` | 274056 / 274053 | `:942-943` | **OR — correct** |
+| B2 | `has_infant` | 257248 | `:950-957` | **OR — correct** |
+| B3 | `needs_accommodation` | 223999 / 274057 / 274055 | `:921-922` | **OR — correct** |
+| B4 | `opt_out_vip` + `accommodation_is_mandatory` | 256927 / 256935 | `:923-939` + `:966-983` | **OR plus an order-independent blocker override.** The best-designed site on this path and the model for what a conflict rule should look like |
+| B5 | `needs_power` + bathroom arm | 256582 / 171577 / 256933 | `:944-949` | OR of two independently-tested needs via `classifyCPAPAnswer` — correct |
 
 ### `CollapseToHouseholdGrain` — `lodging_requests.go:291-390`
 
@@ -101,14 +101,14 @@ The only site with a written-down, reviewed policy.
 | C3 | `wants_near/with/similar_ages` | `:358-364` | OR — correct |
 | C4 | `share_eligibility`, `share_answers_conflict` | `:377-386` | derived from the collapsed set; the conflict flag is computed against the **winner only**, which is `#2269` |
 
-### `processMedical` — `family_camp_derived.go:981-992`, then `:994-1095`
+### `processMedical` — `family_camp_derived.go:1104-1117`, then `:1119-1220`
 
 | # | Column | Line | Rule |
 |---|---|---|---|
-| M0 | *the flatten itself* | `:986-988` | first-wins across **every** field name, before any per-field logic. **This one site is behind M1-M8** |
-| M1 | `cpap_info` | `:1010-1021` | first-wins, **plus a `break` at `:1015`** keeping the older camper generation (171577) over the newer (256582). Adult-CPAP (256933) is correctly additive |
-| M2-M5 | `physician_info`, `special_needs_info`, `allergy_info`, `dietary_info` | `:1024-1065` | each concatenates a **gate token with a narrative**, chosen independently by M0 — so the two halves can come from different people |
-| M6-M8 | `additional_info`, `bathroom_explain`, `accommodation_explain` | `:1068-1084` | first-wins |
+| M0 | *the flatten itself* | `:1113-1115` | first-wins across **every** field name, before any per-field logic. **This one site is behind M1-M8** |
+| M1 | `cpap_info` | `:1137-1150` | first-wins, **plus a `break` at `:1141`** keeping the older camper generation (171577) over the newer (256582). Adult-CPAP (256933) is correctly additive |
+| M2-M5 | `physician_info`, `special_needs_info`, `allergy_info`, `dietary_info` | `:1152-1190` | each concatenates a **gate token with a narrative**, chosen independently by M0 — so the two halves can come from different people |
+| M6-M8 | `additional_info`, `bathroom_explain`, `accommodation_explain` | `:1192-1211` | first-wins |
 
 ---
 
@@ -188,7 +188,7 @@ decision).
 |---|---|---|
 | `#2257` | tracking | Says "20 sites, three mechanisms". The catalogue finds **26 sites**; 20 lossy is right |
 | `#2255` | M0 + the M1 `break` | Anchors correct. Reproduced: 330 rows reading `"No; <narrative>"` (243 with 2+ answerers); 703 household-years hold both camper CPAP generations, **70 disagreeing** |
-| `#2274` | R1-R6 | **Every cell reproduced exactly:** Trans ETA 420/428/121 · Goals 240/247/0 · Anything else 73/75/29 · Share Cabins 30/30/24 · Shared Cabin 16/16/16 · Special occasions 14/14/5. One anchor wrong: "the person loop at `:757`" — it opens at **`:749`** |
+| `#2274` | R1-R6 | **Every cell reproduced exactly:** Trans ETA 420/428/121 · Goals 240/247/0 · Anything else 73/75/29 · Share Cabins 30/30/24 · Shared Cabin 16/16/16 · Special occasions 14/14/5. One anchor wrong: "the person loop at `:757`" — it opens at **`:876`** |
 | `#2275` | A1-A7 | **Reproduced exactly:** DOB 1,124 colliding / **1,151 lost** · first name 791/801 · gender 511/513 · relationship 315/323 · email 326 colliding. Its latent-collision warning is real and confirmed: `FAM CAMP Adult 1/2 Gender-Other` (240871/240872) and `FAM Camp Adult 1/2-Pronouns other` (241040/241042) would funnel into the `gender`/`pronouns` arms and carry zero values in every year |
 | `#2269` | C4 | Not a data-loss site — C1's collapse is correct; the review flag is what is missing. Correctly scoped |
 | `#2270` | ingest upsert, not a transform | Latent — 0 duplicate key groups today. The household twin at `household_custom_field_values.go:319-320`/`:329` has the identical shape |
@@ -202,7 +202,7 @@ changed. See `CLAUDE.md` §4.
 - **`#2255`** and the siblings echoing it — the "random-wins / flaky" framing. Replace with
   deterministic-but-arbitrary, and swap the proposed flakiness test for an
   order-independence probe.
-- **`#2274`** — anchor `:757` → `:749`; loss table omits the share fields.
+- **`#2274`** — anchor `:757` → `:876`; loss table omits the share fields.
 - **`#2275`** — add that slots 3-5 carry *no* attributes in any year, so the entire
   attribute loss is a slots-1-and-2 phenomenon.
 - **`#2276`** — claims three unrouted questions; the live population is **35** admitted-
@@ -216,7 +216,7 @@ changed. See `CLAUDE.md` §4.
 ## 5. Recommended order
 
 **Step 0 is a hard prerequisite and nothing can start without it:** widen
-`customValueEntry` (`family_camp_derived.go:437-445`) to carry the person PB id and cm id.
+`customValueEntry` (`family_camp_derived.go:560-568`) to carry the person PB id and cm id.
 It currently discards the person id at load, which is the root architectural cause of
 every site above. Both `#2255` and `#2275` name it.
 
@@ -230,7 +230,7 @@ every site above. Both `#2255` and `#2275` name it.
    migration. `#2255`, `#2274`, `#2275` all close here.
 4. **Add `session_cm_id`** to `family_camp_registrations`. **The grain triple must move in
    one PR:** the write key in `upsertRegistrations`, the orphan key `ProcessedRegKeys`
-   (`family_camp_derived.go:34`), and `idx_fc_reg_unique` (migration `1500000035:288`).
+   (`family_camp_derived.go:45`), and `idx_fc_reg_unique` (migration `1500000035:288`).
    Then switch `fetch_family_camp_registrations(year)` → `(year, session_cm_id)`.
 5. **Point the weekend medical panel** at the per-answer table and wire
    `original_bunk_requests` into the roster — the two things staff asked for directly.
@@ -307,19 +307,30 @@ which of the two it is before anything is written.
   2026-08-13** — they were the whole content of the first family-camp grain PR, and the
   re-evaluation above is what they unblock:
   1. ~~`family_camp_derived`'s three orphan sweeps are **unguarded**.~~ **Fixed.**
-     `deleteOrphanedAdults`/`…Registrations`/`…Medical` (`family_camp_derived.go:1840`, `:1889`,
-     `:1934`) now each construct an `OrphanSweepGuard` and return `(int, error)`, and `Sync`
+     `deleteOrphanedAdults`/`…Registrations`/`…Medical` (`family_camp_derived.go:1915`, `:1961`,
+     `:2005`) now each construct an `OrphanSweepGuard` and return `(int, error)`, and `Sync`
      joins the three refusals and returns them through `wrapOrphanSweepError`. It was the last
      unguarded sweep in the package; `orphan_guard.go` now enumerates **ten** services that build
      their own guard. `Rejected` is left unset, as it is for the other nine — this service counts
      no rejections.
   2. ~~`DryRun` reports counts, not a diff.~~ **Fixed.** The dry-run return moved past the three
-     `preloadExisting*` calls (`family_camp_derived.go:301`), and `reportDryRun` (`:1292`) now
+     `preloadExisting*` calls (`family_camp_derived.go:301`), and `reportDryRun` (`:1351`) now
      records a per-table `DryRunDiff` — would-create / would-update / unchanged / would-delete,
      judged by the SAME `needsUpdate` comparisons the writing path uses — on `s.DryRunDiff`, logs
-     it, and mirrors it into `Stats`. It also reports `GuardWouldRefuse`, so a diff promising
-     3,000 deletions says whether hazard 1's guard would then block them. **A dry run still
-     writes nothing**, which is pinned by test.
+     it, and mirrors would-create / would-update / unchanged into `Stats`. It also reports
+     `GuardWouldRefuse`, so a diff promising 3,000 deletions says whether hazard 1's guard would
+     then block them. **A dry run still writes nothing**, which is pinned by test.
+
+     **`Stats.Deleted` is deliberately left at 0 on a dry run**, and would-delete is read off
+     `DryRunDiff` instead. `recordSyncRun` writes `Stats.Deleted` straight into
+     `sync_runs.deleted_count` with `status=completed`, and `sync_runs` carries no dry-run
+     marker, so mirroring it would leave one completed run row per dry run asserting deletions
+     that never happened — nine of them once the 2017-2025 dry runs below are done, and
+     afterwards indistinguishable from nine real sweeps. **Residual, unchanged by this work:**
+     a dry run still populates `created_count`, `updated_count` and `skipped_count` in
+     `sync_runs`. Those overstate a harmless act rather than a destructive one, and predate
+     this PR; recording any of it honestly needs a dry-run column or status on `sync_runs`,
+     which is a schema change and a separate decision.
 
      What this does NOT do: it does not answer the replay question, it makes it answerable. Run
      `family_camp_derived` with `DryRun` against 2017-2025 and read the diff before deciding.
@@ -339,9 +350,9 @@ Three things in it to correct before relying on it:
 
 1. **"Random / SQLite paging order" over-generalises.** It is accurate for
    `household_demographics.go:494`, which passes `""` for sort. It is **wrong** for
-   `family_camp_derived.go`, which sorts by `id` at `:523`. Deterministic-but-arbitrary,
+   `family_camp_derived.go`, which sorts by `id` at `:646`. Deterministic-but-arbitrary,
    as §1 above sets out. Its *remedy* — the order-independence probe — is right either way.
-2. **It counts `family_camp_derived.go:988` as one site.** That is site M0 here, and M0
+2. **It counts `family_camp_derived.go:1114` as one site.** That is site M0 here, and M0
    alone is behind M1-M8. The family-camp path holds **26** sites, 20 of them lossy. Its
    per-site figure and this file's path-wide figure are different measurements, not
    competing ones.

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -15,6 +16,15 @@ import (
 
 // serviceNameFamilyCampDerived is the canonical name for this sync service
 const serviceNameFamilyCampDerived = "family_camp_derived"
+
+// familyCampSweepHint points an operator at the upstream behind all three
+// computed sets. Unlike the CampMinder-backed services, nothing here is fetched
+// from the vendor: every one of these tables is derived from custom values
+// already in PocketBase, so a collapse means the custom-value sync or the
+// field-definition map is what came back short, not the API.
+const familyCampSweepHint = "check that person_custom_values, household_custom_values and " +
+	"custom_field_defs hold this season's family-camp rows -- these tables are derived " +
+	"from PocketBase, not fetched from CampMinder"
 
 // FamilyCampDerivedSync computes derived family camp tables from custom values.
 // This service reads from person_custom_values and household_custom_values
@@ -34,6 +44,38 @@ type FamilyCampDerivedSync struct {
 	ProcessedAdultKeys   map[string]bool
 	ProcessedRegKeys     map[string]bool
 	ProcessedMedicalKeys map[string]bool
+
+	// DryRunDiff holds the last DryRun pass's verdict, keyed by collection name.
+	// It is populated only by a dry run and reset at the top of every Sync, so a
+	// writing run never leaves a stale diff behind for a caller to misread.
+	DryRunDiff map[string]DryRunDiff
+}
+
+// DryRunDiff is one table's answer to "what would a real run do here", produced
+// without doing any of it.
+//
+// Why WouldDelete and GuardWouldRefuse are separate fields: a replay's danger is
+// concentrated in its deletions, and counting them is only half the answer. The
+// orphan sweep may REFUSE the whole thing (see OrphanSweepGuard), in which case
+// those rows survive and the run fails instead -- an operationally different
+// outcome from the same number of deletions actually happening.
+type DryRunDiff struct {
+	// WouldCreate counts computed rows with nothing stored under their key.
+	WouldCreate int
+	// WouldUpdate counts computed rows whose stored row differs, judged by the
+	// SAME needsUpdate comparison the writing path uses -- not a second opinion
+	// that could drift from it.
+	WouldUpdate int
+	// Unchanged counts rows a real run would leave exactly as they are. It is
+	// the denominator that makes the other three readable: "40 updates" means
+	// something different against 45 rows than against 4,500.
+	Unchanged int
+	// WouldDelete counts stored rows this run's computed set does not account
+	// for -- what the orphan sweep would TARGET.
+	WouldDelete int
+	// GuardWouldRefuse reports that the sweep would be refused rather than
+	// performed, so WouldDelete describes an intention, not an outcome.
+	GuardWouldRefuse bool
 }
 
 // NewFamilyCampDerivedSync creates a new family camp derived sync service
@@ -168,6 +210,7 @@ func (s *FamilyCampDerivedSync) Sync(ctx context.Context) error {
 	s.ProcessedAdultKeys = make(map[string]bool)
 	s.ProcessedRegKeys = make(map[string]bool)
 	s.ProcessedMedicalKeys = make(map[string]bool)
+	s.DryRunDiff = nil
 
 	// Determine year
 	year := s.Year
@@ -229,18 +272,14 @@ func (s *FamilyCampDerivedSync) Sync(ctx context.Context) error {
 	medical := s.processMedical(personValues)
 	slog.Info("Processed medical", "count", len(medical))
 
-	if s.DryRun {
-		slog.Info("Dry run mode - computed but not writing",
-			"adults", len(adults),
-			"registrations", len(registrations),
-			"medical", len(medical),
-		)
-		s.Stats.Created = len(adults) + len(registrations) + len(medical)
-		s.SyncSuccessful = true
-		return nil
-	}
-
-	// Step 8: Preload existing records for upsert
+	// Step 8: Preload existing records for upsert.
+	//
+	// A dry run reaches this too, and that is the whole point of where it
+	// returns. It used to return above, having seen only the computed set, and
+	// so reported len(adults)+len(registrations)+len(medical) as "created" --
+	// counts, not a diff. That made a replay unmeasurable before it was done,
+	// which is what turned "should we replay 2017-2025" into an unanswerable
+	// question rather than merely an open one. The preloads are reads.
 	existingAdults, err := s.preloadExistingAdults(year)
 	if err != nil {
 		return fmt.Errorf("preloading existing adults: %w", err)
@@ -259,40 +298,66 @@ func (s *FamilyCampDerivedSync) Sync(ctx context.Context) error {
 		"medical", len(existingMedical),
 	)
 
-	// Step 9: Upsert adults
-	created, updated, skipped, errors := s.upsertAdults(ctx, adults, year, existingAdults)
+	if s.DryRun {
+		s.reportDryRun(year, adults, registrations, medical,
+			existingAdults, existingRegs, existingMedical)
+		s.SyncSuccessful = true
+		return nil
+	}
+
+	// Step 9: Upsert adults. The error COUNT is deliberately not named `errors`
+	// -- the orphan sweeps below join real error values, and a local of that
+	// name would shadow the stdlib package.
+	created, updated, skipped, errCount := s.upsertAdults(ctx, adults, year, existingAdults)
 	s.Stats.Created += created
 	s.Stats.Updated += updated
 	s.Stats.Skipped += skipped
-	s.Stats.Errors += errors
+	s.Stats.Errors += errCount
 
 	// Step 10: Upsert registrations
-	created, updated, skipped, errors = s.upsertRegistrations(ctx, registrations, year, existingRegs)
+	created, updated, skipped, errCount = s.upsertRegistrations(ctx, registrations, year, existingRegs)
 	s.Stats.Created += created
 	s.Stats.Updated += updated
 	s.Stats.Skipped += skipped
-	s.Stats.Errors += errors
+	s.Stats.Errors += errCount
 
 	// Step 11: Upsert medical
-	created, updated, skipped, errors = s.upsertMedical(ctx, medical, year, existingMedical)
+	created, updated, skipped, errCount = s.upsertMedical(ctx, medical, year, existingMedical)
 	s.Stats.Created += created
 	s.Stats.Updated += updated
 	s.Stats.Skipped += skipped
-	s.Stats.Errors += errors
+	s.Stats.Errors += errCount
 
 	// Mark sync as successful before orphan deletion
 	s.SyncSuccessful = true
 
-	// Step 12: Delete orphaned records (no longer in source data)
-	s.Stats.Deleted += s.deleteOrphanedAdults(existingAdults)
-	s.Stats.Deleted += s.deleteOrphanedRegistrations(existingRegs)
-	s.Stats.Deleted += s.deleteOrphanedMedical(existingMedical)
+	// Step 12: Delete orphaned records (no longer in source data).
+	//
+	// All three sweeps run even when an earlier one refuses: they guard three
+	// independent tables, and a collapsed adults computation says nothing about
+	// whether the medical computation is trustworthy. The refusals are joined
+	// and returned together so an operator sees every table that stopped, not
+	// just the first.
+	deletedAdults, adultsErr := s.deleteOrphanedAdults(existingAdults, year)
+	s.Stats.Deleted += deletedAdults
+	deletedRegs, regsErr := s.deleteOrphanedRegistrations(existingRegs, year)
+	s.Stats.Deleted += deletedRegs
+	deletedMedical, medicalErr := s.deleteOrphanedMedical(existingMedical, year)
+	s.Stats.Deleted += deletedMedical
+	sweepErr := errors.Join(adultsErr, regsErr, medicalErr)
 
-	// WAL checkpoint
+	// WAL checkpoint BEFORE the refusal return below: the upsert steps above
+	// have already written by this point, and a guard refusal can fire on a
+	// non-empty computed set (a PARTIAL collapse), which is precisely the case
+	// where writes already happened. Same ordering as staff_skills.go.
 	if s.Stats.Created > 0 || s.Stats.Updated > 0 || s.Stats.Deleted > 0 {
 		if err := s.forceWALCheckpoint(); err != nil {
 			slog.Warn("WAL checkpoint failed", "error", err)
 		}
+	}
+
+	if sweepErr != nil {
+		return wrapOrphanSweepError(sweepErr)
 	}
 
 	slog.Info("Family camp derived computation completed",
@@ -1192,6 +1257,162 @@ func parseBoolFieldValue(value string) bool {
 }
 
 // ============================================================================
+// Row keys
+//
+// The upsert path, the preload and the dry-run diff must agree on these
+// EXACTLY: a preload keyed differently from the upsert reads every stored row
+// as an orphan, and a dry run keyed differently from either reports a diff that
+// describes nothing real. They were three separate fmt.Sprintf calls until the
+// dry-run diff needed a fourth.
+// ============================================================================
+
+// familyCampAdultKey keys one family_camp_adults row.
+func familyCampAdultKey(householdPBID string, year, adultNumber int) string {
+	return fmt.Sprintf("%s:%d:%d", householdPBID, year, adultNumber)
+}
+
+// familyCampHouseholdYearKey keys one family_camp_registrations or
+// family_camp_medical row -- both are one row per household per year.
+func familyCampHouseholdYearKey(householdPBID string, year int) string {
+	return fmt.Sprintf("%s:%d", householdPBID, year)
+}
+
+// ============================================================================
+// Dry run
+// ============================================================================
+
+// reportDryRun computes what a real run would do to each of the three tables
+// and records it on s.DryRunDiff, without writing anything.
+//
+// Stats carries the same verdict rather than the old row counts. A dry run's
+// Stats are a FORECAST -- "would create", not "created" -- and the numbers are
+// only useful if they are the honest ones: reporting every computed row as a
+// creation, as this did before, told an operator that a replay of an already
+// derived year would create 4,000 rows when it would in fact change none.
+func (s *FamilyCampDerivedSync) reportDryRun(
+	year int,
+	adults []*adultData, registrations []*registrationData, medical []*medicalData,
+	existingAdults, existingRegs, existingMedical map[string]*core.Record,
+) {
+	// A fixed slice rather than a map range, so the log reads the same way on
+	// every run.
+	tables := []struct {
+		name     string
+		existing map[string]*core.Record
+		diff     DryRunDiff
+	}{
+		{
+			name:     "family_camp_adults",
+			existing: existingAdults,
+			diff: computeDryRunDiff("family_camp_adults", year, adults, existingAdults,
+				func(a *adultData) string {
+					return familyCampAdultKey(a.householdPBID, year, a.adultNumber)
+				},
+				s.adultNeedsUpdate),
+		},
+		{
+			name:     "family_camp_registrations",
+			existing: existingRegs,
+			diff: computeDryRunDiff("family_camp_registrations", year, registrations, existingRegs,
+				func(r *registrationData) string {
+					return familyCampHouseholdYearKey(r.householdPBID, year)
+				},
+				s.registrationNeedsUpdate),
+		},
+		{
+			name:     "family_camp_medical",
+			existing: existingMedical,
+			diff: computeDryRunDiff("family_camp_medical", year, medical, existingMedical,
+				func(m *medicalData) string {
+					return familyCampHouseholdYearKey(m.householdPBID, year)
+				},
+				s.medicalNeedsUpdate),
+		},
+	}
+
+	s.DryRunDiff = make(map[string]DryRunDiff, len(tables))
+	for _, t := range tables {
+		s.DryRunDiff[t.name] = t.diff
+
+		slog.Info("Dry run diff",
+			"table", t.name,
+			"year", year,
+			"would_create", t.diff.WouldCreate,
+			"would_update", t.diff.WouldUpdate,
+			"unchanged", t.diff.Unchanged,
+			"would_delete", t.diff.WouldDelete,
+			"existing", len(t.existing),
+		)
+		if t.diff.GuardWouldRefuse {
+			slog.Warn("Dry run: this table's orphan sweep would be REFUSED, not performed",
+				"table", t.name,
+				"year", year,
+				"computed", t.diff.WouldCreate+t.diff.WouldUpdate+t.diff.Unchanged,
+				"existing", len(t.existing),
+				"hint", familyCampSweepHint,
+			)
+		}
+
+		s.Stats.Created += t.diff.WouldCreate
+		s.Stats.Updated += t.diff.WouldUpdate
+		s.Stats.Skipped += t.diff.Unchanged
+		s.Stats.Deleted += t.diff.WouldDelete
+	}
+}
+
+// computeDryRunDiff classifies every computed row against what is stored, then
+// asks the same OrphanSweepGuard the real sweep would ask.
+//
+// needsUpdate is the production comparison function, passed in rather than
+// reimplemented: a dry run that judged "changed" by its own rule would drift
+// from the writing path silently, and a forecast nobody can trust is worse than
+// no forecast.
+func computeDryRunDiff[T any](
+	entity string,
+	year int,
+	items []T,
+	existing map[string]*core.Record,
+	key func(T) string,
+	needsUpdate func(*core.Record, T) bool,
+) DryRunDiff {
+	var diff DryRunDiff
+
+	computed := make(map[string]bool, len(items))
+	for _, item := range items {
+		k := key(item)
+		computed[k] = true
+
+		record, ok := existing[k]
+		switch {
+		case !ok:
+			diff.WouldCreate++
+		case needsUpdate(record, item):
+			diff.WouldUpdate++
+		default:
+			diff.Unchanged++
+		}
+	}
+
+	for k := range existing {
+		if !computed[k] {
+			diff.WouldDelete++
+		}
+	}
+
+	// Computed is the size of the key set, matching what the real sweep passes
+	// (len(s.Processed*Keys) after the upsert loop has run).
+	guard := OrphanSweepGuard{
+		Entity:   entity,
+		Year:     year,
+		Computed: len(computed),
+		Hint:     familyCampSweepHint,
+	}
+	diff.GuardWouldRefuse = guard.Check(len(existing)) != nil
+
+	return diff
+}
+
+// ============================================================================
 // Upsert helpers: preload existing records
 // ============================================================================
 
@@ -1216,8 +1437,7 @@ func (s *FamilyCampDerivedSync) preloadExistingAdults(year int) (map[string]*cor
 				adultNum = int(num)
 			}
 			if householdID != "" && adultNum > 0 {
-				key := fmt.Sprintf("%s:%d:%d", householdID, year, adultNum)
-				result[key] = record
+				result[familyCampAdultKey(householdID, year, adultNum)] = record
 			}
 		}
 
@@ -1247,8 +1467,7 @@ func (s *FamilyCampDerivedSync) preloadExistingRegistrations(year int) (map[stri
 		for _, record := range records {
 			householdID := record.GetString("household")
 			if householdID != "" {
-				key := fmt.Sprintf("%s:%d", householdID, year)
-				result[key] = record
+				result[familyCampHouseholdYearKey(householdID, year)] = record
 			}
 		}
 
@@ -1278,8 +1497,7 @@ func (s *FamilyCampDerivedSync) preloadExistingMedical(year int) (map[string]*co
 		for _, record := range records {
 			householdID := record.GetString("household")
 			if householdID != "" {
-				key := fmt.Sprintf("%s:%d", householdID, year)
-				result[key] = record
+				result[familyCampHouseholdYearKey(householdID, year)] = record
 			}
 		}
 
@@ -1399,7 +1617,7 @@ func (s *FamilyCampDerivedSync) medicalNeedsUpdate(existing *core.Record, med *m
 // upsertAdults performs upsert for adult records
 func (s *FamilyCampDerivedSync) upsertAdults(
 	ctx context.Context, adults []*adultData, year int, existing map[string]*core.Record,
-) (created, updated, skipped, errors int) {
+) (created, updated, skipped, errCount int) {
 	col, err := s.App.FindCollectionByNameOrId("family_camp_adults")
 	if err != nil {
 		slog.Error("Error finding family_camp_adults collection", "error", err)
@@ -1409,11 +1627,11 @@ func (s *FamilyCampDerivedSync) upsertAdults(
 	for _, adult := range adults {
 		select {
 		case <-ctx.Done():
-			return created, updated, skipped, errors
+			return created, updated, skipped, errCount
 		default:
 		}
 
-		key := fmt.Sprintf("%s:%d:%d", adult.householdPBID, year, adult.adultNumber)
+		key := familyCampAdultKey(adult.householdPBID, year, adult.adultNumber)
 		s.ProcessedAdultKeys[key] = true
 
 		if existingRecord, ok := existing[key]; ok {
@@ -1430,7 +1648,7 @@ func (s *FamilyCampDerivedSync) upsertAdults(
 
 				if err := s.App.Save(existingRecord); err != nil {
 					slog.Error("Error updating adult record", "household", adult.householdPBID, "error", err)
-					errors++
+					errCount++
 					continue
 				}
 				updated++
@@ -1454,20 +1672,20 @@ func (s *FamilyCampDerivedSync) upsertAdults(
 
 			if err := s.App.Save(record); err != nil {
 				slog.Error("Error creating adult record", "household", adult.householdPBID, "error", err)
-				errors++
+				errCount++
 				continue
 			}
 			created++
 		}
 	}
 
-	return created, updated, skipped, errors
+	return created, updated, skipped, errCount
 }
 
 // upsertRegistrations performs upsert for registration records
 func (s *FamilyCampDerivedSync) upsertRegistrations(
 	ctx context.Context, registrations []*registrationData, year int, existing map[string]*core.Record,
-) (created, updated, skipped, errors int) {
+) (created, updated, skipped, errCount int) {
 	col, err := s.App.FindCollectionByNameOrId("family_camp_registrations")
 	if err != nil {
 		slog.Error("Error finding family_camp_registrations collection", "error", err)
@@ -1477,11 +1695,11 @@ func (s *FamilyCampDerivedSync) upsertRegistrations(
 	for _, reg := range registrations {
 		select {
 		case <-ctx.Done():
-			return created, updated, skipped, errors
+			return created, updated, skipped, errCount
 		default:
 		}
 
-		key := fmt.Sprintf("%s:%d", reg.householdPBID, year)
+		key := familyCampHouseholdYearKey(reg.householdPBID, year)
 		s.ProcessedRegKeys[key] = true
 
 		if existingRecord, ok := existing[key]; ok {
@@ -1500,7 +1718,7 @@ func (s *FamilyCampDerivedSync) upsertRegistrations(
 
 				if err := s.App.Save(existingRecord); err != nil {
 					slog.Error("Error updating registration record", "household", reg.householdPBID, "error", err)
-					errors++
+					errCount++
 					continue
 				}
 				updated++
@@ -1525,20 +1743,20 @@ func (s *FamilyCampDerivedSync) upsertRegistrations(
 
 			if err := s.App.Save(record); err != nil {
 				slog.Error("Error creating registration record", "household", reg.householdPBID, "error", err)
-				errors++
+				errCount++
 				continue
 			}
 			created++
 		}
 	}
 
-	return created, updated, skipped, errors
+	return created, updated, skipped, errCount
 }
 
 // upsertMedical performs upsert for medical records
 func (s *FamilyCampDerivedSync) upsertMedical(
 	ctx context.Context, medical []*medicalData, year int, existing map[string]*core.Record,
-) (created, updated, skipped, errors int) {
+) (created, updated, skipped, errCount int) {
 	col, err := s.App.FindCollectionByNameOrId("family_camp_medical")
 	if err != nil {
 		slog.Error("Error finding family_camp_medical collection", "error", err)
@@ -1548,11 +1766,11 @@ func (s *FamilyCampDerivedSync) upsertMedical(
 	for _, med := range medical {
 		select {
 		case <-ctx.Done():
-			return created, updated, skipped, errors
+			return created, updated, skipped, errCount
 		default:
 		}
 
-		key := fmt.Sprintf("%s:%d", med.householdPBID, year)
+		key := familyCampHouseholdYearKey(med.householdPBID, year)
 		s.ProcessedMedicalKeys[key] = true
 
 		if existingRecord, ok := existing[key]; ok {
@@ -1569,7 +1787,7 @@ func (s *FamilyCampDerivedSync) upsertMedical(
 
 				if err := s.App.Save(existingRecord); err != nil {
 					slog.Error("Error updating medical record", "household", med.householdPBID, "error", err)
-					errors++
+					errCount++
 					continue
 				}
 				updated++
@@ -1592,25 +1810,49 @@ func (s *FamilyCampDerivedSync) upsertMedical(
 
 			if err := s.App.Save(record); err != nil {
 				slog.Error("Error creating medical record", "household", med.householdPBID, "error", err)
-				errors++
+				errCount++
 				continue
 			}
 			created++
 		}
 	}
 
-	return created, updated, skipped, errors
+	return created, updated, skipped, errCount
 }
 
 // ============================================================================
 // Orphan deletion functions
+//
+// All three refuse to sweep when this run's computed set is too small to be
+// believed against the rows already on disk (kindred#2257, kindred#2279). These
+// were the last unguarded sweeps in the package, and they guard exactly the
+// three tables a replay of an older season rewrites -- none of which has a
+// history table behind it, so a wrong delete here has no way back.
+//
+// Computed is the size of the key set THIS RUN built, not the number of stored
+// rows it happens to match; see OrphanSweepGuard's doc comment. Rejected is
+// deliberately left unset, matching the nine other services that construct
+// their own guard: this service counts no rejections, so the REJECTION arm
+// cannot fire and there is nothing for it to fire on.
 // ============================================================================
 
-// deleteOrphanedAdults removes adult records that weren't processed
-func (s *FamilyCampDerivedSync) deleteOrphanedAdults(existing map[string]*core.Record) int {
+// deleteOrphanedAdults removes adult records that weren't processed.
+func (s *FamilyCampDerivedSync) deleteOrphanedAdults(
+	existing map[string]*core.Record, year int,
+) (int, error) {
 	if !s.SyncSuccessful {
 		slog.Info("Skipping orphan deletion for adults due to sync failure")
-		return 0
+		return 0, nil
+	}
+
+	guard := OrphanSweepGuard{
+		Entity:   "family_camp_adults",
+		Year:     year,
+		Computed: len(s.ProcessedAdultKeys),
+		Hint:     familyCampSweepHint,
+	}
+	if err := guard.Check(len(existing)); err != nil {
+		return 0, err
 	}
 
 	orphanCount := 0
@@ -1637,14 +1879,26 @@ func (s *FamilyCampDerivedSync) deleteOrphanedAdults(existing map[string]*core.R
 		slog.Info("Deleted orphaned family_camp_adults records", "count", orphanCount)
 	}
 
-	return orphanCount
+	return orphanCount, nil
 }
 
-// deleteOrphanedRegistrations removes registration records that weren't processed
-func (s *FamilyCampDerivedSync) deleteOrphanedRegistrations(existing map[string]*core.Record) int {
+// deleteOrphanedRegistrations removes registration records that weren't processed.
+func (s *FamilyCampDerivedSync) deleteOrphanedRegistrations(
+	existing map[string]*core.Record, year int,
+) (int, error) {
 	if !s.SyncSuccessful {
 		slog.Info("Skipping orphan deletion for registrations due to sync failure")
-		return 0
+		return 0, nil
+	}
+
+	guard := OrphanSweepGuard{
+		Entity:   "family_camp_registrations",
+		Year:     year,
+		Computed: len(s.ProcessedRegKeys),
+		Hint:     familyCampSweepHint,
+	}
+	if err := guard.Check(len(existing)); err != nil {
+		return 0, err
 	}
 
 	orphanCount := 0
@@ -1669,14 +1923,26 @@ func (s *FamilyCampDerivedSync) deleteOrphanedRegistrations(existing map[string]
 		slog.Info("Deleted orphaned family_camp_registrations records", "count", orphanCount)
 	}
 
-	return orphanCount
+	return orphanCount, nil
 }
 
-// deleteOrphanedMedical removes medical records that weren't processed
-func (s *FamilyCampDerivedSync) deleteOrphanedMedical(existing map[string]*core.Record) int {
+// deleteOrphanedMedical removes medical records that weren't processed.
+func (s *FamilyCampDerivedSync) deleteOrphanedMedical(
+	existing map[string]*core.Record, year int,
+) (int, error) {
 	if !s.SyncSuccessful {
 		slog.Info("Skipping orphan deletion for medical due to sync failure")
-		return 0
+		return 0, nil
+	}
+
+	guard := OrphanSweepGuard{
+		Entity:   "family_camp_medical",
+		Year:     year,
+		Computed: len(s.ProcessedMedicalKeys),
+		Hint:     familyCampSweepHint,
+	}
+	if err := guard.Check(len(existing)); err != nil {
+		return 0, err
 	}
 
 	orphanCount := 0
@@ -1701,5 +1967,5 @@ func (s *FamilyCampDerivedSync) deleteOrphanedMedical(existing map[string]*core.
 		slog.Info("Deleted orphaned family_camp_medical records", "count", orphanCount)
 	}
 
-	return orphanCount
+	return orphanCount, nil
 }

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -333,18 +333,41 @@ func (s *FamilyCampDerivedSync) Sync(ctx context.Context) error {
 
 	// Step 12: Delete orphaned records (no longer in source data).
 	//
-	// All three sweeps run even when an earlier one refuses: they guard three
-	// independent tables, and a collapsed adults computation says nothing about
-	// whether the medical computation is trustworthy. The refusals are joined
-	// and returned together so an operator sees every table that stopped, not
-	// just the first.
-	deletedAdults, adultsErr := s.deleteOrphanedAdults(existingAdults, year)
-	s.Stats.Deleted += deletedAdults
-	deletedRegs, regsErr := s.deleteOrphanedRegistrations(existingRegs, year)
-	s.Stats.Deleted += deletedRegs
-	deletedMedical, medicalErr := s.deleteOrphanedMedical(existingMedical, year)
-	s.Stats.Deleted += deletedMedical
-	sweepErr := errors.Join(adultsErr, regsErr, medicalErr)
+	// A CANCELLED RUN SWEEPS NOTHING, and this check is what makes that true.
+	// The three upsert loops above break on ctx.Done() and return their partial
+	// counts with no error -- unlike staff_skills.go, whose loop returns
+	// ctx.Err() up so its sweep is never reached. So an interruption arrives
+	// here looking exactly like a collapsed upstream, and the guard alone
+	// handles neither half of that well:
+	//
+	//   - Below OrphanSweepMinRows the ratio arm is silent, so the guard does
+	//     not refuse and the sweep deletes every row the run never got to. A
+	//     year holding three family_camp_adults rows loses all three to a
+	//     cancellation that fired after the first write.
+	//   - Above it the guard does refuse, but reports "refused ... check that
+	//     person_custom_values ... hold this season's rows" -- sending an
+	//     operator after a feed that was never the problem. Keeping those two
+	//     facts apart is the whole job of wrapOrphanSweepError.
+	//
+	// Reported through the same wrapper rather than returned bare, so an
+	// interrupted run still says which phase it stopped in.
+	var sweepErr error
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		sweepErr = ctxErr
+	} else {
+		// All three sweeps run even when an earlier one refuses: they guard
+		// three independent tables, and a collapsed adults computation says
+		// nothing about whether the medical computation is trustworthy. The
+		// refusals are joined and returned together so an operator sees every
+		// table that stopped, not just the first.
+		deletedAdults, adultsErr := s.deleteOrphanedAdults(existingAdults, year)
+		s.Stats.Deleted += deletedAdults
+		deletedRegs, regsErr := s.deleteOrphanedRegistrations(existingRegs, year)
+		s.Stats.Deleted += deletedRegs
+		deletedMedical, medicalErr := s.deleteOrphanedMedical(existingMedical, year)
+		s.Stats.Deleted += deletedMedical
+		sweepErr = errors.Join(adultsErr, regsErr, medicalErr)
+	}
 
 	// WAL checkpoint BEFORE the refusal return below: the upsert steps above
 	// have already written by this point, and a guard refusal can fire on a

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -333,7 +333,12 @@ func (s *FamilyCampDerivedSync) Sync(ctx context.Context) error {
 
 	// Step 12: Delete orphaned records (no longer in source data).
 	//
-	// A CANCELLED RUN SWEEPS NOTHING, and this check is what makes that true.
+	// A RUN CANCELLED BEFORE STEP 12 SWEEPS NOTHING, and this check is what
+	// makes that true. The claim is deliberately no stronger than that: none of
+	// the three sweeps below takes a context, so a cancellation landing partway
+	// THROUGH Step 12 is a separate case, handled by the re-checks between the
+	// sweep calls rather than here.
+	//
 	// The three upsert loops above break on ctx.Done() and return their partial
 	// counts with no error -- unlike staff_skills.go, whose loop returns
 	// ctx.Err() up so its sweep is never reached. So an interruption arrives
@@ -360,13 +365,43 @@ func (s *FamilyCampDerivedSync) Sync(ctx context.Context) error {
 		// nothing about whether the medical computation is trustworthy. The
 		// refusals are joined and returned together so an operator sees every
 		// table that stopped, not just the first.
-		deletedAdults, adultsErr := s.deleteOrphanedAdults(existingAdults, year)
-		s.Stats.Deleted += deletedAdults
-		deletedRegs, regsErr := s.deleteOrphanedRegistrations(existingRegs, year)
-		s.Stats.Deleted += deletedRegs
-		deletedMedical, medicalErr := s.deleteOrphanedMedical(existingMedical, year)
-		s.Stats.Deleted += deletedMedical
-		sweepErr = errors.Join(adultsErr, regsErr, medicalErr)
+		//
+		// Cancellation is the one thing that DOES stop the sequence early, and
+		// it is re-checked between tables because the sweeps take no context of
+		// their own. Without these checks a cancellation landing on the adults
+		// sweep still ran registrations and medical to completion and then
+		// reported a clean run.
+		//
+		// What is already swept stands, and that is correct rather than merely
+		// convenient: the check above passed, so no upsert loop broke early, so
+		// the computed set is complete and every row deleted was a genuine
+		// orphan an uninterrupted run would also have deleted. The defect being
+		// fixed is that the run kept working after it was told to stop and then
+		// did not say so -- which is why this re-checks here instead of
+		// propagating ctx.Err() out of the three upserts.
+		var adultsErr, regsErr, medicalErr, ctxErr error
+		var deleted int
+
+		deleted, adultsErr = s.deleteOrphanedAdults(existingAdults, year)
+		s.Stats.Deleted += deleted
+
+		if ctxErr = ctx.Err(); ctxErr == nil {
+			deleted, regsErr = s.deleteOrphanedRegistrations(existingRegs, year)
+			s.Stats.Deleted += deleted
+			ctxErr = ctx.Err()
+		}
+
+		if ctxErr == nil {
+			deleted, medicalErr = s.deleteOrphanedMedical(existingMedical, year)
+			s.Stats.Deleted += deleted
+			ctxErr = ctx.Err()
+		}
+
+		// Joined alongside the refusals, so an interrupted run that also hit a
+		// refusal reports both -- and so the cancellation reaches
+		// wrapOrphanSweepError, which is what keeps "interrupted" from being
+		// reported as "refused".
+		sweepErr = errors.Join(adultsErr, regsErr, medicalErr, ctxErr)
 	}
 
 	// WAL checkpoint BEFORE the refusal return below: the upsert steps above
@@ -1285,8 +1320,9 @@ func parseBoolFieldValue(value string) bool {
 // The upsert path, the preload and the dry-run diff must agree on these
 // EXACTLY: a preload keyed differently from the upsert reads every stored row
 // as an orphan, and a dry run keyed differently from either reports a diff that
-// describes nothing real. They were three separate fmt.Sprintf calls until the
-// dry-run diff needed a fourth.
+// describes nothing real. They were SIX separate fmt.Sprintf calls across two
+// format strings -- one per table in the preloads and one per table in the
+// upserts -- until the dry-run diff needed three more.
 // ============================================================================
 
 // familyCampAdultKey keys one family_camp_adults row.
@@ -1379,7 +1415,23 @@ func (s *FamilyCampDerivedSync) reportDryRun(
 		s.Stats.Created += t.diff.WouldCreate
 		s.Stats.Updated += t.diff.WouldUpdate
 		s.Stats.Skipped += t.diff.Unchanged
-		s.Stats.Deleted += t.diff.WouldDelete
+
+		// Stats.Deleted is deliberately NOT mirrored from WouldDelete.
+		//
+		// recordSyncRun writes Stats.Deleted straight into
+		// sync_runs.deleted_count with status=completed, and sync_runs carries
+		// no dry-run marker of any kind. Mirroring here would leave a completed
+		// run row asserting deletions that never happened -- nine of them once
+		// the planned 2017-2025 replay dry runs are done, and afterwards
+		// indistinguishable from nine real sweeps.
+		//
+		// Deleted is singled out because it is the only one of the four that
+		// describes a DESTRUCTIVE act; an overstated created/updated/skipped is
+		// a harmless overcount and predates this. The would-be count is not
+		// lost -- it stays on DryRunDiff.WouldDelete and in the log line above,
+		// which is where a dry run's answer belongs. Recording it in sync_runs
+		// honestly would need a dry-run column or status there, which is a
+		// schema change and a separate decision.
 	}
 }
 

--- a/pocketbase/sync/family_camp_derived_replay_test.go
+++ b/pocketbase/sync/family_camp_derived_replay_test.go
@@ -526,11 +526,29 @@ func TestFamilyCampDryRunReportsAPerTableDiff(t *testing.T) {
 		}
 	}
 
-	// Stats must carry the same verdict, because that is what a run row records
-	// and what an operator reads back afterwards.
-	if s.Stats.Created != 4 || s.Stats.Updated != 1 || s.Stats.Skipped != 1 || s.Stats.Deleted != 1 {
-		t.Errorf("Stats = created:%d updated:%d skipped:%d deleted:%d; want 4/1/1/1",
+	// Stats carries the same verdict, because that is what a run row records and
+	// what an operator reads back afterwards -- with ONE deliberate exception.
+	//
+	// Deleted stays 0 on a dry run. recordSyncRun writes Stats.Deleted straight
+	// into sync_runs.deleted_count with status=completed, and sync_runs has no
+	// dry-run marker of any kind, so mirroring WouldDelete into Stats leaves a
+	// row asserting deletions that never happened -- nine such rows once the
+	// planned 2017-2025 replay dry runs are done, indistinguishable afterwards
+	// from nine real sweeps. The count is not lost: it stays on
+	// DryRunDiff.WouldDelete and in the "Dry run diff" log line, which is where
+	// a dry run's output belongs. Deleted is singled out because it is the only
+	// one of the four that describes a DESTRUCTIVE act; created/updated/skipped
+	// overstate a harmless one and predate this behavior.
+	if s.Stats.Created != 4 || s.Stats.Updated != 1 || s.Stats.Skipped != 1 || s.Stats.Deleted != 0 {
+		t.Errorf("Stats = created:%d updated:%d skipped:%d deleted:%d; want 4/1/1/0",
 			s.Stats.Created, s.Stats.Updated, s.Stats.Skipped, s.Stats.Deleted)
+	}
+	// ...and the would-be count is still reported, on the diff rather than in
+	// Stats. Asserting both together is the point: dropping it from Stats must
+	// not quietly drop it from the dry run's answer.
+	if got := s.DryRunDiff["family_camp_adults"].WouldDelete; got != 1 {
+		t.Errorf("adults WouldDelete = %d, want 1 -- Stats.Deleted is what a dry run "+
+			"must not claim, not the diff", got)
 	}
 	if !s.SyncSuccessful {
 		t.Error("a completed dry run is a successful run")
@@ -659,5 +677,89 @@ func TestFamilyCampSyncDoesNotSweepAfterACancelledRun(t *testing.T) {
 	}
 	if got := countCollection(t, app, "family_camp_registrations", year); got != 40 {
 		t.Errorf("family_camp_registrations holds %d rows, want 40", got)
+	}
+}
+
+// TestFamilyCampSyncStopsSweepingWhenCancelledMidStep12 covers the half the
+// single pre-sweep check cannot see. ctx.Err() is evaluated once, before the
+// three sweeps, and none of deleteOrphanedAdults/...Registrations/...Medical
+// takes a context of its own -- so a cancellation landing BETWEEN two tables
+// ran the remaining ones to completion and then reported a clean sweep.
+//
+// This is an interruptibility and honesty defect, NOT data loss, and the
+// distinction is worth stating because it decides the fix. The check above
+// passed, so no upsert loop broke early, so the computed set is complete and
+// every row these sweeps delete is a genuine orphan that an uninterrupted run
+// would also have deleted. Nothing is lost. What is wrong is that a run told to
+// stop keeps working, and then does not say it was interrupted -- so the fix is
+// to re-check between tables, not to propagate ctx.Err() out of the upserts.
+func TestFamilyCampSyncStopsSweepingWhenCancelledMidStep12(t *testing.T) {
+	t.Parallel()
+
+	const year = 2026
+
+	app := newFamilyCampReplayTestApp(t)
+	seedDryRunFixture(t, app, year)
+
+	// One orphan in each of the two tables swept AFTER adults. The fixture
+	// computes registrations for hhA/hhB and medical for hhA only, so neither
+	// of these keys is accounted for: a sweep that reaches them deletes them.
+	seedRow(t, app, "family_camp_registrations", map[string]any{
+		"year": year, "household": "hhz000000000009",
+	})
+	seedRow(t, app, "family_camp_medical", map[string]any{
+		"year": year, "household": "hhy000000000008", "additional_info": "orphan",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Cancel on the adults sweep's OWN delete -- hhC, the fixture's orphan.
+	// That places the cancellation strictly between the first sweep and the
+	// second, which is the window a single check ahead of all three misses.
+	app.OnRecordAfterDeleteSuccess("family_camp_adults").BindFunc(func(e *core.RecordEvent) error {
+		cancel()
+		return e.Next()
+	})
+
+	s := NewFamilyCampDerivedSync(app)
+	s.Year = year
+
+	err := s.Sync(ctx)
+	if err == nil {
+		t.Fatal("Sync reported success for a run cancelled during its orphan sweeps")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error does not carry the cancellation: %v", err)
+	}
+	if !strings.Contains(err.Error(), "interrupted") {
+		t.Errorf("error does not report an interruption: %v", err)
+	}
+	if strings.Contains(err.Error(), "refused") {
+		t.Errorf("an interrupted sweep must not be reported as a guard refusal: %v", err)
+	}
+
+	// The sweep that had already run stands. hhC was a genuine orphan and the
+	// adults sweep completed before the cancellation landed; re-creating it
+	// would be a different bug, and this pins that the fix does not undo work.
+	adultRows, findErr := app.FindRecordsByFilter("family_camp_adults",
+		fmt.Sprintf("year = %d && household = 'hhc000000000003'", year), "", 0, 0)
+	if findErr != nil {
+		t.Fatalf("query hhC: %v", findErr)
+	}
+	if len(adultRows) != 0 {
+		t.Errorf("hhC survived -- the adults sweep should have completed before the cancel")
+	}
+
+	// The two sweeps that had NOT yet run must not have run. Three
+	// registrations (hhA and hhB written by this run, plus the seeded orphan)
+	// and two medical rows (hhA plus the seeded orphan).
+	if got := countCollection(t, app, "family_camp_registrations", year); got != 3 {
+		t.Errorf("family_camp_registrations holds %d rows, want 3 -- the registrations "+
+			"sweep ran after the run was cancelled", got)
+	}
+	if got := countCollection(t, app, "family_camp_medical", year); got != 2 {
+		t.Errorf("family_camp_medical holds %d rows, want 2 -- the medical sweep ran "+
+			"after the run was cancelled", got)
 	}
 }

--- a/pocketbase/sync/family_camp_derived_replay_test.go
+++ b/pocketbase/sync/family_camp_derived_replay_test.go
@@ -1,0 +1,574 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+)
+
+// ============================================================================
+// Test scaffolding
+//
+// family_camp_derived reads four collections and writes three. Both features
+// under test here -- the orphan-sweep guard and the dry-run diff -- are about
+// what happens BETWEEN the computed set and the rows already on disk, so they
+// cannot be exercised against a struct alone: they need real records.
+//
+// The collections below mirror production's SHAPE (names and types), not its
+// constraints -- no select vocabularies, no length caps, no unique indexes.
+// That is deliberate: these tests pin sweep and diff arithmetic, and a
+// validation failure would fail them for an unrelated reason.
+// ============================================================================
+
+// newFamilyCampReplayTestApp returns a throwaway app carrying every collection
+// FamilyCampDerivedSync.Sync touches.
+func newFamilyCampReplayTestApp(t *testing.T) core.App {
+	t.Helper()
+
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	save := func(col *core.Collection) {
+		if saveErr := app.Save(col); saveErr != nil {
+			t.Fatalf("save %s: %v", col.Name, saveErr)
+		}
+	}
+
+	text := func(col *core.Collection, names ...string) {
+		for _, n := range names {
+			col.Fields.Add(&core.TextField{Name: n})
+		}
+	}
+	boolean := func(col *core.Collection, names ...string) {
+		for _, n := range names {
+			col.Fields.Add(&core.BoolField{Name: n})
+		}
+	}
+
+	defs := core.NewBaseCollection("custom_field_defs")
+	defs.Fields.Add(&core.NumberField{Name: "cm_id"})
+	text(defs, "name")
+	save(defs)
+
+	persons := core.NewBaseCollection("persons")
+	persons.Fields.Add(&core.NumberField{Name: "year"})
+	text(persons, "household")
+	save(persons)
+
+	hcv := core.NewBaseCollection("household_custom_values")
+	hcv.Fields.Add(&core.NumberField{Name: "year"})
+	text(hcv, "household", "field_definition", "value", "last_updated")
+	save(hcv)
+
+	pcv := core.NewBaseCollection("person_custom_values")
+	pcv.Fields.Add(&core.NumberField{Name: "year"})
+	text(pcv, "person", "field_definition", "value", "last_updated")
+	save(pcv)
+
+	adults := core.NewBaseCollection("family_camp_adults")
+	adults.Fields.Add(&core.NumberField{Name: "year"})
+	adults.Fields.Add(&core.NumberField{Name: "adult_number"})
+	text(adults, "household", "name", "first_name", "last_name", "email",
+		"pronouns", "gender", "date_of_birth", "relationship_to_camper")
+	save(adults)
+
+	regs := core.NewBaseCollection("family_camp_registrations")
+	regs.Fields.Add(&core.NumberField{Name: "year"})
+	text(regs, "household", "cabin_assignment", "share_cabin_preference",
+		"shared_cabin_modes_raw", "arrival_eta", "special_occasions", "goals", "notes",
+		"share_cabin_gate", "request_text", "request_source_field", "request_last_updated",
+		"share_eligibility", "share_eligibility_source")
+	boolean(regs, "needs_accommodation", "opt_out_vip", "wants_near", "wants_with",
+		"wants_similar_ages", "needs_private_bathroom", "needs_power",
+		"accommodation_is_mandatory", "has_infant", "share_answers_conflict")
+	save(regs)
+
+	medical := core.NewBaseCollection("family_camp_medical")
+	medical.Fields.Add(&core.NumberField{Name: "year"})
+	text(medical, "household", "cpap_info", "physician_info", "special_needs_info",
+		"allergy_info", "dietary_info", "additional_info", "bathroom_explain",
+		"accommodation_explain")
+	save(medical)
+
+	return app
+}
+
+// seedRow writes one record into collection with the given field values.
+func seedRow(t *testing.T, app core.App, collection string, values map[string]any) *core.Record {
+	t.Helper()
+
+	col, err := app.FindCollectionByNameOrId(collection)
+	if err != nil {
+		t.Fatalf("find %s: %v", collection, err)
+	}
+	rec := core.NewRecord(col)
+	for k, v := range values {
+		rec.Set(k, v)
+	}
+	if saveErr := app.Save(rec); saveErr != nil {
+		t.Fatalf("seed %s: %v", collection, saveErr)
+	}
+	return rec
+}
+
+// countCollection returns how many rows a collection holds for a year.
+func countCollection(t *testing.T, app core.App, collection string, year int) int {
+	t.Helper()
+
+	records, err := app.FindRecordsByFilter(collection, fmt.Sprintf("year = %d", year), "", 0, 0)
+	if err != nil {
+		t.Fatalf("count %s: %v", collection, err)
+	}
+	return len(records)
+}
+
+// seedDerivedRows writes n placeholder rows into one of the three derived
+// tables, so a sweep has something to refuse to delete.
+func seedDerivedRows(t *testing.T, app core.App, collection string, year, n int) {
+	t.Helper()
+
+	for i := 1; i <= n; i++ {
+		values := map[string]any{
+			"household": fmt.Sprintf("hh_%03d", i),
+			"year":      year,
+		}
+		if collection == "family_camp_adults" {
+			values["adult_number"] = 1
+			values["name"] = fmt.Sprintf("Adult %03d", i)
+		}
+		seedRow(t, app, collection, values)
+	}
+}
+
+// ============================================================================
+// P1 -- the three sweeps are guarded (kindred#2257, kindred#2279)
+// ============================================================================
+
+// TestFamilyCampSweepsRefuseACollapsedComputedSet is the whole point of the
+// guard. family_camp_derived owns the last three unguarded sweeps in the
+// package, and they guard exactly the three tables a replay rewrites. A run
+// whose computed set comes back short -- a partial custom-value read, a
+// field-definition map that lost its entries -- must refuse to sweep rather
+// than delete the year and report success. There is no history table behind
+// these three; a wrong delete is unrecoverable.
+func TestFamilyCampSweepsRefuseACollapsedComputedSet(t *testing.T) {
+	t.Parallel()
+
+	const (
+		year   = 2026
+		seeded = 60
+	)
+
+	cases := []struct {
+		name       string
+		collection string
+		// computed is how many keys this run claims to have built. 5 against 60
+		// rows on disk is 8% -- far under OrphanSweepRatioFloor.
+		sweep func(s *FamilyCampDerivedSync, existing map[string]*core.Record) (int, error)
+		mark  func(s *FamilyCampDerivedSync, key string)
+		load  func(s *FamilyCampDerivedSync) (map[string]*core.Record, error)
+	}{
+		{
+			name:       "adults",
+			collection: "family_camp_adults",
+			sweep: func(s *FamilyCampDerivedSync, existing map[string]*core.Record) (int, error) {
+				return s.deleteOrphanedAdults(existing, year)
+			},
+			mark: func(s *FamilyCampDerivedSync, key string) { s.ProcessedAdultKeys[key] = true },
+			load: func(s *FamilyCampDerivedSync) (map[string]*core.Record, error) {
+				return s.preloadExistingAdults(year)
+			},
+		},
+		{
+			name:       "registrations",
+			collection: "family_camp_registrations",
+			sweep: func(s *FamilyCampDerivedSync, existing map[string]*core.Record) (int, error) {
+				return s.deleteOrphanedRegistrations(existing, year)
+			},
+			mark: func(s *FamilyCampDerivedSync, key string) { s.ProcessedRegKeys[key] = true },
+			load: func(s *FamilyCampDerivedSync) (map[string]*core.Record, error) {
+				return s.preloadExistingRegistrations(year)
+			},
+		},
+		{
+			name:       "medical",
+			collection: "family_camp_medical",
+			sweep: func(s *FamilyCampDerivedSync, existing map[string]*core.Record) (int, error) {
+				return s.deleteOrphanedMedical(existing, year)
+			},
+			mark: func(s *FamilyCampDerivedSync, key string) { s.ProcessedMedicalKeys[key] = true },
+			load: func(s *FamilyCampDerivedSync) (map[string]*core.Record, error) {
+				return s.preloadExistingMedical(year)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := newFamilyCampReplayTestApp(t)
+			seedDerivedRows(t, app, tc.collection, year, seeded)
+
+			s := NewFamilyCampDerivedSync(app)
+			s.SyncSuccessful = true
+
+			existing, err := tc.load(s)
+			if err != nil {
+				t.Fatalf("preload: %v", err)
+			}
+			if len(existing) != seeded {
+				t.Fatalf("preloaded %d rows, want %d", len(existing), seeded)
+			}
+
+			// A short computed set: five of the sixty keys came back.
+			marked := 0
+			for key := range existing {
+				if marked == 5 {
+					break
+				}
+				tc.mark(s, key)
+				marked++
+			}
+
+			deleted, sweepErr := tc.sweep(s, existing)
+			if sweepErr == nil {
+				t.Fatalf("sweep accepted a computed set of 5 against %d rows on disk", seeded)
+			}
+			if deleted != 0 {
+				t.Errorf("deleted = %d, want 0 -- a refused sweep must delete nothing", deleted)
+			}
+			if remaining := countCollection(t, app, tc.collection, year); remaining != seeded {
+				t.Errorf("%d rows survived, want %d", remaining, seeded)
+			}
+		})
+	}
+}
+
+// TestFamilyCampSweepsStillDeleteRealOrphans is the other half, and it is the
+// one that would catch a guard tuned so tight it stops working. Normal churn --
+// one household cancelled out of sixty -- must still be swept.
+func TestFamilyCampSweepsStillDeleteRealOrphans(t *testing.T) {
+	t.Parallel()
+
+	const (
+		year   = 2026
+		seeded = 60
+	)
+
+	app := newFamilyCampReplayTestApp(t)
+	seedDerivedRows(t, app, "family_camp_registrations", year, seeded)
+
+	s := NewFamilyCampDerivedSync(app)
+	s.SyncSuccessful = true
+
+	existing, err := s.preloadExistingRegistrations(year)
+	if err != nil {
+		t.Fatalf("preload: %v", err)
+	}
+
+	// Every key but one is accounted for: 59 of 60 is ordinary attrition.
+	skipped := false
+	for key := range existing {
+		if !skipped {
+			skipped = true
+			continue
+		}
+		s.ProcessedRegKeys[key] = true
+	}
+
+	deleted, sweepErr := s.deleteOrphanedRegistrations(existing, year)
+	if sweepErr != nil {
+		t.Fatalf("guard refused an ordinary sweep: %v", sweepErr)
+	}
+	if deleted != 1 {
+		t.Errorf("deleted = %d, want 1", deleted)
+	}
+	if remaining := countCollection(t, app, "family_camp_registrations", year); remaining != seeded-1 {
+		t.Errorf("%d rows remain, want %d", remaining, seeded-1)
+	}
+}
+
+// TestFamilyCampSyncSurfacesASweepRefusal pins the half a guard is useless
+// without. deleteOrphaned* returning an error nobody reads leaves the run
+// green, and "the sweep silently did nothing" is indistinguishable from "the
+// sweep found no orphans" -- which is exactly the state this whole guard exists
+// to end.
+func TestFamilyCampSyncSurfacesASweepRefusal(t *testing.T) {
+	t.Parallel()
+
+	const year = 2026
+
+	app := newFamilyCampReplayTestApp(t)
+	// Rows on disk with no source values behind them at all: the computed set
+	// comes back empty, which is OrphanSweepGuard's total-collapse arm.
+	seedDerivedRows(t, app, "family_camp_registrations", year, 40)
+
+	s := NewFamilyCampDerivedSync(app)
+	s.Year = year
+
+	err := s.Sync(context.Background())
+	if err == nil {
+		t.Fatal("Sync reported success while its sweep refused to run")
+	}
+	if !strings.Contains(err.Error(), "orphan sweep") {
+		t.Errorf("error does not name the sweep: %v", err)
+	}
+	if remaining := countCollection(t, app, "family_camp_registrations", year); remaining != 40 {
+		t.Errorf("%d rows survived, want 40 -- a refused sweep deletes nothing", remaining)
+	}
+}
+
+// ============================================================================
+// P2 -- DryRun reports a real diff, and still writes nothing
+// ============================================================================
+
+// seedDryRunFixture writes the source values behind three adults, two
+// registrations and one medical row for `year`, plus three family_camp_adults
+// rows chosen so every arm of the diff is exercised:
+//
+//	hhA -- computed and stored identically   -> unchanged
+//	hhB -- computed, stored with a stale name -> would update
+//	hhD -- computed, nothing stored           -> would create
+//	hhC -- stored, not computed               -> would delete
+func seedDryRunFixture(t *testing.T, app core.App, year int) {
+	t.Helper()
+
+	const (
+		hhA = "hha000000000001"
+		hhB = "hhb000000000002"
+		hhC = "hhc000000000003"
+		hhD = "hhd000000000004"
+
+		fdAdult1 = "fdaaaaaaaaaaaa1"
+		fdETA    = "fdaaaaaaaaaaaa2"
+		fdMedAdd = "fdaaaaaaaaaaaa3"
+
+		personA = "paaaaaaaaaaaaa1"
+		personB = "pbbbbbbbbbbbbb1"
+	)
+
+	defCol, err := app.FindCollectionByNameOrId("custom_field_defs")
+	if err != nil {
+		t.Fatalf("find custom_field_defs: %v", err)
+	}
+	for _, def := range []struct {
+		id   string
+		cmID int
+		name string
+	}{
+		{fdAdult1, 219270, "Family Camp Adult 1"},
+		{fdETA, 36529, "Family Camp-Trans ETA"},
+		{fdMedAdd, 60414, "Family Medical-Additional"},
+	} {
+		rec := core.NewRecord(defCol)
+		rec.Id = def.id
+		rec.Set("cm_id", def.cmID)
+		rec.Set("name", def.name)
+		if saveErr := app.Save(rec); saveErr != nil {
+			t.Fatalf("seed field def %s: %v", def.name, saveErr)
+		}
+	}
+
+	personsCol, err := app.FindCollectionByNameOrId("persons")
+	if err != nil {
+		t.Fatalf("find persons: %v", err)
+	}
+	for _, p := range []struct{ id, household string }{{personA, hhA}, {personB, hhB}} {
+		rec := core.NewRecord(personsCol)
+		rec.Id = p.id
+		rec.Set("year", year)
+		rec.Set("household", p.household)
+		if saveErr := app.Save(rec); saveErr != nil {
+			t.Fatalf("seed person %s: %v", p.id, saveErr)
+		}
+	}
+
+	// Household partition: the adult NAME column of record.
+	for _, hh := range []struct{ household, name string }{
+		{hhA, "Emma Johnson"},
+		{hhB, "Liam Garcia"},
+		{hhD, "Ava Martinez"},
+	} {
+		seedRow(t, app, "household_custom_values", map[string]any{
+			"year": year, "household": hh.household,
+			"field_definition": fdAdult1, "value": hh.name,
+		})
+	}
+
+	// Person partition: one registration answer each, one medical answer.
+	seedRow(t, app, "person_custom_values", map[string]any{
+		"year": year, "person": personA, "field_definition": fdETA, "value": "Friday around 4pm",
+	})
+	seedRow(t, app, "person_custom_values", map[string]any{
+		"year": year, "person": personB, "field_definition": fdETA, "value": "Saturday morning",
+	})
+	seedRow(t, app, "person_custom_values", map[string]any{
+		"year": year, "person": personA, "field_definition": fdMedAdd, "value": "Inhaler in the day bag",
+	})
+
+	// Rows already on disk.
+	for _, row := range []struct {
+		household, name string
+	}{
+		{hhA, "Emma Johnson"}, // identical to what this run computes
+		{hhB, "Stale Name"},   // differs -> update
+		{hhC, "Noah Wilson"},  // no source values at all -> orphan
+	} {
+		seedRow(t, app, "family_camp_adults", map[string]any{
+			"year": year, "household": row.household,
+			"adult_number": 1, "name": row.name,
+		})
+	}
+}
+
+// TestFamilyCampDryRunWritesNothing is the invariant everything else here rests
+// on. Moving the dry-run return past the preloads puts it one step from the
+// upsert loops, and a dry run that writes is worse than no dry run at all.
+func TestFamilyCampDryRunWritesNothing(t *testing.T) {
+	t.Parallel()
+
+	const year = 2026
+
+	app := newFamilyCampReplayTestApp(t)
+	seedDryRunFixture(t, app, year)
+
+	s := NewFamilyCampDerivedSync(app)
+	s.Year = year
+	s.DryRun = true
+
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("dry run failed: %v", err)
+	}
+
+	// Three adult rows went in; the run computes a create, an update and a
+	// delete against them, so any write at all moves one of these counts.
+	if got := countCollection(t, app, "family_camp_adults", year); got != 3 {
+		t.Errorf("family_camp_adults holds %d rows, want the 3 seeded -- the dry run wrote", got)
+	}
+	if got := countCollection(t, app, "family_camp_registrations", year); got != 0 {
+		t.Errorf("family_camp_registrations holds %d rows, want 0 -- the dry run wrote", got)
+	}
+	if got := countCollection(t, app, "family_camp_medical", year); got != 0 {
+		t.Errorf("family_camp_medical holds %d rows, want 0 -- the dry run wrote", got)
+	}
+
+	// The orphan specifically: a dry run must not sweep.
+	orphans, err := app.FindRecordsByFilter("family_camp_adults",
+		"year = 2026 && household = 'hhc000000000003'", "", 0, 0)
+	if err != nil {
+		t.Fatalf("query orphan: %v", err)
+	}
+	if len(orphans) != 1 {
+		t.Errorf("the orphan row is gone -- the dry run swept")
+	}
+
+	// And the stale row keeps its stale value.
+	stale, err := app.FindRecordsByFilter("family_camp_adults",
+		"year = 2026 && household = 'hhb000000000002'", "", 0, 0)
+	if err != nil {
+		t.Fatalf("query stale row: %v", err)
+	}
+	if len(stale) != 1 || stale[0].GetString("name") != "Stale Name" {
+		t.Errorf("the stale row was updated by a dry run")
+	}
+}
+
+// TestFamilyCampDryRunReportsAPerTableDiff is the feature itself. Before this,
+// DryRun returned before any preload and reported len(computed) as "created" --
+// counts, not a diff -- so a replay could not be measured before it was done,
+// which is what made "should we replay 2017-2025" unanswerable rather than
+// merely undecided.
+func TestFamilyCampDryRunReportsAPerTableDiff(t *testing.T) {
+	t.Parallel()
+
+	const year = 2026
+
+	app := newFamilyCampReplayTestApp(t)
+	seedDryRunFixture(t, app, year)
+
+	s := NewFamilyCampDerivedSync(app)
+	s.Year = year
+	s.DryRun = true
+
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("dry run failed: %v", err)
+	}
+
+	want := map[string]DryRunDiff{
+		// hhD creates, hhB updates, hhA is unchanged, hhC is an orphan.
+		"family_camp_adults": {WouldCreate: 1, WouldUpdate: 1, Unchanged: 1, WouldDelete: 1},
+		// hhA and hhB each answered the arrival question; nothing is stored.
+		"family_camp_registrations": {WouldCreate: 2},
+		// hhA alone carries a medical answer.
+		"family_camp_medical": {WouldCreate: 1},
+	}
+
+	if len(s.DryRunDiff) != len(want) {
+		t.Fatalf("DryRunDiff covers %d tables, want %d: %+v", len(s.DryRunDiff), len(want), s.DryRunDiff)
+	}
+	for table, expected := range want {
+		got, ok := s.DryRunDiff[table]
+		if !ok {
+			t.Errorf("no diff reported for %s", table)
+			continue
+		}
+		if got != expected {
+			t.Errorf("%s diff = %+v, want %+v", table, got, expected)
+		}
+	}
+
+	// Stats must carry the same verdict, because that is what a run row records
+	// and what an operator reads back afterwards.
+	if s.Stats.Created != 4 || s.Stats.Updated != 1 || s.Stats.Skipped != 1 || s.Stats.Deleted != 1 {
+		t.Errorf("Stats = created:%d updated:%d skipped:%d deleted:%d; want 4/1/1/1",
+			s.Stats.Created, s.Stats.Updated, s.Stats.Skipped, s.Stats.Deleted)
+	}
+	if !s.SyncSuccessful {
+		t.Error("a completed dry run is a successful run")
+	}
+}
+
+// TestFamilyCampDryRunFlagsASweepTheGuardWouldRefuse ties P1 and P2 together.
+// The reason to dry-run a replay year is to find out whether it is safe, and
+// "the sweep would be refused" is the single most important thing such a run
+// can tell an operator -- a diff promising 3,000 deletions that the guard would
+// then block is a different fact from one that would actually happen.
+func TestFamilyCampDryRunFlagsASweepTheGuardWouldRefuse(t *testing.T) {
+	t.Parallel()
+
+	const year = 2026
+
+	app := newFamilyCampReplayTestApp(t)
+	seedDryRunFixture(t, app, year)
+	// Sixty registration rows on disk against the two this run computes: an
+	// 3% computed set, far under OrphanSweepRatioFloor.
+	seedDerivedRows(t, app, "family_camp_registrations", year, 60)
+
+	s := NewFamilyCampDerivedSync(app)
+	s.Year = year
+	s.DryRun = true
+
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("dry run failed: %v", err)
+	}
+
+	regs := s.DryRunDiff["family_camp_registrations"]
+	if !regs.GuardWouldRefuse {
+		t.Errorf("registrations diff = %+v; the guard would refuse this sweep and the dry run must say so", regs)
+	}
+	if regs.WouldDelete != 60 {
+		t.Errorf("WouldDelete = %d, want 60 -- report what the sweep WOULD target, then flag the refusal",
+			regs.WouldDelete)
+	}
+	if adults := s.DryRunDiff["family_camp_adults"]; adults.GuardWouldRefuse {
+		t.Errorf("adults diff = %+v; that sweep is healthy and must not be flagged", adults)
+	}
+}

--- a/pocketbase/sync/family_camp_derived_replay_test.go
+++ b/pocketbase/sync/family_camp_derived_replay_test.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -570,5 +571,93 @@ func TestFamilyCampDryRunFlagsASweepTheGuardWouldRefuse(t *testing.T) {
 	}
 	if adults := s.DryRunDiff["family_camp_adults"]; adults.GuardWouldRefuse {
 		t.Errorf("adults diff = %+v; that sweep is healthy and must not be flagged", adults)
+	}
+}
+
+// TestFamilyCampSyncDoesNotSweepAfterACancelledRun is the case the guard alone
+// does not cover, and the one where it does the wrong thing.
+//
+// The three upsert loops break on ctx.Done() and return their PARTIAL counts
+// with no error -- unlike staff_skills.go, the file this service's sweep
+// ordering is modeled on, which returns ctx.Err() up so its sweep is never
+// reached at all. So an interrupted run arrives at Step 12 with a computed set
+// that is short for a reason that has nothing to do with the upstream, and two
+// things go wrong:
+//
+//   - Below OrphanSweepMinRows the ratio arm does not apply, so the guard does
+//     NOT refuse: the sweep proceeds and deletes rows the run simply never got
+//     to. family_camp_adults here holds three rows, one of which (hhA) is
+//     current and correct, and it is deleted.
+//   - Above it the guard DOES refuse, and the run reports "orphan sweep
+//     refused ... check that person_custom_values ... hold this season's
+//     family-camp rows" -- sending an operator to investigate a feed that is
+//     fine. Keeping that apart from an interruption is the entire job of
+//     wrapOrphanSweepError, whose doc comment says so in as many words.
+func TestFamilyCampSyncDoesNotSweepAfterACancelledRun(t *testing.T) {
+	t.Parallel()
+
+	const year = 2026
+
+	app := newFamilyCampReplayTestApp(t)
+	seedDryRunFixture(t, app, year)
+	// Two tables, deliberately on opposite sides of OrphanSweepMinRows:
+	// family_camp_adults holds the fixture's 3 rows (the guard cannot help),
+	// family_camp_registrations holds 40 (the guard refuses and misattributes).
+	seedDerivedRows(t, app, "family_camp_registrations", year, 40)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Cancel on the first derived write. Whichever adult the transform reaches
+	// first, one of these two fires: hhD is a create and hhB an update.
+	cancelOnWrite := func(e *core.RecordEvent) error {
+		cancel()
+		return e.Next()
+	}
+	app.OnRecordAfterCreateSuccess("family_camp_adults").BindFunc(cancelOnWrite)
+	app.OnRecordAfterUpdateSuccess("family_camp_adults").BindFunc(cancelOnWrite)
+
+	s := NewFamilyCampDerivedSync(app)
+	s.Year = year
+
+	err := s.Sync(ctx)
+	if err == nil {
+		t.Fatal("Sync reported success for a cancelled run")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error does not carry the cancellation: %v", err)
+	}
+	if !strings.Contains(err.Error(), "interrupted") {
+		t.Errorf("error does not report an interruption: %v", err)
+	}
+	if strings.Contains(err.Error(), "refused") {
+		t.Errorf("a cancelled run must not be reported as a guard refusal -- that hint "+
+			"points at person_custom_values, and the feed is not what stopped: %v", err)
+	}
+
+	// Nothing was swept. The adults table is the one that matters: at three
+	// rows it is under OrphanSweepMinRows, so the guard's ratio arm is silent
+	// and only skipping the sweep outright keeps these alive.
+	//
+	// Asserted per household rather than as a row COUNT, because the run
+	// legitimately creates hhD's row before the cancellation lands -- a write
+	// that already happened is not the defect. The defect is deletion: hhA is
+	// current and correct, hhB is merely stale, and hhC is a genuine orphan
+	// that a run which never reached it has no business sweeping.
+	for _, household := range []string{
+		"hha000000000001", "hhb000000000002", "hhc000000000003",
+	} {
+		rows, findErr := app.FindRecordsByFilter("family_camp_adults",
+			fmt.Sprintf("year = %d && household = '%s'", year, household), "", 0, 0)
+		if findErr != nil {
+			t.Fatalf("query %s: %v", household, findErr)
+		}
+		if len(rows) != 1 {
+			t.Errorf("family_camp_adults row for %s is gone -- a cancelled run swept a row "+
+				"it never reached, and this table is too small for the guard to catch it", household)
+		}
+	}
+	if got := countCollection(t, app, "family_camp_registrations", year); got != 40 {
+		t.Errorf("family_camp_registrations holds %d rows, want 40", got)
 	}
 }

--- a/pocketbase/sync/orphan_guard.go
+++ b/pocketbase/sync/orphan_guard.go
@@ -51,14 +51,16 @@ const (
 // fifteenth, every guarded service now fills in this struct.
 //
 // The COLLAPSE arm reaches every sweep in the package. BaseSyncService fills this
-// struct in for the sweeps it owns, and the nine services that do not embed it --
-// camper_dietary, camper_history, camper_transportation, household_demographics,
-// normalize_geographic, quest_registrations, staff_skills, staff_applications and
-// staff_vehicle_info -- each construct one inside their own deleteOrphans
-// (kindred#2280, kindred#2296).
+// struct in for the sweeps it owns, and the ten services that do not embed it --
+// camper_dietary, camper_history, camper_transportation, family_camp_derived,
+// household_demographics, normalize_geographic, quest_registrations, staff_skills,
+// staff_applications and staff_vehicle_info -- each construct one inside their own
+// deleteOrphans (kindred#2280, kindred#2296). family_camp_derived is the tenth and
+// the last to arrive: it performs THREE sweeps rather than one, so it builds three
+// guards, one per derived table.
 //
 // The REJECTION arm is narrower, and that is the part to watch. Only BaseSyncService
-// fills in Rejected, so for those nine SkipReason and RejectionsExplainShortfall can
+// fills in Rejected, so for those ten SkipReason and RejectionsExplainShortfall can
 // never fire -- they build the guard without it. That is harmless today because none
 // of them counts a rejection, and nothing pins it: a future reclassification into one
 // of those files gets the collapse guard but no rejection protection and no warning.


### PR DESCRIPTION
## What changed

Two mechanical prerequisites in `pocketbase/sync/family_camp_derived.go`. Neither changes what a normal run computes or writes.

### 1. The three orphan sweeps are guarded

`deleteOrphanedAdults` / `deleteOrphanedRegistrations` / `deleteOrphanedMedical` checked only `SyncSuccessful` and returned a bare `int`. A run whose computed set came back short — a partial `person_custom_values` read, a field-definition map that lost its entries — deleted the remainder of the year and reported success.

These were **the last unguarded sweeps in the package**, and they guard exactly the three tables the family-camp grain campaign rewrites. None of `family_camp_adults` / `family_camp_registrations` / `family_camp_medical` has a history table behind it, so a wrong delete has no way back.

Each now builds an `OrphanSweepGuard` inside its own delete function, copying the shape the ten other self-guarding services use (`camper_history.go:1149` was the template). `Sync` runs all three regardless of an earlier refusal — they guard independent tables — joins the refusals with `errors.Join`, and returns them through `wrapOrphanSweepError` **after** the WAL checkpoint (same ordering as `staff_skills.go`, because a PARTIAL collapse fires after the upserts have already written).

`Rejected` is deliberately left unset, matching the other nine self-guarding services: this service counts no rejections, so the REJECTION arm has nothing to fire on. `Computed` is `len(s.Processed*Keys)` — the size of the set this run built, not the number of stored rows it matches.

### 2. `DryRun` emits a per-year, per-table diff

The dry-run branch fired immediately after `processMedical` and **returned before any `preloadExisting*` call**, setting `Stats.Created = len(adults)+len(registrations)+len(medical)`. That is a count, not a diff: it told an operator that a re-run of an already-derived year would "create" every row in it. A replay could not be measured before it was performed, which is what made the deferred "should we replay 2017-2025?" question *unanswerable* rather than merely open.

The return now sits after the three preloads. `reportDryRun` records a `DryRunDiff` per table on `s.DryRunDiff`, logs it, and mirrors would-create / would-update / unchanged into `Stats` — `Stats.Deleted` deliberately stays 0, see review fix 3:

| field | meaning |
|---|---|
| `WouldCreate` | computed rows with nothing stored under their key |
| `WouldUpdate` | stored row differs — judged by the **same** `adultNeedsUpdate` / `registrationNeedsUpdate` / `medicalNeedsUpdate` the writing path uses, passed in rather than reimplemented |
| `Unchanged` | the denominator that makes the other three readable |
| `WouldDelete` | stored rows the computed set does not account for — what the sweep would **target**. Read off the diff, never mirrored into `Stats.Deleted` |
| `GuardWouldRefuse` | change 1's guard would refuse that sweep, so `WouldDelete` describes an intention, not an outcome |

**A dry run still writes nothing**, and that is pinned by test rather than asserted.

### Incidental, and needed by both

- The **six** `fmt.Sprintf` row-key sites — three in the preloads and three in the upserts, across two format strings — became `familyCampAdultKey` / `familyCampHouseholdYearKey`, so the preload, the upsert and the new diff cannot silently disagree about a key. A diff keyed differently from the upsert describes nothing real.
- The upserts' `errors` named return became `errCount`: `errors.Join` needs the package name, and `golangci-lint`'s `gocritic importShadow` fails the build otherwise.

## Measured justification

Both hazards are recorded verbatim in `docs/reference/family-camp-grain-collapse.md` §6 as the **two things that must be cleared before any replay wider than 2026**. That doc is updated in this PR to say they are cleared (and to correct `orphan_guard.go`'s "nine services" enumeration, which this PR makes ten).

Why a replay is a live question at all, from the same doc: eight derived columns are empty for every year 2017-2025 because only 2026 has been through a current run — `share_eligibility`, `needs_power`, `needs_private_bathroom`, `share_cabin_gate`, `request_text`, `wants_*`, `accommodation_is_mandatory`, `opt_out_vip`. And the blast radius of getting a replay wrong is not hypothetical: `build_household_journey` reads **8,955** adult names and **5,214** relationship labels out of `family_camp_adults` across all years with no year bound, plus **3,459** `family_camp_registrations` rows whose *existence* puts a year on a family's timeline. Whether today's `processAdults` even reproduces the 4,618 rows written for 2017-2021 by an earlier code generation has never been tested — and with the sweep unguarded, "does not reproduce" meant "deletes".

This PR does not answer the replay question. It makes it answerable: run `family_camp_derived` with `DryRun` against an old year and read the diff.

## How this was verified

TDD throughout — every test below was written and run RED first. `deleteOrphanedAdults`'s new `(int, error)` signature meant the first RED was a compile failure:

```
vet: sync/family_camp_derived_replay_test.go:182:45: too many arguments in call to s.deleteOrphanedAdults
	have (map[string]*core.Record, number)
	want (map[string]*core.Record)
```

Commands, all from the worktree, exit codes read rather than pass counts:

| command | exit |
|---|---|
| `cd pocketbase && go build ./...` | 0 |
| `cd pocketbase && go test ./...` | 0 |
| `cd pocketbase && golangci-lint run ./sync/...` | 0 (`0 issues.`) |
| `npx --no-install markdownlint-cli2 docs/reference/family-camp-grain-collapse.md` | `0 issues in 0 files` |
| `bash scripts/pre-push-verify.sh` | 0 (`ALL CHECKS PASSED`) |

`go test ./sync/` alone: `ok github.com/camp/kindred/pocketbase/sync 79.332s`. Under `pre-push-verify` (race + full package): `ok ... 350.070s`.

New tests, all in `pocketbase/sync/family_camp_derived_replay_test.go`, all `t.Parallel()` per the AST guard:

- `TestFamilyCampSweepsRefuseACollapsedComputedSet` — 3 subtests, one per table: 5 computed keys against 60 rows on disk must refuse, delete 0, and leave all 60.
- `TestFamilyCampSweepsStillDeleteRealOrphans` — the other half. 59 of 60 is ordinary attrition and must still sweep exactly 1. Without this, a guard tuned shut would pass everything else.
- `TestFamilyCampSyncSurfacesASweepRefusal` — drives the real `Sync`. A guard whose error nobody returns leaves the run green, and "the sweep silently did nothing" is indistinguishable from "there were no orphans", which is the exact state the guard exists to end.
- `TestFamilyCampDryRunWritesNothing`
- `TestFamilyCampDryRunReportsAPerTableDiff` — a fixture built so every arm fires at once: one create, one update, one unchanged, one delete.
- `TestFamilyCampDryRunFlagsASweepTheGuardWouldRefuse` — ties the two halves together.

## Mutation check

Every test above was checked against deliberately broken code. Transcripts:

**1 — guard result discarded (`_ = guard` in all three sweeps):**
```
--- FAIL: TestFamilyCampSyncSurfacesASweepRefusal (3.21s)
    Sync reported success while its sweep refused to run
--- FAIL: TestFamilyCampSweepsRefuseACollapsedComputedSet/medical (2.99s)
    sweep accepted a computed set of 5 against 60 rows on disk
--- FAIL: TestFamilyCampSweepsRefuseACollapsedComputedSet/adults (3.22s)
    sweep accepted a computed set of 5 against 60 rows on disk
--- FAIL: TestFamilyCampSweepsRefuseACollapsedComputedSet/registrations (3.30s)
    sweep accepted a computed set of 5 against 60 rows on disk
```
(the log also showed `Deleted orphaned family_camp_registrations records count=55` — the mutation really does delete the year)

**2 — dry run falls through to the write path** (this test would have passed on unmodified `main`, so it needed this most):
```
--- FAIL: TestFamilyCampDryRunWritesNothing (0.84s)
    family_camp_registrations holds 2 rows, want 0 -- the dry run wrote
    family_camp_medical holds 1 rows, want 0 -- the dry run wrote
    the orphan row is gone -- the dry run swept
    the stale row was updated by a dry run
```

**3 — every computed row counted as a create (the pre-PR behaviour):**
```
--- FAIL: TestFamilyCampDryRunReportsAPerTableDiff (1.08s)
    family_camp_adults diff = {WouldCreate:3 WouldUpdate:0 Unchanged:0 WouldDelete:1 GuardWouldRefuse:false},
                        want {WouldCreate:1 WouldUpdate:1 Unchanged:1 WouldDelete:1 GuardWouldRefuse:false}
    Stats = created:6 updated:0 skipped:0 deleted:1; want 4/1/1/1
```
(that transcript predates review fix 3, which changed the expected `Stats` to `4/1/1/0`; the assertion it fails on is unchanged)

**4 — `GuardWouldRefuse` hardcoded false:**
```
--- FAIL: TestFamilyCampDryRunFlagsASweepTheGuardWouldRefuse (1.86s)
    registrations diff = {WouldCreate:2 ... WouldDelete:60 GuardWouldRefuse:false};
    the guard would refuse this sweep and the dry run must say so
```

All four restored to green afterwards.

## Review fixes

Four fixes applied after review (our scan plus CodeRabbit's formal review), in commit `6136b6f3`.

**1. Stale doc anchors in `docs/reference/family-camp-grain-collapse.md`.** This PR's own second commit shifted `family_camp_derived.go` under the anchors the doc cites — including the `customValueEntry` range the campaign's next task **A0** is specified against ("widen `customValueEntry`"), which is the concrete way this bites: the doc is the checked-in artifact the next agent implements from.

Rather than patch the four reported anchors, **every** `family_camp_derived.go` anchor in the file was re-extracted against the branch tip and verified by opening the cited line. That turned up staleness this PR did not cause and fixed it too: §1's three "map range" anchors pointed four lines short of the actual `range` statements, `ProcessedRegKeys` was off by one, and the M0/M1 anchors straddled the wrong block. Anchors into other files (`lodging_requests.go`, `household_demographics.go`, `lodging_repository.py`) are untouched — this PR does not move them. The anchors were re-derived a second time after fixes 2-4 landed, since those shift the same file again.

**2. A comment claimed an invariant the code did not deliver.** The Step 12 comment said "A CANCELLED RUN SWEEPS NOTHING, and this check is what makes that true", but `ctx.Err()` was evaluated exactly once, before all three sweeps, and none of `deleteOrphanedAdults` / `…Registrations` / `…Medical` takes or checks a context. A cancellation landing *between* two tables ran the remaining ones to completion and then reported a clean run.

Both halves are fixed: the comment is softened to what the check actually guarantees (a run cancelled **before** Step 12 sweeps nothing), and `ctx.Err()` is re-checked between the three sweep calls and once after, joined into `sweepErr` so it reaches `wrapOrphanSweepError` and is reported as `interrupted` rather than `refused`.

**This is an interruptibility and honesty fix, not a data-loss fix.** CodeRabbit called it a data-loss path; it is not. If `ctx.Err()` is nil at the pre-sweep check then no upsert loop broke early, so the computed set is complete and every row swept is a genuine orphan an uninterrupted run would also have deleted. The wider refactor — propagating `ctx.Err()` out of the three upsert signatures — was considered and **declined**; nothing already swept is undone.

New test, RED first: `TestFamilyCampSyncStopsSweepingWhenCancelledMidStep12` cancels on the adults sweep's own delete, which is exactly the window between table one and table two. Before the fix:

```
--- FAIL: TestFamilyCampSyncStopsSweepingWhenCancelledMidStep12 (0.99s)
    Sync reported success for a run cancelled during its orphan sweeps
```

and the log showed both later sweeps running on regardless:

```
Deleting orphaned family_camp_registrations record household=hhz000000000009
Deleting orphaned family_camp_medical record household=hhy000000000008
Family camp derived computation completed created=4 updated=1 skipped=1 deleted=3 errors=0
```

The test also pins that the adults sweep, which *had* completed, stays completed.

**3. A dry run wrote a non-zero delete count to `sync_runs`.** `Stats.Deleted` was mirrored from `WouldDelete`, and `recordSyncRun` writes `deleted_count` straight from it with `status=completed` — while `sync_runs` carries no dry-run marker of any kind. The campaign plans 2017-2025 dry runs, so this would have left **nine completed run rows asserting deletions that never happened**, indistinguishable afterwards from nine real sweeps.

Fixed with the no-schema-change option: `Stats.Deleted` stays 0 on a dry run, and would-delete lives on `DryRunDiff.WouldDelete` and in the `Dry run diff` log line. No `sync_runs` column, no `Status` flag — that is a schema change nobody has ruled on. `Deleted` is singled out because it is the only one of the four counts that describes a **destructive** act.

Spec test updated first, and it failed as expected:

```
--- FAIL: TestFamilyCampDryRunReportsAPerTableDiff (0.74s)
    Stats = created:4 updated:1 skipped:1 deleted:1; want 4/1/1/0
```

It now asserts `Stats.Deleted == 0` **and** `DryRunDiff["family_camp_adults"].WouldDelete == 1` together, so dropping the count from `Stats` cannot quietly drop it from the dry run's answer.

**Residual, and it predates this PR:** a dry run still populates `created_count`, `updated_count` and `skipped_count` in `sync_runs`. Those overstate a harmless act rather than a destructive one. Recording any of it honestly needs a dry-run column or status on `sync_runs`. Written down in the doc's §6 as well.

**4. The row-key helper comment undercounted.** It said the keys "were three separate `fmt.Sprintf` calls"; they were **six** — three in the preloads and three in the upserts, across two format strings (`"%s:%d:%d"` and `"%s:%d"`). Fixed in the comment and above in this body. Six is the stronger argument for the helper.

### Re-verified after the review fixes

| command | exit |
|---|---|
| `cd pocketbase && go test ./...` | 0 |
| `cd pocketbase && golangci-lint run ./sync/...` | 0 (`0 issues.`) |
| `bash scripts/pre-push-verify.sh` | 0 (`ALL CHECKS PASSED`) |

## Scope

- **No migration.** No schema is touched.
- **Closes no issue.** This is the mechanical base the grain-collapse work sits on. A second PR is stacked on this branch for kindred#2274.
- Nothing outside `family_camp_derived.go` changes behaviour; `orphan_guard.go`'s edit is a doc comment its own enumeration made stale.
- **Review fix 2 is the only behaviour change added after review** — three added `ctx.Err()` checks. Fix 3 changes one reported number, fixes 1 and 4 are comments and docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dry-run previews showing per-table creates, updates, unchanged records, and deletes without modifying data.
  * Added reporting when safety guards would prevent orphan deletions.
  * Improved sync statistics and logs to mirror actual and projected operations.

* **Bug Fixes**
  * Prevented orphan cleanup when source data is incomplete or a sync is cancelled.
  * Preserved cleanup of valid orphaned records while reporting refusal errors clearly.

* **Documentation**
  * Updated replay-safety guidance, dry-run behavior, guard refusals, and reporting details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
