### PR TITLE
feat(sync): route four live 2026 App-* staff-application fields to columns

### DIFF
--- a/frontend/src/types/pocketbase-types.ts
+++ b/frontend/src/types/pocketbase-types.ts
@@ -1596,9 +1596,12 @@ export type StaffApplicationsRecord = {
   favorite_camper_moment?: string
   how_look_at_camp?: string
   id: string
+  jedi_new_staff?: string
+  jedi_returner?: string
   jewish_community?: string
   languages?: string
   last_summer_learned?: string
+  over_18?: boolean
   over_21?: boolean
   person_id: number
   position_pref_1?: string
@@ -1624,6 +1627,7 @@ export type StaffApplicationsRecord = {
   why_work_again?: string
   wish_knew?: string
   work_dates_driver?: string
+  work_dates_kitchen_supervisor?: boolean
   work_dates_supervisor?: string
   work_dates_wild?: string
   work_expectations?: string

--- a/pocketbase/main_test_parallelism_test.go
+++ b/pocketbase/main_test_parallelism_test.go
@@ -165,6 +165,7 @@ var serialGroups = []struct {
 			"TestLoadPersonCustomValuesCountsAndLogsUnmappedFields",
 			"TestLoadPersonCustomValuesNoDiscardsMeansNoWarnAppLog",
 			"TestLoadPersonCustomValuesNoDiscardsMeansNoWarnLog",
+			"TestLoadPersonCustomValuesRoutesTheFourLive2026FieldsAndDoesNotSkipThem",
 		},
 	},
 	{

--- a/pocketbase/pb_migrations/1500000156_staff_applications_live_2026_fields.js
+++ b/pocketbase/pb_migrations/1500000156_staff_applications_live_2026_fields.js
@@ -1,0 +1,120 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: add four columns to staff_applications for the App-* fields
+ * that are new in 2026 and currently route to no column. kindred#2271.
+ *
+ * kindred#2271 originally decided against adding columns for the four fields
+ * still receiving 2026 answers, because nothing downstream read
+ * staff_applications. The owner reversed that call 2026-08-14 for these four
+ * specifically (see #2271) -- Go routing lands in the same PR that adds
+ * pocketbase/sync/staff_applications.go.
+ *
+ * Measured against the production snapshot (all-persons, all-years counts):
+ *   App-over 18                              294 values, 2 distinct (Yes x293, No x1)
+ *   App-Work Camp Dates Kitchen Supervisor    15 values, 2 distinct (Yes x10, No x5)
+ *   App-JEDIreturner                         157 values, 153 distinct free-text, maxlen 1535
+ *   App-JEDInewstaff                         140 values, 136 distinct free-text, maxlen 1129
+ *
+ * over_18 and work_dates_kitchen_supervisor are BOOL, parsed via the same
+ * parseStaffAppBool helper that already converts App-Over 21 -> over_21.
+ *
+ * INTENTIONAL DIVERGENCE: the sibling family work_dates_supervisor,
+ * work_dates_driver and work_dates_wild are all TEXT despite also holding
+ * only Yes/No values. The owner ruled work_dates_kitchen_supervisor BOOLEAN
+ * anyway -- this is a deliberate decision for the new column, not a
+ * retroactive correction, and the three existing siblings are left
+ * untouched.
+ *
+ * jedi_returner and jedi_new_staff are TEXT, max 5000 -- matching the top of
+ * the existing free-text range in 1500000046_staff_applications.js (e.g.
+ * qualifications, why_tawonga, three_rules, autobiography). Both easily
+ * clear the measured max lengths (1535 and 1129). App-Working Across
+ * Differences ran 2024-2025 and stopped; JEDIreturner/JEDInewstaff are its
+ * 2026-only replacement, split into returner and new-staff variants of the
+ * same question -- not a new topic. The existing working_across_differences
+ * column is untouched.
+ *
+ * NO DATA BACKFILL. All four columns are written by the staff_applications
+ * sync, which runs per year. Until that sync runs for 2026, the columns are
+ * empty, which reads correctly as "not yet extracted".
+ *
+ * PocketBase v0.23 syntax: fields.add(new Field({...})) with properties
+ * DIRECT, not inside options{}. A bare add({...}) silently does nothing.
+ * Every add is guarded so a re-run (or a re-applied migration after
+ * consolidation) is a no-op.
+ */
+
+/**
+ * Adds a field unless the collection already has one by that name.
+ * @param {core.Collection} collection
+ * @param {core.Field} field
+ */
+function addField(collection, field) {
+  if (!collection.fields.getByName(field.name)) {
+    collection.fields.add(field);
+  }
+}
+
+migrate(
+  (app) => {
+    const col = app.findCollectionByNameOrId('staff_applications');
+
+    addField(
+      col,
+      new Field({
+        type: 'bool',
+        name: 'over_18',
+        required: false,
+        presentable: false,
+      })
+    );
+
+    addField(
+      col,
+      new Field({
+        type: 'bool',
+        name: 'work_dates_kitchen_supervisor',
+        required: false,
+        presentable: false,
+      })
+    );
+
+    addField(
+      col,
+      new Field({
+        type: 'text',
+        name: 'jedi_returner',
+        required: false,
+        presentable: false,
+        min: 0,
+        max: 5000,
+        pattern: '',
+      })
+    );
+
+    addField(
+      col,
+      new Field({
+        type: 'text',
+        name: 'jedi_new_staff',
+        required: false,
+        presentable: false,
+        min: 0,
+        max: 5000,
+        pattern: '',
+      })
+    );
+
+    app.save(col);
+  },
+  (app) => {
+    const col = app.findCollectionByNameOrId('staff_applications');
+
+    col.fields.removeByName('over_18');
+    col.fields.removeByName('work_dates_kitchen_supervisor');
+    col.fields.removeByName('jedi_returner');
+    col.fields.removeByName('jedi_new_staff');
+
+    app.save(col);
+  }
+);

--- a/pocketbase/sync/staff_applications.go
+++ b/pocketbase/sync/staff_applications.go
@@ -19,7 +19,7 @@ const serviceNameStaffApplications = "staff_applications"
 // Unique key: (person_id, year) - one record per staff applicant per year
 // Links to: staff
 //
-// Field mapping: 40 App-* prefixed fields covering work availability, qualifications,
+// Field mapping: 44 App-* prefixed fields covering work availability, qualifications,
 // position preferences, essays, references, and reflection prompts.
 type StaffApplicationsSync struct {
 	App            core.App
@@ -132,6 +132,12 @@ type staffApplicationRecord struct {
 	tawongaMakesThink    string
 	adviceWouldGive      string
 	howLookAtCamp        string
+
+	// Live 2026 fields, routed per owner ruling 2026-08-14 (see #2271)
+	over18                     bool
+	workDatesKitchenSupervisor bool
+	jediReturner               string
+	jediNewStaff               string
 }
 
 // Sync executes the staff applications extraction
@@ -260,21 +266,21 @@ func (s *StaffApplicationsSync) loadFieldDefinitions(_ context.Context) (map[str
 //
 // This gate is deliberately wider than the routing switch: it admits 88
 // definitions in the production snapshot, of which MapStaffAppFieldToColumn
-// routes 40. The other 48 are enumerated with a reason each in
+// routes 44. The other 44 are enumerated with a reason each in
 // retiredAppFieldReasons, and loadPersonCustomValues counts and logs every
 // discard rather than dropping it in silence (kindred#2271).
 //
-// The gap is intentional, and the reason it is safe to leave it that way is
-// that no downstream consumer reads staff_applications: `grep -rn
+// The gap is intentional for those 44, and the reason it is safe to leave it
+// that way is that no downstream consumer reads staff_applications: `grep -rn
 // "staff_applications" bunking/ api/` returns no hits, and every frontend
 // reference is sync-admin plumbing (SyncTab.tsx, syncTypes.ts,
 // useRunIndividualSync.ts, useSyncStatusAPI.ts, useSyncCompletionToasts.ts,
 // useStaffApplicationsSync.ts) plus the generated pocketbase-types.ts -- no
 // component reads a column. Nothing may assume that an absent answer here
 // means the applicant did not answer; the source values all survive in
-// person_custom_values. If a reader is ever added that does need to make that
-// assumption, the four fields still receiving 2026 answers (see category G in
-// retiredAppFieldReasons) are the ones that would need columns first.
+// person_custom_values. A former fourth group of 4 fields still receiving
+// 2026 answers was in this bucket too; the owner reversed that call
+// 2026-08-14 (see #2271) and they are routed columns now.
 func isStaffApplicationField(name string) bool {
 	// App-* prefixed fields
 	if strings.HasPrefix(name, "App-") {
@@ -641,19 +647,33 @@ func mapAppFieldToRecord(rec *staffApplicationRecord, fieldName, value string) s
 		if rec.howLookAtCamp == "" {
 			rec.howLookAtCamp = value
 		}
+
+	// Live 2026 fields (kindred#2271, owner ruling 2026-08-14)
+	case "over_18":
+		rec.over18 = parseStaffAppBool(value)
+	case "work_dates_kitchen_supervisor":
+		rec.workDatesKitchenSupervisor = parseStaffAppBool(value)
+	case "jedi_returner":
+		if rec.jediReturner == "" {
+			rec.jediReturner = value
+		}
+	case "jedi_new_staff":
+		if rec.jediNewStaff == "" {
+			rec.jediNewStaff = value
+		}
 	}
 
 	return column
 }
 
-// retiredAppFieldReasons documents the 48 App-*/Position Preference custom
+// retiredAppFieldReasons documents the 44 App-*/Position Preference custom
 // field definitions that MapStaffAppFieldToColumn deliberately has no case
 // for, out of the 88 isStaffApplicationField admits (kindred#2271). A name
 // landing in this map is a closed question, not an oversight; do not add a
 // routing case for one without first checking whether CampMinder actually
 // resumed collecting it.
 //
-// The 48 fall into seven groups, verified against the production snapshot:
+// The 44 fall into six groups, verified against the production snapshot:
 //   - 22 retired-2023 long-form essay prompts. The routing switch already
 //     carries a replacement set of 13 essay prompts, which is the strongest
 //     evidence the drop is deliberate.
@@ -668,12 +688,18 @@ func mapAppFieldToRecord(rec *staffApplicationRecord, fieldName, value string) s
 //   - 2 retired-2025 fields (a "weaknesses" free text, misspelled upstream as
 //     "Weakensses"; a WILD-dates explanation whose companion gate IS mapped).
 //   - 4 never-populated leftovers.
-//   - 4 fields still receiving 2026 answers ("over 18", "JEDIreturner",
-//     "JEDInewstaff", "Work Camp Dates Kitchen Supervisor"). kindred#2271
-//     decided against adding columns for these: nothing downstream reads
-//     staff_applications (`grep -rn "staff_applications" bunking/ api/`
-//     exits 1), and a column empty on every historical row (2017-2025) would
-//     look like data that was lost rather than a question never asked.
+//
+// A former seventh group held the 4 fields still receiving 2026 answers
+// ("over 18", "JEDIreturner", "JEDInewstaff", "Work Camp Dates Kitchen
+// Supervisor"). kindred#2271 originally decided against columns for these on
+// the grounds that nothing downstream read staff_applications. The owner
+// reversed that call 2026-08-14 for these four specifically (see #2271):
+// MapStaffAppFieldToColumn now routes them to over_18, jedi_returner,
+// jedi_new_staff and work_dates_kitchen_supervisor. The sibling family
+// work_dates_supervisor/work_dates_wild/work_dates_driver stays TEXT despite
+// also holding Yes/No -- that inconsistency is deliberate, not an oversight:
+// the owner ruled work_dates_kitchen_supervisor BOOLEAN anyway, and the three
+// existing siblings are left untouched rather than retyped to match.
 var retiredAppFieldReasons = map[string]string{
 	// Retired 2023 essay prompts (22)
 	"App-85th Birthday...":       "retired 2023 essay prompt, no values since 2023",
@@ -731,16 +757,16 @@ var retiredAppFieldReasons = map[string]string{
 	"App-Hobbies/Interests/Skills":  "never populated in any year",
 	"App-Relevant Courses":          "never populated in any year",
 
-	// Live 2026 fields, deliberately not given columns (4). See kindred#2271
-	// in the doc comment above for why: no downstream consumer.
-	"App-over 18":                            "live field, no downstream consumer",
-	"App-JEDIreturner":                       "live field, no downstream consumer",
-	"App-JEDInewstaff":                       "live field, no downstream consumer",
-	"App-Work Camp Dates Kitchen Supervisor": "live field, no downstream consumer",
+	// A former "live 2026 fields, deliberately not given columns" group of 4
+	// lived here. kindred#2271's original call (no downstream consumer) was
+	// reversed by the owner 2026-08-14 for these four specifically -- see
+	// #2271 -- and MapStaffAppFieldToColumn now routes App-over 18,
+	// App-JEDIreturner, App-JEDInewstaff and App-Work Camp Dates Kitchen
+	// Supervisor to real columns instead.
 }
 
 // classifyUnmappedAppFields splits per-field discard counts (fields
-// MapStaffAppFieldToColumn returned "" for) into the 48 names
+// MapStaffAppFieldToColumn returned "" for) into the 44 names
 // retiredAppFieldReasons already explains, and everything else. The second
 // bucket is the one an operator needs to act on: it is either a brand-new
 // CampMinder App-* field with no routing case yet, or a retired field this
@@ -759,7 +785,7 @@ func classifyUnmappedAppFields(counts map[string]int) (known, unexpected map[str
 }
 
 // MapStaffAppFieldToColumn maps CampMinder field names to database column
-// names. 48 App-*/Position Preference definitions are deliberately absent
+// names. 44 App-*/Position Preference definitions are deliberately absent
 // from this switch -- see retiredAppFieldReasons immediately above for which
 // ones and why.
 func MapStaffAppFieldToColumn(fieldName string) string {
@@ -857,6 +883,16 @@ func MapStaffAppFieldToColumn(fieldName string) string {
 		return "advice_would_give"
 	case "App-How do you look at camp":
 		return "how_look_at_camp"
+
+	// Live 2026 fields (kindred#2271, owner ruling 2026-08-14). See #2271.
+	case "App-over 18":
+		return "over_18"
+	case "App-Work Camp Dates Kitchen Supervisor":
+		return "work_dates_kitchen_supervisor"
+	case "App-JEDIreturner":
+		return "jedi_returner"
+	case "App-JEDInewstaff":
+		return "jedi_new_staff"
 	}
 	return ""
 }
@@ -1001,6 +1037,12 @@ func (s *StaffApplicationsSync) upsertRecords(
 		record.Set("tawonga_makes_think", rec.tawongaMakesThink)
 		record.Set("advice_would_give", rec.adviceWouldGive)
 		record.Set("how_look_at_camp", rec.howLookAtCamp)
+
+		// Live 2026 fields (kindred#2271, owner ruling 2026-08-14)
+		record.Set("over_18", rec.over18)
+		record.Set("work_dates_kitchen_supervisor", rec.workDatesKitchenSupervisor)
+		record.Set("jedi_returner", rec.jediReturner)
+		record.Set("jedi_new_staff", rec.jediNewStaff)
 
 		if err := s.App.Save(record); err != nil {
 			slog.Error("Error saving staff_applications record",

--- a/pocketbase/sync/staff_applications_test.go
+++ b/pocketbase/sync/staff_applications_test.go
@@ -131,6 +131,12 @@ func TestMapAppFieldToColumn(t *testing.T) {
 		{"App-what advice would you", "advice_would_give"},
 		{"App-How do you look at camp", "how_look_at_camp"},
 
+		// Live 2026 fields, routed per owner ruling (see #2271)
+		{"App-over 18", "over_18"},
+		{"App-Work Camp Dates Kitchen Supervisor", "work_dates_kitchen_supervisor"},
+		{"App-JEDIreturner", "jedi_returner"},
+		{"App-JEDInewstaff", "jedi_new_staff"},
+
 		// Unknown field should return empty
 		{"Unknown-Field", ""},
 	}
@@ -249,12 +255,17 @@ func TestStaffApplicationsFieldMapping(t *testing.T) {
 		"tawonga_makes_think",
 		"advice_would_give",
 		"how_look_at_camp",
+		// Live 2026 fields, routed per owner ruling (see #2271)
+		"over_18",
+		"work_dates_kitchen_supervisor",
+		"jedi_returner",
+		"jedi_new_staff",
 	}
 
-	// Verify we have all 40 expected columns (excluding staff, person_id, year, created, updated)
-	// Note: Plan said 39, but actual count from CampMinder fields is 40
-	if len(expectedFields) != 40 {
-		t.Errorf("Expected 40 custom fields, got %d", len(expectedFields))
+	// Verify we have all 44 expected columns (excluding staff, person_id, year, created, updated)
+	// Note: Plan said 39, then 40; four more were routed 2026-08-14 (see #2271)
+	if len(expectedFields) != 44 {
+		t.Errorf("Expected 44 custom fields, got %d", len(expectedFields))
 	}
 
 	// Test each field has a valid CM field mapping back
@@ -334,6 +345,12 @@ func getAppCMFieldForColumn(column string) string {
 		"tawonga_makes_think":    "App-Tawonga makes me think of",
 		"advice_would_give":      "App-what advice would you",
 		"how_look_at_camp":       "App-How do you look at camp",
+
+		// Live 2026 fields, routed per owner ruling (see #2271)
+		"over_18":                       "App-over 18",
+		"work_dates_kitchen_supervisor": "App-Work Camp Dates Kitchen Supervisor",
+		"jedi_returner":                 "App-JEDIreturner",
+		"jedi_new_staff":                "App-JEDInewstaff",
 	}
 
 	return mapping[column]
@@ -426,16 +443,21 @@ func TestStaffApplicationsDeleteOrphansRefusesEmptyComputedSet(t *testing.T) {
 	}
 }
 
-// unroutedAppFieldNames is the 48 App-* / Position Preference field names
+// unroutedAppFieldNames is the 44 App-* / Position Preference field names
 // admitted by isStaffApplicationField that have no case in
 // MapStaffAppFieldToColumn, byte-verified against the production snapshot at
 // kindred#2271: 22 retired-2023 essay prompts, 9 prior-camp-employment-history
 // fields (6 of which carried data through 2023, 3 of which -- the "Previous
 // Camp 3" trio -- never held a value), 5 Reference #2 fields that never held a
 // value (the form only ever collected one reference), 2 other retired-2023
-// gates, 2 retired-2025 fields, 4 never-populated leftovers, and 4 fields
-// still receiving 2026 answers that kindred#2271 decided against adding
-// columns for.
+// gates, 2 retired-2025 fields, and 4 never-populated leftovers.
+//
+// A former Category G held the four fields still receiving 2026 answers
+// ("App-over 18", "App-JEDIreturner", "App-JEDInewstaff", "App-Work Camp
+// Dates Kitchen Supervisor"). kindred#2271 originally decided against columns
+// for them; the owner reversed that call for these four specifically (see
+// #2271), so they are routed by MapStaffAppFieldToColumn now instead of
+// appearing here.
 var unroutedAppFieldNames = []string{
 	// Category A: retired 2023 essay prompts (22)
 	"App-85th Birthday...",
@@ -487,21 +509,16 @@ var unroutedAppFieldNames = []string{
 	"App-Help Meet Goals",
 	"App-Hobbies/Interests/Skills",
 	"App-Relevant Courses",
-	// Category G: live 2026 fields, deliberately not given columns (4)
-	"App-over 18",
-	"App-JEDIreturner",
-	"App-JEDInewstaff",
-	"App-Work Camp Dates Kitchen Supervisor",
 }
 
-// TestRetiredAppFieldReasonsCoversExactlyTheFortyEightUnroutedNames pins
+// TestRetiredAppFieldReasonsCoversExactlyTheFortyFourUnroutedNames pins
 // kindred#2271's inventory: 88 App-*/Position-Preference definitions
-// admitted, 40 routed, 48 with no case in MapStaffAppFieldToColumn. Every one
-// of those 48 must carry an explicit reason in retiredAppFieldReasons, and
+// admitted, 44 routed, 44 with no case in MapStaffAppFieldToColumn. Every one
+// of those 44 must carry an explicit reason in retiredAppFieldReasons, and
 // MapStaffAppFieldToColumn must agree that none of them route anywhere -- or
 // the "known" bucket in classifyUnmappedAppFields would silently swallow a
 // field that actually needs a routing case added.
-func TestRetiredAppFieldReasonsCoversExactlyTheFortyEightUnroutedNames(t *testing.T) {
+func TestRetiredAppFieldReasonsCoversExactlyTheFortyFourUnroutedNames(t *testing.T) {
 	t.Parallel()
 
 	if len(retiredAppFieldReasons) != len(unroutedAppFieldNames) {
@@ -533,16 +550,16 @@ func TestRetiredAppFieldReasonsCoversExactlyTheFortyEightUnroutedNames(t *testin
 func TestClassifyUnmappedAppFields(t *testing.T) {
 	t.Parallel()
 	counts := map[string]int{
-		"App-over 18":             3, // known -- live field, deliberately uncolumned
+		"App-Camp Goals":          3, // known -- retired 2023 essay prompt
 		"App-Space Rocket Camper": 1, // not on any list
 	}
 
 	known, unexpected := classifyUnmappedAppFields(counts)
 
-	if got := known["App-over 18"]; got != 3 {
-		t.Errorf("known[%q] = %d, want 3", "App-over 18", got)
+	if got := known["App-Camp Goals"]; got != 3 {
+		t.Errorf("known[%q] = %d, want 3", "App-Camp Goals", got)
 	}
-	if _, leaked := unexpected["App-over 18"]; leaked {
+	if _, leaked := unexpected["App-Camp Goals"]; leaked {
 		t.Error("a known-unmapped field leaked into the unexpected bucket")
 	}
 	if got := unexpected["App-Space Rocket Camper"]; got != 1 {
@@ -579,9 +596,93 @@ func TestMapAppFieldToRecordReturnsColumnWritten(t *testing.T) {
 
 	t.Run("unmapped field returns empty string and writes nothing", func(t *testing.T) {
 		rec := &staffApplicationRecord{}
-		got := mapAppFieldToRecord(rec, "App-over 18", "Yes")
+		got := mapAppFieldToRecord(rec, "App-Camp Goals", "Yes")
 		if got != "" {
 			t.Errorf("mapAppFieldToRecord returned %q, want \"\"", got)
+		}
+	})
+}
+
+// TestMapAppFieldToRecordRoutesTheFourLive2026Fields pins the owner's
+// 2026-08-14 reversal of kindred#2271's original "no columns" call for these
+// four fields specifically (see #2271). App-over 18 and App-Work Camp Dates
+// Kitchen Supervisor are boolean gates parsed the same way as the existing
+// over_21 column; App-JEDIreturner and App-JEDInewstaff are free text, split
+// returner/new-staff halves of the single retired "App- Working Across
+// Differences" question rather than a new topic.
+func TestMapAppFieldToRecordRoutesTheFourLive2026Fields(t *testing.T) {
+	t.Parallel()
+
+	t.Run("over 18 Yes parses true", func(t *testing.T) {
+		rec := &staffApplicationRecord{}
+		if got := mapAppFieldToRecord(rec, "App-over 18", "Yes"); got != "over_18" {
+			t.Errorf("mapAppFieldToRecord returned %q, want %q", got, "over_18")
+		}
+		if !rec.over18 {
+			t.Error("over18 = false, want true for a Yes value")
+		}
+	})
+
+	t.Run("over 18 No parses false", func(t *testing.T) {
+		rec := &staffApplicationRecord{}
+		if got := mapAppFieldToRecord(rec, "App-over 18", "No"); got != "over_18" {
+			t.Errorf("mapAppFieldToRecord returned %q, want %q", got, "over_18")
+		}
+		if rec.over18 {
+			t.Error("over18 = true, want false for a No value")
+		}
+	})
+
+	t.Run("kitchen supervisor Yes parses true", func(t *testing.T) {
+		rec := &staffApplicationRecord{}
+		got := mapAppFieldToRecord(rec, "App-Work Camp Dates Kitchen Supervisor", "Yes")
+		if got != "work_dates_kitchen_supervisor" {
+			t.Errorf("mapAppFieldToRecord returned %q, want %q", got, "work_dates_kitchen_supervisor")
+		}
+		if !rec.workDatesKitchenSupervisor {
+			t.Error("workDatesKitchenSupervisor = false, want true for a Yes value")
+		}
+	})
+
+	t.Run("kitchen supervisor No parses false", func(t *testing.T) {
+		rec := &staffApplicationRecord{}
+		got := mapAppFieldToRecord(rec, "App-Work Camp Dates Kitchen Supervisor", "No")
+		if got != "work_dates_kitchen_supervisor" {
+			t.Errorf("mapAppFieldToRecord returned %q, want %q", got, "work_dates_kitchen_supervisor")
+		}
+		if rec.workDatesKitchenSupervisor {
+			t.Error("workDatesKitchenSupervisor = true, want false for a No value")
+		}
+	})
+
+	t.Run("JEDI returner free text is written verbatim", func(t *testing.T) {
+		rec := &staffApplicationRecord{}
+		got := mapAppFieldToRecord(rec, "App-JEDIreturner", "a returner's reflection")
+		if got != "jedi_returner" {
+			t.Errorf("mapAppFieldToRecord returned %q, want %q", got, "jedi_returner")
+		}
+		if rec.jediReturner != "a returner's reflection" {
+			t.Errorf("jediReturner = %q, want %q", rec.jediReturner, "a returner's reflection")
+		}
+	})
+
+	t.Run("JEDI new-staff free text is written verbatim", func(t *testing.T) {
+		rec := &staffApplicationRecord{}
+		got := mapAppFieldToRecord(rec, "App-JEDInewstaff", "a new applicant's reflection")
+		if got != "jedi_new_staff" {
+			t.Errorf("mapAppFieldToRecord returned %q, want %q", got, "jedi_new_staff")
+		}
+		if rec.jediNewStaff != "a new applicant's reflection" {
+			t.Errorf("jediNewStaff = %q, want %q", rec.jediNewStaff, "a new applicant's reflection")
+		}
+	})
+
+	t.Run("first-write-wins like every other text column", func(t *testing.T) {
+		rec := &staffApplicationRecord{}
+		mapAppFieldToRecord(rec, "App-JEDIreturner", "first")
+		mapAppFieldToRecord(rec, "App-JEDIreturner", "second")
+		if rec.jediReturner != "first" {
+			t.Errorf("jediReturner = %q, want %q (first write should win)", rec.jediReturner, "first")
 		}
 	})
 }
@@ -699,6 +800,73 @@ func TestLoadPersonCustomValuesNoDiscardsMeansNoWarnAppLog(t *testing.T) {
 	}
 	if logged := logs.String(); logged != "" {
 		t.Errorf("expected no log output when nothing was discarded, got:\n%s", logged)
+	}
+}
+
+// TestLoadPersonCustomValuesRoutesTheFourLive2026FieldsAndDoesNotSkipThem is
+// the end-to-end pin for the owner's reversal on #2271: before this change
+// these four field names had no case in MapStaffAppFieldToColumn, so each one
+// present in a year's person_custom_values counted as a Stats.Skipped
+// discard event. Now all four must land on the record and Stats.Skipped must
+// stay zero.
+func TestLoadPersonCustomValuesRoutesTheFourLive2026FieldsAndDoesNotSkipThem(t *testing.T) {
+	app := newTransportValuesTestApp(t)
+
+	personsCol, err := app.FindCollectionByNameOrId("persons")
+	if err != nil {
+		t.Fatalf("find persons: %v", err)
+	}
+	person := core.NewRecord(personsCol)
+	person.Set("cm_id", 8003)
+	if saveErr := app.Save(person); saveErr != nil {
+		t.Fatalf("save person: %v", saveErr)
+	}
+
+	const year = 2026
+	addPersonCustomValue(t, app, "fd_over18", person.Id, "Yes", year)
+	addPersonCustomValue(t, app, "fd_kitchen", person.Id, "No", year)
+	addPersonCustomValue(t, app, "fd_jedi_returner", person.Id, "a returner reflection", year)
+	addPersonCustomValue(t, app, "fd_jedi_new", person.Id, "a new-staff reflection", year)
+
+	fieldNameMap := map[string]string{
+		"fd_over18":        "App-over 18",
+		"fd_kitchen":       "App-Work Camp Dates Kitchen Supervisor",
+		"fd_jedi_returner": "App-JEDIreturner",
+		"fd_jedi_new":      "App-JEDInewstaff",
+	}
+	personToStaff := map[int]string{8003: "staffpbid3"}
+
+	logs := captureSweepLogs(t)
+
+	s := NewStaffApplicationsSync(app)
+	records, err := s.loadPersonCustomValues(context.Background(), year, fieldNameMap, personToStaff)
+	if err != nil {
+		t.Fatalf("loadPersonCustomValues: %v", err)
+	}
+
+	key := makeStaffAppKey(8003, year)
+	rec, ok := records[key]
+	if !ok {
+		t.Fatalf("no record for key %q; got %d records", key, len(records))
+	}
+	if !rec.over18 {
+		t.Error("over18 = false, want true")
+	}
+	if rec.workDatesKitchenSupervisor {
+		t.Error("workDatesKitchenSupervisor = true, want false")
+	}
+	if rec.jediReturner != "a returner reflection" {
+		t.Errorf("jediReturner = %q, want %q", rec.jediReturner, "a returner reflection")
+	}
+	if rec.jediNewStaff != "a new-staff reflection" {
+		t.Errorf("jediNewStaff = %q, want %q", rec.jediNewStaff, "a new-staff reflection")
+	}
+
+	if s.Stats.Skipped != 0 {
+		t.Errorf("Stats.Skipped = %d, want 0 -- these four fields must no longer be discarded", s.Stats.Skipped)
+	}
+	if logged := logs.String(); logged != "" {
+		t.Errorf("expected no discard log for fields that now route to columns, got:\n%s", logged)
 	}
 }
 

--- a/pocketbase/sync/staff_applications_test.go
+++ b/pocketbase/sync/staff_applications_test.go
@@ -366,10 +366,17 @@ func makeStaffApplicationsKey(personID, year int) string {
 	return makeStaffAppKey(personID, year)
 }
 
-// newStaffApplicationsTestApp builds the one collection deleteOrphans touches.
+// newStaffApplicationsTestApp builds the one collection deleteOrphans touches,
+// plus the four columns added for the live 2026 App-* fields (see #2271) so
+// that TestUpsertRecordsWritesTheFourLive2026Columns can read them back.
+//
 // Like newStaffVehicleTestApp, this fixture is LAXER than production -- it
-// carries only the fields the guard reads -- so a green test here is not
-// evidence that production writes validate.
+// carries only the fields the tests below read, not all 44 routed columns --
+// so a green test here is not evidence that production writes validate. It is
+// evidence that upsertRecords writes THESE columns under THESE names, which is
+// the part nothing else pins: record.Set on a name the collection does not
+// carry is a silent no-op in PocketBase, so a dropped or misspelled setter
+// leaves the whole package green.
 func newStaffApplicationsTestApp(t *testing.T) core.App {
 	t.Helper()
 	app, err := pbtests.NewTestApp()
@@ -382,6 +389,12 @@ func newStaffApplicationsTestApp(t *testing.T) core.App {
 	apps.Fields.Add(&core.TextField{Name: "staff"})
 	apps.Fields.Add(&core.NumberField{Name: "person_id"})
 	apps.Fields.Add(&core.NumberField{Name: "year"})
+	// Live 2026 fields (see #2271). Types mirror
+	// 1500000156_staff_applications_live_2026_fields.js.
+	apps.Fields.Add(&core.BoolField{Name: "over_18"})
+	apps.Fields.Add(&core.BoolField{Name: "work_dates_kitchen_supervisor"})
+	apps.Fields.Add(&core.TextField{Name: "jedi_returner", Max: 5000})
+	apps.Fields.Add(&core.TextField{Name: "jedi_new_staff", Max: 5000})
 	if saveErr := app.Save(apps); saveErr != nil {
 		t.Fatalf("save staff_applications: %v", saveErr)
 	}
@@ -881,6 +894,88 @@ func TestLoadPersonCustomValuesRoutesTheFourLive2026FieldsAndDoesNotSkipThem(t *
 	}
 	if logged := logs.String(); logged != "" {
 		t.Errorf("expected no discard log for fields that now route to columns, got:\n%s", logged)
+	}
+}
+
+// TestUpsertRecordsWritesTheFourLive2026Columns closes the last gap in the
+// #2271 routing chain. Extraction is pinned above (MapStaffAppFieldToColumn ->
+// mapAppFieldToRecord -> loadPersonCustomValues), but the value only becomes
+// data when upsertRecords writes it, and PocketBase's record.Set is a silent
+// no-op for a name the collection does not carry. So a dropped setter, or one
+// whose column name does not match the migration's, produces four columns that
+// are added, populated in memory and never persisted -- with every other test
+// in this package still green. Measured: deleting all four record.Set lines
+// left `go test ./sync/` passing before this test existed.
+//
+// The reciprocal risk this canNOT cover is a Go/migration name disagreement:
+// the fixture declares these column names by hand rather than replaying
+// pb_migrations. CI's Migration Smoke Test + PocketBase types freshness step
+// is what ties the migration's names to the checked-in
+// frontend/src/types/pocketbase-types.ts.
+func TestUpsertRecordsWritesTheFourLive2026Columns(t *testing.T) {
+	t.Parallel()
+
+	const (
+		colOver18            = "over_18"
+		colKitchenSupervisor = "work_dates_kitchen_supervisor"
+		colJediReturner      = "jedi_returner"
+		colJediNewStaff      = "jedi_new_staff"
+
+		wantReturner = "a returner reflection"
+		wantNewStaff = "a new-staff reflection"
+	)
+
+	app := newStaffApplicationsTestApp(t)
+	s := NewStaffApplicationsSync(app)
+
+	const (
+		personID = 9101
+		year     = 2026
+	)
+	records := map[string]*staffApplicationRecord{
+		makeStaffAppKey(personID, year): {
+			personID: personID,
+			year:     year,
+			// over18 true / workDatesKitchenSupervisor false is deliberate: a
+			// setter that never runs leaves a bool column false, so only the
+			// true one proves the write happened. The false one proves the
+			// column is real rather than swallowed as unknown custom data.
+			over18:                     true,
+			workDatesKitchenSupervisor: false,
+			jediReturner:               wantReturner,
+			jediNewStaff:               wantNewStaff,
+		},
+	}
+
+	created, updated, errCount := s.upsertRecords(
+		context.Background(), records, map[string]string{}, year)
+	if errCount != 0 {
+		t.Fatalf("upsertRecords reported %d errors, want 0", errCount)
+	}
+	if created != 1 || updated != 0 {
+		t.Fatalf("created=%d updated=%d, want created=1 updated=0", created, updated)
+	}
+
+	saved, err := app.FindRecordsByFilter("staff_applications", "year = 2026", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query: %v", err)
+	}
+	if len(saved) != 1 {
+		t.Fatalf("%d rows persisted, want 1", len(saved))
+	}
+	rec := saved[0]
+
+	if !rec.GetBool(colOver18) {
+		t.Errorf("%s = false on the persisted row, want true", colOver18)
+	}
+	if rec.GetBool(colKitchenSupervisor) {
+		t.Errorf("%s = true on the persisted row, want false", colKitchenSupervisor)
+	}
+	if got := rec.GetString(colJediReturner); got != wantReturner {
+		t.Errorf("%s = %q, want %q", colJediReturner, got, wantReturner)
+	}
+	if got := rec.GetString(colJediNewStaff); got != wantNewStaff {
+		t.Errorf("%s = %q, want %q", colJediNewStaff, got, wantNewStaff)
 	}
 }
 

--- a/pocketbase/sync/staff_applications_test.go
+++ b/pocketbase/sync/staff_applications_test.go
@@ -613,10 +613,24 @@ func TestMapAppFieldToRecordReturnsColumnWritten(t *testing.T) {
 func TestMapAppFieldToRecordRoutesTheFourLive2026Fields(t *testing.T) {
 	t.Parallel()
 
+	// Named once and referenced by variable everywhere below, not repeated as
+	// raw literals -- same reasoning as wantColumn in
+	// TestMapAppFieldToRecordReturnsColumnWritten: this file and
+	// staff_applications.go's switch/return/Set already spell each of these
+	// column names three times each, so a second raw literal per name here
+	// trips goconst (min-occurrences: 3).
+	const (
+		colOver18             = "over_18"
+		colKitchenSupervisor  = "work_dates_kitchen_supervisor"
+		colJediReturner       = "jedi_returner"
+		colJediNewStaff       = "jedi_new_staff"
+		fieldJediReturnerName = "App-JEDIreturner"
+	)
+
 	t.Run("over 18 Yes parses true", func(t *testing.T) {
 		rec := &staffApplicationRecord{}
-		if got := mapAppFieldToRecord(rec, "App-over 18", "Yes"); got != "over_18" {
-			t.Errorf("mapAppFieldToRecord returned %q, want %q", got, "over_18")
+		if got := mapAppFieldToRecord(rec, "App-over 18", "Yes"); got != colOver18 {
+			t.Errorf("mapAppFieldToRecord returned %q, want %q", got, colOver18)
 		}
 		if !rec.over18 {
 			t.Error("over18 = false, want true for a Yes value")
@@ -625,8 +639,8 @@ func TestMapAppFieldToRecordRoutesTheFourLive2026Fields(t *testing.T) {
 
 	t.Run("over 18 No parses false", func(t *testing.T) {
 		rec := &staffApplicationRecord{}
-		if got := mapAppFieldToRecord(rec, "App-over 18", "No"); got != "over_18" {
-			t.Errorf("mapAppFieldToRecord returned %q, want %q", got, "over_18")
+		if got := mapAppFieldToRecord(rec, "App-over 18", "No"); got != colOver18 {
+			t.Errorf("mapAppFieldToRecord returned %q, want %q", got, colOver18)
 		}
 		if rec.over18 {
 			t.Error("over18 = true, want false for a No value")
@@ -636,8 +650,8 @@ func TestMapAppFieldToRecordRoutesTheFourLive2026Fields(t *testing.T) {
 	t.Run("kitchen supervisor Yes parses true", func(t *testing.T) {
 		rec := &staffApplicationRecord{}
 		got := mapAppFieldToRecord(rec, "App-Work Camp Dates Kitchen Supervisor", "Yes")
-		if got != "work_dates_kitchen_supervisor" {
-			t.Errorf("mapAppFieldToRecord returned %q, want %q", got, "work_dates_kitchen_supervisor")
+		if got != colKitchenSupervisor {
+			t.Errorf("mapAppFieldToRecord returned %q, want %q", got, colKitchenSupervisor)
 		}
 		if !rec.workDatesKitchenSupervisor {
 			t.Error("workDatesKitchenSupervisor = false, want true for a Yes value")
@@ -647,8 +661,8 @@ func TestMapAppFieldToRecordRoutesTheFourLive2026Fields(t *testing.T) {
 	t.Run("kitchen supervisor No parses false", func(t *testing.T) {
 		rec := &staffApplicationRecord{}
 		got := mapAppFieldToRecord(rec, "App-Work Camp Dates Kitchen Supervisor", "No")
-		if got != "work_dates_kitchen_supervisor" {
-			t.Errorf("mapAppFieldToRecord returned %q, want %q", got, "work_dates_kitchen_supervisor")
+		if got != colKitchenSupervisor {
+			t.Errorf("mapAppFieldToRecord returned %q, want %q", got, colKitchenSupervisor)
 		}
 		if rec.workDatesKitchenSupervisor {
 			t.Error("workDatesKitchenSupervisor = true, want false for a No value")
@@ -657,9 +671,9 @@ func TestMapAppFieldToRecordRoutesTheFourLive2026Fields(t *testing.T) {
 
 	t.Run("JEDI returner free text is written verbatim", func(t *testing.T) {
 		rec := &staffApplicationRecord{}
-		got := mapAppFieldToRecord(rec, "App-JEDIreturner", "a returner's reflection")
-		if got != "jedi_returner" {
-			t.Errorf("mapAppFieldToRecord returned %q, want %q", got, "jedi_returner")
+		got := mapAppFieldToRecord(rec, fieldJediReturnerName, "a returner's reflection")
+		if got != colJediReturner {
+			t.Errorf("mapAppFieldToRecord returned %q, want %q", got, colJediReturner)
 		}
 		if rec.jediReturner != "a returner's reflection" {
 			t.Errorf("jediReturner = %q, want %q", rec.jediReturner, "a returner's reflection")
@@ -669,8 +683,8 @@ func TestMapAppFieldToRecordRoutesTheFourLive2026Fields(t *testing.T) {
 	t.Run("JEDI new-staff free text is written verbatim", func(t *testing.T) {
 		rec := &staffApplicationRecord{}
 		got := mapAppFieldToRecord(rec, "App-JEDInewstaff", "a new applicant's reflection")
-		if got != "jedi_new_staff" {
-			t.Errorf("mapAppFieldToRecord returned %q, want %q", got, "jedi_new_staff")
+		if got != colJediNewStaff {
+			t.Errorf("mapAppFieldToRecord returned %q, want %q", got, colJediNewStaff)
 		}
 		if rec.jediNewStaff != "a new applicant's reflection" {
 			t.Errorf("jediNewStaff = %q, want %q", rec.jediNewStaff, "a new applicant's reflection")
@@ -679,8 +693,8 @@ func TestMapAppFieldToRecordRoutesTheFourLive2026Fields(t *testing.T) {
 
 	t.Run("first-write-wins like every other text column", func(t *testing.T) {
 		rec := &staffApplicationRecord{}
-		mapAppFieldToRecord(rec, "App-JEDIreturner", "first")
-		mapAppFieldToRecord(rec, "App-JEDIreturner", "second")
+		mapAppFieldToRecord(rec, fieldJediReturnerName, "first")
+		mapAppFieldToRecord(rec, fieldJediReturnerName, "second")
 		if rec.jediReturner != "first" {
 			t.Errorf("jediReturner = %q, want %q (first write should win)", rec.jediReturner, "first")
 		}


### PR DESCRIPTION
## What

Adds four columns to `staff_applications` for the App-* fields new in 2026 that currently route to no column. See #2271.

kindred#2271 shipped a fix that documents 48 App-*/Position Preference CampMinder field definitions with no routing case, including four still receiving 2026 answers, and originally decided against columns for those four specifically because nothing downstream read `staff_applications`. The owner has now ruled the other way for these four:

| CampMinder field name (exact) | new column | type | evidence (measured) |
|---|---|---|---|
| `App-over 18` | `over_18` | **bool** | 2 distinct values: Yes x293, No x1 |
| `App-Work Camp Dates Kitchen Supervisor` | `work_dates_kitchen_supervisor` | **bool** | 2 distinct: Yes x10, No x5 |
| `App-JEDIreturner` | `jedi_returner` | **text, max 5000** | 153 distinct free-text, maxlen 1535 |
| `App-JEDInewstaff` | `jedi_new_staff` | **text, max 5000** | 136 distinct free-text, maxlen 1129 |

Issue #2271 was already closed by the owner on 2026-08-14, before this branch existed; this PR is follow-on work and deliberately registers no closing reference. The 44 other discarded App-* definitions catalogued there are untouched here.

## Precedents followed

- **Booleans** use the same `parseStaffAppBool` helper that already converts `App-Over 21` -> `over_21`.
- **Intentional divergence, stated explicitly rather than left to look like an oversight:** the sibling family `work_dates_supervisor`, `work_dates_driver`, `work_dates_wild` are all TEXT despite holding only Yes/No. The owner ruled the new `work_dates_kitchen_supervisor` column **boolean** anyway. The three existing siblings are left untouched -- this PR does not retype them to match.
- **JEDI pair is a split, not a new topic.** `App- Working Across Differences` ran 2024-2025 (272 values) and stopped; `App-JEDIreturner` (157 values) and `App-JEDInewstaff` (140 values) are 2026-only and read as that same question split into returner/new-staff variants. The existing `working_across_differences` column is untouched.

## What changed

1. **Migration** `pocketbase/pb_migrations/1500000156_staff_applications_live_2026_fields.js` -- adds the four columns to the existing `staff_applications` collection. `1500000155` is the `bunk_assignments` grain migration from #2350, merged to main as `c3e3eb43`, so this lands at `1500000156`. Text columns get an explicit `max: 5000`, matching the top of the existing range in `1500000046_staff_applications.js` (e.g. `qualifications`, `why_tawonga`, `three_rules`). Verified by an actual PocketBase boot against a scratch DB copy, both `up` (columns land with the right types/limits) and `down` (columns drop cleanly) -- not inferred from a green `go test`.
2. **`pocketbase/sync/staff_applications.go`** -- struct fields, the extraction `switch` in `mapAppFieldToRecord`, `MapStaffAppFieldToColumn`, and the record setters in `upsertRecords`. The four are removed from `retiredAppFieldReasons`, so the discard-log/`Stats.Skipped` path from #2271 no longer counts them; the doc comments' "48 unrouted" figures are updated to 44 throughout.
3. **`frontend/src/types/pocketbase-types.ts`** -- regenerated via `npm run generate-types` against a scratch DB with the new migration applied (the checked-in `pocketbase/pb_data/data.db` is a large snapshot and was never written to). Diff is exactly the four new fields, no formatting churn.
4. **Tests** -- extraction routes each of the four fields to its column, the two booleans parse Yes -> true / No -> false, and the four no longer count toward `Stats.Skipped` or the discard log, driven through the real production entry points (`MapStaffAppFieldToColumn`, `mapAppFieldToRecord`, `loadPersonCustomValues`), not a re-implementation. Mutation-checked: inverting the `over_18` bool parse and mis-routing `App-JEDIreturner` both turned tests red before the fix was restored. Added during adversarial review: `TestUpsertRecordsWritesTheFourLive2026Columns` drives `upsertRecords` and reads the four columns back off the saved row. It was needed because PocketBase's `record.Set` is a silent no-op for a column name the collection does not carry -- measured, deleting all four `record.Set` lines left `go test ./sync/` entirely green, so the write half of the chain pinned nothing. That test is mutation-checked twice: deleting the four setters, and misspelling one setter's column name, each turn it red.

## What this deliberately does NOT do

- Does not add columns for the other 44 discarded App-* definitions (12 never populated, 32 retired before 2026) -- out of scope, no backfill needed since extraction is per-year.
- Does not retype the existing `work_dates_supervisor`/`work_dates_driver`/`work_dates_wild` text columns to match the new boolean.
- Does not touch `working_across_differences`.
- No data backfill -- all four columns are written by the `staff_applications` sync, which runs per year; a 2026 re-sync fills them.

## Test plan

- [x] `cd pocketbase && go test ./sync/...` -- full package green, including new/mutation-checked tests (`pocketbase/` is its own Go module, so the path must be relative to it)
- [x] `go build ./...`, `gofmt -l .`, `go vet ./...` clean
- [x] Actual PocketBase boot against a scratch DB: migration `up` produces the four columns with correct types/limits, `down` reverts cleanly
- [x] `npm run generate-types` diff reviewed -- exactly the four new fields
- [ ] CI Summary

see #2271

