### PR TITLE
fix(sync): inject the active season into the lodging orphan sweep

### DIFF
--- a/pocketbase/main_test_parallelism_test.go
+++ b/pocketbase/main_test_parallelism_test.go
@@ -61,31 +61,6 @@ var serialGroups = []struct {
 		},
 	},
 	{
-		// LodgingAssignmentsSync.activeSeasonYear() calls ParseSeasonYear()
-		// unconditionally to gate the #2028 orphan sweep, so these eight can
-		// only reach the sweep through the environment.
-		//
-		// They are also the most expensive tests left serial -- ~22s of the
-		// ~25s serial prefix, because each builds a fresh ~15-collection
-		// schema and that is pure CPU under the race detector. Injecting the
-		// active season instead of reading the env would recover most of it.
-		// Deliberately not done here: that is an edit to a deletion gate, and
-		// it should not ride inside a thousand-line mechanical diff where no
-		// reviewer will find it.
-		pkg:    "sync",
-		reason: "t.Setenv: orphan sweep gates on CAMPMINDER_SEASON_ID",
-		tests: []string{
-			"TestLodgingAssignmentsSyncDeletesOrphanedHouseholdMirrorRow",
-			"TestLodgingAssignmentsSyncDeletesOrphanedPersonGrainMirrorRow",
-			"TestLodgingAssignmentsSyncDeletesStaffTouchedOrphanedMirrorRow",
-			"TestLodgingAssignmentsSyncDryRunDoesNotDeleteOrphans",
-			"TestLodgingAssignmentsSyncKeepsMirrorRowForStillEnrolledHousehold",
-			"TestLodgingAssignmentsSyncSkipsMirrorDeletionWhenSessionHasZeroEnrolled",
-			"TestLodgingAssignmentsSyncSkipsOrphanSweepForHistoricalYear",
-			"TestLodgingAssignmentsSyncWritesHistoryOnOrphanDelete",
-		},
-	},
-	{
 		pkg:    "sync",
 		reason: "t.Setenv: asserts the CAMPMINDER_SEASON_ID fallback specifically",
 		tests: []string{

--- a/pocketbase/main_test_parallelism_test.go
+++ b/pocketbase/main_test_parallelism_test.go
@@ -58,6 +58,22 @@ var serialGroups = []struct {
 			"TestParseSeasonYear_BelowRange",
 			"TestParseSeasonYear_AboveRange",
 			"TestParseSeasonYear_Boundaries",
+			"TestActiveSeasonYearFailsClosedWhenUnset",
+		},
+	},
+	{
+		// #2289 review: the eight orphan-sweep tests migrated onto
+		// s.ActiveSeasonYear so they could run in parallel, but that left the
+		// #2028 year gate itself (year != active) and production's actual
+		// CAMPMINDER_SEASON_ID fallback path with zero direct coverage --
+		// s.ActiveSeasonYear always overrides both in every other test in this
+		// file. These two drive Sync() with ActiveSeasonYear left at 0, so
+		// they need the real environment variable.
+		pkg:    "sync",
+		reason: "t.Setenv: CAMPMINDER_SEASON_ID drives the #2028 gate itself, not the ActiveSeasonYear override",
+		tests: []string{
+			"TestLodgingAssignmentsSyncSkipsOrphanSweepWhenSeasonUnresolvable",
+			"TestLodgingAssignmentsSyncDeletesOrphansViaEnvFallback",
 		},
 	},
 	{

--- a/pocketbase/sync/lodging_assignments_sync.go
+++ b/pocketbase/sync/lodging_assignments_sync.go
@@ -31,12 +31,19 @@ const sourceFieldOrphanSweep = "orphan_sweep"
 // household_custom_values / person_custom_values / attendees / persons /
 // camp_sessions and the lodging registry, all from PocketBase.
 type LodgingAssignmentsSync struct {
-	App            core.App
-	Year           int  // 0 = current year from env
-	DryRun         bool // compute but do not write
-	Debug          bool
-	Stats          Stats
-	SyncSuccessful bool
+	App    core.App
+	Year   int  // 0 = current year from env
+	DryRun bool // compute but do not write
+	Debug  bool
+	// ActiveSeasonYear injects the value activeSeasonYear() returns, bypassing
+	// CAMPMINDER_SEASON_ID entirely. 0 (the zero value) means "resolve from
+	// the environment via ParseSeasonYear() at Sync time", matching Year's
+	// existing convention. Set directly by tests exercising the #2028 orphan
+	// sweep so they need not reach for t.Setenv, which cannot be combined with
+	// t.Parallel() (#2289).
+	ActiveSeasonYear int
+	Stats            Stats
+	SyncSuccessful   bool
 
 	resolver *AliasResolver
 	issues   *IssueRecorder
@@ -867,16 +874,23 @@ func (s *LodgingAssignmentsSync) partySize(in *ingestContext, sessionID string) 
 	return enrolled + adultCount
 }
 
-// activeSeasonYear resolves CAMPMINDER_SEASON_ID -- the year this deployment
-// is actively maintaining right now, independent of s.Year. deleteLodgingOrphans
-// must run for THAT year alone; any other caller (an explicit ?year= sync, a
-// historical re-registration) is asking this ingest to compute placements for
-// a year it is not currently responsible for, and must get create/update only.
-// A resolution failure fails closed: 0 can never equal a validated 2017-2050
-// year (Sync already rejected anything outside that range), so an
-// unset/invalid CAMPMINDER_SEASON_ID blocks the sweep rather than accidentally
-// allowing it.
+// activeSeasonYear resolves the year this deployment is actively maintaining
+// right now, independent of s.Year. deleteLodgingOrphans must run for THAT
+// year alone; any other caller (an explicit ?year= sync, a historical
+// re-registration) is asking this ingest to compute placements for a year it
+// is not currently responsible for, and must get create/update only.
+//
+// s.ActiveSeasonYear, when set, is returned directly -- the injection point
+// tests use instead of t.Setenv (#2289). When it is unset (the zero value),
+// this falls back to CAMPMINDER_SEASON_ID via ParseSeasonYear(), same as
+// before. Either way, a resolution failure fails closed: 0 can never equal a
+// validated 2017-2050 year (Sync already rejected anything outside that
+// range), so an unset/invalid season blocks the sweep rather than
+// accidentally allowing it.
 func (s *LodgingAssignmentsSync) activeSeasonYear() int {
+	if s.ActiveSeasonYear != 0 {
+		return s.ActiveSeasonYear
+	}
 	active, err := ParseSeasonYear()
 	if err != nil {
 		return 0

--- a/pocketbase/sync/lodging_assignments_sync_test.go
+++ b/pocketbase/sync/lodging_assignments_sync_test.go
@@ -926,8 +926,15 @@ func stalePersonAssignment(
 // activeSeasonYear() must resolve to 0 -- 0 can never equal a validated
 // 2017-2050 season, so the #2028 orphan sweep's year gate blocks rather than
 // runs.
+//
+// Serial, not t.Parallel(): "unset" has to be true of the actual process
+// environment, not just of whatever this test happens to read, so it clears
+// CAMPMINDER_SEASON_ID with t.Setenv rather than assuming a clean ambient
+// env. A developer who has exported the repo's own .env (which sets
+// CAMPMINDER_SEASON_ID) into their shell would otherwise get a spurious red
+// here on correct code (kindred#2289 review).
 func TestActiveSeasonYearFailsClosedWhenUnset(t *testing.T) {
-	t.Parallel()
+	t.Setenv("CAMPMINDER_SEASON_ID", "")
 	s := NewLodgingAssignmentsSync(nil)
 	if got := s.activeSeasonYear(); got != 0 {
 		t.Errorf("activeSeasonYear() = %d, want 0 (fail closed)", got)
@@ -1202,6 +1209,99 @@ func TestLodgingAssignmentsSyncSkipsOrphanSweepForHistoricalYear(t *testing.T) {
 	}
 	if got := s.GetStats().Deleted; got != 0 {
 		t.Errorf("Stats.Deleted = %d, want 0 -- a historical sync must never lose rows to the orphan sweep", got)
+	}
+}
+
+// TestLodgingAssignmentsSyncSkipsOrphanSweepWhenSeasonUnresolvable pins the
+// #2028 year gate itself, not just activeSeasonYear()'s return value
+// (kindred#2289 review, finding 1). Every other test above sets
+// s.ActiveSeasonYear directly, so the gate's `year != active` comparison is
+// never driven with an unresolvable season -- a mutation that fail-opened the
+// gate to "no configured season means no gate" passed the entire package.
+// This leaves ActiveSeasonYear at its zero value and clears
+// CAMPMINDER_SEASON_ID with t.Setenv, matching production's actual state on
+// a deployment where the env var is missing or invalid, and asserts the
+// cancelled household's row SURVIVES: an unresolvable active season must
+// block the sweep, not accidentally allow it.
+//
+// Serial, not t.Parallel(): t.Setenv panics under Parallel.
+func TestLodgingAssignmentsSyncSkipsOrphanSweepWhenSeasonUnresolvable(t *testing.T) {
+	t.Setenv("CAMPMINDER_SEASON_ID", "")
+	app := newLodgingTestApp(t)
+	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
+		testSessionStart, testSessionEnd, 2025)
+	unit := addUnit(t, app, "ridge-a", 2025)
+	addAlias(t, app, "Ridge A", []string{unit}, 0, 0)
+	cabinDef := addFieldDef(t, app, cmIDFamilyCampCabin, fieldNameFamilyCampCabin)
+
+	hh := addHousehold(t, app, 9001, 2025)
+	emma := addPerson(t, app, 5001, 9001, 2025, hh)
+	addAttendee(t, app, emma, sess, 5001, 32, 2025) // cancelled
+	addHouseholdValue(t, app, hh, cabinDef, "Ridge A", testLastUpdated, 2025)
+	staleRow := staleHouseholdAssignment(t, app, sess, cmIDFamilyCamp1, 9001, 2025, unit, false)
+
+	hh2 := addHousehold(t, app, 9002, 2025)
+	liam := addPerson(t, app, 5002, 9002, 2025, hh2)
+	addAttendee(t, app, liam, sess, 5002, 2, 2025)
+
+	s := NewLodgingAssignmentsSync(app)
+	s.Year = 2025
+	// s.ActiveSeasonYear left at 0 -- CAMPMINDER_SEASON_ID unresolvable too.
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	if _, err := app.FindRecordById("lodging_assignments", staleRow); err != nil {
+		t.Errorf("orphan sweep ran with an unresolvable active season -- real placement deleted: %v", err)
+	}
+	if got := s.GetStats().Deleted; got != 0 {
+		t.Errorf("Stats.Deleted = %d, want 0 -- an unresolvable season must fail closed, not fail open", got)
+	}
+}
+
+// TestLodgingAssignmentsSyncDeletesOrphansViaEnvFallback covers the code
+// path production actually runs: every real deployment leaves
+// s.ActiveSeasonYear at 0 and resolves the active season from
+// CAMPMINDER_SEASON_ID via ParseSeasonYear() (kindred#2289 review, finding
+// 2). Migrating all eight sweep tests onto s.ActiveSeasonYear left that
+// fallback with no coverage at all -- a mutation that deleted the
+// ParseSeasonYear() fallback entirely still passed the whole package. This
+// test is the env-fallback twin of
+// TestLodgingAssignmentsSyncDeletesOrphanedHouseholdMirrorRow: same fixture,
+// but the active season is resolved from the environment, not injected.
+//
+// Serial, not t.Parallel(): t.Setenv panics under Parallel.
+func TestLodgingAssignmentsSyncDeletesOrphansViaEnvFallback(t *testing.T) {
+	t.Setenv("CAMPMINDER_SEASON_ID", "2025")
+	app := newLodgingTestApp(t)
+	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
+		testSessionStart, testSessionEnd, 2025)
+	unit := addUnit(t, app, "ridge-a", 2025)
+	addAlias(t, app, "Ridge A", []string{unit}, 0, 0)
+	cabinDef := addFieldDef(t, app, cmIDFamilyCampCabin, fieldNameFamilyCampCabin)
+
+	hh := addHousehold(t, app, 9001, 2025)
+	emma := addPerson(t, app, 5001, 9001, 2025, hh)
+	addAttendee(t, app, emma, sess, 5001, 32, 2025) // cancelled
+	addHouseholdValue(t, app, hh, cabinDef, "Ridge A", testLastUpdated, 2025)
+	staleRow := staleHouseholdAssignment(t, app, sess, cmIDFamilyCamp1, 9001, 2025, unit, false)
+
+	hh2 := addHousehold(t, app, 9002, 2025)
+	liam := addPerson(t, app, 5002, 9002, 2025, hh2)
+	addAttendee(t, app, liam, sess, 5002, 2, 2025)
+
+	s := NewLodgingAssignmentsSync(app)
+	s.Year = 2025
+	// s.ActiveSeasonYear left at 0 -- must resolve via CAMPMINDER_SEASON_ID.
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	if _, err := app.FindRecordById("lodging_assignments", staleRow); err == nil {
+		t.Error("cancelled household's stale mirror row still exists -- env fallback did not reach the sweep")
+	}
+	if got := s.GetStats().Deleted; got != 1 {
+		t.Errorf("Stats.Deleted = %d, want 1", got)
 	}
 }
 

--- a/pocketbase/sync/lodging_assignments_sync_test.go
+++ b/pocketbase/sync/lodging_assignments_sync_test.go
@@ -921,12 +921,38 @@ func stalePersonAssignment(
 	})
 }
 
+// TestActiveSeasonYearFailsClosedWhenUnset pins #2289's fail-closed contract
+// directly: with neither ActiveSeasonYear nor CAMPMINDER_SEASON_ID set,
+// activeSeasonYear() must resolve to 0 -- 0 can never equal a validated
+// 2017-2050 season, so the #2028 orphan sweep's year gate blocks rather than
+// runs.
+func TestActiveSeasonYearFailsClosedWhenUnset(t *testing.T) {
+	t.Parallel()
+	s := NewLodgingAssignmentsSync(nil)
+	if got := s.activeSeasonYear(); got != 0 {
+		t.Errorf("activeSeasonYear() = %d, want 0 (fail closed)", got)
+	}
+}
+
+// TestActiveSeasonYearFieldOverridesEnv pins the injection point #2289 adds:
+// with ActiveSeasonYear set directly, activeSeasonYear() returns it without
+// needing CAMPMINDER_SEASON_ID in the environment at all -- the reason the
+// eight orphan-sweep tests below no longer need t.Setenv to reach the sweep.
+func TestActiveSeasonYearFieldOverridesEnv(t *testing.T) {
+	t.Parallel()
+	s := NewLodgingAssignmentsSync(nil)
+	s.ActiveSeasonYear = 2025
+	if got := s.activeSeasonYear(); got != 2025 {
+		t.Errorf("activeSeasonYear() = %d, want 2025 (injected field)", got)
+	}
+}
+
 // TestLodgingAssignmentsSyncDeletesOrphanedHouseholdMirrorRow is #2028 itself:
 // nothing ever removed a cancelled household's lodging_assignments row before
 // this pass.
 func TestLodgingAssignmentsSyncDeletesOrphanedHouseholdMirrorRow(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
-	t.Setenv("CAMPMINDER_SEASON_ID", "2025") // orphan sweep only runs for the active season (#2028)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
 	unit := addUnit(t, app, "ridge-a", 2025)
@@ -948,6 +974,7 @@ func TestLodgingAssignmentsSyncDeletesOrphanedHouseholdMirrorRow(t *testing.T) {
 
 	s := NewLodgingAssignmentsSync(app)
 	s.Year = 2025
+	s.ActiveSeasonYear = 2025 // orphan sweep only runs for the active season (#2028)
 	if err := s.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync: %v", err)
 	}
@@ -963,8 +990,8 @@ func TestLodgingAssignmentsSyncDeletesOrphanedHouseholdMirrorRow(t *testing.T) {
 // TestLodgingAssignmentsSyncKeepsMirrorRowForStillEnrolledHousehold is the
 // obvious regression the sweep must not cause.
 func TestLodgingAssignmentsSyncKeepsMirrorRowForStillEnrolledHousehold(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
-	t.Setenv("CAMPMINDER_SEASON_ID", "2025") // orphan sweep only runs for the active season (#2028)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
 	unit := addUnit(t, app, "ridge-a", 2025)
@@ -979,6 +1006,7 @@ func TestLodgingAssignmentsSyncKeepsMirrorRowForStillEnrolledHousehold(t *testin
 
 	s := NewLodgingAssignmentsSync(app)
 	s.Year = 2025
+	s.ActiveSeasonYear = 2025 // orphan sweep only runs for the active season (#2028)
 	if err := s.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync: %v", err)
 	}
@@ -997,8 +1025,8 @@ func TestLodgingAssignmentsSyncKeepsMirrorRowForStillEnrolledHousehold(t *testin
 // sync" as "everyone cancelled" -- indistinguishable from inside this pass --
 // so its placements are left untouched rather than swept.
 func TestLodgingAssignmentsSyncSkipsMirrorDeletionWhenSessionHasZeroEnrolled(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
-	t.Setenv("CAMPMINDER_SEASON_ID", "2025") // orphan sweep only runs for the active season (#2028)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
 	unit := addUnit(t, app, "ridge-a", 2025)
@@ -1008,6 +1036,7 @@ func TestLodgingAssignmentsSyncSkipsMirrorDeletionWhenSessionHasZeroEnrolled(t *
 
 	s := NewLodgingAssignmentsSync(app)
 	s.Year = 2025
+	s.ActiveSeasonYear = 2025 // orphan sweep only runs for the active season (#2028)
 	if err := s.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync: %v", err)
 	}
@@ -1023,8 +1052,8 @@ func TestLodgingAssignmentsSyncSkipsMirrorDeletionWhenSessionHasZeroEnrolled(t *
 // TestLodgingAssignmentsSyncDeletesOrphanedPersonGrainMirrorRow is the adult
 // weekend twin: the sweep must treat person-grain rows the same way.
 func TestLodgingAssignmentsSyncDeletesOrphanedPersonGrainMirrorRow(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
-	t.Setenv("CAMPMINDER_SEASON_ID", "2025") // orphan sweep only runs for the active season (#2028)
 	sess := addSession(t, app, cmIDWomensWeekend, "Women's Weekend", "adult",
 		testAdultSessionStart, testAdultSessionEnd, 2025)
 	unit := addUnit(t, app, "river-c", 2025)
@@ -1042,6 +1071,7 @@ func TestLodgingAssignmentsSyncDeletesOrphanedPersonGrainMirrorRow(t *testing.T)
 
 	s := NewLodgingAssignmentsSync(app)
 	s.Year = 2025
+	s.ActiveSeasonYear = 2025 // orphan sweep only runs for the active season (#2028)
 	if err := s.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync: %v", err)
 	}
@@ -1058,8 +1088,8 @@ func TestLodgingAssignmentsSyncDeletesOrphanedPersonGrainMirrorRow(t *testing.T)
 // matching the ruling #2028 makes for the draft-null pass in
 // stranded_assignment_cleanup.go.
 func TestLodgingAssignmentsSyncDeletesStaffTouchedOrphanedMirrorRow(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
-	t.Setenv("CAMPMINDER_SEASON_ID", "2025") // orphan sweep only runs for the active season (#2028)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
 	unit := addUnit(t, app, "ridge-a", 2025)
@@ -1077,6 +1107,7 @@ func TestLodgingAssignmentsSyncDeletesStaffTouchedOrphanedMirrorRow(t *testing.T
 
 	s := NewLodgingAssignmentsSync(app)
 	s.Year = 2025
+	s.ActiveSeasonYear = 2025 // orphan sweep only runs for the active season (#2028)
 	if err := s.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync: %v", err)
 	}
@@ -1089,8 +1120,8 @@ func TestLodgingAssignmentsSyncDeletesStaffTouchedOrphanedMirrorRow(t *testing.T
 // TestLodgingAssignmentsSyncDryRunDoesNotDeleteOrphans: DryRun computes but
 // does not write, full stop -- including the delete path.
 func TestLodgingAssignmentsSyncDryRunDoesNotDeleteOrphans(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
-	t.Setenv("CAMPMINDER_SEASON_ID", "2025") // orphan sweep only runs for the active season (#2028)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
 	unit := addUnit(t, app, "ridge-a", 2025)
@@ -1108,6 +1139,7 @@ func TestLodgingAssignmentsSyncDryRunDoesNotDeleteOrphans(t *testing.T) {
 
 	s := NewLodgingAssignmentsSync(app)
 	s.Year = 2025
+	s.ActiveSeasonYear = 2025 // orphan sweep only runs for the active season (#2028)
 	s.DryRun = true
 	if err := s.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync: %v", err)
@@ -1133,8 +1165,8 @@ func TestLodgingAssignmentsSyncDryRunDoesNotDeleteOrphans(t *testing.T) {
 // not it. A stale/partial local attendees snapshot for a season that already
 // happened must never read as "everyone cancelled".
 func TestLodgingAssignmentsSyncSkipsOrphanSweepForHistoricalYear(t *testing.T) {
+	t.Parallel()
 	app := newLodgingTestApp(t)
-	t.Setenv("CAMPMINDER_SEASON_ID", "2025") // the ACTIVE season is 2025...
 
 	// ...but this sync targets 2024, a season that already happened.
 	const historicalYear = 2024
@@ -1159,7 +1191,8 @@ func TestLodgingAssignmentsSyncSkipsOrphanSweepForHistoricalYear(t *testing.T) {
 	addAttendee(t, app, liam, sess, 5002, 2, historicalYear)
 
 	s := NewLodgingAssignmentsSync(app)
-	s.Year = historicalYear // the orchestrator's historical path / API ?year=2024
+	s.Year = historicalYear   // the orchestrator's historical path / API ?year=2024
+	s.ActiveSeasonYear = 2025 // ...while the deployment's active season stays 2025
 	if err := s.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync: %v", err)
 	}
@@ -1178,12 +1211,12 @@ func TestLodgingAssignmentsSyncSkipsOrphanSweepForHistoricalYear(t *testing.T) {
 // delete with no history row would be both unrecoverable and untraceable, so
 // the orphan sweep must write one too.
 func TestLodgingAssignmentsSyncWritesHistoryOnOrphanDelete(t *testing.T) {
+	t.Parallel()
 	// unit's own code, not a repeated "ridge-a" literal -- keeps the addUnit
 	// call and the history assertion below in step, and avoids adding a 3rd/4th
 	// hardcoded occurrence of the string across this file (goconst).
 	const unitCode = "ridge-a"
 	app := newLodgingTestApp(t)
-	t.Setenv("CAMPMINDER_SEASON_ID", "2025") // orphan sweep only runs for the active season (#2028)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
 	unit := addUnit(t, app, unitCode, 2025)
@@ -1203,6 +1236,7 @@ func TestLodgingAssignmentsSyncWritesHistoryOnOrphanDelete(t *testing.T) {
 
 	s := NewLodgingAssignmentsSync(app)
 	s.Year = 2025
+	s.ActiveSeasonYear = 2025 // orphan sweep only runs for the active season (#2028)
 	if err := s.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync: %v", err)
 	}


### PR DESCRIPTION
## The defect

`LodgingAssignmentsSync.activeSeasonYear()` (`pocketbase/sync/lodging_assignments_sync.go`) called `ParseSeasonYear()` unconditionally, so the only way to drive the `#2028` orphan sweep was through `CAMPMINDER_SEASON_ID`. That forced its eight tests to use `t.Setenv`, and Go panics on `t.Setenv` combined with `t.Parallel()`. Those eight tests were the "orphan sweep gates on CAMPMINDER_SEASON_ID" entry in `main_test_parallelism_test.go`'s `serialGroups`, which the issue reported as ~22.0s of the serial prefix under `-race`. I could not get a clean isolated re-measurement of that specific 8-test slice on unmodified `main` myself (see "Deliberately not done" below), so I'm not re-quoting that figure as something I personally verified — only citing it as the issue's stated rationale for the change.

## The fix

Added `ActiveSeasonYear` as an injectable field on `LodgingAssignmentsSync`, defaulting to `ParseSeasonYear()` when left at its zero value, so tests set the active season directly instead of reaching for the environment:

```go
func (s *LodgingAssignmentsSync) activeSeasonYear() int {
	if s.ActiveSeasonYear != 0 {
		return s.ActiveSeasonYear
	}
	active, err := ParseSeasonYear()
	if err != nil {
		return 0
	}
	return active
}
```

Fail-closed is unchanged and now pinned directly: a new `TestActiveSeasonYearFailsClosedWhenUnset` asserts that with neither the field nor the env set, `activeSeasonYear()` returns 0 — which can never equal a validated 2017-2050 year, so the deletion gate still blocks the sweep rather than accidentally allowing it. A companion `TestActiveSeasonYearFieldOverridesEnv` pins the injection point itself.

Migrated the eight orphan-sweep tests off `t.Setenv` onto `s.ActiveSeasonYear`, added `t.Parallel()` to each, and removed their `serialGroups` exemption. The historical-year test (`TestLodgingAssignmentsSyncSkipsOrphanSweepForHistoricalYear`) keeps its exact shape — `ActiveSeasonYear = 2025` while `s.Year = 2024` — since that mismatch is the whole point of the test.

## Deliberately not done

- **Deletion semantics are unchanged.** The eight tests still assert exactly what they asserted before (orphaned mirror rows, dry-run, staff-touched rows, historical-year gating) — only *how* the active season arrives changed, not *what* the sweep does. No assertion was weakened.
- **No other `ParseSeasonYear()` call site touched.** It has ~32 call sites (26 non-test); only `lodging_assignments_sync.go`'s needed the injectable field for this issue.
- **No before/after wall-clock comparison quoted.** I measured `go test -race ./sync/` on this branch at 136.4s wall (full package), but the equivalent measurement on unmodified `main` ran inside the shared main checkout while another agent's own test run was actively contending for CPU there, so I did not get a clean baseline and am not quoting one.

## Verification (all measured on this branch)

- `go test -race ./sync/ -run 'Orphan|Sweep|Season|ActiveSeasonYear' -v`: PASS
- `go test -race ./sync/` (full package): PASS, 136.4s wall
- `go test ./...` (full suite): PASS, 108.2s wall
- `go vet ./...`: clean
- `bash scripts/pre-push-verify.sh`: **ALL CHECKS PASSED**
- `TestSyncAndLodgingTestsRunInParallel` / `TestSerialTestExemptionsAreAllStillNeeded`: both PASS with the exemption removed
- **Mutation check**: changed `activeSeasonYear()`'s parse-failure branch to `return 2025` instead of `return 0`. `TestActiveSeasonYearFailsClosedWhenUnset` went RED:
  ```
  lodging_assignments_sync_test.go:933: activeSeasonYear() = 2025, want 0 (fail closed)
  --- FAIL: TestActiveSeasonYearFailsClosedWhenUnset (0.00s)
  ```
  Reverted; test passes again.

Closes #2289.
