### PR TITLE
fix(scripts): scrub real lodging names from test comments, widen guard to catch them

### DIFF
--- a/frontend/src/components/weekend/HouseholdJourneyCard.test.tsx
+++ b/frontend/src/components/weekend/HouseholdJourneyCard.test.tsx
@@ -145,7 +145,7 @@ describe('the housing states', () => {
       _row({
         year: 2025,
         housing: 'placed',
-        cabin_name: 'Clouds Rest Lodge - West Wing Room 12B',
+        cabin_name: 'Fernwood Lodge - West Wing Room 12B',
       }),
     ])
 
@@ -157,7 +157,7 @@ describe('the housing states', () => {
     // wrap instead of overflowing its row.
     expect(housing).toHaveClass('min-w-0')
     expect(housing).not.toHaveClass('truncate')
-    expect(housing).toHaveTextContent('Clouds Rest Lodge - West Wing Room 12B')
+    expect(housing).toHaveTextContent('Fernwood Lodge - West Wing Room 12B')
   })
 })
 

--- a/frontend/src/components/weekend/MapUnitPopover.test.tsx
+++ b/frontend/src/components/weekend/MapUnitPopover.test.tsx
@@ -420,7 +420,7 @@ describe('MapUnitPopover — a cluster of rooms', () => {
   })
 
   it('drops the building name the cluster shares, so cells differ visibly', () => {
-    // A browser found this: every cell read "Clouds Rest Ba…" / "Clouds Rest
+    // A browser found this: every cell read "Cedar Lodge Ba…" / "Cedar Lodge
     // La…" and truncated away the distinguishing word.
     const house = [
       mapUnit(row({ unit_id: 'u1', code: 'cedar-back', name: 'Cedar Lodge Back' })),

--- a/frontend/src/types/beds.test.ts
+++ b/frontend/src/types/beds.test.ts
@@ -39,10 +39,10 @@ describe('suggestedSleeps', () => {
   })
 
   // Twin on top, full underneath. Staff-confirmed as a real and distinct piece
-  // of furniture, found only in the family/guest housing (Tenaya, Tioga, Half
-  // Dome, El Cap, Doctor's House, Manzanita 2) and never in a camper cabin.
-  // Splitting it into a full plus a twin would total the same three people but
-  // describe two separate beds that could sit in different rooms.
+  // of furniture, found only in family/guest housing (a small set of named
+  // units, not camper cabins) and never in a camper cabin. Splitting it into
+  // a full plus a twin would total the same three people but describe two
+  // separate beds that could sit in different rooms.
   it('counts a full-over-twin bunk as three people', () => {
     expect(suggestedSleeps([{ type: 'full_twin_bunk', count: 1 }])).toBe(3)
   })

--- a/scripts/dev/lib/drop_comment_hits.py
+++ b/scripts/dev/lib/drop_comment_hits.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python3
 """Drop grep hits that sit in a comment or a docstring.
 
+With `--only-comments`, the filter inverts: it keeps ONLY the hits that sit
+in a comment or docstring and drops everything else. verify-no-hardcoded-
+lodging.sh uses this second mode for frontend/src/** test files, where a
+fixture literal (code) is a deliberate, exempted case but a needle named in
+an explanatory comment is not (kindred#2367) -- so a test file's hits split
+into "genuine leak" (comment) and "known-legitimate fixture" (code) instead
+of the normal code/comment split going the other way.
+
 Spec 3.8 forbids the lodging registry from living in source. A registry lives
 in *code* -- string literals, lists, maps. Prose that names a unit to explain a
 rule is documentation, and failing on it made the guard red on `main` for a
@@ -176,6 +184,7 @@ def noncode_lines(path: Path) -> set[int]:
 
 
 def main() -> int:
+    only_comments = "--only-comments" in sys.argv[1:]
     cache: dict[str, set[int]] = {}
     for raw in sys.stdin:
         hit = raw.rstrip("\n")
@@ -183,13 +192,16 @@ def main() -> int:
             continue
         parts = hit.split(":", 2)
         if len(parts) < 3 or not parts[1].isdigit():
-            # Not a path:lineno:text hit -- pass it through rather than eat it.
+            # Not a path:lineno:text hit -- pass it through rather than eat
+            # it, in either mode: unparseable input means we learned nothing,
+            # so keep it reportable rather than silently dropping it.
             print(hit)
             continue
         path, lineno = parts[0], int(parts[1])
         if path not in cache:
             cache[path] = noncode_lines(Path(path))
-        if lineno not in cache[path]:
+        is_comment = lineno in cache[path]
+        if is_comment == only_comments:
             print(hit)
     return 0
 

--- a/scripts/dev/test-verify-no-hardcoded-lodging.sh
+++ b/scripts/dev/test-verify-no-hardcoded-lodging.sh
@@ -375,4 +375,39 @@ else
 fi
 
 echo
+echo "=== TEST 13: a needle in a COMMENT under frontend/src/test/ (shared test helpers, not *.test.ts) must exit 1 too ==="
+# FRONTEND_TEST_PATTERN is '^frontend/src/.*(_test\.|\.test\.|/tests?/)'. A
+# file directly under frontend/src/test/ -- the repo's real shared test-helper
+# directory (mockData.ts, mocks/, testUtils.tsx, test-helpers.ts) -- has no
+# '_test.' or '.test.' in its filename, so it can only match via '/tests?/'.
+# It does match that alternative ('/test/' is 'tests?' with the optional s
+# absent), which routes it into OTHER_RAW's blanket exemption instead of
+# FRONTEND_TEST_RAW's comment-only scan -- so a comment leak here sails
+# through exactly the same way test-file comments used to everywhere, the gap
+# kindred#2367 exists to close for frontend/src/**.
+FE_TEST_DIR_PROBE="$REPO_ROOT/frontend/src/test/leak_probe_kindred2367_dir.ts"
+cleanup10() { rm -f "$FE_TEST_DIR_PROBE"; }
+trap 'cleanup10; cleanup9; cleanup8; cleanup7; cleanup6; cleanup5; cleanup4; cleanup3; cleanup' EXIT INT TERM
+cat > "$FE_TEST_DIR_PROBE" <<'PROBE'
+// Regression comment naming Kitty to explain a fixture below.
+export {}
+PROBE
+set +e
+OUT=$("$GUARD_SCRIPT" 2>&1)
+rc=$?
+set -e
+rm -f "$FE_TEST_DIR_PROBE"
+if [[ $rc -ne 1 ]]; then
+  echo "FAIL: expected exit 1 for a needle in a frontend/src/test/ comment, got $rc" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+if ! grep -q "frontend/src/test/leak_probe_kindred2367_dir.ts:1:" <<<"$OUT"; then
+  echo "FAIL: output missing frontend/src/test/ comment probe file:line" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+echo "PASS: a needle in a frontend/src/test/ file's comment is caught"
+
+echo
 echo "All tests passed."

--- a/scripts/dev/test-verify-no-hardcoded-lodging.sh
+++ b/scripts/dev/test-verify-no-hardcoded-lodging.sh
@@ -296,4 +296,83 @@ fi
 echo "PASS: a needle in a .sh file is caught"
 
 echo
+echo "=== TEST 10: a needle in a COMMENT inside a frontend/src/** test file should exit 1 ==="
+# kindred#2367: the blanket test-file exemption (TEST 4's grep -v pattern)
+# used to drop every hit in a test file, comment prose and fixture code alike
+# -- so a real unit name in a test's explanatory comment sailed through the
+# same way a fixture literal legitimately does. Catching needle terms in
+# comments is strictly better than catching them only in production code;
+# this asserts the widening for frontend/src/**, the surface it was scoped to
+# (see the guard's own comment on why it stops there).
+FE_TEST_PROBE="$REPO_ROOT/frontend/src/leak_probe_kindred2367.test.ts"
+cleanup7() { rm -f "$FE_TEST_PROBE"; }
+trap 'cleanup7; cleanup6; cleanup5; cleanup4; cleanup3; cleanup' EXIT INT TERM
+cat > "$FE_TEST_PROBE" <<'PROBE'
+// Regression comment naming Kitty to explain a fixture below.
+export {}
+PROBE
+set +e
+OUT=$("$GUARD_SCRIPT" 2>&1)
+rc=$?
+set -e
+rm -f "$FE_TEST_PROBE"
+if [[ $rc -ne 1 ]]; then
+  echo "FAIL: expected exit 1 for a needle in a frontend/src/** test comment, got $rc" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+if ! grep -q "frontend/src/leak_probe_kindred2367.test.ts:1:" <<<"$OUT"; then
+  echo "FAIL: output missing frontend test-comment probe file:line" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+echo "PASS: a needle in a frontend/src/** test file's comment is caught"
+
+echo
+echo "=== TEST 11: a needle in FIXTURE CODE inside a frontend/src/** test file must still exit 0 ==="
+# The widening in TEST 10 targets comments only. A real unit name as a
+# fixture literal is the exact, deliberate case the test-file exemption
+# exists for (lodging_alias_resolver_test.go, LodgingUnitForm.test.tsx, and
+# others hardcode real unit names on purpose) -- this proves TEST 10 did not
+# also start failing that.
+FE_TEST_CODE_PROBE="$REPO_ROOT/frontend/src/leak_probe_kindred2367_code.test.ts"
+cleanup8() { rm -f "$FE_TEST_CODE_PROBE"; }
+trap 'cleanup8; cleanup7; cleanup6; cleanup5; cleanup4; cleanup3; cleanup' EXIT INT TERM
+echo 'export const UNIT = "Kitty"' > "$FE_TEST_CODE_PROBE"
+set +e
+OUT=$("$GUARD_SCRIPT" 2>&1)
+rc=$?
+set -e
+rm -f "$FE_TEST_CODE_PROBE"
+if [[ $rc -eq 0 ]]; then
+  echo "PASS: a needle as fixture code in a frontend/src/** test file is still exempt"
+else
+  echo "FAIL: expected exit 0 for a needle as fixture code, got $rc" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+
+echo
+echo "=== TEST 12: a needle in a COMMENT inside a non-frontend test file must still exit 0 ==="
+# The comment-scanning widening is deliberately scoped to frontend/src/**
+# (measured blast radius: kindred#2367 PR body). A Go test file's comment
+# stays exempted -- narrowing this far, not repo-wide, is the point.
+GO_TEST_PROBE="$REPO_ROOT/pocketbase/leak_probe_kindred2367_test.go"
+cleanup9() { rm -f "$GO_TEST_PROBE"; }
+trap 'cleanup9; cleanup8; cleanup7; cleanup6; cleanup5; cleanup4; cleanup3; cleanup' EXIT INT TERM
+printf 'package pocketbase\n\n// Regression comment naming Kitty to explain a fixture below.\n' > "$GO_TEST_PROBE"
+set +e
+OUT=$("$GUARD_SCRIPT" 2>&1)
+rc=$?
+set -e
+rm -f "$GO_TEST_PROBE"
+if [[ $rc -eq 0 ]]; then
+  echo "PASS: a needle in a non-frontend test file's comment is still exempt"
+else
+  echo "FAIL: expected exit 0 for a needle in a non-frontend test comment, got $rc" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+
+echo
 echo "All tests passed."

--- a/scripts/dev/verify-no-hardcoded-lodging.sh
+++ b/scripts/dev/verify-no-hardcoded-lodging.sh
@@ -104,7 +104,16 @@ done
 # pocketbase/ side for a future pass, rather than guessing at files another
 # issue may be mid-edit on. Fixture CODE in a frontend/src/** test file is
 # still exempt -- only its comment lines are newly in scope.
-FRONTEND_TEST_PATTERN='^frontend/src/.*(_test\.|\.test\.|/tests?/)'
+# The trailing alternative must anchor to a full PATH SEGMENT: '(.*/)?tests?/'
+# rather than the bare '/tests?/' used previously. The bare form only fires
+# once something has already matched before the slash, so a file directly
+# under frontend/src/test/ (frontend/src/test/mockData.ts -- no '_test.' or
+# '.test.' in the name, and 'test/' immediately follows the 'frontend/src/'
+# prefix with no preceding '/') never matched, and fell through to OTHER_RAW's
+# blanket test-file exemption instead of this comment-only scan -- the exact
+# gap this pattern exists to close. Verified by TEST 13 in
+# test-verify-no-hardcoded-lodging.sh (kindred#2367 review).
+FRONTEND_TEST_PATTERN='^frontend/src/(.*/)?tests?/|^frontend/src/.*(_test\.|\.test\.)'
 HITS=""
 if [[ -n "$RAW" ]]; then
   FRONTEND_TEST_RAW=$(printf '%s\n' "$RAW" | grep -E "$FRONTEND_TEST_PATTERN" || true)

--- a/scripts/dev/verify-no-hardcoded-lodging.sh
+++ b/scripts/dev/verify-no-hardcoded-lodging.sh
@@ -92,11 +92,33 @@ done
 # file only ever proved "no unit name outside a test file", never "no unit
 # name in test fixtures either" -- treat a future NEEDLES hit inside one as
 # worth a look, not an automatic pass.
+#
+# kindred#2367 narrows that blind spot for COMMENTS ONLY, and only under
+# frontend/src/**: catching needle terms in comments is strictly better than
+# catching them only in production code, and a repo-wide measurement found 14
+# comment hits across 6 files, split between frontend/src/** (3 hits, 2 files
+# -- both fixed at the source in this same change) and pocketbase/ Go test
+# files (11 hits, 4 files) that this branch has no reason to touch and did
+# not verify against sibling in-flight PRs. Narrowing to frontend/src/** ships
+# the improvement where it was already fully paid for and leaves the
+# pocketbase/ side for a future pass, rather than guessing at files another
+# issue may be mid-edit on. Fixture CODE in a frontend/src/** test file is
+# still exempt -- only its comment lines are newly in scope.
+FRONTEND_TEST_PATTERN='^frontend/src/.*(_test\.|\.test\.|/tests?/)'
 HITS=""
 if [[ -n "$RAW" ]]; then
-  HITS=$(printf '%s\n' "$RAW" \
+  FRONTEND_TEST_RAW=$(printf '%s\n' "$RAW" | grep -E "$FRONTEND_TEST_PATTERN" || true)
+  OTHER_RAW=$(printf '%s\n' "$RAW" | grep -vE "$FRONTEND_TEST_PATTERN" || true)
+
+  HITS=$(printf '%s\n' "$OTHER_RAW" \
     | grep -v '_test\.\|\.test\.\|/tests\?/' \
     | grep -v 'frontend/src/data/cityGeo\.ts\|frontend/src/data/schoolGeo\.ts' || true)
+
+  FRONTEND_TEST_COMMENT_HITS=""
+  if [[ -n "$FRONTEND_TEST_RAW" ]]; then
+    FRONTEND_TEST_COMMENT_HITS=$(printf '%s\n' "$FRONTEND_TEST_RAW" \
+      | python3 "$REPO_ROOT/scripts/dev/lib/drop_comment_hits.py" --only-comments)
+  fi
 fi
 
 # Prose that names a unit to explain a rule is documentation, not the registry
@@ -111,6 +133,14 @@ fi
 # (a different feature) that coincidentally contain place-name substrings
 # ("Manzanita, OR", "El Capitan, AZ", "Wawona, CA", "Tuolumne City, CA") — not
 # the lodging registry. Excluded to keep this guard meaningful.
+
+# FRONTEND_TEST_COMMENT_HITS is already comment-only (produced by
+# --only-comments above) -- append it here, AFTER the drop-comments step
+# above, not before: running it back through that filter would drop the very
+# comment hits it exists to report.
+if [[ -n "${FRONTEND_TEST_COMMENT_HITS:-}" ]]; then
+  HITS=$(printf '%s\n%s\n' "$HITS" "$FRONTEND_TEST_COMMENT_HITS" | sed '/^$/d')
+fi
 
 if [[ -n "$HITS" ]]; then
   echo "FAIL: lodging unit names found in application source (spec 3.8 — registry is data, not code):" >&2


### PR DESCRIPTION
## What was wrong

`scripts/dev/verify-no-hardcoded-lodging.sh` deliberately greps for a representative sample of
real lodging-unit strings (NEEDLES) and is honest that it drops comment-only hits and exempts test
files entirely — that is correct, spec'd behaviour, not a bug. But two real gaps sat inside that
honest scope:

1. **Two public test fixtures carried real unit names the guard's own scope statement admits it
   cannot see.**
   - `frontend/src/types/beds.test.ts` — a comment listing six real family/guest-housing unit
     names (`Tenaya, Tioga, Half Dome, El Cap, Doctor's House, Manzanita 2`), pure documentation
     that drove no assertion.
   - `frontend/src/components/weekend/HouseholdJourneyCard.test.tsx` — a real unit+wing+room
     string (`Clouds Rest Lodge - West Wing Room 12B`) present as **both** a fixture value (line
     148) and the assertion that reads it back (line 160).
2. **The guard's test-file exemption drops comment hits and fixture hits alike, with no
   distinction.** Catching needle terms in comments is strictly better than catching them only in
   production code — that half of the guard was never built.

## What changed

- `beds.test.ts`: replaced the six real unit names with a generic description
  ("a small set of named units, not camper cabins") — the comment never drove the test, which only
  exercises `full_twin_bunk` arithmetic, so nothing about test coverage changed.
- `HouseholdJourneyCard.test.tsx`: replaced `Clouds Rest Lodge - West Wing Room 12B` with the
  fictional `Fernwood Lodge - West Wing Room 12B` in **both** the fixture (line 148) and the
  assertion (line 160) — same building+wing+room shape, so it still exercises the truncate-vs-wrap
  regression (kindred#2253) it was written for.
- `scripts/dev/lib/drop_comment_hits.py`: added a `--only-comments` mode that inverts the filter —
  keep only comment/docstring hits, drop code hits — for the guard's new comment-in-test-file scan.
- `scripts/dev/verify-no-hardcoded-lodging.sh`: `frontend/src/**` test-file hits are now split —
  fixture code stays exempt (unchanged, deliberate), but comment-line hits are now scanned and fail
  the guard.
- `scripts/dev/test-verify-no-hardcoded-lodging.sh`: added TEST 10-12 pinning the new behaviour —
  a comment leak in a `frontend/src/**` test file fails (TEST 10), a fixture-code leak in the same
  tree still doesn't (TEST 11), and a comment leak in a non-frontend test file still doesn't
  (TEST 12, proving the narrowing below is deliberate, not an oversight).

## Blast radius measured before touching any fixture

Per the issue's instruction, the widened guard was run across the full default scan roots
(`pocketbase/ api/ bunking/ frontend/src/ scripts/`) **before** any fixture was edited, to see what
it would additionally catch if applied repo-wide to every test file's comments, not just
`frontend/src/**`:

- **93** NEEDLES hits total inside files matching the test-file pattern.
- Of those, **14** sit on a comment line (the rest are legitimate fixture literals — the exact
  case the exemption exists for, per the guard's own header comment about kindred#1909).
- The 14 comment hits split **3 hits / 2 files under `frontend/src/**`** (both of which are the
  two fixtures this PR already fixes — `beds.test.ts` and `MapUnitPopover.test.tsx`, the latter a
  one-line M-sized extra hit found by the measurement, fixed in this branch) and **11 hits / 4
  files under `pocketbase/`** (`lodging_alias_resolver_test.go`, `lodging_issues_test.go`,
  `lodging_assignments_sync_test.go`, `registry_alias_target_test.go`).

The `pocketbase/` side is left alone: those files sit in territory this branch has no standing
context on and did not check against sibling in-flight PRs (`#2289` touches
`lodging_assignments_sync.go` in the same package this round), so the comment-scanning widening is
narrowed to `frontend/src/**` test files only — exactly the scope the issue suggested as a fallback
if the blast radius warranted narrowing. The Go-side leaks are real and worth a future look, but
guessing at files another issue may be mid-edit on is worse than leaving them for a scoped pass.

## Deliberately NOT done

- **The four area-name sites are untouched**, per the owner's 2026-08-14 ruling recorded in the
  issue: `pages/WeekendRosterPage.test.tsx`, `pages/WeekendRosterPage.codeSplitting.test.tsx`,
  `types/lodging.test.ts`, `components/weekend/boardLayout.ts:442`. Ordinary-word area names do not
  count as needle-term leaks.
- **The 11 comment hits in `pocketbase/` Go test files** are not fixed and the guard is not widened
  to catch them — narrowed deliberately, see above.
- This is not framed as a PII incident (per the guard's own header): the lodging registry is data
  that now lives in exactly one place, `config/lodging_registry.json` — single-source-of-truth
  hygiene with a privacy flavour, not the camper/family/staff-name rule in CLAUDE.md §4.

## Verification

- `bash scripts/dev/verify-no-hardcoded-lodging.sh` — exit 0 (`verify-no-hardcoded-lodging: OK`)
  on the full tree with the fixtures fixed.
- `bash scripts/dev/test-verify-no-hardcoded-lodging.sh` — all 12 cases pass (9 pre-existing + 3
  new), exit 0.
- `cd frontend && vitest run src/types/beds.test.ts src/components/weekend/HouseholdJourneyCard.test.tsx src/components/weekend/MapUnitPopover.test.tsx`
  — 3 files, **90 tests passed**.
- `uv run pytest tests/unit/scripts/test_drop_comment_hits.py` — 2 passed (unchanged `noncode_lines`
  logic, confirms the new `--only-comments` mode didn't disturb it).

**Mutation checks, all read by exit code:**
- Re-planted a needle term (`Tioga`) inside `beds.test.ts`'s comment: guard exited **1** and named
  the file:line. Reverted: guard exited **0**.
- Changed only the assertion side of the `HouseholdJourneyCard.test.tsx` fixture (line 160) to a
  mismatched string, leaving the fixture value (line 148) alone: the real test failed with an
  explicit content mismatch, proving the assertion drives the real fixture rather than passing
  independently of it. Reverted: test passed again.
- TEST 10 was written and run against the **unmodified** guard first and observed to fail
  (`FAIL: expected exit 1 ... got 0`) before `drop_comment_hits.py`/`verify-no-hardcoded-lodging.sh`
  were changed — confirming the new test actually pins the new behaviour rather than passing
  trivially.

Closes #2367.
