### PR TITLE
fix(frontend): gate four overlays' Escape on the modalStack token, classify the rest

### DIFF
--- a/frontend/src/components/CamperCard.test.tsx
+++ b/frontend/src/components/CamperCard.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * kindred#2237 — CamperCard's right-click context menu and the kindred#2205
+ * overlay token stack.
+ *
+ * The menu is rendered by cards INSIDE the expanded `ui/FloatingQueueBadge`
+ * queue (see `FloatingUnassignedBadge`, which renders CamperCard rows straight
+ * into the badge's popover). Both surfaces listened on `document` in the
+ * bubble phase and neither stopped propagation, so a single Escape closed the
+ * context menu AND collapsed the queue it was opened from — the kindred#2205
+ * double-close, still live on the board.
+ *
+ * The menu is the overlay that sits ON TOP, so it is the one that needs the
+ * token: once it swallows the key while topmost, the badge beneath it never
+ * sees the press and needs no token of its own.
+ *
+ * Fictional data throughout.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+import CamperCard from './CamperCard'
+import { acquireOverlayToken, hasOpenModal, releaseOverlayToken } from './ui/modalStack'
+import { mockCamper } from '../test/mockData'
+import { emptyCamperSatisfaction } from '../types/satisfaction'
+
+vi.mock('../hooks/useCurrentYear', () => ({ useYear: () => 2025 }))
+
+vi.mock('@dnd-kit/sortable', () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}))
+
+vi.mock('../hooks', () => ({
+  useBunkRequestContext: () => ({
+    getSatisfiedRequestInfo: (cmId: number) => emptyCamperSatisfaction(cmId),
+  }),
+  useCamperHistoryContext: () => ({ getLastYearHistory: () => null }),
+}))
+
+vi.mock('../contexts/LockGroupContext', () => ({
+  useLockGroupContext: () => ({
+    addPendingCamper: vi.fn(),
+    removePendingCamper: vi.fn(),
+    getPendingAnimationDelay: () => 0,
+    groups: [],
+    addCamperToGroup: vi.fn(),
+    getCamperLockGroup: () => null,
+    getGroupMembers: () => [],
+    setSelectedGroupId: vi.fn(),
+    setIsLockPanelOpen: vi.fn(),
+  }),
+}))
+
+describe('CamperCard — context-menu overlay token (kindred#2237)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  /**
+   * `handleContextMenu` defers the open by one `requestAnimationFrame` (it
+   * broadcasts `closeAllContextMenus` first and lets that settle), so every
+   * test has to wait for the menu rather than assert synchronously.
+   */
+  async function openMenu() {
+    const view = render(<CamperCard camper={mockCamper({ person_cm_id: 9001 })} isDraftMode />)
+    const card = document.querySelector('[data-camper-card], button') as HTMLElement
+    fireEvent.contextMenu(card)
+    await waitFor(() => {
+      expect(screen.getByText('View Details')).toBeInTheDocument()
+    })
+    return view
+  }
+
+  it('closes the menu on Escape when it is the only open overlay', async () => {
+    await openMenu()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    await waitFor(() => {
+      expect(screen.queryByText('View Details')).not.toBeInTheDocument()
+    })
+  })
+
+  it('does NOT close once an overlay has opened on top of it', async () => {
+    await openMenu()
+
+    const topToken = acquireOverlayToken()
+    try {
+      fireEvent.keyDown(document, { key: 'Escape' })
+      expect(screen.getByText('View Details')).toBeInTheDocument()
+    } finally {
+      releaseOverlayToken(topToken)
+    }
+  })
+
+  // The defect this issue is actually about: the expanded FloatingQueueBadge
+  // beneath the menu listens on `document` too. While the menu is topmost it
+  // must swallow the key so the queue does not collapse alongside it.
+  it('swallows the key while topmost, so the queue beneath does not also close', async () => {
+    const beneath = vi.fn()
+    document.addEventListener('keydown', beneath)
+    try {
+      await openMenu()
+
+      fireEvent.keyDown(document, { key: 'Escape' })
+
+      const escapes = beneath.mock.calls.filter(([e]) => (e as KeyboardEvent).key === 'Escape')
+      expect(escapes).toHaveLength(0)
+    } finally {
+      document.removeEventListener('keydown', beneath)
+    }
+  })
+
+  // A leaked token is invisible to a "does it still close?" test — a newly
+  // acquired token is always last in the stack, so the freshly-opened menu is
+  // topmost either way. Only the emptiness of the stack catches it.
+  it('releases its overlay token on unmount, so the stack does not leak', async () => {
+    const { unmount } = await openMenu()
+    expect(hasOpenModal()).toBe(true)
+
+    unmount()
+
+    expect(hasOpenModal()).toBe(false)
+  })
+
+  it('registers no token while the context menu is closed', () => {
+    render(<CamperCard camper={mockCamper({ person_cm_id: 9002 })} isDraftMode />)
+    expect(hasOpenModal()).toBe(false)
+  })
+})

--- a/frontend/src/components/CamperCard.tsx
+++ b/frontend/src/components/CamperCard.tsx
@@ -16,6 +16,7 @@ import { useYear } from '../hooks/useCurrentYear'
 import type { Camper } from '../types/app-types'
 import { useBunkRequestContext, useCamperHistoryContext } from '../hooks'
 import { useLockGroupContext } from '../contexts/LockGroupContext'
