### PR TITLE
fix(sync): protect nameless-but-attributed family_camp_adults rows from a sweep

### DIFF
--- a/pocketbase/main_test_parallelism_test.go
+++ b/pocketbase/main_test_parallelism_test.go
@@ -162,6 +162,7 @@ var serialGroups = []struct {
 			"TestIsDuplicateStaffStatus",
 			"TestLoadPersonCustomValuesCountsAndLogsUnmappedFields",
 			"TestLoadPersonCustomValuesNoDiscardsMeansNoWarnLog",
+			"TestFamilyCampSweepLogsProtectedNamelessAdultsFor2018",
 		},
 	},
 	{

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -71,8 +71,19 @@ type DryRunDiff struct {
 	// something different against 45 rows than against 4,500.
 	Unchanged int
 	// WouldDelete counts stored rows this run's computed set does not account
-	// for -- what the orphan sweep would TARGET.
+	// for -- what the orphan sweep would TARGET. A row protected by kindred#2335
+	// (see Protected) is excluded from this count: the real sweep never targets
+	// it either, and a forecast that counted it anyway would tell an operator a
+	// replay destroys data it will not actually touch.
 	WouldDelete int
+	// Protected counts stored rows this run's computed set does not account for
+	// but that the sweep will not delete anyway, because they are wholly
+	// nameless (name, first_name, last_name all empty) yet carry another
+	// attribute -- date_of_birth, email, gender, pronouns or
+	// relationship_to_camper (kindred#2335). Only family_camp_adults has these
+	// columns, so this is always 0 for family_camp_registrations and
+	// family_camp_medical.
+	Protected int
 	// GuardWouldRefuse reports that the sweep would be refused rather than
 	// performed, so WouldDelete describes an intention, not an outcome.
 	GuardWouldRefuse bool
@@ -1416,7 +1427,7 @@ func (s *FamilyCampDerivedSync) reportDryRun(
 				func(a *adultData) string {
 					return familyCampAdultKey(a.householdPBID, year, a.adultNumber)
 				},
-				s.adultNeedsUpdate),
+				s.adultNeedsUpdate, isNamelessButAttributedAdult),
 		},
 		{
 			name:     "family_camp_registrations",
@@ -1425,7 +1436,7 @@ func (s *FamilyCampDerivedSync) reportDryRun(
 				func(r *registrationData) string {
 					return familyCampHouseholdYearKey(r.householdPBID, year)
 				},
-				s.registrationNeedsUpdate),
+				s.registrationNeedsUpdate, nil),
 		},
 		{
 			name:     "family_camp_medical",
@@ -1434,7 +1445,7 @@ func (s *FamilyCampDerivedSync) reportDryRun(
 				func(m *medicalData) string {
 					return familyCampHouseholdYearKey(m.householdPBID, year)
 				},
-				s.medicalNeedsUpdate),
+				s.medicalNeedsUpdate, nil),
 		},
 	}
 
