### PR TITLE
fix(frontend): guard the board's conflict warning against two-unit alias double-counting

### DIFF
--- a/docs/reference/lodging-registry.md
+++ b/docs/reference/lodging-registry.md
@@ -257,6 +257,42 @@ a threshold no leaf in the inventory reaches, so every leaf came out
 Like every other field here, the loader is create-if-absent, so the key reaches
 **new rows only** — see the section below.
 
+### A multi-unit alias is ambiguous, not automatically a share (kindred#2339)
+
+`member_units` with 2+ codes denotes a merge — **one** household occupying
+every named unit at once, a whole-house let. It is not evidence that *every*
+household who ever resolves through that alias occupies all of them: the same
+alias string routinely gets reused by different households, on different
+weekends or in different years, for what is really one unit per household —
+ambiguous only in *which* unit, never confirmed as a shared room.
+
+**The rule:** for H households observed resolving through an alias whose
+`member_units` names N units, `H > N` is the earliest point that is provable
+evidence of over-occupancy. At `H <= N` the households fit one per unit and
+the assignment is ambiguous rather than shared.
+
+Six alias rows in the current registry map one string to two units, matching
+this shape. A consumer that credits an occupancy count to every member unit
+for every household resolving through the alias, without applying `H > N`,
+overstates multi-family occupancy — one building's apparent 18 multi-household
+occupancies collapsed to 2 once the `H <= N` cases were excluded.
+
+**Audited consumers**, in case a new one is added:
+
+- The PocketBase loader (`seedAliases`) and the sync-time resolver
+  (`AliasResolver.Resolve`) never tally occupancy across households — the
+  first writes the table, the second resolves one household's own placement —
+  so `H > N` does not apply to either.
+- The sync ingest (`LodgingAssignmentsSync.placementFor`) writes an alias's
+  full member set onto one household's own `lodging_assignments.units` row,
+  deliberately unjudged by design (see "Where enforcement belongs" in
+  `docs/architecture/lodging-occupancy.md`). It is the source of the ambiguous
+  data, not itself an occupancy count.
+- The weekend board's conflict warning (`overlappingPartyKeys` in
+  `frontend/src/components/weekend/boardLayout.ts`) **is** an occupancy count,
+  and needed the guard: two households resolving to the same alias are no
+  longer read as sharing a room with each other while `H <= N`.
+
 ### `max_beds` is not `sleeps`, and neither may overwrite the other
 
 `max_beds` is the total number of sleeping spots in the room. `sleeps` is the

--- a/docs/reference/lodging-registry.md
+++ b/docs/reference/lodging-registry.md
@@ -271,8 +271,12 @@ ambiguous only in *which* unit, never confirmed as a shared room.
 evidence of over-occupancy. At `H <= N` the households fit one per unit and
 the assignment is ambiguous rather than shared.
 
-Six alias rows in the current registry map one string to two units, matching
-this shape. A consumer that credits an occupancy count to every member unit
+Eight alias rows in the current registry map one string to two units, matching
+this shape — seven of them valid for 2026, the eighth expired after 2024.
+(kindred#2339's prose says "six"; that was a miscount of its own by-shape
+enumeration, which described only six of the eight. The issue's other figure,
+"8 alias strings resolve to more than one unit", is the one that matches the
+registry file.) A consumer that credits an occupancy count to every member unit
 for every household resolving through the alias, without applying `H > N`,
 overstates multi-family occupancy — one building's apparent 18 multi-household
 occupancies collapsed to 2 once the `H <= N` cases were excluded.

