### PR TITLE
fix(sync): widen bunk_assignments grain to (person, session, bunk, year)

### DIFF
--- a/pocketbase/pb_migrations/1500000155_bunk_assignments_bunk_grain.js
+++ b/pocketbase/pb_migrations/1500000155_bunk_assignments_bunk_grain.js
@@ -1,0 +1,118 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: widen bunk_assignments' unique index to include `bunk`.
+ * Resolves kindred#2259.
+ *
+ * kindred#2259: `findMatchingSession` derives a session for a CampMinder
+ * bunk assignment by intersecting a person's enrolled sessions with the
+ * sessions a bunk plan covers -- it has no way to see WHICH bunk the
+ * assignment names. When one bunk plan spans several sessions and a person
+ * is enrolled in more than one of them (95 of 97 measured cases in the
+ * production snapshot are Family Camp households booking two or more
+ * weekends under the same multi-session plan), every assignment that
+ * person holds under that plan can resolve to the same session. The write
+ * key -- `person:session:year` -- then collides across assignments that
+ * are genuinely different (different bunks), and the OLD unique index
+ * below enforced that collision at the database layer: the first sync of a
+ * season rejected the second assignment outright (a `Stats.Errors`
+ * increment logged and swallowed), and every sync after that silently
+ * overwrote the first assignment with the second. Exactly one row survived
+ * either way.
+ *
+ * THE FIX IS A WIDER GRAIN, NOT A SMARTER SESSION LOOKUP. The paired PR
+ * also narrows session resolution using the specific bunk on each
+ * assignment where the data allows it (a main+AG plan, where main and AG
+ * bunks are disjoint sets) -- but kindred#2259's own Fix direction rules
+ * out relying on that alone: a bunk shared across every session of its plan
+ * (every family-camp bunk) carries no disambiguating signal at all, no
+ * matter how it is queried. The two assignments in that case still resolve
+ * to the same session. What must not happen is losing one of them, and
+ * that is what this index widening guarantees: two rows for one person
+ * under one plan can now coexist whenever they name different bunks, which
+ * every CampMinder assignment does by construction (two assignments in the
+ * same bunk are the same assignment).
+ *
+ * WHY THIS MIGRATION IS NOT ENOUGH ON ITS OWN -- and is deliberately paired
+ * with a Go change in the same PR. Grain in this codebase is checked in at
+ * least four places for `bunk_assignments`, and they must all move
+ * together (see pocketbase/sync/bunk_assignments.go's comments at
+ * processAssignment, preloadExistingAssignments and deleteOrphans): the
+ * WRITE key, the PRELOAD key, the ORPHAN key (tracked in three places:
+ * processAssignment's TrackProcessedCompositeKey call,
+ * protectNonActiveStaffAssignments, and deleteOrphans's own key rebuild),
+ * and this UNIQUE INDEX. Widening only the index without widening the Go
+ * keys would still collapse assignments in memory before they ever reach
+ * the database. Widening only the Go keys without this index would let a
+ * duplicate-looking write through the Go layer only to be rejected by the
+ * OLD index underneath it. Widening the write key and this index but not
+ * the preload/orphan keys is the sharper trap: every row looks new on every
+ * sync (preload never finds it), so a widened write either duplicates
+ * forever or -- if the orphan key is also unwidened -- deleteOrphans
+ * rebuilds the OLD, narrower key from disk, finds no match in
+ * ProcessedKeys (which was tracked in the NEW, wider shape), and deletes
+ * the very rows this migration exists to stop losing. The Go PR widens all
+ * three non-database keys in the same change as this migration.
+ *
+ * SAFE TO WIDEN WITHOUT A GUARD. Going from (year, person, session) to
+ * (year, person, session, bunk) only ADDS a distinguishing column to an
+ * already-unique constraint -- every pair of rows the OLD index already
+ * kept apart stays apart under the NEW one; the new column can only
+ * separate rows further, never collide two that were previously distinct.
+ * There is no way for existing data to violate the wider constraint, so
+ * unlike 1500000147 (which re-keyed lodging's indexes onto a different
+ * column and had to refuse the migration if any row could not be keyed by
+ * the new column), this migration needs no pre-flight harm check.
+ *
+ * NEXT FREE MIGRATION NUMBER, RE-DERIVED. The campaign plan claimed 153 was
+ * next; 1500000153 (kindred#2308) and 1500000154 (kindred#2323) were both
+ * already taken by the time this shipped. Re-derived from `origin/main` at
+ * write time: 1500000155 is the first free number.
+ */
+
+const COLLECTION_NAME = "bunk_assignments";
+const OLD_INDEX_NAME = "idx_bunk_assignments_person_session_year";
+const NEW_INDEX_NAME = "idx_bunk_assignments_person_session_bunk_year";
+
+const OLD_INDEX_SQL =
+  "CREATE UNIQUE INDEX `" +
+  OLD_INDEX_NAME +
+  "` ON `" +
+  COLLECTION_NAME +
+  "` (`year`, `person`, `session`)";
+
+const NEW_INDEX_SQL =
+  "CREATE UNIQUE INDEX `" +
+  NEW_INDEX_NAME +
+  "` ON `" +
+  COLLECTION_NAME +
+  "` (`year`, `person`, `session`, `bunk`)";
+
+/**
+ * Drop any index carrying `name`, matched on the name itself rather than on
+ * indexOf against a column -- the same idempotency shape 1500000147 and
+ * 1500000151 use. `_migrations` keys on filename, so editing an
+ * already-applied migration silently skips it; matching by name is what
+ * keeps a re-run from pushing a second copy under the same name.
+ */
+function withoutIndex(col, name) {
+  return col.indexes.filter(function (sql) {
+    return sql.indexOf("`" + name + "`") === -1;
+  });
+}
+
+migrate(
+  (app) => {
+    const collection = app.findCollectionByNameOrId(COLLECTION_NAME);
+    collection.indexes = withoutIndex(collection, OLD_INDEX_NAME);
+    collection.indexes = withoutIndex(collection, NEW_INDEX_NAME);
+    collection.indexes.push(NEW_INDEX_SQL);
+    app.save(collection);
+  },
+  (app) => {
+    const collection = app.findCollectionByNameOrId(COLLECTION_NAME);
+    collection.indexes = withoutIndex(collection, NEW_INDEX_NAME);
+    collection.indexes = withoutIndex(collection, OLD_INDEX_NAME);
+    collection.indexes.push(OLD_INDEX_SQL);
+    app.save(collection);
+  }
+);

--- a/pocketbase/pb_migrations/1500000155_bunk_assignments_bunk_grain.js
+++ b/pocketbase/pb_migrations/1500000155_bunk_assignments_bunk_grain.js
@@ -63,6 +63,15 @@
  * column and had to refuse the migration if any row could not be keyed by
  * the new column), this migration needs no pre-flight harm check.
  *
+ * THE DOWN DIRECTION IS NOT SYMMETRICALLY SAFE, and that is inherent to any
+ * narrowing rather than a defect in this file. Once a sync has run under the
+ * wider index, a person can hold two rows for one session that differ only
+ * by bunk -- which is the entire point of the widening. Re-creating the old
+ * (year, person, session) unique index over that data fails on the duplicate,
+ * so `migrate down` succeeds only while no such pair exists yet. If a
+ * rollback is ever genuinely needed after a sync, the duplicate rows have to
+ * be resolved first, deliberately -- do not assume down is a free undo.
+ *
  * NEXT FREE MIGRATION NUMBER, RE-DERIVED. The campaign plan claimed 153 was
  * next; 1500000153 (kindred#2308) and 1500000154 (kindred#2323) were both
  * already taken by the time this shipped. Re-derived from `origin/main` at

--- a/pocketbase/sync/bunk_assignments.go
+++ b/pocketbase/sync/bunk_assignments.go
@@ -26,8 +26,14 @@ type BunkAssignmentsSync struct {
 	bunkPlanSessionsList map[int][]int
 
 	// Staff inclusion: resolve staff assignments to exact sessions
-	staffPersonCMIDs      map[int]bool   // person CM IDs where bunk_staff=true
-	bunkPlanBunkToSession map[string]int // "bunkPlanCMID:bunkCMID" → sessionCMID
+	staffPersonCMIDs map[int]bool // person CM IDs where bunk_staff=true
+	// "bunkPlanCMID:bunkCMID" → candidate sessionCMIDs. NOT one-to-one
+	// (kindred#2264): a bunk_plans row is keyed on (year, bunk, session,
+	// cm_id), so one bunk can legitimately be listed under several
+	// sessions of the same plan -- every family-camp bunk is. Every
+	// candidate is kept; ambiguity is resolved (or reported) at the read
+	// sites, resolveViaBunk and resolveStaffSession.
+	bunkPlanBunkToSession map[string][]int
 	bunkPBIDToCMID        map[string]int // bunk PB ID → bunk CM ID (reverse lookup)
 }
 
@@ -41,7 +47,7 @@ func NewBunkAssignmentsSync(app core.App, client *campminder.Client) *BunkAssign
 		personEnrollments:     make(map[int][]int),
 		bunkPlanSessionsList:  make(map[int][]int),
 		staffPersonCMIDs:      make(map[int]bool),
-		bunkPlanBunkToSession: make(map[string]int),
+		bunkPlanBunkToSession: make(map[string][]int),
 		bunkPBIDToCMID:        make(map[string]int),
 	}
 }
