### PR TITLE
docs(sync): correct the stale Rejected and Errors counter comments

### DIFF
--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -306,22 +306,20 @@ type Stats struct {
 	// run in which this is non-zero, so its tolerance is zero: any non-zero count fails the
 	// run. Do not use it for a rejected upstream record — that is Rejected (kindred#2284).
 	//
-	// Every site currently increments this counter, including per-record transform failures
-	// that belong on Rejected. That is temporary and deliberate: a rejected record skips
-	// TrackProcessedKey via the same `continue`, so the orphan sweep deletes its existing
-	// row in the same run. Until that guard lands, leaving these sites here means the run
-	// fails loud rather than quietly losing a row. Reclassification and the sweep guard are
-	// one unit and ship together in kindred#2295.
+	// The reclassification has shipped (kindred#2295, PR #2299): per-record transform
+	// failures now increment Rejected instead, and base_sync.go's skipSweepForRejections
+	// stops the orphan sweep for any service that rejected a record, so a rejection no
+	// longer costs that record its existing row.
 	//
-	// Some sites will still belong here afterwards, because the function they call returns
-	// both classes of error and the call site cannot tell them apart. attendees.go's
-	// processEnrollment is the type case: it returns `invalid or missing SessionID` (a
-	// rejected record) and also the result of ProcessCompositeRecord's App.Save. Note this
-	// is processEnrollment, NOT its caller processAttendee — processAttendee returns only
-	// `invalid or missing PersonID` or nil, counting and swallowing processEnrollment's
-	// errors itself, so the outer site at attendees.go:121 is unambiguously a rejection.
-	// ProcessSimpleRecord is genuinely mixed too, returning `recordData missing required
-	// 'year' field` alongside its App.Save.
+	// Some sites deliberately stay here, because the function they call returns both
+	// classes of error through one return value and the call site cannot tell them apart.
+	// attendees.go's processEnrollment is the type case: it returns `invalid or missing
+	// SessionID` (a rejected record) and also the result of ProcessCompositeRecord's
+	// App.Save. Note this is processEnrollment, NOT its caller processAttendee —
+	// processAttendee returns only `invalid or missing PersonID` or nil, counting and
+	// swallowing processEnrollment's errors itself, so the outer site in attendees.go is
+	// unambiguously a rejection. processAssignment, processRow, processPerson and
+	// ProcessSimpleRecord are mixed the same way; rejection_sites_test.go names all five.
 	//
 	// Splitting the genuinely mixed ones needs typed errors from the wrappers — kindred#2292.
 	Errors int `json:"errors"`
@@ -330,14 +328,17 @@ type Stats struct {
 	// quality, not a local fault, and it is WARN-ONLY for its first season — surfaced on the
 	// Sync tab, never failing a run.
 	//
-	// The counter is written by 32 sites across the sync pipeline (household_custom_field_values,
-	// financial_lookups, staff, bunks, divisions, person_tag_definitions, custom_field_definitions,
-	// staff_lookups, person_custom_field_values, persons, sessions, session_groups, and
-	// financial_transactions). These were added in kindred#2295, now closed.
+	// The sites that write it shipped in PR #2299 (kindred#2295) alongside the orphan-sweep
+	// guard that made rejecting safe, and the duplicate custom-field-value check added four
+	// more in PR #2320 (kindred#2270). Deliberately not hand-counted here:
+	// rejection_sites_test.go enumerates every site and fails in both directions when one
+	// moves, so that census is the list which stays true — a number in this comment would
+	// not.
 	//
 	// Every completed run is now persisted to sync_runs, including this counter, which is
 	// what makes warn-only a plan rather than a shrug: a threshold picked today would be a
-	// guess, and the season exists to accumulate the distribution to set one from. See kindred#2284.
+	// guess, and the season exists to accumulate the distribution to set one from
+	// (kindred#2284).
 	Rejected int `json:"rejected,omitempty"`
 	// DuplicateStaffStatus counts staff records dropped because the same person appeared
 	// under more than one CampMinder status in one sync run (kindred#2267). staff.go's

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -330,14 +330,14 @@ type Stats struct {
 	// quality, not a local fault, and it is WARN-ONLY for its first season — surfaced on the
 	// Sync tab, never failing a run.
 	//
-	// Nothing writes this counter yet; the sites that will are held back with the orphan
-	// sweep guard in kindred#2295. It is declared here so the escalation, the status JSON
-	// and the badge all land together rather than in three separate PRs.
+	// The counter is written by 32 sites across the sync pipeline (household_custom_field_values,
+	// financial_lookups, staff, bunks, divisions, person_tag_definitions, custom_field_definitions,
+	// staff_lookups, person_custom_field_values, persons, sessions, session_groups, and
+	// financial_transactions). These were added in kindred#2295, now closed.
 	//
 	// Every completed run is now persisted to sync_runs, including this counter, which is
 	// what makes warn-only a plan rather than a shrug: a threshold picked today would be a
-	// guess, and the season exists to accumulate the distribution to set one from. Until the
-	// #2295 sites land the column records honest zeroes (kindred#2284).
+	// guess, and the season exists to accumulate the distribution to set one from. See kindred#2284.
 	Rejected int `json:"rejected,omitempty"`
 	// DuplicateStaffStatus counts staff records dropped because the same person appeared
 	// under more than one CampMinder status in one sync run (kindred#2267). staff.go's

--- a/pocketbase/sync/rejection_sites_test.go
+++ b/pocketbase/sync/rejection_sites_test.go
@@ -47,9 +47,16 @@ type rejectSite struct {
 //     SQLite operations that did not complete: infrastructure, zero tolerance.
 //   - household_demographics.go's sweep refusal -- a refusal is not a counted
 //     failure at all; kindred#2283 moves it onto the returned-error channel.
-//   - wrapper sites whose callee returns both classes (processAttendee,
-//     ProcessSimpleRecord) -- they stay loud until kindred#2292 gives them typed
-//     errors to tell apart.
+//   - wrapper sites whose callee returns both a transform rejection and an
+//     App.Save error through one return value, so the call site cannot tell them
+//     apart: processEnrollment (attendees.go), processAssignment
+//     (bunk_assignments.go), processRow (bunk_requests.go), processPerson
+//     (persons.go) and ProcessSimpleRecord (base_sync.go). They stay loud until
+//     kindred#2292 gives them typed errors. processAttendee is NOT one of them,
+//     despite an earlier revision of this comment saying so: it returns only
+//     `invalid or missing PersonID` or nil, counting and swallowing
+//     processEnrollment's errors itself, so its call site is a pure rejection
+//     that needs no sentinel.
 func expectedRejectSites() []rejectSite {
 	return []rejectSite{
 		{"bunks.go", "Error transforming bunk"},


### PR DESCRIPTION
## Summary

The comment on the `Rejected` counter in `orchestrator.go` claimed nothing wrote it yet and that the sites that would were held back in #2295. Both were false on main: #2295 is closed, its orphan-sweep guard shipped in PR #2299, and the per-record rejection sites now write `Stats.Rejected`. The `Errors` comment immediately above it was stale in the same way, and `rejection_sites_test.go`'s deferral note named the wrong wrappers. All three are corrected here.

## What changed

**`Stats.Errors` doc** — dropped "every site currently increments this counter" and "until that guard lands". Both were untrue after PR #2299, and the first directly contradicted the corrected `Rejected` doc three lines below it. Its list of genuinely-mixed wrappers now names all five — `processEnrollment`, `processAssignment`, `processRow`, `processPerson`, `ProcessSimpleRecord` — instead of two.

**`Stats.Rejected` doc** — points at `rejection_sites_test.go` instead of restating a hand count. Measured today, 32 non-test sites across 13 files write the counter, but nothing enforces that number, so a comment carrying it would go stale the next time a site is added — which is the defect this PR exists to remove. The census test is enforced in both directions (mutation transcript in the review comment). Provenance was wrong too: 4 of the 32 came from PR #2320 (#2270), not from #2299.

**`rejection_sites_test.go` deferral note** — named `processAttendee` as a wrapper whose callee returns both classes. It is not one: it returns only `invalid or missing PersonID` or `nil`, counting and swallowing `processEnrollment`'s errors itself, so its call site is a pure rejection needing no sentinel. The three wrappers that *are* mixed were missing from the list.

## Verification

```bash
grep -rn 'Rejected++' pocketbase/ --include=*.go | grep -v _test.go | wc -l
# 32, across 13 files

# git blame on each of those 32 lines:
# 28 -> a0d88f8c (PR #2299), 4 -> 3524a7bb (PR #2320)
```

`bash scripts/pre-push-verify.sh` — ALL CHECKS PASSED.

## Notes

- Comment-only. No production behaviour changes and no test logic changes; the only edit to `rejection_sites_test.go` is inside a doc comment.
- This PR links no issue for closing. The typed-error refactor these comments point at, see #2292, is deliberately left for a later round.
