### PR TITLE
fix(sync): sort the 24 paginated reads that walk LIMIT/OFFSET unordered

### DIFF
--- a/pocketbase/sync/base_sync.go
+++ b/pocketbase/sync/base_sync.go
@@ -33,6 +33,18 @@ const (
 	LargePageSize = 500
 )
 
+// sortByID is the sort argument every paged FindRecordsByFilter read in this
+// package should pass. PocketBase adds an ORDER BY only when the sort argument
+// is non-empty (core/record_query.go), so an empty one leaves the row order up
+// to whichever index the SQLite planner picks -- which is not stable ACROSS the
+// separate per-page queries a paged read issues, so a plan change between pages
+// can skip or repeat rows. `id` is unique, so it is a total order.
+//
+// Promoted from household_demographics.go (kindred#2286) to here in kindred#2338,
+// so every service in the package can use one constant instead of redeclaring it
+// (or worse, a bare "id" string literal) per file.
+const sortByID = "id"
+
 // JSON null string representation for field comparison
 const jsonNullString = "null"
 

--- a/pocketbase/sync/camper_dietary.go
+++ b/pocketbase/sync/camper_dietary.go
@@ -288,7 +288,7 @@ func (s *CamperDietarySync) loadPersonsWithAttendee(
 		default:
 		}
 