@@ -1449,6 +1460,7 @@ func (s *FamilyCampDerivedSync) reportDryRun(
 			"would_update", t.diff.WouldUpdate,
 			"unchanged", t.diff.Unchanged,
 			"would_delete", t.diff.WouldDelete,
+			"protected", t.diff.Protected,
 			"existing", len(t.existing),
 		)
 		if t.diff.GuardWouldRefuse {
@@ -1491,6 +1503,12 @@ func (s *FamilyCampDerivedSync) reportDryRun(
 // reimplemented: a dry run that judged "changed" by its own rule would drift
 // from the writing path silently, and a forecast nobody can trust is worse than
 // no forecast.
+//
+// protected classifies a stored row this run's computed set does not account
+// for: true means the real sweep would leave it alone (kindred#2335), so it
+// belongs on diff.Protected rather than diff.WouldDelete. Pass nil for tables
+// with no such rule -- family_camp_registrations and family_camp_medical carry
+// no name column, so nothing on them is ever "wholly nameless".
 func computeDryRunDiff[T any](
 	entity string,
 	year int,
@@ -1498,6 +1516,7 @@ func computeDryRunDiff[T any](
 	existing map[string]*core.Record,
 	key func(T) string,
 	needsUpdate func(*core.Record, T) bool,
+	protected func(*core.Record) bool,
 ) DryRunDiff {
 	var diff DryRunDiff
 
@@ -1517,10 +1536,15 @@ func computeDryRunDiff[T any](
 		}
 	}
 
-	for k := range existing {
-		if !computed[k] {
-			diff.WouldDelete++
+	for k, record := range existing {
+		if computed[k] {
+			continue
 		}
+		if protected != nil && protected(record) {
+			diff.Protected++
+			continue
+		}
+		diff.WouldDelete++
 	}
 
 	// Computed is the size of the key set, matching what the real sweep passes
@@ -1960,7 +1984,43 @@ func (s *FamilyCampDerivedSync) upsertMedical(
 // cannot fire and there is nothing for it to fire on.
 // ============================================================================
 
+// isNamelessButAttributedAdult reports whether a family_camp_adults row has no
+// name at all (name, first_name and last_name all empty) but carries at least
+// one of the other adult attributes: date_of_birth, email, gender, pronouns or
+// relationship_to_camper.
+//
+// kindred#2335 measured 188 such rows across 2017-2025 (plus 6 more in 2026),
+// 137 of them holding a date_of_birth and 36 an email. They are households
+// that answered the gender or date-of-birth question for an adult but never
+// the name question -- a real adult with real attributes and no label, not the
+// wholly-empty junk row kindred#2198 stopped ADMITTING. The owner's ruling
+// (2026-08-14) is to protect the ones that already exist until their names can
+// be rescued, which is separate, out-of-scope work: this function decides only
+// whether a row survives a sweep, and recovers nothing.
+//
+// This deliberately does NOT change what gets CREATED -- #2198's admission
+// rule is untouched, so a new wholly-nameless row still cannot come into
+// existence. This only stops an existing one from being deleted.
+func isNamelessButAttributedAdult(record *core.Record) bool {
+	if record.GetString("name") != "" ||
+		record.GetString("first_name") != "" ||
+		record.GetString("last_name") != "" {
+		return false
+	}
+	return record.GetString("date_of_birth") != "" ||
+		record.GetString("email") != "" ||
+		record.GetString("gender") != "" ||
+		record.GetString("pronouns") != "" ||
+		record.GetString("relationship_to_camper") != ""
+}
+
 // deleteOrphanedAdults removes adult records that weren't processed.
+//
+// A row that is wholly nameless but carries another attribute is protected
+// rather than deleted (kindred#2335, isNamelessButAttributedAdult) -- the
+// OrphanSweepGuard above does not catch this: the shortfall it measures is
+// comfortably inside the guard's budget, so the guard is not a backstop for
+// this class of row at all.
 func (s *FamilyCampDerivedSync) deleteOrphanedAdults(
 	existing map[string]*core.Record, year int,
 ) (int, error) {
@@ -1980,8 +2040,14 @@ func (s *FamilyCampDerivedSync) deleteOrphanedAdults(
 	}
 
 	orphanCount := 0
+	protectedCount := 0
 	for key, record := range existing {
 		if s.ProcessedAdultKeys[key] {
+			continue
+		}
+
+		if isNamelessButAttributedAdult(record) {
+			protectedCount++
 			continue
 		}
 
@@ -1997,6 +2063,11 @@ func (s *FamilyCampDerivedSync) deleteOrphanedAdults(
 			continue
 		}
 		orphanCount++
+	}
+
+	if protectedCount > 0 {
+		slog.Info("Protected nameless-but-attributed family_camp_adults from sweep",
+			"count", protectedCount, "year", year)
 	}
 
 	if orphanCount > 0 {

--- a/pocketbase/sync/family_camp_derived_replay_test.go
+++ b/pocketbase/sync/family_camp_derived_replay_test.go
@@ -766,3 +766,231 @@ func TestFamilyCampSyncStopsSweepingWhenCancelledMidStep12(t *testing.T) {
 			"after the run was cancelled", got)
 	}
 }
+
+// ============================================================================
+// P3 -- nameless-but-attributed family_camp_adults rows survive a sweep
+// (kindred#2335)
+//
+// A replay measured 188 family_camp_adults rows across 2017-2025 (plus 6 in
+// 2026) with name, first_name and last_name ALL empty -- the class kindred#2198
+// stopped ADMITTING -- but 137 of them carry a date_of_birth and 36 carry an
+// email. These are real adults whose name answer never made it in, not the
+// wholly-empty rows #2198 targeted, and the owner ruled they must survive a
+// sweep until their names are rescued (separate, out-of-scope work).
+//
+// Every test below proves survival against the REAL sweep function against a
+// real PocketBase app, not a standalone helper: #2335 is explicit that a
+// helper-level test is not sufficient evidence one line from a production
+// data replay.
+// ============================================================================
+
+// TestFamilyCampSweepProtectsNamelessButAttributedAdults exercises all five
+// protected attributes individually, plus the two cases that must NOT be
+// protected: an ordinary named row (still tracked normally) and a genuinely
+// empty orphan (no name, no attribute at all -- still swept).
+func TestFamilyCampSweepProtectsNamelessButAttributedAdults(t *testing.T) {
+	t.Parallel()
+
+	const year = 2026
+
+	app := newFamilyCampReplayTestApp(t)
+
+	// 90 ordinary named rows this run recomputes (marked processed below) --
+	// keeps the guard's ratio comfortably satisfied regardless of how the
+	// other rows are classified.
+	for i := 1; i <= 90; i++ {
+		seedRow(t, app, "family_camp_adults", map[string]any{
+			"household": fmt.Sprintf("hh_named_%04d", i), "year": year,
+			"adult_number": 1, "name": fmt.Sprintf("Adult %04d", i),
+		})
+	}
+
+	// One nameless row per protected attribute.
+	protectedAttrs := []struct{ field, value string }{
+		{"date_of_birth", "1980-01-01"},
+		{"email", "adult@example.com"},
+		{"gender", "female"},
+		{"pronouns", "she/her"},
+		{"relationship_to_camper", "parent"},
+	}
+	for i, pa := range protectedAttrs {
+		seedRow(t, app, "family_camp_adults", map[string]any{
+			"household": fmt.Sprintf("hh_protected_%04d", i), "year": year,
+			"adult_number": 1, pa.field: pa.value,
+		})
+	}
+
+	// One genuinely empty orphan: no name, no attribute at all.
+	seedRow(t, app, "family_camp_adults", map[string]any{
+		"household": "hh_empty_0001", "year": year, "adult_number": 1,
+	})
+
+	s := NewFamilyCampDerivedSync(app)
+	s.SyncSuccessful = true
+
+	existing, err := s.preloadExistingAdults(year)
+	if err != nil {
+		t.Fatalf("preload: %v", err)
+	}
+	if len(existing) != 96 {
+		t.Fatalf("preloaded %d rows, want 96", len(existing))
+	}
+
+	// Mark only the 90 named rows processed. The 5 protected rows and the 1
+	// empty orphan look, to key-matching alone, identical to orphans -- that
+	// is the whole point of the test.
+	for key, record := range existing {
+		if record.GetString("name") != "" {
+			s.ProcessedAdultKeys[key] = true
+		}
+	}
+
+	deleted, sweepErr := s.deleteOrphanedAdults(existing, year)
+	if sweepErr != nil {
+		t.Fatalf("guard refused an ordinary sweep: %v", sweepErr)
+	}
+	if deleted != 1 {
+		t.Errorf("deleted = %d, want 1 -- only the genuinely empty orphan", deleted)
+	}
+
+	for i, pa := range protectedAttrs {
+		rows, findErr := app.FindRecordsByFilter("family_camp_adults",
+			fmt.Sprintf("year = %d && household = 'hh_protected_%04d'", year, i), "", 0, 0)
+		if findErr != nil {
+			t.Fatalf("query protected row %d: %v", i, findErr)
+		}
+		if len(rows) != 1 {
+			t.Errorf("protected row %d (carrying %s) was swept -- it must survive", i, pa.field)
+		}
+	}
+
+	empty, findErr := app.FindRecordsByFilter("family_camp_adults",
+		fmt.Sprintf("year = %d && household = 'hh_empty_0001'", year), "", 0, 0)
+	if findErr != nil {
+		t.Fatalf("query empty orphan: %v", findErr)
+	}
+	if len(empty) != 0 {
+		t.Errorf("the genuinely empty orphan survived -- it carries no name and no attribute, " +
+			"so #2198's admission rule says it should never have existed and #2335 does not " +
+			"protect it")
+	}
+
+	if got := countCollection(t, app, "family_camp_adults", year); got != 95 {
+		t.Errorf("family_camp_adults holds %d rows, want 95 (90 named + 5 protected)", got)
+	}
+}
+
+// TestFamilyCampSweepLogsProtectedNamelessAdultsFor2018 pins the year that
+// carries half of #2335's measured population -- 89 of the 188 -- rather than
+// only asserting an aggregate count, and pins that the protected count is
+// LOGGED per run rather than merely correct on disk (the issue's fix
+// direction: "count and log what was protected... so the population is
+// visible rather than silent").
+//
+// Not parallel: it uses captureSweepLogs (orphan_sweep_test.go), which
+// redirects the process-global slog default for the duration of the test.
+func TestFamilyCampSweepLogsProtectedNamelessAdultsFor2018(t *testing.T) {
+	const (
+		year          = 2018
+		protectedRows = 89
+		namedRows     = 90
+	)
+
+	app := newFamilyCampReplayTestApp(t)
+
+	for i := 1; i <= namedRows; i++ {
+		seedRow(t, app, "family_camp_adults", map[string]any{
+			"household": fmt.Sprintf("hh_2018_named_%04d", i), "year": year,
+			"adult_number": 1, "name": fmt.Sprintf("Adult %04d", i),
+		})
+	}
+	for i := 1; i <= protectedRows; i++ {
+		seedRow(t, app, "family_camp_adults", map[string]any{
+			"household": fmt.Sprintf("hh_2018_nameless_%04d", i), "year": year,
+			"adult_number": 1, "date_of_birth": "1975-06-01",
+		})
+	}
+
+	s := NewFamilyCampDerivedSync(app)
+	s.SyncSuccessful = true
+
+	existing, err := s.preloadExistingAdults(year)
+	if err != nil {
+		t.Fatalf("preload: %v", err)
+	}
+	if len(existing) != namedRows+protectedRows {
+		t.Fatalf("preloaded %d rows, want %d", len(existing), namedRows+protectedRows)
+	}
+	for key, record := range existing {
+		if record.GetString("name") != "" {
+			s.ProcessedAdultKeys[key] = true
+		}
+	}
+
+	logs := captureSweepLogs(t)
+
+	deleted, sweepErr := s.deleteOrphanedAdults(existing, year)
+	if sweepErr != nil {
+		t.Fatalf("guard refused an ordinary sweep: %v", sweepErr)
+	}
+	if deleted != 0 {
+		t.Errorf("deleted = %d, want 0 -- every unmatched 2018 row here is protected", deleted)
+	}
+	if got := countCollection(t, app, "family_camp_adults", year); got != namedRows+protectedRows {
+		t.Errorf("family_camp_adults 2018 holds %d rows, want %d -- all 89 protected rows "+
+			"must survive", got, namedRows+protectedRows)
+	}
+
+	logged := logs.String()
+	if !strings.Contains(logged, "count=89") {
+		t.Errorf("protected count not logged (want count=89):\n%s", logged)
+	}
+	if !strings.Contains(logged, "year=2018") {
+		t.Errorf("protected-row log line does not name the year:\n%s", logged)
+	}
+}
+
+// TestFamilyCampDryRunDoesNotForecastDeletingProtectedNamelessAdults keeps the
+// dry-run diff honest for the case #2335 protects. Dry-running a replay year
+// and reading the diff before deciding is the documented predecessor step
+// (docs/reference/family-camp-grain-collapse.md) -- a diff that still counted
+// a protected row toward WouldDelete would tell an operator a real replay
+// destroys data it will not actually touch.
+func TestFamilyCampDryRunDoesNotForecastDeletingProtectedNamelessAdults(t *testing.T) {
+	t.Parallel()
+
+	const year = 2026
+
+	app := newFamilyCampReplayTestApp(t)
+	seedDryRunFixture(t, app, year)
+
+	// A nameless row with no source values behind it at all -- by key-matching
+	// alone this looks exactly like hhC, the fixture's genuine orphan. It
+	// carries a date_of_birth, so #2335 protects it.
+	seedRow(t, app, "family_camp_adults", map[string]any{
+		"year": year, "household": "hhe000000000005",
+		"adult_number": 1, "date_of_birth": "1990-03-14",
+	})
+
+	s := NewFamilyCampDerivedSync(app)
+	s.Year = year
+	s.DryRun = true
+
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("dry run failed: %v", err)
+	}
+
+	adults := s.DryRunDiff["family_camp_adults"]
+	if adults.WouldDelete != 1 {
+		t.Errorf("adults.WouldDelete = %d, want 1 (hhC only) -- the protected nameless row "+
+			"must not be forecast as a deletion", adults.WouldDelete)
+	}
+	if adults.Protected != 1 {
+		t.Errorf("adults.Protected = %d, want 1", adults.Protected)
+	}
+
+	// A dry run writes nothing either way.
+	if got := countCollection(t, app, "family_camp_adults", year); got != 4 {
+		t.Errorf("family_camp_adults holds %d rows, want 4 -- the dry run wrote", got)
+	}
+}

--- a/pocketbase/sync/family_camp_derived_replay_test.go
+++ b/pocketbase/sync/family_camp_derived_replay_test.go
@@ -785,9 +785,11 @@ func TestFamilyCampSyncStopsSweepingWhenCancelledMidStep12(t *testing.T) {
 // ============================================================================
 
 // TestFamilyCampSweepProtectsNamelessButAttributedAdults exercises all five
-// protected attributes individually, plus the two cases that must NOT be
-// protected: an ordinary named row (still tracked normally) and a genuinely
-// empty orphan (no name, no attribute at all -- still swept).
+// protected attributes individually, plus the three cases that must NOT be
+// protected: an ordinary named row (still tracked normally), a genuinely empty
+// orphan (no name, no attribute at all -- still swept), and a NAMED orphan
+// carrying every one of the five attributes (still swept -- the half of the
+// predicate that keeps this from disabling the sweep outright).
 func TestFamilyCampSweepProtectsNamelessButAttributedAdults(t *testing.T) {
 	t.Parallel()
 
@@ -825,6 +827,20 @@ func TestFamilyCampSweepProtectsNamelessButAttributedAdults(t *testing.T) {
 		"household": "hh_empty_0001", "year": year, "adult_number": 1,
 	})
 
+	// One NAMED orphan that also carries every protected attribute. This is the
+	// row that pins the "wholly nameless" half of the predicate: drop the name
+	// check from isNamelessButAttributedAdult and this row becomes protected
+	// too, which would neuter the family_camp_adults sweep entirely -- a real
+	// adult who left the source data carries a name AND a gender, so nothing
+	// would ever be swept again. #2335 protects rows with no label, not rows
+	// with attributes.
+	seedRow(t, app, "family_camp_adults", map[string]any{
+		"household": "hh_orphan_named_0001", "year": year, "adult_number": 1,
+		"name": "Olivia Chen", "first_name": "Olivia", "last_name": "Chen",
+		"date_of_birth": "1982-07-04", "email": "test@example.com",
+		"gender": "female", "pronouns": "she/her", "relationship_to_camper": "parent",
+	})
+
 	s := NewFamilyCampDerivedSync(app)
 	s.SyncSuccessful = true
 
@@ -832,15 +848,18 @@ func TestFamilyCampSweepProtectsNamelessButAttributedAdults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("preload: %v", err)
 	}
-	if len(existing) != 96 {
-		t.Fatalf("preloaded %d rows, want 96", len(existing))
+	if len(existing) != 97 {
+		t.Fatalf("preloaded %d rows, want 97", len(existing))
 	}
 
-	// Mark only the 90 named rows processed. The 5 protected rows and the 1
-	// empty orphan look, to key-matching alone, identical to orphans -- that
-	// is the whole point of the test.
+	// Mark only the 90 ordinary rows processed, keyed on the household prefix
+	// rather than on the name column: the named orphan above must stay
+	// UNprocessed, and marking by name would have quietly excluded it from the
+	// sweep and pinned nothing. The 5 protected rows, the empty orphan and the
+	// named orphan all look, to key-matching alone, identical to each other --
+	// that is the whole point of the test.
 	for key, record := range existing {
-		if record.GetString("name") != "" {
+		if strings.HasPrefix(record.GetString("household"), "hh_named_") {
 			s.ProcessedAdultKeys[key] = true
 		}
 	}
@@ -849,8 +868,8 @@ func TestFamilyCampSweepProtectsNamelessButAttributedAdults(t *testing.T) {
 	if sweepErr != nil {
 		t.Fatalf("guard refused an ordinary sweep: %v", sweepErr)
 	}
-	if deleted != 1 {
-		t.Errorf("deleted = %d, want 1 -- only the genuinely empty orphan", deleted)
+	if deleted != 2 {
+		t.Errorf("deleted = %d, want 2 -- the genuinely empty orphan and the named orphan", deleted)
 	}
 
 	for i, pa := range protectedAttrs {
@@ -875,6 +894,17 @@ func TestFamilyCampSweepProtectsNamelessButAttributedAdults(t *testing.T) {
 			"protect it")
 	}
 
+	named, findErr := app.FindRecordsByFilter("family_camp_adults",
+		fmt.Sprintf("year = %d && household = 'hh_orphan_named_0001'", year), "", 0, 0)
+	if findErr != nil {
+		t.Fatalf("query named orphan: %v", findErr)
+	}
+	if len(named) != 0 {
+		t.Errorf("the named orphan survived -- #2335 protects rows with no name, not rows " +
+			"that merely carry attributes, and protecting this one would stop the sweep " +
+			"deleting anything at all")
+	}
+
 	if got := countCollection(t, app, "family_camp_adults", year); got != 95 {
 		t.Errorf("family_camp_adults holds %d rows, want 95 (90 named + 5 protected)", got)
 	}
@@ -893,7 +923,13 @@ func TestFamilyCampSweepLogsProtectedNamelessAdultsFor2018(t *testing.T) {
 	const (
 		year          = 2018
 		protectedRows = 89
-		namedRows     = 90
+		// 200 rather than a bare 90: the guard refuses a sweep whose computed
+		// set is below OrphanSweepRatioFloor of what is on disk, and 90 against
+		// 90+89 lands at 50.3% -- half a row above the floor. The real 2018
+		// replay sits at 965 computed against 1,054 existing (91.6%), so the
+		// tight version was neither realistic nor stable against a floor
+		// change. 200 against 289 is 69.2%.
+		namedRows = 200
 	)
 
 	app := newFamilyCampReplayTestApp(t)
@@ -941,12 +977,27 @@ func TestFamilyCampSweepLogsProtectedNamelessAdultsFor2018(t *testing.T) {
 			"must survive", got, namedRows+protectedRows)
 	}
 
-	logged := logs.String()
-	if !strings.Contains(logged, "count=89") {
-		t.Errorf("protected count not logged (want count=89):\n%s", logged)
+	// Assert against the PROTECTION line specifically, not the whole buffer.
+	// A whole-buffer strings.Contains(logged, "count=89") passes on the
+	// "Deleted orphaned family_camp_adults records count=89" line a run with no
+	// protection at all emits -- i.e. it is satisfied by exactly the regression
+	// it is supposed to catch.
+	const protectedMsg = "Protected nameless-but-attributed family_camp_adults from sweep"
+	protectedLine := ""
+	for _, line := range strings.Split(logs.String(), "\n") {
+		if strings.Contains(line, protectedMsg) {
+			protectedLine = line
+			break
+		}
 	}
-	if !strings.Contains(logged, "year=2018") {
-		t.Errorf("protected-row log line does not name the year:\n%s", logged)
+	if protectedLine == "" {
+		t.Fatalf("no %q log line at all:\n%s", protectedMsg, logs.String())
+	}
+	if !strings.Contains(protectedLine, "count=89") {
+		t.Errorf("protected count not logged (want count=89): %s", protectedLine)
+	}
+	if !strings.Contains(protectedLine, "year=2018") {
+		t.Errorf("protected-row log line does not name the year: %s", protectedLine)
 	}
 }
 


### PR DESCRIPTION
## What

A `family_camp_derived` replay deletes 188 `family_camp_adults` rows across 2017-2025. Every one is
wholly nameless (`name`, `first_name`, `last_name` all empty) — the class `#2198` stopped admitting
— but 137 carry a `date_of_birth`, 187 a `gender` and 36 an `email`, across 182 households, all in
adult slots 1 (62) and 2 (126).

Those figures are measured against the dated production snapshot. 2026 is where the two databases
disagree: the snapshot holds none for that year, while the working dev database holds 6 (also all
attributed). #2198 shipped 2026-08-09, so how much 2026 exposure a given database carries depends
on when it was last synced — which is a reason to land the protection before any replay, not a
reason to discount the 188. They are real
adults whose name answer never made it in, not junk rows. `OrphanSweepGuard` (`#2322`) does not
catch this: the shortfall sits comfortably inside its budget, so it is not a backstop here.

## Fix

`deleteOrphanedAdults` now skips (protects) a row that is wholly nameless but carries any of
`date_of_birth`, `email`, `gender`, `pronouns`, or `relationship_to_camper` (the new
`isNamelessButAttributedAdult` helper), logging the protected count per run rather than staying
silent. The dry-run diff (`reportDryRun` / `computeDryRunDiff`), which is how a replay year is
previewed before it runs for real, applies the same rule so its `WouldDelete` forecast stays
honest — a new `DryRunDiff.Protected` field carries the count there too.

## What this deliberately does NOT do

- Does not widen the admission rule — `#2198`'s fix stays intact; a new wholly-nameless row still
  cannot be created. This only stops an already-existing one from being deleted.
- Does not rescue any names. Separate, out-of-scope work per the issue.
- Does not touch `deleteOrphanedRegistrations` or `deleteOrphanedMedical`. Neither
  `family_camp_registrations` nor `family_camp_medical` has a `name`, `first_name`, `last_name`,
  `date_of_birth`, `email`, `gender`, `pronouns` or `relationship_to_camper` column (see
  `pb_migrations/1500000035_family_camp_derived_tables.js`), so "wholly nameless" is not a concept
  that applies to those two tables and there is nothing for this ruling to protect there.

## Tests (TDD — written first, confirmed red, then implemented; mutation-checked)

- `TestFamilyCampSweepProtectsNamelessButAttributedAdults` — exercises the real sweep against a
  real PocketBase app, all five protected attributes individually, and proves both rows that must
  NOT be protected are still swept: a genuinely empty orphan (no name, no attribute at all) and a
  NAMED orphan carrying all five attributes. The second is what pins the *nameless* half of the
  predicate — widened to any attributed row, the protection would neuter the sweep outright, since
  every real adult carries a name and a gender.
- `TestFamilyCampSweepLogsProtectedNamelessAdultsFor2018` — pins 2018 specifically (89 of the
  measured 188, half the population), and asserts `count=89` and `year=2018` on the protection log
  line itself rather than anywhere in the buffer: a whole-buffer match is also satisfied by the
  `Deleted orphaned family_camp_adults records count=89` line an unprotected run emits.
- `TestFamilyCampDryRunDoesNotForecastDeletingProtectedNamelessAdults` — the dry-run diff must not
  forecast deleting a protected row either, and must report it under `Protected`.

Closes #2335.

