### PR TITLE
fix(frontend): explain the always-empty infant chip on pre-2026 years

### DIFF
--- a/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
@@ -1078,6 +1078,29 @@ describe('HouseholdRosterTable — filters by housing need (kindred#2251)', () =
     // zero-match empty state with no context.
     render(<HouseholdRosterTable year={2024} parties={[noNeedsFamily]} />, { wrapper })
     await userEvent.click(screen.getByRole('button', { name: 'Infant in party' }))
+    expect(screen.getByText(/missing data/i)).toBeInTheDocument()
+  })
+
+  it('names the infant question in that caveat, not the bathroom/power one it did not filter on', async () => {
+    // Routing infant through the banner is only worth anything if the banner
+    // says something true about infants. The bathroom/power sentence is both
+    // irrelevant to a click on this chip and wrong about it -- has_infant is
+    // 0 in 2026 as well, so "only recorded starting the 2026 season" does not
+    // describe this flag at any year.
+    render(<HouseholdRosterTable year={2024} parties={[noNeedsFamily]} />, { wrapper })
+    await userEvent.click(screen.getByRole('button', { name: 'Infant in party' }))
+    const caveat = screen.getByText(/missing data/i)
+    expect(caveat.textContent).toMatch(/infant/i)
+    expect(caveat.textContent).not.toMatch(/private bathroom/i)
+  })
+
+  it('keeps the bathroom/power caveat wording when one of those is selected alongside infant', async () => {
+    // The 2026-column sentence is the approved copy for the flags it was
+    // written for, and stays exactly as it shipped whenever one of them is
+    // active -- the infant branch must not swallow it.
+    render(<HouseholdRosterTable year={2024} parties={[noNeedsFamily]} />, { wrapper })
+    await userEvent.click(screen.getByRole('button', { name: 'Power' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Infant in party' }))
     expect(screen.getByText(/2026 season/)).toBeInTheDocument()
   })
 

--- a/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
@@ -1070,6 +1070,17 @@ describe('HouseholdRosterTable — filters by housing need (kindred#2251)', () =
     expect(screen.getByText(/missing data/i)).toBeInTheDocument()
   })
 
+  it('warns that the infant chip has no historical data either, since it can only ever be empty (kindred#2251 D18)', async () => {
+    // D18: has_infant is 0 on all 3,923 family_camp_registrations rows across
+    // all ten years -- the chip is a permanent no-match, not a bathroom/power-
+    // style 2026-only gap. Folding it into the same caveat set means a pre-
+    // 2026 click explains itself instead of silently landing on the generic
+    // zero-match empty state with no context.
+    render(<HouseholdRosterTable year={2024} parties={[noNeedsFamily]} />, { wrapper })
+    await userEvent.click(screen.getByRole('button', { name: 'Infant in party' }))
+    expect(screen.getByText(/2026 season/)).toBeInTheDocument()
+  })
+
   it('warns on a historical season even when the OR filter still finds matches', async () => {
     // The caveat is about the BATHROOM/POWER signal specifically, which is
     // silently incomplete even when the combined OR result is non-empty.

--- a/frontend/src/components/weekend/HouseholdRosterTable.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.tsx
@@ -29,18 +29,22 @@ import { attentionSections, indexUnitsByCode, resolvePartyUnit } from './rosterA
  * Camp-Accommodation" generation), so it carries real, if sparser, historical
  * signal.
  *
- * `infant`, by contrast, is IN this set (kindred#2251 ruling D18, re-measured
- * 2026-08-13): `has_infant` is `0` on all 3,923 `family_camp_registrations`
- * rows across all ten years 2017-2026, so `flags.has_infant` is false on
- * every party the API can emit and the chip can only ever land on the
- * zero-match empty state. It is not a 2026-only-column gap like bathroom and
- * power — the underlying raw field (`Adult-Infant`, cm_id 257248) is answered
- * exclusively by `session_type='adult'` attendees, so on family weekends it
- * is dead by construction, and even on 2026 adult weekends every answer so
- * far reads "No" or an unrelated write-in. There is no true row to surface at
- * any year, which is what routes it through the same pre-2026 caveat as
- * bathroom/power rather than treating it as a normal filter with a real,
- * if currently zero, result.
+ * `infant`, by contrast, is IN this set (kindred#2251 ruling D18). In the
+ * production snapshot `has_infant` is `0` on all 3,923
+ * `family_camp_registrations` rows across all ten years 2017-2026, so
+ * `flags.has_infant` is false on every party the API can emit there and the
+ * chip lands on the zero-match empty state. The cause is not a 2026-only
+ * column the way bathroom/power are — the underlying raw field
+ * (`Adult-Infant`, cm_id 257248) is answered exclusively by
+ * `session_type='adult'` attendees, so on family weekends it is dead by
+ * construction, and every 2026 adult-weekend answer so far reads "No" or an
+ * unrelated write-in.
+ *
+ * Deliberately NOT stated as "no true row exists at any year": a local 2025
+ * replay derives exactly 3 true rows (all adult-session), and some dev
+ * databases carry one, so the banner copy below is scoped to the pre-2026
+ * seasons this set already gates on rather than claiming the filter can
+ * never match anything.
  */
 const NEEDS_DATA_FIRST_YEAR = 2026
 const HISTORICAL_GAP_KEYS: ReadonlySet<NeedFilterKey> = new Set(['bathroom', 'power', 'infant'])
@@ -167,16 +171,23 @@ export function HouseholdRosterTable({
   const showRequests = hasAnyRequest(parties)
 
   // needs_private_bathroom/needs_power are 0 for every pre-2026 row (Trap 1 /
-  // D2 — see the constant above), and has_infant is 0 for EVERY row at any
-  // year (kindred#2251 D18), so an empty or thin result here can read as
-  // "nobody needed it" when the true answer is "we never asked" (or, for
-  // infant, "this can never surface a match"). Shown whenever any gap flag is
-  // part of the ACTIVE filter on a season before the data exists, even if the
-  // OR combination still finds matches through a different flag — the gapped
-  // signal itself stays silently incomplete in that result too.
-  const showHistoricalGapWarning =
-    year < NEEDS_DATA_FIRST_YEAR &&
-    activeNeeds.some((option) => HISTORICAL_GAP_KEYS.has(option.key))
+  // D2 — see the constant above), and has_infant is 0 for every pre-2026 row
+  // as well (kindred#2251 D18), so an empty or thin result here can read as
+  // "nobody needed it" when the true answer is "we never asked". Shown
+  // whenever any gap flag is part of the ACTIVE filter on a season before the
+  // data exists, even if the OR combination still finds matches through a
+  // different flag — the gapped signal itself stays silently incomplete in
+  // that result too.
+  const activeGapNeeds = activeNeeds.filter((option) => HISTORICAL_GAP_KEYS.has(option.key))
+  const showHistoricalGapWarning = year < NEEDS_DATA_FIRST_YEAR && activeGapNeeds.length > 0
+  // The two gaps are not the same gap, so they do not get the same sentence.
+  // Bathroom and power are 2026-onward columns and start carrying signal that
+  // season; has_infant is 0 in 2026 too, so "only recorded starting the 2026
+  // season" is not a true statement about it and must not be shown to someone
+  // who filtered on infants alone. When a 2026-column flag is also active its
+  // as-shipped wording wins — that sentence is still the accurate one for the
+  // flag the roster is mostly being narrowed by.
+  const gapIsInfantOnly = activeGapNeeds.every((option) => option.key === 'infant')
 
   const toggleNeed = (key: NeedFilterKey) => {
     setSelectedNeeds((previous) => {
@@ -223,8 +234,17 @@ export function HouseholdRosterTable({
 
       {showHistoricalGapWarning && (
         <p className="mb-3 rounded border border-amber-200 bg-amber-100 p-2 text-sm text-amber-800 dark:border-amber-900/50 dark:bg-amber-900/50 dark:text-amber-300">
-          Private bathroom and power needs are only recorded starting the 2026 season. A result for{' '}
-          {year} reflects missing data, not that nobody needed one.
+          {gapIsInfantOnly ? (
+            <>
+              Infant in party is not recorded before the 2026 season. A result for {year} reflects
+              missing data, not that nobody had an infant.
+            </>
+          ) : (
+            <>
+              Private bathroom and power needs are only recorded starting the 2026 season. A result
+              for {year} reflects missing data, not that nobody needed one.
+            </>
+          )}
         </p>
       )}
 

--- a/frontend/src/components/weekend/HouseholdRosterTable.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.tsx
@@ -24,13 +24,26 @@ import { attentionSections, indexUnitsByCode, resolvePartyUnit } from './rosterA
  * First season `needs_private_bathroom`/`needs_power` carry real signal.
  * family-camp-grain-campaign.md Trap 1 / decision D2: these are 2 of eight
  * columns the sync only started populating in 2026 — every earlier row reads
- * `false`, not "unknown". `needs_accommodation` and `has_infant` are excluded
- * on purpose: both are sourced from fields that existed in earlier seasons
- * too (an older "FAM Camp-Accommodation" generation, and the adult-weekend
- * infant question), so they carry real, if sparser, historical signal.
+ * `false`, not "unknown". `needs_accommodation` is excluded on purpose: it is
+ * sourced from a field that existed in earlier seasons too (an older "FAM
+ * Camp-Accommodation" generation), so it carries real, if sparser, historical
+ * signal.
+ *
+ * `infant`, by contrast, is IN this set (kindred#2251 ruling D18, re-measured
+ * 2026-08-13): `has_infant` is `0` on all 3,923 `family_camp_registrations`
+ * rows across all ten years 2017-2026, so `flags.has_infant` is false on
+ * every party the API can emit and the chip can only ever land on the
+ * zero-match empty state. It is not a 2026-only-column gap like bathroom and
+ * power — the underlying raw field (`Adult-Infant`, cm_id 257248) is answered
+ * exclusively by `session_type='adult'` attendees, so on family weekends it
+ * is dead by construction, and even on 2026 adult weekends every answer so
+ * far reads "No" or an unrelated write-in. There is no true row to surface at
+ * any year, which is what routes it through the same pre-2026 caveat as
+ * bathroom/power rather than treating it as a normal filter with a real,
+ * if currently zero, result.
  */
 const NEEDS_DATA_FIRST_YEAR = 2026
-const HISTORICAL_GAP_KEYS: ReadonlySet<NeedFilterKey> = new Set(['bathroom', 'power'])
+const HISTORICAL_GAP_KEYS: ReadonlySet<NeedFilterKey> = new Set(['bathroom', 'power', 'infant'])
 
 export interface HouseholdRosterTableProps {
   parties: RosterPartyRow[]
@@ -154,12 +167,13 @@ export function HouseholdRosterTable({
   const showRequests = hasAnyRequest(parties)
 
   // needs_private_bathroom/needs_power are 0 for every pre-2026 row (Trap 1 /
-  // D2 — see the constant above), so an empty or thin result here can read as
-  // "nobody needed it" when the true answer is "we never asked". Shown
-  // whenever either flag is part of the ACTIVE filter on a season before the
-  // data exists, even if the OR combination still finds matches through a
-  // different flag — the bathroom/power signal itself stays silently
-  // incomplete in that result too.
+  // D2 — see the constant above), and has_infant is 0 for EVERY row at any
+  // year (kindred#2251 D18), so an empty or thin result here can read as
+  // "nobody needed it" when the true answer is "we never asked" (or, for
+  // infant, "this can never surface a match"). Shown whenever any gap flag is
+  // part of the ACTIVE filter on a season before the data exists, even if the
+  // OR combination still finds matches through a different flag — the gapped
+  // signal itself stays silently incomplete in that result too.
   const showHistoricalGapWarning =
     year < NEEDS_DATA_FIRST_YEAR &&
     activeNeeds.some((option) => HISTORICAL_GAP_KEYS.has(option.key))


### PR DESCRIPTION
## Summary

The "Infant in party" filter chip shipped in #2324 is a permanent no-match: `family_camp_registrations.has_infant` is 0 on all 3,923 rows across all ten years 2017-2026 (kindred#2251 ruling D18, re-measured 2026-08-13), so `flags.has_infant` is false on every party the API can emit and the chip can only ever land on the zero-match empty state. This is data-true, not a sync defect — the raw `Adult-Infant` field (cm_id 257248) is answered exclusively by `session_type='adult'` attendees, so it is dead by construction on family weekends, and every answer recorded so far on 2026 adult weekends reads "No" or an unrelated write-in.

## Fix

Add `'infant'` to `HISTORICAL_GAP_KEYS` in `HouseholdRosterTable.tsx` so a pre-2026 click on the infant chip surfaces the existing amber caveat banner instead of the bare "No one matches the selected housing needs" empty state. Also corrects the block comment above the constant, which asserted infant "carries real, if sparser, historical signal" — that premise is false as the column stands, and the comment now states the measurement.

The as-shipped "Private bathroom and power needs are only recorded starting the 2026 season" sentence is factually wrong about infants (`has_infant` is 0 in 2026 too, so 2026 does not start carrying signal for it), so an infant-only selection gets its own sentence in the same banner rather than reusing that one verbatim. No new visual channel — same `<p>`, same amber styling, same trigger condition shape — just a second sentence variant for the case the first one doesn't describe. Whenever bathroom or power is *also* active, the original 2026-column sentence still wins unchanged.

## Deliberately did NOT

- Rebuild the housing-need filter — it shipped in #2324 and is not touched here.
- Touch `AccessibilityFlagList.tsx` — the caveat banner copy is rendered entirely from `HouseholdRosterTable.tsx`, not driven from that file.
- Add any new chip, badge, tone, or ARIA attribute — the fix is routing an existing chip through the existing banner mechanism.

## Test plan

- [x] Added a failing Vitest test first (`warns that the infant chip has no historical data either...`), confirmed it failed against the unmodified `HISTORICAL_GAP_KEYS`.
- [x] Implemented the one-line fix, confirmed the new test and all 51 tests in `HouseholdRosterTable.test.tsx` passed.
- [x] Follow-up commit added 2 more tests after finding the shared sentence misnamed bathroom/power on an infant-only selection: one pinning the infant-specific wording, one pinning that the original bathroom/power wording is untouched when one of those flags is also active. `HouseholdRosterTable.test.tsx` now carries 53 tests, all passing.
- [x] Mutation-checked (scan stage, 2026-08-14): reverted `HISTORICAL_GAP_KEYS` to `new Set(['bathroom', 'power'])`, confirmed 2 of the 3 new tests go RED (the third — bathroom/power wording staying intact when infant is also selected — stays green under the revert, since that behavior predates this PR). Restored the fix; all 53 tests pass again.
- [x] Full frontend suite (scan stage, 2026-08-14): `445 files / 6809 tests passed`.
- [x] `bash scripts/pre-push-verify.sh` (no diff against pushed HEAD to scope to); ran the underlying checks directly instead — eslint, tsc --noEmit, prettier --check, full vitest run — all PASS.

Closes #2251.