@@ -66,31 +72,8 @@ func (s *BunkAssignmentsSync) Sync(ctx context.Context) error {
 	// Pre-load all existing assignments using composite key utility
 	// We need to build keys based on person/session CampMinder IDs stored during creation
 	year := s.Client.GetSeasonID()
-	filter := fmt.Sprintf("year = %d", year)
 
-	// First, load mappings of PocketBase IDs to CampMinder IDs for existing assignments
-	assignmentMappings, err := s.BuildRecordCMIDMappings("bunk_assignments", filter, map[string]string{
-		"person":  "persons",
-		"session": "camp_sessions",
-	})
-	if err != nil {
-		return fmt.Errorf("loading assignment mappings: %w", err)
-	}
-
-	// Now load existing assignments with proper composite keys
-	existingAssignments, err := s.PreloadCompositeRecords(
-		"bunk_assignments", filter, func(record *core.Record) (string, bool) {
-			mapping := assignmentMappings[record.Id]
-			personCMID := mapping["personCMID"]
-			sessionCMID := mapping["sessionCMID"]
-			recordYear, _ := record.Get("year").(float64)
-
-			if personCMID > 0 && sessionCMID > 0 && recordYear > 0 {
-				key := fmt.Sprintf("%d:%d:%d", personCMID, sessionCMID, int(recordYear))
-				return key, true
-			}
-			return "", false
-		})
+	existingAssignments, err := s.preloadExistingAssignments(year)
 	if err != nil {
 		return err
 	}
@@ -201,23 +184,20 @@ func (s *BunkAssignmentsSync) Sync(ctx context.Context) error {
 				}
 				personCMID := int(personID)
 
-				// Find the correct session by intersecting person's enrollments with bunk plan's sessions
-				personSessions := s.personEnrollments[personCMID]
-				sessionID := s.findMatchingSession(personSessions, bunkPlanSessions)
+				// Find the correct session. See resolveAssignmentSession for the
+				// full ladder; ambiguous is only ever true on the staff path,
+				// where a (bunkPlan, bunk) key has more than one candidate
+				// session and guessing would be worse than skipping (kindred#2264).
+				sessionID, ambiguous := s.resolveAssignmentSession(personCMID, bunkPlanID, bunkID, bunkPlanSessions)
+				if ambiguous {
+					slog.Warn("Ambiguous (bunkPlan, bunk) staff session lookup, skipping assignment",
+						"bunkPlanCMID", bunkPlanID, "bunkCMID", bunkID, "personCMID", personCMID)
+					s.Stats.Skipped++
+					continue
+				}
 				if sessionID == 0 {
-					// Staff fallback: use (bunkPlan, bunk) → session lookup.
-					// Staff aren't in attendees, so enrollment intersection won't work.
-					// Each (bunkPlanCMID, bunkCMID) pair maps to exactly one session.
-					if s.staffPersonCMIDs[personCMID] {
-						key := fmt.Sprintf("%d:%d", bunkPlanID, bunkID)
-						if sid, ok := s.bunkPlanBunkToSession[key]; ok {
-							sessionID = sid
-						}
-					}
-					if sessionID == 0 {
-						s.Stats.Skipped++
-						continue
-					}
+					s.Stats.Skipped++
+					continue
 				}
 
 				// Add BunkID, BunkPlanID, and SessionID to the assignment data
@@ -357,11 +337,17 @@ func (s *BunkAssignmentsSync) loadMappings() error {
 			s.bunkPlanSessionsList[bpCMID] = append(s.bunkPlanSessionsList[bpCMID], sessionCMID)
 		}
 
-		// Build bunkPlanBunkToSession: each (bunkPlan, bunk) pair maps to exactly one session
+		// Build bunkPlanBunkToSession: collect every session this (bunkPlan,
+		// bunk) pair is associated with -- NOT overwriting. A bunk_plans row
+		// is unique on (year, bunk, session, cm_id), so the same bunk can
+		// legitimately be listed under several sessions of one plan (every
+		// family-camp bunk is, across all 8 of its plan's sessions). This
+		// used to keep only whichever row PaginateRecords visited last,
+		// silently, which is kindred#2264.
 		if bunkPBID := record.GetString("bunk"); bunkPBID != "" {
 			if bunkCMID, ok := s.bunkPBIDToCMID[bunkPBID]; ok && bpCMID > 0 && sessionCMID > 0 {
 				key := fmt.Sprintf("%d:%d", bpCMID, bunkCMID)
-				s.bunkPlanBunkToSession[key] = sessionCMID
+				s.bunkPlanBunkToSession[key] = append(s.bunkPlanBunkToSession[key], sessionCMID)
 			}
 		}
 
@@ -391,11 +377,66 @@ func (s *BunkAssignmentsSync) loadMappings() error {
 	return nil
 }
 
+// preloadExistingAssignments loads this year's bunk_assignments rows keyed on
+// the full (person, session, bunk, year) composite Sync() writes and
+// deleteOrphans reads back (kindred#2259). Extracted out of Sync() so tests
+// can drive the same preload path directly without a live CampMinder HTTP
+// client.
+//
+// "bunk" is part of the mapping -- and every key built from it -- because the
+// grain of bunk_assignments is (person, session, bunk, year), not (person,
+// session, year). A multi-session bunk plan can give one person two
+// assignments that resolve through the same session-derivation path; without
+// bunk in the key the second write collides with the first and one of the
+// two is silently lost. See the write key in processAssignment and the
+// orphan key in deleteOrphans -- all three (plus this preload key, the
+// fourth of the grain) must move together.
+func (s *BunkAssignmentsSync) preloadExistingAssignments(year int) (map[string]*core.Record, error) {
+	filter := fmt.Sprintf("year = %d", year)
+
+	assignmentMappings, err := s.BuildRecordCMIDMappings("bunk_assignments", filter, map[string]string{
+		"person":  "persons",
+		"session": "camp_sessions",
+		"bunk":    "bunks",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("loading assignment mappings: %w", err)
+	}
+
+	return s.PreloadCompositeRecords(
+		"bunk_assignments", filter, func(record *core.Record) (string, bool) {
+			mapping := assignmentMappings[record.Id]
+			personCMID := mapping["personCMID"]
+			sessionCMID := mapping["sessionCMID"]
+			bunkCMID := mapping["bunkCMID"]
+			recordYear, _ := record.Get("year").(float64)
+
+			if personCMID > 0 && sessionCMID > 0 && bunkCMID > 0 && recordYear > 0 {
+				key := fmt.Sprintf("%d:%d:%d:%d", personCMID, sessionCMID, bunkCMID, int(recordYear))
+				return key, true
+			}
+			return "", false
+		})
+}
+
 // findMatchingSession finds the session that a person is enrolled in that also belongs to the bunk plan.
 // CampMinder assignments don't include session ID - we must derive it by intersecting:
 // - The sessions the person is enrolled in (from attendees)
 // - The sessions the bunk plan applies to (from bunk_plans)
 // Returns the first matching session ID, or 0 if no match found.
+//
+// This is the PLAN-WIDE fallback, used when resolveViaBunk cannot narrow the
+// candidates using the specific bunk on this assignment (kindred#2259). It is
+// deliberately imprecise in exactly the case it always was: when a bunk is
+// shared across every session of its plan (the family plan) and the person
+// is enrolled in more than one of those sessions, this returns the first
+// intersecting session for every assignment that person holds under the
+// plan, regardless of which bunk each one names. Widening the storage grain
+// to include bunk (see processAssignment) means both assignments still
+// survive as separate rows even though this function alone cannot tell them
+// apart -- per-bunk disambiguation "cannot be made to work for the family
+// plan" (kindred#2259's Fix direction), so this fallback intentionally does
+// not try.
 func (s *BunkAssignmentsSync) findMatchingSession(personSessions, bunkPlanSessions []int) int {
 	// Build a set of person's sessions for O(1) lookup
 	personSessionSet := make(map[int]bool)
@@ -411,6 +452,101 @@ func (s *BunkAssignmentsSync) findMatchingSession(personSessions, bunkPlanSessio
 	}
 
 	return 0
+}
+
+// resolveViaBunk narrows a camper's session candidates to the ones the
+// SPECIFIC bunk on this assignment is associated with under the plan
+// (s.bunkPlanBunkToSession, kindred#2264), intersected with the sessions the
+// person is actually enrolled in. It reports a session only when that
+// narrowing is unambiguous -- exactly one session that is both a candidate
+// for this bunk and one the person is enrolled in.
+//
+// This is precise whenever a bunk pins to fewer sessions than the whole
+// plan -- e.g. a main+AG plan, where main and AG bunks are disjoint sets, so
+// each bunk's own candidate list already has only one session in it. It
+// deliberately reports no match when the bunk is shared across every
+// session of its plan (the family plan): the candidate list is then as long
+// as the plan's whole session list, narrows nothing, and resolution falls
+// back to the plan-wide findMatchingSession instead of guessing which of
+// several equally-valid sessions this bunk-specific assignment belongs to.
+func (s *BunkAssignmentsSync) resolveViaBunk(personSessions []int, bunkPlanID, bunkID int) (int, bool) {
+	key := fmt.Sprintf("%d:%d", bunkPlanID, bunkID)
+	candidates := s.bunkPlanBunkToSession[key]
+	if len(candidates) == 0 {
+		return 0, false
+	}
+
+	personSessionSet := make(map[int]bool, len(personSessions))
+	for _, sessionID := range personSessions {
+		personSessionSet[sessionID] = true
+	}
+
+	match, matches := 0, 0
+	for _, sessionID := range candidates {
+		if personSessionSet[sessionID] {
+			match = sessionID
+			matches++
+		}
+	}
+	if matches == 1 {
+		return match, true
+	}
+	return 0, false
+}
+
+// resolveStaffSession looks up the session(s) a specific (bunkPlan, bunk)
+// pair is associated with, for staff -- who are not in attendees, so there
+// is no enrollment to intersect against the way resolveViaBunk does for
+// campers. It reports the session only when exactly one candidate exists;
+// ambiguous is true when there is more than one, so the caller can skip and
+// warn instead of guessing. kindred#2264: the map this reads used to
+// silently keep whichever bunk_plans row was written last, so a bunk shared
+// across several sessions of one plan resolved every staff member on it to
+// an arbitrary session with no error and no log line.
+func (s *BunkAssignmentsSync) resolveStaffSession(bunkPlanID, bunkID int) (sessionID int, ambiguous bool) {
+	key := fmt.Sprintf("%d:%d", bunkPlanID, bunkID)
+	candidates := s.bunkPlanBunkToSession[key]
+	switch len(candidates) {
+	case 0:
+		return 0, false
+	case 1:
+		return candidates[0], false
+	default:
+		return 0, true
+	}
+}
+
+// resolveAssignmentSession is the full session-resolution ladder applied to
+// one CampMinder assignment (personCMID, under bunkPlanID, in bunkID):
+//
+//  1. Camper path, narrow: resolveViaBunk, using the specific bunk this
+//     assignment names (kindred#2259/#2264).
+//  2. Camper path, plan-wide fallback: findMatchingSession, unchanged from
+//     before this pair of fixes.
+//  3. Staff fallback: resolveStaffSession, only reached if steps 1-2 found
+//     nothing -- staff are not in attendees, so personSessions is always
+//     empty for them and neither camper path can ever match.
+//
+// ambiguous is true only when step 3 finds more than one candidate session;
+// the caller must skip that assignment rather than guess (kindred#2264).
+func (s *BunkAssignmentsSync) resolveAssignmentSession(
+	personCMID, bunkPlanID, bunkID int, bunkPlanSessions []int,
+) (sessionID int, ambiguous bool) {
+	personSessions := s.personEnrollments[personCMID]
+
+	if sid, ok := s.resolveViaBunk(personSessions, bunkPlanID, bunkID); ok {
+		return sid, false
+	}
+
+	if sid := s.findMatchingSession(personSessions, bunkPlanSessions); sid != 0 {
+		return sid, false
+	}
+
+	if s.staffPersonCMIDs[personCMID] {
+		return s.resolveStaffSession(bunkPlanID, bunkID)
+	}
+
+	return 0, false
 }
 
 // processAssignment processes a single bunk assignment using pre-loaded existing assignments
@@ -444,8 +580,12 @@ func (s *BunkAssignmentsSync) processAssignment(
 	bunkCMID := int(bunkID)
 	bunkPlanCMID := int(bunkPlanID)
 
-	// Track this assignment as processed using base class tracking
-	s.TrackProcessedCompositeKey(fmt.Sprintf("%d:%d", personCMID, sessionCMID), s.Client.GetSeasonID())
+	// Track this assignment as processed using base class tracking. The key
+	// includes bunk (kindred#2259) so it matches the ORPHAN key deleteOrphans
+	// rebuilds and the one protectNonActiveStaffAssignments writes for
+	// protected non-active staff -- all three must move together, or a run
+	// after this one deletes the very rows this widening exists to keep.
+	s.TrackProcessedCompositeKey(fmt.Sprintf("%d:%d:%d", personCMID, sessionCMID, bunkCMID), s.Client.GetSeasonID())
 
 	// Validate person exists
 	if !s.validPersonCMIDs[personCMID] {
@@ -471,9 +611,14 @@ func (s *BunkAssignmentsSync) processAssignment(
 		assignmentCMID = int(id)
 	}
 
-	// Check if assignment already exists using composite key
+	// Check if assignment already exists using composite key. bunk is part
+	// of the grain (kindred#2259): a multi-session bunk plan can give one
+	// person two assignments that resolve to the same session (see
+	// findMatchingSession's doc comment), and without bunk in the key the
+	// second write collides with the first under the unique index and one
+	// row is silently lost.
 	year := s.Client.GetSeasonID()
-	key := fmt.Sprintf("%d:%d:%d", personCMID, sessionCMID, year)
+	key := fmt.Sprintf("%d:%d:%d:%d", personCMID, sessionCMID, bunkCMID, year)
 
 	recordData := map[string]any{
 		"year":  year,
@@ -607,7 +752,28 @@ func (s *BunkAssignmentsSync) protectNonActiveStaffAssignments(year int) (int, e
 			if !ok {
 				continue
 			}
-			key := fmt.Sprintf("%d:%d", personCMID, int(sessionCMID))
+
+			// bunk is part of the grain (kindred#2259) and the same
+			// query-failure-vs-absence distinction applies to it as to
+			// session above: a lookup error must abort, a genuinely missing
+			// bunk relation is a non-destructive skip.
+			bunkPBID := ba.GetString("bunk")
+			if bunkPBID == "" {
+				continue
+			}
+			bunks, err := s.App.FindRecordsByFilter("bunks", fmt.Sprintf("id = '%s'", bunkPBID), "", 1, 0)
+			if err != nil {
+				return fmt.Errorf("resolving bunk %q for person %d: %w", bunkPBID, personCMID, err)
+			}
+			if len(bunks) == 0 {
+				continue
+			}
+			bunkCMID, ok := bunks[0].Get("cm_id").(float64)
+			if !ok {
+				continue
+			}
+
+			key := fmt.Sprintf("%d:%d:%d", personCMID, int(sessionCMID), int(bunkCMID))
 			s.TrackProcessedCompositeKey(key, year)
 			protectedCount++
 		}
@@ -629,10 +795,17 @@ func (s *BunkAssignmentsSync) deleteOrphans() error {
 	year := s.Client.GetSeasonID()
 	filter := fmt.Sprintf("year = %d", year)
 
-	// First, load mappings for all assignments
+	// First, load mappings for all assignments. "bunk" is part of the grain
+	// (kindred#2259) -- see the matching comment on the preload mapping in
+	// Sync(). A widened key that cannot be reconstructed for an existing row
+	// (bunkCMID == 0) must fail to key, not silently fall back to the old
+	// narrower key: that would present as an orphan under the new key format
+	// while never matching anything protectNonActiveStaffAssignments or
+	// processAssignment tracked, and get deleted.
 	assignmentMappings, err := s.BuildRecordCMIDMappings("bunk_assignments", filter, map[string]string{
 		"person":  "persons",
 		"session": "camp_sessions",
+		"bunk":    "bunks",
 	})
 	if err != nil {
 		return fmt.Errorf("loading mappings for orphan detection: %w", err)
@@ -644,16 +817,20 @@ func (s *BunkAssignmentsSync) deleteOrphans() error {
 			mapping := assignmentMappings[record.Id]
 			personCMID := mapping["personCMID"]
 			sessionCMID := mapping["sessionCMID"]
+			bunkCMID := mapping["bunkCMID"]
 			yearValue := record.Get("year")
 
-			if personCMID > 0 && sessionCMID > 0 {
+			if personCMID > 0 && sessionCMID > 0 && bunkCMID > 0 {
 				// Build composite key with year
 				year, ok := yearValue.(float64)
 				if !ok {
 					return "", false
 				}
-				// For composite records, append year to the composite key
-				key := fmt.Sprintf("%d:%d|%d", personCMID, sessionCMID, int(year))
+				// For composite records, append year to the composite key.
+				// This must match TrackProcessedCompositeKey's format exactly
+				// (person:session:bunk, then "|" + year) -- processAssignment
+				// and protectNonActiveStaffAssignments both build it that way.
+				key := fmt.Sprintf("%d:%d:%d|%d", personCMID, sessionCMID, bunkCMID, int(year))
 				return key, true
 			}
 			return "", false

--- a/pocketbase/sync/bunk_assignments.go
+++ b/pocketbase/sync/bunk_assignments.go
@@ -311,8 +311,10 @@ func (s *BunkAssignmentsSync) loadMappings() error {
 
 	// Load bunk plan sessions: bunkPlanCMID -> list of sessionCMIDs
 	// A bunk plan can apply to multiple sessions (e.g., main + AG sessions)
-	// Also build bunkPlanBunkToSession: "bunkPlanCMID:bunkCMID" → sessionCMID
-	// for resolving staff assignments to exact sessions.
+	// Also build bunkPlanBunkToSession: "bunkPlanCMID:bunkCMID" -> the list of
+	// candidate sessionCMIDs, used to narrow a camper's session by the bunk the
+	// assignment names and to resolve (or report as ambiguous) a staff
+	// assignment's session. Both mappings are lists, not single values.
 	slog.Info("Loading bunk plan to sessions mapping")
 	bpFilter := fmt.Sprintf("year = %d", year)
 	if err := s.PaginateRecords("bunk_plans", bpFilter, func(record *core.Record) error {

--- a/pocketbase/sync/bunk_assignments.go
+++ b/pocketbase/sync/bunk_assignments.go
@@ -190,8 +190,10 @@ func (s *BunkAssignmentsSync) Sync(ctx context.Context) error {
 				// session and guessing would be worse than skipping (kindred#2264).
 				sessionID, ambiguous := s.resolveAssignmentSession(personCMID, bunkPlanID, bunkID, bunkPlanSessions)
 				if ambiguous {
+					candidateCount := len(s.bunkPlanBunkToSession[fmt.Sprintf("%d:%d", bunkPlanID, bunkID)])
 					slog.Warn("Ambiguous (bunkPlan, bunk) staff session lookup, skipping assignment",
-						"bunkPlanCMID", bunkPlanID, "bunkCMID", bunkID, "personCMID", personCMID)
+						"bunkPlanCMID", bunkPlanID, "bunkCMID", bunkID, "personCMID", personCMID,
+						"candidateCount", candidateCount)
 					s.Stats.Skipped++
 					continue
 				}

--- a/pocketbase/sync/bunk_assignments_grain_test.go
+++ b/pocketbase/sync/bunk_assignments_grain_test.go
@@ -3,6 +3,8 @@ package sync
 import (
 	"fmt"
 	"os"
+	"slices"
+	"sort"
 	"testing"
 
 	"github.com/camp/kindred/pocketbase/campminder"
@@ -31,18 +33,22 @@ func newParallelTestCampMinderClient(t *testing.T, year int) *campminder.Client 
 }
 
 // setupBunkAssignmentGrainCollections builds the schema needed to drive
-// processAssignment and preloadExistingAssignments directly against a live
-// PocketBase app: persons, camp_sessions, bunks (all year-scoped, matching
-// LookupRelation's year filter for these collections), an empty bunk_plans
-// (LookupBunkPlan queries it even when the optional bunk_plan relation
-// cannot be resolved), bunk_assignments itself, and an empty staff
-// collection (protectThenSweepOrphans's protection pass needs it to exist).
+// processAssignment, preloadExistingAssignments and loadMappings directly
+// against a live PocketBase app: persons, camp_sessions, bunks (all
+// year-scoped, matching LookupRelation's year filter for these
+// collections), bunk_plans (LookupBunkPlan queries it even when the
+// optional bunk_plan relation cannot be resolved, and loadMappings walks it
+// to build bunkPlanBunkToSession), bunk_assignments itself, attendees
+// (loadMappings reads person enrollments from it) and staff
+// (protectThenSweepOrphans's protection pass and loadMappings both need it
+// to exist).
 func setupBunkAssignmentGrainCollections(t *testing.T, app core.App) {
 	t.Helper()
 
 	persons := core.NewBaseCollection("persons")
 	persons.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
 	persons.Fields.Add(&core.NumberField{Name: "year", Required: true})
+	persons.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
 	if err := app.Save(persons); err != nil {
 		t.Fatalf("create persons: %v", err)
 	}
@@ -50,6 +56,7 @@ func setupBunkAssignmentGrainCollections(t *testing.T, app core.App) {
 	sessions := core.NewBaseCollection("camp_sessions")
 	sessions.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
 	sessions.Fields.Add(&core.NumberField{Name: "year", Required: true})
+	sessions.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
 	if err := app.Save(sessions); err != nil {
 		t.Fatalf("create camp_sessions: %v", err)
 	}
@@ -57,6 +64,7 @@ func setupBunkAssignmentGrainCollections(t *testing.T, app core.App) {
 	bunks := core.NewBaseCollection("bunks")
 	bunks.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
 	bunks.Fields.Add(&core.NumberField{Name: "year", Required: true})
+	bunks.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
 	if err := app.Save(bunks); err != nil {
 		t.Fatalf("create bunks: %v", err)
 	}
@@ -66,6 +74,7 @@ func setupBunkAssignmentGrainCollections(t *testing.T, app core.App) {
 	bunkPlans.Fields.Add(&core.RelationField{Name: "bunk", CollectionId: bunks.Id, MaxSelect: 1})
 	bunkPlans.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
 	bunkPlans.Fields.Add(&core.NumberField{Name: "year", Required: true})
+	bunkPlans.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
 	if err := app.Save(bunkPlans); err != nil {
 		t.Fatalf("create bunk_plans: %v", err)
 	}
@@ -91,6 +100,16 @@ func setupBunkAssignmentGrainCollections(t *testing.T, app core.App) {
 	}
 	if err := app.Save(assignments); err != nil {
 		t.Fatalf("create bunk_assignments: %v", err)
+	}
+
+	attendees := core.NewBaseCollection("attendees")
+	attendees.Fields.Add(&core.NumberField{Name: "person_id", Required: true})
+	attendees.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
+	attendees.Fields.Add(&core.NumberField{Name: "status_id"})
+	attendees.Fields.Add(&core.NumberField{Name: "year", Required: true})
+	attendees.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
+	if err := app.Save(attendees); err != nil {
+		t.Fatalf("create attendees: %v", err)
 	}
 
 	staff := core.NewBaseCollection("staff")
@@ -464,5 +483,98 @@ func TestBunkAssignmentGrain_SecondSyncRunNeitherLosesNorDuplicates(t *testing.T
 	if len(rows) != 2 {
 		t.Fatalf("after run 2: bunk_assignments rows = %d, want 2 -- an unwidened orphan key would delete both "+
 			"rows the widening exists to keep, silently", len(rows))
+	}
+}
+
+// TestLoadMappings_KeepsEveryCandidateSessionForASharedBunk drives the
+// PRODUCTION map-building path -- loadMappings walking real bunk_plans
+// records -- rather than hand-assembling s.bunkPlanBunkToSession the way
+// every other test in this package does.
+//
+// That distinction is the whole point of the test. kindred#2264's defect
+// lived in the ASSIGNMENT in loadMappings, not in the read sites: two
+// bunk_plans rows sharing a plan cm_id and a bunk cm_id but naming
+// different sessions used to overwrite each other, so whichever row
+// PaginateRecords visited last became the only surviving candidate. Every
+// test that builds the map itself starts from candidates that already
+// survived, so reverting that one line to an overwrite left the entire sync
+// package green -- verified by mutation before this test was written. This
+// is the acceptance checklist's "feed the map-building path two bunk_plans
+// records sharing plan cm_id and bunk cm_id with different session cm_ids,
+// and assert both survive".
+func TestLoadMappings_KeepsEveryCandidateSessionForASharedBunk(t *testing.T) {
+	t.Parallel()
+
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupBunkAssignmentGrainCollections(t, app)
+
+	const year = 2026
+	const planCMID = 8401
+	const sessionACMID = 5401 // family weekend 1
+	const sessionBCMID = 5402 // family weekend 2
+	const sharedBunkCMID = 6401
+	const soloBunkCMID = 6402
+
+	sessionA := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": sessionACMID, "year": year})
+	sessionB := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": sessionBCMID, "year": year})
+	sharedBunk := saveRec(t, app, "bunks", map[string]any{"cm_id": sharedBunkCMID, "year": year})
+	soloBunk := saveRec(t, app, "bunks", map[string]any{"cm_id": soloBunkCMID, "year": year})
+
+	// The family-camp shape: one plan, one bunk, listed under BOTH of the
+	// plan's sessions. bunk_plans' own unique index is (year, bunk, session,
+	// cm_id), so these two rows are legitimate, not duplicates.
+	saveRec(t, app, "bunk_plans", map[string]any{
+		"cm_id": planCMID, "bunk": sharedBunk.Id, "session": sessionA.Id, "year": year,
+	})
+	saveRec(t, app, "bunk_plans", map[string]any{
+		"cm_id": planCMID, "bunk": sharedBunk.Id, "session": sessionB.Id, "year": year,
+	})
+	// A bunk of the same plan that appears under exactly one session -- the
+	// main+AG shape -- so the test also pins that the unambiguous case is
+	// still a single candidate and still resolves.
+	saveRec(t, app, "bunk_plans", map[string]any{
+		"cm_id": planCMID, "bunk": soloBunk.Id, "session": sessionA.Id, "year": year,
+	})
+
+	s := NewBunkAssignmentsSync(app, newParallelTestCampMinderClient(t, year))
+	if err := s.loadMappings(); err != nil {
+		t.Fatalf("loadMappings: %v", err)
+	}
+
+	sharedKey := fmt.Sprintf("%d:%d", planCMID, sharedBunkCMID)
+	gotShared := append([]int(nil), s.bunkPlanBunkToSession[sharedKey]...)
+	sort.Ints(gotShared)
+	wantShared := []int{sessionACMID, sessionBCMID}
+	if !slices.Equal(gotShared, wantShared) {
+		t.Errorf("bunkPlanBunkToSession[%q] = %v, want %v -- kindred#2264: a bunk listed under several "+
+			"sessions of one plan must keep EVERY candidate, not just the last bunk_plans row read",
+			sharedKey, gotShared, wantShared)
+	}
+
+	soloKey := fmt.Sprintf("%d:%d", planCMID, soloBunkCMID)
+	if got := s.bunkPlanBunkToSession[soloKey]; !slices.Equal(got, []int{sessionACMID}) {
+		t.Errorf("bunkPlanBunkToSession[%q] = %v, want [%d] -- a bunk under one session must stay one candidate",
+			soloKey, got, sessionACMID)
+	}
+
+	// The plan-level list is built by the sibling block that always appended;
+	// pinning it here keeps a future "simplification" from collapsing it too.
+	gotPlan := append([]int(nil), s.bunkPlanSessionsList[planCMID]...)
+	sort.Ints(gotPlan)
+	if !slices.Equal(gotPlan, []int{sessionACMID, sessionACMID, sessionBCMID}) {
+		t.Errorf("bunkPlanSessionsList[%d] = %v, want one entry per bunk_plans row", planCMID, gotPlan)
+	}
+
+	// And the read site sees the ambiguity the build site preserved: this is
+	// what turns the kept candidates into a skip-and-warn instead of a guess.
+	if sessionCMID, ambiguous := s.resolveStaffSession(planCMID, sharedBunkCMID); !ambiguous || sessionCMID != 0 {
+		t.Errorf("resolveStaffSession(shared bunk) = (%d, %v), want (0, true)", sessionCMID, ambiguous)
+	}
+	if sessionCMID, ambiguous := s.resolveStaffSession(planCMID, soloBunkCMID); ambiguous || sessionCMID != sessionACMID {
+		t.Errorf("resolveStaffSession(solo bunk) = (%d, %v), want (%d, false)", sessionCMID, ambiguous, sessionACMID)
 	}
 }

--- a/pocketbase/sync/bunk_assignments_grain_test.go
+++ b/pocketbase/sync/bunk_assignments_grain_test.go
@@ -2,11 +2,33 @@ package sync
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
+	"github.com/camp/kindred/pocketbase/campminder"
 	"github.com/pocketbase/pocketbase/core"
 	pbtests "github.com/pocketbase/pocketbase/tests"
 )
+
+// newParallelTestCampMinderClient is newTestCampMinderClient
+// (bunk_assignments_protection_test.go), adapted for a t.Parallel() caller.
+// t.Setenv panics under Parallel because it cannot be safely undone once
+// sibling tests are running concurrently; os.Setenv has no such restriction,
+// and every caller wants the identical constant value, so leaving it set for
+// the rest of the test binary's life is harmless.
+func newParallelTestCampMinderClient(t *testing.T, year int) *campminder.Client {
+	t.Helper()
+	//nolint:usetesting // t.Setenv panics under t.Parallel(); every caller wants
+	// this identical constant value, so os.Setenv with no cleanup is deliberate.
+	if err := os.Setenv("CAMPMINDER_PRIMARY_KEY", "test-subscription-key"); err != nil {
+		t.Fatalf("os.Setenv: %v", err)
+	}
+	client, err := campminder.NewClient(&campminder.Config{APIKey: "test-key", ClientID: "test-client", SeasonID: year})
+	if err != nil {
+		t.Fatalf("campminder.NewClient: %v", err)
+	}
+	return client
+}
 
 // setupBunkAssignmentGrainCollections builds the schema needed to drive
 // processAssignment and preloadExistingAssignments directly against a live
@@ -119,6 +141,8 @@ func bunkAssignmentsForYear(t *testing.T, app core.App, year int) []*core.Record
 // index rejects. Widening the key is what lets a second, distinct row
 // exist at all; resolveViaBunk is what makes it land on the RIGHT session.
 func TestProcessAssignment_MultiSessionPlanDisambiguatedByBunk(t *testing.T) {
+	t.Parallel()
+
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -141,7 +165,7 @@ func TestProcessAssignment_MultiSessionPlanDisambiguatedByBunk(t *testing.T) {
 	saveRec(t, app, "bunks", map[string]any{"cm_id": bunkBCMID, "year": year})
 
 	s := &BunkAssignmentsSync{BaseSyncService: BaseSyncService{
-		App: app, Client: newTestCampMinderClient(t, year), ProcessedKeys: make(map[string]bool),
+		App: app, Client: newParallelTestCampMinderClient(t, year), ProcessedKeys: make(map[string]bool),
 	}}
 	s.personEnrollments = map[int][]int{personCMID: {sessionACMID, sessionBCMID}}
 	s.bunkPlanSessionsList = map[int][]int{planCMID: {sessionACMID, sessionBCMID}}
@@ -238,6 +262,8 @@ func TestProcessAssignment_MultiSessionPlanDisambiguatedByBunk(t *testing.T) {
 // kindred#2259 (95 of 97 measured collisions): before the fix, this exact
 // scenario silently dropped one of the two rows.
 func TestProcessAssignment_FamilyStylePlanPreservesBothRowsImprecisely(t *testing.T) {
+	t.Parallel()
+
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -260,7 +286,7 @@ func TestProcessAssignment_FamilyStylePlanPreservesBothRowsImprecisely(t *testin
 	saveRec(t, app, "bunks", map[string]any{"cm_id": bunkYCMID, "year": year})
 
 	s := &BunkAssignmentsSync{BaseSyncService: BaseSyncService{
-		App: app, Client: newTestCampMinderClient(t, year), ProcessedKeys: make(map[string]bool),
+		App: app, Client: newParallelTestCampMinderClient(t, year), ProcessedKeys: make(map[string]bool),
 	}}
 	s.personEnrollments = map[int][]int{personCMID: {sessionACMID, sessionBCMID}}
 	s.bunkPlanSessionsList = map[int][]int{planCMID: {sessionACMID, sessionBCMID}}
@@ -278,7 +304,7 @@ func TestProcessAssignment_FamilyStylePlanPreservesBothRowsImprecisely(t *testin
 		t.Fatalf("preloadExistingAssignments: %v", err)
 	}
 
-	var resolvedSessions []int
+	resolvedSessions := make([]int, 0, 2)
 	for _, bunkCMID := range []int{bunkXCMID, bunkYCMID} {
 		sessionID, ambiguous := s.resolveAssignmentSession(personCMID, planCMID, bunkCMID, s.bunkPlanSessionsList[planCMID])
 		if ambiguous {
@@ -341,6 +367,8 @@ func TestProcessAssignment_FamilyStylePlanPreservesBothRowsImprecisely(t *testin
 // does not match it, and the sweep would delete both rows the widening
 // exists to keep, without reporting a single error.
 func TestBunkAssignmentGrain_SecondSyncRunNeitherLosesNorDuplicates(t *testing.T) {
+	t.Parallel()
+
 	app, err := pbtests.NewTestApp()
 	if err != nil {
 		t.Fatal(err)
@@ -364,7 +392,7 @@ func TestBunkAssignmentGrain_SecondSyncRunNeitherLosesNorDuplicates(t *testing.T
 
 	newSync := func() *BunkAssignmentsSync {
 		s := &BunkAssignmentsSync{BaseSyncService: BaseSyncService{
-			App: app, Client: newTestCampMinderClient(t, year), ProcessedKeys: make(map[string]bool),
+			App: app, Client: newParallelTestCampMinderClient(t, year), ProcessedKeys: make(map[string]bool),
 		}}
 		s.personEnrollments = map[int][]int{personCMID: {sessionACMID, sessionBCMID}}
 		s.bunkPlanSessionsList = map[int][]int{planCMID: {sessionACMID, sessionBCMID}}
@@ -424,10 +452,12 @@ func TestBunkAssignmentGrain_SecondSyncRunNeitherLosesNorDuplicates(t *testing.T
 
 	run2 := runOnce(t)
 	if run2.Stats.Errors != 0 {
-		t.Errorf("run 2: Stats.Errors = %d, want 0 -- a widened preload/orphan key mismatch surfaces here first", run2.Stats.Errors)
+		t.Errorf("run 2: Stats.Errors = %d, want 0 -- a widened preload/orphan key mismatch "+
+			"surfaces here first", run2.Stats.Errors)
 	}
 	if run2.Stats.Created != 0 {
-		t.Errorf("run 2: Stats.Created = %d, want 0 -- preloadExistingAssignments must find both rows run 1 wrote", run2.Stats.Created)
+		t.Errorf("run 2: Stats.Created = %d, want 0 -- preloadExistingAssignments must find "+
+			"both rows run 1 wrote", run2.Stats.Created)
 	}
 
 	rows := bunkAssignmentsForYear(t, app, year)

--- a/pocketbase/sync/bunk_assignments_grain_test.go
+++ b/pocketbase/sync/bunk_assignments_grain_test.go
@@ -1,0 +1,438 @@
+package sync
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+)
+
+// setupBunkAssignmentGrainCollections builds the schema needed to drive
+// processAssignment and preloadExistingAssignments directly against a live
+// PocketBase app: persons, camp_sessions, bunks (all year-scoped, matching
+// LookupRelation's year filter for these collections), an empty bunk_plans
+// (LookupBunkPlan queries it even when the optional bunk_plan relation
+// cannot be resolved), bunk_assignments itself, and an empty staff
+// collection (protectThenSweepOrphans's protection pass needs it to exist).
+func setupBunkAssignmentGrainCollections(t *testing.T, app core.App) {
+	t.Helper()
+
+	persons := core.NewBaseCollection("persons")
+	persons.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
+	persons.Fields.Add(&core.NumberField{Name: "year", Required: true})
+	if err := app.Save(persons); err != nil {
+		t.Fatalf("create persons: %v", err)
+	}
+
+	sessions := core.NewBaseCollection("camp_sessions")
+	sessions.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
+	sessions.Fields.Add(&core.NumberField{Name: "year", Required: true})
+	if err := app.Save(sessions); err != nil {
+		t.Fatalf("create camp_sessions: %v", err)
+	}
+
+	bunks := core.NewBaseCollection("bunks")
+	bunks.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
+	bunks.Fields.Add(&core.NumberField{Name: "year", Required: true})
+	if err := app.Save(bunks); err != nil {
+		t.Fatalf("create bunks: %v", err)
+	}
+
+	bunkPlans := core.NewBaseCollection("bunk_plans")
+	bunkPlans.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
+	bunkPlans.Fields.Add(&core.RelationField{Name: "bunk", CollectionId: bunks.Id, MaxSelect: 1})
+	bunkPlans.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
+	bunkPlans.Fields.Add(&core.NumberField{Name: "year", Required: true})
+	if err := app.Save(bunkPlans); err != nil {
+		t.Fatalf("create bunk_plans: %v", err)
+	}
+
+	assignments := core.NewBaseCollection("bunk_assignments")
+	assignments.Fields.Add(&core.NumberField{Name: "cm_id"})
+	assignments.Fields.Add(&core.RelationField{Name: "person", CollectionId: persons.Id, MaxSelect: 1})
+	assignments.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
+	assignments.Fields.Add(&core.RelationField{Name: "bunk", CollectionId: bunks.Id, MaxSelect: 1})
+	assignments.Fields.Add(&core.RelationField{Name: "bunk_plan", CollectionId: bunkPlans.Id, MaxSelect: 1})
+	assignments.Fields.Add(&core.NumberField{Name: "year", Required: true})
+	assignments.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
+	// The widened unique index this PR's migration adds in production
+	// (see pb_migrations/1500000155_bunk_assignments_bunk_grain.js). Pinned
+	// here too so these tests exercise the same DB-level constraint, not
+	// just the in-memory composite key -- confirmed load-bearing: reverting
+	// this to the CURRENT unmigrated (year, person, session) shape makes
+	// TestProcessAssignment_FamilyStylePlanPreservesBothRowsImprecisely fail
+	// with a real uniqueness violation on the second assignment.
+	assignments.Indexes = []string{
+		"CREATE UNIQUE INDEX `idx_grain_test_person_session_bunk_year` " +
+			"ON `bunk_assignments` (`year`, `person`, `session`, `bunk`)",
+	}
+	if err := app.Save(assignments); err != nil {
+		t.Fatalf("create bunk_assignments: %v", err)
+	}
+
+	staff := core.NewBaseCollection("staff")
+	staff.Fields.Add(&core.NumberField{Name: "person_id", Required: true})
+	staff.Fields.Add(&core.TextField{Name: "status"})
+	staff.Fields.Add(&core.BoolField{Name: "bunk_staff"})
+	staff.Fields.Add(&core.NumberField{Name: "year", Required: true})
+	staff.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
+	if err := app.Save(staff); err != nil {
+		t.Fatalf("create staff: %v", err)
+	}
+}
+
+// bunkAssignmentsForYear returns every bunk_assignments row for the given
+// year, sorted by nothing in particular -- tests key off count and content,
+// not order.
+func bunkAssignmentsForYear(t *testing.T, app core.App, year int) []*core.Record {
+	t.Helper()
+	rows, err := app.FindRecordsByFilter("bunk_assignments", fmt.Sprintf("year = %d", year), "", 0, 0)
+	if err != nil {
+		t.Fatalf("query bunk_assignments: %v", err)
+	}
+	return rows
+}
+
+// TestProcessAssignment_MultiSessionPlanDisambiguatedByBunk is the
+// regression test kindred#2259's acceptance checklist asks for: "a
+// bunk_assignments sync test where one bunk plan covers two sessions, one
+// person is enrolled in both, and CampMinder returns two assignments in two
+// different bunks -- assert two rows survive, each with the correct
+// session."
+//
+// The two bunks here are DISJOINT -- each is only ever listed under one of
+// the plan's two sessions in bunk_plans, the same shape as a real main+AG
+// plan (kindred#2264's Traps: "the three main+AG plans have as many
+// distinct bunks as rows, so (plan,bunk) IS unique for them"). That is what
+// makes "correct session" achievable at all: resolveViaBunk narrows using
+// the SPECIFIC bunk on each assignment, not just the plan's whole session
+// list, so the two assignments resolve to two DIFFERENT sessions even
+// though they share a person and a plan.
+//
+// Before kindred#2259, the write key was (person, session, year) with no
+// bunk. Both assignments here would resolve through the OLD plan-wide
+// findMatchingSession to whichever session came first for BOTH of them,
+// then collide on that identical key: the first process call would create
+// the row, the second would find no match in the (stale, pre-loaded)
+// existingAssignments map and attempt a second create, which the unique
+// index rejects. Widening the key is what lets a second, distinct row
+// exist at all; resolveViaBunk is what makes it land on the RIGHT session.
+func TestProcessAssignment_MultiSessionPlanDisambiguatedByBunk(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupBunkAssignmentGrainCollections(t, app)
+
+	const year = 2026
+	const personCMID = 9000001
+	const planCMID = 8001
+	const sessionACMID = 5101 // main
+	const sessionBCMID = 5102 // AG
+	const bunkACMID = 6101    // only ever listed under session A
+	const bunkBCMID = 6102    // only ever listed under session B
+
+	saveRec(t, app, "persons", map[string]any{"cm_id": personCMID, "year": year})
+	saveRec(t, app, "camp_sessions", map[string]any{"cm_id": sessionACMID, "year": year})
+	saveRec(t, app, "camp_sessions", map[string]any{"cm_id": sessionBCMID, "year": year})
+	saveRec(t, app, "bunks", map[string]any{"cm_id": bunkACMID, "year": year})
+	saveRec(t, app, "bunks", map[string]any{"cm_id": bunkBCMID, "year": year})
+
+	s := &BunkAssignmentsSync{BaseSyncService: BaseSyncService{
+		App: app, Client: newTestCampMinderClient(t, year), ProcessedKeys: make(map[string]bool),
+	}}
+	s.personEnrollments = map[int][]int{personCMID: {sessionACMID, sessionBCMID}}
+	s.bunkPlanSessionsList = map[int][]int{planCMID: {sessionACMID, sessionBCMID}}
+	s.bunkPlanBunkToSession = map[string][]int{
+		fmt.Sprintf("%d:%d", planCMID, bunkACMID): {sessionACMID},
+		fmt.Sprintf("%d:%d", planCMID, bunkBCMID): {sessionBCMID},
+	}
+	s.validPersonCMIDs = map[int]bool{personCMID: true}
+	s.validSessionCMIDs = map[int]bool{sessionACMID: true, sessionBCMID: true}
+	s.validBunkCMIDs = map[int]bool{bunkACMID: true, bunkBCMID: true}
+
+	existing, err := s.preloadExistingAssignments(year)
+	if err != nil {
+		t.Fatalf("preloadExistingAssignments: %v", err)
+	}
+	if len(existing) != 0 {
+		t.Fatalf("existing = %d, want 0 on a first sync", len(existing))
+	}
+
+	for _, bunkCMID := range []int{bunkACMID, bunkBCMID} {
+		sessionID, ambiguous := s.resolveAssignmentSession(personCMID, planCMID, bunkCMID, s.bunkPlanSessionsList[planCMID])
+		if ambiguous {
+			t.Fatalf("bunk %d: resolution reported ambiguous, want unambiguous", bunkCMID)
+		}
+		if sessionID == 0 {
+			t.Fatalf("bunk %d: resolution reported no session", bunkCMID)
+		}
+
+		assignmentData := map[string]any{
+			"PersonID":   float64(personCMID),
+			"BunkID":     float64(bunkCMID),
+			"BunkPlanID": float64(planCMID),
+			"SessionID":  float64(sessionID),
+			"ID":         float64(700000 + bunkCMID),
+		}
+		if err := s.processAssignment(assignmentData, existing); err != nil {
+			t.Fatalf("processAssignment(bunk=%d): %v", bunkCMID, err)
+		}
+	}
+
+	if s.Stats.Errors != 0 {
+		t.Errorf("Stats.Errors = %d, want 0", s.Stats.Errors)
+	}
+	if s.Stats.Created != 2 {
+		t.Errorf("Stats.Created = %d, want 2 -- the second assignment must not collide with the first", s.Stats.Created)
+	}
+
+	rows := bunkAssignmentsForYear(t, app, year)
+	if len(rows) != 2 {
+		t.Fatalf("bunk_assignments rows = %d, want 2 -- kindred#2259: a multi-session plan must not collapse "+
+			"two assignments for one person into one row", len(rows))
+	}
+
+	gotSessionByBunk := map[int]string{}
+	for _, row := range rows {
+		bunkRec, err := app.FindRecordById("bunks", row.GetString("bunk"))
+		if err != nil {
+			t.Fatalf("resolve bunk on row %s: %v", row.Id, err)
+		}
+		bunkCMID := int(bunkRec.GetFloat("cm_id"))
+		gotSessionByBunk[bunkCMID] = row.GetString("session")
+	}
+
+	sessionARec, _ := app.FindFirstRecordByFilter("camp_sessions", fmt.Sprintf("cm_id = %d", sessionACMID))
+	sessionBRec, _ := app.FindFirstRecordByFilter("camp_sessions", fmt.Sprintf("cm_id = %d", sessionBCMID))
+
+	if gotSessionByBunk[bunkACMID] != sessionARec.Id {
+		t.Errorf("bunk %d row's session = %q, want session A (%q) -- got the wrong session, not just a lost row",
+			bunkACMID, gotSessionByBunk[bunkACMID], sessionARec.Id)
+	}
+	if gotSessionByBunk[bunkBCMID] != sessionBRec.Id {
+		t.Errorf("bunk %d row's session = %q, want session B (%q) -- got the wrong session, not just a lost row",
+			bunkBCMID, gotSessionByBunk[bunkBCMID], sessionBRec.Id)
+	}
+}
+
+// TestProcessAssignment_FamilyStylePlanPreservesBothRowsImprecisely covers
+// the case kindred#2259's Fix direction says per-bunk disambiguation
+// "cannot be made to work for" -- a bunk shared across every session of its
+// plan, the family-camp shape. Both assignments here use DIFFERENT bunk
+// numbers, but each bunk is (like a real family bunk) listed under every
+// session of the plan, so resolveViaBunk cannot narrow either one and both
+// fall back to the plan-wide findMatchingSession -- which takes the same
+// two arguments both times and therefore returns the same session both
+// times.
+//
+// The point of this test is what the fix does NOT try to do: it does not
+// make the two rows land on different, correct sessions (the issue's own
+// Fix direction rules that out for this shape). What it must still do is
+// keep BOTH rows -- widening the write key by bunk means the two
+// assignments no longer share a key even though they share a resolved
+// session, so the second write updates or creates a second record instead
+// of colliding with the first. This is the primary hazard population from
+// kindred#2259 (95 of 97 measured collisions): before the fix, this exact
+// scenario silently dropped one of the two rows.
+func TestProcessAssignment_FamilyStylePlanPreservesBothRowsImprecisely(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupBunkAssignmentGrainCollections(t, app)
+
+	const year = 2026
+	const personCMID = 9000002
+	const planCMID = 8002
+	const sessionACMID = 5201 // family weekend 1
+	const sessionBCMID = 5202 // family weekend 2
+	const bunkXCMID = 6201    // present under BOTH sessions of the plan
+	const bunkYCMID = 6202    // also present under BOTH sessions of the plan
+
+	saveRec(t, app, "persons", map[string]any{"cm_id": personCMID, "year": year})
+	saveRec(t, app, "camp_sessions", map[string]any{"cm_id": sessionACMID, "year": year})
+	saveRec(t, app, "camp_sessions", map[string]any{"cm_id": sessionBCMID, "year": year})
+	saveRec(t, app, "bunks", map[string]any{"cm_id": bunkXCMID, "year": year})
+	saveRec(t, app, "bunks", map[string]any{"cm_id": bunkYCMID, "year": year})
+
+	s := &BunkAssignmentsSync{BaseSyncService: BaseSyncService{
+		App: app, Client: newTestCampMinderClient(t, year), ProcessedKeys: make(map[string]bool),
+	}}
+	s.personEnrollments = map[int][]int{personCMID: {sessionACMID, sessionBCMID}}
+	s.bunkPlanSessionsList = map[int][]int{planCMID: {sessionACMID, sessionBCMID}}
+	s.bunkPlanBunkToSession = map[string][]int{
+		// family shape: each bunk spans every session of the plan.
+		fmt.Sprintf("%d:%d", planCMID, bunkXCMID): {sessionACMID, sessionBCMID},
+		fmt.Sprintf("%d:%d", planCMID, bunkYCMID): {sessionACMID, sessionBCMID},
+	}
+	s.validPersonCMIDs = map[int]bool{personCMID: true}
+	s.validSessionCMIDs = map[int]bool{sessionACMID: true, sessionBCMID: true}
+	s.validBunkCMIDs = map[int]bool{bunkXCMID: true, bunkYCMID: true}
+
+	existing, err := s.preloadExistingAssignments(year)
+	if err != nil {
+		t.Fatalf("preloadExistingAssignments: %v", err)
+	}
+
+	var resolvedSessions []int
+	for _, bunkCMID := range []int{bunkXCMID, bunkYCMID} {
+		sessionID, ambiguous := s.resolveAssignmentSession(personCMID, planCMID, bunkCMID, s.bunkPlanSessionsList[planCMID])
+		if ambiguous {
+			t.Fatalf("bunk %d: resolution reported ambiguous -- the camper path must fall back, not skip", bunkCMID)
+		}
+		if sessionID == 0 {
+			t.Fatalf("bunk %d: resolution reported no session", bunkCMID)
+		}
+		resolvedSessions = append(resolvedSessions, sessionID)
+
+		assignmentData := map[string]any{
+			"PersonID":   float64(personCMID),
+			"BunkID":     float64(bunkCMID),
+			"BunkPlanID": float64(planCMID),
+			"SessionID":  float64(sessionID),
+			"ID":         float64(710000 + bunkCMID),
+		}
+		if err := s.processAssignment(assignmentData, existing); err != nil {
+			t.Fatalf("processAssignment(bunk=%d): %v", bunkCMID, err)
+		}
+	}
+
+	if s.Stats.Errors != 0 {
+		t.Errorf("Stats.Errors = %d, want 0 -- the widened key must not collide even though both "+
+			"assignments resolve to the same session", s.Stats.Errors)
+	}
+	if s.Stats.Created != 2 {
+		t.Errorf("Stats.Created = %d, want 2", s.Stats.Created)
+	}
+
+	rows := bunkAssignmentsForYear(t, app, year)
+	if len(rows) != 2 {
+		t.Fatalf("bunk_assignments rows = %d, want 2 -- kindred#2259's primary hazard population (a bunk shared "+
+			"across every session of its plan) must not collapse to one row", len(rows))
+	}
+
+	// Documenting the accepted imprecision, not asserting it as a goal:
+	// resolveAssignmentSession is deterministic given the same inputs, so
+	// both calls above returned the same session.
+	if resolvedSessions[0] != resolvedSessions[1] {
+		t.Fatalf("test setup assumption violated: expected both resolutions to agree (imprecise but "+
+			"deterministic), got %d and %d", resolvedSessions[0], resolvedSessions[1])
+	}
+}
+
+// TestBunkAssignmentGrain_SecondSyncRunNeitherLosesNorDuplicates is the
+// acceptance checklist's "second regression test at the orphan layer: run
+// the sync twice over the widened data and assert the second run deletes
+// nothing and records zero Stats.Errors." It exercises all four widened
+// pieces of the grain together across two runs: the write key
+// (processAssignment), the preload key (preloadExistingAssignments), the
+// orphan key (deleteOrphans via protectThenSweepOrphans), and the widened
+// unique index they all rely on the database enforcing (see the
+// bunk_assignments migration for the index itself).
+//
+// Missing the preload key would make run 2 treat both rows as new
+// (Stats.Created again, not Updated/Skipped -- harmless on its own).
+// Missing the orphan key is the dangerous miss: run 2's ProcessedKeys would
+// be tracked in the new 4-part shape while deleteOrphans rebuilt a key that
+// does not match it, and the sweep would delete both rows the widening
+// exists to keep, without reporting a single error.
+func TestBunkAssignmentGrain_SecondSyncRunNeitherLosesNorDuplicates(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupBunkAssignmentGrainCollections(t, app)
+
+	const year = 2026
+	const personCMID = 9000003
+	const planCMID = 8003
+	const sessionACMID = 5301
+	const sessionBCMID = 5302
+	const bunkACMID = 6301
+	const bunkBCMID = 6302
+
+	saveRec(t, app, "persons", map[string]any{"cm_id": personCMID, "year": year})
+	saveRec(t, app, "camp_sessions", map[string]any{"cm_id": sessionACMID, "year": year})
+	saveRec(t, app, "camp_sessions", map[string]any{"cm_id": sessionBCMID, "year": year})
+	saveRec(t, app, "bunks", map[string]any{"cm_id": bunkACMID, "year": year})
+	saveRec(t, app, "bunks", map[string]any{"cm_id": bunkBCMID, "year": year})
+
+	newSync := func() *BunkAssignmentsSync {
+		s := &BunkAssignmentsSync{BaseSyncService: BaseSyncService{
+			App: app, Client: newTestCampMinderClient(t, year), ProcessedKeys: make(map[string]bool),
+		}}
+		s.personEnrollments = map[int][]int{personCMID: {sessionACMID, sessionBCMID}}
+		s.bunkPlanSessionsList = map[int][]int{planCMID: {sessionACMID, sessionBCMID}}
+		s.bunkPlanBunkToSession = map[string][]int{
+			fmt.Sprintf("%d:%d", planCMID, bunkACMID): {sessionACMID},
+			fmt.Sprintf("%d:%d", planCMID, bunkBCMID): {sessionBCMID},
+		}
+		s.validPersonCMIDs = map[int]bool{personCMID: true}
+		s.validSessionCMIDs = map[int]bool{sessionACMID: true, sessionBCMID: true}
+		s.validBunkCMIDs = map[int]bool{bunkACMID: true, bunkBCMID: true}
+		return s
+	}
+
+	runOnce := func(t *testing.T) *BunkAssignmentsSync {
+		t.Helper()
+		s := newSync()
+
+		existing, err := s.preloadExistingAssignments(year)
+		if err != nil {
+			t.Fatalf("preloadExistingAssignments: %v", err)
+		}
+
+		for _, bunkCMID := range []int{bunkACMID, bunkBCMID} {
+			sessionID, ambiguous := s.resolveAssignmentSession(personCMID, planCMID, bunkCMID, s.bunkPlanSessionsList[planCMID])
+			if ambiguous || sessionID == 0 {
+				t.Fatalf("bunk %d: unexpected resolution (ambiguous=%v, sessionID=%d)", bunkCMID, ambiguous, sessionID)
+			}
+			assignmentData := map[string]any{
+				"PersonID":   float64(personCMID),
+				"BunkID":     float64(bunkCMID),
+				"BunkPlanID": float64(planCMID),
+				"SessionID":  float64(sessionID),
+				"ID":         float64(720000 + bunkCMID),
+			}
+			if err := s.processAssignment(assignmentData, existing); err != nil {
+				t.Fatalf("processAssignment(bunk=%d): %v", bunkCMID, err)
+			}
+		}
+
+		s.SyncSuccessful = true // arms deleteOrphans, as Sync() sets after a successful first page fetch
+		if err := s.protectThenSweepOrphans(year); err != nil {
+			t.Fatalf("protectThenSweepOrphans: %v", err)
+		}
+		return s
+	}
+
+	run1 := runOnce(t)
+	if run1.Stats.Errors != 0 {
+		t.Fatalf("run 1: Stats.Errors = %d, want 0", run1.Stats.Errors)
+	}
+	if run1.Stats.Created != 2 {
+		t.Fatalf("run 1: Stats.Created = %d, want 2", run1.Stats.Created)
+	}
+	if rows := bunkAssignmentsForYear(t, app, year); len(rows) != 2 {
+		t.Fatalf("run 1: bunk_assignments rows = %d, want 2", len(rows))
+	}
+
+	run2 := runOnce(t)
+	if run2.Stats.Errors != 0 {
+		t.Errorf("run 2: Stats.Errors = %d, want 0 -- a widened preload/orphan key mismatch surfaces here first", run2.Stats.Errors)
+	}
+	if run2.Stats.Created != 0 {
+		t.Errorf("run 2: Stats.Created = %d, want 0 -- preloadExistingAssignments must find both rows run 1 wrote", run2.Stats.Created)
+	}
+
+	rows := bunkAssignmentsForYear(t, app, year)
+	if len(rows) != 2 {
+		t.Fatalf("after run 2: bunk_assignments rows = %d, want 2 -- an unwidened orphan key would delete both "+
+			"rows the widening exists to keep, silently", len(rows))
+	}
+}

--- a/pocketbase/sync/bunk_assignments_protection_test.go
+++ b/pocketbase/sync/bunk_assignments_protection_test.go
@@ -70,9 +70,19 @@ func setupBunkAssignmentProtectionCollections(t *testing.T, app core.App) {
 		t.Fatalf("create persons: %v", err)
 	}
 
+	// bunk is part of the bunk_assignments grain alongside person and
+	// session (kindred#2259) -- protectNonActiveStaffAssignments and
+	// deleteOrphans both resolve it into their composite keys.
+	bunks := core.NewBaseCollection("bunks")
+	bunks.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
+	if err := app.Save(bunks); err != nil {
+		t.Fatalf("create bunks: %v", err)
+	}
+
 	assignments := core.NewBaseCollection("bunk_assignments")
 	assignments.Fields.Add(&core.RelationField{Name: "person", CollectionId: persons.Id, MaxSelect: 1})
 	assignments.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
+	assignments.Fields.Add(&core.RelationField{Name: "bunk", CollectionId: bunks.Id, MaxSelect: 1})
 	assignments.Fields.Add(&core.NumberField{Name: "year", Required: true})
 	// PaginateRecords sorts by "-created" unconditionally, and deleteOrphans's
 	// call to BuildRecordCMIDMappings goes through it.
@@ -116,11 +126,13 @@ func TestProtectNonActiveStaffAssignments_ProtectsDismissedStaff(t *testing.T) {
 	const year = 2025
 	const personCMID = 3000001
 	const sessionCMID = 5001
+	const bunkCMID = 7001
 
 	person := saveRec(t, app, "persons", map[string]any{"cm_id": personCMID, "year": year})
 	session := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": sessionCMID, "year": year})
+	bunk := saveRec(t, app, "bunks", map[string]any{"cm_id": bunkCMID})
 	saveRec(t, app, "bunk_assignments", map[string]any{
-		"person": person.Id, "session": session.Id, "year": year,
+		"person": person.Id, "session": session.Id, "bunk": bunk.Id, "year": year,
 	})
 	saveRec(t, app, "staff", map[string]any{
 		"person_id": personCMID, "status": "dismissed", "bunk_staff": true, "year": year,
@@ -136,7 +148,7 @@ func TestProtectNonActiveStaffAssignments_ProtectsDismissedStaff(t *testing.T) {
 		t.Fatal("protectedCount = 0, want > 0 for a year with a known non-active bunk staff assignment")
 	}
 
-	wantKey := fmt.Sprintf("%d:%d|%d", personCMID, sessionCMID, year)
+	wantKey := fmt.Sprintf("%d:%d:%d|%d", personCMID, sessionCMID, bunkCMID, year)
 	if !s.ProcessedKeys[wantKey] {
 		t.Errorf("ProcessedKeys[%q] missing -- assignment was not protected from orphan deletion", wantKey)
 	}
@@ -171,9 +183,16 @@ func setupBunkAssignmentSweepCollections(t *testing.T, app core.App) {
 		t.Fatalf("create persons: %v", err)
 	}
 
+	bunks := core.NewBaseCollection("bunks")
+	bunks.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
+	if err := app.Save(bunks); err != nil {
+		t.Fatalf("create bunks: %v", err)
+	}
+
 	assignments := core.NewBaseCollection("bunk_assignments")
 	assignments.Fields.Add(&core.RelationField{Name: "person", CollectionId: persons.Id, MaxSelect: 1})
 	assignments.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
+	assignments.Fields.Add(&core.RelationField{Name: "bunk", CollectionId: bunks.Id, MaxSelect: 1})
 	assignments.Fields.Add(&core.NumberField{Name: "year", Required: true})
 	assignments.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
 	if err := app.Save(assignments); err != nil {
@@ -216,24 +235,26 @@ func TestProtectThenSweepOrphans_ProtectionFailureAbortsSweep(t *testing.T) {
 	// orphan-sweep guard sees a non-empty computed set and does not refuse the
 	// sweep as a total collapse (which would pass this test for the wrong
 	// reason).
+	keptBunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 7101})
 	keptPerson := saveRec(t, app, "persons", map[string]any{"cm_id": 4000001, "year": year})
 	keptSession := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 6001, "year": year})
 	saveRec(t, app, "bunk_assignments", map[string]any{
-		"person": keptPerson.Id, "session": keptSession.Id, "year": year,
+		"person": keptPerson.Id, "session": keptSession.Id, "bunk": keptBunk.Id, "year": year,
 	})
 
 	// An orphan: NOT in ProcessedKeys. If the sweep runs, this gets deleted.
+	orphanBunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 7102})
 	orphanPerson := saveRec(t, app, "persons", map[string]any{"cm_id": 4000002, "year": year})
 	orphanSession := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 6002, "year": year})
 	orphanAssignment := saveRec(t, app, "bunk_assignments", map[string]any{
-		"person": orphanPerson.Id, "session": orphanSession.Id, "year": year,
+		"person": orphanPerson.Id, "session": orphanSession.Id, "bunk": orphanBunk.Id, "year": year,
 	})
 
 	s := &BunkAssignmentsSync{BaseSyncService: BaseSyncService{
 		App: app, Client: newTestCampMinderClient(t, year), ProcessedKeys: make(map[string]bool),
 	}}
 	s.SyncSuccessful = true // arms deleteOrphans; otherwise it no-ops regardless of ordering
-	s.TrackProcessedCompositeKey(fmt.Sprintf("%d:%d", 4000001, 6001), year)
+	s.TrackProcessedCompositeKey(fmt.Sprintf("%d:%d:%d", 4000001, 6001, 7101), year)
 
 	s.protectThenSweepOrphans(year)
 
@@ -260,23 +281,25 @@ func TestProtectThenSweepOrphans_ProtectionSuccessStillSweeps(t *testing.T) {
 
 	const year = 2025
 
+	keptBunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 7103})
 	keptPerson := saveRec(t, app, "persons", map[string]any{"cm_id": 4000003, "year": year})
 	keptSession := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 6003, "year": year})
 	saveRec(t, app, "bunk_assignments", map[string]any{
-		"person": keptPerson.Id, "session": keptSession.Id, "year": year,
+		"person": keptPerson.Id, "session": keptSession.Id, "bunk": keptBunk.Id, "year": year,
 	})
 
+	orphanBunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 7104})
 	orphanPerson := saveRec(t, app, "persons", map[string]any{"cm_id": 4000004, "year": year})
 	orphanSession := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 6004, "year": year})
 	orphanAssignment := saveRec(t, app, "bunk_assignments", map[string]any{
-		"person": orphanPerson.Id, "session": orphanSession.Id, "year": year,
+		"person": orphanPerson.Id, "session": orphanSession.Id, "bunk": orphanBunk.Id, "year": year,
 	})
 
 	s := &BunkAssignmentsSync{BaseSyncService: BaseSyncService{
 		App: app, Client: newTestCampMinderClient(t, year), ProcessedKeys: make(map[string]bool),
 	}}
 	s.SyncSuccessful = true
-	s.TrackProcessedCompositeKey(fmt.Sprintf("%d:%d", 4000003, 6003), year)
+	s.TrackProcessedCompositeKey(fmt.Sprintf("%d:%d:%d", 4000003, 6003, 7103), year)
 
 	s.protectThenSweepOrphans(year)
 
@@ -305,11 +328,13 @@ func TestProtectNonActiveStaffAssignments_ActiveStaffUntouched(t *testing.T) {
 	const year = 2025
 	const personCMID = 3000002
 	const sessionCMID = 5002
+	const bunkCMID = 7002
 
 	person := saveRec(t, app, "persons", map[string]any{"cm_id": personCMID, "year": year})
 	session := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": sessionCMID, "year": year})
+	bunk := saveRec(t, app, "bunks", map[string]any{"cm_id": bunkCMID})
 	saveRec(t, app, "bunk_assignments", map[string]any{
-		"person": person.Id, "session": session.Id, "year": year,
+		"person": person.Id, "session": session.Id, "bunk": bunk.Id, "year": year,
 	})
 	saveRec(t, app, "staff", map[string]any{
 		"person_id": personCMID, "status": "active", "bunk_staff": true, "year": year,
@@ -349,14 +374,16 @@ func TestProtectThenSweepOrphans_DismissedStaffAssignmentSurvivesSweep(t *testin
 	const year = 2025
 	const dismissedCMID = 3000004
 	const dismissedSessionCMID = 5004
+	const dismissedBunkCMID = 7004
 
 	// The dismissed staff member: CampMinder has stopped reporting the
 	// assignment, so nothing in this run marks it processed. Only protection
 	// can save it.
 	dismissedPerson := saveRec(t, app, "persons", map[string]any{"cm_id": dismissedCMID, "year": year})
 	dismissedSession := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": dismissedSessionCMID, "year": year})
+	dismissedBunk := saveRec(t, app, "bunks", map[string]any{"cm_id": dismissedBunkCMID})
 	dismissedAssignment := saveRec(t, app, "bunk_assignments", map[string]any{
-		"person": dismissedPerson.Id, "session": dismissedSession.Id, "year": year,
+		"person": dismissedPerson.Id, "session": dismissedSession.Id, "bunk": dismissedBunk.Id, "year": year,
 	})
 	saveRec(t, app, "staff", map[string]any{
 		"person_id": dismissedCMID, "status": "dismissed", "bunk_staff": true, "year": year,
@@ -365,10 +392,11 @@ func TestProtectThenSweepOrphans_DismissedStaffAssignmentSurvivesSweep(t *testin
 	// A genuine orphan: nobody's staff record, never marked processed. The
 	// sweep must still delete this, or the test would pass simply because the
 	// sweep did nothing at all.
+	orphanBunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 7005})
 	orphanPerson := saveRec(t, app, "persons", map[string]any{"cm_id": 4000005, "year": year})
 	orphanSession := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 6005, "year": year})
 	orphanAssignment := saveRec(t, app, "bunk_assignments", map[string]any{
-		"person": orphanPerson.Id, "session": orphanSession.Id, "year": year,
+		"person": orphanPerson.Id, "session": orphanSession.Id, "bunk": orphanBunk.Id, "year": year,
 	})
 
 	s := &BunkAssignmentsSync{BaseSyncService: BaseSyncService{
@@ -385,7 +413,7 @@ func TestProtectThenSweepOrphans_DismissedStaffAssignmentSurvivesSweep(t *testin
 	}
 
 	// protectedCount > 0, observed through the key protection wrote.
-	wantKey := fmt.Sprintf("%d:%d|%d", dismissedCMID, dismissedSessionCMID, year)
+	wantKey := fmt.Sprintf("%d:%d:%d|%d", dismissedCMID, dismissedSessionCMID, dismissedBunkCMID, year)
 	if !s.ProcessedKeys[wantKey] {
 		t.Errorf("ProcessedKeys[%q] missing -- protection did not run or used a different key format", wantKey)
 	}
@@ -425,11 +453,13 @@ func TestProtectThenSweepOrphans_SessionLookupFailureAbortsSweep(t *testing.T) {
 	const year = 2025
 	const dismissedCMID = 3000005
 	const dismissedSessionCMID = 5005
+	const dismissedBunkCMID = 7006
 
 	dismissedPerson := saveRec(t, app, "persons", map[string]any{"cm_id": dismissedCMID, "year": year})
 	dismissedSession := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": dismissedSessionCMID, "year": year})
+	dismissedBunk := saveRec(t, app, "bunks", map[string]any{"cm_id": dismissedBunkCMID})
 	dismissedAssignment := saveRec(t, app, "bunk_assignments", map[string]any{
-		"person": dismissedPerson.Id, "session": dismissedSession.Id, "year": year,
+		"person": dismissedPerson.Id, "session": dismissedSession.Id, "bunk": dismissedBunk.Id, "year": year,
 	})
 	saveRec(t, app, "staff", map[string]any{
 		"person_id": dismissedCMID, "status": "dismissed", "bunk_staff": true, "year": year,
@@ -438,10 +468,11 @@ func TestProtectThenSweepOrphans_SessionLookupFailureAbortsSweep(t *testing.T) {
 	// A second assignment whose key IS tracked, so the computed set is
 	// non-empty and OrphanSweepGuard does not refuse the sweep as a total
 	// collapse -- which would make this test pass without proving anything.
+	keptBunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 7007})
 	keptPerson := saveRec(t, app, "persons", map[string]any{"cm_id": 4000006, "year": year})
 	keptSession := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 6006, "year": year})
 	saveRec(t, app, "bunk_assignments", map[string]any{
-		"person": keptPerson.Id, "session": keptSession.Id, "year": year,
+		"person": keptPerson.Id, "session": keptSession.Id, "bunk": keptBunk.Id, "year": year,
 	})
 
 	// Fail exactly one camp_sessions lookup: the single one protection makes
@@ -455,7 +486,7 @@ func TestProtectThenSweepOrphans_SessionLookupFailureAbortsSweep(t *testing.T) {
 		App: flaky, Client: newTestCampMinderClient(t, year), ProcessedKeys: make(map[string]bool),
 	}}
 	s.SyncSuccessful = true
-	s.TrackProcessedCompositeKey(fmt.Sprintf("%d:%d", 4000006, 6006), year)
+	s.TrackProcessedCompositeKey(fmt.Sprintf("%d:%d:%d", 4000006, 6006, 7007), year)
 
 	err = s.protectThenSweepOrphans(year)
 	if err == nil {
@@ -500,8 +531,9 @@ func TestProtectThenSweepOrphans_SweepRefusalIsCountedAndReturned(t *testing.T) 
 
 	person := saveRec(t, app, "persons", map[string]any{"cm_id": 4000007, "year": year})
 	session := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 6007, "year": year})
+	bunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 7008})
 	assignment := saveRec(t, app, "bunk_assignments", map[string]any{
-		"person": person.Id, "session": session.Id, "year": year,
+		"person": person.Id, "session": session.Id, "bunk": bunk.Id, "year": year,
 	})
 
 	s := &BunkAssignmentsSync{BaseSyncService: BaseSyncService{
@@ -543,8 +575,9 @@ func TestProtectNonActiveStaffAssignments_MissingSessionIsNonDestructiveSkip(t *
 
 	dismissedPerson := saveRec(t, app, "persons", map[string]any{"cm_id": dismissedCMID, "year": year})
 	session := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 5006, "year": year})
+	bunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 7009})
 	saveRec(t, app, "bunk_assignments", map[string]any{
-		"person": dismissedPerson.Id, "session": session.Id, "year": year,
+		"person": dismissedPerson.Id, "session": session.Id, "bunk": bunk.Id, "year": year,
 	})
 	saveRec(t, app, "staff", map[string]any{
 		"person_id": dismissedCMID, "status": "resigned", "bunk_staff": true, "year": year,

--- a/pocketbase/sync/bunk_assignments_protection_test.go
+++ b/pocketbase/sync/bunk_assignments_protection_test.go
@@ -557,6 +557,60 @@ func TestProtectThenSweepOrphans_SweepRefusalIsCountedAndReturned(t *testing.T) 
 	}
 }
 
+// TestProtectNonActiveStaffAssignments_MissingBunkIsNonDestructiveSkip is the
+// bunk-shaped twin of the session case below, added when bunk joined the
+// bunk_assignments grain (kindred#2259): protection now has to resolve a bunk
+// as well as a session before it can build a composite key, which is a second
+// place the function can fail to protect a row.
+//
+// A row with no bunk relation is a skip and NOT an error, for the same reason a
+// missing session is: deleteOrphans cannot derive a composite key for such a
+// record either (its keyFunc requires bunkCMID > 0), so the sweep will not
+// touch it and there is nothing to protect it from. What must not happen is an
+// abort, which would take protection down for every other non-active staff
+// member in the year.
+//
+// The row is asserted to still exist afterwards so the test cannot pass
+// vacuously by the assignment having disappeared.
+func TestProtectNonActiveStaffAssignments_MissingBunkIsNonDestructiveSkip(t *testing.T) {
+	t.Parallel()
+
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupBunkAssignmentProtectionCollections(t, app)
+
+	const year = 2025
+	const dismissedCMID = 3000007
+
+	dismissedPerson := saveRec(t, app, "persons", map[string]any{"cm_id": dismissedCMID, "year": year})
+	session := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 5007, "year": year})
+	assignment := saveRec(t, app, "bunk_assignments", map[string]any{
+		"person": dismissedPerson.Id, "session": session.Id, "year": year,
+	})
+	saveRec(t, app, "staff", map[string]any{
+		"person_id": dismissedCMID, "status": "dismissed", "bunk_staff": true, "year": year,
+	})
+
+	s := &BunkAssignmentsSync{BaseSyncService: BaseSyncService{App: app, ProcessedKeys: make(map[string]bool)}}
+
+	protectedCount, err := s.protectNonActiveStaffAssignments(year)
+	if err != nil {
+		t.Fatalf("a missing bunk must be a skip, not an error: %v", err)
+	}
+	if protectedCount != 0 {
+		t.Errorf("protectedCount = %d, want 0 -- there is no bunk to build a composite key from", protectedCount)
+	}
+	if len(s.ProcessedKeys) != 0 {
+		t.Errorf("ProcessedKeys = %v, want empty -- a key that omits bunk would never match deleteOrphans", s.ProcessedKeys)
+	}
+	if _, findErr := app.FindRecordById("bunk_assignments", assignment.Id); findErr != nil {
+		t.Fatalf("the assignment row must still exist for this test to mean anything: %v", findErr)
+	}
+}
+
 // TestProtectNonActiveStaffAssignments_MissingSessionIsNonDestructiveSkip is the
 // other half of the test above: a session record that is genuinely absent is not
 // an error, and must not abort protection or the sweep for everyone else.

--- a/pocketbase/sync/bunk_assignments_test.go
+++ b/pocketbase/sync/bunk_assignments_test.go
@@ -65,83 +65,186 @@ func TestBunkAssignmentsSync_findMatchingSession(t *testing.T) {
 	}
 }
 
+// TestBunkAssignmentsSync_StaffSessionLookup exercises the PRODUCTION
+// resolveStaffSession method against the PRODUCTION s.bunkPlanBunkToSession
+// field -- not a locally reimplemented map -- so a change to either one
+// makes this test fail. kindred#2264: (bunkPlanCMID, bunkCMID) does NOT map
+// to exactly one session; bunk_plans can legitimately list a bunk under
+// several sessions of the same plan (e.g. the family plan's 12 bunks, each
+// present in all 8 of its sessions), and the old code silently kept
+// whichever bunk_plans row PaginateRecords visited last. The field is
+// therefore map[string][]int: every candidate session survives, and
+// resolveStaffSession reports ambiguity instead of guessing.
 func TestBunkAssignmentsSync_StaffSessionLookup(t *testing.T) {
 	t.Parallel()
-	// Tests the (bunkPlanCMID, bunkCMID) → sessionCMID lookup pattern
-	// used to resolve staff assignments to exact sessions.
-	//
-	// Key insight: A bunk plan can span main+AG sessions (e.g., plan 12424 = Session 2 + AG-Session 2),
-	// but each individual bunk disambiguates: AG-8 → AG-Session 2, B-3 → Session 2.
 
 	tests := []struct {
-		name         string
-		bpBunkToSess map[string]int
-		bunkPlanCMID int
-		bunkCMID     int
-		wantSession  int
-		wantOK       bool
+		name          string
+		bpBunkToSess  map[string][]int
+		bunkPlanCMID  int
+		bunkCMID      int
+		wantSession   int
+		wantAmbiguous bool
 	}{
 		{
 			name: "regular bunk resolves to main session",
-			bpBunkToSess: map[string]int{
-				"12424:200": 5001, // B-3 in plan 12424 → Session 2
-				"12424:300": 5002, // AG-8 in plan 12424 → AG-Session 2
+			bpBunkToSess: map[string][]int{
+				"12424:200": {5001}, // B-3 in plan 12424 → Session 2
+				"12424:300": {5002}, // AG-8 in plan 12424 → AG-Session 2
 			},
 			bunkPlanCMID: 12424,
 			bunkCMID:     200,
 			wantSession:  5001,
-			wantOK:       true,
 		},
 		{
 			name: "AG bunk resolves to AG session from same plan",
-			bpBunkToSess: map[string]int{
-				"12424:200": 5001,
-				"12424:300": 5002,
+			bpBunkToSess: map[string][]int{
+				"12424:200": {5001},
+				"12424:300": {5002},
 			},
 			bunkPlanCMID: 12424,
 			bunkCMID:     300,
 			wantSession:  5002,
-			wantOK:       true,
 		},
 		{
 			name: "embedded session bunk resolves correctly",
-			bpBunkToSess: map[string]int{
-				"12500:200": 5010, // B-3 in plan 12500 → Session 2a (embedded)
+			bpBunkToSess: map[string][]int{
+				"12500:200": {5010}, // B-3 in plan 12500 → Session 2a (embedded)
 			},
 			bunkPlanCMID: 12500,
 			bunkCMID:     200,
 			wantSession:  5010,
-			wantOK:       true,
 		},
 		{
-			name: "unknown bunk plan returns not found",
-			bpBunkToSess: map[string]int{
-				"12424:200": 5001,
+			name: "unknown bunk plan returns not found, not ambiguous",
+			bpBunkToSess: map[string][]int{
+				"12424:200": {5001},
 			},
 			bunkPlanCMID: 99999,
 			bunkCMID:     200,
 			wantSession:  0,
-			wantOK:       false,
 		},
 		{
-			name: "unknown bunk in known plan returns not found",
-			bpBunkToSess: map[string]int{
-				"12424:200": 5001,
+			name: "unknown bunk in known plan returns not found, not ambiguous",
+			bpBunkToSess: map[string][]int{
+				"12424:200": {5001},
 			},
 			bunkPlanCMID: 12424,
 			bunkCMID:     999,
 			wantSession:  0,
-			wantOK:       false,
+		},
+		{
+			name: "bunk shared across several sessions of one plan is ambiguous",
+			bpBunkToSess: map[string][]int{
+				// The family plan pattern (kindred#2264): one bunk, every
+				// session of the plan.
+				"20001:200": {5001, 5002, 5003},
+			},
+			bunkPlanCMID:  20001,
+			bunkCMID:      200,
+			wantSession:   0,
+			wantAmbiguous: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			key := fmt.Sprintf("%d:%d", tt.bunkPlanCMID, tt.bunkCMID)
-			sessionCMID, ok := tt.bpBunkToSess[key]
+			s := &BunkAssignmentsSync{bunkPlanBunkToSession: tt.bpBunkToSess}
+			sessionCMID, ambiguous := s.resolveStaffSession(tt.bunkPlanCMID, tt.bunkCMID)
+
+			if ambiguous != tt.wantAmbiguous {
+				t.Errorf("ambiguous = %v, want %v", ambiguous, tt.wantAmbiguous)
+			}
+			if sessionCMID != tt.wantSession {
+				t.Errorf("sessionCMID = %d, want %d", sessionCMID, tt.wantSession)
+			}
+		})
+	}
+}
+
+// TestBunkAssignmentsSync_resolveViaBunk exercises the PRODUCTION
+// resolveViaBunk method, which narrows a camper's session candidates to the
+// ones the SPECIFIC bunk on this assignment is used for under the plan,
+// intersected with the sessions the person is actually enrolled in
+// (kindred#2259). It is precise exactly when the bunk pins to fewer
+// sessions than the whole plan -- e.g. a main+AG plan where main and AG
+// bunks are disjoint sets. When a bunk is shared across every session of
+// its plan (the family plan), narrowing by bunk alone still leaves as many
+// candidates as the person has weekends, and resolveViaBunk deliberately
+// reports no match so the caller falls back to the plan-wide
+// findMatchingSession instead of guessing.
+func TestBunkAssignmentsSync_resolveViaBunk(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		bpBunkToSess   map[string][]int
+		personSessions []int
+		bunkPlanCMID   int
+		bunkCMID       int
+		wantSession    int
+		wantOK         bool
+	}{
+		{
+			name: "bunk pins to a single session the person is enrolled in",
+			bpBunkToSess: map[string][]int{
+				"12424:200": {5001}, // a main-only bunk
+			},
+			personSessions: []int{5001, 5002},
+			bunkPlanCMID:   12424,
+			bunkCMID:       200,
+			wantSession:    5001,
+			wantOK:         true,
+		},
+		{
+			name: "second bunk of the same plan pins to the other session",
+			bpBunkToSess: map[string][]int{
+				"12424:300": {5002}, // an AG-only bunk
+			},
+			personSessions: []int{5001, 5002},
+			bunkPlanCMID:   12424,
+			bunkCMID:       300,
+			wantSession:    5002,
+			wantOK:         true,
+		},
+		{
+			name: "bunk shared across every session of the plan is not narrowed",
+			bpBunkToSess: map[string][]int{
+				// family-plan shape: one bunk, all 3 (of the plan's) sessions
+				"20001:200": {5001, 5002, 5003},
+			},
+			personSessions: []int{5001, 5002}, // enrolled in two family weekends
+			bunkPlanCMID:   20001,
+			bunkCMID:       200,
+			wantOK:         false,
+		},
+		{
+			name:           "bunk not present in the map at all",
+			bpBunkToSess:   map[string][]int{},
+			personSessions: []int{5001},
+			bunkPlanCMID:   99999,
+			bunkCMID:       200,
+			wantOK:         false,
+		},
+		{
+			name: "candidate session the person is not enrolled in",
+			bpBunkToSess: map[string][]int{
+				"12424:200": {5001},
+			},
+			personSessions: []int{5002},
+			bunkPlanCMID:   12424,
+			bunkCMID:       200,
+			wantOK:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &BunkAssignmentsSync{bunkPlanBunkToSession: tt.bpBunkToSess}
+			sessionCMID, ok := s.resolveViaBunk(tt.personSessions, tt.bunkPlanCMID, tt.bunkCMID)
 
 			if ok != tt.wantOK {
-				t.Errorf("lookup ok = %v, want %v", ok, tt.wantOK)
+				t.Errorf("ok = %v, want %v", ok, tt.wantOK)
 			}
 			if sessionCMID != tt.wantSession {
 				t.Errorf("sessionCMID = %d, want %d", sessionCMID, tt.wantSession)
@@ -281,32 +384,28 @@ func TestBunkAssignmentsSync_OrphanProtectionKeyFormat(t *testing.T) {
 	}
 }
 
+// TestBunkAssignmentsSync_StaffSkipLogicIntegration exercises the
+// PRODUCTION resolution ladder, resolveAssignmentSession, end to end --
+// against the production personEnrollments, bunkPlanBunkToSession and
+// staffPersonCMIDs fields, not a locally reimplemented copy. Two tests in
+// this file used to rebuild the lookup inline (kindred#2264's Traps: "the
+// false invariant is not pinned... changing the production map's type
+// leaves both compiling and green while testing nothing"); this drives the
+// real method so a change to the resolution rule fails this test.
 func TestBunkAssignmentsSync_StaffSkipLogicIntegration(t *testing.T) {
 	t.Parallel()
-	// Integration test: verifies the complete staff assignment resolution flow.
-	//
-	// When findMatchingSession returns 0 (person not in attendees),
-	// the staff fallback path should use bunkPlanBunkToSession to resolve the session.
-	// Non-staff, non-enrolled persons should be skipped.
-
-	staffPersonCMIDs := map[int]bool{
-		3000001: true, // Bunk staff (fictional)
-	}
-	bunkPlanBunkToSession := map[string]int{
-		"12424:200": 5001, // Plan 12424 + Bunk 200 → Session 5001
-	}
-
-	s := &BunkAssignmentsSync{}
 
 	tests := []struct {
-		name              string
-		personCMID        int
-		bunkPlanID        int
-		bunkID            int
-		personEnrollments map[int][]int
-		bpSessionsList    map[int][]int
-		wantSessionID     int
-		wantSkipped       bool
+		name                  string
+		personCMID            int
+		bunkPlanID            int
+		bunkID                int
+		personEnrollments     map[int][]int
+		staffPersonCMIDs      map[int]bool
+		bunkPlanBunkToSession map[string][]int
+		bpSessionsList        map[int][]int
+		wantSessionID         int
+		wantSkipped           bool
 	}{
 		{
 			name:       "camper resolved via enrollment intersection",
@@ -328,6 +427,10 @@ func TestBunkAssignmentsSync_StaffSkipLogicIntegration(t *testing.T) {
 			bunkPlanID:        12424,
 			bunkID:            200,
 			personEnrollments: map[int][]int{}, // Staff not in attendees
+			staffPersonCMIDs:  map[int]bool{3000001: true},
+			bunkPlanBunkToSession: map[string][]int{
+				"12424:200": {5001}, // Plan 12424 + Bunk 200 → Session 5001
+			},
 			bpSessionsList: map[int][]int{
 				12424: {5001, 5003},
 			},
@@ -352,8 +455,25 @@ func TestBunkAssignmentsSync_StaffSkipLogicIntegration(t *testing.T) {
 			bunkPlanID:        99999,
 			bunkID:            999,
 			personEnrollments: map[int][]int{},
+			staffPersonCMIDs:  map[int]bool{3000001: true},
 			bpSessionsList: map[int][]int{
 				99999: {5001},
+			},
+			wantSessionID: 0,
+			wantSkipped:   true,
+		},
+		{
+			name:              "staff on an ambiguous bunk+plan combo is skipped, not guessed",
+			personCMID:        3000001,
+			bunkPlanID:        20001,
+			bunkID:            200,
+			personEnrollments: map[int][]int{},
+			staffPersonCMIDs:  map[int]bool{3000001: true},
+			bunkPlanBunkToSession: map[string][]int{
+				"20001:200": {5001, 5002, 5003}, // family-plan shape: shared across every session
+			},
+			bpSessionsList: map[int][]int{
+				20001: {5001, 5002, 5003},
 			},
 			wantSessionID: 0,
 			wantSkipped:   true,
@@ -362,22 +482,15 @@ func TestBunkAssignmentsSync_StaffSkipLogicIntegration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Replicate the resolution logic from the Sync loop
-			personSessions := tt.personEnrollments[tt.personCMID]
+			s := &BunkAssignmentsSync{
+				personEnrollments:     tt.personEnrollments,
+				staffPersonCMIDs:      tt.staffPersonCMIDs,
+				bunkPlanBunkToSession: tt.bunkPlanBunkToSession,
+			}
 			bunkPlanSessions := tt.bpSessionsList[tt.bunkPlanID]
 
-			// Step 1: Camper path (enrollment intersection)
-			sessionID := s.findMatchingSession(personSessions, bunkPlanSessions)
-
-			// Step 2: Staff fallback via (bunkPlan, bunk) → session
-			if sessionID == 0 && staffPersonCMIDs[tt.personCMID] {
-				key := fmt.Sprintf("%d:%d", tt.bunkPlanID, tt.bunkID)
-				if sid, ok := bunkPlanBunkToSession[key]; ok {
-					sessionID = sid
-				}
-			}
-
-			skipped := sessionID == 0
+			sessionID, ambiguous := s.resolveAssignmentSession(tt.personCMID, tt.bunkPlanID, tt.bunkID, bunkPlanSessions)
+			skipped := sessionID == 0 || ambiguous
 
 			if sessionID != tt.wantSessionID {
 				t.Errorf("sessionID = %d, want %d", sessionID, tt.wantSessionID)


### PR DESCRIPTION
## What is wrong

Two defects in `bunk_assignments`' session resolution share one root cause — a `-created` sorted read whose winner depends on write order — but produce **opposite** failure shapes depending on how the result is consumed. Both are fixed in this one PR because #2264's fix is what makes #2259's precise case testable at all.

**#2259 — camper session collapses (APPEND, then first-match wins).** `findMatchingSession` derives a session by intersecting a person's enrolled sessions with a bunk plan's sessions, with no visibility into which *bunk* a given assignment names. When a plan spans several sessions and a person is enrolled in more than one, every assignment that person holds under the plan can resolve to the same session and collide on the `(person, session, year)` write key. 95 of 97 measured hazard pairs in the production snapshot are Family Camp households booking two-plus weekends under one multi-session plan; **0 of 97** have both rows present today.

**#2264 — staff session picks an arbitrary session (MAP OVERWRITE, last-processed wins).** The same-shaped bug at the staff fallback is a plain `map[string]int` that kept only the last `bunk_plans` row `PaginateRecords` visited for a given `(plan, bunk)` key. 205 of 1,146 map keys (17.9%) are ambiguous across all years; 2018 alone has 72 staff rows landing on a session picked this way.

**Same `-created` sort, opposite outcome** — one site appends candidates and takes the first live match (so the *first*-processed row wins on a season's first sync, then the *last*-written row wins every sync after, once the row exists to update in place); the other overwrites a single map slot outright (so the *last*-processed row always wins). Both are correct descriptions of the same underlying nondeterminism, read through different consumption patterns.

## Fix

- `bunkPlanBunkToSession` is now `map[string][]int` — every candidate session survives instead of the last one silently winning (#2264).
- Camper resolution (`resolveViaBunk`) narrows using the **specific bunk** on each assignment before falling back to the plan-wide `findMatchingSession`. Precise when a bunk pins to fewer sessions than the whole plan (main+AG bunks are disjoint sets); reports no match when a bunk is shared across every session of its plan (every family bunk) — per-bunk disambiguation cannot separate that case, so this deliberately does not try (see Traps below).
- Staff resolution (`resolveStaffSession`) reports ambiguity instead of guessing: **skip-and-warn** on more than one candidate.
- The `bunk_assignments` grain widens to `(person, session, bunk, year)` in all four places that must move together: the write key (`processAssignment`), the preload key (`preloadExistingAssignments`, extracted out of `Sync()` so it's directly testable), the orphan key (three call sites: `TrackProcessedCompositeKey`, `protectNonActiveStaffAssignments`, `deleteOrphans`), and the unique index (`pb_migrations/1500000155`).

## ⚠️ Both fixes are correct even though they look contradictory

A reviewer skimming this diff will see the **same `-created` sort** blamed for **opposite** winners and reasonably suspect one of the two write-ups is wrong. They aren't — the two sites *consume* the same nondeterministic ordering differently:

- **#2264's site is a MAP OVERWRITE.** `bunkPlanBunkToSession[key] = sessionCMID` (old code) replaces the previous value every time a matching `bunk_plans` row is visited, so whichever row is processed **last** wins.
- **#2259's site is APPEND-then-first-match.** `bunkPlanSessionsList[bpCMID]` appends every session (never overwrites), and the read side (`findMatchingSession`) walks that list and returns on the **first** session that's also in the person's enrollment set — so whichever candidate appears **first** in the (already-nondeterministic) append order wins.

Same underlying sort, same absence of a tiebreak rule, genuinely opposite winner semantics because of what happens to the candidates *after* the sort. Fixing them together — turning both into `map[string][]int` and being explicit about the tiebreak at each read site — is what a narrower, single-issue PR would have missed.

## Ruling: proceeding without a live CampMinder API call (#2259)

#2259's corrected body no longer treats a live API confirmation as a blocker. The snapshot rejects the benign hypothesis (CampMinder issuing one bunk assignment per person regardless of how many weekends they're enrolled in) at **p = 0.003** in 2023's cleanest case: 20 of 20 multi-weekend people hold exactly one family bunk assignment, where that hypothesis predicts 14.9. The live call would *confirm* that, not *decide* it — so this ships the grain-widening fix without waiting on it.

## Ruling: skip-and-warn for #2264's tie-break

Of the realistic options (prefer a session type, skip-and-warn, emit one assignment per candidate, or disambiguate against staff employment dates), this PR implements **skip-and-warn**. 2026's ambiguity is entirely *within one program* — family/quest/scit bunks shared across their own plan's sessions, not across session types — so a session-type preference rule has no signal to act on for the current operational year. No 2026 staff row lands on an ambiguous key today, so skipping costs nothing for the current season, and the `slog.Warn` this adds starts generating the evidence a better rule (e.g. against `staff.employment_start_date`/`employment_end_date`) would actually need.

**What it costs if a historical year is ever re-synced, stated rather than left to be discovered.** #2264's acceptance asks whether re-running a 2018 sync still produces its 72 staff rows on `main` sessions. It does not, and the change is deliberate: all 72 of 2018's bunk-staff rows sit on ambiguous `(plan, bunk)` keys, so skip-and-warn skips every one of them. A skipped assignment is never passed to `TrackProcessedCompositeKey`, so the orphan sweep that follows treats the existing rows as unprocessed and deletes them. Re-measured on the snapshot for this PR, per year (`staff_rows` / `on_ambiguous_key`): 2017 228/0, 2018 284/**72**, 2019 265/0, 2021 136/0, 2023 279/0, 2024 242/0, 2025 245/0, 2026 262/0. 2018 is the only year affected, and #2264 records that its winner is "very likely the right answer" there — so this trades 72 probably-correct historical rows for the removal of a silent guess, which is exactly the tradeoff that issue names under "Skip and warn when ambiguous". The current season is untouched. Nothing re-syncs a past year on its own; this is only reachable by deliberately pointing a sync at one.

## Factual correction: 2026 carries 197 family bunk assignments, not 198

Both issue bodies' original text said 198; both were corrected 2026-08-14 to 197, and this PR does not repeat 198 anywhere. Independently reproducible:

```sql
SELECT COUNT(*) FROM bunk_assignments ba
JOIN camp_sessions cs ON cs.id = ba.session
WHERE ba.year = 2026 AND cs.session_type = 'family';
-- 197
```

## Deliberately not done

- **No live CampMinder API call** — see ruling above.
- **No attempt to make the family-plan case resolve to a precisely correct session per assignment.** #2259's own Fix direction states per-bunk disambiguation "cannot be made to work for the family plan" — every family bunk is present in all 8 of its plan's sessions, so narrowing by bunk alone leaves as many candidates as the person has weekends. The fix guarantees **both rows survive**; which single session a genuinely ambiguous pair lands on is unchanged from before this PR for that population, by design. Pinned by `TestProcessAssignment_FamilyStylePlanPreservesBothRowsImprecisely`.

  Spelled out, because "both rows survive" is easy to read as more than it is: for the primary hazard population the two rows land on the **same** weekend. A household member booked into weekend 1 and weekend 2 under one family plan gets two rows both naming weekend 1 — one per bunk — and still nothing on weekend 2. That is a change in kind from before this PR, where one row was lost outright: the recovered row is present but attributed to the wrong weekend. Two consequences follow and are not addressed here. `pocketbase/sync/camper_history.go`'s `loadBunkAssignmentsBySession` keys on `(person, session, year)` and last-write-wins, so a family weekend's recorded cabin can now flip between the two. `bunking/graph/social_graph_builder.py`'s `get_first_list_item` already picks one row per person-year arbitrarily, and gains one more candidate to pick from; #2259 says that lookup "should be tightened in the same change" and it has not been. Scale, from #2259's re-measured figures: ~54 rows across 2023-2025 and ~4 expected in 2026 (11 hazard pairs). The solver paths are unaffected — `api/services/data_fetcher.py` filters to the session being solved, and family sessions are not solved.
- **No change to the `main+AG` latent-exposure story.** The hazard query still returns zero `main+ag` pairs in the snapshot; this PR does not special-case `session_type = 'family'`, so the same fix covers that population if it ever gets data behind it.

## Testing

- TDD throughout: every behavioral test below was written and run RED before the corresponding implementation change, and the two rewritten integration tests (`TestBunkAssignmentsSync_StaffSessionLookup`, `TestBunkAssignmentsSync_StaffSkipLogicIntegration`) now exercise the *production* `bunkPlanBunkToSession` field and resolution methods instead of a locally reimplemented map — the coverage gap #2264's Traps section called out ("changing the production map's type leaves both compiling and green while testing nothing").
- Those cover the **read** sites only, which review caught: reverting `loadMappings`' `append` back to the pre-#2264 overwrite left the whole `sync` package green, because every one of those tests hand-builds `bunkPlanBunkToSession` and so starts from candidates that already survived the broken line. `TestLoadMappings_KeepsEveryCandidateSessionForASharedBunk` closes it by driving the real `loadMappings` over real `bunk_plans` records — #2264's acceptance item verbatim — and was verified RED against the overwrite (`bunkPlanBunkToSession["8401:6401"] = [5402], want [5401 5402]`) before the shipped fix turned it green.
- New unit tests: `TestBunkAssignmentsSync_resolveViaBunk`, `TestBunkAssignmentsSync_resolveStaffSession`, plus an added ambiguous-key case in `TestBunkAssignmentsSync_StaffSessionLookup`.
- New integration tests against a live PocketBase test app (`bunk_assignments_grain_test.go`):
  - `TestProcessAssignment_MultiSessionPlanDisambiguatedByBunk` — the acceptance checklist's literal scenario: one plan, two sessions, two disjoint bunks, one person enrolled in both — asserts two rows survive **each with the correct session**.
  - `TestProcessAssignment_FamilyStylePlanPreservesBothRowsImprecisely` — the primary hazard population (a bunk shared across every session of its plan) — asserts both rows survive, and documents (does not merely assume) that both resolve to the same session.
  - `TestBunkAssignmentGrain_SecondSyncRunNeitherLosesNorDuplicates` — runs the sync twice over the same widened data and asserts the second run creates nothing new, errors nothing, and deletes nothing — the acceptance checklist's "second regression test at the orphan layer."
- **Mutation-checked**: the widened DB unique index is genuinely load-bearing, not cosmetic. Temporarily pinning the test schema back to the *current, unmigrated* `(year, person, session)` index reproduces a real uniqueness violation in `TestProcessAssignment_FamilyStylePlanPreservesBothRowsImprecisely` (`person: Value must be unique; session: Value must be unique; year: Value must be unique.`); restoring the widened index turns it green again.
- Existing `bunk_assignments_protection_test.go` suite updated for the new `bunk` grain component (schema gains a `bunks` collection + relation; every composite-key assertion now includes `bunkCMID`) and re-verified green.
- Migration verified by an **actual PocketBase boot**, not just a green `go test ./...`: `migrate up` → live index confirmed via `_collections.indexes` → a real `serve` with a passing `/api/health` check → `migrate down 1` (confirmed the old narrower index is restored) → `migrate up` again to leave the dev DB in the forward state.
- The down direction is only safe while no duplicate-by-bunk row exists yet — re-creating the narrow unique index fails once a sync has written the rows the widening exists to allow. That is inherent to any narrowing, not specific to this file, and the migration now says so rather than leaving `migrate down` looking like a free undo.
- `cd pocketbase && go test ./sync/...` — full package green.
- `cd pocketbase && go test -race ./...` — full module green, including `TestSyncAndLodgingTestsRunInParallel`, the AST guard that requires every top-level test to call `t.Parallel()`. The three new grain tests do; since that guard's own source file is locked to another in-flight PR, they carry a small parallel-safe CampMinder test-client helper (`os.Setenv`, not `t.Setenv`, which panics under `t.Parallel()`) instead of an exemption entry.
- `go build ./...`, `go vet ./...`, `gofmt -l .`, `golangci-lint run` — clean.
- `npm run lint` (pb-js-lint) on the new migration — clean.

Part of kindred#2257.

Closes #2259.
Closes #2264.