--- a/frontend/src/components/weekend/boardLayout.test.ts
+++ b/frontend/src/components/weekend/boardLayout.test.ts
@@ -1608,10 +1608,11 @@ describe('overlappingPartyKeys — a two-unit alias is ambiguous, not a confirme
   })
 
   it('still flags an alias household against a household confirmed in one of its rooms', () => {
-    // The ambiguous pair covers `alpha` alone here (H == N == 1 signature
-    // member for `alpha`'s own set is irrelevant -- what matters is `beta` is
-    // NOT in the same signature group, so the pair is never ambiguous between
-    // them), and `beta`'s single-leaf placement is a confirmed claim on `r1`.
+    // `alpha`'s own signature group has H = 1 household claiming its N = 2
+    // codes -- ambiguous on its own, but irrelevant here, because `beta` is
+    // NOT in that same signature group (`beta` names one code, not two), so
+    // the pair between them is never treated as ambiguous. `beta`'s
+    // single-leaf placement is a confirmed claim on `r1`.
     const alpha = party({ household_cm_id: 500001, unit_code: '', unit_codes: ['r1', 'r2'] })
     const beta = party({ household_cm_id: 500002, unit_code: 'r1', unit_codes: ['r1'] })
     expect(overlappingPartyKeys([alpha, beta], twoUnitAlias)).toEqual(

--- a/frontend/src/components/weekend/boardLayout.test.ts
+++ b/frontend/src/components/weekend/boardLayout.test.ts
@@ -20,6 +20,7 @@ import {
   areaTokens,
   buildBoard,
   countBoardSlots,
+  overlappingPartyKeys,
   partySize,
   SHARE_WORDING,
   slotOccupancy,
@@ -1568,5 +1569,53 @@ describe("wholeBuildingHolders — #2008's placement marker, keyed by party", ()
   it('never marks a party alone in a freestanding room with no registry parent', () => {
     const alpha = party({ household_cm_id: 500001, unit_code: 'cedar-1', unit_codes: ['cedar-1'] })
     expect(wholeBuildingHolders([alpha], [unit()]).size).toBe(0)
+  })
+})
+
+describe('overlappingPartyKeys — a two-unit alias is ambiguous, not a confirmed share (kindred#2339)', () => {
+  // A `lodging_unit_aliases` row mapping one alias string to TWO units writes
+  // BOTH member codes onto every household that resolves through it
+  // (`lodging_assignments_sync.go`'s `placementFor` records the alias's own
+  // member set verbatim, deliberately unjudged). Two DIFFERENT households
+  // independently resolving through the same alias then each claim the
+  // identical two-code set -- which reads exactly like a shared room unless
+  // this is guarded, even though the honest state is "one per unit,
+  // unconfirmed which". The rule: H households on an N-unit alias is only
+  // evidence of a real double-booking once H > N.
+  const twoUnitAlias = [unit({ unit_id: 'u1', code: 'r1' }), unit({ unit_id: 'u2', code: 'r2' })]
+
+  it('does not flag two households who each resolved to the same two-unit alias (H == N)', () => {
+    const alpha = party({ household_cm_id: 500001, unit_code: '', unit_codes: ['r1', 'r2'] })
+    const beta = party({ household_cm_id: 500002, unit_code: '', unit_codes: ['r1', 'r2'] })
+    expect(overlappingPartyKeys([alpha, beta], twoUnitAlias).size).toBe(0)
+  })
+
+  it('flags all three once a two-unit alias is claimed by a third household (H > N)', () => {
+    const alpha = party({ household_cm_id: 500001, unit_code: '', unit_codes: ['r1', 'r2'] })
+    const beta = party({ household_cm_id: 500002, unit_code: '', unit_codes: ['r1', 'r2'] })
+    const gamma = party({ household_cm_id: 500003, unit_code: '', unit_codes: ['r1', 'r2'] })
+    expect(overlappingPartyKeys([alpha, beta, gamma], twoUnitAlias)).toEqual(
+      new Set([partyKey(alpha), partyKey(beta), partyKey(gamma)])
+    )
+  })
+
+  it('still flags a genuine same-room share unrelated to any alias', () => {
+    const alpha = party({ household_cm_id: 500001, unit_code: 'r1', unit_codes: ['r1'] })
+    const beta = party({ household_cm_id: 500002, unit_code: 'r1', unit_codes: ['r1'] })
+    expect(overlappingPartyKeys([alpha, beta], twoUnitAlias)).toEqual(
+      new Set([partyKey(alpha), partyKey(beta)])
+    )
+  })
+
+  it('still flags an alias household against a household confirmed in one of its rooms', () => {
+    // The ambiguous pair covers `alpha` alone here (H == N == 1 signature
+    // member for `alpha`'s own set is irrelevant -- what matters is `beta` is
+    // NOT in the same signature group, so the pair is never ambiguous between
+    // them), and `beta`'s single-leaf placement is a confirmed claim on `r1`.
+    const alpha = party({ household_cm_id: 500001, unit_code: '', unit_codes: ['r1', 'r2'] })
+    const beta = party({ household_cm_id: 500002, unit_code: 'r1', unit_codes: ['r1'] })
+    expect(overlappingPartyKeys([alpha, beta], twoUnitAlias)).toEqual(
+      new Set([partyKey(alpha), partyKey(beta)])
+    )
   })
 })

--- a/frontend/src/components/weekend/boardLayout.test.ts
+++ b/frontend/src/components/weekend/boardLayout.test.ts
@@ -1619,4 +1619,52 @@ describe('overlappingPartyKeys — a two-unit alias is ambiguous, not a confirme
       new Set([partyKey(alpha), partyKey(beta)])
     )
   })
+
+  // Through `buildBoard`, the real entry point the board renders from --
+  // `overlappingPartyKeys` is not what staff see. `consentFlag` reads its
+  // output and `flaggedCount` sums the result, so the amber ring is what the
+  // guard actually silences; a test only on the helper would pass even if the
+  // wiring above it stopped reading the guarded value.
+  function aliasBoard(householdCount: number) {
+    const parties = Array.from({ length: householdCount }, (_, index) =>
+      party({
+        household_cm_id: 500101 + index,
+        display_name: `H${String(index)}`,
+        unit_code: '',
+        unit_name: 'R 1 + R 2',
+        unit_codes: ['r1', 'r2'],
+        // `is_merged_slot` is what makes `buildBoard` DRAW a multi-code
+        // placement instead of railing it as unplaced -- without it this
+        // fixture yields an empty board, which would satisfy the H <= N
+        // assertion below for entirely the wrong reason.
+        is_merged_slot: true,
+        share: {
+          preference: 'unknown',
+          proximity: [],
+          request_text: '',
+          needs_resolution: false,
+          // `declined` is the eligibility that DOES raise the flag once an
+          // overlap is found, so a silent board here is the guard working
+          // rather than the fixture having nothing to report.
+          eligibility: 'declined',
+          eligibility_source: 'form',
+          answers_conflict: false,
+        },
+      })
+    )
+    return buildBoard(parties, twoUnitAlias)
+  }
+
+  it('raises no amber flag on the BOARD for two households on one two-unit alias', () => {
+    const board = aliasBoard(2)
+    expect(board.flaggedCount).toBe(0)
+    expect(board.areas.flatMap((area) => area.slots).map((slot) => slot.consent)).toEqual([
+      null,
+      null,
+    ])
+  })
+
+  it('still raises the board flag once a third household claims the same two units', () => {
+    expect(aliasBoard(3).flaggedCount).toBeGreaterThan(0)
+  })
 })

