### PR TITLE
test(sync): pin that a duplicate-inflated rejection mask cannot delete

### DIFF
--- a/pocketbase/sync/base_sync.go
+++ b/pocketbase/sync/base_sync.go
@@ -301,6 +301,13 @@ func (b *BaseSyncService) deleteOrphans(
 			return guardErr
 		}
 
+		// RejectionsExplainShortfall's arithmetic can be fooled by a
+		// duplicate-in-run rejection that never shrank Computed (kindred#2325,
+		// documented on that method). It does not matter here: whatever the
+		// arithmetic decided above, a Rejected > 0 still routes through
+		// skipSweepForRejections below, which abandons the sweep outright. A
+		// masked refusal can only turn a failed run into a warned one -- it can
+		// never reach the delete loop past this point.
 		if b.skipSweepForRejections(entityName, guard) {
 			return nil
 		}

--- a/pocketbase/sync/orphan_guard.go
+++ b/pocketbase/sync/orphan_guard.go
@@ -205,13 +205,14 @@ func (g OrphanSweepGuard) SkipReason() string {
 // arithmetic wave through a refusal it should not.
 //
 // This is left as documented risk rather than a second counter that tracks
-// "rejections that did / didn't remove a key" (which would have to reach all
-// 12 guarded services, not just the two kindred#2320 touched), because the
-// failure is ONE-WAY and cannot delete anything: deleteOrphans (base_sync.go)
-// never acts on a masked refusal directly -- skipSweepForRejections runs right
-// after, unconditionally on Rejected > 0, and IT decides whether the sweep
-// proceeds. A duplicate-inflated mask can only turn a run that should fail
-// loud into one that logs a warning; it can never turn into a delete.
+// "rejections that did / didn't remove a key" (which means reopening the shared
+// contract every guarded sweep reads, not just the two files kindred#2320
+// touched), because the failure is ONE-WAY and cannot delete anything:
+// deleteOrphans (base_sync.go) never acts on a masked refusal directly --
+// skipSweepForRejections runs right after, unconditionally on Rejected > 0, and
+// IT decides whether the sweep proceeds. A duplicate-inflated mask can only
+// turn a run that should fail loud into one that logs a warning; it can never
+// turn into a delete.
 // TestDuplicateInflatedRejectionsCannotDeleteDespiteMaskingACollapse
 // (orphan_guard_test.go) pins that half of the property. Today Rejected from
 // the duplicate guard is 0 in every real run -- CampMinder packs multi-selects

--- a/pocketbase/sync/orphan_guard.go
+++ b/pocketbase/sync/orphan_guard.go
@@ -194,6 +194,29 @@ func (g OrphanSweepGuard) SkipReason() string {
 // set, so `Rejected` is an exact upper bound on how much of the shortfall they can
 // explain. A shortfall of zero or less -- a computed set at least as large as the
 // rows on disk -- is trivially explained.
+//
+// KNOWN RESIDUAL RISK (kindred#2325): "each rejection removes exactly one key"
+// stopped being universally true the moment person_custom_field_values.go and
+// household_custom_field_values.go started rejecting a SECOND entry for a key
+// already tracked this run (kindred#2320's duplicate-in-run guard). That
+// rejection bumps Rejected without shrinking Computed -- the key it
+// "corresponds to" was never missing. Enough of those landing in the same run
+// as an unrelated genuine shortfall of comparable size could make this
+// arithmetic wave through a refusal it should not.
+//
+// This is left as documented risk rather than a second counter that tracks
+// "rejections that did / didn't remove a key" (which would have to reach all
+// 12 guarded services, not just the two kindred#2320 touched), because the
+// failure is ONE-WAY and cannot delete anything: deleteOrphans (base_sync.go)
+// never acts on a masked refusal directly -- skipSweepForRejections runs right
+// after, unconditionally on Rejected > 0, and IT decides whether the sweep
+// proceeds. A duplicate-inflated mask can only turn a run that should fail
+// loud into one that logs a warning; it can never turn into a delete.
+// TestDuplicateInflatedRejectionsCannotDeleteDespiteMaskingACollapse
+// (orphan_guard_test.go) pins that half of the property. Today Rejected from
+// the duplicate guard is 0 in every real run -- CampMinder packs multi-selects
+// into one delimited value rather than repeating a field id -- so the compound
+// precondition this needs has never actually occurred.
 func (g OrphanSweepGuard) RejectionsExplainShortfall(existing int) bool {
 	return existing-g.Computed <= g.Rejected
 }

--- a/pocketbase/sync/orphan_guard_test.go
+++ b/pocketbase/sync/orphan_guard_test.go
@@ -524,38 +524,107 @@ func TestOrphanSweepRejectionDoesNotMaskACollapse(t *testing.T) {
 // shrinking Computed, so it can inflate the shortfall budget enough to wave
 // through a Check refusal that is real and unrelated.
 //
-// This test drives that exact masking -- Computed is far below the 50%-of-disk
-// floor, so Check refuses on its own, and Rejected is set high enough to
-// "explain" the whole shortfall even though none of it actually corresponds to
-// a missing key. What it proves is the other half of the story: the same
-// Rejected > 0 that produced the mask also drives skipSweepForRejections
-// (base_sync.go), which abandons the sweep unconditionally. So the masked
-// refusal never reaches a delete -- not even the one genuine orphan
-// (orphanWidget) sitting in this fixture, untracked, ready to be swept if the
-// guard ever let the run proceed. If this ever goes red, the one-way,
-// benign-for-data property the issue relies on has broken -- reach for a
-// second counter (RejectedButKeyRetained) at that point, not before.
+// The inflation is produced HERE, not asserted into place. An earlier revision
+// of this test set Stats.Rejected to a synthetic int on the widget fixture,
+// which made it a re-run of TestOrphanSweepRejectionDoesNotMaskACollapse's
+// "rejections that explain the whole shortfall" row -- every mutation it caught,
+// that row already caught -- and it never touched the rejection flavor the
+// issue is actually about. So this drives the production entry point:
+// processPersonCustomFieldValue, called twice for a key it has already tracked,
+// which is the one code path that bumps Rejected while ProcessedKeys (and
+// therefore Computed) stands still.
+//
+// The fixture is sized so the two arms meet. 50 rows on disk against a computed
+// set of 5 is a genuine Check refusal at 10% of the 50% floor, and the 45
+// duplicate rejections exactly cover the 45-row shortfall -- none of which they
+// explain, since all five tracked keys are present.
+//
+// What it proves is the other half of the story: the same Rejected > 0 that
+// produced the mask also drives skipSweepForRejections (base_sync.go), which
+// abandons the sweep unconditionally. So the masked refusal never reaches a
+// delete -- not even the 45 genuine orphans this fixture leaves untracked on
+// disk. If this ever goes red, the one-way, benign-for-data property the issue
+// relies on has broken -- reach for a second counter (RejectedButKeyRetained) at
+// that point, not before.
 func TestDuplicateInflatedRejectionsCannotDeleteDespiteMaskingACollapse(t *testing.T) {
 	t.Parallel()
 
-	const inflatedRejected = 45 // >= the shortfall below, none of it a real missing key
-	app, b := rejectingSweepFixture(t, inflatedRejected)
+	const (
+		owner        = "pers_0000000001"
+		year         = 2026
+		trackedKeys  = 5  // the computed set this run legitimately builds
+		orphanRows   = 45 // untracked rows on disk: the shortfall, and real sweep candidates
+		duplicates   = 45 // == orphanRows, so the inflated budget exactly covers it
+		rowsOnDisk   = trackedKeys + orphanRows
+		firstFieldCM = 901
+	)
 
-	err := b.DeleteOrphansGuarded("widgets", widgetIDFunc, "widget", "year = 2026",
-		OrphanSweepGuard{Entity: "widgets", Year: 2026, Computed: 5})
+	app := newOrphanSweepTestApp(t, "person_custom_values",
+		"person", "field_definition", "value", "last_updated")
+	// Rows this run never accounts for. They are keyable and owned by a swept
+	// owner, so a sweep that proceeded would delete every one of them.
+	bulkInsertRows(t, app, "person_custom_values", "person", owner, year, orphanRows)
+
+	s := &PersonCustomFieldValuesSync{BaseSyncService: BaseSyncService{
+		App:            app,
+		ProcessedKeys:  map[string]bool{},
+		SyncSuccessful: true,
+	}}
+
+	fieldDefMapping := map[int]string{}
+	for i := 0; i < trackedKeys; i++ {
+		fieldDefMapping[firstFieldCM+i] = fmt.Sprintf("fdtracked%02d", i)
+	}
+	existingRecords := map[string]*core.Record{}
+
+	// One real entry per field definition: creates the row and tracks the key.
+	for i := 0; i < trackedKeys; i++ {
+		entry := map[string]any{"id": float64(firstFieldCM + i), "value": "first"}
+		if err := s.processPersonCustomFieldValue(
+			entry, 12345, owner, year, fieldDefMapping, existingRecords); err != nil {
+			t.Fatalf("tracked entry %d: %v", i, err)
+		}
+	}
+
+	// Now the duplicates, through the same entry point. Each one hits the
+	// kindred#2320 guard, bumps Rejected, and leaves ProcessedKeys alone.
+	for i := 0; i < duplicates; i++ {
+		entry := map[string]any{
+			"id":    float64(firstFieldCM + i%trackedKeys),
+			"value": fmt.Sprintf("duplicate-%d", i),
+		}
+		if err := s.processPersonCustomFieldValue(
+			entry, 12345, owner, year, fieldDefMapping, existingRecords); err != nil {
+			t.Fatalf("duplicate entry %d: %v", i, err)
+		}
+	}
+
+	// Fixture preconditions. Without these a drift in the duplicate guard would
+	// quietly turn this into a test of nothing rather than a failure.
+	if s.Stats.Rejected != duplicates {
+		t.Fatalf("Stats.Rejected = %d, want %d -- the duplicate guard is what has to "+
+			"produce the inflation this test is about, not the test itself",
+			s.Stats.Rejected, duplicates)
+	}
+	if len(s.ProcessedKeys) != trackedKeys {
+		t.Fatalf("Computed = %d, want %d -- the whole defect is that a duplicate "+
+			"rejection does NOT shrink the computed set", len(s.ProcessedKeys), trackedKeys)
+	}
+	if seeded := countRows(t, app, "person_custom_values", "year = 2026"); seeded != rowsOnDisk {
+		t.Fatalf("fixture holds %d rows, want %d", seeded, rowsOnDisk)
+	}
+
+	err := s.deleteOrphans(year, map[string]bool{owner: true})
 
 	if err != nil {
-		t.Fatalf("DeleteOrphansGuarded returned %v, want nil -- the inflated Rejected count "+
+		t.Fatalf("deleteOrphans returned %v, want nil -- the inflated Rejected count "+
 			"masks the Check refusal (that is the defect kindred#2325 documents), so the run "+
 			"must still come back as a benign skip, not an error", err)
 	}
-	if alive := countRows(t, app, "widgets", "year = 2026"); alive != seededWidgets {
+	if alive := countRows(t, app, "person_custom_values", "year = 2026"); alive != rowsOnDisk {
 		t.Fatalf("%d rows survived, want %d -- a masked collapse must never delete a row, "+
-			"including the genuine orphan this fixture seeds untracked", alive, seededWidgets)
-	}
-	if _, findErr := app.FindRecordById("widgets", orphanTestID(orphanWidget)); findErr != nil {
-		t.Fatalf("the untracked orphan was deleted despite the masked refusal: %v -- "+
-			"this is exactly the data-loss direction kindred#2325 rules out", findErr)
+			"including the %d genuine orphans this fixture leaves untracked",
+			alive, rowsOnDisk, orphanRows)
 	}
 }
 

--- a/pocketbase/sync/orphan_guard_test.go
+++ b/pocketbase/sync/orphan_guard_test.go
@@ -518,6 +518,47 @@ func TestOrphanSweepRejectionDoesNotMaskACollapse(t *testing.T) {
 	}
 }
 
+// TestDuplicateInflatedRejectionsCannotDeleteDespiteMaskingACollapse pins the
+// residual risk documented on RejectionsExplainShortfall (kindred#2325): a
+// duplicate-in-run rejection (kindred#2320) increments Rejected without
+// shrinking Computed, so it can inflate the shortfall budget enough to wave
+// through a Check refusal that is real and unrelated.
+//
+// This test drives that exact masking -- Computed is far below the 50%-of-disk
+// floor, so Check refuses on its own, and Rejected is set high enough to
+// "explain" the whole shortfall even though none of it actually corresponds to
+// a missing key. What it proves is the other half of the story: the same
+// Rejected > 0 that produced the mask also drives skipSweepForRejections
+// (base_sync.go), which abandons the sweep unconditionally. So the masked
+// refusal never reaches a delete -- not even the one genuine orphan
+// (orphanWidget) sitting in this fixture, untracked, ready to be swept if the
+// guard ever let the run proceed. If this ever goes red, the one-way,
+// benign-for-data property the issue relies on has broken -- reach for a
+// second counter (RejectedButKeyRetained) at that point, not before.
+func TestDuplicateInflatedRejectionsCannotDeleteDespiteMaskingACollapse(t *testing.T) {
+	t.Parallel()
+
+	const inflatedRejected = 45 // >= the shortfall below, none of it a real missing key
+	app, b := rejectingSweepFixture(t, inflatedRejected)
+
+	err := b.DeleteOrphansGuarded("widgets", widgetIDFunc, "widget", "year = 2026",
+		OrphanSweepGuard{Entity: "widgets", Year: 2026, Computed: 5})
+
+	if err != nil {
+		t.Fatalf("DeleteOrphansGuarded returned %v, want nil -- the inflated Rejected count "+
+			"masks the Check refusal (that is the defect kindred#2325 documents), so the run "+
+			"must still come back as a benign skip, not an error", err)
+	}
+	if alive := countRows(t, app, "widgets", "year = 2026"); alive != seededWidgets {
+		t.Fatalf("%d rows survived, want %d -- a masked collapse must never delete a row, "+
+			"including the genuine orphan this fixture seeds untracked", alive, seededWidgets)
+	}
+	if _, findErr := app.FindRecordById("widgets", orphanTestID(orphanWidget)); findErr != nil {
+		t.Fatalf("the untracked orphan was deleted despite the masked refusal: %v -- "+
+			"this is exactly the data-loss direction kindred#2325 rules out", findErr)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // kindred#2283 row 2 -- classifying a sweep failure
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What was wrong

`OrphanSweepGuard.RejectionsExplainShortfall` (`pocketbase/sync/orphan_guard.go`)
treats `Stats.Rejected` as an exact upper bound on how much of a computed-set
shortfall is explained by rejections, on the premise that every rejection
removes exactly one key from the computed set. #2320's duplicate-in-run guard
broke that premise: it increments `Rejected` on the *second* entry for a key
already tracked this run, so `Computed` never shrinks for that rejection. If
enough duplicate-in-run rejections landed in the same run as an unrelated
genuine shortfall of comparable size, the arithmetic could wave a real Check
refusal through as a benign warning.

## Ruling: documented residual risk + regression test, not a second counter

The failure is one-way and cannot delete data. `deleteOrphans`
(`pocketbase/sync/base_sync.go`) never acts on a masked Check refusal by
itself — `skipSweepForRejections` runs immediately after, unconditionally on
`Rejected > 0`, and it is what decides whether the sweep proceeds at all. A
duplicate-inflated mask can therefore only turn a run that should fail loud
into one that logs a warning; it can never reach the delete loop. Splitting
`Rejected` into two counters (one that shrinks `Computed`, one that doesn't)
means reopening the shared `OrphanSweepGuard` contract that every guarded
sweep reads, rather than only the two files #2320 touched — for a risk that
has never actually occurred: today `Rejected` from the duplicate guard is 0 in
every real run, because CampMinder packs multi-selects into one delimited
value rather than repeating a field id.

## What changed

- Documented the residual risk on `RejectionsExplainShortfall`
  (`pocketbase/sync/orphan_guard.go`), spelling out the mechanism, why it's
  left undone, and pointing at the test below.
- Added a short cross-reference at the `skipSweepForRejections` call site in
  `pocketbase/sync/base_sync.go` explaining why the mask can't reach a delete.
- Added `TestDuplicateInflatedRejectionsCannotDeleteDespiteMaskingACollapse`
  (`pocketbase/sync/orphan_guard_test.go`). It builds the inflation rather
  than asserting it into place: `processPersonCustomFieldValue` — the
  production entry point — is called five times to build a real computed set,
  then 45 more times for keys it has already tracked, so #2320's guard itself
  produces `Rejected = 45` while `ProcessedKeys` stands at 5. 45 untracked
  rows sit on disk as genuine sweep candidates. 5 computed against 50 on disk
  is a real Check refusal at 10% of the 50% floor, and the 45 rejections
  exactly cover the 45-row shortfall none of them explain. The test then
  asserts the run comes back with no error *and* all 50 rows survive.

## Mutation transcript

- Drop `s.Stats.Rejected++` from the duplicate guard in
  `person_custom_field_values.go` → this test RED (`Stats.Rejected = 0, want
  45`), while all four rows of `TestOrphanSweepRejectionDoesNotMaskACollapse`
  stay GREEN. That is the coverage the widget fixture cannot provide.
- Neuter `skipSweepForRejections` in `deleteOrphans`' guarded branch → this
  test RED (`5 rows survived, want 50`), i.e. 45 orphans deleted behind a
  masked refusal.
- Restore either → GREEN.

## What I deliberately did not do

No new counter, no change to `Stats.Rejected` semantics, no touch to
`person_custom_field_values.go` / `household_custom_field_values.go` (the
#2320 call sites). The arithmetic in `RejectionsExplainShortfall` is
unchanged — this PR is documentation plus a pinning test.

Closes #2325.
