### PR TITLE
fix(pb): curate leaf shareability instead of deriving it from sleeps

### DIFF
--- a/docs/reference/lodging-registry.md
+++ b/docs/reference/lodging-registry.md
@@ -210,7 +210,9 @@ loud on purpose, rather than a silently empty registry.
       "has_lights": true,
 
       "has_ramp": "partial",    // yes | no | partial; "" or absent = NOT ASSESSED
-      "max_beds": 14            // total sleeping spots. NOT sleeps — see below
+      "max_beds": 14,           // total sleeping spots. NOT sleeps — see below
+
+      "shareability": "shareable"  // shareable | single_party; absent = not curated
     }
   ],
   "aliases": [
@@ -234,6 +236,26 @@ CampMinder-id discipline used across the rest of the schema.
 - `is_confirmed` — always `false` on create. Every seeded value is a guess until
   staff verify it against the actual cabin, so nothing the loader writes may
   claim otherwise. Staff confirm through `/manage/lodging`.
+
+### `shareability` is CURATED, not derived
+
+Whether more than one party may sleep in a unit is a fact staff maintain per
+unit, not something any formula produces (kindred#2331, owner ruling D17,
+2026-08-14). It used to be derived on a family-pool leaf from `sleeps >= 12` —
+a threshold no leaf in the inventory reaches, so every leaf came out
+`single_party` and the board warned on correct multi-family placements.
+
+- **Vocabulary**: exactly `"shareable"` or `"single_party"`. Anything else
+  **fails the file load**, before any row is written — a typo must not degrade
+  into "not classified".
+- **Absent, `null`, or `""` all mean NOT YET CURATED** and land the unit blank.
+  A leaf the file says nothing about never becomes shareable by default.
+- **Only meaningful on a family-pool LEAF.** A container classifies from
+  `is_container` alone and a `staff_default` row is always `single_party`; both
+  ignore the key, so there is no need to set it on either.
+
+Like every other field here, the loader is create-if-absent, so the key reaches
+**new rows only** — see the section below.
 
 ### `max_beds` is not `sleeps`, and neither may overwrite the other
 

--- a/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
@@ -172,13 +172,18 @@ describe('LodgingUnitForm — create', () => {
     expect(screen.queryByText(/but the unit as edited reads/)).not.toBeInTheDocument()
   })
 
-  it('stays quiet on a leaf at any other sleeps value too', async () => {
+  it('stays quiet on a leaf in the OTHER direction too — one-family at a large capacity', async () => {
+    // The mirror of the test above, and the half that actually distinguishes
+    // the two rules: under the retired `sleeps >= 12` derivation a leaf stored
+    // `single_party` at sleeps 15 derived `shareable` and warned. A leaf
+    // curated one-family is now the registry's answer at any capacity, so
+    // nothing here has an opinion about it.
     const user = userEvent.setup()
     render(
       <LodgingUnitForm areas={AREAS} units={[]} year={2026} onSaved={vi.fn()} onCancel={vi.fn()} />
     )
 
-    await user.selectOptions(screen.getByLabelText('Sharing'), 'shareable')
+    await user.selectOptions(screen.getByLabelText('Sharing'), 'single_party')
     await user.type(screen.getByLabelText('Sleeps'), '15')
 
     expect(screen.queryByText(/but the unit as edited reads/)).not.toBeInTheDocument()

--- a/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
@@ -154,11 +154,13 @@ describe('LodgingUnitForm — create', () => {
     }
   )
 
-  it('warns when a shareable unit is edited below the capacity threshold', async () => {
-    // The staleness this feature can create: shareability is derived once and
-    // then human-owned, so correcting `sleeps` downward leaves an affirmative
-    // "Shared OK" chip on the board endorsing a double-booking. Advisory only
-    // — settling it is the staffer's ruling, not the form's.
+  it('stays quiet on a leaf regardless of sleeps — the comparison is retired (kindred#2331)', async () => {
+    // Before owner ruling D17 (2026-08-14) this warned at sleeps: 8, because
+    // the advisory re-derived `sleeps >= 12` here. It no longer does: a
+    // LEAF's shareability is now a curated registry fact this form has no
+    // formula for, so there is nothing left to compare `Sharing` against.
+    // The retired threshold never matched the owner's real enumeration
+    // anyway — no leaf in the inventory ever reached 12.
     const user = userEvent.setup()
     render(
       <LodgingUnitForm areas={AREAS} units={[]} year={2026} onSaved={vi.fn()} onCancel={vi.fn()} />
@@ -167,12 +169,10 @@ describe('LodgingUnitForm — create', () => {
     await user.selectOptions(screen.getByLabelText('Sharing'), 'shareable')
     await user.type(screen.getByLabelText('Sleeps'), '8')
 
-    expect(
-      await screen.findByText(/but the unit as edited reads one family only/)
-    ).toBeInTheDocument()
+    expect(screen.queryByText(/but the unit as edited reads/)).not.toBeInTheDocument()
   })
 
-  it('stays quiet while the unit still agrees with its classification', async () => {
+  it('stays quiet on a leaf at any other sleeps value too', async () => {
     const user = userEvent.setup()
     render(
       <LodgingUnitForm areas={AREAS} units={[]} year={2026} onSaved={vi.fn()} onCancel={vi.fn()} />

--- a/frontend/src/components/admin/lodging/LodgingUnitForm.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitForm.tsx
@@ -389,7 +389,6 @@ export function LodgingUnitForm({
         onShareabilityChange={setShareability}
         inventoryClass={inventoryClass}
         isContainer={isContainer}
-        sleeps={capacity.sleeps}
       />
 
       <div className="flex flex-col justify-end gap-2 pb-1 text-sm">

--- a/frontend/src/components/admin/lodging/UnitAmenityFieldset.tsx
+++ b/frontend/src/components/admin/lodging/UnitAmenityFieldset.tsx
@@ -76,7 +76,6 @@ export interface UnitAmenityFieldsetProps {
    */
   inventoryClass: InventoryClassValue | ''
   isContainer: boolean
-  sleeps: string
 }
 
 export function UnitAmenityFieldset({
@@ -92,9 +91,8 @@ export function UnitAmenityFieldset({
   onShareabilityChange,
   inventoryClass,
   isContainer,
-  sleeps,
 }: UnitAmenityFieldsetProps) {
-  const drift = shareabilityDrift({ inventoryClass, isContainer, sleeps, stored: shareability })
+  const drift = shareabilityDrift({ inventoryClass, isContainer, stored: shareability })
   const [pendingPeer, setPendingPeer] = useState('')
   // The candidate list SHRINKS as rooms are added, so a held selection goes
   // stale — and a `<select>` whose value is not among its options renders

--- a/frontend/src/components/admin/lodging/shareabilityDrift.test.ts
+++ b/frontend/src/components/admin/lodging/shareabilityDrift.test.ts
@@ -2,11 +2,25 @@
  * The classification is derived ONCE and then owned by a human, so its inputs
  * can move out from under it. This is the advisory that says so.
  *
- * The dangerous direction is `shareable` outliving a capacity correction: a
- * staffer fixing a cabin from `sleeps: 15` to `sleeps: 8` leaves the unit
- * marked shareable, and the board goes on showing an affirmative "Shared OK"
- * chip inviting a second household into a room the rule now says holds one —
- * the exact double-booking kindred#2026 exists to prevent, endorsed.
+ * RETIRED, kindred#2331 (owner ruling D17, 2026-08-14): the LEAF comparison.
+ * `shareability` on a family_pool leaf used to be derived from `sleeps >= 12`
+ * — a threshold no leaf in the inventory ever reached, so it never matched the
+ * owner's actual multi-family enumeration. It is now a CURATED registry fact
+ * (`config/lodging_registry.json`'s per-unit `shareability` key,
+ * `pocketbase/lodging/registry.go`'s `classifyShareability`), not something
+ * this file can re-derive from form fields at all. Comparing `stored` against
+ * a `sleeps` threshold that no longer governs anything would warn on every
+ * staff correction that curated a small cabin shareable — the exact "every
+ * staff correction warns forever" failure kindred#2331 exists to close.
+ *
+ * The CONTAINER and staff_default legs are UNCHANGED: both are still real,
+ * live-computable rules (container-ness, and the housing role), not curated
+ * facts, so there is still something honest to compare `stored` against.
+ *
+ * The dangerous direction, for what remains, is `shareable` outliving a role
+ * change: a cabin moved from family_pool to staff_default stays marked
+ * shareable, and the board goes on showing an affirmative "Shared OK" chip on
+ * a room that is no longer family-camp inventory at all.
  *
  * Advisory only, with no "apply" button, for the same reason `capacityFlag`'s
  * conflict branch has none: the classification is a human ruling and this file
@@ -16,7 +30,7 @@ import { describe, expect, it } from 'vitest'
 
 import { shareabilityDrift } from './shareabilityDrift'
 
-const base = {
+const leafBase = {
   inventoryClass: 'family_pool',
   isContainer: false,
   sleeps: '15',
@@ -24,59 +38,60 @@ const base = {
 } as const
 
 describe('shareabilityDrift', () => {
-  it('is silent when the stored classification still matches the rule', () => {
-    expect(shareabilityDrift(base)).toBeNull()
+  describe('a LEAF (retired comparison)', () => {
+    it('says nothing for a curated-shareable leaf, whatever sleeps reads', () => {
+      // THE case kindred#2331 exists to fix: a leaf staff curated shareable
+      // at any capacity must never be nagged back toward single_party by a
+      // `sleeps` number the rule no longer consults.
+      expect(shareabilityDrift(leafBase)).toBeNull()
+      expect(shareabilityDrift({ ...leafBase, sleeps: '4' })).toBeNull()
+      expect(shareabilityDrift({ ...leafBase, sleeps: '' })).toBeNull()
+    })
+
+    it('says nothing for a curated-single_party leaf, whatever sleeps reads', () => {
+      expect(shareabilityDrift({ ...leafBase, stored: 'single_party', sleeps: '15' })).toBeNull()
+      expect(shareabilityDrift({ ...leafBase, stored: 'single_party', sleeps: '' })).toBeNull()
+    })
+
+    it('says nothing on an UNCLASSIFIED leaf', () => {
+      // '' is not a wrong answer that drifted, it is the absence of one. The
+      // board already badges it "Sharing unset"; a second nag in the form for
+      // a staffer who has not answered yet would train them to dismiss this.
+      expect(shareabilityDrift({ ...leafBase, stored: '' })).toBeNull()
+    })
   })
 
-  it('flags a shareable unit whose capacity has dropped below the threshold', () => {
-    // THE case this exists for, and the only one where staying silent would
-    // leave a green chip endorsing a double-booking.
-    const drift = shareabilityDrift({ ...base, sleeps: '8' })
-    expect(drift?.stored).toBe('shareable')
-    expect(drift?.derived).toBe('single_party')
+  describe('a CONTAINER (unchanged rule)', () => {
+    it('flags a room promoted to a container while still marked one-family', () => {
+      const drift = shareabilityDrift({ ...leafBase, isContainer: true, stored: 'single_party' })
+      expect(drift?.stored).toBe('single_party')
+      expect(drift?.derived).toBe('shareable')
+    })
+
+    it('ignores capacity entirely on a container, as the rule does', () => {
+      // A container's `sleeps` is a DELTA over its rooms (kindred#2041), so a
+      // small number on one is not evidence of anything. A shareable
+      // container must not be nagged about its delta.
+      expect(shareabilityDrift({ ...leafBase, isContainer: true, sleeps: '1' })).toBeNull()
+      expect(shareabilityDrift({ ...leafBase, isContainer: true, sleeps: '' })).toBeNull()
+    })
   })
 
-  it('flags the conservative direction too, so a cabin is not left under-used', () => {
-    const drift = shareabilityDrift({ ...base, sleeps: '15', stored: 'single_party' })
-    expect(drift?.stored).toBe('single_party')
-    expect(drift?.derived).toBe('shareable')
-  })
+  describe('staff_default (unchanged rule)', () => {
+    it('flags a unit moved to staff housing while still marked shareable', () => {
+      const drift = shareabilityDrift({ ...leafBase, inventoryClass: 'staff_default' })
+      expect(drift?.stored).toBe('shareable')
+      expect(drift?.derived).toBe('single_party')
+    })
 
-  it('flags a unit moved to staff housing while still marked shareable', () => {
-    const drift = shareabilityDrift({ ...base, inventoryClass: 'staff_default' })
-    expect(drift?.derived).toBe('single_party')
-  })
-
-  it('flags a room promoted to a container while still marked one-family', () => {
-    const drift = shareabilityDrift({ ...base, isContainer: true, stored: 'single_party' })
-    expect(drift?.derived).toBe('shareable')
-  })
-
-  it('says nothing on an UNCLASSIFIED unit', () => {
-    // '' is not a wrong answer that drifted, it is the absence of one. The
-    // board already badges it "Sharing unset"; a second nag in the form for a
-    // staffer who has not answered yet would train them to dismiss this.
-    expect(shareabilityDrift({ ...base, stored: '' })).toBeNull()
-    expect(shareabilityDrift({ ...base, sleeps: '8', stored: '' })).toBeNull()
-  })
-
-  it('says nothing when capacity is unknown, rather than guessing', () => {
-    // Blank sleeps is UNKNOWN. The rule declines to classify an unmeasured
-    // leaf, so it has no derived answer to disagree with, and asserting drift
-    // off a missing number is exactly the guess the select exists to refuse.
-    expect(shareabilityDrift({ ...base, sleeps: '' })).toBeNull()
-    expect(shareabilityDrift({ ...base, sleeps: '0' })).toBeNull()
+    it('says nothing when the stored value already matches staff_default', () => {
+      expect(
+        shareabilityDrift({ ...leafBase, inventoryClass: 'staff_default', stored: 'single_party' })
+      ).toBeNull()
+    })
   })
 
   it('says nothing when the role is unrecorded', () => {
-    expect(shareabilityDrift({ ...base, inventoryClass: '' })).toBeNull()
-  })
-
-  it('ignores capacity entirely on a container, as the rule does', () => {
-    // A container's `sleeps` is a DELTA over its rooms (kindred#2041), so a
-    // small number on one is not evidence of anything. A shareable container
-    // must not be nagged about its delta.
-    expect(shareabilityDrift({ ...base, isContainer: true, sleeps: '1' })).toBeNull()
-    expect(shareabilityDrift({ ...base, isContainer: true, sleeps: '' })).toBeNull()
+    expect(shareabilityDrift({ ...leafBase, inventoryClass: '' })).toBeNull()
   })
 })

--- a/frontend/src/components/admin/lodging/shareabilityDrift.test.ts
+++ b/frontend/src/components/admin/lodging/shareabilityDrift.test.ts
@@ -33,24 +33,22 @@ import { shareabilityDrift } from './shareabilityDrift'
 const leafBase = {
   inventoryClass: 'family_pool',
   isContainer: false,
-  sleeps: '15',
   stored: 'shareable',
 } as const
 
 describe('shareabilityDrift', () => {
   describe('a LEAF (retired comparison)', () => {
-    it('says nothing for a curated-shareable leaf, whatever sleeps reads', () => {
+    it('says nothing for a curated-shareable leaf', () => {
       // THE case kindred#2331 exists to fix: a leaf staff curated shareable
-      // at any capacity must never be nagged back toward single_party by a
-      // `sleeps` number the rule no longer consults.
+      // must never be nagged back toward single_party. Capacity cannot even
+      // be expressed here any more — `sleeps` is off the input type — so the
+      // end-to-end proof that typing a capacity raises nothing lives at the
+      // form level, in LodgingUnitForm.test.tsx.
       expect(shareabilityDrift(leafBase)).toBeNull()
-      expect(shareabilityDrift({ ...leafBase, sleeps: '4' })).toBeNull()
-      expect(shareabilityDrift({ ...leafBase, sleeps: '' })).toBeNull()
     })
 
-    it('says nothing for a curated-single_party leaf, whatever sleeps reads', () => {
-      expect(shareabilityDrift({ ...leafBase, stored: 'single_party', sleeps: '15' })).toBeNull()
-      expect(shareabilityDrift({ ...leafBase, stored: 'single_party', sleeps: '' })).toBeNull()
+    it('says nothing for a curated-single_party leaf', () => {
+      expect(shareabilityDrift({ ...leafBase, stored: 'single_party' })).toBeNull()
     })
 
     it('says nothing on an UNCLASSIFIED leaf', () => {
@@ -68,12 +66,12 @@ describe('shareabilityDrift', () => {
       expect(drift?.derived).toBe('shareable')
     })
 
-    it('ignores capacity entirely on a container, as the rule does', () => {
+    it('is silent on a container that already agrees with the rule', () => {
       // A container's `sleeps` is a DELTA over its rooms (kindred#2041), so a
-      // small number on one is not evidence of anything. A shareable
-      // container must not be nagged about its delta.
-      expect(shareabilityDrift({ ...leafBase, isContainer: true, sleeps: '1' })).toBeNull()
-      expect(shareabilityDrift({ ...leafBase, isContainer: true, sleeps: '' })).toBeNull()
+      // small number on one was never evidence of anything — which is why the
+      // container leg never read capacity, and why removing `sleeps` from the
+      // input took nothing away from it.
+      expect(shareabilityDrift({ ...leafBase, isContainer: true })).toBeNull()
     })
   })
 

--- a/frontend/src/components/admin/lodging/shareabilityDrift.ts
+++ b/frontend/src/components/admin/lodging/shareabilityDrift.ts
@@ -7,13 +7,25 @@
  * registry is canonical, and a rule that silently overwrote a staffer's ruling
  * every time a neighbouring field moved would be worse than no rule.
  *
- * The cost of that choice is that the INPUTS can move out from under the
- * answer. `sleeps` is staff-owned and editable in this same form;
- * `inventory_class` and `is_container` are two controls above it. A staffer who
- * corrects a cabin from `sleeps: 15` to `sleeps: 8` leaves it marked
- * `shareable`, and the board goes on rendering an affirmative "Shared OK" chip
- * inviting a second household into a room the rule now says holds one — the
- * exact double-booking kindred#2026 exists to prevent, now endorsed.
+ * THE LEAF COMPARISON IS RETIRED (kindred#2331, owner ruling D17, 2026-08-14).
+ * A family_pool LEAF's shareability used to be re-derivable from `sleeps >= 12`
+ * here, matching `classifyShareability`. That threshold never matched anything
+ * real — no leaf in the inventory ever reaches 12 — and the owner's actual
+ * rule is now a CURATED fact per unit in the registry file, not a formula over
+ * `sleeps`. There is nothing left in a form's live values for a leaf to
+ * compare `stored` against, so `derive` below declines to answer for a leaf
+ * the same way it already declined for an unrecorded role: no live rule, no
+ * drift to report. Reporting one here off the retired threshold would warn on
+ * every leaf a staffer correctly curates shareable below 12 — the "every staff
+ * correction warns forever" failure the retirement exists to close.
+ *
+ * The CONTAINER and staff_default legs are UNCHANGED: both are still real,
+ * live-computable rules (container-ness, and the housing role) rather than
+ * curated facts, so the cost that motivated this file in the first place still
+ * applies to them. `inventory_class` and `is_container` are controls in this
+ * same form. A staffer who reclassifies a cabin to `staff_default` leaves it
+ * marked `shareable`, and the board goes on rendering an affirmative
+ * "Shared OK" chip on a room that is no longer family-camp inventory at all.
  *
  * So this states the disagreement and asks nothing. NO "apply" BUTTON, for the
  * same reason `capacityFlag`'s conflict branch has none: settling it is a
@@ -21,28 +33,26 @@
  * classification by a derived guess is precisely the automation the select was
  * chosen over a bool to avoid.
  *
- * BOTH DIRECTIONS are reported, not just the permissive one. `shareable` gone
- * stale is the hazard; `single_party` gone stale silently costs the camp a
- * cabin's worth of capacity every weekend, which staff also want to know.
+ * BOTH DIRECTIONS are reported, not just the permissive one, for what remains.
  *
  * SILENT on the states where there is nothing honest to say: an unclassified
- * unit (no answer has drifted — the board already badges that), an unmeasured
- * leaf (the rule declines to classify it, so there is nothing to disagree
- * with), an unrecorded role, and a container's capacity (a container's `sleeps`
- * is a DELTA over its rooms, kindred#2041, so a small number on one is not
- * evidence).
+ * unit (no answer has drifted — the board already badges that), any LEAF
+ * (retired, above), an unrecorded role, and a container's capacity (a
+ * container's `sleeps` is a DELTA over its rooms, kindred#2041, so a small
+ * number on one is not evidence).
  *
- * THE RULE ITSELF IS NOT RESTATED HERE AS A NEW SOURCE OF TRUTH — it is the
- * third and last expression of the one in 1500000145's header and
- * registry.go's `classifyShareability`, and it exists only to say when the
- * stored value and the rule disagree. If you change the rule, change all three.
+ * THE RULE ITSELF IS NOT RESTATED HERE AS A NEW SOURCE OF TRUTH for the two
+ * legs that remain — it is the second live expression of the one in
+ * `registry.go`'s `classifyShareability` (1500000145's header is the historical
+ * record of what already-applied production rows were classified from, and is
+ * frozen). If you change the container or staff_default rule, change both.
  */
 import type { InventoryClassValue, ShareabilityStoredValue } from '../../../types/lodging'
 
 export interface ShareabilityDriftInput {
   inventoryClass: InventoryClassValue | ''
   isContainer: boolean
-  /** The raw form string. Blank is a real value: UNKNOWN. */
+  /** The raw form string. Unused for a LEAF — see the retirement note above. */
   sleeps: string
   stored: ShareabilityStoredValue
 }
@@ -57,11 +67,11 @@ function derive(input: ShareabilityDriftInput): ShareabilityStoredValue {
   if (input.inventoryClass === 'staff_default') return 'single_party'
   if (input.inventoryClass !== 'family_pool') return ''
   if (input.isContainer) return 'shareable'
-  // Blank and 0 are both UNMEASURED — PocketBase stores an unset number as 0,
-  // and this codebase reads 0 as unknown, never as "zero capacity".
-  const sleeps = Number.parseInt(input.sleeps, 10)
-  if (!Number.isFinite(sleeps) || sleeps < 1) return ''
-  return sleeps >= 12 ? 'shareable' : 'single_party'
+  // A LEAF's shareability is a CURATED registry fact (kindred#2331), not
+  // derived from `sleeps` — there is no live rule left to compare `stored`
+  // against, so this declines to answer for the same reason an unrecorded
+  // role does.
+  return ''
 }
 
 export function shareabilityDrift(input: ShareabilityDriftInput): ShareabilityDrift | null {

--- a/frontend/src/components/admin/lodging/shareabilityDrift.ts
+++ b/frontend/src/components/admin/lodging/shareabilityDrift.ts
@@ -37,9 +37,15 @@
  *
  * SILENT on the states where there is nothing honest to say: an unclassified
  * unit (no answer has drifted — the board already badges that), any LEAF
- * (retired, above), an unrecorded role, and a container's capacity (a
- * container's `sleeps` is a DELTA over its rooms, kindred#2041, so a small
- * number on one is not evidence).
+ * (retired, above), and an unrecorded role.
+ *
+ * `sleeps` IS NO LONGER AN INPUT AT ALL, and that is structural rather than
+ * conventional. The leaf leg was its only reader; the container leg never
+ * consulted it (a container's `sleeps` is a DELTA over its rooms,
+ * kindred#2041, so a small number on one is not evidence) and staff_default
+ * answers from the role. Taking it off `ShareabilityDriftInput` is what stops
+ * the retired threshold being reintroduced here by someone who reads the
+ * field as an invitation.
  *
  * THE RULE ITSELF IS NOT RESTATED HERE AS A NEW SOURCE OF TRUTH for the two
  * legs that remain — it is the second live expression of the one in
@@ -52,8 +58,6 @@ import type { InventoryClassValue, ShareabilityStoredValue } from '../../../type
 export interface ShareabilityDriftInput {
   inventoryClass: InventoryClassValue | ''
   isContainer: boolean
-  /** The raw form string. Unused for a LEAF — see the retirement note above. */
-  sleeps: string
   stored: ShareabilityStoredValue
 }
 

--- a/pocketbase/lodging/registry.go
+++ b/pocketbase/lodging/registry.go
@@ -35,37 +35,36 @@ const (
 // classifyShareability decides whether a unit about to be CREATED may hold
 // more than one party. Returns "" when it cannot honestly answer.
 //
-// The rule, and why each leg is what it is, is documented in full on
-// pb_migrations/1500000145 -- read that header before changing this, because
-// the two implementations have to agree. In short: a family LEAF sleeping 12
-// or more is shareable (this reproduces the owner's own enumeration of the
-// shared cabins exactly); a family CONTAINER is shareable at its own level,
-// because two households on one container occupy different rooms beneath it
-// and that is a legitimate share rather than a violation (owner ruling); staff
-// housing is not family-camp inventory, so multi-family occupancy is not a
-// question it answers.
+// RE-RULED by kindred#2331 (owner ruling D17, 2026-08-14). The LEAF leg used
+// to derive from `sleeps >= 12`. It never worked: no leaf in the inventory
+// ever reaches 12, so every family-pool leaf classified `single_party`
+// regardless of the owner's actual multi-family enumeration -- exactly 30
+// leaves, named in the private registry, not a capacity threshold. A LEAF's
+// shareability is now a CURATED fact the registry file supplies per unit
+// (`curated` below), never derived. See registryUnit.Shareability for the
+// JSON shape.
 //
-// A container is deliberately NOT tested against `sleeps`. A container's
-// `sleeps` is a DELTA over its rooms (kindred#2041), not a whole-house total,
-// and the whole-house total is not the right input either -- the container
-// carrying the most historical two-household shares totals 9 across its rooms.
-// What makes a container shareable is having rooms, not having capacity.
+// The CONTAINER leg is UNCHANGED by this ruling and takes no input from
+// `curated`: a family CONTAINER is shareable at its own level, because two
+// households on one container occupy different rooms beneath it and that is
+// a legitimate share rather than a violation (owner ruling, 2026-08-07). A
+// container is deliberately NOT tested against any capacity number either --
+// see pb_migrations/1500000145's header for why `sleeps` and `max_beds` both
+// fail as a container-level test. What makes a container shareable is having
+// rooms, not having capacity.
 //
-// NEVER `max_beds`: it disagrees with the unit's own recorded bed inventory on
-// roughly a third of rows, including rows where it falls BELOW the bed count.
+// Staff housing is not family-camp inventory, so multi-family occupancy is
+// not a question it answers, and no curated value can override that.
 //
-// A FRESH DATABASE CARRIES A SUBSET OF PRODUCTION'S CLASSIFICATION, never a
-// contradicting one, and that is enforced at the CALL SITE rather than here:
-// `seedUnits` passes nil for `sleeps` because the registry file's capacities
-// are a pre-inventory guess (77 of 118 disagree with production, and no leaf in
-// the file reaches 12). Read the note there before changing either.
-//
-// This function stays a total, honest rule over whatever it is given. Do not
-// "fix" the fresh-database gap by loosening the thresholds here or by seeding
-// from a second column; the fix, if one is wanted, is to refresh `sleeps` in
-// the private registry file, which is a data decision for the owner rather
-// than a code change.
-func classifyShareability(inventoryClass string, isContainer bool, sleeps *int) string {
+// This function stays a total, honest rule over whatever it is given: an
+// absent or empty curated value on a leaf returns "" rather than guessing in
+// either direction. THIS IS THE SAFETY REQUIREMENT -- a leaf the registry
+// says nothing about must never silently become shareable. A malformed
+// curated string (anything other than the two DB values) falls through to
+// "" for the same reason; validateRegistry is what fails the file loudly
+// before this is ever called, so this is defense-in-depth, not the
+// validation layer.
+func classifyShareability(inventoryClass string, isContainer bool, curated *string) string {
 	switch inventoryClass {
 	case "staff_default":
 		return shareabilitySingleParty
@@ -73,16 +72,18 @@ func classifyShareability(inventoryClass string, isContainer bool, sleeps *int) 
 		if isContainer {
 			return shareabilityShareable
 		}
-		// nil is "never observed" and 0 is how PocketBase stores that, so both
-		// mean UNMEASURED -- never "zero capacity". An unmeasured leaf cannot
-		// be classified, and guessing would be wrong in both directions.
-		if sleeps == nil || *sleeps < 1 {
+		if curated == nil {
 			return ""
 		}
-		if *sleeps >= 12 {
-			return shareabilityShareable
+		switch *curated {
+		case shareabilityShareable, shareabilitySingleParty:
+			return *curated
+		default:
+			// Empty string ("registry says nothing", the JSON-explicit form
+			// of nil) and anything malformed both mean the same thing here:
+			// no honest answer, so decline rather than guess.
+			return ""
 		}
-		return shareabilitySingleParty
 	default:
 		// No role recorded, so a role-dependent question has no answer.
 		return ""
@@ -144,6 +145,20 @@ type registryUnit struct {
 	NearBathhouse  bool   `json:"near_bathhouse"`
 	InventoryClass string `json:"inventory_class"`
 	IsContainer    bool   `json:"is_container"`
+	// Shareability is the CURATED answer to "may more than one party sleep
+	// here" for a family_pool LEAF (kindred#2331, owner ruling D17). It
+	// replaced the retired `sleeps >= 12` derivation, which never fired: no
+	// leaf in the inventory reaches 12. Nil means "not yet curated" -- the
+	// honest unclassified state, never treated as shareable. When set, the
+	// value must be exactly one of shareabilityShareable /
+	// shareabilitySingleParty (validateRegistry rejects anything else);
+	// classifyShareability also falls back to "" defensively if it ever sees
+	// something else.
+	//
+	// Ignored on a CONTAINER row (classifies from IsContainer alone) and on a
+	// staff_default row (always single_party) -- both unchanged by this
+	// ruling, so the file need not carry it there.
+	Shareability *string `json:"shareability"`
 	// DefaultCombined is the registry default draw level, meaningful on
 	// CONTAINER rows only: true means "draw the board's card at this node and
 	// stop descending" — the whole-house let.
@@ -414,7 +429,33 @@ func validateRegistry(doc *registryDoc) error {
 	if err := validateUnitReferences(doc.Units, areaCodes, unitCodes); err != nil {
 		return err
 	}
+	if err := validateUnitShareability(doc.Units); err != nil {
+		return err
+	}
 	return validateAliases(doc.Aliases, unitCodes)
+}
+
+// validateUnitShareability rejects a curated `shareability` value that is not
+// exactly one of the two DB select options (kindred#2331). classifyShareability
+// falls back to "" for anything malformed as a second line of defense, but
+// letting a typo silently become "unclassified" here would hide a mistake in
+// the very file this loader treats as canonical — the same "no silent
+// fallback for a curated fact" discipline the rest of this file follows.
+// nil (the key absent) and "" (the key explicitly blank) are both legal: both
+// mean "not yet curated", not a typo.
+func validateUnitShareability(units []registryUnit) error {
+	for i := range units {
+		u := &units[i]
+		if u.Shareability == nil || *u.Shareability == "" {
+			continue
+		}
+		if *u.Shareability != shareabilityShareable && *u.Shareability != shareabilitySingleParty {
+			return fmt.Errorf(
+				"unit %q has shareability %q, which is not %q or %q",
+				u.Code, *u.Shareability, shareabilityShareable, shareabilitySingleParty)
+		}
+	}
+	return nil
 }
 
 func validateAreaCodes(areas []registryArea) (map[string]bool, error) {
@@ -570,37 +611,29 @@ func seedUnits(
 		rec.Set("near_bathhouse", u.NearBathhouse)
 		rec.Set("inventory_class", u.InventoryClass)
 		rec.Set("is_container", u.IsContainer)
-		// NOTE THE `nil`: the loader deliberately declines to classify from the
-		// file's `sleeps`.
-		//
-		// Measured 2026-08-08, the registry file disagrees with production on
-		// `sleeps` for 77 of 118 units and NO leaf in it reaches 12, while it
-		// disagrees on `is_container` for 0 and on `inventory_class` for 2.
-		// So the file is authoritative for the two structural fields and is a
-		// pre-inventory guess for the capacity one -- production's capacities
-		// arrived later, from the Master Housing import and from staff editing
-		// confirmed rows, neither of which writes back to the file.
-		//
-		// Feeding that guess in would stamp every family leaf `single_party`
-		// off a number known to be wrong, on a row this same loop marks
-		// `is_confirmed: false` three lines below precisely because "every
-		// seeded value is a guess until staff confirm it". Unlike the amenity
-		// flags, nothing downstream discounts shareability for being
-		// unconfirmed, so that stamp would be read as settled. Passing nil
-		// makes the leaf legs return "" -- the honest "nobody has classified
-		// this" the select exists to represent -- while the container and
-		// staff-housing legs, which need no capacity, still classify.
+		// The leaf leg now reads `u.Shareability` straight through
+		// (kindred#2331, owner ruling D17) instead of guessing from `sleeps`.
+		// Unlike the retired capacity guess, this IS the owner's actual
+		// enumeration -- a curated fact staff maintain in the file, not a
+		// pre-inventory placeholder -- so there is no reason to withhold it
+		// the way `nil` used to withhold `sleeps` here. A leaf the file has
+		// not yet curated still lands unclassified: `classifyShareability`
+		// returns "" for a nil or malformed curated value on a leaf, and
+		// this `if` only ever writes a non-empty answer.
 		//
 		// The RULE is not forked to achieve this: `classifyShareability` has
-		// one definition, shared with 1500000145, and only the input differs.
-		// A fresh database therefore classifies strictly FEWER units than
-		// production -- measured, 14 containers and 23 staff rows against
-		// production's 44 and 74, with all 81 family leaves left honestly
-		// blank. It is not literally a subset: the file also disagrees with
-		// production on `inventory_class` for TWO units, so those two can land
-		// differently. That is an inventory_class data divergence rather than
-		// anything this rule does, and it predates this feature.
-		if s := classifyShareability(u.InventoryClass, u.IsContainer, nil); s != "" {
+		// one definition. Containers and staff housing are unaffected by this
+		// ruling and still classify without consulting `u.Shareability` at
+		// all.
+		//
+		// This loader is CREATE-ONLY (skips any existing code+year), so it
+		// only ever reaches a genuinely fresh database -- a worktree, a new
+		// deployment, a rebuilt CD seed. Production's 118 existing rows are
+		// untouched by this path; carrying a newly-curated value onto a row
+		// that already exists is the same "existing row" gap every other
+		// registry field has (`apply_lodging_inventory.py`'s whole reason for
+		// existing), and is not solved here.
+		if s := classifyShareability(u.InventoryClass, u.IsContainer, u.Shareability); s != "" {
 			rec.Set("shareability", s)
 		}
 		rec.Set("default_combined", u.DefaultCombined)

--- a/pocketbase/lodging/registry_shareability_test.go
+++ b/pocketbase/lodging/registry_shareability_test.go
@@ -2,70 +2,69 @@ package lodging
 
 import "testing"
 
-// The seed-time half of kindred#2026.
+// The seed-time half of kindred#2026, RE-RULED by kindred#2331 (owner ruling
+// D17, 2026-08-14): a LEAF's shareability is a CURATED registry fact, never a
+// `sleeps` derivation. The `sleeps >= 12` floor reproduced nothing — no leaf
+// in the inventory ever reaches 12, so every family-pool leaf classified
+// `single_party` regardless of the owner's actual multi-family enumeration.
 //
 // classifyShareability answers "may more than one party sleep here at once"
-// for a row the loader is about to CREATE. The other half -- rows that already
-// exist -- is pb_migrations/1500000145, because neither named seed path can
-// reach them (seedUnits skips any existing code+year, and
-// apply_lodging_inventory.py withholds every non-notes change from a confirmed
-// row, which in production is all of them). The two implementations state the
-// same rule and this file is what stops them drifting apart in the direction
-// that matters: a Go loader that classified a small room `shareable` on a
-// fresh database would seed permission to double-book a bedroom.
-
-func intPtr(v int) *int { return &v }
+// for a row the loader is about to CREATE. A CONTAINER still classifies by
+// having rooms (`isContainer`), unchanged by this ruling — only the LEAF leg
+// moved, from a `sleeps` threshold to the `curated` value the registry file
+// now carries per unit. pb_migrations/1500000145's historical backfill is
+// FROZEN (already applied to production) and is not re-derived here; it
+// remains the accurate record of what production's existing rows were
+// classified from at the time it ran.
+func strPtr(v string) *string { return &v }
 
 func TestClassifyShareability(t *testing.T) {
 	cases := []struct {
 		name           string
 		inventoryClass string
 		isContainer    bool
-		sleeps         *int
+		curated        *string
 		want           string
 	}{
-		// The rule proper: 12 is the floor, on LEAF rows.
-		{"large leaf cabin is shareable", "family_pool", false, intPtr(15), shareabilityShareable},
-		{"exactly at the floor is shareable", "family_pool", false, intPtr(12), shareabilityShareable},
-		{"one below the floor is one family", "family_pool", false, intPtr(11), shareabilitySingleParty},
-		{"a bedroom is one family", "family_pool", false, intPtr(4), shareabilitySingleParty},
+		// The rule proper, on LEAF rows: read the curated value straight
+		// through. No threshold, no capacity math.
+		{"registry says shareable", "family_pool", false, strPtr(shareabilityShareable), shareabilityShareable},
+		{"registry says single_party", "family_pool", false, strPtr(shareabilitySingleParty), shareabilitySingleParty},
 
-		// A container's own `sleeps` is a DELTA over its rooms (kindred#2041),
-		// so the >= 12 test does not apply to it and is not applied. Under the
-		// owner's settled ruling two households on one container is a
-		// legitimate share, not a violation -- the parties occupy different
-		// rooms beneath it and CampMinder has no sub-room concept for every
-		// building, so staff assign at container level and will keep doing so.
-		{"a family container is shareable whatever its delta", "family_pool", true, intPtr(0), shareabilityShareable},
-		{"a family container with a small delta is still shareable", "family_pool", true, intPtr(1), shareabilityShareable},
-		{"a family container with no measured delta is shareable", "family_pool", true, nil, shareabilityShareable},
+		// THE SAFETY REQUIREMENT: a leaf the registry says nothing about must
+		// NOT silently become shareable. It stays unclassified, same as the
+		// old "unmeasured" state did.
+		{"registry says nothing (nil) leaves it unclassified", "family_pool", false, nil, ""},
+		{"registry says nothing (empty string) leaves it unclassified", "family_pool", false, strPtr(""), ""},
+
+		// A container's own curated value, if the file ever set one, is not
+		// consulted -- it classifies by having rooms alone, unchanged from
+		// before this ruling. Under the owner's settled ruling two households
+		// on one container is a legitimate share: they occupy different rooms
+		// beneath it, CampMinder has no sub-room concept for every building,
+		// so staff assign at container level and will keep doing so.
+		{"a family container is shareable regardless of any curated value",
+			"family_pool", true, nil, shareabilityShareable},
+		{"a family container ignores a curated single_party too",
+			"family_pool", true, strPtr(shareabilitySingleParty), shareabilityShareable},
 
 		// Staff housing is not family-camp inventory, so multi-party family
-		// occupancy is not a question it answers. This is also the mechanism
-		// that lands the owner's call on the one residue row -- a staff
-		// building sleeping 19 that would otherwise clear the leaf floor.
-		{"a large staff building is one party", "staff_default", false, intPtr(19), shareabilitySingleParty},
+		// occupancy is not a question it answers -- also unmoved by this
+		// ruling, and also blind to any curated value.
+		{"staff housing is one party regardless of curated value",
+			"staff_default", false, strPtr(shareabilityShareable), shareabilitySingleParty},
 		{"a staff container is one party", "staff_default", true, nil, shareabilitySingleParty},
 
-		// UNKNOWN, and it stays unknown. A leaf nobody has measured cannot be
-		// classified either way, and guessing here is the failure the select
-		// exists to prevent: `single_party` would block legitimate work and
-		// `shareable` would permit a double-booking.
-		{"an unmeasured leaf is left unclassified", "family_pool", false, nil, ""},
-		// PocketBase stores an unset number as 0, and registry.go's own
-		// comment says consumers read 0 as UNKNOWN, never "zero capacity".
-		{"a leaf sleeping zero is unclassified, not tiny", "family_pool", false, intPtr(0), ""},
-
 		// An unclassified ROLE cannot decide a role-dependent question.
-		{"a leaf with no inventory class is unclassified", "", false, intPtr(15), ""},
+		{"a leaf with no inventory class is unclassified", "", false, strPtr(shareabilityShareable), ""},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := classifyShareability(tc.inventoryClass, tc.isContainer, tc.sleeps)
+			got := classifyShareability(tc.inventoryClass, tc.isContainer, tc.curated)
 			if got != tc.want {
 				t.Errorf("classifyShareability(%q, %v, %v) = %q, want %q",
-					tc.inventoryClass, tc.isContainer, tc.sleeps, got, tc.want)
+					tc.inventoryClass, tc.isContainer, tc.curated, got, tc.want)
 			}
 		})
 	}

--- a/pocketbase/lodging/registry_test.go
+++ b/pocketbase/lodging/registry_test.go
@@ -86,6 +86,13 @@ func setupRegistryCollections(t *testing.T, app core.App) {
 		Name: "has_ramp", Values: []string{"yes", "no", "partial"}, MaxSelect: 1,
 	})
 	units.Fields.Add(&core.NumberField{Name: "max_beds", OnlyInt: true})
+	// 1500000145. The loader writes this from classifyShareability's result —
+	// see registry_shareability_test.go for the pure-function coverage and the
+	// TestSeedRegistryWritesCuratedLeafShareability family below for the
+	// seed-time write path kindred#2331 changed.
+	units.Fields.Add(&core.SelectField{
+		Name: "shareability", Values: []string{"shareable", "single_party"}, MaxSelect: 1,
+	})
 	// Required, same reason as lodging_areas' year field above.
 	units.Fields.Add(&core.NumberField{
 		Name: "year", Required: true, OnlyInt: true,
@@ -399,6 +406,108 @@ func TestSeedRegistryWritesAmenities(t *testing.T) {
 	}
 	if got := unit.GetInt("sleeps"); got != 0 {
 		t.Errorf("sleeps = %d, want 0 — max_beds must not leak into sleeps", got)
+	}
+}
+
+// The seed-time half of kindred#2331 (owner ruling D17): a LEAF's
+// `shareability` is read straight from the registry file's curated
+// `shareability` key, not derived from `sleeps`.
+func TestSeedRegistryWritesCuratedLeafShareability(t *testing.T) {
+	t.Parallel()
+	app := newRegistryTestApp(t)
+
+	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
+	  {"area": "AREA1", "code": "curated-shareable", "name": "Curated Shareable",
+	   "bathroom": "none", "inventory_class": "family_pool", "sleeps": 4,
+	   "shareability": "shareable"},
+	  {"area": "AREA1", "code": "curated-single", "name": "Curated Single",
+	   "bathroom": "none", "inventory_class": "family_pool", "sleeps": 4,
+	   "shareability": "single_party"}
+	], "aliases": []}`
+
+	if err := seedRegistryFromFile(app, writeRegistry(t, body), testYear); err != nil {
+		t.Fatalf("seedRegistryFromFile: %v", err)
+	}
+
+	// A small `sleeps: 4` leaf the file curates shareable must land shareable
+	// — the whole point of retiring the `sleeps >= 12` floor, which would have
+	// classified this row single_party no matter what the file said.
+	shareableUnit := findByCode(t, app, "lodging_units", "curated-shareable", testYear)
+	if got := shareableUnit.GetString("shareability"); got != "shareable" {
+		t.Errorf("shareability = %q for a curated-shareable leaf, want %q", got, "shareable")
+	}
+	singleUnit := findByCode(t, app, "lodging_units", "curated-single", testYear)
+	if got := singleUnit.GetString("shareability"); got != "single_party" {
+		t.Errorf("shareability = %q for a curated-single_party leaf, want %q", got, "single_party")
+	}
+}
+
+// THE SAFETY REQUIREMENT (kindred#2331): a leaf the file has not curated must
+// land unclassified, never silently shareable.
+func TestSeedRegistryLeafWithNoCuratedShareabilityStaysUnclassified(t *testing.T) {
+	t.Parallel()
+	app := newRegistryTestApp(t)
+
+	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
+	  {"area": "AREA1", "code": "not-yet-curated", "name": "Not Yet Curated",
+	   "bathroom": "none", "inventory_class": "family_pool", "sleeps": 15}
+	], "aliases": []}`
+
+	if err := seedRegistryFromFile(app, writeRegistry(t, body), testYear); err != nil {
+		t.Fatalf("seedRegistryFromFile: %v", err)
+	}
+
+	// sleeps: 15 would have cleared the retired >= 12 floor. It must have NO
+	// effect now — the row stays unclassified because the file names no
+	// curated value, not because of its capacity.
+	if got := findByCode(t, app, "lodging_units", "not-yet-curated", testYear).GetString("shareability"); got != "" {
+		t.Errorf("shareability = %q for an uncurated leaf, want blank (unclassified)", got)
+	}
+}
+
+// A CONTAINER classifies from `is_container` alone, unchanged by kindred#2331
+// — a curated value in the file, if one is ever present on a container row,
+// is not consulted.
+func TestSeedRegistryContainerShareabilityIgnoresCuratedField(t *testing.T) {
+	t.Parallel()
+	app := newRegistryTestApp(t)
+
+	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
+	  {"area": "AREA1", "code": "container-ignores-curated", "name": "Container",
+	   "bathroom": "none", "inventory_class": "family_pool", "is_container": true,
+	   "shareability": "single_party"}
+	], "aliases": []}`
+
+	if err := seedRegistryFromFile(app, writeRegistry(t, body), testYear); err != nil {
+		t.Fatalf("seedRegistryFromFile: %v", err)
+	}
+
+	unit := findByCode(t, app, "lodging_units", "container-ignores-curated", testYear)
+	if got := unit.GetString("shareability"); got != "shareable" {
+		t.Errorf("shareability = %q for a container curated single_party in the file, want %q (isContainer wins)",
+			got, "shareable")
+	}
+}
+
+// validateRegistry rejects a malformed curated value loudly, at load time,
+// rather than letting classifyShareability's own defense-in-depth silently
+// swallow a typo into "unclassified" — the same "fail loud on a bad file"
+// discipline every other cross-reference check here follows.
+func TestSeedRegistryInvalidCuratedShareabilityIsAnError(t *testing.T) {
+	t.Parallel()
+	app := newRegistryTestApp(t)
+
+	body := `{"areas": [{"code": "AREA1", "name": "First Area"}], "units": [
+	  {"area": "AREA1", "code": "typo-shareability", "name": "Typo",
+	   "bathroom": "none", "inventory_class": "family_pool", "shareability": "sometimes"}
+	], "aliases": []}`
+
+	err := seedRegistryFromFile(app, writeRegistry(t, body), testYear)
+	if err == nil {
+		t.Fatal("expected an error for a malformed shareability value, got nil")
+	}
+	if n := countRecords(t, app, "lodging_units"); n != 0 {
+		t.Errorf("a rejected file left %d units written, want 0 (nothing written on a bad file)", n)
 	}
 }
 

--- a/pocketbase/pb_migrations/1500000145_lodging_unit_shareability.js
+++ b/pocketbase/pb_migrations/1500000145_lodging_unit_shareability.js
@@ -17,7 +17,25 @@
  * warns about exactly that: "a rule encoded early and wrongly is worse than no
  * rule".
  *
- * ── THE RULE ────────────────────────────────────────────────────────────────
+ * ── SUPERSEDED IN PART, kindred#2331 (owner ruling D17, 2026-08-14) ─────────
+ *
+ * THE LEAF LEG BELOW IS HISTORY, NOT THE LIVE RULE. `sleeps >= 12` on leaves
+ * did not reproduce the owner's enumeration after all: no unit in the
+ * inventory reaches 12, so every family-pool leaf was stamped `single_party`
+ * and the board warned on correct multi-family placements. A LEAF's
+ * shareability is now a CURATED per-unit fact carried in the registry file and
+ * read straight through by `classifyShareability` (pocketbase/lodging/
+ * registry.go); `frontend/.../shareabilityDrift.ts` no longer re-derives it.
+ *
+ * This header stays as written because it is the accurate record of what
+ * production's existing rows were classified from when this migration ran, and
+ * the file is already applied. Do not read the leaf line below as current, and
+ * do not treat this file as one of the places to change when the leaf rule
+ * changes. The CONTAINER and staff_default legs ARE unchanged and still live,
+ * so the reasoning below about why a container is never tested against a
+ * capacity number remains the canonical explanation.
+ *
+ * ── THE RULE, AS IT STOOD WHEN THIS MIGRATION RAN ───────────────────────────
  *
  *   family_pool  + leaf      + sleeps >= 12  ->  shareable
  *   family_pool  + leaf      + sleeps 1..11  ->  single_party
@@ -78,8 +96,9 @@
  * databases: migrations run before SeedRegistry (main.go), so on a new
  * worktree or a rebuilt CD seed the UPDATEs below hit an empty table and
  * `classifyShareability` in registry.go supplies the value instead. The two
- * implementations state the same rule and `registry_shareability_test.go`
- * pins the Go half.
+ * implementations stated the same rule when this ran; since kindred#2331 they
+ * agree on containers and staff housing only, and the leaf leg here is frozen
+ * history. `registry_shareability_test.go` pins the current Go half.
  *
  * A FRESH DATABASE STILL WILL NOT MATCH PRODUCTION, because its INPUTS do not:
  * the registry file's `sleeps` disagrees with production on 77 of 118 units and


### PR DESCRIPTION
## What this fixes

`classifyShareability` (`pocketbase/lodging/registry.go`) classified a family_pool **leaf** as `shareable` only when `sleeps >= 12`. No leaf in the inventory ever reaches 12, so every family-pool leaf classified `single_party` regardless of the owner's actual multi-family enumeration — 30 leaves, per owner ruling D17 on #2331. The board's `sharingConflictBadge` (`frontend/src/components/weekend/unitBadges.ts`) then warned on every correct multi-family placement in those cabins.

Per D17: **shareability becomes a curated registry fact for LEAVES.** Containers keep the unchanged `isContainer` rule.

## How the board actually stops warning

This PR is what makes the data fix available; it is not itself the data fix.
The moment it merges, a staffer can open `/manage/lodging` and set **Sharing =
Shared** on the 30 real leaves, and the amber "One-family space" chip stops
appearing on those cabins immediately — the badges read the *stored* column, so
an admin edit is enough. That path existed before this PR and was unusable:
`shareabilityDrift.ts` re-derived `single_party` from `sleeps < 12`, so every
unit corrected that way carried a permanent "stored disagrees with derived"
banner in the form. Retiring the leaf comparison is what removes the nag.

**Editing the private registry file does not reach production.** The registry
key added below is for genuinely fresh databases only (see "What this
deliberately does NOT do"). Curating the file is still worth doing so a rebuilt
database carries the enumeration, but on production it changes nothing on its
own — the admin edit above is the action that clears the reported symptom.

## What changed

**`pocketbase/lodging/registry.go`**
- `classifyShareability`'s leaf leg no longer takes `sleeps *int`. It now takes `curated *string` and reads it straight through when it is exactly `"shareable"` or `"single_party"`. `nil`, `""`, or anything malformed returns `""` (unclassified) — **a leaf the registry says nothing about never silently becomes shareable.**
- New `registryUnit.Shareability *string` field (JSON key `shareability`), read at seed time and passed into `classifyShareability`.
- New `validateUnitShareability` rejects a malformed curated value loudly at file-load time, before any row is written, rather than letting a typo silently degrade to "unclassified."
- Container leg is byte-for-byte unchanged: still classifies from `isContainer` alone, still ignores any curated value on a container row.
- No new DB column, no migration: this only changes what's fed into the existing `lodging_units.shareability` select at seed time.

**`frontend/src/components/admin/lodging/shareabilityDrift.ts`**
- Retired the leaf `sleeps >= 12` re-derivation. `derive()` now returns `''` (declines to answer) for a family_pool leaf, same as it already does for an unrecorded role — there is no live rule left to compare `stored` against, only a curated fact this file has no formula for. Without this, every leaf a staffer correctly curates shareable below 12 would warn forever in `/manage/lodging`, since nothing ever settles a stored value the advisory keeps calling wrong.
- Container and `staff_default` legs are unchanged — both are still real, live-computable rules, so the drift advisory keeps firing for them.

## What this deliberately does NOT do

- **Does not touch production's 118 existing rows.** `seedUnits` is create-only (skips any existing `code+year`), so this reaches a genuinely fresh database only — a worktree, a new deployment, a rebuilt CD seed. Getting a newly-curated value from the registry file onto an already-seeded row (production's actual situation) is the same "existing row" gap every other registry field has, and is what `scripts/dev/apply_lodging_inventory.py` exists for — that script does not yet know about `shareability` (it isn't in `INVENTORY_FIELDS`, `STRUCTURAL_FIELDS`, or `STAFF_OWNED`), and whether it should be treated like `sleeps` (staff-owned, never overwritten by the script — `shareability` is already staff-editable in `/manage/lodging`) or like the amenity columns (script fills it once) is an owner call this PR does not make. Flagging this explicitly so it isn't lost: **without a follow-up, curating the 30 real leaves in the private registry file has no effect on production until that gap is closed by hand or by a future PR.**
- Does not add a migration. The registry file alone carries the new field into the existing `shareability` select column.
- Does not touch `unitBadges.ts`. `sharingConflictBadge`/`shareabilityBadge` already read the *stored* DB value and are correct however that value got set — no code change needed there, and #2339/#2252 are sequenced behind this PR on that file.
- Does not widen the enumeration or add real unit names anywhere — only fictional codes in tests, per repo policy.

## Shape the private registry (`config/lodging_registry.json`) must supply

For each family_pool **leaf** unit that should be shareable, add to that unit's object in the `units` array:

```json
"shareability": "shareable"
```

For a leaf that should stay one-family, either omit the key entirely or set it explicitly:

```json
"shareability": "single_party"
```

- **Key**: `shareability`, sitting directly on the unit object (same level as `sleeps`, `bathroom`, `inventory_class`).
- **Vocabulary**: exactly `"shareable"` or `"single_party"` — anything else fails the file load loudly (`validateUnitShareability`). Omitting the key, or an explicit `""`, both mean "not yet curated."
- **Scope**: only meaningful on a family_pool leaf (`is_container: false`). It is read but ignored on a container row (classifies from `is_container` alone) and on a `staff_default` row (always `single_party`) — no need to set it there.
- Per D17: the 30 leaves that should carry `"shareable"` are the two main cabin rows (13 each) and units 1–4 of the village area.

The same schema notes are now in `docs/reference/lodging-registry.md`, which is where whoever curates the file will look.

## Added during review

- `sleeps` came off `ShareabilityDriftInput` and off `UnitAmenityFieldset`'s props. Retiring the leaf comparison left it an input nothing read on any leg, still threaded down from `LodgingUnitForm`; removing it makes the retirement structural rather than a comment.
- The second form-level drift test pinned nothing — at `shareable` + sleeps 15 the retired rule agreed, so it stayed green with the derivation reinstated. It now drives `single_party` + sleeps 15, the case the retired rule warned on.
- `pb_migrations/1500000145`'s header carried a SUPERSEDED banner: it still stated the leaf leg as live and claimed the two implementations agree. Comment only — the migration is applied and its behaviour is untouched.

Closes #2331.

