### PR TITLE
fix(frontend): hide cancelled weekends from the roster page switcher

### DIFF
--- a/frontend/src/pages/WeekendRosterPage.test.tsx
+++ b/frontend/src/pages/WeekendRosterPage.test.tsx
@@ -356,6 +356,50 @@ describe('header', () => {
   })
 })
 
+describe('the switcher and cancelled weekends (kindred#2333)', () => {
+  // Staff-owned, no CampMinder equivalent (kindred#2092). Absence of a status
+  // row — every fixture above this point — and an explicit `'active'` both
+  // mean the same thing, and only `'cancelled'` is a claim.
+  const WOMENS_CANCELLED = { ...WOMENS, status: 'cancelled' }
+
+  it('omits a cancelled weekend from the switcher options', async () => {
+    sessionsQuery.data = { year: 2026, sessions: [FAMILY_CAMP_1, WOMENS_CANCELLED] }
+    renderPage()
+    await userEvent.click(screen.getByRole('button', { name: /Family Camp 1/ }))
+    const options = (await screen.findAllByRole('option')).map((o) => o.textContent)
+    expect(options).toEqual(['Family Camp 1'])
+  })
+
+  it('still offers a weekend with no status row, or an explicit active status', async () => {
+    const FAMILY_CAMP_1_ACTIVE = { ...FAMILY_CAMP_1, status: 'active' }
+    sessionsQuery.data = { year: 2026, sessions: [FAMILY_CAMP_1_ACTIVE, WOMENS] }
+    renderPage()
+    await userEvent.click(screen.getByRole('button', { name: /Family Camp 1/ }))
+    const options = (await screen.findAllByRole('option')).map((o) => o.textContent)
+    expect(options).toEqual(['Family Camp 1', "Women's Weekend"])
+  })
+
+  it('still lists the cancelled weekend you are currently viewing, in its own switcher', async () => {
+    // Otherwise the control has a `value` matching no `option` — the one case
+    // where a cancelled entry belongs in the list.
+    sessionsQuery.data = { year: 2026, sessions: [FAMILY_CAMP_1, WOMENS_CANCELLED] }
+    rosterQuery.data = { year: 2026, session_cm_id: 1000002, parties: [], units: [], counts: {} }
+    renderPage('1000002')
+    expect(screen.getByRole('button', { name: /Women's Weekend/ })).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: /Women's Weekend/ }))
+    const options = (await screen.findAllByRole('option')).map((o) => o.textContent)
+    expect(options).toEqual(['Family Camp 1', "Women's Weekend"])
+  })
+
+  it('still reaches a cancelled weekend directly by URL', () => {
+    sessionsQuery.data = { year: 2026, sessions: [FAMILY_CAMP_1, WOMENS_CANCELLED] }
+    rosterQuery.data = { year: 2026, session_cm_id: 1000002, parties: [], units: [], counts: {} }
+    renderPage('1000002')
+    expect(screen.queryByRole('button', { name: /Weekend not found/ })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Women's Weekend/ })).toBeInTheDocument()
+  })
+})
+
 describe('query states', () => {
   it('shows the loading state while the roster loads', () => {
     rosterQuery.data = undefined

--- a/frontend/src/pages/WeekendRosterPage.tsx
+++ b/frontend/src/pages/WeekendRosterPage.tsx
@@ -177,6 +177,26 @@ export default function WeekendRosterPage() {
 
   const selectedSession = sessions.find((session) => session.session_cm_id === selectedCmId)
 
+  // The switcher must not OFFER a cancelled weekend (kindred#2333) — it stays
+  // reachable by URL and still resolves `selectedSession` above from the full
+  // `sessions` list, this filters only what the picker lists as destinations.
+  //
+  // Two things this deliberately does NOT do:
+  //  - Filter on `status === 'active'`. `status` is staff-owned with no
+  //    CampMinder equivalent (kindred#2092); its absence IS "active" (the
+  //    migration seeds no row), so a positive check would empty the switcher
+  //    of every weekend nobody has ever touched the status page for.
+  //  - Drop `completed` weekends too. Staff plausibly switch into a finished
+  //    weekend to look something up, which isn't true of a cancelled one —
+  //    left visible on purpose, not an oversight.
+  //
+  // The weekend you are CURRENTLY viewing is the one exception: if it is
+  // itself cancelled it stays in this list, or the control would carry a
+  // `value` matching no `option` and read as "Weekend not found".
+  const switcherSessions = sessions.filter(
+    (session) => session.status !== 'cancelled' || session.session_cm_id === selectedCmId
+  )
+
   // Memoised on the payload, not left to run per render. The `?? []` fallbacks
   // are inside the memo on purpose: a bare `?? []` mints a new array every
   // render while the roster is loading, which would defeat every dependency
@@ -270,7 +290,10 @@ export default function WeekendRosterPage() {
                     : 'Weekend not found'
               }
               value={selectedSession ? weekendRef(selectedSession, sessions) : ''}
-              options={sessions.map((session) => ({
+              options={switcherSessions.map((session) => ({
+                // Disambiguated against the FULL list, not `switcherSessions`
+                // — a slug's uniqueness must not shift depending on which
+                // other weekends happen to be cancelled this season.
                 value: weekendRef(session, sessions),
                 label: shortWeekendName(session.name),
               }))}


### PR DESCRIPTION
The weekend switcher in `WeekendRosterPage.tsx` built its options straight from the session list
with no status predicate, so a weekend staff marked `cancelled` was offered as a destination
alongside every active one. The landing page (`WeekendSessionList.tsx`) already treats
`status === 'cancelled'` as "nothing to do here" and groups it separately; this brought the
switcher in line with it.

## Fix

`WeekendRosterPage.tsx` now derives a `switcherSessions` list — `sessions` filtered to
`status !== 'cancelled'` — and passes that to the `TitleSwitcher`'s `options`, instead of the raw
`sessions` list. Two things preserved deliberately:

- The currently-viewed weekend is always kept in `switcherSessions`, even if it is itself
  cancelled — otherwise the control's `value` would match no `option` and read as "Weekend not
  found" for the one weekend you're actually looking at.
- `weekendRef(session, sessions)` is still computed against the full, unfiltered `sessions` list
  (not `switcherSessions`), so a weekend's slug disambiguation never shifts depending on which
  other weekends happen to be cancelled.

`selectedSession`, `resolveWeekendRef`, and everything else on the page still read the full
`sessions` list — only the switcher's option set changed. A cancelled weekend therefore stays
reachable by direct URL, and the landing page's own grouping/badging is untouched.

## The trap avoided

`status` is staff-owned with no CampMinder equivalent (kindred#2092). Absence of a status row *is*
"active" — the migration seeds nothing — so filtering on `status === 'active'` would have emptied
the switcher of nearly every weekend. The filter here is `status !== 'cancelled'`, matching the
same predicate `weekendStatus()` already uses to sort a weekend into the landing page's cancelled
group.

## What I deliberately did not do

The decision kindred#2333 asks for, on its own reasoning rather than any wider policy:
**`completed` weekends stay visible** in the switcher. Staff plausibly switch into a finished
weekend to look something up, which isn't true of a cancelled one — this PR filters only
`cancelled`, not `completed`, and does not add a toggle for either.

## Testing

Added a `describe` block to `WeekendRosterPage.test.tsx` covering:
- a cancelled weekend is omitted from the switcher's options
- a weekend with no status row, or an explicit `status: 'active'`, still appears
- the weekend currently being viewed still appears in its own switcher even when cancelled
- a cancelled weekend is still directly reachable by URL (no "Weekend not found")

Written first and confirmed failing (`AssertionError: expected [ 'Family Camp 1', 'Women\'s
Weekend' ] to deeply equal [ 'Family Camp 1' ]`) before the fix; mutation-checked by reverting the
filter to `() => true` and confirming the same test goes red again.

```
cd frontend && ./node_modules/.bin/vitest run src/pages/WeekendRosterPage.test.tsx
# 41 passed
```

Closes #2333.

