### PR TITLE
test(tests): pin all four predicates of the last-year bunk-history query

### DIFF
--- a/tests/unit/bunking/graph/test_last_year_history_type_filter.py
+++ b/tests/unit/bunking/graph/test_last_year_history_type_filter.py
@@ -16,13 +16,16 @@ per year than before, raising the odds an arbitrary, unfiltered pick returns
 the wrong one.
 """
 
+import re
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from bunking.graph.social_graph_builder import SocialGraphBuilder
 
 CAMPER_ID = 1001
+OTHER_CAMPER_ID = 2002
 BUNK_CM_ID, SESSION_CM_ID, YEAR = 555, 999, 2026
+LAST_YEAR = YEAR - 1
 
 
 def _assignment(person_cm_id: int) -> SimpleNamespace:
@@ -41,12 +44,25 @@ def _person(cm_id: int, first_name: str) -> SimpleNamespace:
     )
 
 
-def _historical_row(session_type: str, session_name: str, bunk_name: str, record_id: str) -> SimpleNamespace:
+def _historical_row(
+    session_type: str,
+    session_name: str,
+    bunk_name: str,
+    record_id: str,
+    person_cm_id: int = CAMPER_ID,
+    year: int = LAST_YEAR,
+) -> SimpleNamespace:
     """A bunk_assignments row as PocketBase actually returns it: ``expand`` is
     a dict keyed by relation name (matching real client behavior -- see
-    ``expand.get("bunk")`` in the production code under test)."""
+    ``expand.get("bunk")`` in the production code under test).
+
+    ``person_cm_id``/``year`` carry the values the query's OTHER two predicates
+    select on, so the mock below can honour them the way the database does.
+    """
     return SimpleNamespace(
         id=record_id,
+        person_cm_id=person_cm_id,
+        year=year,
         expand={
             "session": SimpleNamespace(session_type=session_type, name=session_name),
             "bunk": SimpleNamespace(name=bunk_name),
@@ -56,32 +72,49 @@ def _historical_row(session_type: str, session_name: str, bunk_name: str, record
 
 def _pb_with_last_year_rows(rows: list[SimpleNamespace]) -> MagicMock:
     """Build a mock PB whose BUNK_ASSIGNMENTS historical lookup behaves like a
-    real database: it returns the row whose session_type is named in the
-    caller's filter string, when the filter names one. When the filter names
-    none (the pre-fix, unfiltered query), it falls back to returning the
-    first row in ``rows`` -- an arbitrary pick, standing in for whatever order
-    SQLite happens to return without an explicit sort."""
+    real database for EVERY predicate the production query sends, not just the
+    session-type clause.
+
+    A mock that reads only one predicate silently blesses the other three: with
+    an earlier version of this helper, dropping ``sort``, widening
+    ``year = {last_year}`` to the current year, and deleting the
+    ``person.cm_id`` scoping each left all three tests GREEN. So this one
+    parses ``person.cm_id`` and ``year`` out of the filter and applies
+    ``query_params["sort"]``, exactly as PocketBase would:
+
+    * a predicate the filter OMITS stops narrowing anything, so a decoy row
+      that only that predicate excludes will win the pick and fail the test;
+    * with no ``sort``, ties resolve to the caller's row order -- standing in
+      for whatever order SQLite returns from an unordered ``LIMIT 1``.
+    """
+
+    def _matches(row: SimpleNamespace, filt: str) -> bool:
+        person = re.search(r"person\.cm_id = (\d+)", filt)
+        if person and row.person_cm_id != int(person.group(1)):
+            return False
+        year = re.search(r"(?<!\.)\byear = (\d+)", filt)
+        if year and row.year != int(year.group(1)):
+            return False
+        if "session.session_type" in filt:
+            clause = f'session.session_type = "{row.expand["session"].session_type}"'
+            if clause not in filt:
+                return False
+        return True
 
     def _collection_side_effect(name: str) -> MagicMock:
         col = MagicMock()
         if name == "bunk_assignments":
             col.get_full_list.side_effect = lambda *_a, **_kw: [_assignment(CAMPER_ID)]
 
-            def _get_first(filt: str, **_kw: object) -> SimpleNamespace:
-                if "session.session_type" in filt:
-                    # Filtered (new) query: behave like a real DB -- return
-                    # only a row whose type clause is actually in the filter,
-                    # else nothing matched.
-                    for row in rows:
-                        clause = f'session.session_type = "{row.expand["session"].session_type}"'
-                        if clause in filt:
-                            return row
+            def _get_first(filt: str, query_params: dict[str, object] | None = None) -> SimpleNamespace:
+                matched = [row for row in rows if _matches(row, filt)]
+                sort = (query_params or {}).get("sort")
+                if sort:
+                    key = str(sort)
+                    matched.sort(key=lambda r: r.id, reverse=key.startswith("-"))
+                if not matched:
                     raise Exception("404 not found")
-                # Unfiltered (old, pre-fix) query: arbitrary pick -- stands in
-                # for whatever order SQLite returns without an explicit sort.
-                if rows:
-                    return rows[0]
-                raise Exception("404 not found")
+                return matched[0]
 
             col.get_first_list_item.side_effect = _get_first
         elif name == "attendees":
@@ -98,6 +131,15 @@ def _pb_with_last_year_rows(rows: list[SimpleNamespace]) -> MagicMock:
     pb = MagicMock()
     pb.collection.side_effect = _collection_side_effect
     return pb
+
+
+def _last_year_attrs(rows: list[SimpleNamespace]) -> tuple[str | None, str | None]:
+    """Drive the production entry point and read the node attributes back."""
+    graph = SocialGraphBuilder(pb=_pb_with_last_year_rows(rows)).build_bunk_graph(
+        year=YEAR, bunk_cm_id=BUNK_CM_ID, session_cm_id=SESSION_CM_ID
+    )
+    node = graph.nodes[CAMPER_ID]
+    return node["last_year_session"], node["last_year_bunk"]
 
 
 def test_last_year_history_prefers_main_over_family_row() -> None:
@@ -141,3 +183,34 @@ def test_last_year_history_none_when_only_ineligible_rows_exist() -> None:
     node = graph.nodes[CAMPER_ID]
     assert node["last_year_session"] is None
     assert node["last_year_bunk"] is None
+
+
+def test_last_year_history_queries_the_prior_year_not_the_current_one() -> None:
+    """The lookup must select ``year = year - 1``. A current-year row for the
+    same person is a decoy: it exists (campers are assigned this year too) and
+    is an eligible type, so only the year predicate keeps it out."""
+    prior = _historical_row("main", "Session 1", "Cabin A-1", "aaa00000000001", year=LAST_YEAR)
+    current = _historical_row("main", "Session 3", "Cabin C-3", "bbb00000000002", year=YEAR)
+
+    assert _last_year_attrs([current, prior]) == ("Session 1", "Cabin A-1")
+
+
+def test_last_year_history_is_scoped_to_the_person() -> None:
+    """The lookup must select ``person.cm_id``. Another camper's prior-year row
+    is a decoy: same year, same eligible type, so only the person predicate
+    keeps it out -- without it every node would inherit one camper's history."""
+    other = _historical_row("main", "Session 4", "Cabin D-4", "aaa00000000001", person_cm_id=OTHER_CAMPER_ID)
+    mine = _historical_row("main", "Session 1", "Cabin A-1", "bbb00000000002")
+
+    assert _last_year_attrs([other, mine]) == ("Session 1", "Cabin A-1")
+
+
+def test_last_year_history_tie_break_is_deterministic_by_record_id() -> None:
+    """Two ELIGIBLE rows for one person-year must resolve by ``sort: "id"``, so
+    repeated builds agree. Rows are handed over in DESCENDING id order, which
+    is what an unsorted ``LIMIT 1`` would return first -- only the sort makes
+    the lowest id win."""
+    high = _historical_row("main", "Session B", "Cabin B-2", "zzz00000000009")
+    low = _historical_row("main", "Session A", "Cabin A-1", "aaa00000000001")
+
+    assert _last_year_attrs([high, low]) == ("Session A", "Cabin A-1")


### PR DESCRIPTION
## What

#2362 pushed the session-type filter for `build_bunk_graph`'s prior-year history
lookup into the PocketBase query. Its test file introduced a hand-rolled mock
that reads the filter STRING and decides what to return — but the mock only
ever looked for `session.session_type`. The query's other three moving parts
(`person.cm_id`, `year = {last_year}`, and the `sort: "id"` tie-break) were
therefore unpinned, while the file's name and docstring imply the whole query
is under test.

Mutation-proved against the merged tree, before this change:

| mutation applied to `bunking/graph/social_graph_builder.py` | result |
|---|---|
| drop `"sort": "id"` from `query_params` | **3 passed** |
| `year = {last_year}` → `year = {year}` (queries the WRONG year) | **3 passed** |
| delete the `person.cm_id = {person_cm_id}` predicate | **3 passed** |
| revert the type clause (i.e. undo #2362 itself) | 2 failed ✅ |

Only the fix #2362 shipped was actually pinned. A later edit could have deleted
the person scoping — giving every node in a bunk the same camper's history — and
the suite would have stayed green.

## Fix

Teach the mock to honour every predicate the production query sends, the way
the database does:

- parse `person.cm_id` and `year` out of the filter and narrow by them;
- a predicate the filter OMITS stops narrowing, so a decoy row that only that
  predicate excludes wins the pick and the test fails;
- apply `query_params["sort"]`; with no sort, ties resolve to the caller's row
  order — standing in for an unordered `LIMIT 1`.

Three tests added, each driving the real entry point (`build_bunk_graph`) and
reading the node attributes back, never poking a field directly:

- `test_last_year_history_queries_the_prior_year_not_the_current_one` — a
  current-year row of an eligible type is the decoy; only the year predicate
  excludes it.
- `test_last_year_history_is_scoped_to_the_person` — another camper's
  prior-year row is the decoy; only the person predicate excludes it.
- `test_last_year_history_tie_break_is_deterministic_by_record_id` — two
  eligible rows handed over in DESCENDING id order; only `sort: "id"` makes
  the lowest id win.

## Verification

Same four mutations, after this change:

```
##### A: drop sort:"id"                     -> 1 failed, 5 passed
##### B: year = last_year -> year           -> 5 failed, 1 passed
##### C: drop person.cm_id predicate        -> 1 failed, 5 passed
##### D: revert the type filter (#2362)     -> 2 failed, 4 passed
```

```
uv run pytest tests/unit/bunking/graph/ tests/unit/bunking/test_bunk_graph_staff_exclusion.py \
              tests/unit/sync/test_networkx_integration.py -q
# 142 passed

bash scripts/pre-push-verify.sh
# ruff, mypy, api-types freshness, pytest (6152 passed, 14 skipped) — ALL CHECKS PASSED
```

Tests only — no production code changes. This PR closes no issue; it is
follow-up review work on #2362.
