### PR TITLE
fix(sync): count a failed App.Delete as Stats.Errors at ten orphan-sweep sites

### DIFF
--- a/pocketbase/sync/bunk_requests.go
+++ b/pocketbase/sync/bunk_requests.go
@@ -382,6 +382,7 @@ func (s *BunkRequestsSync) purgeOrphanedRequests(year int) (map[int]bool, error)
 		for _, obr := range obrsByPerson[cmID] {
 			if err := s.App.Delete(obr); err != nil {
 				slog.Error("Failed to delete orphaned OBR", "person_cm_id", cmID, "error", err)
+				s.Stats.Errors++
 				continue
 			}
 			totalOBRs++
@@ -400,6 +401,7 @@ func (s *BunkRequestsSync) purgeOrphanedRequests(year int) (map[int]bool, error)
 		for _, br := range brs {
 			if err := s.App.Delete(br); err != nil {
 				slog.Error("Failed to delete orphaned BR", "person_cm_id", cmID, "error", err)
+				s.Stats.Errors++
 				continue
 			}
 			totalBRs++
@@ -476,6 +478,7 @@ func (s *BunkRequestsSync) purgeZombieBRs(year int, obrPersonIDs map[int]bool) e
 		for _, br := range brsByRequester[cmID] {
 			if err := s.App.Delete(br); err != nil {
 				slog.Error("Failed to delete zombie BR", "requester_cm_id", cmID, "error", err)
+				s.Stats.Errors++
 				continue
 			}
 			totalBRs++

--- a/pocketbase/sync/camper_dietary.go
+++ b/pocketbase/sync/camper_dietary.go
@@ -661,6 +661,7 @@ func (s *CamperDietarySync) deleteOrphans(
 
 			if err := s.App.Delete(record); err != nil {
 				slog.Error("Error deleting orphan record", "id", recordID, "error", err)
+				s.Stats.Errors++
 				continue
 			}
 			deleted++

--- a/pocketbase/sync/camper_transportation.go
+++ b/pocketbase/sync/camper_transportation.go
@@ -867,6 +867,7 @@ func (s *CamperTransportationSync) deleteOrphans(
 
 			if err := s.App.Delete(record); err != nil {
 				slog.Error("Error deleting orphan record", "id", recordID, "error", err)
+				s.Stats.Errors++
 				continue
 			}
 			deleted++

--- a/pocketbase/sync/delete_orphans_counts_errors_test.go
+++ b/pocketbase/sync/delete_orphans_counts_errors_test.go
@@ -1,0 +1,149 @@
+package sync
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// TestPerServiceDeleteOrphansCountsBlockedDeletesAsErrors pins the convention
+// settled by kindred#2284/#2285/#2296 and shipped for base_sync.go's shared
+// sweep by PR #2341 (kindred#2302): a delete that FAILS must increment
+// Stats.Errors, not just get logged. kindred#2347 found ten per-service sites
+// that logged the failure, `continue`d, and left the counter untouched, so a
+// run that failed to delete a row still reported success.
+//
+// One case per representative service is enough to pin the shape -- see
+// kindred#2347's "one test per file is overkill" note -- rather than
+// duplicating this across all eight files it touches. camper_dietary and
+// quest_registrations cover the simple map[string]string existing-set shape;
+// household_demographics covers the composite-key shape.
+func TestPerServiceDeleteOrphansCountsBlockedDeletesAsErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("camper_dietary", func(t *testing.T) {
+		t.Parallel()
+		app := newOrphanSweepTestApp(t, "camper_dietary", "person_id")
+		col, err := app.FindCollectionByNameOrId("camper_dietary")
+		if err != nil {
+			t.Fatalf("find camper_dietary: %v", err)
+		}
+		orphan := core.NewRecord(col)
+		orphan.Set("person_id", 8002)
+		orphan.Set("year", 2026)
+		if saveErr := app.Save(orphan); saveErr != nil {
+			t.Fatalf("save orphan: %v", saveErr)
+		}
+		blockDeleteWithRequiredRelation(t, app, col, orphan.Id)
+
+		s := NewCamperDietarySync(app)
+		s.SyncSuccessful = true
+		records := map[string]*camperDietaryRecord{
+			makeCamperDietaryKey(8001, 2026): {personID: 8001, year: 2026},
+		}
+		existing := map[string]string{makeCamperDietaryKey(8002, 2026): orphan.Id}
+
+		deleted, err := s.deleteOrphans(context.Background(), records, existing, 2026)
+		if err != nil {
+			t.Fatalf("deleteOrphans: %v", err)
+		}
+		if deleted != 0 {
+			t.Errorf("deleted = %d, want 0 -- the delete was blocked", deleted)
+		}
+		if s.Stats.Errors != 1 {
+			t.Errorf("Stats.Errors = %d, want 1 -- a blocked delete must count as a failure", s.Stats.Errors)
+		}
+	})
+
+	t.Run("quest_registrations", func(t *testing.T) {
+		t.Parallel()
+		app := newOrphanSweepTestApp(t, "quest_registrations", "person_id")
+		col, err := app.FindCollectionByNameOrId("quest_registrations")
+		if err != nil {
+			t.Fatalf("find quest_registrations: %v", err)
+		}
+		orphan := core.NewRecord(col)
+		orphan.Set("person_id", 9002)
+		orphan.Set("year", 2026)
+		if saveErr := app.Save(orphan); saveErr != nil {
+			t.Fatalf("save orphan: %v", saveErr)
+		}
+		blockDeleteWithRequiredRelation(t, app, col, orphan.Id)
+
+		s := NewQuestRegistrationsSync(app)
+		s.SyncSuccessful = true
+		records := map[string]*questRegistrationRecord{
+			makeQuestRegistrationKey(9001, 2026): {personID: 9001, year: 2026},
+		}
+		existing := map[string]string{makeQuestRegistrationKey(9002, 2026): orphan.Id}
+
+		deleted, err := s.deleteOrphans(context.Background(), records, existing, 2026)
+		if err != nil {
+			t.Fatalf("deleteOrphans: %v", err)
+		}
+		if deleted != 0 {
+			t.Errorf("deleted = %d, want 0 -- the delete was blocked", deleted)
+		}
+		if s.Stats.Errors != 1 {
+			t.Errorf("Stats.Errors = %d, want 1 -- a blocked delete must count as a failure", s.Stats.Errors)
+		}
+	})
+
+	t.Run("household_demographics", func(t *testing.T) {
+		t.Parallel()
+		app := newOrphanSweepTestApp(t, "household_demographics", "household", "person_id")
+		col, err := app.FindCollectionByNameOrId("household_demographics")
+		if err != nil {
+			t.Fatalf("find household_demographics: %v", err)
+		}
+		orphan := core.NewRecord(col)
+		orphan.Set("household", "hh_fixed")
+		orphan.Set("person_id", 2)
+		orphan.Set("year", 2026)
+		if saveErr := app.Save(orphan); saveErr != nil {
+			t.Fatalf("save orphan: %v", saveErr)
+		}
+		blockDeleteWithRequiredRelation(t, app, col, orphan.Id)
+
+		s := NewHouseholdDemographicsSync(app)
+		s.SyncSuccessful = true
+		records := map[string]*householdDemographicsRecord{
+			MakeCompositeKey("hh_fixed", 1, 2026): {householdPBID: "hh_fixed", personCMID: 1, year: 2026},
+		}
+		existing := map[string]string{MakeCompositeKey("hh_fixed", 2, 2026): orphan.Id}
+
+		deleted, err := s.deleteOrphans(context.Background(), records, existing, 2026)
+		if err != nil {
+			t.Fatalf("deleteOrphans: %v", err)
+		}
+		if deleted != 0 {
+			t.Errorf("deleted = %d, want 0 -- the delete was blocked", deleted)
+		}
+		if s.Stats.Errors != 1 {
+			t.Errorf("Stats.Errors = %d, want 1 -- a blocked delete must count as a failure", s.Stats.Errors)
+		}
+	})
+}
+
+// blockDeleteWithRequiredRelation adds a collection holding a required,
+// non-cascading relation into `collection` and points it at `targetID`, so
+// App.Delete(targetID) fails for real rather than via a mock. Modeled on
+// TestBaseDeleteOrphansCountsOnlyCompletedDeletes in orphan_sweep_test.go.
+func blockDeleteWithRequiredRelation(t *testing.T, app core.App, collection *core.Collection, targetID string) {
+	t.Helper()
+
+	holders := core.NewBaseCollection(collection.Name + "_holders")
+	holders.Fields.Add(&core.RelationField{
+		Name: "target", CollectionId: collection.Id, CascadeDelete: false, Required: true,
+	})
+	if err := app.Save(holders); err != nil {
+		t.Fatalf("save %s_holders: %v", collection.Name, err)
+	}
+
+	holder := core.NewRecord(holders)
+	holder.Set("target", targetID)
+	if err := app.Save(holder); err != nil {
+		t.Fatalf("seed holder for %s: %v", collection.Name, err)
+	}
+}

--- a/pocketbase/sync/household_demographics.go
+++ b/pocketbase/sync/household_demographics.go
@@ -1012,6 +1012,7 @@ func (s *HouseholdDemographicsSync) deleteOrphans(
 
 			if err := s.App.Delete(record); err != nil {
 				slog.Error("Error deleting orphan record", "id", recordID, "error", err)
+				s.Stats.Errors++
 				continue
 			}
 			deleted++

--- a/pocketbase/sync/persons.go
+++ b/pocketbase/sync/persons.go
@@ -396,11 +396,28 @@ func (s *PersonsSync) updateRelationsAndCleanup(
 		slog.Warn("Failed to update person-household relations", "error", err)
 	}
 
+	// COUNT rather than propagate, decided deliberately per kindred#2347 rather
+	// than left as the slog.Warn that reached nothing. This function has no error
+	// return, and giving it one would abort the rest of Sync -- the household
+	// stats, the data-quality summary and updateAttendeeRelations -- on a sweep
+	// problem that has already left the data intact.
+	//
+	// One caveat, recorded so the next reader does not think it was overlooked:
+	// deleteOrphans returns the collapse guard's REFUSAL as well as real query
+	// failures, and household_demographics.go's deleteOrphans doc argues a refusal
+	// is not an infrastructure failure and must not be counted (kindred#2293).
+	// That argument rests on the refusal already reaching the operator as the error
+	// Sync() returns, which is true there and false here. So it is counted, and the
+	// refusal's own message -- thresholds, ratio and hint -- is preserved in the
+	// Error log line below; only the run's summary string generalises to
+	// "N database operations failed".
 	if err := s.deleteOrphans(year); err != nil {
 		slog.Error("Failed to delete orphaned persons", "error", err)
 		s.Stats.Errors++
 	}
 
+	// deleteHouseholdOrphans has no guard, so its error is only ever a real query
+	// failure; the caveat above does not apply to this one.
 	if err := s.deleteHouseholdOrphans(year, processedHouseholdIDs); err != nil {
 		slog.Error("Failed to delete orphaned households", "error", err)
 		s.Stats.Errors++

--- a/pocketbase/sync/persons.go
+++ b/pocketbase/sync/persons.go
@@ -397,11 +397,13 @@ func (s *PersonsSync) updateRelationsAndCleanup(
 	}
 
 	if err := s.deleteOrphans(year); err != nil {
-		slog.Warn("Failed to delete orphaned persons", "error", err)
+		slog.Error("Failed to delete orphaned persons", "error", err)
+		s.Stats.Errors++
 	}
 
 	if err := s.deleteHouseholdOrphans(year, processedHouseholdIDs); err != nil {
-		slog.Warn("Failed to delete orphaned households", "error", err)
+		slog.Error("Failed to delete orphaned households", "error", err)
+		s.Stats.Errors++
 	}
 
 	if err := s.ForceWALCheckpoint(); err != nil {
@@ -1610,6 +1612,7 @@ func (s *PersonsSync) deleteHouseholdOrphans(year int, processedIDs map[int]bool
 		if !processedIDs[int(cmID)] {
 			if err := s.App.Delete(record); err != nil {
 				slog.Error("Error deleting orphaned household", "cm_id", int(cmID), "error", err)
+				s.Stats.Errors++
 			} else {
 				deleted++
 			}

--- a/pocketbase/sync/persons_delete_orphans_wrapper_test.go
+++ b/pocketbase/sync/persons_delete_orphans_wrapper_test.go
@@ -1,0 +1,120 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+)
+
+// The tests in this file pin kindred#2347's persons.go correction: the two
+// updateRelationsAndCleanup call sites downgraded a real error from
+// deleteOrphans / deleteHouseholdOrphans to slog.Warn and dropped it, so a
+// query failure that aborted the sweep never touched Stats.Errors and the
+// persons run still reported success. Each site is forced to fail by omitting
+// the collection its query targets -- a real error from a real PocketBase
+// call, not a mock.
+
+// newMinimalPersonsTestApp returns a test app with only a "persons"
+// collection, holding the fields the two queries this file drives touch:
+// `year` (the sweep's filter) and the three relation-shaped fields
+// updatePersonHouseholdRelations filters on. No "households" collection.
+func newMinimalPersonsTestApp(t *testing.T) core.App {
+	t.Helper()
+
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	col := core.NewBaseCollection("persons")
+	col.Fields.Add(&core.NumberField{Name: "cm_id"})
+	col.Fields.Add(&core.NumberField{Name: "year"})
+	for _, f := range []string{"household", "primary_childhood_household", "alternate_childhood_household"} {
+		col.Fields.Add(&core.TextField{Name: f})
+	}
+	if saveErr := app.Save(col); saveErr != nil {
+		t.Fatalf("save persons: %v", saveErr)
+	}
+
+	return app
+}
+
+// TestUpdateRelationsAndCleanupCountsHouseholdSweepFailure drives
+// updateRelationsAndCleanup with a "persons" collection but no "households"
+// collection, so deleteHouseholdOrphans's own query fails for real
+// (FindRecordsByFilter against a collection that does not exist).
+func TestUpdateRelationsAndCleanupCountsHouseholdSweepFailure(t *testing.T) {
+	t.Parallel()
+
+	app := newMinimalPersonsTestApp(t)
+	s := &PersonsSync{BaseSyncService: BaseSyncService{
+		App:            app,
+		ProcessedKeys:  map[string]bool{},
+		SyncSuccessful: true,
+	}}
+
+	s.updateRelationsAndCleanup(2026, map[int]*core.Record{}, map[int]personHouseholdIDs{}, map[int]bool{})
+
+	if s.Stats.Errors != 1 {
+		t.Errorf("Stats.Errors = %d, want 1 -- deleteHouseholdOrphans's query failed for real "+
+			"and must not be downgraded to a Warn that reaches nothing", s.Stats.Errors)
+	}
+}
+
+// TestUpdateRelationsAndCleanupCountsPersonSweepFailure drives
+// updateRelationsAndCleanup with a "households" collection but no "persons"
+// collection, so deleteOrphans's underlying scan fails for real (the shared
+// base_sync.go sweep queries "persons", which does not exist).
+func TestUpdateRelationsAndCleanupCountsPersonSweepFailure(t *testing.T) {
+	t.Parallel()
+
+	app := newHouseholdsTestApp(t) // defined in orphan_rejection_test.go; no "persons" collection
+	s := &PersonsSync{BaseSyncService: BaseSyncService{
+		App:            app,
+		ProcessedKeys:  map[string]bool{},
+		SyncSuccessful: true,
+	}}
+
+	s.updateRelationsAndCleanup(2026, map[int]*core.Record{}, map[int]personHouseholdIDs{}, map[int]bool{})
+
+	if s.Stats.Errors != 1 {
+		t.Errorf("Stats.Errors = %d, want 1 -- deleteOrphans's scan failed for real "+
+			"and must not be downgraded to a Warn that reaches nothing", s.Stats.Errors)
+	}
+}
+
+// TestDeleteHouseholdOrphansCountsBlockedDeleteAsError drives the household
+// sweep's own delete loop (persons.go's deleteHouseholdOrphans), not the
+// wrapper -- a blocked App.Delete must increment Stats.Errors even though the
+// function still returns nil (the row is a genuine orphan; only the delete
+// failed). Same blocking mechanism as
+// TestPerServiceDeleteOrphansCountsBlockedDeletesAsErrors.
+func TestDeleteHouseholdOrphansCountsBlockedDeleteAsError(t *testing.T) {
+	t.Parallel()
+
+	app := newHouseholdsTestApp(t)
+	col, err := app.FindCollectionByNameOrId("households")
+	if err != nil {
+		t.Fatalf("find households: %v", err)
+	}
+
+	seedHousehold(t, app, 900, 2026) // a genuine orphan -- not in processedIDs below
+	orphan, findErr := app.FindFirstRecordByFilter("households", "cm_id = 900")
+	if findErr != nil {
+		t.Fatalf("find seeded household: %v", findErr)
+	}
+	blockDeleteWithRequiredRelation(t, app, col, orphan.Id)
+
+	s := &PersonsSync{BaseSyncService: BaseSyncService{App: app}}
+
+	if err := s.deleteHouseholdOrphans(2026, map[int]bool{}); err != nil {
+		t.Fatalf("deleteHouseholdOrphans: %v", err)
+	}
+
+	if s.Stats.Errors != 1 {
+		t.Errorf("Stats.Errors = %d, want 1 -- a blocked household delete must count as a failure",
+			s.Stats.Errors)
+	}
+}

--- a/pocketbase/sync/quest_registrations.go
+++ b/pocketbase/sync/quest_registrations.go
@@ -1154,6 +1154,7 @@ func (s *QuestRegistrationsSync) deleteOrphans(
 
 			if err := s.App.Delete(record); err != nil {
 				slog.Error("Error deleting orphan record", "id", recordID, "error", err)
+				s.Stats.Errors++
 				continue
 			}
 			deleted++

--- a/pocketbase/sync/staff_applications.go
+++ b/pocketbase/sync/staff_applications.go
@@ -1112,6 +1112,7 @@ func (s *StaffApplicationsSync) deleteOrphans(
 
 			if err := s.App.Delete(record); err != nil {
 				slog.Error("Error deleting orphan record", "id", recordID, "error", err)
+				s.Stats.Errors++
 				continue
 			}
 			deleted++

--- a/pocketbase/sync/staff_vehicle_info.go
+++ b/pocketbase/sync/staff_vehicle_info.go
@@ -703,6 +703,7 @@ func (s *StaffVehicleInfoSync) deleteOrphans(
 
 			if err := s.App.Delete(record); err != nil {
 				slog.Error("Error deleting orphan record", "id", recordID, "error", err)
+				s.Stats.Errors++
 				continue
 			}
 			deleted++


### PR DESCRIPTION
## Defect

Ten orphan/cleanup delete sites in `pocketbase/sync/*.go` logged a failed
`App.Delete` and `continue`d **without touching `Stats.Errors`** — so a run
that failed to delete a row still reported success. Two adjacent
`persons.go` wrapper sites made the persons half of this invisible: they
downgraded a real error from `deleteOrphans`/`deleteHouseholdOrphans` to
`slog.Warn` and dropped it.

Re-verified against `main` @ `dc176747` (no PRs merged since the campaign
launched): the denominator and 9/1/10 split reproduced exactly. Every line
number was re-derived fresh from `grep` rather than trusted from the issue
body — `staff_applications.go` in particular had moved from :896 to :1113
since the issue was corrected, on top of two same-day PRs (#2355, #2361) that
grew that file after the correction landed.

## Fix

`log, Stats.Errors++, continue` — the shape kindred#2284/#2285/#2296 settled
and PR #2341 (kindred#2302) shipped for the shared `base_sync.go` sweep.
Applied at:

- `bunk_requests.go` (three sites: orphaned OBR, orphaned BR, zombie BR)
- `camper_dietary.go`, `camper_transportation.go`, `household_demographics.go`,
  `quest_registrations.go`, `staff_applications.go`, `staff_vehicle_info.go`
  (one site each, all the identical `FindRecordById` → `App.Delete` shape)
- `persons.go`'s `deleteHouseholdOrphans` delete loop (the one hand-rolled
  sweep in this set)
- `persons.go`'s `updateRelationsAndCleanup` wrapper: both the
  `deleteOrphans(year)` and `deleteHouseholdOrphans(...)` call sites now log
  at `Error` and increment `Stats.Errors` instead of warning into nothing.

**Which services can realistically hit this** (the issue's Scope item 4).
PocketBase blocks a delete when some other row holds a `required` relation to
it with `cascadeDelete: false` — that is the mechanism the tests below use, and
in practice the only one short of a SQLite-level failure. No such relation
exists anywhere in this schema: every `required: true` relation into the ten
swept collections (`persons`, `households`, `bunk_requests`,
`original_bunk_requests`, `camper_dietary`, `camper_transportation`,
`household_demographics`, `quest_registrations`, `staff_applications`,
`staff_vehicle_info`) also sets `cascadeDelete: true`, and no `OnRecordDelete`
hook is bound to any of them (the only two are on the lodging units/aliases
collections). Verified against the applied schema in `_collections` and
cross-checked against `pb_migrations/`.

So these ten increments should fire only on a genuine local failure — a locked
or failing SQLite write — which is exactly what `Stats.Errors` is for. **A
currently-green run can still start failing, and that is the point of the fix**;
the point of this paragraph is that the schema gives no reason to expect it
routinely.

## Tests

TDD: each fix has a test that fails red against the pre-fix code and passes
green after.

- `delete_orphans_counts_errors_test.go` — new test with one subtest per
  representative service (three of them; not a literal Go table, because each
  service's computed-set and existing-set types differ) (`camper_dietary`, `quest_registrations`,
  `household_demographics`, covering both the simple `map[string]string`
  existing-set shape and the composite-key shape) that blocks a delete with a
  required non-cascading relation (same mechanism as
  `TestBaseDeleteOrphansCountsOnlyCompletedDeletes` in `orphan_sweep_test.go`)
  and asserts `Stats.Errors == 1`.
- `persons_delete_orphans_wrapper_test.go` — three tests: the
  `deleteHouseholdOrphans` delete-loop fix directly (blocked delete), and the
  two `updateRelationsAndCleanup` wrapper sites independently, each forced to
  fail via a real missing-collection query error (not a mock).

Per the issue's own note, one test per file is overkill since the shape is
identical everywhere — `bunk_requests.go`, `camper_transportation.go`,
`staff_applications.go`, and `staff_vehicle_info.go` get the mechanical fix
without a dedicated fixture test.

## Deliberately not done

- `base_sync.go` — already carries this fix (PR #2341) and is explicitly out
  of scope per the issue's "Why it is filed rather than folded into PR #2341"
  section.
- `normalize_geographic.go`, `orchestrator.go`, `api.go` — owned by an
  in-flight PR removing `camper_history`; not touched.
- Any change to which services get swept, guard thresholds, or rejection
  handling — this PR is only the missing counter increment.

Closes #2347.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Failed orphan-record deletions are now accurately counted as sync errors.
  - Person and household cleanup failures are logged at error level for improved visibility.
  - Sync statistics now consistently reflect blocked or unsuccessful cleanup operations.

- **Tests**
  - Added coverage for failed orphan deletions across dietary, registration, demographic, person, and household records.
  - Added validation for cleanup failures involving required relationships and composite keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
