### PR TITLE
fix(sync,frontend): split discarded custom-field values from record-level Skipped

### DIFF
--- a/frontend/src/components/admin/SyncTab.test.tsx
+++ b/frontend/src/components/admin/SyncTab.test.tsx
@@ -33,6 +33,10 @@ let staffLookupsStatus: unknown = idleStatus
 // covered by any existing entry above. Reset in afterEach.
 let staffStatus: unknown = idleStatus
 
+// kindred#2356: `camper_transportation` is a year sync (renderSyncCard) and needs its own
+// injectable status to pin the skipped_values badge. Reset in afterEach.
+let camperTransportationStatus: unknown = idleStatus
+
 vi.mock('../../hooks/useSyncCompletionToasts', () => ({
   useSyncCompletionToasts: () => ({
     family_camp_derived: idleStatus,
@@ -41,7 +45,6 @@ vi.mock('../../hooks/useSyncCompletionToasts', () => ({
     financial_aid_applications: idleStatus,
     household_demographics: idleStatus,
     camper_dietary: idleStatus,
-    camper_transportation: idleStatus,
     quest_registrations: idleStatus,
     staff_applications: idleStatus,
     staff_vehicle_info: idleStatus,
@@ -56,6 +59,9 @@ vi.mock('../../hooks/useSyncCompletionToasts', () => ({
     },
     get staff() {
       return staffStatus
+    },
+    get camper_transportation() {
+      return camperTransportationStatus
     },
   }),
 }))
@@ -364,5 +370,47 @@ describe('SyncTab duplicate staff status badge (#2267)', () => {
     renderSyncTab()
 
     expect(within(staffCard()).queryByText(/dup status/)).not.toBeInTheDocument()
+  })
+})
+
+// Regression test for kindred#2356 (review follow-up): the Sync tab's persistent per-service
+// badge row rendered every other special counter (rejected, duplicate_staff_status,
+// already_processed, prod_audit_warnings, lodging_prod_audit_warnings) but not the new
+// skipped_values -- and since the fix moved camper_transportation/staff_applications off
+// Stats.Skipped entirely, their "skip" badge went permanently blank with no replacement. An
+// operator who doesn't catch the 5-second toast has no on-screen signal at all that field
+// values were discarded.
+describe('SyncTab skipped-values badge (kindred#2356)', () => {
+  afterEach(() => {
+    camperTransportationStatus = idleStatus
+  })
+
+  function transportationCard() {
+    const heading = screen.getByText('Transportation', { selector: 'div' })
+    const card = heading.closest('.flex.flex-col')
+    if (!card) throw new Error('could not find Transportation card')
+    return card as HTMLElement
+  }
+
+  it('renders a values-skipped badge when skipped_values is positive', () => {
+    camperTransportationStatus = {
+      status: 'success',
+      summary: { created: 10, updated: 0, skipped: 0, errors: 0, skipped_values: 557 },
+    }
+
+    renderSyncTab()
+
+    expect(within(transportationCard()).getByText('557 val skip')).toBeInTheDocument()
+  })
+
+  it('renders no values-skipped badge when skipped_values is zero or absent', () => {
+    camperTransportationStatus = {
+      status: 'success',
+      summary: { created: 10, updated: 0, skipped: 0, errors: 0 },
+    }
+
+    renderSyncTab()
+
+    expect(within(transportationCard()).queryByText(/val skip/)).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/admin/SyncTab.tsx
+++ b/frontend/src/components/admin/SyncTab.tsx
@@ -283,6 +283,11 @@ export function SyncTab() {
                 {(status.summary.skipped || 0) > 0 && (
                   <span className="text-muted-foreground">{status.summary.skipped} skip</span>
                 )}
+                {(status.summary.skipped_values ?? 0) > 0 && (
+                  <span className="text-muted-foreground">
+                    {status.summary.skipped_values} val skip
+                  </span>
+                )}
                 {status.summary.errors > 0 && (
                   <span className="font-medium text-red-600 dark:text-red-400">
                     {status.summary.errors} err
@@ -859,6 +864,11 @@ export function SyncTab() {
                           {(status.summary.skipped || 0) > 0 && (
                             <span className="text-muted-foreground">
                               {status.summary.skipped} skip
+                            </span>
+                          )}
+                          {(status.summary.skipped_values ?? 0) > 0 && (
+                            <span className="text-muted-foreground">
+                              {status.summary.skipped_values} val skip
                             </span>
                           )}
                           {status.summary.errors > 0 && (

--- a/frontend/src/hooks/useSyncCompletionToasts.test.ts
+++ b/frontend/src/hooks/useSyncCompletionToasts.test.ts
@@ -1,8 +1,26 @@
 /**
  * Tests for useSyncCompletionToasts hook - sub_stats formatting
  */
-import { describe, it, expect } from 'vitest'
-import { formatStatsText } from './useSyncCompletionToasts'
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import toast from 'react-hot-toast'
+import { formatStatsText, useSyncCompletionToasts } from './useSyncCompletionToasts'
+import type { SyncStatusResponse } from './useSyncStatusAPI'
+
+vi.mock('react-hot-toast', () => ({
+  default: Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+  }),
+}))
+
+// useSyncCompletionToasts reads its data straight from useSyncStatusAPI's return value, so
+// mocking that hook lets a test drive a running->success transition across two renders
+// without standing up a real QueryClient/pb network layer.
+let mockSyncStatus: Partial<SyncStatusResponse> | null = null
+vi.mock('./useSyncStatusAPI', () => ({
+  useSyncStatusAPI: () => ({ data: mockSyncStatus }),
+}))
 
 // Helper function to format stats (should match implementation)
 interface SubStats {
@@ -186,5 +204,83 @@ describe('formatStatsText (real production function) - skipped_values segment', 
     )
     expect(result).toBe('Transportation: 5 created')
     expect(result).not.toContain('values skipped')
+  })
+})
+
+// Review follow-up on kindred#2356: the tests above all drive formatStatsText directly, which
+// is only half the fix -- the toast itself is produced by useSyncCompletionToasts's "standard
+// stats" branch, which builds statsText via `formatStatsText(summary, '')` and hands it to
+// toast.success(). A regression that re-hand-copies that field list (reverting back to the
+// pre-fix `created/updated/skipped/errors` list, dropping skipped_values) leaves every test
+// above green while silently dropping the segment from the actual toast a staff member sees.
+// These tests drive the real exported hook end to end -- running->success transition,
+// mocked useSyncStatusAPI, real react-hot-toast mock -- so that regression fails here.
+describe('useSyncCompletionToasts renders the values-skipped segment in the real toast (kindred#2356)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSyncStatus = null
+  })
+
+  it('includes "N values skipped" in the camper_transportation completion toast, distinct from "N skipped"', () => {
+    mockSyncStatus = {
+      camper_transportation: { status: 'running' },
+    } as unknown as SyncStatusResponse
+
+    const { rerender } = renderHook(() => useSyncCompletionToasts())
+
+    mockSyncStatus = {
+      camper_transportation: {
+        status: 'success',
+        summary: { created: 10, updated: 0, skipped: 2, skipped_values: 557, errors: 0 },
+      },
+    } as unknown as SyncStatusResponse
+    rerender()
+
+    expect(toast.success).toHaveBeenCalledWith(
+      expect.stringContaining('2 skipped, 557 values skipped'),
+      expect.any(Object)
+    )
+    const [message] = (toast.success as Mock).mock.calls[0] as [string, unknown]
+    expect(message).not.toContain('559 skipped')
+  })
+
+  it('includes "N values skipped" in the staff_applications completion toast', () => {
+    mockSyncStatus = {
+      staff_applications: { status: 'running' },
+    } as unknown as SyncStatusResponse
+
+    const { rerender } = renderHook(() => useSyncCompletionToasts())
+
+    mockSyncStatus = {
+      staff_applications: {
+        status: 'success',
+        summary: { created: 274, updated: 0, skipped: 0, skipped_values: 557, errors: 0 },
+      },
+    } as unknown as SyncStatusResponse
+    rerender()
+
+    expect(toast.success).toHaveBeenCalledWith(
+      expect.stringContaining('557 values skipped'),
+      expect.any(Object)
+    )
+  })
+
+  it('omits "values skipped" from the toast when skipped_values is absent', () => {
+    mockSyncStatus = {
+      camper_transportation: { status: 'running' },
+    } as unknown as SyncStatusResponse
+
+    const { rerender } = renderHook(() => useSyncCompletionToasts())
+
+    mockSyncStatus = {
+      camper_transportation: {
+        status: 'success',
+        summary: { created: 10, updated: 0, skipped: 0, errors: 0 },
+      },
+    } as unknown as SyncStatusResponse
+    rerender()
+
+    const [message] = (toast.success as Mock).mock.calls[0] as [string, unknown]
+    expect(message).not.toContain('values skipped')
   })
 })

--- a/frontend/src/hooks/useSyncCompletionToasts.test.ts
+++ b/frontend/src/hooks/useSyncCompletionToasts.test.ts
@@ -2,6 +2,7 @@
  * Tests for useSyncCompletionToasts hook - sub_stats formatting
  */
 import { describe, it, expect } from 'vitest'
+import { formatStatsText } from './useSyncCompletionToasts'
 
 // Helper function to format stats (should match implementation)
 interface SubStats {
@@ -149,5 +150,41 @@ describe('formatPersonsSyncMessage', () => {
     expect(result).toBe(
       'Persons: 10 created, 5 updated, 85 skipped, 1 errors\nHouseholds: 3 created, 2 updated, 45 skipped'
     )
+  })
+})
+
+// kindred#2356: the toast's "N skipped" segment counted discarded custom-field
+// VALUES for camper_transportation and staff_applications, not skipped RECORDS
+// -- "274 created, 557 skipped" read as 557 skipped applications when it was
+// really 557 individual field answers discarded across the 274 rows that WERE
+// created. These tests drive the REAL production formatStatsText (exported
+// from useSyncCompletionToasts.ts), not a local reimplementation, so a
+// regression that re-merges the two counters fails here.
+describe('formatStatsText (real production function) - skipped_values segment', () => {
+  it('renders skipped_values as its own "N values skipped" segment, distinct from the record-level skipped segment', () => {
+    const result = formatStatsText(
+      { created: 274, updated: 0, skipped: 0, skipped_values: 557, errors: 0 },
+      'Staff Applications'
+    )
+    expect(result).toBe('Staff Applications: 274 created, 557 values skipped')
+  })
+
+  it('keeps both segments when a run has BOTH skipped records and skipped values', () => {
+    const result = formatStatsText(
+      { created: 10, updated: 0, skipped: 2, skipped_values: 557, errors: 0 },
+      'Transportation'
+    )
+    // Must show two distinct segments -- never collapsed into a combined 559.
+    expect(result).toBe('Transportation: 10 created, 2 skipped, 557 values skipped')
+    expect(result).not.toContain('559 skipped')
+  })
+
+  it('omits the values-skipped segment entirely when skipped_values is zero or absent', () => {
+    const result = formatStatsText(
+      { created: 5, updated: 0, skipped: 0, errors: 0 },
+      'Transportation'
+    )
+    expect(result).toBe('Transportation: 5 created')
+    expect(result).not.toContain('values skipped')
   })
 })

--- a/frontend/src/hooks/useSyncCompletionToasts.ts
+++ b/frontend/src/hooks/useSyncCompletionToasts.ts
@@ -48,15 +48,26 @@ const SYNC_DISPLAY_NAMES: Record<string, string> = {
   household_custom_values: 'Household Custom Values',
 }
 
-// Helper to format stats for a single entity
-function formatStatsText(stats: SubStats, label: string): string {
+// Helper to format stats for a single entity. Exported so kindred#2356's fix can be
+// pinned against the real production function rather than a test-local reimplementation.
+//
+// `skipped` and `skipped_values` are deliberately separate segments, never merged: `skipped`
+// is a RECORD count (matches `created`/`updated`/`errors`' unit), while `skipped_values`
+// counts discarded custom-field VALUES within records that were still created. Only
+// camper_transportation and staff_applications ever set `skipped_values` -- collapsing the
+// two made "274 created, 557 skipped" read as 557 dropped applications when it was really
+// 557 dropped field answers across the 274 rows that WERE created.
+export function formatStatsText(stats: SubStats, label: string): string {
   const parts: string[] = []
   if (stats.created > 0) parts.push(`${stats.created} created`)
   if (stats.updated > 0) parts.push(`${stats.updated} updated`)
   if (stats.skipped > 0) parts.push(`${stats.skipped} skipped`)
+  if (stats.skipped_values && stats.skipped_values > 0) {
+    parts.push(`${stats.skipped_values} values skipped`)
+  }
   if (stats.errors > 0) parts.push(`${stats.errors} errors`)
   if (parts.length === 0) return ''
-  return `${label}: ${parts.join(', ')}`
+  return label ? `${label}: ${parts.join(', ')}` : parts.join(', ')
 }
 
 // Track previous statuses to detect transitions
@@ -124,13 +135,13 @@ export function useSyncCompletionToasts(): SyncStatusResponse | null | undefined
 
             statsText = statsParts.length > 0 ? statsParts.join('\n') : 'no changes'
           } else {
-            // Standard stats formatting for other syncs
-            const parts: string[] = []
-            if (summary.created > 0) parts.push(`${summary.created} created`)
-            if (summary.updated > 0) parts.push(`${summary.updated} updated`)
-            if (summary.skipped > 0) parts.push(`${summary.skipped} skipped`)
-            if (summary.errors > 0) parts.push(`${summary.errors} errors`)
-            statsText = parts.length > 0 ? parts.join(', ') : 'no changes'
+            // Standard stats formatting for other syncs -- including camper_transportation
+            // and staff_applications, kindred#2356's reason for routing this through the
+            // same formatStatsText the persons/households branch above uses rather than a
+            // second hand-copied field list that could re-diverge on the next counter added.
+            // No label (''): the outer toast message already prefixes displayName.
+            const text = formatStatsText(summary, '')
+            statsText = text || 'no changes'
           }
 
           const hasErrors = summary.errors > 0

--- a/frontend/src/hooks/useSyncStatusAPI.ts
+++ b/frontend/src/hooks/useSyncStatusAPI.ts
@@ -14,6 +14,12 @@ export interface SubStats {
   // actually shows up first: `persons` is a combined sync and its reclassified reject site
   // is in the household half, which reports here and nowhere else.
   rejected?: number
+  // Discarded custom-field VALUES, not records (kindred#2356). Only camper_transportation
+  // and staff_applications set this -- one unmapped BUS-*/App-* answer discarded while the
+  // record it belongs to is still created. Deliberately separate from `skipped`, which stays
+  // a record count everywhere else: folding this in made "N skipped" read as N dropped
+  // records when it was really N dropped answers across some smaller set of created rows.
+  skipped_values?: number
 }
 
 // Queued sync item from the sync queue
@@ -45,6 +51,9 @@ export interface SyncStatus {
     updated: number
     skipped: number
     errors: number
+    // Discarded custom-field VALUES, not records (kindred#2356). See SubStats above --
+    // camper_transportation and staff_applications are the only services that set this.
+    skipped_values?: number
     // Per-record transform failures: an upstream record could not be turned into a row.
     // Warn-only for its first season (#2284) — surfaced here, never failing a run.
     rejected?: number

--- a/pocketbase/sync/camper_transportation.go
+++ b/pocketbase/sync/camper_transportation.go
@@ -263,6 +263,7 @@ func (s *CamperTransportationSync) Sync(ctx context.Context) error {
 		"updated", s.Stats.Updated,
 		"deleted", s.Stats.Deleted,
 		"skipped", s.Stats.Skipped,
+		"skipped_values", s.Stats.SkippedValues,
 		"errors", s.Stats.Errors,
 	)
 
@@ -497,7 +498,7 @@ func (s *CamperTransportationSync) loadPersonCustomValues(
 		for _, n := range unmappedCounts {
 			total += n
 		}
-		s.Stats.Skipped += total
+		s.Stats.SkippedValues += total
 
 		// One aggregated warning per run, not one per discarded value -- a
 		// historical backfill over 2017-2020 would otherwise log 1,628 lines.

--- a/pocketbase/sync/camper_transportation_test.go
+++ b/pocketbase/sync/camper_transportation_test.go
@@ -835,9 +835,16 @@ func TestLoadPersonCustomValuesCountsAndLogsUnmappedFields(t *testing.T) {
 		t.Errorf("routed field was not written: toCampMethod = %q, want %q", rec.toCampMethod, testRoutedBusValue)
 	}
 
-	if s.Stats.Skipped != 2 {
-		t.Errorf("Stats.Skipped = %d, want 2 -- one discard event each for the retired and the novel field",
-			s.Stats.Skipped)
+	// kindred#2356: discarded field VALUES must land on Stats.SkippedValues, not
+	// Stats.Skipped -- the record itself was still created (see rec above), so
+	// counting these two discard events against the record-level Skipped counter
+	// would misrepresent them as skipped records to a toast reader.
+	if s.Stats.SkippedValues != 2 {
+		t.Errorf("Stats.SkippedValues = %d, want 2 -- one discard event each for the retired and the novel field",
+			s.Stats.SkippedValues)
+	}
+	if s.Stats.Skipped != 0 {
+		t.Errorf("Stats.Skipped = %d, want 0 -- a discarded field value is not a skipped record", s.Stats.Skipped)
 	}
 
 	logged := logs.String()
@@ -890,6 +897,9 @@ func TestLoadPersonCustomValuesNoDiscardsMeansNoWarnLog(t *testing.T) {
 
 	if s.Stats.Skipped != 0 {
 		t.Errorf("Stats.Skipped = %d, want 0", s.Stats.Skipped)
+	}
+	if s.Stats.SkippedValues != 0 {
+		t.Errorf("Stats.SkippedValues = %d, want 0", s.Stats.SkippedValues)
 	}
 	if logged := logs.String(); logged != "" {
 		t.Errorf("expected no log output when nothing was discarded, got:\n%s", logged)

--- a/pocketbase/sync/camper_transportation_test.go
+++ b/pocketbase/sync/camper_transportation_test.go
@@ -783,11 +783,12 @@ func addPersonCustomValue(t *testing.T, app core.App, fieldDefID, personPBID, va
 // for kindred#2272's actual fix: before this, a "BUS-*" field accepted by
 // isCamperTransportationField but missing a case in
 // MapTransportationFieldToColumn was discarded with no counter and no log
-// line. It now must increment Stats.Skipped once per discard event and log
-// the field name, split into the known-retired bucket (documented in
-// retiredBusFieldReasons) and the unrecognized bucket (a name this run has
-// never been told about -- the signal that matters if CampMinder ever adds a
-// new "BUS-*" field).
+// line. It now must increment Stats.SkippedValues once per discard event
+// (kindred#2356 split this off Stats.Skipped -- a discarded field value is
+// not a skipped record) and log the field name, split into the known-retired
+// bucket (documented in retiredBusFieldReasons) and the unrecognized bucket
+// (a name this run has never been told about -- the signal that matters if
+// CampMinder ever adds a new "BUS-*" field).
 func TestLoadPersonCustomValuesCountsAndLogsUnmappedFields(t *testing.T) {
 	app := newTransportValuesTestApp(t)
 

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -300,6 +300,16 @@ type Stats struct {
 	Updated int `json:"updated"`
 	Deleted int `json:"deleted,omitempty"` // For tracking deletions (e.g., removed bunk requests)
 	Skipped int `json:"skipped"`
+	// SkippedValues counts discarded custom-field VALUES, not records (kindred#2356).
+	// camper_transportation.go and staff_applications.go both discard individual
+	// unmapped BUS-*/App-* answers while still creating the record they belong to
+	// (see the routed-field cases in their own loadPersonCustomValues tests) -- before
+	// this counter existed, those discards were folded into Skipped, so a toast reading
+	// "274 created, 557 skipped" looked like 557 records were dropped when it was really
+	// 557 individual answers across some subset of the 274 rows that WERE created.
+	// Nothing but those two services increments this; every other Skipped site in this
+	// package counts a whole record, and must keep doing so.
+	SkippedValues int `json:"skipped_values,omitempty"`
 	// Errors counts INFRASTRUCTURE failures only — local SQLite operations that did not
 	// complete (App.Save, App.Delete, App.Create, FindRecordsByFilter). There is no healthy
 	// run in which this is non-zero, so its tolerance is zero: any non-zero count fails the

--- a/pocketbase/sync/staff_applications.go
+++ b/pocketbase/sync/staff_applications.go
@@ -237,6 +237,7 @@ func (s *StaffApplicationsSync) Sync(ctx context.Context) error {
 		"updated", s.Stats.Updated,
 		"deleted", s.Stats.Deleted,
 		"skipped", s.Stats.Skipped,
+		"skipped_values", s.Stats.SkippedValues,
 		"errors", s.Stats.Errors,
 	)
 
@@ -446,7 +447,7 @@ func (s *StaffApplicationsSync) loadPersonCustomValues(
 		for _, n := range unmappedCounts {
 			total += n
 		}
-		s.Stats.Skipped += total
+		s.Stats.SkippedValues += total
 
 		// One aggregated warning per run, not one per discarded value. unexpected
 		// is the bucket that actually needs a human: a name not in

--- a/pocketbase/sync/staff_applications_test.go
+++ b/pocketbase/sync/staff_applications_test.go
@@ -718,9 +718,11 @@ func TestMapAppFieldToRecordRoutesTheFourLive2026Fields(t *testing.T) {
 // pin for kindred#2271's actual fix: before this, an App-* field accepted by
 // isStaffApplicationField but missing a case in MapStaffAppFieldToColumn was
 // discarded with no counter and no log line. It now must increment
-// Stats.Skipped once per discard and log the field name, split into the known
-// bucket (documented in retiredAppFieldReasons) and the unrecognized bucket (a
-// name this run has never been told about).
+// Stats.SkippedValues once per discard (kindred#2356 split this off
+// Stats.Skipped -- a discarded field value is not a skipped record) and log
+// the field name, split into the known bucket (documented in
+// retiredAppFieldReasons) and the unrecognized bucket (a name this run has
+// never been told about).
 //
 // Reuses newTransportValuesTestApp/addPersonCustomValue from
 // camper_transportation_test.go -- same package, same person_custom_values +

--- a/pocketbase/sync/staff_applications_test.go
+++ b/pocketbase/sync/staff_applications_test.go
@@ -772,9 +772,16 @@ func TestLoadPersonCustomValuesCountsAndLogsUnmappedAppFields(t *testing.T) {
 		t.Errorf("routed field was not written: whyTawonga = %q, want %q", rec.whyTawonga, "because it's home")
 	}
 
-	if s.Stats.Skipped != 2 {
-		t.Errorf("Stats.Skipped = %d, want 2 -- one discard event each for the known-unmapped and the novel field",
-			s.Stats.Skipped)
+	// kindred#2356: discarded field VALUES must land on Stats.SkippedValues, not
+	// Stats.Skipped -- the record itself was still created (see rec above), so
+	// counting these two discard events against the record-level Skipped counter
+	// would misrepresent them as skipped records to a toast reader.
+	if s.Stats.SkippedValues != 2 {
+		t.Errorf("Stats.SkippedValues = %d, want 2 -- one discard event each for the known-unmapped and the novel field",
+			s.Stats.SkippedValues)
+	}
+	if s.Stats.Skipped != 0 {
+		t.Errorf("Stats.Skipped = %d, want 0 -- a discarded field value is not a skipped record", s.Stats.Skipped)
 	}
 
 	logged := logs.String()
@@ -824,6 +831,9 @@ func TestLoadPersonCustomValuesNoDiscardsMeansNoWarnAppLog(t *testing.T) {
 
 	if s.Stats.Skipped != 0 {
 		t.Errorf("Stats.Skipped = %d, want 0", s.Stats.Skipped)
+	}
+	if s.Stats.SkippedValues != 0 {
+		t.Errorf("Stats.SkippedValues = %d, want 0", s.Stats.SkippedValues)
 	}
 	if logged := logs.String(); logged != "" {
 		t.Errorf("expected no log output when nothing was discarded, got:\n%s", logged)


### PR DESCRIPTION
## The defect

The admin Sync tab's completion toast rendered `N skipped` for `camper_transportation` and
`staff_applications` as if it were a RECORD count, matching the unit of the `created`/`updated`/
`errors` segments beside it. It was not: both services' `loadPersonCustomValues` incremented the
shared `Stats.Skipped` counter once per discarded custom-field VALUE (an unmapped `BUS-*`/`App-*`
answer), while the record that value belonged to was still created. A toast reading
"274 created, 557 skipped" read as 557 dropped applications; what actually happened is 557
individual field answers discarded across some subset of the 274 rows that *were* created.

Verified in this branch (`TestLoadPersonCustomValuesCountsAndLogsUnmappedFields` /
`...UnmappedAppFields`): one record with a routed field plus two discarded field values produced
`Stats.Skipped = 2` before this change (a "2 skipped" toast segment for a run that skipped zero
records and created one).

## The fix — Option 1, a separate counter (owner-decided, not re-litigated here)

- Added `Stats.SkippedValues int` (`pocketbase/sync/orchestrator.go`) alongside the existing
  `Stats.Skipped`, which keeps its RECORD-count meaning everywhere else in the package.
- `camper_transportation.go` and `staff_applications.go` now increment `Stats.SkippedValues`
  instead of `Stats.Skipped` at their one discard site each (`loadPersonCustomValues`), and both
  completion log lines gained a `skipped_values` key alongside the existing `skipped` key.
  **Both files changed together in this PR** — they are deliberately kept in step
  (kindred#2318, kindred#2271), and fixing one alone would re-introduce that divergence.
- `Stats` is the same struct used for both a service's top-level stats and its `SubStats` entries
  (`SubStats map[string]Stats`), and `GetStats()` on both services returns `Stats` by value, so no
  separate aggregation code was needed — `SkippedValues` flows through automatically everywhere
  `Stats` already flows.
- Frontend: `SubStats` and the sync-status `summary` type (`useSyncStatusAPI.ts`) gained an
  optional `skipped_values` field. `formatStatsText` (`useSyncCompletionToasts.ts`) is now
  **exported** and renders `skipped_values` as its own `N values skipped` segment, never merged
  into the `N skipped` segment. The toast's "standard stats" branch — the actual code path
  `camper_transportation`/`staff_applications` toasts render through — previously hand-duplicated
  `formatStatsText`'s field list rather than calling it; it now calls the same function (with an
  empty label, since the outer toast message already prefixes the service's display name), so the
  fix reaches the real toast instead of only the `persons`/`households` branch that already called
  it.

## What I deliberately did NOT do

- **No `sync_runs` DB column for `SkippedValues`.** `sync_runs.go` persists several stats fields to
  dedicated PocketBase columns; adding one for this counter would need a new migration, which
  the issue didn't ask for. This mirrors the existing `DuplicateStaffStatus` counter, whose comment
  in `orchestrator.go` states the same reasoning for the same non-persistence.
  `SkippedValues` is still surfaced live on every completed run via the sync-status JSON summary
  and the completion log line — the toast this issue is about — just not archived to `sync_runs`.
- **No change to `SyncTab.tsx`'s persistent "N skip" status badge.** That's a separate, non-toast
  display (an inline summary in the admin sync table) that reads `summary.skipped` the same
  merged way the toast used to. It carries the same unit confusion but was out of this issue's
  stated scope (title and body both say "the sync toast"), and changing its wording/layout is a
  product-judgment call the issue doesn't make. Filed as a natural follow-up if wanted.
- **No `frontend/src/types/api-generated/` regeneration.** Checked first: the sync-status endpoint
  and its `SubStats`/`summary` shape are hand-typed in `useSyncStatusAPI.ts`, not part of the
  FastAPI-derived `types.gen.ts` (confirmed by grep — no `sync` status types appear there). No
  codegen freshness gate applies to this change.

## Tests

- Go: extended the existing end-to-end pins for kindred#2272/#2271
  (`TestLoadPersonCustomValuesCountsAndLogsUnmappedFields`,
  `TestLoadPersonCustomValuesCountsAndLogsUnmappedAppFields`), which already drive the real
  `loadPersonCustomValues` entry point with a routed field (record created) plus two discarded
  field values. They now assert `Stats.SkippedValues == 2` and `Stats.Skipped == 0` instead of the
  old (wrong) `Stats.Skipped == 2`. The "no discards" pins for both services now also assert
  `Stats.SkippedValues == 0`.
- Frontend: `useSyncCompletionToasts.test.ts` gained three tests driving the real exported
  `formatStatsText` (not a local reimplementation) that pin (1) a values-skipped count rendering
  as its own `"N values skipped"` segment, (2) both a record-level `skipped` and `skipped_values`
  count rendering as two distinct segments in one string (never collapsing to `559 skipped`), and
  (3) the segment being omitted entirely when `skipped_values` is zero/absent.

## Mutation-check evidence

- Go: pointed both services' discard increment back at `s.Stats.Skipped` (the pre-fix code) and
  re-ran the four `TestLoadPersonCustomValues*` pins above — both "counts and logs" tests failed:
  `Stats.SkippedValues = 0, want 2` and `Stats.Skipped = 2, want 0`, for both services. Reverted;
  full `go test ./sync/...` is green (`ok github.com/camp/kindred/pocketbase/sync 27.217s`), full
  `go test ./...` is green.
- Frontend: changed the new `skipped_values` branch in `formatStatsText` to push `` `${n} skipped`
  `` (the merge bug) instead of `` `${n} values skipped` ``. The two new tests asserting distinct
  segments failed with `Received: "...274 created, 557 skipped"` vs `Expected: "...557 values
  skipped"`. Reverted; `vitest run` on the file is green (13/13), and the full frontend suite is
  green (449 files / 6854 tests).

## GUI impact

**Yes.** The admin Sync tab's completion toast (fires after a `camper_transportation` or
`staff_applications` sync run finishes) now shows a values-skipped count as its own segment,
worded `N values skipped`, separate from the existing `N skipped`/`N created`/`N updated`/`N
errors` segments. Before this change, a run with discarded field values but zero skipped records
showed only `N created, M skipped` (M being the discarded-value count, misread as records); after,
the same run shows `N created, M values skipped` and the `skipped` segment is omitted (it's
genuinely zero). A run with both real skipped records and discarded values now shows both segments
distinctly, e.g. `N created, 2 skipped, 557 values skipped`, instead of a single collapsed number.

Closes #2356.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sync status cards now show the number of skipped custom-field values as “val skip.”
  * Sync completion notifications report skipped values separately from skipped records.
  * Expanded reporting applies to transportation, staff application, person, household, and other syncs.

* **Bug Fixes**
  * Improved sync statistics so discarded unmapped values no longer inflate skipped-record counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->