### PR TITLE
feat(frontend): filter the weekend household roster by housing need

### DIFF
--- a/frontend/src/components/weekend/AccessibilityFlagList.tsx
+++ b/frontend/src/components/weekend/AccessibilityFlagList.tsx
@@ -19,6 +19,52 @@ export interface AccessibilityFlagListProps {
   flags: AccessibilityFlags
 }
 
+/**
+ * The four flags this file renders, as a filter vocabulary (kindred#2251).
+ * One definition feeding both the per-row chips below and
+ * `HouseholdRosterTable`'s roster-level filter, so a fifth need can never
+ * exist in one without the other. `accommodation_is_mandatory` only changes
+ * a CHIP's label/tone below — it plays no part in whether the accommodation
+ * need matches, since the filter asks "does this household need one" and a
+ * staff member can already see mandatory-vs-preferred once they open a row.
+ */
+export type NeedFilterKey = 'accommodation' | 'bathroom' | 'power' | 'infant'
+
+export interface NeedFilterOption {
+  key: NeedFilterKey
+  label: string
+  icon: typeof Bath
+  matches: (flags: AccessibilityFlags) => boolean
+}
+
+// eslint-disable-next-line react-refresh/only-export-components -- Shared filter vocabulary, not a component
+export const NEED_FILTER_OPTIONS: NeedFilterOption[] = [
+  {
+    key: 'accommodation',
+    label: 'Accommodation',
+    icon: Accessibility,
+    matches: (flags) => flags.needs_accommodation === true,
+  },
+  {
+    key: 'bathroom',
+    label: 'Private bathroom',
+    icon: Bath,
+    matches: (flags) => flags.needs_private_bathroom === true,
+  },
+  {
+    key: 'power',
+    label: 'Power',
+    icon: Plug,
+    matches: (flags) => flags.needs_power === true,
+  },
+  {
+    key: 'infant',
+    label: 'Infant in party',
+    icon: Baby,
+    matches: (flags) => flags.has_infant === true,
+  },
+]
+
 type Tone = 'red' | 'amber' | 'neutral'
 
 const TONE_ROW: Record<Tone, string> = {

--- a/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
@@ -941,3 +941,142 @@ describe('HouseholdRosterTable — the actual PHI fetch (kindred#2139)', () => {
     expect(mockFetchHouseholdMedical).not.toHaveBeenCalled()
   })
 })