+import { useOverlayEscape } from '../hooks/useOverlayEscape'
 import { emptyCamperSatisfaction } from '../types/satisfaction'
 
 interface CamperCardProps {
@@ -95,16 +96,17 @@ function CamperCard({
 
   // Escape dismisses the context menu — the keyboard equivalent for the
   // full-viewport backdrop's click-to-close (see the backdrop's own
-  // eslint-disable below). Matches the pattern already used for the social
-  // graph's expand overlay and several other dismissible surfaces.
-  useEffect(() => {
-    if (!showContextMenu) return
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setShowContextMenu(false)
-    }
-    document.addEventListener('keydown', handleEscape)
-    return () => document.removeEventListener('keydown', handleEscape)
-  }, [showContextMenu])
+  // eslint-disable below).
+  //
+  // NEEDS AN OVERLAY TOKEN (kindred#2237): these cards are rendered INSIDE the
+  // expanded `ui/FloatingQueueBadge` queue (`FloatingUnassignedBadge`), which
+  // closes itself on Escape from its own ungated `document` listener. Two
+  // bubble-phase handlers, neither stopping propagation, meant one press
+  // dismissed the menu AND collapsed the queue it was opened from. The menu is
+  // the overlay on TOP, so it is the one that takes the token; once it
+  // swallows the key while topmost the badge beneath never sees the press,
+  // which is why the badge needs no token of its own.
+  useOverlayEscape(showContextMenu, () => setShowContextMenu(false))
 
   const {
     attributes,

--- a/frontend/src/components/CamperDetailsPanel.test.tsx
+++ b/frontend/src/components/CamperDetailsPanel.test.tsx
@@ -8,6 +8,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '../test/testUtils'
 import CamperDetailsPanel from './CamperDetailsPanel'
+import { acquireOverlayToken, hasOpenModal, releaseOverlayToken } from './ui/modalStack'
 import { mockPerson } from '../test/mockData'
 import { SourceField } from '../types/sourceField'
 import type { CamperSatisfaction, PerRequestStatus } from '../types/satisfaction'
@@ -417,6 +418,73 @@ describe('CamperDetailsPanel', () => {
       } finally {
         document.removeEventListener('keydown', outerHandler)
       }
+    })
+
+    // kindred#2237. The panel used to install its capture-phase listener with
+    // an UNCONDITIONAL `stopPropagation()`, which beat the one outer listener
+    // it was written against but also beat every overlay stacked ABOVE it --
+    // including `AllCamperRequestsModal`, a token-gated `ui/Modal` this very
+    // panel opens. One Escape closed the panel and left the dialog on top of
+    // it open: the wrong overlay, not merely an extra one.
+    describe('overlay token (kindred#2237)', () => {
+      async function renderOpenPanel() {
+        const result = render(<CamperDetailsPanel camperId="12345" onClose={mockOnClose} />)
+        await waitFor(() => {
+          expect(document.querySelector('[data-testid="panel-backdrop"]')).toBeInTheDocument()
+        })
+        return result
+      }
+
+      it('does NOT close once an overlay has opened on top of it', async () => {
+        await renderOpenPanel()
+
+        const topToken = acquireOverlayToken()
+        try {
+          fireEvent.keyDown(document, { key: 'Escape' })
+          expect(document.querySelectorAll('.animate-slide-out-right')).toHaveLength(0)
+        } finally {
+          releaseOverlayToken(topToken)
+        }
+      })
+
+      // The half that the unconditional `stopPropagation` broke: the overlay
+      // above must actually RECEIVE the key the panel stood down from. Without
+      // this the panel merely stops closing and nothing closes at all.
+      it('lets Escape reach the overlay stacked above it', async () => {
+        await renderOpenPanel()
+
+        const outerHandler = vi.fn()
+        document.addEventListener('keydown', outerHandler)
+        const topToken = acquireOverlayToken()
+        try {
+          fireEvent.keyDown(document, { key: 'Escape' })
+          const escapeCalls = outerHandler.mock.calls.filter(
+            ([event]) => (event as KeyboardEvent).key === 'Escape'
+          )
+          expect(escapeCalls).toHaveLength(1)
+        } finally {
+          releaseOverlayToken(topToken)
+          document.removeEventListener('keydown', outerHandler)
+        }
+      })
+
+      it('releases its overlay token on unmount, so the stack does not leak', async () => {
+        const { unmount } = await renderOpenPanel()
+        expect(hasOpenModal()).toBe(true)
+
+        unmount()
+
+        expect(hasOpenModal()).toBe(false)
+      })
+
+      it('registers no token in embedded mode, which handles no Escape at all', async () => {
+        render(<CamperDetailsPanel camperId="12345" onClose={mockOnClose} embedded={true} />)
+        await waitFor(() => {
+          expect(screen.getByText('Camper not found')).toBeInTheDocument()
+        })
+
+        expect(hasOpenModal()).toBe(false)
+      })
     })
   })
 

--- a/frontend/src/components/CamperDetailsPanel.tsx
+++ b/frontend/src/components/CamperDetailsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useMemo } from 'react'
+import { useState, useCallback, useMemo } from 'react'
 import { Link } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
 import {
@@ -55,6 +55,7 @@ import { useOriginalBunkData } from '../hooks/camper/useOriginalBunkData'
 import { fetchCamperJourney, fetchParentMainSessions } from '../hooks/camper/fetchCamperJourney'
 import { collapseAgEnrollments, buildAgParentPairs } from '../hooks/camper/agCollapse'
 import type { HistoricalRecord } from '../hooks/camper/types'
+import { useOverlayEscape } from '../hooks/useOverlayEscape'
 import { useYear } from '../hooks/useCurrentYear'
 import { getDisplayAgeForYear } from '../utils/displayAge'
 import { CampMinderIcon } from './icons'
@@ -539,20 +540,24 @@ export default function CamperDetailsPanel({
     }
   }, [embedded, onClose])
 