--- a/frontend/src/components/weekend/boardLayout.test.ts
+++ b/frontend/src/components/weekend/boardLayout.test.ts
@@ -1340,9 +1340,12 @@ describe('buildBoard — consent flag follows leaf overlap, not the card (task-1
   /**
    * A combined container: `house` draws ONE card, and both `r1` and `r2` roll
    * up onto it (the roll-up `indexPayload` already does for a merged
-   * building). Modelled on the real report: two households in Wawona Front
-   * and Wawona Back went unflagged split, then flagged the moment the card
-   * was merged, though nothing about either household changed.
+   * building). Modelled on the real report: two households in the front and
+   * back halves of one combined building went unflagged split, then flagged
+   * the moment the card was merged, though nothing about either household
+   * changed. (Unit named structurally, not literally -- the Lodging Name
+   * Guard drops comments and exempts test files, so a real name here would
+   * never be caught. See the sweep issue for the rest.)
    */
   const combinedHouse = [
     unit({ code: 'house', is_container: true, is_combined: true, sleeps: 8 }),

--- a/frontend/src/components/weekend/boardLayout.ts
+++ b/frontend/src/components/weekend/boardLayout.ts
@@ -582,12 +582,65 @@ function areaSortOrder(unit: LodgingUnitRow): number {
  * party in that building's room. A plain leaf slot is unaffected either way —
  * its parties all name that one leaf code, which expands to itself and
  * trivially overlaps every other party there, exactly as before this existed.
+ *
+ * GUARDS the two-unit-alias case (kindred#2339). A `lodging_unit_aliases` row
+ * mapping one alias string to two-or-more units writes the WHOLE member set
+ * onto every household that resolves through it — `lodging_assignments_sync.go`
+ * (`placementFor`) records an alias's member set verbatim and deliberately does
+ * not judge it (`docs/architecture/lodging-occupancy.md`: that judgement
+ * belongs where a human chooses, not the ingest). Two DIFFERENT households
+ * independently resolving through the SAME alias then each claim the identical
+ * N-code set, which reads exactly like both parties sharing every one of those
+ * rooms unless this is guarded — the rule this function applies (also stated at
+ * `lodging_unit_aliases` and in `docs/reference/lodging-registry.md`): H
+ * households all claiming the same N-unit set is only evidence of a real
+ * double-booking once H exceeds N. At H <= N the assignment is ambiguous — one
+ * household per unit fits, staff just have not said which — and must not read
+ * as a confirmed share. `mergeGroupSignature`/`isAmbiguousMergePair` below
+ * apply this ONLY to a pair drawn from the identical multi-code group; a third
+ * party outside the group sharing one of those same leaves still flags
+ * normally, on either side of the pair — failing permissive is what the rest of
+ * this function already does, and the guard narrows nothing beyond the exact
+ * ambiguous case.
  */
+function mergeGroupSignature(party: RosterPartyRow): string | null {
+  const codes = occupiedCodes(party)
+  // A SINGLE named code (including a container) is one confirmed claim, not a
+  // multi-unit alias resolution, and must never enter this grouping — see
+  // `occupiedCodes`'s own doc comment for why a container name stays as itself.
+  if (codes.length < 2) return null
+  return [...codes].sort().join(' ')
+}
+
 export function overlappingPartyKeys(
   parties: RosterPartyRow[],
   units: LodgingUnitRow[]
 ): Set<string> {
   const unitsByCode = new Map(units.map((unit) => [unit.code, unit]))
+
+  // Group parties by the exact multi-code set they themselves name. A group
+  // no larger than the set it names (H <= N) is the ambiguous alias case;
+  // `isAmbiguousMergePair` below reads this to skip mutual attribution WITHIN
+  // one such group only.
+  const partySignature = new Map<string, string>()
+  const groupMembers = new Map<string, Set<string>>()
+  const groupSize = new Map<string, number>()
+  for (const party of parties) {
+    const signature = mergeGroupSignature(party)
+    if (signature === null) continue
+    const key = partyKey(party)
+    partySignature.set(key, signature)
+    groupSize.set(signature, occupiedCodes(party).length)
+    const members = groupMembers.get(signature) ?? new Set<string>()
+    members.add(key)
+    groupMembers.set(signature, members)
+  }
+  const isAmbiguousMergePair = (keyA: string, keyB: string): boolean => {
+    const signature = partySignature.get(keyA)
+    if (signature === undefined || signature !== partySignature.get(keyB)) return false
+    return (groupMembers.get(signature)?.size ?? 0) <= (groupSize.get(signature) ?? 0)
+  }
+
   const ownersByCode = new Map<string, RosterPartyRow[]>()
   for (const party of parties) {
     for (const code of occupiedLeafCodes(party, units, unitsByCode)) {
@@ -600,7 +653,17 @@ export function overlappingPartyKeys(
   const overlapping = new Set<string>()
   for (const owners of ownersByCode.values()) {
     if (owners.length < 2) continue
-    for (const owner of owners) overlapping.add(partyKey(owner))
+    for (let i = 0; i < owners.length; i++) {
+      const ownerA = owners[i]
+      if (ownerA === undefined) continue
+      for (const ownerB of owners.slice(i + 1)) {
+        const keyA = partyKey(ownerA)
+        const keyB = partyKey(ownerB)
+        if (isAmbiguousMergePair(keyA, keyB)) continue
+        overlapping.add(keyA)
+        overlapping.add(keyB)
+      }
+    }
   }
   return overlapping
 }

--- a/frontend/src/components/weekend/boardLayout.ts
+++ b/frontend/src/components/weekend/boardLayout.ts
@@ -550,6 +550,26 @@ function areaSortOrder(unit: LodgingUnitRow): number {
 }
 
 /**
+ * The exact multi-code set a party names, as a stable grouping key — the input
+ * to `overlappingPartyKeys`'s `H <= N` guard, which is described in full on
+ * that function below.
+ */
+function mergeGroupSignature(party: RosterPartyRow): string | null {
+  const codes = occupiedCodes(party)
+  // A SINGLE named code (including a container) is one confirmed claim, not a
+  // multi-unit alias resolution, and must never enter this grouping — see
+  // `occupiedCodes`'s own doc comment for why a container name stays as itself.
+  if (codes.length < 2) return null
+  // U+0000 joins, never a space: it cannot occur inside a unit code, so two
+  // different code sets can never collide on one signature. Written as the
+  // ESCAPE and never as a raw byte — a literal NUL in the file makes grep
+  // classify this whole source as binary, and
+  // `scripts/dev/verify-no-hardcoded-lodging.sh` passes `-I`, so the lodging
+  // name guard would skip every line of this file without reporting anything.
+  return [...codes].sort().join('\u0000')
+}
+
+/**
  * Which of these parties share an occupied LEAF code with at least one
  * OTHER party in the list — keyed by `partyKey`, the project's one stable
  * identity for a roster party.
@@ -596,22 +616,13 @@ function areaSortOrder(unit: LodgingUnitRow): number {
  * households all claiming the same N-unit set is only evidence of a real
  * double-booking once H exceeds N. At H <= N the assignment is ambiguous — one
  * household per unit fits, staff just have not said which — and must not read
- * as a confirmed share. `mergeGroupSignature`/`isAmbiguousMergePair` below
- * apply this ONLY to a pair drawn from the identical multi-code group; a third
+ * as a confirmed share. `mergeGroupSignature` (above) and
+ * `isAmbiguousMergePair` (inside this function) apply this ONLY to a pair drawn from the identical multi-code group; a third
  * party outside the group sharing one of those same leaves still flags
  * normally, on either side of the pair — failing permissive is what the rest of
  * this function already does, and the guard narrows nothing beyond the exact
  * ambiguous case.
  */
-function mergeGroupSignature(party: RosterPartyRow): string | null {
-  const codes = occupiedCodes(party)
-  // A SINGLE named code (including a container) is one confirmed claim, not a
-  // multi-unit alias resolution, and must never enter this grouping — see
-  // `occupiedCodes`'s own doc comment for why a container name stays as itself.
-  if (codes.length < 2) return null
-  return [...codes].sort().join(' ')
-}
-
 export function overlappingPartyKeys(
   parties: RosterPartyRow[],
   units: LodgingUnitRow[]

--- a/frontend/src/components/weekend/unitBadges.ts
+++ b/frontend/src/components/weekend/unitBadges.ts
@@ -180,8 +180,9 @@ export function shareabilityBadge(unit: LodgingUnitRow): UnitBadge | null {
  * DIFFERENT households independently resolving through the same alias can
  * each claim the identical two-code set without ever having agreed to share
  * either room. `overlappingPartyKeys` guards exactly that: it will not read
- * such a pair as sharing a room with EACH OTHER while their claimed set is no
- * bigger than the number of households claiming it (H <= N). This badge takes
+ * such a pair as sharing a room with EACH OTHER while the number of
+ * households claiming that set is no bigger than the set itself (H <= N).
+ * This badge takes
  * `overlappingParties` as given and needs no guard of its own — it only ever
  * sees the count after that ambiguity has already been resolved upstream.
  *

--- a/frontend/src/components/weekend/unitBadges.ts
+++ b/frontend/src/components/weekend/unitBadges.ts
@@ -175,6 +175,17 @@ export function shareabilityBadge(unit: LodgingUnitRow): UnitBadge | null {
  * container `shareable`, a whole-house let cannot fire this. That is the ruling
  * working, not a gap.
  *
+ * AUDITED against kindred#2339 — a two-unit `lodging_unit_aliases` row writes
+ * its whole member set onto every household that resolves through it, so two
+ * DIFFERENT households independently resolving through the same alias can
+ * each claim the identical two-code set without ever having agreed to share
+ * either room. `overlappingPartyKeys` guards exactly that: it will not read
+ * such a pair as sharing a room with EACH OTHER while their claimed set is no
+ * bigger than the number of households claiming it (H <= N). This badge takes
+ * `overlappingParties` as given and needs no guard of its own — it only ever
+ * sees the count after that ambiguity has already been resolved upstream.
+ *
+
  * Silent on an unclassified unit for the reason the doc gives: a unit nobody
  * has classified has no rule to violate, and nagging there teaches dismissal.
  * This reads the STORED value and re-states the classification rule nowhere —

--- a/frontend/src/components/weekend/unitBadges.ts
+++ b/frontend/src/components/weekend/unitBadges.ts
@@ -182,11 +182,10 @@ export function shareabilityBadge(unit: LodgingUnitRow): UnitBadge | null {
  * either room. `overlappingPartyKeys` guards exactly that: it will not read
  * such a pair as sharing a room with EACH OTHER while the number of
  * households claiming that set is no bigger than the set itself (H <= N).
- * This badge takes
- * `overlappingParties` as given and needs no guard of its own — it only ever
- * sees the count after that ambiguity has already been resolved upstream.
+ * This badge takes `overlappingParties` as given and needs no guard of its
+ * own — it only ever sees the count after that ambiguity has already been
+ * resolved upstream.
  *
-
  * Silent on an unclassified unit for the reason the doc gives: a unit nobody
  * has classified has no rule to violate, and nagging there teaches dismissal.
  * This reads the STORED value and re-states the classification rule nowhere —

--- a/pocketbase/lodging/registry.go
+++ b/pocketbase/lodging/registry.go
@@ -221,6 +221,39 @@ type registryBed struct {
 	Count int    `json:"count"`
 }
 
+// registryAlias is one row of lodging_unit_aliases: a free-text cabin string
+// CampMinder stores, mapped onto one or more current units.
+//
+// MemberUnits with 2+ codes denotes a merge -- ONE household occupying every
+// named unit at once, which is rare and deliberate (a whole-house let). It is
+// NOT evidence that every household who ever resolves through this alias
+// occupies all N units: the same alias string commonly gets reused by
+// DIFFERENT households across different weekends/years for what is really one
+// room per household, ambiguous only in which. kindred#2339's rule for
+// telling the two apart: for H households observed resolving through an
+// N-member alias, H > N is the earliest point over-occupancy is provable --
+// at H <= N, one household per unit fits and nothing says otherwise. A
+// consumer that credits an occupancy count to every member unit for every
+// household resolving through the alias, without applying this H > N test,
+// will overstate multi-family occupancy -- one area's apparent 18
+// multi-household occupancies collapsed to 2 once the H <= N cases were
+// excluded (kindred#2339). `docs/reference/lodging-registry.md` carries the
+// same rule for anyone editing the JSON file directly.
+//
+// Audited consumers (kindred#2339):
+//   - seedAliases (this file) writes the table from the registry file; it does
+//     not count occupancy, so H > N does not apply.
+//   - sync.AliasResolver.Resolve resolves ONE household's own raw cabin
+//     string to its own placement; it never tallies across households, so
+//     H > N does not apply there either.
+//   - sync.LodgingAssignmentsSync.placementFor writes an alias's member set
+//     onto ONE household's own lodging_assignments.units row, unjudged by
+//     design (docs/architecture/lodging-occupancy.md: "Not in the ingest").
+//     It is the source of the ambiguous data, not itself an occupancy count.
+//   - frontend's overlappingPartyKeys (boardLayout.ts) IS an occupancy count
+//     -- the board's own conflict warning -- and is the one that needed the
+//     guard. Fixed there: two households resolving to the same alias are no
+//     longer read as sharing a room with each other while H <= N.
 type registryAlias struct {
 	AliasString string   `json:"alias_string"`
 	MemberUnits []string `json:"member_units"` // unit codes; 2+ denotes a merge


### PR DESCRIPTION
Closes #2339.

## What was wrong

**Eight** `lodging_unit_aliases` rows map one alias string to **two** units
-- eight distinct alias strings, every member a leaf with no children, seven
valid for 2026 and one expired after 2024. (kindred#2339's prose says "six",
which is a miscount of its own by-shape enumeration; the issue's other figure,
"8 alias strings resolve to more than one unit", is the one that matches
`config/lodging_registry.json`. Counted against the file during review.) The
sync ingest (`lodging_assignments_sync.go`'s `placementFor`) writes an
alias's whole member set onto every household that resolves through it —
deliberately, by design (`docs/architecture/lodging-occupancy.md`: the
ingest records what CampMinder holds and does not judge it). But the same
alias string gets reused by *different* households across different
weekends and years, and the weekend board's own conflict warning
(`overlappingPartyKeys` in `boardLayout.ts`) read "two households both claim
this two-unit set" as both of them sharing *every one* of those rooms —
even though the honest state is one household per unit, unconfirmed which.

The missing rule: a string covering N units with H households is only
evidence of over-occupancy once **H > N**. At H ≤ N the households fit one
per unit and the assignment is ambiguous, not shared. One building's
apparent 18 multi-household occupancies collapsed to 2 once this was
excluded.

## The fix

- `overlappingPartyKeys` (`frontend/src/components/weekend/boardLayout.ts`)
  now groups parties by the exact multi-code set they themselves name, and
  skips mutual "sharing a room" attribution *within* one such group only
  when the group is no larger than the set it names (H ≤ N). A third party
  outside the group sharing one of those same leaves still flags normally,
  on either side of the pair — the guard narrows nothing beyond the exact
  ambiguous case. `consentFlag` and `sharingConflictBadge` both inherit the
  fix, since both read this function's output.
- Doc comment on `registryAlias` (`pocketbase/lodging/registry.go`) and a
  new section in `docs/reference/lodging-registry.md` state the H > N rule
  and carry the audit of every `member_units` consumer.

## Audit (acceptance criterion: every consumer, with a verdict)

| Consumer | Expands `member_units` for an occupancy count? | Verdict |
|---|---|---|
| `seedAliases` (registry.go) | No — writes the table from the JSON file | No guard needed |
| `sync.AliasResolver.Resolve` | No — resolves *one* household's own raw string to its own placement, never tallies across households | No guard needed |
| `sync.LodgingAssignmentsSync.placementFor` | Writes the alias's member set onto one household's placement, but is itself unjudged by design | No guard needed — the ambiguity belongs where a human chooses, not the ingest (existing architecture doc) |
| Frontend alias admin CRUD (`LodgingAliasForm.tsx`, `LodgingAliasesPanel.tsx`) | No — edits the mapping itself | No guard needed |
| `overlappingPartyKeys` (board's conflict warning) | Yes — counts distinct parties per leaf across the whole roster | **Needed the guard — fixed here** |

## What I deliberately did not do

- Did not change what `lodging_assignments_sync.go` writes. The ingest
  recording an alias's member set verbatim is correct and documented
  behavior (`docs/architecture/lodging-occupancy.md`); the ambiguity has to
  be resolved by whoever counts occupancy, not by degrading the stored
  fact.
- Did not add a registry flag marking a multi-unit alias as "these are
  separate locations routinely allocated independently" — the issue raises
  it as something to *consider*, not a requirement, and the H > N guard
  already resolves the concrete bug without it. Left for a future call if
  staff want to distinguish a genuine merge from an ambiguous alias more
  explicitly.
- Did not touch `frontend/src/components/weekend/unitBadges.ts` beyond a
  short doc-comment breadcrumb on `sharingConflictBadge` recording the
  audit — it takes `overlappingParties` as a given count and needs no guard
  of its own. Kept deliberately small since #2252 is sequenced behind this
  PR on the same file.

## Testing

TDD: added a failing test (`overlappingPartyKeys` — two households both
resolving to the same two-unit alias — H == N) confirming the current
double-count, ran it RED, implemented the guard, ran it GREEN, then
mutation-checked by disabling the guard and confirming the same test (and
only that test) goes RED again before restoring. Three more cases added
alongside it: H > N still flags all three households; a genuine same-room
share unrelated to any alias still flags; an alias household against a
household confirmed in one of its own rooms still flags.

Two further cases were added during review at `buildBoard`, the entry point
the board actually renders from, because staff never see the helper's Set —
`consentFlag` reads it and `flaggedCount` sums the result, so the amber ring
is what the guard silences. Both mutation-checked in each direction. They also
pin the fixture trap that caught the first draft: without `is_merged_slot`,
`buildBoard` rails a multi-code placement as unplaced, and the resulting EMPTY
board satisfies the H <= N assertion for entirely the wrong reason.

Full `boardLayout.test.ts` (97 tests) and the whole `weekend/` suite (1187
tests) pass. `go build ./...`, `go vet ./lodging/...`, `golangci-lint run
./lodging/...` and `go test ./lodging/...` all pass. `tsc --noEmit`, `eslint`,
`prettier --check`, `markdownlint-cli2` and
`scripts/dev/verify-no-hardcoded-lodging.sh` are clean.

## Review follow-ups (fixed in-branch)

- **A raw NUL byte** had been written into `boardLayout.ts` as
  `mergeGroupSignature`'s join separator, in place of the `\u0000` escape. GNU
  grep then classifies the file as binary, and
  `scripts/dev/verify-no-hardcoded-lodging.sh` passes `-I`, so the lodging name
  guard was silently skipping every line of the weekend board's largest source
  file while still printing OK. Demonstrated by appending a needle literal to
  the file: invisible to the guard's grep with the NUL present, found
  immediately without it. Replaced with the escape, plus a comment saying why
  it must stay one.
- **The 54-line "THE ONE DEFINITION OF OVERLAP" JSDoc** had the new private
  helper inserted between it and `overlappingPartyKeys`, so it documented the
  helper while the exported function had none. Helper moved above the block.
- **`sharingConflictBadge`'s doc block** carried a bare blank line with no
  leading asterisk, left by the wording fix in 04568107. Reflowed.
- The registry-name sweep was re-run over the full diff against **every** unit,
  area and alias string in `config/lodging_registry.json` — not just the
  guard's 15-needle sample: zero hits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved weekend lodging conflict detection for multi-unit aliases.
  * Prevented false room-sharing warnings when the number of households matches available units.
  * Continued flagging genuine same-room conflicts and cases exceeding available capacity.

* **Documentation**
  * Clarified how multi-unit lodging aliases are interpreted and when over-occupancy applies.

* **Tests**
  * Added coverage for valid shared aliases, over-capacity aliases, and confirmed room conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
