### PR TITLE
docs(docs): correct the family camp splice ceiling and gate pair table

### DIFF
--- a/docs/reference/family-camp-field-provenance.md
+++ b/docs/reference/family-camp-field-provenance.md
@@ -394,9 +394,8 @@ Known pairs — housing plus the medical forms that use the same convention:
 | `Family Camp-Physician ` (39680) | `Family Camp-Physician If Yes` (39681) |
 
 > `Family Camp-Physician ` carries a **trailing space** in its own name — that is not a
-> typo here or in the CampMinder admin UI. See [§7](#7-standing-traps): it is the field
-> `normalizeFieldName` exists to work around, and the adult pipeline currently ignores the
-> lesson and routes on display-name substrings instead of `cm_id`.
+> typo here or in the CampMinder admin UI. It is the field `normalizeFieldName` exists to
+> work around; see [§7](#7-standing-traps).
 
 ### The splice: a gate and its explanation can survive from different children
 
@@ -415,22 +414,28 @@ id-min explain row belong to different children**:
 | Housing Accommodation | — | — | 11 / 30 · 36.7% |
 | Bathroom | — | — | 17 / 45 · 37.8% |
 
-**This is worse than losing a sibling's text for Special Needs and CPAP only.** Those two
-pairs concatenate a **stored gate string** with a stored explanation, so the two halves of
-one question get spliced across two children and the explanation staff read does not
-necessarily describe the need that raised the flag.
+**Of the four rows above, this is worse than losing a sibling's text for Special Needs and
+CPAP only.** Those two pairs concatenate a **stored gate string** with a stored explanation
+in `processMedical`, so the two halves of one question get spliced across two children and
+the explanation staff read does not necessarily describe the need that raised the flag.
 
 **Housing Accommodation and Bathroom are not the same claim, and their rows should not be
-read against the other two.** Both gates are stored as household-wide OR booleans, and
-`family_camp_medical` stores no gate string for either — there is no second *stored* half
-to splice against, so their rows above measure winner provenance only: whether the
-household's stored explanation came from a child other than the id-min child who answered
-the gate Yes. Measured 2026: **0 of 30** and **0 of 45** households have a stored
-explanation from a child who did not themselves answer the gate Yes. Their residual defect
-is narrative **loss** — an answering child's explanation can still be dropped in favor of
-another answering child's — not splice; the loss is kindred#2255.
+read against the other two.** Both gates are stored as household-wide OR booleans by
+`processRegistrations`, and `family_camp_medical` stores no gate string for either — there
+is no second *stored* half to splice against, so their rows above measure winner provenance
+only, exactly as the heading says: the id-min gate row and the id-min explain row belong to
+different children.
 
-**The highest actual stored splice is CPAP 2025 at 33.3% (13 of 39), not the ~38% the
+**That is a different quantity from harm, and the second does not replace the first.**
+Winner provenance is the 11 / 30 and 17 / 45 in the table. *Harm* — households whose stored
+explanation came from a child who did not themselves answer the gate Yes — is **0 of 30**
+and **0 of 45** for 2026, and is zero structurally, because the gate is an OR across the
+whole household and no gate string is stored for it to disagree with. Re-running the first
+measurement will keep giving 11 / 30; that is not a contradiction of the zero. Their
+residual defect is narrative **loss** — an answering child's explanation can still be
+dropped in favor of another answering child's — not splice; the loss is kindred#2255.
+
+**The highest measured stored splice is CPAP 2025 at 33.3% (13 of 39), not the ~38% the
 Bathroom row implies if all four rows are read as one measurement.** Housing Accommodation
 and Bathroom have 2026-only rows because their derived columns have only ever been computed
 for 2026.
@@ -450,9 +455,12 @@ fanned onto three children still collapses to a single value while two members w
 answered keep both explanations beside the gate that member gave. The other four pairs
 measured above (Special Needs, CPAP, Housing Accommodation, Bathroom) still collapse
 independently in `processMedical` — that is kindred#2255. Allergies, Dietary Needs and
-`Family Camp-Physician ` (added to the pair table above but not separately measured here)
-are the same gate/explain shape on the same medical forms; Adult-Bathroom's collapse
-behavior has not been measured here either.
+`Family Camp-Physician ` are not merely the same shape on the form: `processMedical`
+concatenates each one's stored gate string with its stored explanation exactly as it does
+for Special Needs and CPAP, so they are in the same splice class and any fix has to cover
+them. They are not measured in the table above — which is why the ceiling is stated as the
+highest *measured* one. Adult-Bathroom's collapse behavior has not been measured here
+either.
 
 ---
 

--- a/docs/reference/family-camp-field-provenance.md
+++ b/docs/reference/family-camp-field-provenance.md
@@ -379,7 +379,7 @@ every such pair lands as an ordinary **per-child custom value**.
 <Gate> Yes      free text, shown only when the gate is Yes
 ```
 
-Known pairs in the housing set:
+Known pairs — housing plus the medical forms that use the same convention:
 
 | Gate | Explain |
 |------|---------|
@@ -388,6 +388,15 @@ Known pairs in the housing set:
 | `Housing Accommodation` (274057) | `Housing Accommodation-Yes` (274058) |
 | `FAM CAMP-bathroom` (274056) | `Housing-Bathroom` (274059) |
 | `Family Camp-Special occasions` (60413) | `Family Camp-describe special occasion` |
+| `Adult-Bathroom` (274053) | `Bathroom-Yes` (274054) |
+| `Family Medical-Allergies` (36870) | `Family Medical-Allergy Info` (36871) |
+| `Family Medical-Dietary Needs` (36872) | `Family Medical-Dietary Explain` (36873) |
+| `Family Camp-Physician ` (39680) | `Family Camp-Physician If Yes` (39681) |
+
+> `Family Camp-Physician ` carries a **trailing space** in its own name — that is not a
+> typo here or in the CampMinder admin UI. See [§7](#7-standing-traps): it is the field
+> `normalizeFieldName` exists to work around, and the adult pipeline currently ignores the
+> lesson and routes on display-name substrings instead of `cm_id`.
 
 ### The splice: a gate and its explanation can survive from different children
 
@@ -396,8 +405,8 @@ Known pairs in the housing set:
 values. Because the two halves of a pair are separate fields, their winners can be
 different children.
 
-Measured share of households (where both halves have a value) whose stored gate and
-stored explanation come from **different children**:
+Measured share of households (where both halves have a value) whose **id-min gate row and
+id-min explain row belong to different children**:
 
 | Pair | 2024 | 2025 | 2026 |
 |------|------|------|------|
@@ -406,21 +415,44 @@ stored explanation come from **different children**:
 | Housing Accommodation | — | — | 11 / 30 · 36.7% |
 | Bathroom | — | — | 17 / 45 · 37.8% |
 
-This is worse than losing a sibling's text: the two halves of one question get spliced
-across two children, so the explanation staff read does not necessarily describe the need
-that raised the flag. Housing Accommodation and Bathroom have 2026-only rows because their
-derived columns have only ever been computed for 2026.
+**This is worse than losing a sibling's text for Special Needs and CPAP only.** Those two
+pairs concatenate a **stored gate string** with a stored explanation, so the two halves of
+one question get spliced across two children and the explanation staff read does not
+necessarily describe the need that raised the flag.
+
+**Housing Accommodation and Bathroom are not the same claim, and their rows should not be
+read against the other two.** Both gates are stored as household-wide OR booleans, and
+`family_camp_medical` stores no gate string for either — there is no second *stored* half
+to splice against, so their rows above measure winner provenance only: whether the
+household's stored explanation came from a child other than the id-min child who answered
+the gate Yes. Measured 2026: **0 of 30** and **0 of 45** households have a stored
+explanation from a child who did not themselves answer the gate Yes. Their residual defect
+is narrative **loss** — an answering child's explanation can still be dropped in favor of
+another answering child's — not splice; the loss is kindred#2255.
+
+**The highest actual stored splice is CPAP 2025 at 33.3% (13 of 39), not the ~38% the
+Bathroom row implies if all four rows are read as one measurement.** Housing Accommodation
+and Bathroom have 2026-only rows because their derived columns have only ever been computed
+for 2026.
 
 **Design rule that follows:** a gate and its explain must stay bound to the same person
 through any transform. In a per-answer layer that is automatic. In any household rollup it
-has to be explicit — collapse the *pair*, never the two fields independently.
+has to be explicit — collapse the *pair*, never the two fields independently. This is a rule
+about **not selecting a winner**, not about the two fields sitting next to each other on the
+form — so a future change that gives a gate its own column does not, by itself, satisfy it
+unless the collapse rule for both halves moves together, in the same change, from
+first-non-empty-wins to something that never picks a winner.
 
 The special-occasion pair is the first one collapsed that way (2026-08-13,
 `registrationText.specialOccasions` in `family_camp_registration_text.go`): the two fields
 are accumulated per answering person and deduplicated as one unit, so one parent's answer
 fanned onto three children still collapses to a single value while two members who each
-answered keep both explanations beside the gate that member gave. The other four pairs in
-the table above still collapse independently in `processMedical` — that is kindred#2255.
+answered keep both explanations beside the gate that member gave. The other four pairs
+measured above (Special Needs, CPAP, Housing Accommodation, Bathroom) still collapse
+independently in `processMedical` — that is kindred#2255. Allergies, Dietary Needs and
+`Family Camp-Physician ` (added to the pair table above but not separately measured here)
+are the same gate/explain shape on the same medical forms; Adult-Bathroom's collapse
+behavior has not been measured here either.
 
 ---
 

--- a/docs/reference/family-camp-grain-collapse.md
+++ b/docs/reference/family-camp-grain-collapse.md
@@ -242,11 +242,24 @@ every site above. Both `#2255` and `#2275` name it.
    probe belongs.
 3. **Re-derive the three existing tables** from the new person tables rather than from
    `personValues`, adding dedup-and-join plus a single `answer_conflicts` JSON array naming
-   which fields disagreed — one column, not four booleans, so adding a field later needs no
-   migration. `#2255` and `#2275` close here. **`#2274` did not wait for step 2** — it closed
-   2026-08-13 by adding the dedup-and-join directly to `processRegistrations`, since its six
-   columns are plain free text with no gate/narrative split to unpick. Step 0 shipped with it:
-   `customValueEntry` now carries `personPBID`.
+   which free-text fields disagreed — one column, not four booleans, so adding a field later
+   needs no migration. **`answer_conflicts` and #2255's per-gate boolean columns are different
+   things, not competing proposals for the same slot:** a conflict entry is a *signal* — "these
+   answers disagreed" — while a gate column is a *value* — what the household's stored answer
+   to that gate actually is. A table can carry both at once, and neither substitutes for the
+   other; read them as contradictory only if you assume there is one JSON-or-columns decision
+   to make, and there is not. `#2275` closes here.
+
+   **`#2255` does not wait for step 2 or this step.** Like `#2274`, it ships its fix directly
+   against the existing collapse function rather than through the per-answer dual-write table
+   this step's ordering implies: it makes each medical gate column nullable (three states —
+   answered Yes, answered No, never reached that question block, since families reach
+   different question blocks rather than uniformly declining) and binds each gate to its
+   explain as one non-selecting collapse in `processMedical` — the same "bind the pair, never
+   select" rule `#2274` applied to `processRegistrations`. **`#2274` did not wait for step 2
+   either** — it closed 2026-08-13 by adding the dedup-and-join directly to
+   `processRegistrations`, since its six columns are plain free text with no gate/narrative
+   split to unpick. Step 0 shipped with it: `customValueEntry` now carries `personPBID`.
 4. **Add `session_cm_id`** to `family_camp_registrations`. **The grain triple must move in
    one PR:** the write key in `upsertRegistrations`, the orphan key `ProcessedRegKeys`
    (`family_camp_derived.go:45`), and `idx_fc_reg_unique` (migration `1500000035:288`).

--- a/docs/reference/family-camp-grain-collapse.md
+++ b/docs/reference/family-camp-grain-collapse.md
@@ -243,7 +243,7 @@ every site above. Both `#2255` and `#2275` name it.
 3. **Re-derive the three existing tables** from the new person tables rather than from
    `personValues`, adding dedup-and-join plus a single `answer_conflicts` JSON array naming
    which free-text fields disagreed — one column, not four booleans, so adding a field later
-   needs no migration. **`answer_conflicts` and #2255's per-gate boolean columns are different
+   needs no migration. **`answer_conflicts` and `#2255`'s per-gate columns are different
    things, not competing proposals for the same slot:** a conflict entry is a *signal* — "these
    answers disagreed" — while a gate column is a *value* — what the household's stored answer
    to that gate actually is. A table can carry both at once, and neither substitutes for the


### PR DESCRIPTION
## What

Two reference-doc corrections, per the family-camp phase-C master doc's §6 edit list
(`docs/plans/2026-08-14-family-camp-phase-c-master.md`, local-only — not in this diff).
No code, no closing keyword: this PR closes nothing.

### `docs/reference/family-camp-field-provenance.md` §4

**The defect, with its measured number.** §4's gate/explain splice table was headed as
measuring "stored gate and stored explanation" for all four of its rows, but for two of
them — Housing Accommodation and Bathroom — there is no stored gate string at all:
both gates are collapsed to household-wide OR booleans by `processRegistrations`, and
`family_camp_medical` stores no gate column for either. That let the doc imply the splice
reaches Bathroom's 37.8% (~38%) as if it were the same measurement as the other rows. The
highest **measured stored** splice is CPAP 2025 at **33.3% (13 of 39)**.

**The fix:**

- Retitled the measurement to what it actually counts — "id-min gate row and id-min
  explain row belong to different children" — instead of implying every row has a stored
  gate.
- Scoped the "worse than losing a sibling's text" splice framing to Special Needs and
  CPAP *of the four rows above*, and named the mechanism: those two concatenate a stored
  gate string with a stored explanation in `processMedical`.
- Added the Housing Accommodation / Bathroom caveat, stating winner provenance and harm
  as two separate quantities so the second does not read as replacing the first: winner
  provenance is the table's 11 / 30 and 17 / 45; harm — a stored explanation from a child
  who did not themselves answer the gate Yes — is **0 of 30** and **0 of 45** for 2026,
  and is zero structurally. Their residual defect is narrative *loss*, not splice —
  kindred#2255 (mentioned, not closed).
- Extended the gate/explain pair table from 5 rows to 9: `Adult-Bathroom` (274053) /
  `Bathroom-Yes` (274054), `Family Medical-Allergies` (36870) / `Family Medical-Allergy
  Info` (36871), `Family Medical-Dietary Needs` (36872) / `Family Medical-Dietary Explain`
  (36873), and `Family Camp-Physician ` (39680, trailing space — not a typo) / `Family
  Camp-Physician If Yes` (39681).
- Noted that Allergies, Dietary Needs and `Family Camp-Physician ` are not merely the same
  shape on the form — `processMedical` concatenates each one's stored gate string with its
  stored explanation exactly as it does for Special Needs and CPAP, so they are in the same
  splice class even though they are not measured in that table.
- Kept the "collapse the pair, never the two fields independently" design rule verbatim,
  and added one sentence: it's a rule about *not selecting a winner*, not about textual
  adjacency on the form, so a future change that gives a gate its own nullable column
  doesn't satisfy the rule on its own — both halves have to move together.

**What this deliberately does NOT do:** it does not add splice percentages for the four
newly-added pairs to the 2024/2025/2026 measurement table. Master §6 specified extending
the *pair* table with cm_ids, not new percentages. The scan stage did measure Allergies,
Dietary and Physician out-of-band to test the ceiling claim — all three come in below CPAP
2025 — but those denominators are camp-wide medical answers rather than family-camp
households, so they are not comparable with the rows already in the table and were left
out of it.

### `docs/reference/family-camp-grain-collapse.md`

**The defect.** The recommended-order section's step numbering read as if `#2255` were
gated behind step 2 (an unbuilt per-answer dual-write table), even though the doc's own
issue map records that `#2274` — the sibling issue sharing the same mechanism — shipped
directly against `processRegistrations` on 2026-08-13 without waiting for step 2. Left
uncorrected, the next reader implements `#2255` against a table that isn't being built.
Separately, the doc's `answer_conflicts` JSON proposal (step 3) and `#2255`'s per-gate
columns read as competing designs for the same slot, when they're different things.

**The fix:**

- Stated explicitly that `#2255` does not wait for step 2 or step 3 — like `#2274`, it
  ships directly against `processMedical`, making each medical gate column nullable
  (three states) and binding gate to explain as one non-selecting collapse, the same
  "bind the pair, never select" rule `#2274` already applied.
- Reconciled `answer_conflicts` against `#2255`'s gate columns: a conflict entry is a
  *signal* ("these answers disagreed"), a gate column is a *value* (what the household's
  answer actually is). A table can carry both; they aren't alternatives. The columns are
  described as per-gate columns rather than booleans, because the same paragraph rules
  them nullable with three states and two-state-versus-three-state is the one-shot schema
  decision behind `#2255`.

**What this deliberately does NOT do:** it does not touch `#2275`'s "closes here" framing.
Master §6 only asked for `#2255`'s ordering, and nothing in the master doc says `#2275`
also bypasses step 2/3, so that claim is left as-is rather than extending an unverified
correction to a second issue.

## Verification

- All nine gate/explain pairs in the table were confirmed cm_id → name against
  `custom_field_defs`, including the trailing space on 39680. In the source tree only two
  of the four newly-added pairs appear by cm_id — `Adult-Bathroom` / `Bathroom-Yes`
  (`pocketbase/sync/lodging_fields.go:69`, `family_camp_derived.go:493-494`) and the
  Physician pair (`family_camp_derived_test.go:1356-1357`); the Allergies and Dietary
  fields are routed by display name in `camper_dietary.go` and carry no cm_id in code.
- Every cell of the §4 measurement table was reproduced independently from
  `person_custom_values` using the same id-min rule the code applies (values loaded sorted
  by `id`, first non-empty wins): Special Needs 7/66, 11/66, 2/40; CPAP 9/36, 13/39, 2/20;
  Housing Accommodation 11/30; Bathroom 17/45. The 0 of 30 and 0 of 45 harm figures
  reproduce on the same denominators.
- `./node_modules/.bin/markdownlint-cli2` on both files: 0 issues, and markdownlint runs
  again in the pre-commit and pre-push hooks — clean in all three.