-		records, err := s.App.FindRecordsByFilter("attendees", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("attendees", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying attendees page %d: %w", page, err)
 		}
@@ -335,7 +335,7 @@ func (s *CamperDietarySync) loadPersonCustomValues(
 		default:
 		}
 
-		records, err := s.App.FindRecordsByFilter("person_custom_values", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("person_custom_values", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying person custom values page %d: %w", page, err)
 		}
@@ -505,7 +505,7 @@ func (s *CamperDietarySync) loadExistingRecords(ctx context.Context, year int) (
 		default:
 		}
 
-		records, err := s.App.FindRecordsByFilter("camper_dietary", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("camper_dietary", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying camper_dietary page %d: %w", page, err)
 		}

--- a/pocketbase/sync/camper_history.go
+++ b/pocketbase/sync/camper_history.go
@@ -859,7 +859,7 @@ func (c *CamperHistorySync) loadSynagogueByHousehold(ctx context.Context, year i
 		records, err := c.App.FindRecordsByFilter(
 			"household_custom_values",
 			filter,
-			"",
+			sortByID,
 			perPage,
 			(page-1)*perPage,
 		)
@@ -943,7 +943,7 @@ func (c *CamperHistorySync) loadCongregationByPerson(ctx context.Context, year i
 		records, err := c.App.FindRecordsByFilter(
 			"person_custom_values",
 			filter,
-			"",
+			sortByID,
 			perPage,
 			(page-1)*perPage,
 		)

--- a/pocketbase/sync/camper_transportation.go
+++ b/pocketbase/sync/camper_transportation.go
@@ -289,7 +289,7 @@ func (s *CamperTransportationSync) loadAttendeeMapping(
 		default:
 		}
 
-		records, err := s.App.FindRecordsByFilter("attendees", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("attendees", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying attendees page %d: %w", page, err)
 		}
@@ -359,7 +359,7 @@ func (s *CamperTransportationSync) loadPersonCustomValues(
 		default:
 		}
 
-		records, err := s.App.FindRecordsByFilter("person_custom_values", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("person_custom_values", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying person custom values page %d: %w", page, err)
 		}
@@ -681,7 +681,7 @@ func (s *CamperTransportationSync) loadExistingRecords(ctx context.Context, year
 		default:
 		}
 
-		records, err := s.App.FindRecordsByFilter("camper_transportation", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("camper_transportation", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying camper_transportation page %d: %w", page, err)
 		}

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -535,7 +535,7 @@ func (s *FamilyCampDerivedSync) loadPersonHouseholdMapping(ctx context.Context, 
 		default:
 		}
 
-		records, err := s.App.FindRecordsByFilter("persons", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("persons", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying persons page %d: %w", page, err)
 		}
@@ -1542,7 +1542,7 @@ func (s *FamilyCampDerivedSync) preloadExistingAdults(year int) (map[string]*cor
 	perPage := 500
 
 	for {
-		records, err := s.App.FindRecordsByFilter("family_camp_adults", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("family_camp_adults", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying family_camp_adults page %d: %w", page, err)
 		}
@@ -1576,7 +1576,7 @@ func (s *FamilyCampDerivedSync) preloadExistingRegistrations(year int) (map[stri
 	perPage := 500
 
 	for {
-		records, err := s.App.FindRecordsByFilter("family_camp_registrations", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("family_camp_registrations", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying family_camp_registrations page %d: %w", page, err)
 		}
@@ -1606,7 +1606,7 @@ func (s *FamilyCampDerivedSync) preloadExistingMedical(year int) (map[string]*co
 	perPage := 500
 
 	for {
-		records, err := s.App.FindRecordsByFilter("family_camp_medical", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("family_camp_medical", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying family_camp_medical page %d: %w", page, err)
 		}

--- a/pocketbase/sync/financial_aid_applications.go
+++ b/pocketbase/sync/financial_aid_applications.go
@@ -333,7 +333,7 @@ func (s *FinancialAidApplicationsSync) loadPersonInfo(
 		default:
 		}
 
-		records, err := s.App.FindRecordsByFilter("persons", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("persons", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying persons page %d: %w", page, err)
 		}
@@ -379,7 +379,7 @@ func (s *FinancialAidApplicationsSync) loadPersonCustomValues(
 		default:
 		}
 
-		records, err := s.App.FindRecordsByFilter("person_custom_values", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("person_custom_values", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying person custom values page %d: %w", page, err)
 		}
@@ -987,7 +987,7 @@ func (s *FinancialAidApplicationsSync) loadExistingApplications(
 		default:
 		}
 
-		records, err := s.App.FindRecordsByFilter("financial_aid_applications", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("financial_aid_applications", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying existing applications page %d: %w", page, err)
 		}

--- a/pocketbase/sync/household_demographics.go
+++ b/pocketbase/sync/household_demographics.go
@@ -15,14 +15,6 @@ const serviceNameHouseholdDemographics = "household_demographics"
 // customFieldNameSynagogue is the custom field name for synagogue data
 const customFieldNameSynagogue = "Synagogue"
 
-// sortByID is the sort argument every paged read in this service passes.
-// PocketBase adds an ORDER BY only when the sort argument is non-empty
-// (core/record_query.go), so an empty one leaves the row order up to whichever
-// index the SQLite planner picks -- which is not stable ACROSS the separate
-// per-page queries a paged read issues, so a plan change between pages can skip
-// or repeat rows. `id` is unique, so it is a total order.
-const sortByID = "id"
-
 // HouseholdDemographicsSync computes household demographics from custom values.
 // This service reads from person_custom_values (HH- prefixed fields) and
 // household_custom_values, then populates the household_demographics table.

--- a/pocketbase/sync/paginated_sort_guard_test.go
+++ b/pocketbase/sync/paginated_sort_guard_test.go
@@ -1,0 +1,205 @@
+package sync
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// This guard pins kindred#2338: FindRecordsByFilter(collection, filter, sort,
+// perPage, offset, ...) only emits an ORDER BY when its sort argument is
+// non-empty -- verified against the module source at
+// pocketbase@v0.39.x/core/record_query.go:398-407, where `offset` and `limit`
+// are applied unconditionally below the `if sort != ""` block that builds the
+// ordering. A read that WALKS pages -- i.e. its offset argument varies across
+// calls rather than always being the literal 0 -- is therefore free to skip a
+// row or return one twice across page boundaries the moment the SQLite planner
+// picks a different index, completely silently. sortByID (base_sync.go) is the
+// fix: pass it (or any other explicit sort) at every walked read.
+//
+// A single-record lookup ("", 1, 0) and an unpaginated fetch-all ("", 0, 0)
+// carry none of this hazard -- their offset is always the literal 0, so there
+// is no second page to disagree with the first about row order -- which is why
+// this guard keys specifically on "offset is not the literal 0", not on
+// "perPage looks large" or any other proxy for pagination.
+
+// paginatedSortSite identifies one offending FindRecordsByFilter call by the
+// file it lives in and the literal collection name it queries. Within a single
+// file, each walked collection is queried by at most one such call, so this
+// pair is a stable key -- unlike a line number, it survives the file being
+// edited above the call.
+type paginatedSortSite struct {
+	file       string
+	collection string
+}
+
+// preexistingSortGuardExemptions are real instances of the kindred#2338 defect
+// -- a paginated FindRecordsByFilter walk with an empty sort -- that are
+// DELIBERATELY NOT fixed by kindred#2338. That issue enumerated exactly 22
+// sites across 7 files (camper_dietary.go, camper_transportation.go,
+// quest_registrations.go, staff_applications.go, staff_vehicle_info.go,
+// financial_aid_applications.go, family_camp_derived.go); these 2 sites in an
+// 8th file, camper_history.go, carry the identical defect but were not among
+// the counted 22, and fixing them here would be scope creep on a campaign-wide
+// prerequisite other issues are waiting on.
+//
+// They are exempted here -- rather than left to pass silently because the
+// guard only ever checked the 7 named files -- so the guard covers the whole
+// package (and so catches a brand-new file copied from a sibling, which is the
+// whole point) while staying honest that these two are known and still open.
+var preexistingSortGuardExemptions = map[paginatedSortSite]string{
+	{"camper_history.go", "household_custom_values"}: "loadSynagogueByHousehold's page walk; " +
+		"same defect as kindred#2338's 22, not one of them",
+	{"camper_history.go", "person_custom_values"}: "the parallel HH- custom value page walk " +
+		"a few hundred lines below; same story",
+}
+
+// collectPaginatedSortSites walks every non-test .go file in this package and
+// returns one entry per FindRecordsByFilter call whose sort argument is the
+// empty string literal AND whose offset argument (5th positional arg) is
+// anything other than the literal 0.
+func collectPaginatedSortSites(t *testing.T) []struct {
+	paginatedSortSite
+	line int
+} {
+	t.Helper()
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+
+	var found []struct {
+		paginatedSortSite
+		line int
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		fset := token.NewFileSet()
+		parsed, parseErr := parser.ParseFile(fset, filepath.Join(".", name), nil, 0)
+		if parseErr != nil {
+			t.Fatalf("parse %s: %v", name, parseErr)
+		}
+
+		ast.Inspect(parsed, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "FindRecordsByFilter" {
+				return true
+			}
+			// collection, filter, sort, perPage, offset, [optFilterParams...]
+			if len(call.Args) < 5 {
+				return true
+			}
+			if !isEmptyStringLit(call.Args[2]) {
+				return true
+			}
+			if isZeroIntLit(call.Args[4]) {
+				return true
+			}
+			collection, _ := stringLitValue(call.Args[0])
+			if collection == "" {
+				collection = "<non-literal collection expr>"
+			}
+			found = append(found, struct {
+				paginatedSortSite
+				line int
+			}{
+				paginatedSortSite: paginatedSortSite{file: name, collection: collection},
+				line:              fset.Position(call.Pos()).Line,
+			})
+			return true
+		})
+	}
+	return found
+}
+
+func isEmptyStringLit(e ast.Expr) bool {
+	lit, ok := e.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return false
+	}
+	v, err := strconv.Unquote(lit.Value)
+	return err == nil && v == ""
+}
+
+func isZeroIntLit(e ast.Expr) bool {
+	lit, ok := e.(*ast.BasicLit)
+	return ok && lit.Kind == token.INT && lit.Value == "0"
+}
+
+func stringLitValue(e ast.Expr) (string, bool) {
+	lit, ok := e.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	v, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+	return v, true
+}
+
+// TestNoPaginatedReadWalksWithAnEmptySort is the kindred#2338 guard. It fails
+// the moment a NEW FindRecordsByFilter call walks pages (a non-literal-0
+// offset) with an empty sort -- which is exactly how this class of bug has
+// reappeared before: a service written by copying a sibling, with the sibling's
+// missing sort argument copied right along with it.
+func TestNoPaginatedReadWalksWithAnEmptySort(t *testing.T) {
+	t.Parallel()
+
+	var unexpected []string
+	for _, site := range collectPaginatedSortSites(t) {
+		if _, exempt := preexistingSortGuardExemptions[site.paginatedSortSite]; exempt {
+			continue
+		}
+		unexpected = append(unexpected, site.file+":"+strconv.Itoa(site.line)+
+			": FindRecordsByFilter(\""+site.collection+"\", ..., \"\", perPage, offset) walks "+
+			"pages with no ORDER BY -- pass sortByID (base_sync.go)")
+	}
+	sort.Strings(unexpected)
+
+	if len(unexpected) > 0 {
+		t.Errorf("%d paginated read(s) walk LIMIT/OFFSET with an empty sort (kindred#2338):\n  %s",
+			len(unexpected), strings.Join(unexpected, "\n  "))
+	}
+}
+
+// TestSortGuardExemptionsAreStillNeeded keeps preexistingSortGuardExemptions
+// from going stale the way a forgotten allowlist entry always eventually does:
+// if one of the two sites gets fixed (or removed) without its exemption being
+// dropped, this fails and says so -- exactly the shape of
+// TestSerialTestExemptionsAreAllStillNeeded in main_test_parallelism_test.go.
+func TestSortGuardExemptionsAreStillNeeded(t *testing.T) {
+	t.Parallel()
+
+	stillViolating := map[paginatedSortSite]bool{}
+	for _, site := range collectPaginatedSortSites(t) {
+		stillViolating[site.paginatedSortSite] = true
+	}
+
+	var stale []string
+	for site, reason := range preexistingSortGuardExemptions {
+		if !stillViolating[site] {
+			stale = append(stale, site.file+" / \""+site.collection+"\": no longer violates "+
+				"(fixed or removed) -- drop the exemption. Reason was: "+reason)
+		}
+	}
+	sort.Strings(stale)
+
+	if len(stale) > 0 {
+		t.Errorf("%d stale sort-guard exemption(s):\n  %s", len(stale), strings.Join(stale, "\n  "))
+	}
+}

--- a/pocketbase/sync/paginated_sort_guard_test.go
+++ b/pocketbase/sync/paginated_sort_guard_test.go
@@ -28,46 +28,22 @@ import (
 // is no second page to disagree with the first about row order -- which is why
 // this guard keys specifically on "offset is not the literal 0", not on
 // "perPage looks large" or any other proxy for pagination.
+//
+// The guard deliberately carries no allowlist: every paginated read in this
+// package passes an explicit sort, so a new violation is always a new mistake.
 
-// paginatedSortSite identifies one offending FindRecordsByFilter call by the
-// file it lives in and the literal collection name it queries. Within a single
-// file, each walked collection is queried by at most one such call, so this
-// pair is a stable key -- unlike a line number, it survives the file being
-// edited above the call.
+// paginatedSortSite is one offending FindRecordsByFilter call.
 type paginatedSortSite struct {
 	file       string
 	collection string
-}
-
-// preexistingSortGuardExemptions are real instances of the kindred#2338 defect
-// -- a paginated FindRecordsByFilter walk with an empty sort -- that are
-// DELIBERATELY NOT fixed by kindred#2338. That issue enumerated exactly 22
-// sites across 7 files (camper_dietary.go, camper_transportation.go,
-// quest_registrations.go, staff_applications.go, staff_vehicle_info.go,
-// financial_aid_applications.go, family_camp_derived.go); these 2 sites in an
-// 8th file, camper_history.go, carry the identical defect but were not among
-// the counted 22, and fixing them here would be scope creep on a campaign-wide
-// prerequisite other issues are waiting on.
-//
-// They are exempted here -- rather than left to pass silently because the
-// guard only ever checked the 7 named files -- so the guard covers the whole
-// package (and so catches a brand-new file copied from a sibling, which is the
-// whole point) while staying honest that these two are known and still open.
-var preexistingSortGuardExemptions = map[paginatedSortSite]string{
-	{"camper_history.go", "household_custom_values"}: "loadSynagogueByHousehold's page walk; " +
-		"same defect as kindred#2338's 22, not one of them",
-	{"camper_history.go", "person_custom_values"}: "the parallel HH- custom value page walk " +
-		"a few hundred lines below; same story",
+	line       int
 }
 
 // collectPaginatedSortSites walks every non-test .go file in this package and
 // returns one entry per FindRecordsByFilter call whose sort argument is the
 // empty string literal AND whose offset argument (5th positional arg) is
 // anything other than the literal 0.
-func collectPaginatedSortSites(t *testing.T) []struct {
-	paginatedSortSite
-	line int
-} {
+func collectPaginatedSortSites(t *testing.T) []paginatedSortSite {
 	t.Helper()
 
 	entries, err := os.ReadDir(".")
@@ -75,10 +51,7 @@ func collectPaginatedSortSites(t *testing.T) []struct {
 		t.Fatalf("read package dir: %v", err)
 	}
 
-	var found []struct {
-		paginatedSortSite
-		line int
-	}
+	var found []paginatedSortSite
 	for _, entry := range entries {
 		name := entry.Name()
 		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
@@ -109,16 +82,14 @@ func collectPaginatedSortSites(t *testing.T) []struct {
 			if isZeroIntLit(call.Args[4]) {
 				return true
 			}
-			collection, _ := stringLitValue(call.Args[0])
-			if collection == "" {
+			collection, ok := stringLitValue(call.Args[0])
+			if !ok {
 				collection = "<non-literal collection expr>"
 			}
-			found = append(found, struct {
-				paginatedSortSite
-				line int
-			}{
-				paginatedSortSite: paginatedSortSite{file: name, collection: collection},
-				line:              fset.Position(call.Pos()).Line,
+			found = append(found, paginatedSortSite{
+				file:       name,
+				collection: collection,
+				line:       fset.Position(call.Pos()).Line,
 			})
 			return true
 		})
@@ -160,11 +131,9 @@ func stringLitValue(e ast.Expr) (string, bool) {
 func TestNoPaginatedReadWalksWithAnEmptySort(t *testing.T) {
 	t.Parallel()
 
-	var unexpected []string
-	for _, site := range collectPaginatedSortSites(t) {
-		if _, exempt := preexistingSortGuardExemptions[site.paginatedSortSite]; exempt {
-			continue
-		}
+	sites := collectPaginatedSortSites(t)
+	unexpected := make([]string, 0, len(sites))
+	for _, site := range sites {
 		unexpected = append(unexpected, site.file+":"+strconv.Itoa(site.line)+
 			": FindRecordsByFilter(\""+site.collection+"\", ..., \"\", perPage, offset) walks "+
 			"pages with no ORDER BY -- pass sortByID (base_sync.go)")
@@ -174,32 +143,5 @@ func TestNoPaginatedReadWalksWithAnEmptySort(t *testing.T) {
 	if len(unexpected) > 0 {
 		t.Errorf("%d paginated read(s) walk LIMIT/OFFSET with an empty sort (kindred#2338):\n  %s",
 			len(unexpected), strings.Join(unexpected, "\n  "))
-	}
-}
-
-// TestSortGuardExemptionsAreStillNeeded keeps preexistingSortGuardExemptions
-// from going stale the way a forgotten allowlist entry always eventually does:
-// if one of the two sites gets fixed (or removed) without its exemption being
-// dropped, this fails and says so -- exactly the shape of
-// TestSerialTestExemptionsAreAllStillNeeded in main_test_parallelism_test.go.
-func TestSortGuardExemptionsAreStillNeeded(t *testing.T) {
-	t.Parallel()
-
-	stillViolating := map[paginatedSortSite]bool{}
-	for _, site := range collectPaginatedSortSites(t) {
-		stillViolating[site.paginatedSortSite] = true
-	}
-
-	var stale []string
-	for site, reason := range preexistingSortGuardExemptions {
-		if !stillViolating[site] {
-			stale = append(stale, site.file+" / \""+site.collection+"\": no longer violates "+
-				"(fixed or removed) -- drop the exemption. Reason was: "+reason)
-		}
-	}
-	sort.Strings(stale)
-
-	if len(stale) > 0 {
-		t.Errorf("%d stale sort-guard exemption(s):\n  %s", len(stale), strings.Join(stale, "\n  "))
 	}
 }

--- a/pocketbase/sync/quest_registrations.go
+++ b/pocketbase/sync/quest_registrations.go
@@ -410,7 +410,7 @@ func (s *QuestRegistrationsSync) loadPersonsWithAttendee(
 		default:
 		}
 
-		records, err := s.App.FindRecordsByFilter("attendees", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("attendees", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, 0, fmt.Errorf("querying attendees page %d: %w", page, err)
 		}
@@ -494,7 +494,7 @@ func (s *QuestRegistrationsSync) loadPersonCustomValues(
 		default:
 		}
 
-		records, err := s.App.FindRecordsByFilter("person_custom_values", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("person_custom_values", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying person custom values page %d: %w", page, err)
 		}
@@ -953,7 +953,7 @@ func (s *QuestRegistrationsSync) loadExistingRecords(ctx context.Context, year i
 		default:
 		}
 
-		records, err := s.App.FindRecordsByFilter("quest_registrations", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("quest_registrations", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying quest_registrations page %d: %w", page, err)
 		}

--- a/pocketbase/sync/staff_applications.go
+++ b/pocketbase/sync/staff_applications.go
@@ -278,7 +278,7 @@ func (s *StaffApplicationsSync) loadPersonStaffMapping(
 		default:
 		}
 
-		records, err := s.App.FindRecordsByFilter("staff", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("staff", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying staff page %d: %w", page, err)
 		}
@@ -328,7 +328,7 @@ func (s *StaffApplicationsSync) loadPersonCustomValues(
 		default:
 		}
 
-		records, err := s.App.FindRecordsByFilter("person_custom_values", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("person_custom_values", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying person custom values page %d: %w", page, err)
 		}
@@ -713,7 +713,7 @@ func (s *StaffApplicationsSync) loadExistingRecords(ctx context.Context, year in
 		default:
 		}
 
-		records, err := s.App.FindRecordsByFilter("staff_applications", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("staff_applications", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying staff_applications page %d: %w", page, err)
 		}

--- a/pocketbase/sync/staff_vehicle_info.go
+++ b/pocketbase/sync/staff_vehicle_info.go
@@ -258,7 +258,7 @@ func (s *StaffVehicleInfoSync) loadPersonStaffMapping(
 		default:
 		}
 
-		records, err := s.App.FindRecordsByFilter("staff", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("staff", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying staff page %d: %w", page, err)
 		}
@@ -308,7 +308,7 @@ func (s *StaffVehicleInfoSync) loadPersonCustomValues(
 		default:
 		}
 
-		records, err := s.App.FindRecordsByFilter("person_custom_values", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("person_custom_values", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying person custom values page %d: %w", page, err)
 		}
@@ -556,7 +556,7 @@ func (s *StaffVehicleInfoSync) loadExistingRecords(ctx context.Context, year int
 		default:
 		}
 
-		records, err := s.App.FindRecordsByFilter("staff_vehicle_info", filter, "", perPage, (page-1)*perPage)
+		records, err := s.App.FindRecordsByFilter("staff_vehicle_info", filter, sortByID, perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying staff_vehicle_info page %d: %w", page, err)
 		}


### PR DESCRIPTION
## What

`FindRecordsByFilter(collection, filter, sort, limit, offset)` only emits an `ORDER BY` when
`sort != ""` (verified against `pocketbase@v0.39.10/core/record_query.go`: the `if sort != ""` block
at :398 builds the ordering, while `offset` and `limit` are applied unconditionally below it at
:416/:420). 24 paginated reads across 8 sync services walked `LIMIT`/`OFFSET` with `sort == ""`,
which is free to skip one row and return another twice across page boundaries the moment the SQLite
planner picks a different index for the underlying filter.

All 24 now pass an explicit sort:

| File | Lines |
|---|---|
| `camper_dietary.go` | 291, 338, 508 |
| `camper_transportation.go` | 292, 362, 684 |
| `quest_registrations.go` | 413, 497, 956 |
| `staff_applications.go` | 281, 331, 716 |
| `staff_vehicle_info.go` | 261, 311, 559 |
| `financial_aid_applications.go` | 336, 382, 990 |
| `family_camp_derived.go` | 538, 1545, 1579, 1609 |
| `camper_history.go` | 859, 943 |

Issue #2338 enumerated the first 22. `camper_history.go`'s 2 are the identical defect in an 8th file
and are fixed here too — see "On the extra two" below.

`sortByID` (previously private to `household_demographics.go`, introduced in kindred#2286) is
promoted to `base_sync.go`, carrying its explanatory comment — the reasoning is unchanged, re-worded
for package scope and extended with a note on where it came from. It is now declared once for the
whole package rather than per file.

Four reads still pass a bare `"id"` literal rather than the constant (`base_sync.go:392`,
`lodging_session_attribution.go:260`, `family_camp_derived.go:608` and `:661`). Those already emit an
`ORDER BY` and are correct as-is; churning them was not worth the diff.

## Guard test

`pocketbase/sync/paginated_sort_guard_test.go` adds an AST census, in the style of
`../main_test_parallelism_test.go` / `rejection_sites_test.go`, over every non-test `.go` file in the
package: any `FindRecordsByFilter` call whose sort argument is the empty string literal AND whose
offset argument is not the literal `0` (i.e. it genuinely walks pages) fails the build. A
single-record lookup (`"", 1, 0`) and an unpaginated fetch-all (`"", 0, 0`) are unaffected — their
offset is always the literal `0`, so there's no second page to disagree with the first.

The guard carries **no allowlist**. Every paginated read in the package now passes an explicit sort,
so any future violation is a new mistake rather than a known one.

Load-bearing check, run three ways: reverting `preloadExistingAdults` (`family_camp_derived.go:1545`)
to `""` fails the guard naming that exact file and line; adding a brand-new file with an unsorted
page walk fails it naming the new file; and the guard stays green with 98 `("", 1, 0)` / `("", 0, 0)`
calls present in the package, so it discriminates on offset rather than passing vacuously.

## On the extra two

An earlier revision of this PR left `camper_history.go`'s 2 sites unfixed and instead exempted them
in the guard via a `preexistingSortGuardExemptions` allowlist. That was wrong twice over:

- The exemption was keyed on `(file, collection)`, not on a specific call — so it did not merely
  excuse the two known sites, it blanket-excused that pair permanently. A **brand-new** paginated
  walk over `person_custom_values` added to `camper_history.go` (the likeliest place for one, since
  the file already walks that collection) passed the guard silently. Verified by adding exactly such
  a call: green with the allowlist, red without it.
- The fix is the same one-word change as the other 22, so the allowlist and its staleness test cost
  the guard its whole point and bought nothing.

Both sites now pass `sortByID` and the exemption machinery is gone.

## Deliberately out of scope

- The single-record `(.., "", 1, 0)` lookups and unpaginated `(.., "", 0, 0)` fetch-alls are
  untouched — different question, no page-skip hazard.
- Sites with a non-empty but non-unique sort (`"-created"`, e.g. `camper_history.go:465`,
  `base_sync.go:530`, several in `normalize_geographic.go`) are untouched — they do have an
  `ORDER BY`, just not a guaranteed-unique one. That's a related but distinct question from "no
  `ORDER BY` at all", which is what this change and its guard are scoped to.
- Packages outside `pocketbase/sync` are not covered by the guard. Checked: `lodging/`, `rbac/` and
  `bunk_requests/` have no paginated walk with an empty sort — every call there is either a
  fetch-all or a capped read at literal offset `0` — so there is nothing to fix and nothing to guard
  yet.

Closes #2338.
