### PR TITLE
fix(frontend): drop the redundant write-in chip, relabel its clear button

### DIFF
--- a/frontend/src/components/weekend/LodgingBoard.availability.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.availability.test.tsx
@@ -222,7 +222,7 @@ describe('LodgingBoard — clearing a write-in this card inherited', () => {
     const user = userEvent.setup()
     renderBoard({ units: [room] })
 
-    await user.click(screen.getByRole('button', { name: 'Clear House A' }))
+    await user.click(screen.getByRole('button', { name: 'Clear Write-in House A' }))
 
     expect(setAvailability).toHaveBeenCalledWith({
       unitId: 'u-house',
@@ -241,6 +241,6 @@ describe('LodgingBoard — clearing a write-in this card inherited', () => {
     pendingUnitId = 'u-house'
     renderBoard({ units: [room] })
 
-    expect(screen.getByRole('button', { name: 'Clear House A' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Clear Write-in House A' })).toBeDisabled()
   })
 })

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -2321,6 +2321,32 @@ describe('LodgingUnitCard — the write-in chip, dropped in favour of the well (
     expect(screen.getByText('Shared OK')).toBeInTheDocument()
   })
 
+  it('does not suppress the "Staff" badge — a closed staff cabin is exempt from the gate, not just no write-in', () => {
+    // This is the case `writeInBadgeApplies`'s `inventory_class !==
+    // 'staff_default'` half exists for: a staff cabin closed for the weekend
+    // synthesises a `writeInOccupant` cover the same way a family room's
+    // write-in does (`writeIn.ts`'s `coveringWriteIn` fallback reads
+    // `family_available_override === false` for either role), so reading
+    // `writeInOccupant(unit) !== null` alone here would swallow the "Staff"
+    // chip along with the "Write-in" one. Pins both halves of the gate at
+    // once — the class check AND the scoping to this card only.
+    render(
+      <LodgingUnitCard
+        slot={slot({
+          unit: unit({
+            inventory_class: 'staff_default',
+            family_available_override: false,
+            occupant_name: 'Emma Johnson',
+            is_family_available: false,
+          }),
+        })}
+        hue={HUE}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Staff')).toBeInTheDocument()
+  })
+
   it('labels the availability control "Clear Write-in" rather than a bare "Clear"', () => {
     // The chip is gone, so the button is now the ONLY thing on this card
     // saying what a click removes. "Clear" alone stopped saying that.

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -2288,3 +2288,51 @@ describe('LodgingUnitCard — no sr-only text of any kind (kindred#2348)', () =>
     )
   })
 })
+
+describe('LodgingUnitCard — the write-in chip, dropped in favour of the well (kindred#2252)', () => {
+  const HUE = 'hsl(160 45% 42%)'
+  const WRITTEN_IN = unit({
+    family_available_override: false,
+    occupant_name: 'Emma Johnson',
+    is_family_available: false,
+  })
+
+  it('drops the redundant "Write-in" chip from the badge row — WriteInCard already names the occupant', () => {
+    // Before #2252 a written-into card said the same thing twice: a slate
+    // "Write-in" chip in the badge row, and the occupant's own name in the
+    // `WriteInCard` drawn in the well below. The chip is gone from THIS card;
+    // the well is untouched.
+    render(<LodgingUnitCard slot={slot({ unit: WRITTEN_IN })} hue={HUE} onOpenParty={vi.fn()} />)
+
+    expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
+    expect(screen.queryByText('Write-in')).not.toBeInTheDocument()
+  })
+
+  it('does not suppress OTHER badges on this card — the sharing badge survives untouched', () => {
+    // Regression guard: the suppression is scoped to the write-in chip only,
+    // not to `reservationBadge`'s output wholesale on this card.
+    render(
+      <LodgingUnitCard
+        slot={slot({ unit: unit({ shareability: 'shareable' }) })}
+        hue={HUE}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Shared OK')).toBeInTheDocument()
+  })
+
+  it('labels the availability control "Clear Write-in" rather than a bare "Clear"', () => {
+    // The chip is gone, so the button is now the ONLY thing on this card
+    // saying what a click removes. "Clear" alone stopped saying that.
+    render(
+      <LodgingUnitCard
+        slot={slot({ unit: WRITTEN_IN })}
+        hue={HUE}
+        canSetAvailability
+        onSetAvailability={vi.fn()}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByRole('button', { name: 'Clear Write-in Cedar 1' })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -33,6 +33,7 @@ import {
   reservationBadge,
   shareabilityBadge,
   sharingConflictBadge,
+  writeInBadgeApplies,
   type UnitBadge,
 } from './unitBadges'
 import { UnitAvailabilityControl } from './UnitAvailabilityControl'
@@ -304,7 +305,14 @@ export function LodgingUnitCard({
   onOpenParty,
 }: LodgingUnitCardProps) {
   const { unit, parties, consent } = slot
-  const badge = reservationBadge(unit)
+  // Suppressed for a write-in ONLY on this card (kindred#2252). The chip and
+  // the well's `WriteInCard` below said the same thing twice — the occupant's
+  // own name, once as a slate "Write-in" chip and once spelled out in the
+  // well — and the well is the one that actually names them, so the chip is
+  // redundant here. `reservationBadge` itself is untouched: `MapUnitPopover`'s
+  // header and its collapsed grid cell draw no `WriteInCard` of their own and
+  // still call it directly, so the chip is still the only signal there.
+  const badge = writeInBadgeApplies(unit) ? null : reservationBadge(unit)
   // On every unit this card can be a SLOT for, which includes a COMBINED
   // container and excludes a split one.
   //

--- a/frontend/src/components/weekend/UnitAvailabilityControl.test.tsx
+++ b/frontend/src/components/weekend/UnitAvailabilityControl.test.tsx
@@ -273,14 +273,19 @@ describe('UnitAvailabilityControl', () => {
     expect(screen.queryByText(/say who is in it/i)).not.toBeInTheDocument()
   })
 
-  it('clears an override in one click, writing null rather than a value that agrees', async () => {
+  it('clears a write-in in one click, writing null rather than a value that agrees, and names what it clears (#2252)', async () => {
     // `null` DELETES the row. Writing "available" onto a family cabin instead
     // would pin it against a later change to its role -- the reversal-encoding
     // failure spec §5.4 rejected, arriving through the UI.
+    //
+    // The exact button name is the assertion: kindred#2252 dropped the
+    // redundant "Write-in" chip from `LodgingUnitCard`'s badge row, which
+    // made this the only thing on the card saying what a click removes. A
+    // bare "Clear" would pass the loose `/clear/i` query this used to use.
     const user = userEvent.setup()
     const { onSubmit } = renderControl({ unit: WRITTEN_IN_CABIN })
 
-    await user.click(screen.getByRole('button', { name: /clear/i }))
+    await user.click(screen.getByRole('button', { name: 'Clear Write-in Cedar 1' }))
 
     expect(onSubmit).toHaveBeenCalledWith({
       unitId: 'u1',
@@ -336,7 +341,7 @@ describe('UnitAvailabilityControl', () => {
     const user = userEvent.setup()
     const { onSubmit } = renderControl({ unit: WRITTEN_IN_CABIN, isSaving: true })
 
-    await user.click(screen.getByRole('button', { name: /clear/i }))
+    await user.click(screen.getByRole('button', { name: 'Clear Write-in Cedar 1' }))
 
     expect(onSubmit).not.toHaveBeenCalled()
   })
@@ -425,11 +430,14 @@ describe('a write-in this unit inherited from elsewhere in the tree', () => {
     },
   })
 
-  it('offers to clear it, and names the unit that actually holds the row', async () => {
+  it('offers to clear it, labelled "Clear Write-in" and naming the unit that actually holds the row (#2252)', async () => {
+    // The button reads on the INHERITING card ("House A"), and the label is
+    // still "Clear Write-in" there — the relabel is keyed on what the action
+    // clears, not on whose own row it happens to be.
     const user = userEvent.setup()
     const { onSubmit } = renderControl({ unit: ROOM_UNDER_A_WRITTEN_IN_HOUSE })
 
-    await user.click(screen.getByRole('button', { name: /clear/i }))
+    await user.click(screen.getByRole('button', { name: 'Clear Write-in House A' }))
 
     expect(onSubmit).toHaveBeenCalledWith({
       unitId: 'u-house',

--- a/frontend/src/components/weekend/unitBadges.test.ts
+++ b/frontend/src/components/weekend/unitBadges.test.ts
@@ -222,16 +222,22 @@ describe('availabilityAction', () => {
     })
   })
 
-  it('offers to clear a held family cabin, and asks for no reason to do it', () => {
+  it('offers to clear a held family cabin, labelled for what it actually removes (#2252)', () => {
     // `null` DELETES the row. There is no value meaning "normal": writing one
     // would pin the unit against a later change to its role.
+    //
+    // The label is 'Clear Write-in', not the bare 'Clear' this used to read.
+    // kindred#2252: the badge chip that used to sit beside this button on
+    // `LodgingUnitCard` is gone there (the well's `WriteInCard` already names
+    // the occupant), so the button is now the only thing on that card saying
+    // what a click does — and "Clear" alone does not say what it clears.
     expect(
       availabilityAction(
         unit({ family_available_override: false, reason: 'Burst pipe', is_family_available: false })
       )
     ).toEqual({
       kind: 'clear',
-      label: 'Clear',
+      label: 'Clear Write-in',
       familyAvailable: null,
       prompt: 'none',
       unitId: 'u1',
@@ -239,7 +245,12 @@ describe('availabilityAction', () => {
     })
   })
 
-  it('offers to clear a released staff cabin', () => {
+  it('offers to clear a released staff cabin, and does NOT borrow the write-in wording (#2252)', () => {
+    // This branch clears a RELEASE, not a write-in — `writeInSource` never
+    // matches a staff cabin's own release row, so it never reaches the
+    // relabelled branch. Asserted by name, not just by kind: a copy/paste that
+    // pointed this branch at the write-in label too would say "Clear
+    // Write-in" on a card that was never written into.
     expect(
       availabilityAction(
         unit({
@@ -247,8 +258,8 @@ describe('availabilityAction', () => {
           family_available_override: true,
           is_family_available: true,
         })
-      )?.kind
-    ).toBe('clear')
+      )
+    ).toMatchObject({ kind: 'clear', label: 'Clear' })
   })
 
   it('offers to clear a row that merely agrees with the unit role', () => {

--- a/frontend/src/components/weekend/unitBadges.ts
+++ b/frontend/src/components/weekend/unitBadges.ts
@@ -39,6 +39,21 @@ export interface UnitBadge {
   title?: string
 }
 
+/**
+ * Whether `reservationBadge` badges this unit "Write-in" — exported so a
+ * caller that shows the same fact another way can suppress the chip WITHOUT
+ * re-deriving the branch's own gate and risking drift from it (kindred#2252).
+ *
+ * `LodgingUnitCard` is that caller: the occupant already gets a `WriteInCard`
+ * in the unit's well, so the chip beside it repeated the same fact under a
+ * second name. The two other surfaces that draw this chip — `MapUnitPopover`'s
+ * header and its collapsed grid cell — carry no such card and still call
+ * `reservationBadge` directly, unaffected by this function existing.
+ */
+export function writeInBadgeApplies(unit: LodgingUnitRow): boolean {
+  return unit.inventory_class !== 'staff_default' && writeInOccupant(unit) !== null
+}
+
 export function reservationBadge(unit: LodgingUnitRow): UnitBadge | null {
   const staff = {
     label: 'Staff',
@@ -85,13 +100,14 @@ export function reservationBadge(unit: LodgingUnitRow): UnitBadge | null {
   // It still does not read `occupant_name`: "written in for a caretaker" and
   // "written in for a burst pipe" are the same fact about availability, which
   // is the same reason the reason text never reached this badge.
-  // Read through `writeInOccupant`, never the raw `family_available_override`.
-  // The board draws whichever level the tree resolves to, so the card carrying
-  // a write-in is often not the unit whose row it is: split a written-into
-  // building and its ROOMS carry it; merge over a written-into room and the
-  // BUILDING does. The column answers only for the unit it sits on, which is
-  // how a write-in went silent the moment somebody merged or split around it.
-  if (unit.inventory_class !== 'staff_default' && writeInOccupant(unit) !== null) {
+  // Read through `writeInBadgeApplies` (`writeInOccupant`, never the raw
+  // `family_available_override`). The board draws whichever level the tree
+  // resolves to, so the card carrying a write-in is often not the unit whose
+  // row it is: split a written-into building and its ROOMS carry it; merge
+  // over a written-into room and the BUILDING does. The column answers only
+  // for the unit it sits on, which is how a write-in went silent the moment
+  // somebody merged or split around it.
+  if (writeInBadgeApplies(unit)) {
     return {
       label: 'Write-in',
       className: 'bg-slate-200 text-slate-800 dark:bg-slate-800 dark:text-slate-200',
@@ -309,9 +325,20 @@ export function availabilityAction(
   // (closed this weekend) are different answers, and collapsing them makes
   // either "Write in" or "Clear" unreachable across most of the board.
   const own = { unitId: unit.unit_id, unitName: unit.name }
-  const clear = (target: { unitId: string; unitName: string }): AvailabilityAction => ({
+  // `label` defaults to the bare 'Clear' the RELEASE and the "agrees with the
+  // role" branches keep — neither of those undoes a write-in, so borrowing
+  // its wording would name a fact that is not there. The write-in branch below
+  // passes 'Clear Write-in' explicitly (kindred#2252): the chip that used to
+  // sit beside this button on `LodgingUnitCard` said "Write-in" out loud, and
+  // #2252 dropped it from that card as redundant with the well's `WriteInCard`
+  // — so the button is now the only thing left on that card naming what a
+  // click removes, and a bare 'Clear' stopped saying that.
+  const clear = (
+    target: { unitId: string; unitName: string },
+    label = 'Clear'
+  ): AvailabilityAction => ({
     kind: 'clear',
-    label: 'Clear',
+    label,
     familyAvailable: null,
     prompt: 'none',
     ...target,
@@ -345,7 +372,7 @@ export function availabilityAction(
   // split does to it.
   const source = writeInSource(unit)
   if (source !== null) {
-    return clear({ unitId: source.unitId, unitName: source.unitName })
+    return clear({ unitId: source.unitId, unitName: source.unitName }, 'Clear Write-in')
   }
   // Any other override of its own. Reachable for a `true` on a family-pool
   // row: it AGREES with that unit's role so no surface writes one and the


### PR DESCRIPTION
## The defect

A write-in has two affordances on `LodgingUnitCard`: a slate "Write-in" chip in the badge row (`reservationBadge`) and the occupant's name printed again below it in `WriteInCard`, in the well. The button that undoes it just said "Clear" — no chip, no button text, said what a click removes.

## Where D9's own precondition failed

D9 ruled "drop the write-in chip and relabel the button 'Clear Write-in'", conditioned on `WriteInCard` covering every zoom/collapsed state before the chip goes. It does not: `reservationBadge` (the function that produces the chip) has **3 call sites**, not 1 — `LodgingUnitCard.tsx:315` (the card with `WriteInCard`), and two on `MapUnitPopover.tsx` (`:179`, the popover header; `:597`, the collapsed grid cell, whose own comment reads "The grid has no room for badges, so status rides in the tooltip"). Neither `MapUnitPopover` site draws a `WriteInCard`. Deleting the chip from `reservationBadge` wholesale, as D9 as written would do, would make a write-in invisible on the entire map surface.

## What changed

- **`unitBadges.ts`**: exported `writeInBadgeApplies(unit)`, mirroring the exact gate `reservationBadge`'s write-in branch already used (`inventory_class !== 'staff_default' && writeInOccupant(unit) !== null`), so a caller can suppress the chip without re-deriving — and risking drifting from — that gate. `reservationBadge` itself is otherwise untouched: it still returns the "Write-in" chip for `MapUnitPopover`'s two call sites exactly as before.
- **`LodgingUnitCard.tsx`**: the badge row now suppresses the chip only when `writeInBadgeApplies(unit)` is true, since `WriteInCard` already names the occupant in the well below. Every other badge on this card (Staff, Released, Building, Shared OK, sharing-conflict, over-capacity, etc.) is unaffected.
- **`unitBadges.ts` `availabilityAction`**: the shared `clear()` helper now takes an optional `label`, defaulting to `'Clear'`. Only the write-in-clear branch (`writeInSource(unit) !== null`) passes `'Clear Write-in'`. The release-clear branch (a staff cabin's own `Released` override) and the generic "agrees with role" clear branch keep the bare `'Clear'` — neither of those undoes a write-in, so borrowing the wording would name a fact that isn't there.
- **Inherited write-in path** (`LodgingBoard.tsx`'s `writeAvailability`, driven by `UnitAvailabilityWrite`): untouched. `availabilityAction` still resolves the clear to the unit that HOLDS the row via `writeInSource`, and the button on the inheriting card now reads "Clear Write-in" while still writing against the covering unit's id/name — pinned by an updated `LodgingBoard.availability.test.tsx` test.
- **`UnitAvailabilityControl.tsx`**'s "Optional beside a write-in; required on a release. `''` on a clear." contract is untouched — only the button's `label` changed, never the prompt/required-field logic.

## Deliberately NOT done

- No confirm dialog — D9 rules that out explicitly.
- No relabelling of the `Release` clear or the generic-override clear; both keep `'Clear'`.
- No change to `reservationBadge`'s output or call sites on `MapUnitPopover` — the map surface still shows the "Write-in" chip exactly as before.
- No doc updates — no architecture doc referenced the write-in chip's presence on `LodgingUnitCard` specifically.

## Tests

- `unitBadges.test.ts`: updated the existing write-in-clear test to assert `label: 'Clear Write-in'` (was `'Clear'`), and added a test that the released-staff-cabin clear keeps the bare `'Clear'` — proving the relabel is scoped to the write-in branch alone.
- `LodgingUnitCard.test.tsx`: 3 new tests — the chip is gone from the badge row while `WriteInCard`'s own occupant name is still present; an unrelated badge (`Shared OK`) still renders on the same card (suppression is scoped, not wholesale); the availability button reads "Clear Write-in Cedar 1".
- `UnitAvailabilityControl.test.tsx`: tightened 3 existing tests from a loose `/clear/i` query to the exact accessible name `'Clear Write-in Cedar 1'` / `'Clear Write-in House A'`, including the INHERITED-write-in test, which also confirms the clear still targets the covering unit (`House`), not the inheriting card.
- `LodgingBoard.availability.test.tsx`: tightened its 2 existing inherited-clear assertions to the new exact button name.
- Targeted run across all 6 touched/adjacent spec files: **252 tests passed**. Full frontend suite: **449 files, 6854 tests, all passed**. `tsc --noEmit`: clean.

## Mutation-check evidence

1. Deleted the write-in branch from `reservationBadge` wholesale (returning nothing for a write-in unit). Result: **9 tests went RED** — 6 in `unitBadges.test.ts`, 3 in `MapUnitPopover.test.tsx` (including "badges a written-into room, reusing the inventory and board wording" and "renders the whole-building badge and a write-in badge together, legibly" — the exact tests proving the map surface still shows a write-in). Restored; suite back to green.
2. Reverted the write-in-clear branch to the bare `'Clear'` label. Result: **7 tests went RED** across `unitBadges.test.ts`, `LodgingUnitCard.test.tsx`, `UnitAvailabilityControl.test.tsx`, and `LodgingBoard.availability.test.tsx`. Restored; suite back to green.

Closes #2252.
