### PR TITLE
fix(sync): stop counting a failed orphan delete as a deletion

### DIFF
--- a/pocketbase/main_test_parallelism_test.go
+++ b/pocketbase/main_test_parallelism_test.go
@@ -128,6 +128,29 @@ var serialGroups = []struct {
 		},
 	},
 	{
+		// captureSweepLogs (orphan_sweep_test.go) swaps slog's default handler,
+		// which is process-global -- the exact second reason this list exists,
+		// and the same one already recorded for lodging's captureLogs below.
+		//
+		// It slipped through because slog.SetDefault is internally atomic, so
+		// -race sees nothing: the corruption is logical, not a data race. Two
+		// of these tests assert on the ABSENCE of a log line, so a parallel
+		// sibling that grabs the global mid-run writes its output into the
+		// wrong buffer and the assertion reads someone else's sweep. Measured
+		// on `go test ./sync/ -run TestBaseDeleteOrphans`: 2 failures in 12
+		// runs with three parallel capturers, 0 in 36 with these serial.
+		pkg:    "sync",
+		reason: "captureSweepLogs swaps the process-global slog default",
+		tests: []string{
+			"TestBaseDeleteOrphansCountsOnlyCompletedDeletes",
+			"TestBaseDeleteOrphansFromPreloadedCountsOnlyCompletedDeletes",
+			"TestBaseDeleteOrphansWarnsWhenNothingCanBeKeyed",
+			"TestIsDuplicateStaffStatus",
+			"TestLoadPersonCustomValuesCountsAndLogsUnmappedFields",
+			"TestLoadPersonCustomValuesNoDiscardsMeansNoWarnLog",
+		},
+	},
+	{
 		// registryBasePath / registryAbsoluteRoots (lodging/registry.go) are
 		// the only true data races the detector found when the whole tree was
 		// made parallel at once: withRegistryBasePath writes them, and every

--- a/pocketbase/sync/base_sync.go
+++ b/pocketbase/sync/base_sync.go
@@ -461,14 +461,17 @@ func (b *BaseSyncService) DeleteOrphansFromPreloaded(
 			continue
 		}
 		if !b.ProcessedKeys[keyStr] {
-			orphanCount++
 			name := b.getRecordName(record, entityName)
 			slog.Info("Deleting orphaned record", "entity", entityName, "name", name, "key", keyStr)
 
+			// Counted AFTER the delete lands. A failed delete leaves the row on disk,
+			// and reporting it as deleted tells an operator the opposite of the truth.
 			if err := b.App.Delete(record); err != nil {
 				slog.Error("Failed to delete orphaned record", "entity", entityName, "key", keyStr, "error", err)
 				b.Stats.Errors++
+				continue
 			}
+			orphanCount++
 		}
 	}
 

