### PR TITLE
fix(graph): scope last-year bunk history to eligible session types in the query

### DIFF
--- a/bunking/graph/social_graph_builder.py
+++ b/bunking/graph/social_graph_builder.py
@@ -45,6 +45,15 @@ def filter_to_enrolled(member_cm_ids: list[int], enrolled_cm_ids: set[int]) -> l
     return [cm_id for cm_id in member_cm_ids if cm_id in enrolled_cm_ids]
 
 
+# Session types eligible to populate a bunk-graph node's last-year history
+# (`last_year_session`/`last_year_bunk`). Deliberately NOT the same set as
+# `VALID_BUNKING_SESSION_TYPES` (which excludes "taste") -- that constant
+# scopes a different check (staff-enrollment rescue, #1791) with different
+# requirements. Keep these in sync only if a future change means they should
+# actually mean the same thing; today they don't.
+LAST_YEAR_HISTORY_SESSION_TYPES = ("main", "taste", "embedded", "ag")
+
+
 @dataclass
 class SocialEdge:
     """Represents a relationship between two campers"""
@@ -336,25 +345,60 @@ class SocialGraphBuilder:
                 last_year_bunk = None
                 last_year = year - 1  # bind before inner try so except handler can reference it
                 try:
-                    # Query bunk_assignments with expanded relations
+                    # Push the session-type filter INTO the query, so the
+                    # database returns only eligible rows for (person, year)
+                    # rather than an ARBITRARY row that then gets a post-hoc
+                    # type check in Python. The old code fetched whichever row
+                    # get_first_list_item happened to return first and only
+                    # THEN checked its type -- so a person who held BOTH a
+                    # family-camp row AND a main-session row last year could
+                    # have the family row win the pick, fail the type check,
+                    # and silently lose their real main-session history
+                    # (indistinguishable from "no history at all", since both
+                    # land in this file's `except`/no-op path). #2350 widened
+                    # bunk_assignments' write key so a person can hold MORE
+                    # rows per year than before, raising the odds an arbitrary
+                    # pick returns the wrong one (see #2259, #2358).
+                    #
+                    # `session` is a single-select relation (maxSelect=1), so
+                    # dot-notation into `session.session_type` reaches the
+                    # related row's field directly -- same pattern already
+                    # used by `_enrolled_member_cm_ids` above against
+                    # `attendees`. Verified against the local dev DB: with the
+                    # unfiltered (old) query, a real person/year pair returned
+                    # a "family" row first; with this filter added, the same
+                    # pair returns only the "main" row.
+                    #
+                    # `sort: "id"` breaks ties deterministically for the rarer
+                    # case where more than one ELIGIBLE row exists for the
+                    # year (e.g. two main-session assignments) -- same
+                    # STABLE_SORT convention as `api/routers/scenarios.py` /
+                    # `api/services/lodging_repository.py`: the PocketBase
+                    # record id is stable and indexed, so repeated queries
+                    # return the same row instead of depending on SQLite's
+                    # unordered LIMIT/OFFSET result order.
+                    type_clause = " || ".join(f'session.session_type = "{t}"' for t in LAST_YEAR_HISTORY_SESSION_TYPES)
                     historical = self.pb.collection(BUNK_ASSIGNMENTS).get_first_list_item(
-                        f"person.cm_id = {person_cm_id} && year = {last_year}", query_params={"expand": "session,bunk"}
+                        f"person.cm_id = {person_cm_id} && year = {last_year} && ({type_clause})",
+                        query_params={"expand": "session,bunk", "sort": "id"},
                     )
                     # Access expanded data safely
                     expand = getattr(historical, "expand", {}) or {}
                     session_data = get_session_from_expand(historical)
                     bunk_data = expand.get("bunk")
 