-  // Dismiss overlay with Escape key (non-embedded mode only). When mounted
-  // inside a Modal, both listen on `document` for Escape — we register in
-  // the capture phase and stop propagation so the panel closes first and
-  // the underlying modal stays open (LIFO close behaviour).
-  useEffect(() => {
-    if (embedded || isClosing) return
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== 'Escape') return
-      e.stopPropagation()
-      handleClose()
-    }
-    document.addEventListener('keydown', handleKeyDown, true)
-    return () => document.removeEventListener('keydown', handleKeyDown, true)
-  }, [embedded, isClosing, handleClose])
+  // Dismiss overlay with Escape key (non-embedded mode only).
+  //
+  // NEEDS AN OVERLAY TOKEN (kindred#2237), and this was the worst of the
+  // twelve. It used to install a capture-phase `document` listener that called
+  // `stopPropagation()` UNCONDITIONALLY. That beat the one outer listener it
+  // was written against, but a capture-phase stop at `document` halts the
+  // event before the bubble phase begins -- so it also beat every overlay
+  // stacked ABOVE it, all of which (`ui/Modal`, `ConfirmActionPopover`) listen
+  // in the bubble phase and gate on `isTopOverlay` without stopping anything.
+  // `AllCamperRequestsModal`, a `ui/Modal` THIS PANEL ITSELF OPENS, was the
+  // concrete casualty: one Escape closed the panel out from under the dialog
+  // and left the dialog open. Not an extra close -- the wrong one.
+  //
+  // `useOverlayEscape` keeps the capture phase (it must, to stay ahead of the
+  // still-unconverted bubble-phase listeners beneath) but makes the stop
+  // CONDITIONAL on being topmost, so an overlay above this panel now receives
+  // the key it owns.
+  useOverlayEscape(!embedded && !isClosing, handleClose)
 
   // Helper: get location from person's discrete address columns
   const location = getLocationDisplay(

--- a/frontend/src/components/CsvPipelineIndicator.tsx
+++ b/frontend/src/components/CsvPipelineIndicator.tsx
@@ -19,6 +19,10 @@ export default function CsvPipelineIndicator() {
 
   useClickOutside(wrapperRef, () => setPopoverOpen(false), popoverOpen)
 
+  // CORRECT AS-IS, no overlay token (kindred#2237): a trigger popover in the
+  // app shell that `useClickOutside` above dismisses on any outside pointer
+  // press, so opening anything else closes it first. It hosts no overlay and
+  // has no host relationship with one.
   useEffect(() => {
     if (!popoverOpen) return
     const handleKeyDown = (event: KeyboardEvent) => {

--- a/frontend/src/components/CsvPipelineIndicator.tsx
+++ b/frontend/src/components/CsvPipelineIndicator.tsx
@@ -21,8 +21,9 @@ export default function CsvPipelineIndicator() {
 
   // CORRECT AS-IS, no overlay token (kindred#2237): a trigger popover in the
   // app shell that `useClickOutside` above dismisses on any outside pointer
-  // press, so opening anything else closes it first. It hosts no overlay and
-  // has no host relationship with one.
+  // press, so opening anything else closes it first. It IS an overlay, but
+  // no other Escape-handling surface is expected to coexist with it open --
+  // nothing to yield to, nothing that yields to it.
   useEffect(() => {
     if (!popoverOpen) return
     const handleKeyDown = (event: KeyboardEvent) => {

--- a/frontend/src/components/OptimizeBunksButton.tsx
+++ b/frontend/src/components/OptimizeBunksButton.tsx
@@ -199,7 +199,11 @@ export default function OptimizeBunksButton({
     }
   }, [isOpen])
 
-  // Handle escape key to close dropdown
+  // Handle escape key to close dropdown.
+  //
+  // CORRECT AS-IS, no overlay token (kindred#2237): same self-limiting shape
+  // as `CsvPipelineIndicator` -- a header dropdown dismissed by the
+  // outside-mousedown listener directly above, hosting no overlay of its own.
   useEffect(() => {
     function handleEscape(event: KeyboardEvent) {
       if (event.key === 'Escape') {

--- a/frontend/src/components/OptimizeBunksButton.tsx
+++ b/frontend/src/components/OptimizeBunksButton.tsx
@@ -202,8 +202,10 @@ export default function OptimizeBunksButton({
   // Handle escape key to close dropdown.
   //
   // CORRECT AS-IS, no overlay token (kindred#2237): same self-limiting shape
-  // as `CsvPipelineIndicator` -- a header dropdown dismissed by the
-  // outside-mousedown listener directly above, hosting no overlay of its own.
+  // as `CsvPipelineIndicator` -- the portal dropdown below IS an overlay
+  // surface, but it's dismissed by the outside-mousedown listener directly
+  // above, and no other Escape-handling surface is expected to coexist with
+  // it open.
   useEffect(() => {
     function handleEscape(event: KeyboardEvent) {
       if (event.key === 'Escape') {

--- a/frontend/src/components/RequestReviewPanel.test.tsx
+++ b/frontend/src/components/RequestReviewPanel.test.tsx
@@ -16,6 +16,7 @@ import { screen, fireEvent, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { render, waitFor } from '../test/testUtils'
 import RequestReviewPanel from './RequestReviewPanel'
+import { acquireOverlayToken, hasOpenModal, releaseOverlayToken } from './ui/modalStack'
 import type { BunkRequestsResponse, PersonsResponse } from '../types/pocketbase-types'
 
 /**
@@ -2369,5 +2370,139 @@ describe('RequestReviewPanel', () => {
       const mobileRowPath = resolve(__dirname, 'RequestRowMobile.tsx')
       expect(existsSync(mobileRowPath)).toBe(false)
     })
+  })
+})
+
+/**
+ * kindred#2237 — the bulk-confirm dialog's Escape handler.
+ *
+ * This panel renders FIVE independently-stated overlays (`CreateRequestModal`,
+ * `CamperDetailsPanel`, `MergeRequestsModal`, `SplitRequestModal`,
+ * `ConfirmActionPopover`) plus this `role="dialog"` bulk-confirm. Nothing
+ * makes them mutually exclusive, and neither `ui/Modal` nor
+ * `ConfirmActionPopover` calls `stopPropagation()` — both merely gate on
+ * `isTopOverlay`. So an ungated bubble-phase listener here fired ALONGSIDE
+ * whichever of them was genuinely on top: the original kindred#2205
+ * double-close, reachable from this panel six different ways.
+ *
+ * Fictional data throughout.
+ */
+describe('RequestReviewPanel — bulk-confirm overlay token (kindred#2237)', () => {
+  async function openBulkConfirmDialog() {
+    window.localStorage.setItem(
+      'kindred-requests-filters-1001',
+      JSON.stringify({
+        filters: { requestTypes: [], statuses: ['pending'], searchQuery: '' },
+        sort: { sortBy: 'requester', sortOrder: 'asc' },
+      })
+    )
+
+    const records: BunkRequestsResponse[] = [
+      {
+        id: 'esc-rec-1',
+        requester_id: 610,
+        requestee_id: 611,
+        session_id: 1001,
+        year: 2025,
+        status: 'pending',
+        request_type: 'bunk_with',
+        confidence_score: 0.8,
+      } as BunkRequestsResponse,
+    ]
+
+    const { pb } = (await import('../lib/pocketbase')) as unknown as {
+      pb: { collection: ReturnType<typeof vi.fn> }
+    }
+    pb.collection.mockImplementation((name: string) => {
+      if (name === 'bunk_requests') {
+        return {
+          getFullList: vi.fn(async () => records.map((r) => ({ ...r }))),
+          getList: vi.fn(async () => ({
+            items: records.map((r) => ({ ...r })),
+            totalItems: records.length,
+          })),
+          update: vi.fn().mockResolvedValue({}),
+        }
+      }
+      return {
+        getFullList: vi.fn().mockResolvedValue([]),
+        getList: vi.fn().mockResolvedValue({ items: [], totalItems: 0 }),
+        update: vi.fn().mockResolvedValue({}),
+      }
+    })
+
+    const view = render(<RequestReviewPanel sessionId={1001} year={2025} />)
+    const user = userEvent.setup()
+
+    await waitFor(() => expect(screen.getAllByText('Pending').length).toBeGreaterThanOrEqual(1), {
+      timeout: 3000,
+    })
+
+    for (const cb of screen.getAllByRole('checkbox')) {
+      if ((cb as HTMLInputElement).checked) continue
+      fireEvent.click(cb)
+      const bar = screen.queryByRole('toolbar', { name: /bulk actions/i })
+      if (bar && within(bar).queryByText(/^1 selected$/)) break
+    }
+
+    const toolbar = await waitFor(
+      () => {
+        const t = screen.queryByRole('toolbar', { name: /bulk actions/i })
+        if (!t) throw new Error('no toolbar yet')
+        if (!within(t).queryByText(/^1 selected$/)) throw new Error('not 1 selected yet')
+        return t
+      },
+      { timeout: 3000 }
+    )
+    await user.click(within(toolbar).getByRole('button', { name: /reject/i }))
+    await screen.findByRole('dialog')
+
+    return view
+  }
+
+  it('closes the dialog on Escape when it is the topmost overlay', async () => {
+    await openBulkConfirmDialog()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+  })
+
+  it('does NOT close once an overlay has opened on top of it', async () => {
+    await openBulkConfirmDialog()
+
+    const topToken = acquireOverlayToken()
+    try {
+      fireEvent.keyDown(document, { key: 'Escape' })
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    } finally {
+      releaseOverlayToken(topToken)
+    }
+  })
+
+  // A leaked token is invisible to a "does it still close?" test, because a
+  // newly acquired token is always last in the stack. Only stack emptiness
+  // catches it — kindred#2205 shipped exactly that false-green.
+  it('releases its overlay token on unmount, so the stack does not leak', async () => {
+    const { unmount } = await openBulkConfirmDialog()
+    expect(hasOpenModal()).toBe(true)
+
+    unmount()
+
+    expect(hasOpenModal()).toBe(false)
+  })
+
+  it('registers no token while the bulk-confirm dialog is closed', async () => {
+    await renderPanelWithRequest({
+      id: 'esc-none',
+      requester_id: 620,
+      requestee_id: 621,
+      session_id: 1001,
+      year: 2025,
+      status: 'pending',
+      request_type: 'bunk_with',
+    })
+
+    expect(hasOpenModal()).toBe(false)
   })
 })

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -44,6 +44,7 @@ import MergeRequestsModal from './MergeRequestsModal'
 import SplitRequestModal from './SplitRequestModal'
 import { ConfirmActionPopover } from './ConfirmActionPopover'
 import { useOptimisticValidation } from '../hooks/useOptimisticValidation'
+import { useOverlayEscape } from '../hooks/useOverlayEscape'
 
 interface RequestReviewPanelProps {
   sessionId: number
@@ -112,23 +113,30 @@ export default function RequestReviewPanel({
   const bulkConfirmRef = useRef<HTMLDivElement>(null)
   const bulkConfirmPreviousFocusRef = useRef<HTMLElement | null>(null)
 
+  // NEEDS AN OVERLAY TOKEN (kindred#2237). This panel renders five other
+  // independently-stated overlays — CreateRequestModal, CamperDetailsPanel,
+  // MergeRequestsModal, SplitRequestModal and ConfirmActionPopover — with
+  // nothing making them mutually exclusive with this dialog. Neither
+  // `ui/Modal` nor `ConfirmActionPopover` calls `stopPropagation()`; both only
+  // gate on `isTopOverlay`. So this dialog's ungated bubble-phase listener
+  // fired alongside whichever of them was genuinely on top, and one Escape
+  // closed two overlays.
+  useOverlayEscape(!!bulkConfirm, () => setBulkConfirm(null))
+
   useEffect(() => {
     if (bulkConfirm) {
       bulkConfirmPreviousFocusRef.current = document.activeElement as HTMLElement | null
       const buttons = bulkConfirmRef.current?.querySelectorAll<HTMLElement>('button')
       buttons?.[buttons.length - 1]?.focus()
 
-      // Escape-to-close + Tab focus trap, as a document-level listener rather
-      // than an inline onKeyDown on the role="dialog" element — matching
-      // ui/Modal.tsx's own pattern. jsx-a11y/no-noninteractive-element-interactions
-      // flags an onKeyDown JSX prop on a non-interactive role like "dialog";
-      // an imperative listener sidesteps that while keeping identical behavior
+      // Tab focus trap only — Escape belongs to `useOverlayEscape` below
+      // (kindred#2237). A document-level listener rather than an inline
+      // onKeyDown on the role="dialog" element, matching ui/Modal.tsx's own
+      // pattern: jsx-a11y/no-noninteractive-element-interactions flags an
+      // onKeyDown JSX prop on a non-interactive role like "dialog", and an
+      // imperative listener sidesteps that while keeping identical behavior
       // (keydown bubbles from any focused button inside the dialog either way).
       const handleKeyDown = (e: KeyboardEvent) => {
-        if (e.key === 'Escape') {
-          setBulkConfirm(null)
-          return
-        }
         if (e.key === 'Tab') {
           const dialogButtons = Array.from(
             bulkConfirmRef.current?.querySelectorAll<HTMLElement>('button') ?? []

--- a/frontend/src/components/SocialNetworkGraph.tsx
+++ b/frontend/src/components/SocialNetworkGraph.tsx
@@ -280,7 +280,18 @@ export default function SocialNetworkGraph({ sessionCmId }: SocialNetworkGraphPr
       .map((n) => ({ cmId: n.id, grade: n.grade }))
   }, [graphData, selectedNodeId])
 
-  // Handle escape key for expanded mode
+  // Handle escape key for expanded mode.
+  //
+  // CORRECT AS-IS, no overlay token (kindred#2237). This is a CONTAINER: the
+  // expanded graph is the bottom of its own stack and never sits on top of
+  // another Escape-handling surface. The two overlays it hosts --
+  // `GraphFilterPopover` and `CamperDetailsPanel` -- both went through
+  // `useOverlayEscape` in kindred#2237, and that hook stops propagation in the
+  // document CAPTURE phase while topmost, which lands before this `window`
+  // bubble listener ever runs. So the pairing that used to double-close (open
+  // the filter inside the expanded graph, press Escape, watch the graph
+  // collapse out from under it) is already fixed from the child's side. Giving
+  // this a token would add a lifetime to get wrong for no behaviour gained.
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === 'Escape' && isExpanded) {

--- a/frontend/src/components/graph/filter/GraphFilterPopover.test.tsx
+++ b/frontend/src/components/graph/filter/GraphFilterPopover.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { useRef } from 'react'
 import GraphFilterPopover from './GraphFilterPopover'
+import { acquireOverlayToken, hasOpenModal, releaseOverlayToken } from '../../ui/modalStack'
 import type { BunkSummary } from '../graphFilter'
 
 const ALL_BUNKS: BunkSummary[] = [
@@ -38,7 +39,7 @@ describe('GraphFilterPopover', () => {
   it('Escape calls onClose', () => {
     const props = defaultProps()
     render(<GraphFilterPopover {...props} />)
-    fireEvent.keyDown(window, { key: 'Escape' })
+    fireEvent.keyDown(document, { key: 'Escape' })
     expect(props.onClose).toHaveBeenCalled()
   })
 
@@ -77,5 +78,69 @@ describe('GraphFilterPopover', () => {
     render(<Wrapper />)
     fireEvent.mouseDown(screen.getByTestId('trigger'))
     expect(props.onClose).not.toHaveBeenCalled()
+  })
+
+  // kindred#2237. This popover renders INSIDE the expanded SocialNetworkGraph,
+  // which collapses itself on Escape from its own `window` listener. Before the
+  // kindred#2205 token stack was wired up here, one Escape press ran both
+  // handlers: the popover closed AND the graph collapsed out from under it.
+  describe('overlay token (kindred#2237)', () => {
+    it('does NOT close once a further overlay has opened on top of it', () => {
+      const props = defaultProps()
+      render(<GraphFilterPopover {...props} />)
+
+      const topToken = acquireOverlayToken()
+      try {
+        fireEvent.keyDown(document, { key: 'Escape' })
+        expect(props.onClose).not.toHaveBeenCalled()
+      } finally {
+        // `finally`, not a trailing call: a failing assertion would otherwise
+        // leave this token on the stack and every later test in the file would
+        // see a phantom overlay above it.
+        releaseOverlayToken(topToken)
+      }
+    })
+
+    it('swallows the key while topmost, so the surface underneath does not also close', () => {
+      const props = defaultProps()
+      const beneath = vi.fn()
+      document.addEventListener('keydown', beneath)
+      window.addEventListener('keydown', beneath)
+      try {
+        render(<GraphFilterPopover {...props} />)
+        fireEvent.keyDown(document, { key: 'Escape' })
+        expect(props.onClose).toHaveBeenCalled()
+        expect(beneath).not.toHaveBeenCalled()
+      } finally {
+        document.removeEventListener('keydown', beneath)
+        window.removeEventListener('keydown', beneath)
+      }
+    })
+
+    // A leaked token is invisible to a "does it still close?" test -- a newly
+    // acquired token is always last in the stack, so the freshly-opened overlay
+    // is topmost either way. Only the emptiness of the stack catches it.
+    it('releases its overlay token on unmount, so the stack does not leak', () => {
+      const { unmount } = render(<GraphFilterPopover {...defaultProps()} />)
+      expect(hasOpenModal()).toBe(true)
+
+      unmount()
+
+      expect(hasOpenModal()).toBe(false)
+    })
+
+    it('releases its overlay token when it closes without unmounting', () => {
+      const { rerender } = render(<GraphFilterPopover {...defaultProps()} />)
+      expect(hasOpenModal()).toBe(true)
+
+      rerender(<GraphFilterPopover {...defaultProps()} open={false} />)
+
+      expect(hasOpenModal()).toBe(false)
+    })
+
+    it('registers no token while closed', () => {
+      render(<GraphFilterPopover {...defaultProps()} open={false} />)
+      expect(hasOpenModal()).toBe(false)
+    })
   })
 })

--- a/frontend/src/components/graph/filter/GraphFilterPopover.tsx
+++ b/frontend/src/components/graph/filter/GraphFilterPopover.tsx
@@ -5,9 +5,19 @@
  * `triggerRef`, so the parent button's onClick can toggle without
  * race-canceling itself). Focuses the search input on open and restores focus
  * to the trigger on close.
+ *
+ * NEEDS AN OVERLAY TOKEN (kindred#2237): this popover is rendered by the
+ * EXPANDED `SocialNetworkGraph`, which collapses itself on Escape from its own
+ * `window` listener. Two ungated handlers, one keypress, both fired -- the
+ * filter closed and the graph it was filtering collapsed with it. Going
+ * through `useOverlayEscape` makes this the topmost overlay while it is open,
+ * and its conditional `stopPropagation` keeps the key from ever reaching the
+ * graph beneath. That also means the graph itself needs no token: a
+ * document-capture stop lands before any `window` bubble listener runs.
  */
 import { useEffect, useRef, type RefObject } from 'react'
 import GraphFilterTree, { type GraphFilterTreeProps } from './GraphFilterTree'
+import { useOverlayEscape } from '../../../hooks/useOverlayEscape'
 
 export interface GraphFilterPopoverProps extends GraphFilterTreeProps {
   open: boolean
@@ -19,15 +29,15 @@ export default function GraphFilterPopover(props: GraphFilterPopoverProps) {
   const { open, onClose, triggerRef, ...treeProps } = props
   const ref = useRef<HTMLDivElement>(null)
 
-  // Event listeners — depend on onClose; no focus side effects so onClose identity
-  // changes while open don't accidentally steal focus from the search input.
+  useOverlayEscape(open, onClose)
+
+  // Outside-click only — Escape is owned by `useOverlayEscape` above. Depends
+  // on onClose; no focus side effects so onClose identity changes while open
+  // don't accidentally steal focus from the search input.
   useEffect(() => {
     if (!open) return
     const trigger = triggerRef?.current ?? null
 
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
-    }
     const onMouseDown = (e: MouseEvent) => {
       const popover = ref.current
       const target = e.target as Node | null
@@ -37,10 +47,8 @@ export default function GraphFilterPopover(props: GraphFilterPopoverProps) {
       onClose()
     }
 
-    window.addEventListener('keydown', onKeyDown)
     document.addEventListener('mousedown', onMouseDown)
     return () => {
-      window.removeEventListener('keydown', onKeyDown)
       document.removeEventListener('mousedown', onMouseDown)
     }
   }, [open, onClose, triggerRef])

--- a/frontend/src/components/metrics/DrillDownModal.tsx
+++ b/frontend/src/components/metrics/DrillDownModal.tsx
@@ -116,9 +116,11 @@ export function DrillDownModal({
 
   // Handle escape key to close modal.
   //
-  // CORRECT AS-IS, no overlay token (kindred#2237): it renders no overlay of
-  // its own, and its single mount site (`hooks/useDrilldown.tsx`, on the
-  // metrics pages) puts no other Escape-handling surface on screen with it.
+  // CORRECT AS-IS, no overlay token (kindred#2237): it IS a full-viewport
+  // modal (the fixed backdrop below), but its single mount site
+  // (`hooks/useDrilldown.tsx`, on the metrics pages) puts no other
+  // Escape-handling surface on screen with it — nothing to yield to, and
+  // nothing that needs to yield to it.
   useEffect(() => {
     if (!filter) return
 

--- a/frontend/src/components/metrics/DrillDownModal.tsx
+++ b/frontend/src/components/metrics/DrillDownModal.tsx
@@ -114,7 +114,11 @@ export function DrillDownModal({
     duration,
   })
 
-  // Handle escape key to close modal
+  // Handle escape key to close modal.
+  //
+  // CORRECT AS-IS, no overlay token (kindred#2237): it renders no overlay of
+  // its own, and its single mount site (`hooks/useDrilldown.tsx`, on the
+  // metrics pages) puts no other Escape-handling surface on screen with it.
   useEffect(() => {
     if (!filter) return
 

--- a/frontend/src/components/metrics/WaitlistGradePopover.tsx
+++ b/frontend/src/components/metrics/WaitlistGradePopover.tsx
@@ -33,6 +33,11 @@ export function WaitlistGradePopover({
   persons,
   onClose,
 }: WaitlistGradePopoverProps) {
+  // CORRECT AS-IS, no overlay token (kindred#2237): this component is not
+  // rendered by any production surface. The only non-test reference anywhere
+  // in `src/` is to `transformWaitlistGradeData`, a same-prefixed function in
+  // `pages/metrics/registration/WaitlistAnalysis.tsx`. It cannot co-occur with
+  // another overlay because nothing mounts it.
   useEffect(() => {
     if (!isOpen) return
 

--- a/frontend/src/components/ui/FloatingQueueBadge.tsx
+++ b/frontend/src/components/ui/FloatingQueueBadge.tsx
@@ -125,6 +125,16 @@ export function FloatingQueueBadge<T>({
   )
 
   // ESC clears an active filter first, and only closes on the second press.
+  //
+  // CORRECT AS-IS, no overlay token (kindred#2237). Another CONTAINER: the
+  // expanded queue is never the overlay ON TOP. The two things that stack
+  // above it both hold tokens now -- the `CamperCard` context menu opened from
+  // a row in this very list, and the `CamperDetailsPanel` that `isPanelOpen`
+  // deliberately keeps this list open beside -- and each swallows Escape in
+  // the document capture phase while topmost, before this bubble listener
+  // runs. The double-close this badge was part of (menu open inside the queue,
+  // one press dismissed the menu AND collapsed the queue) is fixed from the
+  // card's side.
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
       if (event.key === 'Escape' && isExpanded) {

--- a/frontend/src/components/weekend/LodgingMap.tsx
+++ b/frontend/src/components/weekend/LodgingMap.tsx
@@ -297,6 +297,16 @@ export function LodgingMap({ parties, units, year, sessionCmId = 0 }: LodgingMap
         )
       )
     }
+    // CORRECT AS-IS, and deliberately so (kindred#2237): taking a token here
+    // would REGRESS the panel beside it. `FamilyDetailsPanel` stands down for
+    // any overlay in the stack via `hasOpenModal()`, which is a "is anything
+    // else open" test, not a LIFO one. A peek can be open BEHIND that panel --
+    // `MapUnitPopover` passes `onOpenParty` straight through and nothing on
+    // that path calls `closePeek()` -- so a peek token would make the panel
+    // yield Escape to a transient hover popover underneath it, and the family
+    // the staff member was reading would stop closing on the key entirely.
+    // Fixing this pair properly means converting `FamilyDetailsPanel` too,
+    // which kindred#2237 pre-classifies as correct as-is and out of scope.
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') closePeek()
     }

--- a/frontend/src/components/weekend/PlaceFamilyPicker.tsx
+++ b/frontend/src/components/weekend/PlaceFamilyPicker.tsx
@@ -156,6 +156,14 @@ export function PlaceFamilyPicker({ unit, parties, units = [], onSelect }: Place
     close()
   }
 
+  // CORRECT AS-IS, no overlay token (kindred#2237). This is a React SYNTHETIC
+  // handler bound to the combobox input, not a document listener: it only ever
+  // fires while that input holds focus, and the control closes on blur, so an
+  // overlay opening on top takes focus and this stops firing on its own. It
+  // also sits on the weekend roster alongside `FamilyDetailsPanel`, which
+  // stands down for anything in the token stack -- so a token here would make
+  // that panel yield Escape to a combobox, the same regression documented on
+  // `LodgingMap` above.
   const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Escape') {
       if (!open) return


### PR DESCRIPTION
#2205 shipped the LIFO token stack in `components/ui/modalStack.ts`; #2359 added the shared
`hooks/useOverlayEscape.ts` and converted three weekend overlays. This finishes the classification
pass over what was left.

The reproduce command returned **13** files on `main` @ 8fb02894 and returns **9** on this branch.
`weekend/FamilyDetailsPanel` was pre-classified correct as-is, leaving **12** to call. Four needed a
token; eight did not, and the reason for each is now recorded at its own Escape handler.

## The defect, per adopter

**`CamperDetailsPanel` was the bad one.** It installed a capture-phase `document` listener with an
**unconditional** `stopPropagation()`. A capture-phase stop at `document` halts the event before the
bubble phase begins, and both `ui/Modal` and `ConfirmActionPopover` listen in the bubble phase and
gate on `isTopOverlay` *without* stopping anything. So the panel beat every overlay stacked above it
— including `AllCamperRequestsModal`, a `ui/Modal` the panel itself opens. One Escape closed the
panel out from under the dialog and left the dialog open. That is the wrong overlay closing, not
merely an extra one.

**`graph/filter/GraphFilterPopover`** and **`CamperCard`**'s context menu were the plain #2205
double-close: each is rendered inside a container that also handles Escape ungated (the expanded
`SocialNetworkGraph` on `window`, the expanded `ui/FloatingQueueBadge` on `document`), so one press
ran both handlers — the filter closed and the graph collapsed with it; the context menu closed and
the queue it was opened from collapsed with it.

**`RequestReviewPanel`**'s bulk-confirm dialog sits in a component that renders five other
independently-stated overlays with nothing making them mutually exclusive. Its ungated bubble
listener fired alongside whichever was genuinely on top.

## Classification of all twelve

| Component | Call | Why |
|---|---|---|
| `CamperDetailsPanel` | **needs a token** | capture-phase + unconditional stop; hosts a `ui/Modal` and is itself hosted inside `BunkSocialGraphModal` |
| `graph/filter/GraphFilterPopover` | **needs a token** | rendered inside the expanded `SocialNetworkGraph`, which closes on Escape too |
| `CamperCard` | **needs a token** | context menu opens inside the expanded `FloatingQueueBadge`, which closes on Escape too |
| `RequestReviewPanel` | **needs a token** | bulk-confirm dialog coexists with five sibling overlays, none of which stops propagation |
| `SocialNetworkGraph` | correct as-is | a container at the bottom of its own stack; both overlays it hosts are converted here and stop the key in the capture phase, before its `window` bubble listener |
| `ui/FloatingQueueBadge` | correct as-is | same — the two things that stack above it (the `CamperCard` menu, `CamperDetailsPanel` via `isPanelOpen`) now both hold tokens |
| `weekend/LodgingMap` | correct as-is — **would regress** | a peek token makes `hasOpenModal()` true, and `FamilyDetailsPanel` yields to *anything* in the stack rather than to the topmost. A peek can sit behind that panel, so a token here would stop the panel closing on Escape. Fixing it properly means converting `FamilyDetailsPanel`, which #2237 pre-classifies as out of scope |
| `weekend/PlaceFamilyPicker` | correct as-is | React synthetic handler on the combobox input — fires only while that input has focus, and the control closes on blur. Same weekend `hasOpenModal` hazard as above |
| `metrics/WaitlistGradePopover` | correct as-is | **not rendered by any production surface** — the only non-test reference in `src/` is to `transformWaitlistGradeData`, a same-prefixed function. It cannot co-occur with anything |
| `metrics/DrillDownModal` | correct as-is | hosts no overlay; its one mount site puts no other Escape-handling surface on screen |
| `CsvPipelineIndicator` | correct as-is | app-shell trigger popover dismissed by `useClickOutside` on any outside press |
| `OptimizeBunksButton` | correct as-is | header dropdown dismissed by its outside-mousedown listener; hosts no overlay |

The load-bearing observation behind six of the eight: **the overlay that can be ON TOP is the one
that needs the token.** `useOverlayEscape` stops propagation in the document capture phase while
topmost, which lands before any `document`- or `window`-bubble listener beneath it. Converting the
child therefore fixes the pair, and giving the container a token would only add a lifecycle to get
wrong — a token acquired and not released silently disables Escape for every overlay after it.

## Mutation-check evidence

Deleting `releaseOverlayToken(token)` from the unmount path of `useOverlayEscape` turned **9 tests
red across all four adopter files**. Critically, the **150 other tests in those files stayed green**,
including every "does this overlay still close on Escape?" assertion — reproducing the exact
false-green #2205 shipped, since a newly acquired token is always last in the stack whether or not
the previous one leaked. Only the `hasOpenModal()`-is-empty assertions catch a leak, and every
adopter has one.

Also added per adopter: a test that the overlay does **not** close while a token is held above it,
and, where it applies, that the key is swallowed so the surface beneath does not close too.

## Deliberately not done

- Did not convert the eight classified correct as-is; `LodgingMap` and `PlaceFamilyPicker`
  specifically because converting them without `FamilyDetailsPanel` would make Escape *worse*.
- Did not touch `weekend/FamilyDetailsPanel` (pre-classified).
- Did not delete the unmounted `metrics/WaitlistGradePopover` — recorded, not swept, as it is a
  separate question from Escape handling.
- No `aria-*`, `role`, or `sr-only` text added anywhere.

## Verification

- Full frontend suite: **450 files, 6869 tests, all passing**.
- `bash scripts/pre-push-verify.sh`: prettier, eslint, tsc, vitest all PASS.

**GUI impact:** this changes keyboard behaviour on live overlays and wants a human look before merge.

Closes #2237.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Escape-key handling across menus, panels, dialogs, and graph filters.
  * Ensured only the topmost open overlay closes when Escape is pressed.
  * Prevented Escape events from unintentionally closing underlying overlays.
  * Improved cleanup when overlays close or are removed.

* **Tests**
  * Added regression coverage for overlay stacking, keyboard dismissal, event propagation, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->