+
+/** The row's own identity label (kindred#2084: attending adults, not `display_name`). */
+function visibleRowNames(): Array<string | null> {
+  return screen.getAllByTestId('household-row-name').map((el) => el.textContent)
+}
+
+describe('HouseholdRosterTable — filters by housing need (kindred#2251)', () => {
+  // Each override carries its own `adults` entry with a name distinct from
+  // the household `display_name` -- `partyIdentityLabel` renders the
+  // ATTENDING ADULTS, not `display_name` (kindred#2084), so `visibleRowNames`
+  // above is what these tests assert against.
+  const bathroomFamily = party({
+    display_name: 'Bathroom Family',
+    household_cm_id: 2000010,
+    adults: [{ adult_number: 1, display_name: 'Bathroom Parent', relationship: 'Parent' }],
+    flags: {
+      needs_private_bathroom: true,
+      needs_power: false,
+      needs_accommodation: false,
+      accommodation_is_mandatory: false,
+      has_infant: false,
+    },
+  })
+  const powerFamily = party({
+    display_name: 'Power Family',
+    household_cm_id: 2000011,
+    adults: [{ adult_number: 1, display_name: 'Power Parent', relationship: 'Parent' }],
+    flags: {
+      needs_private_bathroom: false,
+      needs_power: true,
+      needs_accommodation: false,
+      accommodation_is_mandatory: false,
+      has_infant: false,
+    },
+  })
+  const infantFamily = party({
+    display_name: 'Infant Family',
+    household_cm_id: 2000012,
+    adults: [{ adult_number: 1, display_name: 'Infant Parent', relationship: 'Parent' }],
+    flags: {
+      needs_private_bathroom: false,
+      needs_power: false,
+      needs_accommodation: false,
+      accommodation_is_mandatory: false,
+      has_infant: true,
+    },
+  })
+  const noNeedsFamily = party({
+    display_name: 'No Needs Family',
+    household_cm_id: 2000013,
+    adults: [{ adult_number: 1, display_name: 'No Needs Parent', relationship: 'Parent' }],
+  })
+
+  it('offers one toggle per flag AccessibilityFlagList already renders', () => {
+    render(<HouseholdRosterTable year={2026} parties={[bathroomFamily, powerFamily]} />, {
+      wrapper,
+    })
+    expect(screen.getByRole('button', { name: 'Accommodation' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Private bathroom' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Power' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Infant in party' })).toBeInTheDocument()
+  })
+
+  it('narrows the roster to parties matching the selected need', async () => {
+    render(
+      <HouseholdRosterTable year={2026} parties={[bathroomFamily, powerFamily, noNeedsFamily]} />,
+      { wrapper }
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Power' }))
+    expect(visibleRowNames()).toEqual(['Power Parent'])
+  })
+
+  it('marks the active toggle pressed, and clears it back to the full roster on a second click', async () => {
+    render(<HouseholdRosterTable year={2026} parties={[powerFamily, noNeedsFamily]} />, {
+      wrapper,
+    })
+    const powerToggle = screen.getByRole('button', { name: 'Power' })
+    expect(powerToggle).toHaveAttribute('aria-pressed', 'false')
+
+    await userEvent.click(powerToggle)
+    expect(powerToggle).toHaveAttribute('aria-pressed', 'true')
+    expect(visibleRowNames()).toEqual(['Power Parent'])
+
+    await userEvent.click(powerToggle)
+    expect(powerToggle).toHaveAttribute('aria-pressed', 'false')
+    expect(visibleRowNames().sort()).toEqual(['No Needs Parent', 'Power Parent'])
+  })
+
+  it('is an OR across two selected needs, not an AND', async () => {
+    render(
+      <HouseholdRosterTable year={2026} parties={[powerFamily, infantFamily, noNeedsFamily]} />,
+      { wrapper }
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Power' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Infant in party' }))
+
+    // Neither family has BOTH flags -- an AND filter would show zero rows.
+    expect(visibleRowNames().sort()).toEqual(['Infant Parent', 'Power Parent'])
+  })
+
+  it('reports a filtered-empty roster distinctly from an actually-empty one', async () => {
+    render(<HouseholdRosterTable year={2026} parties={[noNeedsFamily]} />, { wrapper })
+    await userEvent.click(screen.getByRole('button', { name: 'Power' }))
+    expect(screen.queryByText('No one is enrolled for this weekend.')).not.toBeInTheDocument()
+    expect(screen.getByText(/No one matches the selected housing needs/)).toBeInTheDocument()
+  })
+
+  it('does not warn about historical data on the current season', async () => {
+    render(<HouseholdRosterTable year={2026} parties={[powerFamily]} />, { wrapper })
+    await userEvent.click(screen.getByRole('button', { name: 'Power' }))
+    expect(screen.queryByText(/2026 season/)).not.toBeInTheDocument()
+  })
+
+  it('does not warn on a historical season when the selected need has real history (accommodation)', async () => {
+    render(<HouseholdRosterTable year={2024} parties={[noNeedsFamily]} />, { wrapper })
+    await userEvent.click(screen.getByRole('button', { name: 'Accommodation' }))
+    expect(screen.queryByText(/2026 season/)).not.toBeInTheDocument()
+  })
+
+  it('warns that private-bathroom/power data does not exist before the 2026 season (kindred#2251 caveat)', async () => {
+    // family-camp-grain-campaign.md Trap 1 / D2: needs_private_bathroom and
+    // needs_power are 0 for every pre-2026 row. An empty result here must not
+    // read as "nobody needed it" -- it is "we never asked the question yet."
+    render(<HouseholdRosterTable year={2024} parties={[noNeedsFamily]} />, { wrapper })
+    await userEvent.click(screen.getByRole('button', { name: 'Power' }))
+    expect(screen.getByText(/2026 season/)).toBeInTheDocument()
+    expect(screen.getByText(/missing data/i)).toBeInTheDocument()
+  })
+
+  it('warns on a historical season even when the OR filter still finds matches', async () => {
+    // The caveat is about the BATHROOM/POWER signal specifically, which is
+    // silently incomplete even when the combined OR result is non-empty.
+    render(<HouseholdRosterTable year={2025} parties={[infantFamily]} />, { wrapper })
+    await userEvent.click(screen.getByRole('button', { name: 'Power' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Infant in party' }))
+    expect(visibleRowNames()).toEqual(['Infant Parent'])
+    expect(screen.getByText(/2026 season/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
@@ -1079,4 +1079,31 @@ describe('HouseholdRosterTable — filters by housing need (kindred#2251)', () =
     expect(visibleRowNames()).toEqual(['Infant Parent'])
     expect(screen.getByText(/2026 season/)).toBeInTheDocument()
   })
+
+  // The companion trap to the kindred#2138 panel-reset tests above
+  // (:850-919): a filter chosen on one weekend must not silently keep
+  // narrowing the roster after staff switch to a different weekend.
+  // `sessionCmId` is the only thing that changes across the rerender --
+  // same component instance, same `parties` shape -- mirroring how those
+  // tests isolate the session-change path from a household dropping out of
+  // `parties` entirely.
+  it('clears the selected-needs filter on a session change (kindred#2138 companion)', async () => {
+    const rosterForEitherWeekend = () => [powerFamily, noNeedsFamily]
+    const { rerender } = render(
+      <HouseholdRosterTable year={2026} sessionCmId={101} parties={rosterForEitherWeekend()} />,
+      { wrapper }
+    )
+    const powerToggle = screen.getByRole('button', { name: 'Power' })
+    await userEvent.click(powerToggle)
+    expect(powerToggle).toHaveAttribute('aria-pressed', 'true')
+    expect(visibleRowNames()).toEqual(['Power Parent'])
+
+    // A weekend switch -- staff picks a different session from the switcher.
+    rerender(
+      <HouseholdRosterTable year={2026} sessionCmId={202} parties={rosterForEitherWeekend()} />
+    )
+
+    expect(screen.getByRole('button', { name: 'Power' })).toHaveAttribute('aria-pressed', 'false')
+    expect(visibleRowNames().sort()).toEqual(['No Needs Parent', 'Power Parent'])
+  })
 })

--- a/frontend/src/components/weekend/HouseholdRosterTable.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.tsx
@@ -13,10 +13,24 @@ import { useState } from 'react'
 import { useDismissOnDeadSpace } from '../../hooks/useDismissOnDeadSpace'
 import { usePanelParty } from '../../hooks/usePanelParty'
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+import type { NeedFilterKey } from './AccessibilityFlagList'
+import { NEED_FILTER_OPTIONS } from './AccessibilityFlagList'
 import { FamilyDetailsPanel } from './FamilyDetailsPanel'
 import { HouseholdRosterRow } from './HouseholdRosterRow'
 import { partyKey } from './partyKey'
 import { attentionSections, indexUnitsByCode, resolvePartyUnit } from './rosterAttention'
+
+/**
+ * First season `needs_private_bathroom`/`needs_power` carry real signal.
+ * family-camp-grain-campaign.md Trap 1 / decision D2: these are 2 of eight
+ * columns the sync only started populating in 2026 — every earlier row reads
+ * `false`, not "unknown". `needs_accommodation` and `has_infant` are excluded
+ * on purpose: both are sourced from fields that existed in earlier seasons
+ * too (an older "FAM Camp-Accommodation" generation, and the adult-weekend
+ * infant question), so they carry real, if sparser, historical signal.
+ */
+const NEEDS_DATA_FIRST_YEAR = 2026
+const HISTORICAL_GAP_KEYS: ReadonlySet<NeedFilterKey> = new Set(['bathroom', 'power'])
 
 export interface HouseholdRosterTableProps {
   parties: RosterPartyRow[]
@@ -93,6 +107,15 @@ export function HouseholdRosterTable({
 
   useDismissOnDeadSpace(panelParty !== null, requestPanelClose)
 
+  // Filter by housing need (kindred#2251) -- OR across whatever is selected,
+  // matching the standard "broaden as you add a chip" reading of a
+  // multi-select filter group. An AND reading would frequently show zero
+  // rows, since the four flags name unrelated needs rather than degrees of
+  // one need. Local state, not the URL: this narrows an in-page scan rather
+  // than picking a view, so it does not need to survive a reload or be
+  // linked, unlike the weekend TAB itself (CLAUDE.md §4 "URL style").
+  const [selectedNeeds, setSelectedNeeds] = useState<Set<NeedFilterKey>>(() => new Set())
+
   if (parties.length === 0) {
     return (
       <div className="dark:bg-card rounded-xl border border-dashed border-stone-300 bg-white p-8 text-center dark:border-stone-600">
@@ -104,64 +127,141 @@ export function HouseholdRosterTable({
     )
   }
 
+  const activeNeeds = NEED_FILTER_OPTIONS.filter((option) => selectedNeeds.has(option.key))
+  const filteredParties =
+    activeNeeds.length === 0
+      ? parties
+      : parties.filter((p) => activeNeeds.some((option) => option.matches(p.flags ?? {})))
+
   const unitsByCode = indexUnitsByCode(units)
-  const sections = attentionSections(parties, unitsByCode)
+  const sections = attentionSections(filteredParties, unitsByCode)
   // An untouched adult weekend is 123 parties all in one state; heading that
   // with "Needs a cabin (123)" repeats what the banner already said.
   const showSectionHeads = sections.length > 1
   // Adult weekends carry no share requests — don't render a dead column.
+  // Keyed off the FULL roster, not the filtered one: the column set is a
+  // property of the weekend, not of whatever is currently toggled, and
+  // letting it flicker in and out as a filter narrows the rows would be a
+  // second, unrelated thing changing on every click.
   const showRequests = hasAnyRequest(parties)
+
+  // needs_private_bathroom/needs_power are 0 for every pre-2026 row (Trap 1 /
+  // D2 — see the constant above), so an empty or thin result here can read as
+  // "nobody needed it" when the true answer is "we never asked". Shown
+  // whenever either flag is part of the ACTIVE filter on a season before the
+  // data exists, even if the OR combination still finds matches through a
+  // different flag — the bathroom/power signal itself stays silently
+  // incomplete in that result too.
+  const showHistoricalGapWarning =
+    year < NEEDS_DATA_FIRST_YEAR &&
+    activeNeeds.some((option) => HISTORICAL_GAP_KEYS.has(option.key))
+
+  const toggleNeed = (key: NeedFilterKey) => {
+    setSelectedNeeds((previous) => {
+      const next = new Set(previous)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }
 
   return (
     <>
-      <div className="dark:bg-card overflow-x-auto rounded-xl border border-stone-200 bg-white shadow-sm dark:border-stone-700">
-        <table className="w-full min-w-3xl text-left">
-          <thead>
-            <tr className="border-border border-b">
-              <th className={`${HEAD_CELL} pt-4 pl-3`}>Party</th>
-              <th className={`${HEAD_CELL} pt-4`}>Cabin</th>
-              {showRequests && <th className={`${HEAD_CELL} pt-4`}>Requests</th>}
-              <th className={`${HEAD_CELL} pt-4 pr-3`}>Housing needs</th>
-            </tr>
-          </thead>
-
-          {sections.map((section) => (
-            <tbody key={section.level}>
-              {showSectionHeads && (
-                <tr>
-                  <th
-                    scope="colgroup"
-                    colSpan={showRequests ? 4 : 3}
-                    className="bg-forest-50/70 dark:bg-forest-900/40 text-forest-800 dark:text-forest-200 border-border/60 border-y px-3 py-2 text-left text-xs font-bold tracking-wider uppercase"
-                  >
-                    {section.label}
-                    <span className="text-muted-foreground ml-2 font-semibold normal-case tabular-nums">
-                      {section.parties.length}
-                    </span>
-                  </th>
-                </tr>
-              )}
-              {section.parties.map((party) => (
-                // `partyKey`, not a hand-rolled string (kindred#2139): the two
-                // used to disagree on an unresolved household (both ids 0),
-                // where this file's own inline key collapsed two different
-                // households into one React key and `partyKey` did not, by
-                // falling through to `display_name`. No live incidence — see
-                // `partyKey.ts`'s own docstring — but importing `partyKey`
-                // into this file and then hand-rolling a second, weaker
-                // definition beside it was the inconsistency worth fixing.
-                <HouseholdRosterRow
-                  key={partyKey(party)}
-                  party={party}
-                  showRequests={showRequests}
-                  unit={resolvePartyUnit(party, unitsByCode)}
-                  onOpen={openParty}
-                />
-              ))}
-            </tbody>
-          ))}
-        </table>
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <div className="bg-muted/50 dark:bg-muted/30 border-border/50 flex flex-wrap items-center gap-1 rounded-xl border p-1">
+          {NEED_FILTER_OPTIONS.map((option) => {
+            const Icon = option.icon
+            const isSelected = selectedNeeds.has(option.key)
+            return (
+              <button
+                key={option.key}
+                type="button"
+                aria-pressed={isSelected}
+                onClick={() => {
+                  toggleNeed(option.key)
+                }}
+                className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-all duration-200 ${
+                  isSelected
+                    ? 'bg-primary text-primary-foreground shadow-lodge-sm'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-muted dark:hover:bg-muted/80'
+                }`}
+              >
+                <Icon className="h-3.5 w-3.5 flex-shrink-0" />
+                {option.label}
+              </button>
+            )
+          })}
+        </div>
+        {activeNeeds.length > 0 && (
+          <span className="text-muted-foreground text-sm tabular-nums">
+            {filteredParties.length} of {parties.length}
+          </span>
+        )}
       </div>
+
+      {showHistoricalGapWarning && (
+        <p className="mb-3 rounded border border-amber-200 bg-amber-100 p-2 text-sm text-amber-800 dark:border-amber-900/50 dark:bg-amber-900/50 dark:text-amber-300">
+          Private bathroom and power needs are only recorded starting the 2026 season. A result for{' '}
+          {year} reflects missing data, not that nobody needed one.
+        </p>
+      )}
+
+      {filteredParties.length === 0 ? (
+        <div className="dark:bg-card rounded-xl border border-dashed border-stone-300 bg-white p-8 text-center dark:border-stone-600">
+          <p className="text-foreground text-sm font-medium">
+            No one matches the selected housing needs.
+          </p>
+        </div>
+      ) : (
+        <div className="dark:bg-card overflow-x-auto rounded-xl border border-stone-200 bg-white shadow-sm dark:border-stone-700">
+          <table className="w-full min-w-3xl text-left">
+            <thead>
+              <tr className="border-border border-b">
+                <th className={`${HEAD_CELL} pt-4 pl-3`}>Party</th>
+                <th className={`${HEAD_CELL} pt-4`}>Cabin</th>
+                {showRequests && <th className={`${HEAD_CELL} pt-4`}>Requests</th>}
+                <th className={`${HEAD_CELL} pt-4 pr-3`}>Housing needs</th>
+              </tr>
+            </thead>
+
+            {sections.map((section) => (
+              <tbody key={section.level}>
+                {showSectionHeads && (
+                  <tr>
+                    <th
+                      scope="colgroup"
+                      colSpan={showRequests ? 4 : 3}
+                      className="bg-forest-50/70 dark:bg-forest-900/40 text-forest-800 dark:text-forest-200 border-border/60 border-y px-3 py-2 text-left text-xs font-bold tracking-wider uppercase"
+                    >
+                      {section.label}
+                      <span className="text-muted-foreground ml-2 font-semibold normal-case tabular-nums">
+                        {section.parties.length}
+                      </span>
+                    </th>
+                  </tr>
+                )}
+                {section.parties.map((party) => (
+                  // `partyKey`, not a hand-rolled string (kindred#2139): the two
+                  // used to disagree on an unresolved household (both ids 0),
+                  // where this file's own inline key collapsed two different
+                  // households into one React key and `partyKey` did not, by
+                  // falling through to `display_name`. No live incidence — see
+                  // `partyKey.ts`'s own docstring — but importing `partyKey`
+                  // into this file and then hand-rolling a second, weaker
+                  // definition beside it was the inconsistency worth fixing.
+                  <HouseholdRosterRow
+                    key={partyKey(party)}
+                    party={party}
+                    showRequests={showRequests}
+                    unit={resolvePartyUnit(party, unitsByCode)}
+                    onOpen={openParty}
+                  />
+                ))}
+              </tbody>
+            ))}
+          </table>
+        </div>
+      )}
 
       {panelParty !== null && (
         <FamilyDetailsPanel

--- a/frontend/src/components/weekend/HouseholdRosterTable.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.tsx
@@ -83,6 +83,19 @@ export function HouseholdRosterTable({
   const { panelParty, requestClose, openParty, closePanel, requestPanelClose } =
     usePanelParty(parties)
 
+  // Filter by housing need (kindred#2251) -- OR across whatever is selected,
+  // matching the standard "broaden as you add a chip" reading of a
+  // multi-select filter group. An AND reading would frequently show zero
+  // rows, since the four flags name unrelated needs rather than degrees of
+  // one need. Local state, not the URL: this narrows an in-page scan rather
+  // than picking a view, so it does not need to survive a reload or be
+  // linked, unlike the weekend TAB itself (CLAUDE.md §4 "URL style").
+  //
+  // Declared ABOVE the session-reset block below so its setter is in scope
+  // there. Both `useState` calls stay above the `parties.length === 0` early
+  // return -- rules of hooks.
+  const [selectedNeeds, setSelectedNeeds] = useState<Set<NeedFilterKey>>(() => new Set())
+
   // RESET, not filtered (kindred#2138) — the owner's ruling was explicit: a
   // session change closes the panel outright, it does not merely stop
   // rendering it while the selection quietly survives underneath.
@@ -90,7 +103,10 @@ export function HouseholdRosterTable({
   // `parties`; a household enrolled in two weekends never does that, since
   // `partyKey` (deliberately — see partyKey.ts) carries no session
   // dimension, so the same key still matches after the switch and the panel
-  // would keep rendering the PREVIOUS weekend's placement data.
+  // would keep rendering the PREVIOUS weekend's placement data. The needs
+  // filter above gets the same treatment for the same reason: a filter
+  // chosen on one weekend must not quietly keep narrowing a different
+  // weekend's roster after staff switch sessions.
   //
   // This is React's own "storing information from previous renders"
   // pattern: compare this render's prop against the last one seen, and if
@@ -103,18 +119,10 @@ export function HouseholdRosterTable({
   if (sessionCmId !== lastSessionCmId) {
     setLastSessionCmId(sessionCmId)
     closePanel()
+    setSelectedNeeds(new Set())
   }
 
   useDismissOnDeadSpace(panelParty !== null, requestPanelClose)
-
-  // Filter by housing need (kindred#2251) -- OR across whatever is selected,
-  // matching the standard "broaden as you add a chip" reading of a
-  // multi-select filter group. An AND reading would frequently show zero
-  // rows, since the four flags name unrelated needs rather than degrees of
-  // one need. Local state, not the URL: this narrows an in-page scan rather
-  // than picking a view, so it does not need to survive a reload or be
-  // linked, unlike the weekend TAB itself (CLAUDE.md §4 "URL style").
-  const [selectedNeeds, setSelectedNeeds] = useState<Set<NeedFilterKey>>(() => new Set())
 
   if (parties.length === 0) {
     return (


### PR DESCRIPTION
## What changed

Adds a multi-select toggle filter above `HouseholdRosterTable`, one chip per flag `AccessibilityFlagList` already renders and already draws on every row: **Accommodation**, **Private bathroom**, **Power**, **Infant in party**.

- Selecting one or more toggles narrows the roster to households matching **ANY** selected need (OR, not AND) — the standard "broaden as you add a chip" reading of a multi-select filter group. An AND reading would frequently show zero rows, since these are four independent needs rather than degrees of one.
- The vocabulary (`NEED_FILTER_OPTIONS` — key, label, icon, match predicate) is exported from `AccessibilityFlagList.tsx` and consumed by `HouseholdRosterTable.tsx`, so the per-row chips and the roster-level filter share one definition. A fifth need can't exist in one without the other.
- Visual grammar reused wholesale, nothing new introduced: the toggle group is `session/AreaFilterBar.tsx`'s pill container adapted from single- to multi-select, the selected state is the same `bg-primary`/`text-primary-foreground` pair used roughly 30 other places in this app, and `aria-pressed` on each toggle mirrors the existing precedent at `weekend/MapUnitPopover.tsx:656`. No new control style, colour, token, or interaction.
- A distinct **"No one matches the selected housing needs."** empty state when a filter narrows the roster to zero rows — kept separate from the pre-existing "No one is enrolled for this weekend." state, which now only fires when the raw (unfiltered) roster itself is empty.
- A small `{filtered} of {total}` counter beside the chips, shown only while a filter is active. The weekend page's own "Roster (N)" tab count is untouched by this — it's computed from the unfiltered roster at the page level, so the honest total stays visible even while the table itself is narrowed.
- Filter state is local `useState`, not the URL: this narrows an in-page scan rather than picking a distinct view, unlike the weekend page's own tab (`CLAUDE.md` §4 "URL style" governs linkable views, not a transient scan filter).
- **Review fix, owner-approved 2026-08-14:** `selectedNeeds` was not reset when `sessionCmId` changed, so a housing-need filter chosen on one weekend silently kept narrowing the roster after staff switched to a different one. `setSelectedNeeds(new Set())` was added to the existing kindred#2138 session-reset block alongside `closePanel()` — same fix shape, same reasoning: a session change resets stale local state outright rather than letting a selection quietly survive underneath. TDD transcript (RED test, GREEN fix, mutation-check) is in this PR's review comment.

## Filter vs. highlight — owner-approved ruling (2026-08-14)

kindred#2251's body flagged **"Filter or highlight"** as a question worth settling before building, warning that hiding non-matching households changes the placement denominator on a board whose job is fitting everyone. This PR chose **filter (hide)** on its own reasoning; the owner has since reviewed and approved that choice for the Roster tab.

What makes filter safe here, not merely chosen:

- The `{filtered} of {total}` counter (above) keeps the true roster size visible even while the table is narrowed — nobody has to remember what got hidden.
- The page-level **"Roster (N)" tab count** (`WeekendRosterPage.tsx:~239`) is computed from the unfiltered roster and is untouched by this in-table filter, so the honest total staff actually track lives on the tab, not inside this table.
- `HouseholdRosterTable` is the **read-only Roster tab**. It is not the drag-and-drop Housing/board tab that #2251's "changes the placement denominator" language most sharply describes — filtering a party out of a live placement surface mid-drag is a materially different risk than filtering a read-only list, and this PR only touches the latter.

## ⚠️ Scoped to the current season — required caveat

`needs_private_bathroom` and `needs_power` are 0 for **every** pre-2026 row — 2 of the eight derived columns the sync only started populating in the 2026 season (`docs/plans/2026-08-13-family-camp-grain-campaign.md` Trap 1 / decision D2). An empty or thin filtered result on an earlier season therefore risks reading as *"nobody needed it"* when the true answer is *"we never asked yet."*

Mitigation: whenever the active filter includes Private bathroom or Power **and** the roster's `year` is before 2026, an amber banner reads:

> Private bathroom and power needs are only recorded starting the 2026 season. A result for {year} reflects missing data, not that nobody needed one.

This fires even when the OR-combined result is **non-empty** — e.g. selecting Power + Infant together on 2025 data still finds infant matches — because the bathroom/power *signal itself* stays silently incomplete in that result too. The caveat is not gated on the result being empty.

`needs_accommodation` and `has_infant` are deliberately **excluded** from this caveat: unlike the other two, both carry real (if sparser) historical signal — `needs_accommodation` ORs across three field generations, one of which (`FAM Camp-Accommodation`) predates 2026 and retired after 2024; `has_infant` comes from the adult-weekend infant question, which is not one of the eight 2026-only columns.

No historical replay or backfill was attempted — out of scope per campaign decision D2 ("replay 2026 only for now").

## Not mockup-gated

This is a filter over four flags that already exist and already render — no new visual surface, so it doesn't fall under the campaign's mockup-gated items (`family-camp-grain-campaign.md` §11 confirms #2251 as "not gated").

## How I verified

- **TDD**: wrote 9 failing tests first in `HouseholdRosterTable.test.tsx`, ran them, confirmed RED (all 9 failed against the pre-change component; 40 pre-existing tests in the file stayed green).
- **Mutation check**: forced `activeNeeds` to always be `[]` (breaks the filter narrowing) and `showHistoricalGapWarning` to always be `false` (breaks the caveat banner), reran the suite — 6 of the 9 new tests correctly went RED (the remaining 3 don't exercise either mutated path), then restored and confirmed all 9 green again.
- **Review fix (session-reset, above)**: one more RED-then-GREEN-then-mutation-check cycle for the `sessionCmId` reset bug — full transcript in this PR's review comment.
- `cd frontend && ./node_modules/.bin/vitest run src/components/weekend/HouseholdRosterTable.test.tsx src/components/weekend/AccessibilityFlagList.test.tsx` → **58 passed**, exit=0
- `cd frontend && ./node_modules/.bin/tsc --noEmit -p tsconfig.json` → exit=0
- `cd frontend && ./node_modules/.bin/eslint src/components/weekend/HouseholdRosterTable.tsx src/components/weekend/AccessibilityFlagList.tsx src/components/weekend/HouseholdRosterTable.test.tsx` → 0 errors (3 pre-existing warnings, all outside the lines this PR touches)
- Full frontend suite: `cd frontend && ./node_modules/.bin/vitest run` → **445 files / 6796 tests passed**, exit=0
- `bash scripts/pre-push-verify.sh` → **ALL CHECKS PASSED** (prettier, eslint, tsc, vitest)
- Push verified by the remote ref moving: `git fetch -q && git rev-list --count origin/feature/household-roster-needs-filter..HEAD` → `0`

**Deliberately does not retire kindred#2251.** The filter itself is approved and merged, but it is
unconfirmed that the **weekend roster page** is where staff want it — that placement was chosen by
this PR's own reasoning, not by a request. kindred#2251 stays open to carry that question, and a
note recording exactly what shipped has been added to it.

Refs kindred#2251.


