### PR TITLE
feat(frontend): link a journey year's members to that year's camper page

### DIFF
--- a/frontend/src/components/CamperDetail.test.tsx
+++ b/frontend/src/components/CamperDetail.test.tsx
@@ -8,33 +8,42 @@ import type { SatisfactionResponse } from '../types/satisfaction'
 let mockSessionYear = 2026
 let mockAttendeeYear = 2026
 let mockSessionType = 'main'
+// kindred#2329: which year `CamperDetail` actually asked the enrollment
+// hook for. A journey-year link (`?year=2019`) must win over the app's
+// global year (mocked at 2026 below) — this is how the tests below tell
+// "resolved the query param" apart from "resolved the global default"
+// without needing the hook itself to do any real filtering.
+let lastEnrollmentYearArg: number | null = null
 
 // Mock the camper data hooks to return a minimal fixture.
 vi.mock('../hooks/camper', () => ({
-  useCamperEnrollment: () => ({
-    enrolledCampers: [
-      {
-        id: 'att1',
-        person_cm_id: 1000001,
-        session_cm_id: 2,
-        attendee_status: 'enrolled',
-        year: mockAttendeeYear,
-        first_name: 'Emma',
-        last_name: 'Johnson',
-        expand: {
-          session: {
-            cm_id: 2,
-            name: 'Session 2',
-            year: mockSessionYear,
-            session_type: mockSessionType,
+  useCamperEnrollment: (_personCmId: number | null, currentYear: number) => {
+    lastEnrollmentYearArg = currentYear
+    return {
+      enrolledCampers: [
+        {
+          id: 'att1',
+          person_cm_id: 1000001,
+          session_cm_id: 2,
+          attendee_status: 'enrolled',
+          year: mockAttendeeYear,
+          first_name: 'Emma',
+          last_name: 'Johnson',
+          expand: {
+            session: {
+              cm_id: 2,
+              name: 'Session 2',
+              year: mockSessionYear,
+              session_type: mockSessionType,
+            },
           },
         },
-      },
-    ],
-    allAttendees: [],
-    isLoading: false,
-    error: null,
-  }),
+      ],
+      allAttendees: [],
+      isLoading: false,
+      error: null,
+    }
+  },
   useCamperHistory: () => ({ camperHistory: [] }),
   useSiblings: () => ({ siblings: [], isLoading: false, error: null }),
   useOriginalBunkData: () => ({
@@ -142,11 +151,14 @@ vi.mock('../contexts/AuthContext', () => ({
   useAuth: () => mockAuthValue,
 }))
 
-function renderDetail() {
+// kindred#2329: `path` defaults to the plain route every other describe
+// block in this file exercises, so those callers are unaffected; the
+// year-query-param tests pass an explicit `?year=` path.
+function renderDetail(path = '/camper/1000001') {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <QueryClientProvider client={qc}>
-      <MemoryRouter initialEntries={['/camper/1000001']}>
+      <MemoryRouter initialEntries={[path]}>
         <Routes>
           <Route path="/camper/:camperId" element={<CamperDetail />} />
         </Routes>
@@ -160,6 +172,7 @@ beforeEach(() => {
   mockSessionYear = 2026
   mockAttendeeYear = 2026
   mockSessionType = 'main'
+  lastEnrollmentYearArg = null
   // Finding #19: tests below mutate `mockFetchWithAuth`; reset to default so
   // a later test doesn't inherit a prior suite's stub state.
   mockFetchWithAuth = _defaultMockFetchWithAuth
@@ -313,5 +326,52 @@ describe('CamperDetail teen programs', () => {
     mockSessionType = 'main'
     renderDetail()
     expect(await screen.findByText(/Parsed Bunk Requests/i)).toBeTruthy()
+  })
+})
+
+describe('CamperDetail ?year= query param (kindred#2329)', () => {
+  beforeEach(() => {
+    mockAuthValue = { user: { is_admin: true, cached_permissions: [] }, isLoading: false }
+  })
+
+  it('prefers the ?year= query param over the app-global year when fetching enrollment', async () => {
+    renderDetail('/camper/1000001?year=2019')
+    await screen.findByText(/Emma/i).catch(() => null)
+
+    // The global year is mocked at 2026 (see `useYear` mock above) — 2019
+    // proves the query param won, not the fallback.
+    expect(lastEnrollmentYearArg).toBe(2019)
+  })
+
+  it('falls back to the app-global year when no ?year= param is present', async () => {
+    renderDetail('/camper/1000001')
+    await screen.findByText(/Emma/i).catch(() => null)
+
+    expect(lastEnrollmentYearArg).toBe(2026)
+  })
+
+  it('ignores a malformed ?year= and falls back to the global year rather than fetching NaN', async () => {
+    renderDetail('/camper/1000001?year=not-a-year')
+    await screen.findByText(/Emma/i).catch(() => null)
+
+    expect(lastEnrollmentYearArg).toBe(2026)
+  })
+
+  it('shows the historical-data banner when the requested year differs from the global year', async () => {
+    // Simulates what a real, year-filtered fetch would return for a 2019
+    // link: an attendee row whose own session year is 2019, against the
+    // app's global year of 2026.
+    mockSessionYear = 2019
+    mockAttendeeYear = 2019
+    renderDetail('/camper/1000001?year=2019')
+
+    expect(await screen.findByText(/viewing historical data from 2019/i)).toBeInTheDocument()
+  })
+
+  it('does not show the historical-data banner on the plain (no query param) route', async () => {
+    renderDetail('/camper/1000001')
+    await screen.findByText(/Emma/i).catch(() => null)
+
+    expect(screen.queryByText(/viewing historical data/i)).toBeNull()
   })
 })

--- a/frontend/src/components/CamperDetail.tsx
+++ b/frontend/src/components/CamperDetail.tsx
@@ -5,7 +5,7 @@
  * delegates rendering to extracted UI components.
  */
 import { useContext, useEffect, useMemo } from 'react'
-import { Link, useParams } from 'react-router'
+import { Link, useParams, useSearchParams } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
 import { Calendar } from 'lucide-react'
 import { pb } from '../lib/pocketbase'
@@ -68,6 +68,16 @@ interface CamperDetailBodyProps {
   camper: Camper
   enrolledCampers: Camper[]
   currentYear: number
+  /**
+   * The app's real global year (`useYear()`), independent of `currentYear`
+   * above — which, since kindred#2329, can instead be an explicit
+   * `?year=` from a journey-year link. Only the historical-data banner
+   * needs this: it must fire whenever a requested year differs from what
+   * the app currently considers "now", even though `camper`'s own fetched
+   * `session.year` always equals `currentYear` by construction (that's the
+   * exact-match filter every enrollment query uses).
+   */
+  appCurrentYear: number
   person: PersonsResponse | undefined
   allBunkRequests: EnhancedBunkRequest[]
   originalBunkData: OriginalBunkData | null | undefined
@@ -87,6 +97,7 @@ function CamperDetailBody({
   camper,
   enrolledCampers,
   currentYear,
+  appCurrentYear,
   person,
   allBunkRequests,
   originalBunkData,
@@ -142,8 +153,11 @@ function CamperDetailBody({
 
   return (
     <div className="space-y-6">
-      {/* Historical Data Notice */}
-      {camper.expand?.session?.year && camper.expand.session.year !== currentYear && (
+      {/* Historical Data Notice. Compares against the app's actual global
+          year, NOT `currentYear` — `currentYear` here can itself be the
+          requested historical year (kindred#2329), which the fetched
+          `camper.expand.session.year` will always equal by construction. */}
+      {camper.expand?.session?.year && camper.expand.session.year !== appCurrentYear && (
         <div className="rounded-2xl border-2 border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-900/20">
           <div className="flex items-center gap-2">
             <Calendar className="h-5 w-5 text-amber-600 dark:text-amber-400" />
@@ -239,7 +253,17 @@ function CamperDetailBody({
 
 export default function CamperDetail() {
   const { camperId } = useParams<{ camperId: string }>()
-  const currentYear = useYear()
+  const appCurrentYear = useYear()
+  const [searchParams] = useSearchParams()
+  // A journey-year link needs the record as it stood THAT year, not as the
+  // app's global year currently sees it (kindred#2329) — `?year=` wins over
+  // the global context when present and a valid positive integer; every
+  // existing caller (no param, or a malformed one) falls straight back to
+  // the global year, same as before this param existed.
+  const yearParam = searchParams.get('year')
+  const parsedYearParam = yearParam !== null ? Number(yearParam) : NaN
+  const currentYear =
+    Number.isInteger(parsedYearParam) && parsedYearParam > 0 ? parsedYearParam : appCurrentYear
   const { hasPermission, isAdmin } = usePermissions()
   const canManageBunking = hasPermission(Permission.BUNKING_MANAGE)
 
@@ -384,6 +408,7 @@ export default function CamperDetail() {
         camper={camper}
         enrolledCampers={enrolledCampers}
         currentYear={currentYear}
+        appCurrentYear={appCurrentYear}
         person={person}
         allBunkRequests={allBunkRequests}
         originalBunkData={originalBunkData}

--- a/frontend/src/components/weekend/FamilyDetailsPanel.test.tsx
+++ b/frontend/src/components/weekend/FamilyDetailsPanel.test.tsx
@@ -11,6 +11,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
+import { MemoryRouter } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
@@ -64,8 +65,15 @@ beforeEach(() => {
   client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 })
 
+// MemoryRouter added for kindred#2329: a linked child's name inside the
+// household-year-members modal this panel hosts is now a `<Link>`, which
+// throws outside a Router context.
 function wrapper({ children }: { children: ReactNode }) {
-  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  return (
+    <QueryClientProvider client={client}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  )
 }
 
 /**

--- a/frontend/src/components/weekend/HouseholdJourneyCard.test.tsx
+++ b/frontend/src/components/weekend/HouseholdJourneyCard.test.tsx
@@ -20,9 +20,21 @@
  */
 import { fireEvent, render, screen, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MemoryRouter } from 'react-router'
 
 import type { HouseholdJourney, HouseholdJourneyRow } from '../../types/lodging'
 import { HouseholdJourneyCard } from './HouseholdJourneyCard'
+
+// A linked child's name is a `<Link>` (kindred#2329), which throws outside a
+// Router context — the modal is closed by default in most of these tests,
+// so it wouldn't render, but "see members" tests below open it.
+function renderCard(props: Parameters<typeof HouseholdJourneyCard>[0]) {
+  return render(
+    <MemoryRouter>
+      <HouseholdJourneyCard {...props} />
+    </MemoryRouter>
+  )
+}
 
 const journeyResult = {
   value: { data: undefined, isLoading: false, error: null } as {
@@ -69,7 +81,7 @@ function show(years: HouseholdJourneyRow[], currentYear = 2026) {
     isLoading: false,
     error: null,
   }
-  return render(<HouseholdJourneyCard householdCmId={2000001} currentYear={currentYear} />)
+  return renderCard({ householdCmId: 2000001, currentYear })
 }
 
 function rowFor(year: number): HTMLElement {
@@ -362,7 +374,7 @@ describe('see members', () => {
 describe('the four query states', () => {
   it('renders a loading state', () => {
     journeyResult.value = { data: undefined, isLoading: true, error: null }
-    render(<HouseholdJourneyCard householdCmId={2000001} currentYear={2026} />)
+    renderCard({ householdCmId: 2000001, currentYear: 2026 })
 
     expect(screen.getByText(/Loading family history/)).toBeInTheDocument()
   })
@@ -373,14 +385,14 @@ describe('the four query states', () => {
     // a spinner tells a staff member a returning family is a first-timer —
     // for the whole fetch, on every open of the panel.
     journeyResult.value = { data: undefined, isLoading: true, error: null }
-    render(<HouseholdJourneyCard householdCmId={2000001} currentYear={2026} />)
+    renderCard({ householdCmId: 2000001, currentYear: 2026 })
 
     expect(screen.queryByText(/on file/)).not.toBeInTheDocument()
   })
 
   it('renders the error inline rather than escalating to the page boundary', () => {
     journeyResult.value = { data: undefined, isLoading: false, error: new Error('boom') }
-    render(<HouseholdJourneyCard householdCmId={2000001} currentYear={2026} />)
+    renderCard({ householdCmId: 2000001, currentYear: 2026 })
 
     expect(screen.getByText(/boom/)).toBeInTheDocument()
     // Same reason as the loading case: a failed read knows nothing about how
@@ -418,7 +430,7 @@ describe('the four query states', () => {
 
 describe('a party with no household', () => {
   it('renders nothing and never fetches', () => {
-    const { container } = render(<HouseholdJourneyCard householdCmId={null} currentYear={2026} />)
+    const { container } = renderCard({ householdCmId: null, currentYear: 2026 })
 
     expect(container.textContent).toBe('')
     expect(useHouseholdJourney).toHaveBeenCalledWith(null)

--- a/frontend/src/components/weekend/HouseholdYearMembersModal.test.tsx
+++ b/frontend/src/components/weekend/HouseholdYearMembersModal.test.tsx
@@ -117,6 +117,30 @@ describe('the party for one year', () => {
     expect(children).not.toContain('Grade 0')
     expect(children).not.toContain('Age')
   })
+
+  // CampMinder stores 13 for a camper past 12th grade: 224 persons carry it
+  // and nothing above it. It is a real value but a nonsensical label, so it
+  // is suppressed the same way an absent grade is -- the age still prints.
+  it('omits a grade above 12 rather than printing a nonsensical one', () => {
+    open(
+      _row({
+        children: [
+          {
+            display_name: 'Emma Johnson',
+            last_name: 'Johnson',
+            person_cm_id: 1000001,
+            age: 18,
+            grade: 13,
+          },
+        ],
+      })
+    )
+
+    const children = screen.getByRole('dialog').textContent
+    expect(children).not.toContain('Grade 13')
+    expect(children).not.toContain('Grade')
+    expect(children).toContain('Age 18')
+  })
 })
 
 describe('a year with no enrolment on file', () => {
@@ -186,6 +210,16 @@ describe('linking a member to their camper page for that year (kindred#2329)', (
 
     const link = screen.getByRole('link', { name: /Emma Johnson/ })
     expect(link).toHaveAttribute('href', '/camper/1000001?year=2019')
+  })
+
+  it('opens the camper page in a NEW TAB, safely rel-ed', () => {
+    open(_row({ year: 2019 }))
+
+    const link = screen.getByRole('link', { name: /Emma Johnson/ })
+    expect(link).toHaveAttribute('target', '_blank')
+    // Without noopener the opened tab gets a live `window.opener` handle
+    // back into this one.
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'))
   })
 
   it('renders a child with no person_cm_id as plain text, never a broken link', () => {
@@ -273,27 +307,26 @@ describe('navigating to a linked camper unwinds the modal stack (kindred#2329)',
     )
   }
 
-  it('closes the dialog, empties the overlay stack, and clears background inert on click', () => {
+  // The link opens a NEW TAB, so THIS tab must not move and the modal must
+  // stay exactly as it was. The previous behaviour closed the modal on click,
+  // which is wrong here: the user returns to this tab and finds their place
+  // gone. `target="_blank"` also means react-router hands the click to the
+  // browser rather than navigating in place, so no route change happens.
+  it('leaves this tab untouched: modal open, stack intact, no navigation', () => {
     renderAtWeekendRoute()
 
-    // Sanity: the dialog is actually open and registered before the click —
-    // otherwise the assertions below would trivially pass on an unmounted
-    // modal that never mounted in the first place.
     expect(screen.getByRole('dialog')).toBeInTheDocument()
     expect(document.getElementById('root')).toHaveAttribute('inert')
     expect(hasOpenModal()).toBe(true)
 
     fireEvent.click(screen.getByRole('link', { name: /Emma Johnson/ }))
 
-    // Real navigation happened — proves this isn't just `onClose` firing
-    // while still parked on the weekend route.
-    expect(screen.getByTestId('camper-page')).toBeInTheDocument()
+    // This tab did NOT navigate -- the camper page belongs to the new tab.
+    expect(screen.queryByTestId('camper-page')).not.toBeInTheDocument()
 
-    // The unwind: the stack must not believe a modal is still mounted once
-    // the route has moved on, or the NEXT overlay opened anywhere in the
-    // app inherits a stuck `inert` background / wrong Escape ownership.
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
-    expect(document.getElementById('root')).not.toHaveAttribute('inert')
-    expect(hasOpenModal()).toBe(false)
+    // And the modal is still standing, with the overlay stack still owning it.
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(document.getElementById('root')).toHaveAttribute('inert')
+    expect(hasOpenModal()).toBe(true)
   })
 })

--- a/frontend/src/components/weekend/HouseholdYearMembersModal.test.tsx
+++ b/frontend/src/components/weekend/HouseholdYearMembersModal.test.tsx
@@ -211,6 +211,22 @@ describe('linking a member to their camper page for that year (kindred#2329)', (
     expect(screen.queryByRole('link', { name: /Olivia Johnson/ })).not.toBeInTheDocument()
     expect(screen.getByTestId('year-members-adults').textContent).toContain('Olivia Johnson')
   })
+
+  it('renders a fractional person_cm_id as plain text rather than a link to a truncated (wrong) camper', () => {
+    // CodeRabbit review on PR #2345: `parseInt('1000001.5', 10)` truncates to
+    // 1000001 — a link built from a non-integer id can silently land on a
+    // DIFFERENT camper record than the one that was actually being shown.
+    open(
+      _row({
+        children: [
+          { person_cm_id: 1000001.5, display_name: 'Ava Martinez', last_name: 'Martinez' },
+        ],
+      })
+    )
+
+    expect(screen.queryByRole('link', { name: /Ava Martinez/ })).not.toBeInTheDocument()
+    expect(screen.getByTestId('year-members-children').textContent).toContain('Ava Martinez')
+  })
 })
 
 describe('navigating to a linked camper unwinds the modal stack (kindred#2329)', () => {

--- a/frontend/src/components/weekend/HouseholdYearMembersModal.test.tsx
+++ b/frontend/src/components/weekend/HouseholdYearMembersModal.test.tsx
@@ -16,10 +16,13 @@
  *   was cancelled outright and 2021 has no family attendee rows at all
  *   despite 247 registrations — while adults exist for both years.
  */
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { useState } from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest'
+import { MemoryRouter, Route, Routes } from 'react-router'
 
 import type { HouseholdJourneyRow } from '../../types/lodging'
+import { hasOpenModal } from '../ui/modalStack'
 import { HouseholdYearMembersModal } from './HouseholdYearMembersModal'
 
 function _row(overrides: Partial<HouseholdJourneyRow> = {}): HouseholdJourneyRow {
@@ -42,9 +45,13 @@ function _row(overrides: Partial<HouseholdJourneyRow> = {}): HouseholdJourneyRow
   }
 }
 
+// A child's name is a `<Link>` (kindred#2329), which throws outside a Router
+// context — every caller needs one now, not just the navigation tests below.
 function open(row: HouseholdJourneyRow | null, familyLabel = 'The Johnson Family') {
   return render(
-    <HouseholdYearMembersModal isOpen onClose={vi.fn()} row={row} familyLabel={familyLabel} />
+    <MemoryRouter>
+      <HouseholdYearMembersModal isOpen onClose={vi.fn()} row={row} familyLabel={familyLabel} />
+    </MemoryRouter>
   )
 }
 
@@ -170,5 +177,107 @@ describe('nothing to show', () => {
     open(null)
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})
+
+describe('linking a member to their camper page for that year (kindred#2329)', () => {
+  it("links a child with a person_cm_id to /camper/:id, carrying THIS row's year", () => {
+    open(_row({ year: 2019 }))
+
+    const link = screen.getByRole('link', { name: /Emma Johnson/ })
+    expect(link).toHaveAttribute('href', '/camper/1000001?year=2019')
+  })
+
+  it('renders a child with no person_cm_id as plain text, never a broken link', () => {
+    open(
+      _row({
+        children: [
+          // No `person_cm_id` at all — the data-completeness case, distinct
+          // from the resolvability question the corrected issue body
+          // settles (own-year resolution is 100% BY CONSTRUCTION once a
+          // person_cm_id exists; this row simply doesn't have one).
+          { display_name: 'Noah Smith', last_name: 'Smith', age: 7, grade: 2 },
+        ],
+      })
+    )
+
+    expect(screen.queryByRole('link', { name: /Noah Smith/ })).not.toBeInTheDocument()
+    expect(screen.getByTestId('year-members-children').textContent).toContain('Noah Smith')
+  })
+
+  it('never links an adult — PartyAdult carries no person_cm_id to link with', () => {
+    open(_row())
+
+    expect(screen.queryByRole('link', { name: /Olivia Johnson/ })).not.toBeInTheDocument()
+    expect(screen.getByTestId('year-members-adults').textContent).toContain('Olivia Johnson')
+  })
+})
+
+describe('navigating to a linked camper unwinds the modal stack (kindred#2329)', () => {
+  // `ui/Modal` targets `#root` for background inert; jsdom doesn't load
+  // index.html, so tests recreate that element — same pattern as
+  // `ui/Modal.test.tsx`'s "background inert" describe block.
+  beforeEach(() => {
+    const root = document.createElement('div')
+    root.id = 'root'
+    document.body.appendChild(root)
+  })
+
+  afterEach(() => {
+    document.getElementById('root')?.remove()
+  })
+
+  // Mimics `HouseholdJourneyCard`'s own `openRow` state exactly: `onClose`
+  // clears it, which is what flips the `Modal`'s `isOpen` prop to false.
+  function Harness() {
+    const [isOpen, setIsOpen] = useState(true)
+    return (
+      <HouseholdYearMembersModal
+        isOpen={isOpen}
+        onClose={() => {
+          setIsOpen(false)
+        }}
+        row={_row({ year: 2019 })}
+        familyLabel="The Johnson Family"
+      />
+    )
+  }
+
+  function renderAtWeekendRoute() {
+    return render(
+      <MemoryRouter initialEntries={['/weekend/roster']}>
+        <Routes>
+          <Route path="/weekend/roster" element={<Harness />} />
+          <Route
+            path="/camper/:camperId"
+            element={<p data-testid="camper-page">Camper detail page</p>}
+          />
+        </Routes>
+      </MemoryRouter>
+    )
+  }
+
+  it('closes the dialog, empties the overlay stack, and clears background inert on click', () => {
+    renderAtWeekendRoute()
+
+    // Sanity: the dialog is actually open and registered before the click —
+    // otherwise the assertions below would trivially pass on an unmounted
+    // modal that never mounted in the first place.
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(document.getElementById('root')).toHaveAttribute('inert')
+    expect(hasOpenModal()).toBe(true)
+
+    fireEvent.click(screen.getByRole('link', { name: /Emma Johnson/ }))
+
+    // Real navigation happened — proves this isn't just `onClose` firing
+    // while still parked on the weekend route.
+    expect(screen.getByTestId('camper-page')).toBeInTheDocument()
+
+    // The unwind: the stack must not believe a modal is still mounted once
+    // the route has moved on, or the NEXT overlay opened anywhere in the
+    // app inherits a stuck `inert` background / wrong Escape ownership.
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(document.getElementById('root')).not.toHaveAttribute('inert')
+    expect(hasOpenModal()).toBe(false)
   })
 })

--- a/frontend/src/components/weekend/HouseholdYearMembersModal.tsx
+++ b/frontend/src/components/weekend/HouseholdYearMembersModal.tsx
@@ -21,13 +21,31 @@
  * `FamilyDetailsPanel`'s, and this imitates it deliberately: same forest
  * gradient, same `truncate text-lg font-bold` heading, same `text-forest-100
  * mt-0.5 text-xs` sub-line. A sibling surface, not a new visual language.
+ *
+ * A child's name links to their camper detail page FOR THIS ROW'S YEAR
+ * (kindred#2329) — `/camper/:id?year=N`, same tab, same `<Link>` +
+ * `onClick={onClose}` pattern `CamperDetailsPanel`'s sibling links already
+ * use. Adults never link: `PartyAdult` (from `family_camp_adults`, a
+ * name-only scrape) carries no `person_cm_id` to link with, unlike
+ * `PartyChild`. The unwind itself needs no new plumbing — navigating to
+ * `/camper/:id` swaps to a sibling Route, unmounting this Modal, and
+ * `ui/Modal`'s own effect cleanup (see that file) already releases the
+ * background inert and its `modalStack` overlay token on unmount. Nothing
+ * here talks to `modalStack` directly.
  */
 import { Baby, Users } from 'lucide-react'
+import { Link } from 'react-router'
 
 import type { HouseholdJourneyRow } from '../../types/lodging'
 import { displayCampMinderAge } from '../../utils/age'
 import { Modal } from '../ui/Modal'
 import { isAttendingAdultName } from './householdIdentity'
+
+/** Mirrors `CamperLink.tsx`'s own validity check — a CampMinder ID is only
+ *  ever a positive integer, so this also rules out a stray `0`. */
+function hasValidPersonCmId(personCmId: number | null | undefined): personCmId is number {
+  return personCmId != null && personCmId > 0
+}
 
 export interface HouseholdYearMembersModalProps {
   isOpen: boolean
@@ -146,7 +164,32 @@ export function HouseholdYearMembersModal({
                       is the card's treatment. A vertical list has no run to factor out, and
                       dropping the surname from each line would make a mixed-surname household
                       unreadable. */}
-                  <span className="text-foreground">{child.display_name}</span>
+                  {hasValidPersonCmId(child.person_cm_id) ? (
+                    // Same tab, this row's own year travels with the link —
+                    // NOT the app's current year (kindred#2329). `onClose`
+                    // closes the modal the same way its own close button
+                    // does; the route change (a sibling Route, not this
+                    // one) unmounts it regardless, but calling it too keeps
+                    // this in step with `CamperDetailsPanel`'s sibling
+                    // links rather than relying on unmount alone.
+                    <Link
+                      to={`/camper/${String(child.person_cm_id)}${
+                        row.year != null ? `?year=${String(row.year)}` : ''
+                      }`}
+                      onClick={onClose}
+                      className="text-foreground hover:text-primary font-medium transition-colors hover:underline"
+                    >
+                      {child.display_name}
+                    </Link>
+                  ) : (
+                    // No `person_cm_id` on file for this child — render as
+                    // plain text rather than a link that would 404. Per the
+                    // corrected issue body, a valid `person_cm_id` always
+                    // resolves for ITS OWN year by construction, so the only
+                    // reason to fall back here is a missing id, never an
+                    // unresolvable one.
+                    <span className="text-foreground">{child.display_name}</span>
+                  )}
                   <span className="text-muted-foreground text-xs">
                     {childDetail(child.age, child.grade)}
                   </span>

--- a/frontend/src/components/weekend/HouseholdYearMembersModal.tsx
+++ b/frontend/src/components/weekend/HouseholdYearMembersModal.tsx
@@ -41,10 +41,18 @@ import { displayCampMinderAge } from '../../utils/age'
 import { Modal } from '../ui/Modal'
 import { isAttendingAdultName } from './householdIdentity'
 
-/** Mirrors `CamperLink.tsx`'s own validity check — a CampMinder ID is only
- *  ever a positive integer, so this also rules out a stray `0`. */
+/**
+ * Mirrors `CamperLink.tsx`'s own validity check — a CampMinder ID is only
+ * ever a positive integer, so this also rules out a stray `0`.
+ *
+ * `Number.isInteger` matters, not just `> 0` (CodeRabbit review on
+ * kindred#2329's PR): `CamperDetail` resolves the id with `parseInt`, which
+ * TRUNCATES rather than rejects a fractional value — a link built from
+ * `1000001.5` would silently land on person 1000001, a different camper
+ * than the one this row is actually showing.
+ */
 function hasValidPersonCmId(personCmId: number | null | undefined): personCmId is number {
-  return personCmId != null && personCmId > 0
+  return personCmId != null && Number.isInteger(personCmId) && personCmId > 0
 }
 
 export interface HouseholdYearMembersModalProps {

--- a/frontend/src/components/weekend/HouseholdYearMembersModal.tsx
+++ b/frontend/src/components/weekend/HouseholdYearMembersModal.tsx
@@ -23,15 +23,14 @@
  * mt-0.5 text-xs` sub-line. A sibling surface, not a new visual language.
  *
  * A child's name links to their camper detail page FOR THIS ROW'S YEAR
- * (kindred#2329) — `/camper/:id?year=N`, same tab, same `<Link>` +
- * `onClick={onClose}` pattern `CamperDetailsPanel`'s sibling links already
- * use. Adults never link: `PartyAdult` (from `family_camp_adults`, a
- * name-only scrape) carries no `person_cm_id` to link with, unlike
- * `PartyChild`. The unwind itself needs no new plumbing — navigating to
- * `/camper/:id` swaps to a sibling Route, unmounting this Modal, and
- * `ui/Modal`'s own effect cleanup (see that file) already releases the
- * background inert and its `modalStack` overlay token on unmount. Nothing
- * here talks to `modalStack` directly.
+ * (kindred#2329) — `/camper/:id?year=N`, opened in a NEW TAB. Adults never
+ * link: `PartyAdult` (from `family_camp_adults`, a name-only scrape) carries
+ * no `person_cm_id` to link with, unlike `PartyChild`.
+ *
+ * Because the link opens elsewhere, THIS tab does not navigate and the modal
+ * deliberately stays open — there is no unwind to perform and nothing here
+ * talks to `modalStack`. `ui/Modal` still owns the background inert and the
+ * overlay token for as long as the modal is mounted, exactly as before.
  */
 import { Baby, Users } from 'lucide-react'
 import { Link } from 'react-router'
@@ -71,11 +70,23 @@ export interface HouseholdYearMembersModalProps {
 
 const TITLE_ID = 'household-year-members-title'
 
-/** An age or grade we do not have is omitted, never printed as zero. */
+/**
+ * An age or grade we do not have is omitted, never printed as zero.
+ *
+ * A grade above 12 is omitted too. CampMinder stores 13 for a camper past
+ * 12th grade -- 224 `persons` rows carry it and nothing carries more -- so
+ * it is a real value with no sensible label. School grades stop at 12; past
+ * that we show the age alone rather than inventing a "Grade 13".
+ */
+const HIGHEST_SCHOOL_GRADE = 12
+
 function childDetail(age: number | null | undefined, grade: number | null | undefined): string {
+  const gradeIsShowable =
+    grade !== null && grade !== undefined && grade > 0 && grade <= HIGHEST_SCHOOL_GRADE
+
   return [
     age === null || age === undefined ? '' : `Age ${displayCampMinderAge(age)}`,
-    grade === null || grade === undefined || grade === 0 ? '' : `Grade ${String(grade)}`,
+    gradeIsShowable ? `Grade ${String(grade)}` : '',
   ]
     .filter((part) => part.length > 0)
     .join(' · ')
@@ -173,18 +184,20 @@ export function HouseholdYearMembersModal({
                       dropping the surname from each line would make a mixed-surname household
                       unreadable. */}
                   {hasValidPersonCmId(child.person_cm_id) ? (
-                    // Same tab, this row's own year travels with the link —
-                    // NOT the app's current year (kindred#2329). `onClose`
-                    // closes the modal the same way its own close button
-                    // does; the route change (a sibling Route, not this
-                    // one) unmounts it regardless, but calling it too keeps
-                    // this in step with `CamperDetailsPanel`'s sibling
-                    // links rather than relying on unmount alone.
+                    // NEW TAB, and this row's own year travels with the
+                    // link — NOT the app's current year (kindred#2329).
+                    // Deliberately NO `onClick={onClose}`: this tab does not
+                    // move, so closing the modal here would drop the reader's
+                    // place in the roster for a page they are reading
+                    // elsewhere. `target="_blank"` also hands the click to
+                    // the browser rather than react-router, so no route
+                    // change happens in this tab at all.
                     <Link
                       to={`/camper/${String(child.person_cm_id)}${
                         row.year != null ? `?year=${String(row.year)}` : ''
                       }`}
-                      onClick={onClose}
+                      target="_blank"
+                      rel="noopener noreferrer"
                       className="text-foreground hover:text-primary font-medium transition-colors hover:underline"
                     >
                       {child.display_name}


### PR DESCRIPTION
## What

A child in `HouseholdYearMembersModal`'s per-year party list is now a link to `/camper/:id?year=N`, **opened in a new tab**. This row's own year travels with the link rather than falling through to the app's global year. `CamperDetail` now prefers `?year=` over the global context when resolving every enrollment/history/sibling fetch, so a 2019 journey row lands on that camper as they were in 2019, not as the app's global-year filter currently sees them.

Adults never link: `PartyAdult` (from `family_camp_adults`, a name-only scrape) carries no `person_cm_id` to link with, unlike `PartyChild`. A child missing `person_cm_id` also renders as plain text, never a broken link.

The existing "You are viewing historical data" banner on `CamperDetail` — previously unreachable, since every fetch always matched whatever year it was asked for — now compares against the app's real global year (a new `appCurrentYear` prop threaded separately from the effective fetch year) and fires correctly for a historical link.

## Navigation — a new tab, so this tab does not move

The link carries `target="_blank"` + `rel="noopener noreferrer"` and deliberately has **no** `onClick={onClose}`. Opening elsewhere means this tab stays put, so closing the modal here would drop the reader's place in the roster for a page they are reading in another tab.

`target="_blank"` also means react-router hands the click to the browser rather than navigating in place, so **no route change happens in this tab and there is no modal-stack unwind to perform**. `modalStack.ts` is untouched; `ui/Modal` keeps owning the background `inert` and the overlay token for as long as the modal is mounted, exactly as before.

A test pins this: it mounts the modal behind a real `MemoryRouter` route swap, clicks the link, and asserts the camper route did **not** render, the dialog is still present, `hasOpenModal()` is still true, and `#root` is still `inert`. Mutation-checked by removing `target="_blank"` — 2 tests went red (the attribute assertion and the no-navigation assertion), then restored green.

## Grade above 12 is not shown

Rolled in from the same review. CampMinder stores `13` for a camper past 12th grade — 224 `persons` rows carry it and nothing carries more — so the list was rendering a nonsensical "Grade 13". School grades stop at 12; above that the age prints alone, the same way an absent or zero grade is already omitted. Mutation-checked by widening the predicate back (1 test red, then restored green).

## Test-only changes

Adding a `<Link>` inside the modal means every render of it now needs a Router context. `HouseholdYearMembersModal.test.tsx`, `HouseholdJourneyCard.test.tsx`, and `FamilyDetailsPanel.test.tsx` (whose "Escape with a dialog open on top" suite opens this modal) are updated to wrap with `MemoryRouter` — no assertions changed.

## What I deliberately did not do

- Did not touch `frontend/src/ui/modalStack.ts` or `App.tsx` — neither needed a change, and the new-tab behaviour removes the unwind question entirely; #2237 is sequenced directly behind this PR on `modalStack.ts`, so the stack stays untouched rather than gaining modal-specific plumbing.
- Did not investigate *why* CampMinder emits grade 13, or change any stored value — this is a display guard only. The 224 rows keep their data.
- Did not add any ARIA — accessibility is opt-out on this surface (see `frontend/CLAUDE.md`), and the link's accessible name comes for free from its text content.
- Did not change the Siblings panel's existing (year-less) camper links — out of scope for this issue.

Closes #2329.
