### PR TITLE
docs(sync): document the camper_transportation cascade as intentional

### DIFF
--- a/pocketbase/sync/camper_transportation.go
+++ b/pocketbase/sync/camper_transportation.go
@@ -51,9 +51,10 @@ const (
 // and camper_dietary, because those tables are person x year and the stored link was one
 // arbitrarily-chosen attendee row that could never answer the enrolment question. This table's
 // link is sound -- idx_camper_transportation_unique is (person_id, session_id, year), so exactly
-// one attendee row can match, and every production row (17,628 of 17,628, measured under
-// kindred#2311) points at an attendee whose session matches the row. Do not carry #2261's
-// remedy over here: dropping this column would remove a link that works.
+// one attendee row can match, and on the production snapshot EVERY row's stored attendee is for
+// that row's own session, with zero exceptions (measured under kindred#2311 and re-measured at
+// review; the count moves between snapshots, the zero does not). Do not carry #2261's remedy
+// over here: dropping this column would remove a link that works.
 //
 // Dropping the cascade instead would preserve nothing. Two reasons, either one sufficient:
 //   - `required: true` means PocketBase refuses to delete the referenced attendee at all when

--- a/pocketbase/sync/camper_transportation.go
+++ b/pocketbase/sync/camper_transportation.go
@@ -39,16 +39,29 @@ const (
 // This service reads from person_custom_values and populates the camper_transportation table.
 //
 // Unique key: (person_id, session_id, year) - one record per camper per session
-// Links to: attendees
+// Links to: attendees, via a relation field that carries cascadeDelete: true. That cascade is
+// KEPT DELIBERATELY: transportation is enrolment-scoped, so a bus pickup contact is meaningless
+// once CampMinder no longer lists the attendee for that session -- removing it with the attendee
+// row is correct, not an accident. This is the opposite conclusion from kindred#2261/#2265, where
+// the cascaded relation was an arbitrarily-chosen row that could never answer the enrolment
+// question; dropping the cascade there was the fix. Do not apply that fix here.
+//
+// Dropping the cascade would not preserve anything anyway: this table runs its own orphan sweep
+// (deleteOrphans, below), which removes a row whenever its (person_id, session_id) has no
+// attendeeMap hit in loadAttendeeMapping -- exactly the condition that holds once CampMinder
+// drops the attendee. So the row already dies on this sync's own next run; the cascade only
+// makes it happen one run sooner. See kindred#2311 for the full analysis and options considered.
 //
 // Field mapping handles both new BUS-* fields and legacy "Bus to/From Camp" fields.
 // New fields take priority; legacy fields are used as fallback.
 //
-// Rows persist after a camper cancels; this table is never swept by deletion. A future reader
-// (e.g. a staff dashboard) must filter by active enrolment for the view's own year -- an
-// `attendees` row with status_id = 2 for that person and year -- and must not filter across
-// years. See "Reading Derived Informational Tables (Active-Enrolment Filtering)" in
-// docs/architecture/sync-layer.md.
+// Rows persist after a camper CANCELS: loadAttendeeMapping applies no status filter, so a
+// cancelled camper's attendees row -- and therefore this table's row -- survives cancellation
+// untouched. That is not the same claim as "never swept by deletion": deleteOrphans below does
+// delete rows, just not merely for a status change. A future reader (e.g. a staff dashboard)
+// must filter by active enrolment for the view's own year -- an `attendees` row with
+// status_id = 2 for that person and year -- and must not filter across years. See "Reading
+// Derived Informational Tables (Active-Enrolment Filtering)" in docs/architecture/sync-layer.md.
 type CamperTransportationSync struct {
 	App    core.App
 	Year   int

--- a/pocketbase/sync/camper_transportation.go
+++ b/pocketbase/sync/camper_transportation.go
@@ -39,18 +39,36 @@ const (
 // This service reads from person_custom_values and populates the camper_transportation table.
 //
 // Unique key: (person_id, session_id, year) - one record per camper per session
-// Links to: attendees, via a relation field that carries cascadeDelete: true. That cascade is
-// KEPT DELIBERATELY: transportation is enrolment-scoped, so a bus pickup contact is meaningless
-// once CampMinder no longer lists the attendee for that session -- removing it with the attendee
-// row is correct, not an accident. This is the opposite conclusion from kindred#2261/#2265, where
-// the cascaded relation was an arbitrarily-chosen row that could never answer the enrolment
-// question; dropping the cascade there was the fix. Do not apply that fix here.
+// Links to: attendees, via a relation field that is `required: true` and carries
+// `cascadeDelete: true` (pb_migrations/1500000043_camper_transportation.js). That cascade is
+// KEPT DELIBERATELY -- reviewed and re-affirmed under kindred#2311, whatever the original author
+// weighed: transportation is enrolment-scoped, so a bus pickup contact is meaningless once
+// CampMinder no longer lists the attendee for that session, and taking the row with the attendee
+// is the behavior we want.
 //
-// Dropping the cascade would not preserve anything anyway: this table runs its own orphan sweep
-// (deleteOrphans, below), which removes a row whenever its (person_id, session_id) has no
-// attendeeMap hit in loadAttendeeMapping -- exactly the condition that holds once CampMinder
-// drops the attendee. So the row already dies on this sync's own next run; the cascade only
-// makes it happen one run sooner. See kindred#2311 for the full analysis and options considered.
+// kindred#2261/#2265 reached the opposite conclusion, and the remedy there was NOT a cascade
+// flag flip: migration 1500000153 dropped the whole `attendee` column from quest_registrations
+// and camper_dietary, because those tables are person x year and the stored link was one
+// arbitrarily-chosen attendee row that could never answer the enrolment question. This table's
+// link is sound -- idx_camper_transportation_unique is (person_id, session_id, year), so exactly
+// one attendee row can match, and every production row (17,628 of 17,628, measured under
+// kindred#2311) points at an attendee whose session matches the row. Do not carry #2261's
+// remedy over here: dropping this column would remove a link that works.
+//
+// Dropping the cascade instead would preserve nothing. Two reasons, either one sufficient:
+//   - `required: true` means PocketBase refuses to delete the referenced attendee at all when
+//     the relation does not cascade (core.deleteRefRecords returns "part of a required
+//     reference"), so that change alone turns a silent row deletion into a failing attendees
+//     sweep rather than into a surviving row.
+//   - This table runs its own orphan sweep (deleteOrphans, below), which removes a row whenever
+//     its (person_id, session_id) has no attendeeMap hit in loadAttendeeMapping -- exactly the
+//     condition that holds once CampMinder drops the attendee. The row dies on this sync's own
+//     next run either way; the cascade only makes it happen one run sooner.
+//
+// The row is what is lost, not the content: this table is fully derived from
+// person_custom_values, with no staff_touched column and no GUI write path, so an attendee that
+// reappears upstream is recomputed with the same values. See kindred#2311 for the full analysis
+// and the options considered.
 //
 // Field mapping handles both new BUS-* fields and legacy "Bus to/From Camp" fields.
 // New fields take priority; legacy fields are used as fallback.

--- a/pocketbase/sync/camper_transportation_test.go
+++ b/pocketbase/sync/camper_transportation_test.go
@@ -895,3 +895,70 @@ func TestLoadPersonCustomValuesNoDiscardsMeansNoWarnLog(t *testing.T) {
 		t.Errorf("expected no log output when nothing was discarded, got:\n%s", logged)
 	}
 }
+
+// TestLoadPersonCustomValuesDropsAPersonWithNoAttendeeRow pins the claim the
+// CamperTransportationSync doc comment makes about the cascade (kindred#2311):
+// that dropping the cascade would preserve nothing, because this table's own
+// sweep removes the same row anyway. That argument only holds if a person with
+// no attendeeMap hit falls OUT of the computed set -- deleteOrphans deletes
+// whatever is on disk but not in that set, and TestCamperTransportation-
+// DeleteOrphansStillSweepsGenuineOrphans already pins the second half.
+//
+// The gate is implicit and doubled, which is why it is worth a named test:
+// loadPersonCustomValues fans each person's values across personSessions (built
+// only from attendeeMap, so a person with no entry emits no entries), and its
+// aggregation loop then drops any entry whose (person, session) misses
+// attendeeMap a second time. Defeating either one alone changes nothing
+// observable, so neither is individually load-bearing and neither reads as
+// load-bearing to someone editing it; only the pair is. This test pins the
+// OUTCOME rather than either mechanism, and goes red when both go.
+func TestLoadPersonCustomValuesDropsAPersonWithNoAttendeeRow(t *testing.T) {
+	t.Parallel()
+	app := newTransportValuesTestApp(t)
+
+	personsCol, err := app.FindCollectionByNameOrId("persons")
+	if err != nil {
+		t.Fatalf("find persons: %v", err)
+	}
+	// Two campers with identical BUS-* answers. Only the first still has an
+	// attendees row for the year; CampMinder has dropped the second's.
+	stillEnrolled := core.NewRecord(personsCol)
+	stillEnrolled.Set("cm_id", 7101)
+	if saveErr := app.Save(stillEnrolled); saveErr != nil {
+		t.Fatalf("save person: %v", saveErr)
+	}
+	attendeeGone := core.NewRecord(personsCol)
+	attendeeGone.Set("cm_id", 7102)
+	if saveErr := app.Save(attendeeGone); saveErr != nil {
+		t.Fatalf("save person: %v", saveErr)
+	}
+
+	const year = 2026
+	addPersonCustomValue(t, app, "fd_routed", stillEnrolled.Id, testRoutedBusValue, year)
+	addPersonCustomValue(t, app, "fd_routed", attendeeGone.Id, testRoutedBusValue, year)
+
+	fieldNameMap := map[string]string{"fd_routed": "BUS-to camp"}
+	attendeeMap := map[attendeeKey]string{
+		{personID: 7101, sessionID: 9101}: "att1",
+	}
+
+	s := NewCamperTransportationSync(app)
+	records, err := s.loadPersonCustomValues(context.Background(), year, fieldNameMap, attendeeMap)
+	if err != nil {
+		t.Fatalf("loadPersonCustomValues: %v", err)
+	}
+
+	if _, ok := records[makeTransportationKey(7101, 9101, year)]; !ok {
+		t.Errorf("the still-enrolled camper is missing from the computed set; got %d records", len(records))
+	}
+	for key := range records {
+		if strings.HasPrefix(key, "7102:") {
+			t.Errorf("a camper with no attendees row reached the computed set under key %q; "+
+				"the doc comment's 'the row dies on this sync's own next run either way' no longer holds",
+				key)
+		}
+	}
+	if len(records) != 1 {
+		t.Errorf("computed set has %d records, want exactly 1 (only the still-enrolled camper)", len(records))
+	}
+}


### PR DESCRIPTION
## Summary

`camper_transportation.attendee` carries `cascadeDelete: true`, and the type-level doc comment at the top of `pocketbase/sync/camper_transportation.go` claimed *"this table is never swept by deletion."* That second half was false: `deleteOrphans` (implemented lower in the same file) deletes any row whose `(person_id, session_id)` has no `attendeeMap` hit in `loadAttendeeMapping` — exactly the condition that holds once CampMinder drops the underlying attendee. The comment was added by #2225, after the sweep already existed.

The intent behind the cascade itself was undecided as of #2311's filing. It is now settled: **keep the cascade**, because dropping it would not preserve anything.

Two independent reasons, either one sufficient:

- The relation is `required: true` as well as cascading (`pb_migrations/1500000043_camper_transportation.js`). With `cascadeDelete` off, PocketBase refuses to delete a referenced record at all when the referencing relation is required — `core.deleteRefRecords` returns *"the record cannot be deleted because it is part of a required reference"*. So that change on its own does not produce a surviving transportation row; it produces a failing attendees sweep.
- `camper_transportation` runs its own orphan sweep on the same attendee gate the cascade reacts to. When CampMinder drops an attendee, the transportation row dies either way — via the cascade today, or via this table's own sweep on its next run. The cascade is not load-bearing for retention; it just makes the deletion happen one sync run sooner.

Transportation is also enrolment-scoped by nature (a bus pickup contact for a session the camper is no longer attending is meaningless), which is the opposite situation from #2261/#2265, where the cascaded relation was an arbitrarily-chosen row that could never answer the enrolment question. The remedy there was **not** a cascade flag flip: migration `1500000153` dropped the whole `attendee` column from `quest_registrations` and `camper_dietary`. That remedy must not be carried over here — this table's link is sound, because `idx_camper_transportation_unique` is `(person_id, session_id, year)` and already carries the session dimension, so exactly one attendee row can match — and on the production snapshot every row's stored attendee is for that row's own session, with zero exceptions. Re-measured during review: the join returns 17,628 rows on one local snapshot and 17,632 on another, both with zero mismatches. The count moves between snapshots; the zero is the claim, which is why the code comment states the invariant rather than a total.

Worth stating alongside the decision: the row is what is lost, not the content. This table is fully derived from `person_custom_values`, with no `staff_touched` column and no GUI write path, so an attendee that reappears upstream is recomputed with the same values.

## What changed

Documentation at the `CamperTransportationSync` type doc comment — the place the next reader stands before touching this relation:

- States plainly that the cascade is kept **deliberately**, and why (enrolment-scoped data, `required: true`, and this table's own sweep).
- Corrects the false "never swept by deletion" claim to describe what `deleteOrphans` actually does, and separates it from the true claim it was conflated with (a *cancelled* camper's row does survive, because `loadAttendeeMapping` applies no status filter — cancellation alone doesn't touch this table).
- Records what #2261/#2265 actually did, so the next reader consulting that precedent does not mistake a column removal for a cascade flip and re-apply it here.

One new test, `TestLoadPersonCustomValuesDropsAPersonWithNoAttendeeRow`, pins the claim the comment now rests on: a person with values but no `attendees` row for the year falls out of the computed set, which is what makes this table's own sweep remove the row the cascade would have removed. The existing `TestCamperTransportationDeleteOrphansStillSweepsGenuineOrphans` already pins the other half (a key on disk but not in the computed set is deleted); nothing pinned the first half, so a future change could have made the comment quietly false.

## What this PR does NOT do

- **No migration.** The cascade itself is unchanged — `cascadeDelete: true` stays as-is on the `attendee` relation. This PR does not touch `pb_migrations/`.
- **No behavior change.** `deleteOrphans`, `loadAttendeeMapping`, and the sweep logic are untouched; the only non-comment change is the added test.
- **No change to `locked_group_members.attendee`'s cascade** (also `cascadeDelete: true`, flagged in #2311 as "not investigated" and out of scope here).

Closes #2311.