--- a/pocketbase/sync/camper_transportation_test.go
+++ b/pocketbase/sync/camper_transportation_test.go
@@ -789,7 +789,6 @@ func addPersonCustomValue(t *testing.T, app core.App, fieldDefID, personPBID, va
 // never been told about -- the signal that matters if CampMinder ever adds a
 // new "BUS-*" field).
 func TestLoadPersonCustomValuesCountsAndLogsUnmappedFields(t *testing.T) {
-	t.Parallel()
 	app := newTransportValuesTestApp(t)
 
 	personsCol, err := app.FindCollectionByNameOrId("persons")
@@ -862,7 +861,6 @@ func TestLoadPersonCustomValuesCountsAndLogsUnmappedFields(t *testing.T) {
 // all and must leave Stats.Skipped at zero, matching the actual 2021+ data
 // (kindred#2272 measured zero discards in every year since 2021).
 func TestLoadPersonCustomValuesNoDiscardsMeansNoWarnLog(t *testing.T) {
-	t.Parallel()
 	app := newTransportValuesTestApp(t)
 
 	personsCol, err := app.FindCollectionByNameOrId("persons")

--- a/pocketbase/sync/orphan_sweep_test.go
+++ b/pocketbase/sync/orphan_sweep_test.go
@@ -402,6 +402,59 @@ func TestBaseDeleteOrphansCountsOnlyCompletedDeletes(t *testing.T) {
 	}
 }
 
+// orphanCount is what the completion log reports as deleted, same property as
+// TestBaseDeleteOrphansCountsOnlyCompletedDeletes above but for the preloaded
+// entry point (kindred#2302) -- financial_transactions is the one production
+// caller. A delete that FAILS must not be counted: the row is still on disk.
+func TestBaseDeleteOrphansFromPreloadedCountsOnlyCompletedDeletes(t *testing.T) {
+	t.Parallel()
+	app := newOrphanSweepTestApp(t, "widgets", "name")
+	widgets, err := app.FindCollectionByNameOrId("widgets")
+	if err != nil {
+		t.Fatalf("find widgets: %v", err)
+	}
+
+	orphan := core.NewRecord(widgets)
+	orphan.Id = orphanTestID(1)
+	orphan.Set("name", "widget-001")
+	orphan.Set("year", 2026)
+	if saveErr := app.Save(orphan); saveErr != nil {
+		t.Fatalf("seed orphan: %v", saveErr)
+	}
+
+	// A non-cascading relation pointing at the orphan blocks its deletion.
+	holders := core.NewBaseCollection("holders")
+	holders.Fields.Add(&core.RelationField{
+		Name: "widget", CollectionId: widgets.Id, CascadeDelete: false, Required: true,
+	})
+	if saveErr := app.Save(holders); saveErr != nil {
+		t.Fatalf("save holders: %v", saveErr)
+	}
+	holder := core.NewRecord(holders)
+	holder.Set("widget", orphan.Id)
+	if saveErr := app.Save(holder); saveErr != nil {
+		t.Fatalf("seed holder: %v", saveErr)
+	}
+
+	logs := captureSweepLogs(t)
+
+	b := BaseSyncService{App: app, ProcessedKeys: map[string]bool{}, SyncSuccessful: true}
+	preloaded := map[any]*core.Record{orphan.Id: orphan}
+	if sweepErr := b.DeleteOrphansFromPreloaded(preloaded, "widget"); sweepErr != nil {
+		t.Fatalf("sweep returned an error: %v", sweepErr)
+	}
+
+	// The row must still be there -- otherwise the fixture did not block anything
+	// and the assertion below would pass for the wrong reason.
+	if _, findErr := app.FindRecordById("widgets", orphan.Id); findErr != nil {
+		t.Fatalf("fixture is wrong: the delete was not blocked (%v)", findErr)
+	}
+
+	if got := logs.String(); strings.Contains(got, "Deleted orphaned records") {
+		t.Errorf("a failed delete was counted as deleted; got:\n%s", got)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // The scan must not mint a new filter string per page (kindred#2279 follow-up)
 // ---------------------------------------------------------------------------

--- a/pocketbase/sync/orphan_sweep_test.go
+++ b/pocketbase/sync/orphan_sweep_test.go
@@ -282,6 +282,12 @@ func TestBaseDeleteOrphansDeletesNothingWhenNoRecordCanBeKeyed(t *testing.T) {
 // captureSweepLogs redirects slog for the duration of one test and returns the
 // buffer. The sweep's only operator-facing signal is its log line, so the log IS
 // the behavior under test here, not an incidental side effect.
+//
+// A caller MUST NOT be parallel. slog's default handler is process-global, so a
+// parallel sibling swaps it mid-run and the buffer fills with someone else's
+// output. -race does not catch it (slog.SetDefault is internally atomic), so the
+// guard in main_test_parallelism_test.go carries the list instead -- add any new
+// caller there and leave t.Parallel() off.
 func captureSweepLogs(t *testing.T) *strings.Builder {
 	t.Helper()
 
@@ -300,7 +306,6 @@ func captureSweepLogs(t *testing.T) *strings.Builder {
 // (attendees, bunk_assignments, bunk_plans) tell the reader to look for an
 // unkeyable-record warning, so one has to exist.
 func TestBaseDeleteOrphansWarnsWhenNothingCanBeKeyed(t *testing.T) {
-	t.Parallel()
 	const seeded = 30
 
 	app := newOrphanSweepTestApp(t, "widgets", "name")
@@ -350,7 +355,6 @@ func TestBaseDeleteOrphansWarnsWhenNothingCanBeKeyed(t *testing.T) {
 // told the opposite of the truth. A blocking relation is the cheapest way to
 // make App.Delete fail for real rather than mocking it.
 func TestBaseDeleteOrphansCountsOnlyCompletedDeletes(t *testing.T) {
-	t.Parallel()
 	app := newOrphanSweepTestApp(t, "widgets", "name")
 	widgets, err := app.FindCollectionByNameOrId("widgets")
 	if err != nil {
@@ -407,7 +411,6 @@ func TestBaseDeleteOrphansCountsOnlyCompletedDeletes(t *testing.T) {
 // entry point (kindred#2302) -- financial_transactions is the one production
 // caller. A delete that FAILS must not be counted: the row is still on disk.
 func TestBaseDeleteOrphansFromPreloadedCountsOnlyCompletedDeletes(t *testing.T) {
-	t.Parallel()
 	app := newOrphanSweepTestApp(t, "widgets", "name")
 	widgets, err := app.FindCollectionByNameOrId("widgets")
 	if err != nil {
@@ -450,7 +453,21 @@ func TestBaseDeleteOrphansFromPreloadedCountsOnlyCompletedDeletes(t *testing.T) 
 		t.Fatalf("fixture is wrong: the delete was not blocked (%v)", findErr)
 	}
 
-	if got := logs.String(); strings.Contains(got, "Deleted orphaned records") {
+	got := logs.String()
+
+	// Positive half first. Without it the assertion below is satisfied by a sweep
+	// that returned early and never reached App.Delete at all -- a future guard
+	// added ahead of the loop would leave this test green while pinning nothing.
+	if !strings.Contains(got, "Failed to delete orphaned record") {
+		t.Fatalf("the delete was never attempted, so the count assertion proves nothing; got:\n%s", got)
+	}
+	// kindred#2302 scope item 3: the two counters must tell one story. The row is
+	// not counted as deleted, and the same row IS counted as an error.
+	if b.Stats.Errors != 1 {
+		t.Errorf("Stats.Errors = %d, want 1 -- a failed delete must still fail the run", b.Stats.Errors)
+	}
+
+	if strings.Contains(got, "Deleted orphaned records") {
 		t.Errorf("a failed delete was counted as deleted; got:\n%s", got)
 	}
 }

--- a/pocketbase/sync/staff_test.go
+++ b/pocketbase/sync/staff_test.go
@@ -143,7 +143,6 @@ func TestAllStaffStatuses(t *testing.T) {
 // syncStaff ("no matching person"), which already does both -- this test is the mirror of
 // that precedent.
 func TestIsDuplicateStaffStatus(t *testing.T) {
-	t.Parallel()
 	s := &StaffSync{BaseSyncService: BaseSyncService{ProcessedKeys: map[string]bool{}}}
 	buf := captureSweepLogs(t)
 


### PR DESCRIPTION
## Defect

`BaseSyncService.DeleteOrphansFromPreloaded` incremented its local `orphanCount`
before attempting `App.Delete`, and never backed it out on failure. A run in
which every delete was rejected still logged `"Deleted orphaned records"
count=N` for a summary line that had deleted nothing.

Per the corrected issue body: the miscounted value is only the local
`orphanCount` (base_sync.go:457 as of main @ 3eb44ba4), whose sole consumer is
the summary log line at :476. `Stats.Deleted` is never written by
`DeleteOrphansFromPreloaded` (nor by `deleteOrphans`), so the Sync tab,
`sync_runs.deleted_count`, and the run's pass/fail verdict were never affected.
The net effect was one dishonest log line, printed next to N "Failed to delete
orphaned record" errors, on a run that already fails because each failure also
increments `Stats.Errors`.

## Fix

Moved the increment to after a successful delete, matching the shape already
settled in `deleteOrphans` (base_sync.go:325-330, from kindred#2285 /
kindred#2296): log, `Stats.Errors++`, `continue`, and only then `orphanCount++`.

Added `TestBaseDeleteOrphansFromPreloadedCountsOnlyCompletedDeletes`, modeled on
the existing sibling `TestBaseDeleteOrphansCountsOnlyCompletedDeletes`: a
blocking relation makes `App.Delete` fail for real, and the test asserts the
"Deleted orphaned records" log line is never emitted for a row that is still on
disk. It also pins scope item 3 of the issue — the same row that is not counted
as deleted IS counted in `Stats.Errors`, so the two counters tell one story —
and asserts the "Failed to delete orphaned record" line is present, so the
negative assertion cannot be satisfied by a sweep that returned early and never
reached `App.Delete` at all.

Mutation-checked twice, each read by exit code: restoring the pre-increment
fails the test (`a failed delete was counted as deleted`), and dropping
`Stats.Errors++` fails it (`Stats.Errors = 0, want 1`). The shipped code passes.

## Also in this diff: a test flake the new test would otherwise have shipped

`captureSweepLogs` swaps slog's **process-global** default handler, while all
six of its callers ran `t.Parallel()`. Everything a parallel sibling logs
therefore lands in whichever buffer is installed at that instant — the polluter
does not have to be another capturer, it only has to log — and two of these
tests assert on the *absence* of a line, which is exactly the assertion that
contamination breaks. `-race` never flagged it, because `slog.SetDefault` is
internally atomic: the corruption is logical, not a data race.

Serialising the six capturers is a complete remedy even so, not merely a
narrower one: Go runs every non-parallel test to completion before releasing any
parallel test, so nothing else in the package is running while the global is
swapped.

Adding a third parallel capturer to `orphan_sweep_test.go` tipped it from latent
to reproducible. Measured with `go test ./sync/ -run TestBaseDeleteOrphans -count=1`:

| tree | failures |
| --- | --- |
| main, 2 parallel capturers | 0 / 36 |
| this branch before the fix, 3 | 2 / 12 |
| this branch after the fix | 0 / 15 |

One of those two failures was the new test itself going red against the
*correct* implementation — a false red headed straight for CI.

The remedy is the one the repo already applies to the identical hazard in
`lodging/`: drop `t.Parallel()` from the six `captureSweepLogs` callers and
record them in `serialGroups` in `main_test_parallelism_test.go`, under that
list's own second sanctioned reason ("a package-level variable the test swaps").
`captureSweepLogs`'s doc comment now states the constraint at the helper, so the
next caller does not have to rediscover it.

## What this deliberately does not touch

- `Stats.Deleted` — never written by this function; out of scope.
- The sibling `deleteOrphans`'s counting behaviour — already corrected in
  kindred#2285 / kindred#2296; this PR only brings `DeleteOrphansFromPreloaded`
  in line with that shape.
- The summary line's `else` branch, which now logs "No orphaned records found"
  on a run where an orphan *was* found but could not be deleted. That is a
  second, milder wrong log line; it is identical in `deleteOrphans` today, and
  correcting it here alone would re-create the very divergence this issue exists
  to remove. Left deliberately, with the ERROR line for the failed delete
  sitting directly above it.

Closes #2302.