-                    # Only include if it's a valid session type
-                    session_type = getattr(session_data, "session_type", None) if session_data else None
-                    if session_type in ["main", "taste", "embedded", "ag"]:
-                        last_year_session = getattr(session_data, "name", None) if session_data else None
-                        last_year_bunk = getattr(bunk_data, "name", None) if bunk_data else None
-                        logger.debug(
-                            f"Found {last_year} history for {person_cm_id}: {last_year_session} - {last_year_bunk}"
-                        )
+                    # The query already scoped this to an eligible session
+                    # type, so the returned row (if any) is always usable.
+                    last_year_session = getattr(session_data, "name", None) if session_data else None
+                    last_year_bunk = getattr(bunk_data, "name", None) if bunk_data else None
+                    logger.debug(
+                        f"Found {last_year} history for {person_cm_id}: {last_year_session} - {last_year_bunk}"
+                    )
                 except Exception as e:
-                    # No historical data is fine
+                    # No eligible historical data is fine -- either no row at
+                    # all for (person, year), or the person's only row(s) that
+                    # year were a non-eligible type (e.g. family camp), which
+                    # the query above already excluded.
                     logger.debug(f"No historical data for {person_cm_id} in {last_year}: {e}")
 
                 # Add node with attributes

--- a/tests/unit/bunking/graph/test_last_year_history_type_filter.py
+++ b/tests/unit/bunking/graph/test_last_year_history_type_filter.py
@@ -1,0 +1,143 @@
+"""Last-year bunk history must be scoped to eligible session types in the
+QUERY, not filtered after an arbitrary pick (see #2259, #2358).
+
+``build_bunk_graph`` looks up each member's PRIOR-year ``bunk_assignments``
+row to populate the ``last_year_session``/``last_year_bunk`` node attributes.
+The lookup used to call ``get_first_list_item`` with no session-type filter --
+an ARBITRARY row for ``(person, year)`` -- and only THEN check in Python
+whether its session type was eligible ("main", "taste", "embedded", "ag"). A
+person who held BOTH a family-camp row AND a main-session row for the prior
+year could have the family row win the arbitrary pick, fail the type check,
+and lose their real main-session history entirely -- silently, since "row
+found but wrong type" and "no row at all" both leave the attributes ``None``.
+
+#2350 widened ``bunk_assignments``' write key so a person can hold MORE rows
+per year than before, raising the odds an arbitrary, unfiltered pick returns
+the wrong one.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from bunking.graph.social_graph_builder import SocialGraphBuilder
+
+CAMPER_ID = 1001
+BUNK_CM_ID, SESSION_CM_ID, YEAR = 555, 999, 2026
+
+
+def _assignment(person_cm_id: int) -> SimpleNamespace:
+    return SimpleNamespace(expand=SimpleNamespace(person=SimpleNamespace(cm_id=person_cm_id)))
+
+
+def _person(cm_id: int, first_name: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        cm_id=cm_id,
+        first_name=first_name,
+        last_name="Example",
+        grade=7,
+        gender="F",
+        age=12,
+        family_id=None,
+    )
+
+
+def _historical_row(session_type: str, session_name: str, bunk_name: str, record_id: str) -> SimpleNamespace:
+    """A bunk_assignments row as PocketBase actually returns it: ``expand`` is
+    a dict keyed by relation name (matching real client behavior -- see
+    ``expand.get("bunk")`` in the production code under test)."""
+    return SimpleNamespace(
+        id=record_id,
+        expand={
+            "session": SimpleNamespace(session_type=session_type, name=session_name),
+            "bunk": SimpleNamespace(name=bunk_name),
+        },
+    )
+
+
+def _pb_with_last_year_rows(rows: list[SimpleNamespace]) -> MagicMock:
+    """Build a mock PB whose BUNK_ASSIGNMENTS historical lookup behaves like a
+    real database: it returns the row whose session_type is named in the
+    caller's filter string, when the filter names one. When the filter names
+    none (the pre-fix, unfiltered query), it falls back to returning the
+    first row in ``rows`` -- an arbitrary pick, standing in for whatever order
+    SQLite happens to return without an explicit sort."""
+
+    def _collection_side_effect(name: str) -> MagicMock:
+        col = MagicMock()
+        if name == "bunk_assignments":
+            col.get_full_list.side_effect = lambda *_a, **_kw: [_assignment(CAMPER_ID)]
+
+            def _get_first(filt: str, **_kw: object) -> SimpleNamespace:
+                if "session.session_type" in filt:
+                    # Filtered (new) query: behave like a real DB -- return
+                    # only a row whose type clause is actually in the filter,
+                    # else nothing matched.
+                    for row in rows:
+                        clause = f'session.session_type = "{row.expand["session"].session_type}"'
+                        if clause in filt:
+                            return row
+                    raise Exception("404 not found")
+                # Unfiltered (old, pre-fix) query: arbitrary pick -- stands in
+                # for whatever order SQLite returns without an explicit sort.
+                if rows:
+                    return rows[0]
+                raise Exception("404 not found")
+
+            col.get_first_list_item.side_effect = _get_first
+        elif name == "attendees":
+            col.get_full_list.return_value = [SimpleNamespace(person_id=CAMPER_ID)]
+        elif name == "bunk_requests":
+            col.get_full_list.return_value = []
+        elif name == "persons":
+            col.get_first_list_item.return_value = _person(CAMPER_ID, "Emma")
+        else:
+            col.get_full_list.return_value = []
+            col.get_first_list_item.side_effect = RuntimeError("no record")
+        return col
+
+    pb = MagicMock()
+    pb.collection.side_effect = _collection_side_effect
+    return pb
+
+
+def test_last_year_history_prefers_main_over_family_row() -> None:
+    """A person with a family-camp row AND a main-session row for last year
+    must yield the MAIN bunk/session -- not lose history to the family row
+    just because it happened to be the arbitrary pick."""
+    family_row = _historical_row("family", "Family Weekend", "Cabin F", "aaa00000000001")
+    main_row = _historical_row("main", "Session 2", "Cabin B-3", "bbb00000000002")
+    pb = _pb_with_last_year_rows([family_row, main_row])
+
+    graph = SocialGraphBuilder(pb=pb).build_bunk_graph(year=YEAR, bunk_cm_id=BUNK_CM_ID, session_cm_id=SESSION_CM_ID)
+
+    node = graph.nodes[CAMPER_ID]
+    assert node["last_year_session"] == "Session 2"
+    assert node["last_year_bunk"] == "Cabin B-3"
+
+
+def test_last_year_history_still_works_with_a_single_eligible_row() -> None:
+    """The overwhelming-majority case -- exactly one eligible row -- must be
+    unaffected by pushing the type filter into the query."""
+    main_row = _historical_row("main", "Session 1", "Cabin A-1", "ccc00000000003")
+    pb = _pb_with_last_year_rows([main_row])
+
+    graph = SocialGraphBuilder(pb=pb).build_bunk_graph(year=YEAR, bunk_cm_id=BUNK_CM_ID, session_cm_id=SESSION_CM_ID)
+
+    node = graph.nodes[CAMPER_ID]
+    assert node["last_year_session"] == "Session 1"
+    assert node["last_year_bunk"] == "Cabin A-1"
+
+
+def test_last_year_history_none_when_only_ineligible_rows_exist() -> None:
+    """A person whose only prior-year row is a non-eligible type (e.g. family
+    camp) must still get ``None`` attributes -- same end result as before,
+    just reached via the query returning nothing rather than a post-hoc
+    Python check."""
+    family_row = _historical_row("family", "Family Weekend", "Cabin F", "ddd00000000004")
+    pb = _pb_with_last_year_rows([family_row])
+
+    graph = SocialGraphBuilder(pb=pb).build_bunk_graph(year=YEAR, bunk_cm_id=BUNK_CM_ID, session_cm_id=SESSION_CM_ID)
+
+    node = graph.nodes[CAMPER_ID]
+    assert node["last_year_session"] is None
+    assert node["last_year_bunk"] is None


### PR DESCRIPTION
> **Correction (post-merge scan, 2026-08-14).** The "**796 person-year pairs**"
> figure below is wrong; on the same 14,402-row snapshot the real count is
> **322**. Re-measured by full scan: 322 pairs hold both a `main` and a `family`
> row, 411 hold an eligible row and a `family` row, 646 hold an eligible and an
> ineligible row. No reading of the data reaches 796. The **545** figure in the
> same section is correct, and the fix itself verifies clean — see the scan
> comment on this PR for the full old-vs-new replay. The squash commit message
> in `main` still carries the original number and cannot be corrected without
> rewriting history.

## What

`build_bunk_graph`'s prior-year history lookup fetched an ARBITRARY row for `(person, year)` from `bunk_assignments` — no session-type filter — and only THEN checked in Python whether the row's session type was eligible (`main`/`taste`/`embedded`/`ag`). A person who held BOTH a family-camp row and a main-session row for the prior year could have the family row win that arbitrary pick, fail the type check, and silently lose their real main-session bunk history: "wrong type" and "no row at all" both leave `last_year_session`/`last_year_bunk` as `None`, so nothing distinguished the two cases.

kindred#2350 (merged today) widened `bunk_assignments`' write key so a person can now hold more rows per year than before, raising the odds an arbitrary, unfiltered pick returns the wrong one.

## Fix

Push the session-type filter into the query via PocketBase's relation dot-notation (`session.session_type = "..."`), the same pattern already used a few lines above by `_enrolled_member_cm_ids` against `attendees`. The database now returns only eligible rows, instead of the caller filtering after an arbitrary pick.

The eligible type set (`main`, `taste`, `embedded`, `ag`) is **unchanged** — same four types as before, pulled into a new `LAST_YEAR_HISTORY_SESSION_TYPES` module constant. It's deliberately kept distinct from sync's `VALID_BUNKING_SESSION_TYPES` (which excludes `"taste"`), since that constant scopes a different, unrelated check (#1791 staff-enrollment rescue).

For the rarer case where more than one *eligible* row exists for a person-year (e.g. two main-session assignments in the same year), the query now adds `sort: "id"` to pick deterministically — same `STABLE_SORT` convention already used by `api/routers/scenarios.py` and `api/services/lodging_repository.py`: the PocketBase record id is stable and indexed, so repeated queries return the same row instead of depending on SQLite's unordered `LIMIT`/`OFFSET` result order.

## How I verified the filter

Ran it against the local dev DB's seeded snapshot (14,402 `bunk_assignments` rows):

- **322 person-year pairs** hold both a `main` row and a `family` row for the same year (this line originally read 796 — see the correction note at the top). For one such pair, the *old* unfiltered query (`person.cm_id = X && year = Y`) returned the `family` row first; the *new* filtered query (`... && (session.session_type = "main" || ...)`) returned only the `main` row — confirming the relation dot-notation reaches the expanded `session` record's field correctly.
- **545 person-year pairs** hold more than one *eligible* row (mostly two `main`-session assignments in the same year). Confirmed the `sort: "id"` tie-break returns the same row across three repeated queries against one such pair.

## What I deliberately did NOT do

- Did **not** change which session types are eligible — still exactly `main`/`taste`/`embedded`/`ag`.
- Did **not** touch `VALID_BUNKING_SESSION_TYPES` or `_enrolled_member_cm_ids` — different constant, different check, already correct.
- Did **not** change behavior for the overwhelming-majority case (exactly one eligible row) — a test pins that this stays identical.
- Did **not** add a redundant Python-side type check after the fetch — the query already guarantees eligibility, so re-checking would be dead code.

## Tests

New file `tests/unit/bunking/graph/test_last_year_history_type_filter.py`:
- `test_last_year_history_prefers_main_over_family_row` — the defect-reproducing case (family row must not win over main). Written first, confirmed RED against the pre-fix code, then GREEN after the fix. Mutation-checked: reverting only the implementation (`git stash` on the source file, keeping the test as-is) reproduces the RED failure.
- `test_last_year_history_still_works_with_a_single_eligible_row` — the majority case is unaffected.
- `test_last_year_history_none_when_only_ineligible_rows_exist` — zero-eligible-rows still yields `None`/`None`, same end result as before via a different code path.

```
uv run pytest tests/unit/bunking/graph/ tests/unit/bunking/test_bunk_graph_staff_exclusion.py tests/unit/sync/test_networkx_integration.py -q
# 139 passed

bash scripts/pre-push-verify.sh
# ruff, mypy, api-types-freshness, full pytest (6310 passed, 41 skipped) — ALL CHECKS PASSED
```

This PR does not close any issue — it's a defect found during #2259 review. See #2259, #2358.

