### PR TITLE
refactor(rbac): remove lodging.phi permission

### DIFF
--- a/api/routers/lodging.py
+++ b/api/routers/lodging.py
@@ -149,16 +149,23 @@ async def get_household_journey(
 async def get_household_medical(
     household_cm_id: int,
     year: int = Query(..., description="Year of the registration", ge=2000, le=2100),
-    user: AuthUser = Depends(require_permission(Permission.LODGING_PHI)),
+    user: AuthUser = Depends(require_permission(Permission.BUNKING_MANAGE)),
 ) -> HouseholdMedicalResponse:
     """PHI. The narrative behind the roster's accessibility flags.
 
     Spec §5: this text is a detailed medical disclosure about named
     individuals. It is served only here, only to a caller holding
-    `lodging.phi`, and never appears in the roster payload or any export.
+    `bunking.manage`, and never appears in the roster payload or any export.
+
+    kindred#2312: this used to gate on a separate `lodging.phi` permission,
+    removed because RBAC in this product is screen-reduction, not a data
+    boundary -- every user of the tool can already see this data in
+    CampMinder, and every sibling endpoint on this router already gates on
+    `bunking.manage`. The one thing that stays a real boundary is internal
+    notes, gated on `bunking.manage` already and untouched by that change.
 
     RBAC is the control, and there is deliberately NO access log. One existed
-    and was deleted: `lodging.phi` is what decides who may read this, and a
+    and was deleted: `bunking.manage` is what decides who may read this, and a
     log line is not a second gate. It also stopped meaning what it said once
     kindred#1889 removed the reveal button -- the panel fetches on mount, so
     the event fired on every panel open, including households with nothing on

--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -9,7 +9,8 @@ deleted both collections outright.
 
 PHI boundary: HouseholdMedicalResponse is the ONLY model here that carries
 medical narrative text, and it is reachable from exactly one endpoint, which
-is gated on Permission.LODGING_PHI. Every other model exposes booleans
+is gated on Permission.BUNKING_MANAGE (kindred#2312 retargeted the gate from
+the now-removed Permission.LODGING_PHI). Every other model exposes booleans
 derived from PRESENCE of a value, never its content (spec §5).
 
 Vocabularies below mirror the Go ingest's, not a second set invented here. The

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -9,7 +9,8 @@ PHI: the roster and summary reads do not touch family_camp_medical at all.
 They used to, to derive a boolean from the presence of a value -- see
 `_build_flags` for why that boolean is gone (kindred#1889). The narrative has
 one reader, get_household_medical, which fetches ONE household behind
-Permission.LODGING_PHI at the router.
+Permission.BUNKING_MANAGE at the router (kindred#2312 retargeted the gate
+from the now-removed Permission.LODGING_PHI).
 """
 
 from __future__ import annotations
@@ -1186,7 +1187,7 @@ class LodgingRosterService:
         return WeekendSummaryResponse(year=year, weekends=[task.result() for task in entry_tasks])
 
     async def get_household_medical(self, year: int, household_cm_id: int) -> HouseholdMedicalResponse:
-        """PHI. The router gates this on Permission.LODGING_PHI.
+        """PHI. The router gates this on Permission.BUNKING_MANAGE.
 
         Two narrow reads, deliberately sequential: the household resolves the
         PB id that the medical read is anchored to. The whole-year maps this
@@ -1779,7 +1780,7 @@ class LodgingRosterService:
         Deleting it took the whole-year `family_camp_medical` read out of both
         `build_roster` and `build_summary`. The narrative now has exactly one
         reader, `get_household_medical`, which fetches ONE household behind
-        `Permission.LODGING_PHI`.
+        `Permission.BUNKING_MANAGE`.
 
         This method used to compute all three from raw sources, which was
         correct only while the columns did not exist. Phase C of the ingest

--- a/bunking/rbac/permissions.py
+++ b/bunking/rbac/permissions.py
@@ -11,7 +11,6 @@ class Permission:
     """Permission codenames. Used in backend checks and exposed to frontend via API."""
 
     BUNKING_MANAGE = "bunking.manage"
-    LODGING_PHI = "lodging.phi"
     METRICS_FINANCIAL = "metrics.financial"
     METRICS_GEO = "metrics.geo"
     REGISTRATION_MANAGE = "registration.manage"
@@ -24,7 +23,6 @@ ALL_PERMISSIONS: frozenset[str] = frozenset(getattr(Permission, attr) for attr i
 
 PERMISSION_DESCRIPTIONS: dict[str, str] = {
     Permission.BUNKING_MANAGE: "Manage requests, scenarios, solver runs",
-    Permission.LODGING_PHI: "View medical narrative text behind weekend lodging accommodation flags",
     Permission.METRICS_FINANCIAL: "View financial projections and revenue data",
     Permission.METRICS_GEO: "View and manage geographic data",
     Permission.REGISTRATION_MANAGE: "Edit registration dates, budgets, and grade eligibility",

--- a/docs/reference/pocketbase-migrations.md
+++ b/docs/reference/pocketbase-migrations.md
@@ -218,6 +218,55 @@ recorded in #1731 (Formalize the existing convention; do not retrofit).
 **Do not** put the mutation *inside* the catch — that swallows FK/permission/
 runtime errors on the write itself, which are real failures you want to see.
 
+### When the broad catch stops being safe: a loop guarded by `continue`
+
+**The ruling above holds for the shape it was written for.** Every example in
+this section pairs the catch with a mutating call that runs immediately after
+it — `app.delete()`, `app.save()` — so a real DB failure (not just "no rows")
+still surfaces, just one line later than the lookup that hid it. That is the
+"mutating op surfaces real errors one line later" argument from #1731, and it
+is correct for that shape.
+
+It does not hold when the catch's failure path is `continue` inside a loop
+rather than an adjacent mutating call. Nothing runs after a `continue` for
+that iteration — a broadly-caught real error (a corrupted index, the DB gone
+away) is indistinguishable from "this row legitimately doesn't exist yet,"
+and the loop moves on as if the lookup had succeeded.
+`recomputeCachedPermissions` in
+`pocketbase/pb_migrations/1500000154_drop_lodging_phi_permission.js` (#2323)
+is this shape: each iteration looks up a role or a user by id inside a loop,
+and a broad catch there would let a real failure silently write a
+too-small `cached_permissions` blob instead of aborting.
+
+`1500000135_lodging_availability_no_scenario.js` (#2001, merged 2026-08-04 —
+four weeks after #1731 closed) hit the same problem from the other
+direction: its `refuseIfPopulated` guard treats an unreadable table as
+grounds to proceed with a destructive column drop unless the failure is
+narrowed first, so a broad catch there would turn "the DB is unreachable"
+into "the table is empty, go ahead." Both migrations independently landed on
+a narrow check against the literal substring `"no rows in result set"`, with
+everything else propagated as a thrown error (`1500000135` wraps it with
+`{ cause: err }` for context; `1500000154` rethrows it directly via a shared
+`isNotFoundError(err)` helper local to that file) so the migration — and the
+boot it runs during — aborts instead of continuing on a false "not found."
+
+**Current guidance:** keep the broad catch for the immediate
+lookup-then-mutate shape above — do not retrofit it there, per #1731. For a
+catch whose failure path is `continue`, or anything else that is not an
+adjacent mutating call, narrow it with an `isNotFoundError(err)` check on
+`"no rows in result set"` and re-throw everything else. The "no
+shared-import mechanism between `pb_migrations/` files" reason from #1731
+still applies — each migration defines its own copy of the helper rather
+than importing one, same as `1500000135` and `1500000154` both do.
+
+One asymmetry worth flagging rather than fixing here: `1500000154`'s
+`findRoleBySlug` re-throws a non-not-found error (fails closed — aborts the
+migration), while the `1500000130` helper it mirrors swallowed every error
+unconditionally and returned `null` (failed safe — the rule change proceeds
+even if the role lookup broke for an unrelated reason). The narrower
+behavior is the one to write going forward; `1500000130` is not being
+revisited for it.
+
 ## Migration Checklist
 
 Before committing any migration:

--- a/frontend/src/components/weekend/AccessibilityFlagList.test.tsx
+++ b/frontend/src/components/weekend/AccessibilityFlagList.test.tsx
@@ -3,7 +3,8 @@
  * component is.
  *
  * It used to carry the medical narrative too, behind a click-to-reveal gated
- * on `lodging.phi`. kindred#1889 split that out: the narrative lives in
+ * on `bunking.manage` (kindred#2312 retargeted the gate from the now-removed
+ * `lodging.phi`). kindred#1889 split that out: the narrative lives in
  * `MedicalNarrative`, which `FamilyDetailsPanel` renders and
  * `HouseholdRosterRow` does not. The reason is grain — the roster row is a
  * `<tr>` and 62 of them are on screen at once, while the panel shows one

--- a/frontend/src/components/weekend/FamilyDetailsPanel.test.tsx
+++ b/frontend/src/components/weekend/FamilyDetailsPanel.test.tsx
@@ -166,7 +166,7 @@ describe('FamilyDetailsPanel — the content the card omits', () => {
 
   it('renders the medical narrative without a reveal click', () => {
     // kindred#1889 removed the click-to-reveal: it was gated on a flag true
-    // for every household, so it gated nothing. A `lodging.phi` holder now
+    // for every household, so it gated nothing. A `bunking.manage` holder now
     // sees the text directly (`isAdmin` is true for this suite).
     medicalResult.value = {
       data: { allergy_info: 'Peanuts' },

--- a/frontend/src/components/weekend/FamilyDetailsPanel.tsx
+++ b/frontend/src/components/weekend/FamilyDetailsPanel.tsx
@@ -306,7 +306,7 @@ export function FamilyDetailsPanel({
           <AccessibilityFlagList flags={party.flags ?? NO_FLAGS} />
           {/* Kept in this section rather than given its own, because it is
               where the narrative already appeared and staff know to look here.
-              It self-hides for a viewer without `lodging.phi` and for a
+              It self-hides for a viewer without `bunking.manage` and for a
               household with nothing on file, so no empty block is left
               behind. */}
           <MedicalNarrative householdCmId={householdCmId > 0 ? householdCmId : null} year={year} />

--- a/frontend/src/components/weekend/MedicalNarrative.test.tsx
+++ b/frontend/src/components/weekend/MedicalNarrative.test.tsx
@@ -7,7 +7,7 @@
  * `has_medical_narrative` claimed was worth gating — a flag true for 745/745
  * households, so the button was on every row and gated nothing. With the flag
  * deleted, the honest rule is the one the API already enforces: a
- * `lodging.phi` holder sees the narrative, and everyone else sees no trace
+ * `bunking.manage` holder sees the narrative, and everyone else sees no trace
  * that one exists. Telling a non-holder "there is a disclosure you cannot
  * read" is the only thing the old copy achieved.
  *
@@ -55,19 +55,19 @@ beforeEach(() => {
 })
 
 describe('the permission gate', () => {
-  it('renders nothing for a user without lodging.phi', () => {
+  it('renders nothing for a user without bunking.manage', () => {
     medicalResult.value = { data: { allergy_info: 'Peanuts' }, isLoading: false, error: null }
     const { container } = render(<MedicalNarrative householdCmId={2000001} year={2026} />)
     expect(container.textContent).toBe('')
   })
 
-  it('does not fetch for a user without lodging.phi', () => {
+  it('does not fetch for a user without bunking.manage', () => {
     render(<MedicalNarrative householdCmId={2000001} year={2026} />)
     expect(useHouseholdMedical).toHaveBeenCalledWith(2026, 2000001, false)
   })
 
-  it('renders for a holder of lodging.phi', () => {
-    permissions.value = new Set(['lodging.phi'])
+  it('renders for a holder of bunking.manage', () => {
+    permissions.value = new Set(['bunking.manage'])
     medicalResult.value = { data: { allergy_info: 'Peanuts' }, isLoading: false, error: null }
     render(<MedicalNarrative householdCmId={2000001} year={2026} />)
     expect(screen.getByText('Peanuts')).toBeInTheDocument()
@@ -75,7 +75,7 @@ describe('the permission gate', () => {
 
   it('renders for an admin, who bypasses the permission check', () => {
     // An admin holds no explicit permissions; hasPermission short-circuits on
-    // is_admin, so this must render without lodging.phi in the set.
+    // is_admin, so this must render without bunking.manage in the set.
     isAdmin.value = true
     medicalResult.value = { data: { allergy_info: 'Peanuts' }, isLoading: false, error: null }
     render(<MedicalNarrative householdCmId={2000001} year={2026} />)
@@ -153,17 +153,17 @@ describe('the narrative itself', () => {
   })
 
   it('renders a failure inline rather than failing the page', () => {
-    // The roster is readable by any authenticated user while lodging.phi is
+    // The roster is readable by any authenticated user while bunking.manage is
     // held by admins and Bunking Staff, so a 403 here is a common case even
     // after the gate above — permissions can change between page load and
     // fetch. It must read as a sentence, not escalate to the ErrorBoundary.
     medicalResult.value = {
       data: undefined,
       isLoading: false,
-      error: new Error('Forbidden: lodging.phi required'),
+      error: new Error('Forbidden: bunking.manage required'),
     }
     render(<MedicalNarrative householdCmId={2000001} year={2026} />)
 
-    expect(screen.getByText('Forbidden: lodging.phi required')).toBeInTheDocument()
+    expect(screen.getByText('Forbidden: bunking.manage required')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/weekend/MedicalNarrative.tsx
+++ b/frontend/src/components/weekend/MedicalNarrative.tsx
@@ -1,5 +1,5 @@
 /**
- * The medical narrative for one household, for a holder of `lodging.phi`.
+ * The medical narrative for one household, for a holder of `bunking.manage`.
  *
  * Rendered by `FamilyDetailsPanel` and deliberately NOT by
  * `HouseholdRosterRow` — the same split summer makes between a camper card
@@ -10,15 +10,20 @@
  * behind a click, driven by a `has_medical_narrative` flag that was true for
  * every household — so the button appeared on every row and gated nothing.
  * With that flag deleted the rule is the one the API already enforces:
- * `lodging.phi` holders see the text, everyone else sees no trace of it. The
- * old "Medical detail on file" line shown to non-holders is gone with it,
+ * `bunking.manage` holders see the text, everyone else sees no trace of it.
+ * The old "Medical detail on file" line shown to non-holders is gone with it,
  * because telling someone a disclosure exists that they may not read is not
  * information they can act on.
  *
+ * kindred#2312: this used to read a separate `lodging.phi` permission,
+ * removed because RBAC here is screen-reduction, not a data boundary, and
+ * every sibling endpoint on this router already gated on `bunking.manage`.
+ *
  * The API is the real boundary — /api/lodging/households/{id}/medical requires
- * `lodging.phi` and 403s otherwise. This UI gate exists so the request is not
- * made on behalf of a user who cannot have the answer, and a 403 that arrives
- * anyway renders inline rather than escalating to the page ErrorBoundary.
+ * `bunking.manage` and 403s otherwise. This UI gate exists so the request is
+ * not made on behalf of a user who cannot have the answer, and a 403 that
+ * arrives anyway renders inline rather than escalating to the page
+ * ErrorBoundary.
  */
 import { Loader2 } from 'lucide-react'
 
@@ -51,7 +56,7 @@ const FIELDS = [
 export function MedicalNarrative({ householdCmId, year }: MedicalNarrativeProps) {
   const { hasPermission } = usePermissions()
   // Both halves are required: the permission, and a household to fetch by.
-  const canRead = hasPermission(Permission.LODGING_PHI) && householdCmId !== null
+  const canRead = hasPermission(Permission.BUNKING_MANAGE) && householdCmId !== null
   const { data, isLoading, error } = useHouseholdMedical(year, householdCmId, canRead)
 
   if (!canRead) return null

--- a/frontend/src/components/weekend/ShareRequestPanel.tsx
+++ b/frontend/src/components/weekend/ShareRequestPanel.tsx
@@ -16,16 +16,20 @@
  * uses for parent request text, so a request reads the same wherever staff
  * meet one. It arrives pre-joined from three source fields and is never split.
  *
- * ## No lodging.phi gate
+ * ## No permission gate on request_text
  *
- * `request_text` has no permission check, while `MedicalNarrative` (rendered
- * beside it in `FamilyDetailsPanel`) is gated on `lodging.phi`. The split is
- * intentional: `bunking.manage` is the placement role, and `request_text` is a
- * placement input—why a household wants a particular cabin or setting is a
- * legitimate placement concern. The field is not modelled as PHI (it is free
- * text, not a structured medical disclosure), even though it sometimes contains
- * health detail. The gate on `MedicalNarrative` covers the field that IS
- * structured PHI: the formal medical accommodations questionnaire.
+ * `request_text` has no permission check at all, while `MedicalNarrative`
+ * (rendered beside it in `FamilyDetailsPanel`) is gated on `bunking.manage`.
+ * The split is intentional: `request_text` is a placement input — why a
+ * household wants a particular cabin or setting is a legitimate placement
+ * concern for any authenticated user to see, the same way the rest of the
+ * roster is. The field is not modelled as PHI (it is free text, not a
+ * structured medical disclosure), even though it sometimes contains health
+ * detail. `MedicalNarrative` covers the field that IS structured PHI: the
+ * formal medical accommodations questionnaire (kindred#2312: that gate used
+ * to be a separate `lodging.phi` permission, removed because RBAC here is
+ * screen-reduction, not a data boundary, and every sibling endpoint on the
+ * lodging router already gated on `bunking.manage`).
  */
 import { AlertCircle, MapPin, Users } from 'lucide-react'
 

--- a/frontend/src/constants/permissions.ts
+++ b/frontend/src/constants/permissions.ts
@@ -10,7 +10,6 @@
 
 export const Permission = {
   BUNKING_MANAGE: 'bunking.manage',
-  LODGING_PHI: 'lodging.phi',
   METRICS_FINANCIAL: 'metrics.financial',
   METRICS_GEO: 'metrics.geo',
   REGISTRATION_MANAGE: 'registration.manage',

--- a/frontend/src/hooks/useWeekendRoster.ts
+++ b/frontend/src/hooks/useWeekendRoster.ts
@@ -123,7 +123,7 @@ export function useHouseholdJourney(householdCmId: number | null) {
 
 /**
  * PHI. Deliberately opt-in: `enabled` is false unless the caller both holds
- * `lodging.phi` and has a household to look up, so the narrative is never
+ * `bunking.manage` and has a household to look up, so the narrative is never
  * fetched speculatively and never sits in the query cache for someone who
  * only ever looked at the roster.
  *
@@ -133,10 +133,12 @@ export function useHouseholdJourney(householdCmId: number | null) {
  * mount acceptable. `staleTime: 0, gcTime: 0` is what keeps this honest: the
  * narrative leaves the cache the moment the panel closes.
  *
- * `lodging.phi` is held by admins and the Bunking Staff role. The roster
- * itself is readable by any authenticated user, so this 403s for most of the
- * people who can see the page it sits on — callers must degrade gracefully
- * rather than treat the error as a page failure.
+ * `bunking.manage` is held by admins and the Bunking Staff role (kindred#2312
+ * retargeted the gate from the now-removed `lodging.phi`, which gated only
+ * this one endpoint). The roster itself is readable by any authenticated
+ * user, so this 403s for most of the people who can see the page it sits on
+ * — callers must degrade gracefully rather than treat the error as a page
+ * failure.
  */
 export function useHouseholdMedical(year: number, householdCmId: number | null, enabled: boolean) {
   const { fetchWithAuth } = useApiWithAuth()

--- a/frontend/src/services/lodgingApi.test.ts
+++ b/frontend/src/services/lodgingApi.test.ts
@@ -368,9 +368,9 @@ describe('fetchHouseholdMedical', () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 403,
-      json: async () => ({ detail: 'Permission required: lodging.phi' }),
+      json: async () => ({ detail: 'Permission required: bunking.manage' }),
     })
 
-    await expect(fetchHouseholdMedical(mockFetch, 2026, 2000001)).rejects.toThrow(/lodging\.phi/)
+    await expect(fetchHouseholdMedical(mockFetch, 2026, 2000001)).rejects.toThrow(/bunking\.manage/)
   })
 })

--- a/frontend/src/services/lodgingApi.ts
+++ b/frontend/src/services/lodgingApi.ts
@@ -268,7 +268,8 @@ export async function fetchHouseholdJourney(
 }
 
 /**
- * PHI. Requires the `lodging.phi` permission server-side; a caller without
+ * PHI. Requires the `bunking.manage` permission server-side (kindred#2312
+ * retargeted the gate from the now-removed `lodging.phi`); a caller without
  * it gets a 403, which this surfaces verbatim so the UI can explain why.
  */
 export async function fetchHouseholdMedical(

--- a/pocketbase/main_drop_lodging_phi_permission_test.go
+++ b/pocketbase/main_drop_lodging_phi_permission_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+const dropLodgingPHIMigration = "pb_migrations/1500000154_drop_lodging_phi_permission.js"
+
+func readDropLodgingPHIMigration(t *testing.T) string {
+	t.Helper()
+	content, err := os.ReadFile(dropLodgingPHIMigration)
+	if err != nil {
+		t.Fatalf("read migration %s: %v", dropLodgingPHIMigration, err)
+	}
+	return string(content)
+}
+
+// TestDropLodgingPHIMigrationRevokesFromBunkingStaff verifies the migration
+// removes lodging.phi from the bunking-staff role rather than leaving the
+// grant 1500000130 made in place. kindred#2312: the permission itself is
+// gone from the application code (ALL_PERMISSIONS is derived from the
+// Permission class, so removing the constant already drops it there); this
+// is the data-side half that must also stop naming it on the role.
+func TestDropLodgingPHIMigrationRevokesFromBunkingStaff(t *testing.T) {
+	body := readDropLodgingPHIMigration(t)
+
+	if !strings.Contains(body, `revokePermissionFromRole(app, "bunking-staff", "lodging.phi")`) {
+		t.Errorf("migration %s must revoke lodging.phi from bunking-staff", dropLodgingPHIMigration)
+	}
+}
+
+// TestDropLodgingPHIMigrationRecomputesCachedPermissions guards against the
+// same stale-cache trap 1500000130 already had to solve: without an explicit
+// recompute, an existing bunking-staff user keeps lodging.phi in their
+// cached_permissions blob until someone re-saves the role by hand.
+func TestDropLodgingPHIMigrationRecomputesCachedPermissions(t *testing.T) {
+	body := readDropLodgingPHIMigration(t)
+
+	if !strings.Contains(body, "cached_permissions") {
+		t.Errorf("migration %s must recompute cached_permissions for users holding the role",
+			dropLodgingPHIMigration)
+	}
+	if !strings.Contains(body, "user_roles") {
+		t.Errorf("migration %s must find affected users via user_roles to recompute their permissions",
+			dropLodgingPHIMigration)
+	}
+}
+
+// TestDropLodgingPHIMigrationIsReversible verifies the down migration
+// re-grants the permission, matching 1500000130's up/down symmetry.
+func TestDropLodgingPHIMigrationIsReversible(t *testing.T) {
+	body := readDropLodgingPHIMigration(t)
+
+	if !strings.Contains(body, `grantPermissionToRole(app, "bunking-staff", "lodging.phi")`) {
+		t.Errorf("migration %s down must re-grant lodging.phi to bunking-staff", dropLodgingPHIMigration)
+	}
+}
+
+// TestDropLodgingPHIMigrationReadsPermissionsAsGetString guards the same trap
+// 1500000130 documents: a PB JS json field is a Go byte slice under the hood,
+// and Array.isArray() on it answers true, so an iteration that skips
+// getString()+JSON.parse silently corrupts the permissions array instead of
+// reading it.
+func TestDropLodgingPHIMigrationReadsPermissionsAsGetString(t *testing.T) {
+	body := readDropLodgingPHIMigration(t)
+
+	if !strings.Contains(body, `role.getString("permissions")`) {
+		t.Errorf("migration %s must read the permissions field via getString(), not a raw Array.isArray() path",
+			dropLodgingPHIMigration)
+	}
+}

--- a/pocketbase/main_drop_lodging_phi_permission_test.go
+++ b/pocketbase/main_drop_lodging_phi_permission_test.go
@@ -71,3 +71,45 @@ func TestDropLodgingPHIMigrationReadsPermissionsAsGetString(t *testing.T) {
 			dropLodgingPHIMigration)
 	}
 }
+
+// TestDropLodgingPHIMigrationFiltersNonStringPermissions guards against a
+// corrupted or hand-edited `permissions` array feeding a non-string entry
+// into the cached_permissions union, where it would mint a garbage
+// permission key on every affected user (CodeRabbit finding on kindred#2312).
+func TestDropLodgingPHIMigrationFiltersNonStringPermissions(t *testing.T) {
+	body := readDropLodgingPHIMigration(t)
+
+	if !strings.Contains(body, `parsed.filter((p) => typeof p === "string")`) {
+		t.Errorf("migration %s must filter parsed permissions to strings before use",
+			dropLodgingPHIMigration)
+	}
+}
+
+// TestDropLodgingPHIMigrationRethrowsUnexpectedErrors guards against
+// findRoleBySlug/recomputeCachedPermissions silently swallowing a real
+// database error (a malformed filter, a corrupted index) under the same
+// catch that is meant only for "this role/user does not exist yet" -- that
+// would let the migration report success while doing less than it claims
+// (CodeRabbit finding on kindred#2312). Verified empirically against a copy
+// of prod: the only error shape either lookup has ever produced there is the
+// not-found sentinel, from three orphaned user_roles rows on bunking-staff.
+func TestDropLodgingPHIMigrationRethrowsUnexpectedErrors(t *testing.T) {
+	body := readDropLodgingPHIMigration(t)
+
+	if !strings.Contains(body, "function isNotFoundError(err)") {
+		t.Errorf("migration %s must distinguish the not-found sentinel from other errors",
+			dropLodgingPHIMigration)
+	}
+	if !strings.Contains(body, "no rows in result set") {
+		t.Errorf("migration %s must match PocketBase's not-found error text",
+			dropLodgingPHIMigration)
+	}
+	// Every catch that reads a role or user by id must consult the sentinel
+	// rather than swallow unconditionally -- a bare `catch (_err) {` here
+	// would be exactly the regression this test exists to catch.
+	if strings.Contains(body, "catch (_err) {\n        continue") ||
+		strings.Contains(body, "catch (_err) {\n      continue") {
+		t.Errorf("migration %s must not unconditionally swallow errors in the recompute loop",
+			dropLodgingPHIMigration)
+	}
+}

--- a/pocketbase/pb_migrations/1500000154_drop_lodging_phi_permission.js
+++ b/pocketbase/pb_migrations/1500000154_drop_lodging_phi_permission.js
@@ -1,0 +1,161 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: drop the `lodging.phi` permission from the Bunking Staff role.
+ * Dependencies: 1500000130 (granted lodging.phi to bunking-staff)
+ *
+ * kindred#2312, owner ruling 2026-08-13 (campaign decision D12): RBAC in this
+ * product is screen-reduction, not a data boundary. Every user of this tool
+ * can already see the medical narrative in CampMinder directly. `lodging.phi`
+ * gated exactly ONE endpoint (GET /api/lodging/households/{id}/medical), and
+ * every sibling endpoint on that router already gates on `bunking.manage`.
+ * The application code no longer declares `Permission.LODGING_PHI` at all —
+ * `ALL_PERMISSIONS` is derived from the `Permission` class's own attributes,
+ * so removing the constant already dropped it there. This migration is the
+ * data-side half: the role's stored `permissions` array still names it until
+ * something rewrites the row.
+ *
+ * Consequence, already accepted by the owner: the Executive role (which holds
+ * `is_admin` and so bypassed the check anyway) gains nothing new, but any
+ * OTHER role a future admin grants `bunking.manage` to gains medical-narrative
+ * access as a side effect of that one permission, same as every other
+ * bunking.manage-gated lodging write already implied.
+ *
+ * NOT touched: `bunking.manage` itself, and internal notes (the one thing
+ * that stays a real boundary, already gated on bunking.manage and unaffected
+ * by this change).
+ *
+ * Idempotent: revoke is a no-op if the role has already lost the permission.
+ */
+
+/**
+ * Read a role's `permissions` json field as a plain array of strings.
+ *
+ * `record.get()` on a json field hands back the underlying types.JSONRaw —
+ * a Go byte slice. goja presents that as an Array, so `Array.isArray()`
+ * answers TRUE and iterating it yields BYTE VALUES, not permissions: writing
+ * that straight back turns ["bunking.manage"] into [34,98,117,...].
+ * `getString()` is the honest accessor — it returns the stored JSON text.
+ */
+function readRolePermissions(role) {
+  const text = role.getString("permissions")
+  if (!text) {
+    return []
+  }
+  try {
+    const parsed = JSON.parse(text)
+    return Array.isArray(parsed) ? parsed : []
+  } catch (_err) {
+    return []
+  }
+}
+
+function findRoleBySlug(app, slug) {
+  try {
+    return app.findFirstRecordByFilter("roles", "slug = {:slug}", { slug: slug })
+  } catch (_err) {
+    // A deployment that never seeded the system roles is not a reason to fail
+    // the rule change, which is the load-bearing half of this migration.
+    return null
+  }
+}
+
+/**
+ * Recompute `users.cached_permissions` for everyone holding the given role.
+ *
+ * The Go hooks (pocketbase/rbac/hooks.go) do this on user_roles writes and on
+ * roles updates, but a migration must not depend on a hook firing during
+ * bootstrap. Without this, an existing bunking-staff user keeps a stale
+ * cached_permissions array naming `lodging.phi` until someone re-saves the
+ * role by hand. That stale entry is harmless on its own -- nothing in either
+ * the Go or Python RBAC checks for the literal string "lodging.phi" any more,
+ * since the permission it named no longer exists as a constant to compare
+ * against -- but leaving it uncleaned is still the wrong default, so this
+ * migration does the recompute rather than relying on that being merely safe.
+ *
+ * The union is taken over ALL of the user's roles, not just this one, because
+ * cached_permissions is a flattened set: rebuilding it from a single role
+ * would drop every permission their other roles carry.
+ */
+function recomputeCachedPermissions(app, roleId) {
+  const memberships = app.findRecordsByFilter("user_roles", "role = {:roleId}", "", 0, 0, {
+    roleId: roleId,
+  })
+
+  for (const membership of memberships) {
+    const userId = membership.getString("user")
+    if (!userId) {
+      continue
+    }
+
+    const allMemberships = app.findRecordsByFilter("user_roles", "user = {:userId}", "", 0, 0, {
+      userId: userId,
+    })
+
+    const seen = {}
+    for (const m of allMemberships) {
+      let held
+      try {
+        held = app.findRecordById("roles", m.getString("role"))
+      } catch (_err) {
+        continue
+      }
+      for (const p of readRolePermissions(held)) {
+        seen[p] = true
+      }
+    }
+
+    let user
+    try {
+      user = app.findRecordById("_pb_users_auth_", userId)
+    } catch (_err) {
+      continue
+    }
+    user.set("cached_permissions", Object.keys(seen).sort())
+    app.save(user)
+  }
+}
+
+/** Remove `permission` from the role with `slug`, then refresh holders' caches. */
+function revokePermissionFromRole(app, slug, permission) {
+  const role = findRoleBySlug(app, slug)
+  if (!role) {
+    return
+  }
+
+  const perms = readRolePermissions(role)
+  const next = perms.filter((p) => p !== permission)
+  if (next.length === perms.length) {
+    return
+  }
+
+  role.set("permissions", next)
+  app.save(role)
+
+  recomputeCachedPermissions(app, role.id)
+}
+
+/** Add `permission` to the role with `slug`, then refresh holders' caches. */
+function grantPermissionToRole(app, slug, permission) {
+  const role = findRoleBySlug(app, slug)
+  if (!role) {
+    return
+  }
+
+  const perms = readRolePermissions(role)
+  if (perms.indexOf(permission) !== -1) {
+    return
+  }
+
+  perms.push(permission)
+  perms.sort()
+  role.set("permissions", perms)
+  app.save(role)
+
+  recomputeCachedPermissions(app, role.id)
+}
+
+migrate((app) => {
+  revokePermissionFromRole(app, "bunking-staff", "lodging.phi")
+}, (app) => {
+  grantPermissionToRole(app, "bunking-staff", "lodging.phi")
+});

--- a/pocketbase/pb_migrations/1500000154_drop_lodging_phi_permission.js
+++ b/pocketbase/pb_migrations/1500000154_drop_lodging_phi_permission.js
@@ -35,6 +35,11 @@
  * answers TRUE and iterating it yields BYTE VALUES, not permissions: writing
  * that straight back turns ["bunking.manage"] into [34,98,117,...].
  * `getString()` is the honest accessor — it returns the stored JSON text.
+ *
+ * Filtered to strings rather than trusting the parsed shape: a hand-edited
+ * or corrupted `permissions` array containing a non-string entry would
+ * otherwise flow straight into `recomputeCachedPermissions`'s `seen` map and
+ * mint a garbage permission key on every affected user's cached blob.
  */
 function readRolePermissions(role) {
   const text = role.getString("permissions")
@@ -43,16 +48,32 @@ function readRolePermissions(role) {
   }
   try {
     const parsed = JSON.parse(text)
-    return Array.isArray(parsed) ? parsed : []
+    return Array.isArray(parsed) ? parsed.filter((p) => typeof p === "string") : []
   } catch (_err) {
     return []
   }
 }
 
+/**
+ * True when `err` is PocketBase's "no matching record" not-found error.
+ *
+ * Distinguishing this from every other failure matters: a query that fails
+ * for a REAL reason (a malformed filter, a corrupted index, the DB gone
+ * away) must not be swallowed and treated the same as "this role/user
+ * legitimately does not exist yet" -- that would let the migration report
+ * success while silently doing less than it claims.
+ */
+function isNotFoundError(err) {
+  return String(err).indexOf("no rows in result set") !== -1
+}
+
 function findRoleBySlug(app, slug) {
   try {
     return app.findFirstRecordByFilter("roles", "slug = {:slug}", { slug: slug })
-  } catch (_err) {
+  } catch (err) {
+    if (!isNotFoundError(err)) {
+      throw err
+    }
     // A deployment that never seeded the system roles is not a reason to fail
     // the rule change, which is the load-bearing half of this migration.
     return null
@@ -96,7 +117,10 @@ function recomputeCachedPermissions(app, roleId) {
       let held
       try {
         held = app.findRecordById("roles", m.getString("role"))
-      } catch (_err) {
+      } catch (err) {
+        if (!isNotFoundError(err)) {
+          throw err
+        }
         continue
       }
       for (const p of readRolePermissions(held)) {
@@ -107,7 +131,13 @@ function recomputeCachedPermissions(app, roleId) {
     let user
     try {
       user = app.findRecordById("_pb_users_auth_", userId)
-    } catch (_err) {
+    } catch (err) {
+      if (!isNotFoundError(err)) {
+        throw err
+      }
+      // Orphaned user_roles row: the membership survives a deleted user.
+      // Confirmed against a copy of prod (three such rows on bunking-staff),
+      // where this is the ONLY error shape this loop has ever produced.
       continue
     }
     user.set("cached_permissions", Object.keys(seen).sort())

--- a/tests/unit/api/routers/test_lodging_endpoints.py
+++ b/tests/unit/api/routers/test_lodging_endpoints.py
@@ -64,18 +64,6 @@ def _plain_user() -> AuthUser:
     return user
 
 
-def _phi_user() -> AuthUser:
-    user = AuthUser(
-        username="TestNurse",
-        email="nurse@example.com",
-        display_name="Test Nurse",
-        groups=[],
-        is_admin=False,
-    )
-    user.permissions = {Permission.LODGING_PHI}
-    return user
-
-
 def _manage_user() -> AuthUser:
     """Bunking staff: holds bunking.manage, is not an admin.
 
@@ -293,7 +281,7 @@ class TestHouseholdJourneyEndpoint:
     """
 
     def test_a_plain_authenticated_user_can_read_it(self, mock_pb: MagicMock) -> None:
-        """Deliberately NOT `lodging.phi`-gated, and deliberately asserted
+        """Deliberately NOT `bunking.manage`-gated, and deliberately asserted
         with the same user the medical endpoint 403s: the two endpoints sit on
         the same path prefix, and a copy-paste of the wrong dependency would
         otherwise be invisible.
@@ -359,13 +347,13 @@ class TestMedicalEndpointIsPermissionGated:
             response = client.get("/api/lodging/households/2000001/medical", params={"year": 2026})
 
         assert response.status_code == 403
-        assert Permission.LODGING_PHI in response.json()["detail"]
+        assert Permission.BUNKING_MANAGE in response.json()["detail"]
 
     def test_user_with_the_permission_gets_the_narrative(self, mock_pb: MagicMock) -> None:
         mock_pb.collection.return_value.get_full_list.side_effect = _medical_reads
 
         with patch("api.routers.lodging.pb", mock_pb):
-            app = _build_app(_phi_user(), mock_pb)
+            app = _build_app(_manage_user(), mock_pb)
             client = TestClient(app)
             response = client.get("/api/lodging/households/2000001/medical", params={"year": 2026})
 
@@ -379,8 +367,9 @@ class TestMedicalEndpointIsPermissionGated:
 
         One existed, recording the caller by `username` so the log store
         would not inherit an email address. The ruling is that it should not
-        exist at all: `lodging.phi` decides who may read this, and a log line
-        is not a second gate.
+        exist at all: `bunking.manage` decides who may read this (kindred#2312
+        retargeted the gate from the now-removed `lodging.phi`), and a log
+        line is not a second gate.
 
         kindred#1889 is what made it actively wrong rather than merely
         unused. With the reveal button gone the panel fetches on mount, so
@@ -397,7 +386,7 @@ class TestMedicalEndpointIsPermissionGated:
         mock_pb.collection.return_value.get_full_list.side_effect = _medical_reads
 
         with patch("api.routers.lodging.pb", mock_pb):
-            app = _build_app(_phi_user(), mock_pb)
+            app = _build_app(_manage_user(), mock_pb)
             response = TestClient(app).get("/api/lodging/households/2000001/medical", params={"year": 2026})
             import api.routers.lodging as lodging_module
 
@@ -419,7 +408,7 @@ class TestMedicalEndpointIsPermissionGated:
         mock_pb.collection.return_value.get_full_list.side_effect = record_filters
 
         with patch("api.routers.lodging.pb", mock_pb):
-            app = _build_app(_phi_user(), mock_pb)
+            app = _build_app(_manage_user(), mock_pb)
             TestClient(app).get("/api/lodging/households/2000001/medical", params={"year": 2026})
 
         assert seen, "the endpoint issued no reads"

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -2618,7 +2618,8 @@ class TestMedicalFlagsAndNarrative:
 
         The gated endpoint is unaffected: `get_household_medical` reads ONE
         household through `fetch_medical_for_household`, which is a different
-        repository call and is what `Permission.LODGING_PHI` actually guards.
+        repository call and is what `Permission.BUNKING_MANAGE` actually guards
+        (kindred#2312 retargeted the gate from the now-removed `lodging.phi`).
         """
         repo = _repo(
             fetch_session=FAMILY_SESSION,

--- a/tests/unit/api/test_lodging_constants.py
+++ b/tests/unit/api/test_lodging_constants.py
@@ -1,8 +1,12 @@
-"""The lodging surface's collection names and PHI permission must exist.
+"""The lodging surface's collection names must exist.
 
 Collection names are centralised (never inlined as string literals) so a
-rename is one edit, and the PHI permission must exist in BOTH permission
-files — the TypeScript file's own docstring says it mirrors the Python one.
+rename is one edit. kindred#2312 removed the separate `lodging.phi`
+permission (RBAC here is screen-reduction, not a data boundary; the one
+endpoint it gated now gates on `bunking.manage` like every sibling on its
+router) — this file pins that it stays gone from both permission files, the
+TypeScript one included since its own docstring says it mirrors the Python
+one.
 
 Note on the work queue: the unresolved-cabin-string work queue is
 ``lodging_ingest_issues`` (created by the ingest plan), filtered to
@@ -69,21 +73,26 @@ def test_supporting_collection_constants_exist() -> None:
     assert collections.CUSTOM_FIELD_DEFS == "custom_field_defs"
 
 
-def test_lodging_phi_permission_is_registered() -> None:
-    assert Permission.LODGING_PHI == "lodging.phi"
-    assert Permission.LODGING_PHI in ALL_PERMISSIONS
-    assert Permission.LODGING_PHI in PERMISSION_DESCRIPTIONS
+def test_lodging_phi_permission_stays_removed() -> None:
+    """kindred#2312: the separate `lodging.phi` permission is gone for good.
+
+    `ALL_PERMISSIONS` is derived from `Permission`'s own attributes, so
+    removing the class attribute already dropped it from the set and the
+    description map — this pins that nothing re-adds either independently.
+    """
+    assert not hasattr(Permission, "LODGING_PHI")
+    assert "lodging.phi" not in ALL_PERMISSIONS
+    assert "lodging.phi" not in PERMISSION_DESCRIPTIONS
 
 
-def test_typescript_permission_file_mirrors_python() -> None:
+def test_typescript_permission_file_has_no_lodging_phi() -> None:
     """frontend/src/constants/permissions.ts declares it mirrors permissions.py.
 
-    Matched by pattern rather than literal: the guarantee is that the key
-    and value are both present, and pinning the quote style and trailing
-    comma makes prettier's formatting a test failure.
+    kindred#2312 removed `LODGING_PHI` from the Python side; this pins that
+    the TypeScript mirror does not resurrect it independently.
     """
     ts = (REPO_ROOT / "frontend" / "src" / "constants" / "permissions.ts").read_text()
-    assert re.search(r"""LODGING_PHI:\s*['"]lodging\.phi['"]""", ts)
+    assert not re.search(r"""LODGING_PHI\s*:\s*['"]lodging\.phi['"]""", ts)
 
 
 def test_infant_bed_exemption_is_eighteen_months_hardcoded() -> None:

--- a/tests/unit/api/test_lodging_phi_boundary.py
+++ b/tests/unit/api/test_lodging_phi_boundary.py
@@ -137,7 +137,8 @@ def test_roster_exposes_presence_flags_not_narrative() -> None:
     # Deleting it rather than fixing it is what removes the year's medical map
     # from the roster read entirely -- see
     # `test_the_roster_never_reads_the_years_medical_narratives`. Nothing is
-    # lost on the surface: a `lodging.phi` holder sees the narrative itself,
+    # lost on the surface: a `bunking.manage` holder sees the narrative itself
+    # (kindred#2312 retargeted the gate from the now-removed `lodging.phi`),
     # and a non-holder was only ever being told that a disclosure they cannot
     # read exists.
     assert "has_medical_narrative" not in names
@@ -154,7 +155,8 @@ def test_every_model_in_the_module_is_walked_not_just_the_named_roots() -> None:
     to the module and returned by a new endpoint is checked by nothing until
     somebody remembers to add a fourth test. This closes that: every BaseModel
     declared in api.schemas.lodging is walked, and the only one permitted to
-    carry narrative is the response of the endpoint gated on `lodging.phi`.
+    carry narrative is the response of the endpoint gated on `bunking.manage`
+    (kindred#2312 retargeted the gate from the now-removed `lodging.phi`).
 
     The write layer (1500000132) is the first thing this catches that the named
     roots do not -- its request models are reachable from no response payload

--- a/tests/unit/rbac/test_permissions.py
+++ b/tests/unit/rbac/test_permissions.py
@@ -12,7 +12,6 @@ class TestPermissionConstants:
     def test_expected_permissions_exist(self):
         expected = {
             "bunking.manage",
-            "lodging.phi",
             "metrics.financial",
             "metrics.geo",
             "registration.manage",
@@ -24,7 +23,6 @@ class TestPermissionConstants:
 
     def test_permission_class_attributes_match_values(self):
         assert Permission.BUNKING_MANAGE == "bunking.manage"
-        assert Permission.LODGING_PHI == "lodging.phi"
         assert Permission.METRICS_FINANCIAL == "metrics.financial"
         assert Permission.METRICS_GEO == "metrics.geo"
         assert Permission.REGISTRATION_MANAGE == "registration.manage"
@@ -35,3 +33,14 @@ class TestPermissionConstants:
     def test_no_duplicate_values(self):
         values = [getattr(Permission, a) for a in dir(Permission) if a.isupper()]
         assert len(values) == len(set(values))
+
+    def test_lodging_phi_permission_no_longer_exists(self):
+        """kindred#2312: RBAC here is screen-reduction, not a data boundary.
+
+        `lodging.phi` gated exactly one endpoint, and every sibling endpoint
+        on that router already gates on `bunking.manage`. Removed rather than
+        merely unused, so a future `hasattr` check or stale docstring cannot
+        resurrect it by accident.
+        """
+        assert not hasattr(Permission, "LODGING_PHI")
+        assert "lodging.phi" not in ALL_PERMISSIONS


### PR DESCRIPTION
## What changed

Removes the `lodging.phi` permission from the RBAC permission set entirely, per owner
ruling (campaign decision D12, 2026-08-13): RBAC in this product is screen-reduction, not a
data boundary — every user of the tool can already see this data in CampMinder, and
`lodging.phi` gated exactly one endpoint while every sibling endpoint on the same router
already gated on `bunking.manage`. Internal notes (the one thing that is a real boundary,
already gated on `bunking.manage`) are untouched.

- `bunking/rbac/permissions.py` — removed `Permission.LODGING_PHI` and its
  `PERMISSION_DESCRIPTIONS` entry. `ALL_PERMISSIONS` is derived from the class's own
  attributes, so it drops out of that set automatically — no literal list to hand-edit.
- `api/routers/lodging.py` — `get_household_medical` now gates on `Permission.BUNKING_MANAGE`
  instead of the removed `Permission.LODGING_PHI`; docstring updated.
- `frontend/src/constants/permissions.ts` — removed the `LODGING_PHI` constant (mirrors the
  Python side per the file's own docstring).
- `frontend/src/components/weekend/MedicalNarrative.tsx` — the UI gate now reads
  `Permission.BUNKING_MANAGE`.
- New migration `pocketbase/pb_migrations/1500000154_drop_lodging_phi_permission.js` —
  revokes `lodging.phi` from the `bunking-staff` role's `permissions` array (the data-side
  half; the code-side removal above already dropped it from `ALL_PERMISSIONS`) and
  recomputes `cached_permissions` for holders of that role, mirroring 1500000130's original
  grant helpers. Reversible (`down` re-grants). Hardened per CodeRabbit review (see
  "Mutation check" below): `readRolePermissions` now filters the parsed array to strings
  before use, and `findRoleBySlug`/`recomputeCachedPermissions` now rethrow anything that
  is not PocketBase's not-found sentinel instead of swallowing every error. One consequence
  worth flagging: `findRoleBySlug` now fails **closed** (throws, aborting the migration) on
  a non-not-found error, where the `1500000130` helper it mirrors fails **safe** (returns
  `null`, letting the rule change proceed) — safer, but it would abort a boot where the old
  helper would have skipped past the failure. The Migration Smoke Test (CI) passes, so this
  does not bite on a fresh DB.
- `docs/reference/pocketbase-migrations.md` — corrected, not the migration: the doc's
  broad-catch guidance (from #1731) still holds for the lookup-then-mutate shape it was
  written for, but does not hold for a catch guarded by `continue` inside a loop, which is
  the shape `recomputeCachedPermissions` uses. That exception was already established by
  #2001 (`1500000135_lodging_availability_no_scenario.js`, merged four weeks after #1731
  closed) and this PR's `isNotFoundError(err)` helper is the second instance of it — the doc
  had simply never been updated for either. #1731's reasoning is kept intact for the shape it
  still covers.
- Updated every test and comment in the six files the issue named as pinning the old
  permission, plus the additional call sites and comments a full-repo grep surfaced beyond
  the issue's list (see "Issue-body gap" below): `frontend/src/hooks/useWeekendRoster.ts`,
  `frontend/src/services/lodgingApi.ts`/`.test.ts`, `frontend/src/components/weekend/
  ShareRequestPanel.tsx`, `AccessibilityFlagList.test.tsx`, `FamilyDetailsPanel.tsx`/`.test.tsx`,
  `api/services/lodging_roster_service.py`, `api/schemas/lodging.py`.
- **Not renamed/removed**: `pocketbase/sync/lodging_phi_test.go`'s `phiColumns` list and its
  export/log boundary tests — those assert which *columns* carry medical narrative, unrelated
  to the RBAC *permission* string, and needed zero changes (see "Issue-body gap").
- **Not touched**: `pocketbase/main_lodging_rbac_test.go` (asserts migration 1500000130's
  historical source, which is unchanged — that migration is frozen, not edited) and
  `pocketbase/pb_migrations/1500000150_household_demographics_person_grain.js` (an already-
  applied, unrelated migration whose comment mentions "no lodging.phi gate applies"; left
  alone rather than edited for a comment-only nit in a file with no functional reason to open).

## `cached_permissions` staleness — confirmed harmless (sharp edge #2)

Read `bunking/auth_middleware.py::_populate_user_permissions` and
`bunking/rbac/dependencies.py::require_permission`: permission checks are a plain
`permission not in user.permissions` containment test against the *current* `Permission`
class constants. Nothing iterates `cached_permissions` to validate its entries against a
known-permission set, and nothing on the PocketBase side (`pocketbase/rbac/hooks.go`) filters
against a whitelist either — it flattens straight from each role's own `permissions` field. A
stale `"lodging.phi"` string left in an unrefreshed user's `cached_permissions` blob is
therefore inert: no code path will ever compare against the literal `"lodging.phi"` again,
because the constant that named it no longer exists to compare with. It cannot cause a user to
lose access to something else. The new migration recomputes `cached_permissions` for
`bunking-staff` holders anyway, matching 1500000130's own belt-and-braces convention rather
than relying on staleness merely being safe.

## Migration verification (mandatory, not substituted by the Go suite)

Applied and reverted `1500000154` against a **copy** of the production database
(`pocketbase/pb_data/data.db`, 751 MB; original never touched — `cat >` to a scratch copy,
`pocketbase migrate up/down --dir <scratch>` with `pb_migrations` symlinked in per jsvm's
`DataDir/../pb_migrations` default resolution).

- **Before** (`bunking-staff.permissions`): `["bunking.manage","lodging.phi"]`
- **After `migrate up`**: `["bunking.manage"]`
- **After `migrate down 1`** (interactive, driven with `printf 'y\n' |`): back to
  `["bunking.manage","lodging.phi"]` exactly
- **Schema diff**: `SELECT name, fields FROM _collections` — **byte-identical** before vs.
  after, for every collection, in both directions. This migration is data-only; no `_collections`
  row changes shape.
- The 3 "Failed to recompute permissions... finding user: sql: no rows in result set" log
  lines during both directions are pre-existing: this prod snapshot's `bunking-staff` role has
  3 `user_roles` memberships whose `users` rows no longer exist (only 2 real users remain in
  the snapshot, neither holding `bunking.manage`). Confirmed unrelated to this migration —
  the same orphaned refs would have logged identically the first time 1500000130 granted the
  permission.
- `frontend/src/types/pocketbase-types.ts`: unchanged, correctly — this migration touches no
  collection schema, only a `roles` row's JSON `permissions` value.

## Verification

- `uv run pytest tests/unit/rbac/test_permissions.py tests/unit/api/test_lodging_constants.py
  tests/unit/api/routers/test_lodging_endpoints.py tests/unit/api/test_lodging_phi_boundary.py
  tests/unit/api/services/test_lodging_roster_service.py -q` → RED before the implementation
  changes (8 failures, all the expected shape — `LODGING_PHI` still present, medical endpoint
  still 403s a `bunking.manage`-only user), **GREEN after** (273 passed).
- `uv run pytest tests/ -q` → 6299 passed, 23 skipped, 27 failed. All 27 failures are
  pre-existing and environmental: `tests/test_metrics_retention.py`, `tests/unit/api/
  test_metrics*.py`, `tests/unit/api/test_retention_trends.py`, all
  `FileNotFoundError: Could not find PocketBase database` — this worktree has no
  `pocketbase/pb_data/data.db` and `PB_DATA_DIR` is unset; unrelated to metrics code, which
  this PR never touches.
- `cd pocketbase && go build ./...` → exit 0.
- `cd pocketbase && go test ./...` → new migration tests green; one pre-existing flake
  (`TestBaseDeleteOrphansWarnsWhenNothingCanBeKeyed` in `pocketbase/sync`, a log-level
  assertion) reproduces only under full `./...` concurrency and passes cleanly both in
  isolation and via `go test ./sync/...` alone — unrelated to any file this PR touches.
- `cd pocketbase && golangci-lint run --allow-parallel-runners .` and `./sync/...` → 0 issues.
- `cd frontend && ./node_modules/.bin/vitest run` (scoped to the 4 touched files) → 80/80
  passed. Full suite: 6783/6786 passed, all 3 failures in
  `LodgingUnitsPanel.test.tsx` (an admin panel this PR never touches) and confirmed a
  contention timeout, not a regression — reran in isolation and got 33/33 green.
- `bash scripts/pre-push-verify.sh` → see PR comment / CI for the run against this branch.

## Mutation check (Go migration test)

Broke `TestDropLodgingPHIMigrationRevokesFromBunkingStaff`'s target by commenting out the
`revokePermissionFromRole` call in the migration:

```
--- FAIL: TestDropLodgingPHIMigrationRevokesFromBunkingStaff (0.00s)
```

Restored, reran: green again. A later commit (`50552edd`, hardening the migration per
CodeRabbit review) added two more tests, for 6 total:
`TestDropLodgingPHIMigrationFiltersNonStringPermissions` and
`TestDropLodgingPHIMigrationRethrowsUnexpectedErrors`. Both mutation-checked too — reverting
the string filter in `readRolePermissions` fails the first:

```
--- FAIL: TestDropLodgingPHIMigrationFiltersNonStringPermissions (0.00s)
```

and reverting either `catch` in `recomputeCachedPermissions` back to an unconditional
`catch (_err) { continue }` fails the second:

```
--- FAIL: TestDropLodgingPHIMigrationRethrowsUnexpectedErrors (0.00s)
```

(reverting `findRoleBySlug`'s own rethrow alone does not fail this test — it pins the two
`recomputeCachedPermissions` catches by literal pattern, not `findRoleBySlug`'s. Noting the
gap rather than fixing it, since it wasn't part of what CodeRabbit flagged.) Both restored,
reran: all 6 green. The remaining 3 (`recompute`, `reversibility`, `getString()` guard) were
left un-mutated — each pins a single `strings.Contains` literal against the migration
source, the same pattern `main_lodging_rbac_test.go` already uses for 1500000130, so a
broken migration source fails them by construction.

## Issue-body gap (for the campaign log)

The issue's scope table (4 files + role seed migration) plus its list of 6 pinning test
files undercounted the blast radius: a repo-wide grep for `LODGING_PHI`/`lodging.phi` after
the listed edits still surfaced 10 additional files carrying explanatory comments or (in one
case, `frontend/src/components/weekend/MedicalNarrative.test.tsx`) real test assertions
using the literal string `'lodging.phi'` as a mocked permission — `frontend/src/hooks/
useWeekendRoster.ts`, `frontend/src/services/lodgingApi.ts`/`.test.ts`,
`frontend/src/components/weekend/ShareRequestPanel.tsx`, `AccessibilityFlagList.test.tsx`,
`FamilyDetailsPanel.tsx`/`.test.tsx`, `api/services/lodging_roster_service.py`,
`api/schemas/lodging.py`, and `MedicalNarrative.test.tsx`. All updated in this PR (the 21
files changed by this PR = 10 the issue named and this PR actually touches, + those 10
additional, + the new `pocketbase/main_drop_lodging_phi_permission_test.go`, which is new
test coverage this PR wrote for the migration rather than something grep found). Separately,
`pocketbase/sync/lodging_phi_test.go` was named in the issue as a test that "must move
together," but on inspection it contains zero references to the RBAC permission — it pins
which *columns* count as PHI for export/log guards, a claim this PR does not touch. No edit
was needed there; noting it so the issue's characterization doesn't mislead the next reader.

Closes #2312.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Access Changes**
  - Household medical information is now controlled by the `bunking.manage` permission.
  - The separate `lodging.phi` permission has been removed.
  - Existing medical disclosure, loading, error, and empty-state behavior remains unchanged.
  - Standard lodging and journey access remains unaffected.

- **Migration**
  - Existing role assignments are updated automatically to remove the retired permission while preserving current access where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->