### PR TITLE
fix(frontend): gate three weekend overlays' Escape on the modalStack token

### DIFF
--- a/frontend/src/components/LockGroupPanel.test.tsx
+++ b/frontend/src/components/LockGroupPanel.test.tsx
@@ -94,6 +94,7 @@ vi.mock('../contexts/LockGroupContext', () => ({
 }))
 
 import LockGroupPanel from './LockGroupPanel'
+import { acquireOverlayToken, hasOpenModal, releaseOverlayToken } from './ui/modalStack'
 
 beforeEach(() => {
   mockQueryData = []
@@ -509,6 +510,56 @@ describe('LockGroupPanel — AddMemberPicker a11y + portal tagging (#1499 issues
     expect(screen.getByPlaceholderText(/filter campers/i)).toBeInTheDocument()
     fireEvent.keyDown(document, { key: 'Escape' })
     expect(screen.queryByPlaceholderText(/filter campers/i)).not.toBeInTheDocument()
+  })
+
+  it('kindred#2237: does NOT close on Escape once a further overlay has opened on top of it', () => {
+    // AddMemberPicker used a capture-phase `document` listener with
+    // `stopPropagation` "to stop it before an outer modal listener reacts"
+    // (its own comment) — precisely the shape kindred#2237 flags: it wins
+    // against the ONE outer listener it names, but a genuine second overlay
+    // (registered in the same kindred#2205 token stack) opened on top of
+    // THIS picker still needs the key, not the picker underneath it.
+    mockGroups = [testGroup]
+    mockContext.getCamperLockGroup = () => null
+    render(
+      <LockGroupPanel
+        isOpen={true}
+        onClose={() => {}}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        selectedGroupId="group-abc"
+        sessionCampers={[{ id: 'pb-1', person_cm_id: 1000001, name: 'Emma Johnson' } as never]}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /add member/i }))
+    expect(screen.getByPlaceholderText(/filter campers/i)).toBeInTheDocument()
+
+    const topToken = acquireOverlayToken()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.getByPlaceholderText(/filter campers/i)).toBeInTheDocument()
+
+    releaseOverlayToken(topToken)
+  })
+
+  it('kindred#2237: releases its overlay token on unmount, so the stack does not leak', () => {
+    mockGroups = [testGroup]
+    mockContext.getCamperLockGroup = () => null
+    const { unmount } = render(
+      <LockGroupPanel
+        isOpen={true}
+        onClose={() => {}}
+        sessionPbId="sess-1"
+        scenarioId="scn-1"
+        selectedGroupId="group-abc"
+        sessionCampers={[{ id: 'pb-1', person_cm_id: 1000001, name: 'Emma Johnson' } as never]}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /add member/i }))
+    expect(screen.getByPlaceholderText(/filter campers/i)).toBeInTheDocument()
+
+    unmount()
+
+    expect(hasOpenModal()).toBe(false)
   })
 
   it('portaled dropdown carries data-panel="lock-group-picker" so the board click-outside whitelists it', () => {

--- a/frontend/src/components/LockGroupPanel.tsx
+++ b/frontend/src/components/LockGroupPanel.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useMemo, useRef, useEffect } from 'react'
+import { useOverlayEscape } from '../hooks/useOverlayEscape'
 import { createPortal } from 'react-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { X, Trash2, Users, ChevronRight, AlertTriangle, Plus } from 'lucide-react'
@@ -163,20 +164,18 @@ function AddMemberPicker({
     return () => document.removeEventListener('mousedown', handler)
   }, [open])
 
-  // Escape dismisses the picker. Capture phase so we stop it before outer
-  // modal listeners (e.g. CamperDetailsPanel) react.
-  useEffect(() => {
-    if (!open) return
-    const handler = (e: KeyboardEvent) => {
-      if (e.key !== 'Escape') return
-      e.stopPropagation()
-      setOpen(false)
-      setFilter('')
-      triggerRef.current?.focus()
-    }
-    document.addEventListener('keydown', handler, true)
-    return () => document.removeEventListener('keydown', handler, true)
-  }, [open])
+  // kindred#2237: gated by the shared overlay token stack (kindred#2205)
+  // rather than a capture-phase listener racing to beat an outer one — see
+  // `useOverlayEscape` for why. Only the topmost registered overlay acts,
+  // which still covers the case this used to name explicitly (an outer
+  // `CamperDetailsPanel`), and also every OTHER overlay opened on top of
+  // this picker, which capture-phase-vs-one-named-listener never could.
+  const closeOnEscape = useCallback(() => {
+    setOpen(false)
+    setFilter('')
+    triggerRef.current?.focus()
+  }, [])
+  useOverlayEscape(open, closeOnEscape)
 
   const handleSelect = (camper: Camper) => {
     void addCamperToGroup(camper, groupId)

--- a/frontend/src/components/LockGroupPanel.tsx
+++ b/frontend/src/components/LockGroupPanel.tsx
@@ -164,12 +164,22 @@ function AddMemberPicker({
     return () => document.removeEventListener('mousedown', handler)
   }, [open])
 
-  // kindred#2237: gated by the shared overlay token stack (kindred#2205)
-  // rather than a capture-phase listener racing to beat an outer one — see
-  // `useOverlayEscape` for why. Only the topmost registered overlay acts,
-  // which still covers the case this used to name explicitly (an outer
-  // `CamperDetailsPanel`), and also every OTHER overlay opened on top of
-  // this picker, which capture-phase-vs-one-named-listener never could.
+  // kindred#2237: Escape now goes through the shared overlay token stack
+  // (kindred#2205) via `useOverlayEscape`. Still a capture-phase `document`
+  // listener — see that hook for why the phase has to stay — but it acts,
+  // and swallows the key, only while this picker is the TOPMOST registered
+  // overlay. What that buys over the hand-rolled listener this replaces is
+  // deference to overlays opened ON TOP of the picker, which
+  // capture-phase-plus-unconditional-`stopPropagation` could never give.
+  //
+  // It does NOT fix the pairing the old comment named. `CamperDetailsPanel`
+  // is one of kindred#2237's twelve still-unconverted overlays and installs
+  // its own capture-phase `document` listener with an unconditional
+  // `stopPropagation` (`CamperDetailsPanel.tsx:546-555`); registered first,
+  // it still fires first, so one Escape with both open still closes both —
+  // exactly as before this change, no better and no worse. Only converting
+  // that panel closes that gap, and kindred#2237 is explicit that each
+  // component is its own call.
   const closeOnEscape = useCallback(() => {
     setOpen(false)
     setFilter('')

--- a/frontend/src/components/weekend/AddHouseholdPicker.test.tsx
+++ b/frontend/src/components/weekend/AddHouseholdPicker.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * kindred#2237 — AddHouseholdPicker's Escape handling now goes through the
+ * shared kindred#2205 token stack (`useOverlayEscape`) instead of a
+ * capture-phase `document` listener with `stopPropagation` — a mechanism
+ * that only ever beat the ONE outer listener it was written against, and
+ * still let two overlays close on a single Escape press once a second one
+ * opened on top of THIS picker (kindred#2237's whole point).
+ *
+ * Fictional data throughout.
+ */
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { AddHouseholdPicker } from './AddHouseholdPicker'
+import { acquireOverlayToken, hasOpenModal, releaseOverlayToken } from '../ui/modalStack'
+import type { RosterPartyRow } from '../../types/lodging'
+
+function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
+  return {
+    grain: 'household',
+    household_cm_id: 201,
+    person_cm_id: 0,
+    display_name: 'Rivera',
+    sort_name: 'Rivera',
+    adults: [{ adult_number: 1, display_name: 'Maria Rivera', relationship: 'Mother' }],
+    children: [],
+    party_size: 1,
+    unit_code: '',
+    unit_name: '',
+    unit_codes: [],
+    is_merged_slot: false,
+    arrival_eta: '',
+    is_returning: false,
+    ...overrides,
+  }
+}
+
+function renderPicker() {
+  return render(
+    <AddHouseholdPicker
+      groupName="The Riveras"
+      households={[party()]}
+      memberCmIds={new Set()}
+      householdToGroup={new Map()}
+      disabled={false}
+      onAdd={vi.fn()}
+    />
+  )
+}
+
+describe('AddHouseholdPicker — Escape', () => {
+  it('closes on Escape when it is the only open overlay', () => {
+    renderPicker()
+    fireEvent.click(screen.getByRole('button', { name: /add household/i }))
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('does NOT close on Escape once a further overlay has opened on top of it', () => {
+    renderPicker()
+    fireEvent.click(screen.getByRole('button', { name: /add household/i }))
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+
+    const topToken = acquireOverlayToken()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+
+    releaseOverlayToken(topToken)
+  })
+
+  it('releases its overlay token on unmount, so the stack does not leak', () => {
+    const { unmount } = renderPicker()
+    fireEvent.click(screen.getByRole('button', { name: /add household/i }))
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+
+    unmount()
+
+    expect(hasOpenModal()).toBe(false)
+  })
+
+  it('registers no token while closed', () => {
+    renderPicker()
+    expect(hasOpenModal()).toBe(false)
+  })
+})

--- a/frontend/src/components/weekend/AddHouseholdPicker.test.tsx
+++ b/frontend/src/components/weekend/AddHouseholdPicker.test.tsx
@@ -20,9 +20,9 @@ function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
     grain: 'household',
     household_cm_id: 201,
     person_cm_id: 0,
-    display_name: 'Rivera',
-    sort_name: 'Rivera',
-    adults: [{ adult_number: 1, display_name: 'Maria Rivera', relationship: 'Mother' }],
+    display_name: 'The Chen Family',
+    sort_name: 'Chen',
+    adults: [{ adult_number: 1, display_name: 'Olivia Chen', relationship: 'Mother' }],
     children: [],
     party_size: 1,
     unit_code: '',
@@ -38,7 +38,7 @@ function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
 function renderPicker() {
   return render(
     <AddHouseholdPicker
-      groupName="The Riveras"
+      groupName="The Chen Family"
       households={[party()]}
       memberCmIds={new Set()}
       householdToGroup={new Map()}

--- a/frontend/src/components/weekend/AddHouseholdPicker.tsx
+++ b/frontend/src/components/weekend/AddHouseholdPicker.tsx
@@ -37,13 +37,14 @@
  * Summer's gender filter does not come across: weekends do not split by
  * gender (see `FriendGroupActionBar.tsx`'s header).
  */
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Plus } from 'lucide-react'
 
 import type { FriendGroupRow } from '../../types/friendGroups'
 import type { RosterPartyRow } from '../../types/lodging'
 import { householdLabel, pickableHouseholds } from './friendGroups'
+import { useOverlayEscape } from '../../hooks/useOverlayEscape'
 
 export interface AddHouseholdPickerProps {
   groupName: string
@@ -113,20 +114,15 @@ export function AddHouseholdPicker({
     return () => document.removeEventListener('mousedown', handler)
   }, [open])
 
-  // Escape dismisses the picker. Capture phase, same reason AddMemberPicker
-  // gives: stop it before an outer modal listener reacts.
-  useEffect(() => {
-    if (!open) return
-    const handler = (e: KeyboardEvent) => {
-      if (e.key !== 'Escape') return
-      e.stopPropagation()
-      setOpen(false)
-      setFilter('')
-      triggerRef.current?.focus()
-    }
-    document.addEventListener('keydown', handler, true)
-    return () => document.removeEventListener('keydown', handler, true)
-  }, [open])
+  // kindred#2237: gated by the shared overlay token stack (kindred#2205)
+  // rather than a capture-phase listener racing to beat an outer one — see
+  // `useOverlayEscape` for why. Only the topmost registered overlay acts.
+  const closeOnEscape = useCallback(() => {
+    setOpen(false)
+    setFilter('')
+    triggerRef.current?.focus()
+  }, [])
+  useOverlayEscape(open, closeOnEscape)
 
   const handleSelect = (party: RosterPartyRow) => {
     onAdd(party)

--- a/frontend/src/components/weekend/AddHouseholdPicker.tsx
+++ b/frontend/src/components/weekend/AddHouseholdPicker.tsx
@@ -114,9 +114,11 @@ export function AddHouseholdPicker({
     return () => document.removeEventListener('mousedown', handler)
   }, [open])
 
-  // kindred#2237: gated by the shared overlay token stack (kindred#2205)
-  // rather than a capture-phase listener racing to beat an outer one — see
-  // `useOverlayEscape` for why. Only the topmost registered overlay acts.
+  // kindred#2237: Escape now goes through the shared overlay token stack
+  // (kindred#2205) via `useOverlayEscape` — still a capture-phase `document`
+  // listener, but one that acts, and swallows the key, only while this
+  // picker is the topmost registered overlay. See that hook for why the
+  // phase stays and why the `stopPropagation` became conditional.
   const closeOnEscape = useCallback(() => {
     setOpen(false)
     setFilter('')

--- a/frontend/src/components/weekend/AddToGroupPicker.test.tsx
+++ b/frontend/src/components/weekend/AddToGroupPicker.test.tsx
@@ -20,7 +20,7 @@ function group(overrides: Partial<FriendGroupRow> = {}): FriendGroupRow {
     group_id: 'group-1',
     year: 2026,
     session_cm_id: 5001,
-    name: 'The Riveras',
+    name: 'The Chen Family',
     color: '#84cc16',
     source: 'staff_manual',
     ...overrides,

--- a/frontend/src/components/weekend/AddToGroupPicker.test.tsx
+++ b/frontend/src/components/weekend/AddToGroupPicker.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * kindred#2237 — AddToGroupPicker's Escape handling now goes through the
+ * shared kindred#2205 token stack (`useOverlayEscape`) instead of a
+ * capture-phase `document` listener with `stopPropagation` — a mechanism
+ * that only ever beat the ONE outer listener it was written against, and
+ * still let two overlays close on a single Escape press once a second one
+ * opened on top of THIS picker (kindred#2237's whole point).
+ *
+ * Fictional data throughout.
+ */
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { AddToGroupPicker } from './AddToGroupPicker'
+import { acquireOverlayToken, hasOpenModal, releaseOverlayToken } from '../ui/modalStack'
+import type { FriendGroupRow } from '../../types/friendGroups'
+
+function group(overrides: Partial<FriendGroupRow> = {}): FriendGroupRow {
+  return {
+    group_id: 'group-1',
+    year: 2026,
+    session_cm_id: 5001,
+    name: 'The Riveras',
+    color: '#84cc16',
+    source: 'staff_manual',
+    ...overrides,
+  }
+}
+
+function renderPicker() {
+  return render(<AddToGroupPicker groups={[group()]} onSelect={vi.fn()} disabled={false} />)
+}
+
+describe('AddToGroupPicker — Escape', () => {
+  it('closes on Escape when it is the only open overlay', () => {
+    renderPicker()
+    fireEvent.click(screen.getByRole('button', { name: /add to group/i }))
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('does NOT close on Escape once a further overlay has opened on top of it', () => {
+    renderPicker()
+    fireEvent.click(screen.getByRole('button', { name: /add to group/i }))
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+
+    const topToken = acquireOverlayToken()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+
+    releaseOverlayToken(topToken)
+  })
+
+  it('releases its overlay token on unmount, so the stack does not leak', () => {
+    const { unmount } = renderPicker()
+    fireEvent.click(screen.getByRole('button', { name: /add to group/i }))
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+
+    unmount()
+
+    expect(hasOpenModal()).toBe(false)
+  })
+
+  it('registers no token while closed', () => {
+    renderPicker()
+    expect(hasOpenModal()).toBe(false)
+  })
+})

--- a/frontend/src/components/weekend/AddToGroupPicker.tsx
+++ b/frontend/src/components/weekend/AddToGroupPicker.tsx
@@ -55,9 +55,11 @@ export function AddToGroupPicker({ groups, onSelect, disabled }: AddToGroupPicke
     return () => document.removeEventListener('mousedown', handler)
   }, [open])
 
-  // kindred#2237: gated by the shared overlay token stack (kindred#2205)
-  // rather than a capture-phase listener racing to beat an outer one — see
-  // `useOverlayEscape` for why. Only the topmost registered overlay acts.
+  // kindred#2237: Escape now goes through the shared overlay token stack
+  // (kindred#2205) via `useOverlayEscape` — still a capture-phase `document`
+  // listener, but one that acts, and swallows the key, only while this
+  // picker is the topmost registered overlay. See that hook for why the
+  // phase stays and why the `stopPropagation` became conditional.
   const closeOnEscape = useCallback(() => {
     setOpen(false)
     triggerRef.current?.focus()

--- a/frontend/src/components/weekend/AddToGroupPicker.tsx
+++ b/frontend/src/components/weekend/AddToGroupPicker.tsx
@@ -8,11 +8,12 @@
  * to select a group from, so the target is picked here instead, through the
  * same portal + filter-free listbox mechanics `AddHouseholdPicker` uses.
  */
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Plus } from 'lucide-react'
 
 import type { FriendGroupRow } from '../../types/friendGroups'
+import { useOverlayEscape } from '../../hooks/useOverlayEscape'
 
 export interface AddToGroupPickerProps {
   groups: FriendGroupRow[]
@@ -54,17 +55,14 @@ export function AddToGroupPicker({ groups, onSelect, disabled }: AddToGroupPicke
     return () => document.removeEventListener('mousedown', handler)
   }, [open])
 
-  useEffect(() => {
-    if (!open) return
-    const handler = (e: KeyboardEvent) => {
-      if (e.key !== 'Escape') return
-      e.stopPropagation()
-      setOpen(false)
-      triggerRef.current?.focus()
-    }
-    document.addEventListener('keydown', handler, true)
-    return () => document.removeEventListener('keydown', handler, true)
-  }, [open])
+  // kindred#2237: gated by the shared overlay token stack (kindred#2205)
+  // rather than a capture-phase listener racing to beat an outer one — see
+  // `useOverlayEscape` for why. Only the topmost registered overlay acts.
+  const closeOnEscape = useCallback(() => {
+    setOpen(false)
+    triggerRef.current?.focus()
+  }, [])
+  useOverlayEscape(open, closeOnEscape)
 
   const handleSelect = (groupId: string) => {
     onSelect(groupId)

--- a/frontend/src/hooks/useOverlayEscape.test.ts
+++ b/frontend/src/hooks/useOverlayEscape.test.ts
@@ -1,0 +1,110 @@
+/**
+ * kindred#2237 — the shared Escape-handling hook every overlay adopter of
+ * the kindred#2205 token stack should use, rather than each hand-rolling its
+ * own acquire/listen/release effect.
+ *
+ * No blanket `afterEach(() => expect(hasOpenModal()).toBe(false))` guard
+ * here, unlike `modalStack.test.ts` — that file manipulates tokens directly,
+ * so its guard runs synchronously relative to every test. This file's
+ * release happens on REACT unmount, which for a test that doesn't call
+ * `unmount()` itself only happens via `@testing-library/react`'s automatic
+ * `cleanup()` — a root-level `afterEach` registered in `src/test/setup.ts`.
+ * Vitest runs a describe-scoped `afterEach` (this file) BEFORE an outer
+ * root-level one (the setup file), so a blanket guard here would assert
+ * before that automatic unmount has actually run. Each test below either
+ * doesn't need a released token (still open) or unmounts explicitly first,
+ * matching `ConfirmActionPopover.test.tsx`'s own pattern.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { fireEvent } from '@testing-library/react'
+import { useState } from 'react'
+import { useOverlayEscape } from './useOverlayEscape'
+import { acquireOverlayToken, hasOpenModal, releaseOverlayToken } from '../components/ui/modalStack'
+
+describe('useOverlayEscape', () => {
+  it('calls onEscape when Escape is pressed while open', () => {
+    const onEscape = vi.fn()
+    const { unmount } = renderHook(() => useOverlayEscape(true, onEscape))
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onEscape).toHaveBeenCalledTimes(1)
+    unmount()
+  })
+
+  it('does nothing while closed', () => {
+    const onEscape = vi.fn()
+    const { unmount } = renderHook(() => useOverlayEscape(false, onEscape))
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onEscape).not.toHaveBeenCalled()
+    unmount()
+    expect(hasOpenModal()).toBe(false)
+  })
+
+  it('ignores a non-Escape key', () => {
+    const onEscape = vi.fn()
+    const { unmount } = renderHook(() => useOverlayEscape(true, onEscape))
+
+    fireEvent.keyDown(document, { key: 'Enter' })
+
+    expect(onEscape).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('does NOT act on Escape once a further overlay has opened on top of it', () => {
+    // The exact scenario kindred#2237 is about: a second, independently
+    // portalled overlay acquires a token after this one, so it — not this
+    // hook's caller — owns the next Escape press.
+    const onEscape = vi.fn()
+    const { unmount } = renderHook(() => useOverlayEscape(true, onEscape))
+
+    const topToken = acquireOverlayToken()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onEscape).not.toHaveBeenCalled()
+
+    releaseOverlayToken(topToken)
+    unmount()
+  })
+
+  it('acts again once the overlay on top of it releases its token', () => {
+    const onEscape = vi.fn()
+    const { unmount } = renderHook(() => useOverlayEscape(true, onEscape))
+
+    const topToken = acquireOverlayToken()
+    releaseOverlayToken(topToken)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onEscape).toHaveBeenCalledTimes(1)
+    unmount()
+  })
+
+  it('releases its overlay token on unmount, so the stack does not leak', () => {
+    const { unmount } = renderHook(() => useOverlayEscape(true, vi.fn()))
+
+    unmount()
+
+    expect(hasOpenModal()).toBe(false)
+  })
+
+  it('releases its overlay token when isOpen flips back to false, not only on unmount', () => {
+    const { result, rerender, unmount } = renderHook(
+      ({ isOpen }: { isOpen: boolean }) => {
+        const [calls, setCalls] = useState(0)
+        useOverlayEscape(isOpen, () => setCalls((c) => c + 1))
+        return calls
+      },
+      { initialProps: { isOpen: true } }
+    )
+
+    expect(hasOpenModal()).toBe(true)
+
+    rerender({ isOpen: false })
+
+    expect(hasOpenModal()).toBe(false)
+    expect(result.current).toBe(0)
+    unmount()
+  })
+})

--- a/frontend/src/hooks/useOverlayEscape.test.ts
+++ b/frontend/src/hooks/useOverlayEscape.test.ts
@@ -89,6 +89,114 @@ describe('useOverlayEscape', () => {
     expect(hasOpenModal()).toBe(false)
   })
 
+  it('still acts when an UNCONVERTED overlay stops propagation in the capture phase', () => {
+    // Twelve of kindred#2237's overlays are not token-gated yet, and one of
+    // them — `CamperDetailsPanel` — installs a capture-phase `document`
+    // listener that calls `stopPropagation()` unconditionally. A capture-phase
+    // stop at `document` halts the event before it ever reaches the bubble
+    // phase, so a bubble-phase listener on `document` never runs at all. An
+    // overlay stacked ABOVE such a listener must therefore not depend on the
+    // bubble phase to receive Escape, or the gate silently costs it the key
+    // it is supposed to own.
+    const onEscape = vi.fn()
+    const legacyCapture = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') e.stopPropagation()
+    }
+    // Registered BEFORE the hook, mirroring reality: the outer panel opens
+    // first, then the picker inside it.
+    document.addEventListener('keydown', legacyCapture, true)
+    const { unmount } = renderHook(() => useOverlayEscape(true, onEscape))
+
+    // Dispatch from a descendant, not from `document` itself — an event whose
+    // target IS `document` runs every listener in the at-target phase and so
+    // cannot tell capture from bubble.
+    const target = document.createElement('div')
+    document.body.appendChild(target)
+    fireEvent.keyDown(target, { key: 'Escape' })
+
+    document.removeEventListener('keydown', legacyCapture, true)
+    target.remove()
+    unmount()
+
+    expect(onEscape).toHaveBeenCalledTimes(1)
+  })
+
+  it('swallows the key while topmost, so an unconverted listener below does not also fire', () => {
+    const onEscape = vi.fn()
+    const below = vi.fn()
+    document.addEventListener('keydown', below)
+    const { unmount } = renderHook(() => useOverlayEscape(true, onEscape))
+
+    const target = document.createElement('div')
+    document.body.appendChild(target)
+    fireEvent.keyDown(target, { key: 'Escape' })
+
+    document.removeEventListener('keydown', below)
+    target.remove()
+    unmount()
+
+    expect(onEscape).toHaveBeenCalledTimes(1)
+    expect(below).not.toHaveBeenCalled()
+  })
+
+  it('lets the key through untouched while NOT topmost', () => {
+    const onEscape = vi.fn()
+    const other = vi.fn()
+    document.addEventListener('keydown', other)
+    const { unmount } = renderHook(() => useOverlayEscape(true, onEscape))
+    const topToken = acquireOverlayToken()
+
+    const target = document.createElement('div')
+    document.body.appendChild(target)
+    fireEvent.keyDown(target, { key: 'Escape' })
+
+    document.removeEventListener('keydown', other)
+    target.remove()
+    releaseOverlayToken(topToken)
+    unmount()
+
+    expect(onEscape).not.toHaveBeenCalled()
+    expect(other).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not re-acquire (and so jump back to the top) when the caller re-renders', () => {
+    // A caller that passes an inline arrow gets a new `onEscape` identity on
+    // every render. If the token is tied to that identity, an ordinary
+    // re-render of a BACKGROUND overlay — a query refetch, a parent state
+    // change — silently republishes it as the topmost overlay and steals
+    // Escape from whatever genuinely is on top.
+    const onEscape = vi.fn()
+    const { rerender, unmount } = renderHook(
+      ({ cb }: { cb: () => void }) => useOverlayEscape(true, () => cb()),
+      { initialProps: { cb: onEscape } }
+    )
+
+    const topToken = acquireOverlayToken()
+    rerender({ cb: onEscape })
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    releaseOverlayToken(topToken)
+    unmount()
+
+    expect(onEscape).not.toHaveBeenCalled()
+  })
+
+  it('invokes the LATEST callback after a re-render, not the one captured on open', () => {
+    const first = vi.fn()
+    const second = vi.fn()
+    const { rerender, unmount } = renderHook(
+      ({ cb }: { cb: () => void }) => useOverlayEscape(true, cb),
+      { initialProps: { cb: first } }
+    )
+
+    rerender({ cb: second })
+    fireEvent.keyDown(document, { key: 'Escape' })
+    unmount()
+
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledTimes(1)
+  })
+
   it('releases its overlay token when isOpen flips back to false, not only on unmount', () => {
     const { result, rerender, unmount } = renderHook(
       ({ isOpen }: { isOpen: boolean }) => {

--- a/frontend/src/hooks/useOverlayEscape.ts
+++ b/frontend/src/hooks/useOverlayEscape.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 import { acquireOverlayToken, isTopOverlay, releaseOverlayToken } from '../components/ui/modalStack'
 
@@ -7,23 +7,54 @@ import { acquireOverlayToken, isTopOverlay, releaseOverlayToken } from '../compo
  * stack should use to wire up Escape — one hook, not fifteen hand-rolled
  * acquire/listen/release effects that can each drift slightly.
  *
- * Mirrors `ConfirmActionPopover`'s already-shipped inline pattern exactly:
- * acquire a token while `isOpen`, act on Escape only while that token is
- * topmost, release it on close or unmount. A token acquired but not
- * released on every exit path silently disables Escape for every overlay
- * opened after it — see kindred#2237 and the leak `#2205` pins for the
- * three existing adopters (`Modal`, `ConfirmActionPopover`, `Tooltip`).
+ * Acquire a token while `isOpen`, act on Escape only while that token is
+ * topmost, release it on close or unmount. A token acquired but not released
+ * on every exit path silently disables Escape for every overlay opened after
+ * it — see kindred#2237 and the leak `#2205` pins for the three existing
+ * adopters (`Modal`, `ConfirmActionPopover`, `Tooltip`).
  *
- * Deliberately bubble-phase, no `stopPropagation` — the token gate is what
- * arbitrates who acts, not a capture-phase race to get there first. Several
- * pre-#2237 overlays used a capture-phase listener with `stopPropagation`
- * specifically "to stop it before an outer modal listener reacts"; that
- * approach only works against the ONE outer listener it was written to
- * beat, and still leaves two overlays open at once colliding with each
- * other. The token stack is the general fix; this hook is how a caller
- * opts into it without re-deriving the pattern.
+ * ## Why the CAPTURE phase, and why `stopPropagation` is conditional
+ *
+ * This is `ui/Tooltip`'s shipped kindred#2205 shape, not a new one: capture
+ * on `document`, and swallow the key *only* while topmost.
+ *
+ * Both halves are load-bearing, and bubble-phase would break the first.
+ * Twelve of kindred#2237's overlays are still unconverted, and one of them
+ * — `CamperDetailsPanel` — installs a capture-phase `document` listener that
+ * calls `stopPropagation()` unconditionally. A capture-phase stop at
+ * `document` halts the event before the bubble phase begins, so a
+ * bubble-phase `document` listener never runs at all. An adopter of this
+ * hook stacked ABOVE such a listener would therefore lose Escape entirely,
+ * which is worse than the double-close it replaced: the overlay the key was
+ * pressed for stays open while the one underneath it closes.
+ *
+ * The conditional stop is the other half. Unconverted overlays that listen
+ * on `document` or `window` in the BUBBLE phase (`CsvPipelineIndicator`,
+ * `SocialNetworkGraph`, `metrics/DrillDownModal`, …) would otherwise close
+ * alongside an adopter that is genuinely on top — the original kindred#2205
+ * defect. Swallowing while topmost prevents that; NOT swallowing while a
+ * token-gated overlay sits above us is what lets that overlay's own listener
+ * (bubble-phase, gated identically) receive the key it owns.
+ *
+ * This does not fix the unconverted capture-phase listener above; only
+ * converting `CamperDetailsPanel` can, and kindred#2237 is explicit that
+ * each component is its own call. It does guarantee this hook never makes
+ * that pairing worse.
+ *
+ * ## Why the callback is held in a ref
+ *
+ * The effect depends on `isOpen` alone. A caller passing an inline arrow
+ * gets a fresh `onEscape` identity every render; if the token were tied to
+ * that identity, an ordinary re-render of a BACKGROUND overlay — a query
+ * refetch, a parent state change — would release and re-acquire its token,
+ * republishing it as topmost and stealing Escape from whatever genuinely is
+ * on top. The ref keeps the token's lifetime equal to the overlay's while
+ * still invoking the latest callback.
  */
 export function useOverlayEscape(isOpen: boolean, onEscape: () => void): void {
+  const onEscapeRef = useRef(onEscape)
+  onEscapeRef.current = onEscape
+
   useEffect(() => {
     if (!isOpen) return
 
@@ -32,13 +63,14 @@ export function useOverlayEscape(isOpen: boolean, onEscape: () => void): void {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return
       if (!isTopOverlay(token)) return
-      onEscape()
+      e.stopPropagation()
+      onEscapeRef.current()
     }
 
-    document.addEventListener('keydown', handleKeyDown)
+    document.addEventListener('keydown', handleKeyDown, true)
     return () => {
-      document.removeEventListener('keydown', handleKeyDown)
+      document.removeEventListener('keydown', handleKeyDown, true)
       releaseOverlayToken(token)
     }
-  }, [isOpen, onEscape])
+  }, [isOpen])
 }

--- a/frontend/src/hooks/useOverlayEscape.ts
+++ b/frontend/src/hooks/useOverlayEscape.ts
@@ -1,0 +1,44 @@
+import { useEffect } from 'react'
+
+import { acquireOverlayToken, isTopOverlay, releaseOverlayToken } from '../components/ui/modalStack'
+
+/**
+ * kindred#2237. The shared shape every overlay in the kindred#2205 token
+ * stack should use to wire up Escape — one hook, not fifteen hand-rolled
+ * acquire/listen/release effects that can each drift slightly.
+ *
+ * Mirrors `ConfirmActionPopover`'s already-shipped inline pattern exactly:
+ * acquire a token while `isOpen`, act on Escape only while that token is
+ * topmost, release it on close or unmount. A token acquired but not
+ * released on every exit path silently disables Escape for every overlay
+ * opened after it — see kindred#2237 and the leak `#2205` pins for the
+ * three existing adopters (`Modal`, `ConfirmActionPopover`, `Tooltip`).
+ *
+ * Deliberately bubble-phase, no `stopPropagation` — the token gate is what
+ * arbitrates who acts, not a capture-phase race to get there first. Several
+ * pre-#2237 overlays used a capture-phase listener with `stopPropagation`
+ * specifically "to stop it before an outer modal listener reacts"; that
+ * approach only works against the ONE outer listener it was written to
+ * beat, and still leaves two overlays open at once colliding with each
+ * other. The token stack is the general fix; this hook is how a caller
+ * opts into it without re-deriving the pattern.
+ */
+export function useOverlayEscape(isOpen: boolean, onEscape: () => void): void {
+  useEffect(() => {
+    if (!isOpen) return
+
+    const token = acquireOverlayToken()
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      if (!isTopOverlay(token)) return
+      onEscape()
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      releaseOverlayToken(token)
+    }
+  }, [isOpen, onEscape])
+}


### PR DESCRIPTION
## What

`AddHouseholdPicker`, `AddToGroupPicker`, and `LockGroupPanel`'s inner
`AddMemberPicker` each installed a capture-phase `document` keydown listener
with an unconditional `stopPropagation()`, explicitly "to stop it before an
outer modal listener reacts." That mechanism only ever beats the ONE outer
listener the comment names — once a second, independently-portalled overlay
(registered in the same kindred#2205 token stack) opens on top of one of
these pickers, both still close on a single Escape press, because
capture-phase-plus-unconditional-`stopPropagation` has no way to ask "am I
actually on top right now?"

`LockGroupPanel`'s `AddMemberPicker` is the clearest case: its own comment
names `CamperDetailsPanel` as the exact overlay it was written to beat, and
`AddHouseholdPicker`'s own doc comment says it was "ported from
`LockGroupPanel.tsx`'s `AddMemberPicker` ... line for line" — so this is the
same defect, at the same severity, in three places, not three unrelated
ones.

## Fix

Adds `frontend/src/hooks/useOverlayEscape.ts`, one hook wrapping the
acquire/listen/release pattern `ConfirmActionPopover` and `ui/Tooltip`
already use inline — acquire a token while open, act on Escape only while
that token is topmost, release on close or unmount. New adopters share one
implementation instead of each re-deriving the token dance, including its
easiest-to-get-wrong step: releasing on every exit path, not only on
unmount. A token acquired but not released silently disables Escape for
every overlay opened after it — the exact leak kindred#2205 already pins for
`Modal`/`ConfirmActionPopover`/`Tooltip`, and this hook's own test suite pins
it again (`useOverlayEscape.test.ts`).

All three components above now use it. The listener stays in the **capture**
phase, but what changes is that both the action and the `stopPropagation()`
are gated on `isTopOverlay`. This is `ui/Tooltip`'s already-shipped
kindred#2205 shape, and both halves of it are load-bearing:

- **Capture phase, not bubble.** `CamperDetailsPanel` — one of the overlays
  kindred#2237 leaves unconverted — installs a capture-phase `document`
  listener with an unconditional `stopPropagation()`
  (`CamperDetailsPanel.tsx:546-555`). A capture-phase stop at `document`
  halts the event before the bubble phase begins, so a bubble-phase
  `document` listener never runs at all. A bubble-phase gate would therefore
  have cost the converted `AddMemberPicker` Escape entirely whenever a
  camper panel was also open — closing the panel underneath and leaving the
  picker up, which is worse than the double-close it replaced.
- **Conditional swallow, not none.** Unconverted overlays that listen on
  `document`/`window` in the bubble phase would otherwise close alongside a
  picker that is genuinely on top — the original kindred#2205 defect.
  Swallowing while topmost prevents that; declining to swallow while a
  token-gated overlay sits above is what lets that overlay's own listener
  receive the key it owns.

The effect depends on `isOpen` alone and holds the callback in a ref. Tying
the token's lifetime to the `onEscape` identity would mean a caller passing
an inline arrow releases and re-acquires on every render, republishing a
background overlay as topmost and stealing Escape from whatever really is on
top.

## What this deliberately does NOT do

kindred#2237 lists fifteen overlays with unconverted Escape handling (after
its own correction removed a sixteenth, `weekend/FamilyDetailsPanel.tsx`,
which was already correctly guarded via `hasOpenModal()`). This PR converts
three. The other twelve are not a mechanical sweep — the issue is explicit
that wrapping all of them blindly is worse than the bug being fixed, since
an overlay that can never co-occur with another doesn't need a token, and a
token leaked on an unconsidered exit path silently breaks Escape everywhere
downstream of it. Per component:

- **`CamperDetailsPanel.tsx`** — intentionally uses capture-phase +
  unconditional `stopPropagation` for a documented LIFO reason ("both listen
  on `document` for Escape ... register in the capture phase ... so the panel
  closes first and the underlying modal stays open"), and is embedded from
  many call sites (`CamperCard`, `SocialNetworkGraph`, session/board views).
  Redesigning its Escape handling safely needs more care than fits this PR's
  scope. **This is the one pairing this PR leaves exactly as it found it:**
  with both the panel and `AddMemberPicker` open, the panel's listener
  registered first and still fires first, so one Escape still closes both.
  Not a regression, but not a fix either — only converting the panel closes
  that gap.
- **`weekend/PlaceFamilyPicker.tsx`** — the issue's own correction already
  downgrades this to "largely self-limiting" / lower priority. It also has a
  pinned regression test from kindred#2080 (`PlaceFamilyPicker.test.tsx`,
  "does not let Escape reach a DOCUMENT listener either") asserting Escape
  never reaches *any* `document`-level listener, by design — an owner-ruled
  containment model stricter than "whoever is topmost wins." Converting it
  would mean either breaking that pinned test's premise or reconciling two
  different containment philosophies, which is a design decision this PR
  shouldn't make unilaterally.
- **`SocialNetworkGraph.tsx` + `components/graph/filter/GraphFilterPopover.tsx`**
  — a confirmed pair, not a guess: both listen on `window` with no
  `stopPropagation`, and the filter popover is reachable any time the graph
  is in its expanded (fullscreen) view, so both fire on the same Escape
  press today. But `SocialNetworkGraph.tsx` (887 lines, Cytoscape-backed)
  has no behavioural test coverage — its only test file,
  `SocialNetworkGraph.test.ts`, reads the component's source with
  `readFileSync` and asserts on the text, and never renders it — and fixing
  only `GraphFilterPopover.tsx` fixes nothing, since both sides of a pair
  need the token gate for either to matter. Building safe Cytoscape mocking
  infrastructure for the first rendering test of that file is its own piece
  of work.
- **`components/CsvPipelineIndicator.tsx`** — lives in the global
  `AppLayout` header (`AppLayout.tsx:501`). It is inside `#root`, so a
  `ui/Modal` does make it `inert`; what matters is that the overlays it
  would collide with are not `ui/Modal`s at all (confirmed by reading
  `DrillDownModal.tsx` and `CamperDetailsPanel.tsx`: neither imports
  `ui/Modal`, so neither ever makes the background inert). That means this
  indicator's popover can genuinely open while almost any other overlay in
  the app is open — a real defect, but its actual fix reaches into most of
  the remaining list at once and deserves its own PR rather than being
  folded in here as a side effect.
- **`CamperCard.tsx`, `RequestReviewPanel.tsx`, `ui/FloatingQueueBadge.tsx`,
  `weekend/LodgingMap.tsx`, `metrics/DrillDownModal.tsx`,
  `OptimizeBunksButton.tsx`** — plausible candidates (several are reachable
  from pages where `CsvPipelineIndicator` or other overlays could also be
  open) but no *direct, demonstrated* co-occurrence was found for any of
  them, unlike the pair above. Left undetermined rather than converted on
  speculation.
- **`metrics/WaitlistGradePopover.tsx`** — not rendered anywhere in the
  current app tree (only its own test imports it). Dead code cannot
  co-occur with anything.
- **`weekend/FamilyDetailsPanel.tsx`** — already correctly classified by the
  issue's own correction: it calls `hasOpenModal()` and stands down for any
  overlay on top of it, so it needs no token of its own.

Because three of those (`CamperDetailsPanel`, the
`SocialNetworkGraph`/`GraphFilterPopover` pair, `CsvPipelineIndicator`) are
named here as live defects rather than as "correct as-is", and six more are
undetermined, this PR advances kindred#2237 rather than completing it. See
#2237 for the remainder; no new issue is filed.

## Testing

- New: `frontend/src/hooks/useOverlayEscape.test.ts` (12 tests). Seven were
  written TDD-first against a `./useOverlayEscape` module that didn't exist
  yet; five more were added by the review pass on this PR, three of them red
  before the capture-phase/conditional-swallow/ref fix landed. Mutation
  transcript, run against the final implementation:
  - dropping `isTopOverlay` → 5 of 12 fail
  - reverting the listener to the bubble phase → 2 of 12 fail
  - dropping the ref refresh (stale callback) → 1 of 12 fails
- New: `AddHouseholdPicker.test.tsx`, `AddToGroupPicker.test.tsx` (both had
  zero prior coverage) — each opens the picker, pushes a second overlay
  token on top, asserts Escape no longer closes the picker, and asserts the
  token releases on unmount.
- Extended: `LockGroupPanel.test.tsx` with the same two assertions for
  `AddMemberPicker`. Mutation-checked by reverting the conversion locally —
  both new assertions failed as expected, all 23 pre-existing tests in the
  file still passed.
- Full frontend suite: `./node_modules/.bin/vitest run` — 448 files, 6847
  tests, all passing.
- `bash scripts/pre-push-verify.sh` — prettier, eslint, tsc, vitest all pass.
