### PR TITLE
test(sync): widen the shared fixture builder to cover bunk_assignments/staff/bunks/bunk_plans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -831,7 +831,7 @@ jobs:
         # REQUIRED_COLLECTIONS/REQUIRED_FIELDS happens to be an early one that
         # already fell inside the first 30 -- but kindred#1921's
         # fixture-schema-agreement step (below) walks every collection
-        # newLodgingTestApp builds, several of them late (lodging_* from
+        # newSyncTestApp builds, several of them late (lodging_* from
         # migration 1500000116+), which is what surfaced this. Pinned to
         # PocketBase's own MaxPerPage (tools/search/provider.go) rather than
         # some smaller headroom number: a perPage above MaxPerPage is
@@ -869,8 +869,8 @@ jobs:
         echo "✅ Migration smoke test passed"
 
     # kindred#1921: the sync package's fixtures build their PocketBase
-    # collections by hand (see newLodgingTestApp in
-    # pocketbase/sync/lodging_testsupport_test.go) rather than replaying
+    # collections by hand (see newSyncTestApp in
+    # pocketbase/sync/sync_testsupport_test.go) rather than replaying
     # pb_migrations, so a column a migration drops or renames can stay in the
     # fixture indefinitely -- go test ./... never notices. /tmp/collections.json
     # above is the real schema those same migrations just produced; this step

--- a/pocketbase/lodging/registry_test.go
+++ b/pocketbase/lodging/registry_test.go
@@ -30,7 +30,7 @@ func setupRegistryCollections(t *testing.T, app core.App) {
 	areas.Fields.Add(&core.NumberField{Name: "map_y"})
 	areas.Fields.Add(&core.NumberField{Name: "sort_order", OnlyInt: true})
 	// Required, mirroring migration 1500000141 (and the sync package's own
-	// tightened twin, lodging_testsupport_test.go:114): PocketBase's Set on a
+	// tightened twin, sync_testsupport_test.go:114): PocketBase's Set on a
 	// column that does not exist is a silent no-op, so a fixture that forgot
 	// this column would resolve every season against a row stored at year 0
 	// instead of failing loudly here. Min/Max mirror the same migration's

--- a/pocketbase/lodging/registry_test.go
+++ b/pocketbase/lodging/registry_test.go
@@ -30,7 +30,7 @@ func setupRegistryCollections(t *testing.T, app core.App) {
 	areas.Fields.Add(&core.NumberField{Name: "map_y"})
 	areas.Fields.Add(&core.NumberField{Name: "sort_order", OnlyInt: true})
 	// Required, mirroring migration 1500000141 (and the sync package's own
-	// tightened twin, sync_testsupport_test.go:114): PocketBase's Set on a
+	// tightened twin, sync_testsupport_test.go:124): PocketBase's Set on a
 	// column that does not exist is a silent no-op, so a fixture that forgot
 	// this column would resolve every season against a row stored at year 0
 	// instead of failing loudly here. Min/Max mirror the same migration's

--- a/pocketbase/sync/bunk_assignments_grain_test.go
+++ b/pocketbase/sync/bunk_assignments_grain_test.go
@@ -61,46 +61,18 @@ func setupBunkAssignmentGrainCollections(t *testing.T, app core.App) {
 		t.Fatalf("create camp_sessions: %v", err)
 	}
 
-	bunks := core.NewBaseCollection("bunks")
-	bunks.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
-	bunks.Fields.Add(&core.NumberField{Name: "year", Required: true})
-	bunks.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
-	if err := app.Save(bunks); err != nil {
-		t.Fatalf("create bunks: %v", err)
-	}
-
-	bunkPlans := core.NewBaseCollection("bunk_plans")
-	bunkPlans.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
-	bunkPlans.Fields.Add(&core.RelationField{Name: "bunk", CollectionId: bunks.Id, MaxSelect: 1})
-	bunkPlans.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
-	bunkPlans.Fields.Add(&core.NumberField{Name: "year", Required: true})
-	bunkPlans.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
-	if err := app.Save(bunkPlans); err != nil {
-		t.Fatalf("create bunk_plans: %v", err)
-	}
-
-	assignments := core.NewBaseCollection("bunk_assignments")
-	assignments.Fields.Add(&core.NumberField{Name: "cm_id"})
-	assignments.Fields.Add(&core.RelationField{Name: "person", CollectionId: persons.Id, MaxSelect: 1})
-	assignments.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
-	assignments.Fields.Add(&core.RelationField{Name: "bunk", CollectionId: bunks.Id, MaxSelect: 1})
-	assignments.Fields.Add(&core.RelationField{Name: "bunk_plan", CollectionId: bunkPlans.Id, MaxSelect: 1})
-	assignments.Fields.Add(&core.NumberField{Name: "year", Required: true})
-	assignments.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
-	// The widened unique index this PR's migration adds in production
-	// (see pb_migrations/1500000155_bunk_assignments_bunk_grain.js). Pinned
-	// here too so these tests exercise the same DB-level constraint, not
-	// just the in-memory composite key -- confirmed load-bearing: reverting
-	// this to the CURRENT unmigrated (year, person, session) shape makes
+	// bunks, bunk_plans, bunk_assignments and staff are kindred#2300's shared
+	// fixture builder (sync_testsupport_test.go) -- widened there so this
+	// file's copies didn't keep drifting from production on their own.
+	// addBunkAssignmentsCollection pins production's post-kindred#2259
+	// widened unique index (year, person, session, bunk; migration
+	// 1500000155) -- confirmed still load-bearing here: reverting it to the
+	// old (year, person, session) shape makes
 	// TestProcessAssignment_FamilyStylePlanPreservesBothRowsImprecisely fail
 	// with a real uniqueness violation on the second assignment.
-	assignments.Indexes = []string{
-		"CREATE UNIQUE INDEX `idx_grain_test_person_session_bunk_year` " +
-			"ON `bunk_assignments` (`year`, `person`, `session`, `bunk`)",
-	}
-	if err := app.Save(assignments); err != nil {
-		t.Fatalf("create bunk_assignments: %v", err)
-	}
+	bunks := addBunksCollection(t, app)
+	bunkPlans := addBunkPlansCollection(t, app, bunks, sessions)
+	addBunkAssignmentsCollection(t, app, persons, sessions, bunks, bunkPlans)
 
 	attendees := core.NewBaseCollection("attendees")
 	attendees.Fields.Add(&core.NumberField{Name: "person_id", Required: true})
@@ -112,15 +84,7 @@ func setupBunkAssignmentGrainCollections(t *testing.T, app core.App) {
 		t.Fatalf("create attendees: %v", err)
 	}
 
-	staff := core.NewBaseCollection("staff")
-	staff.Fields.Add(&core.NumberField{Name: "person_id", Required: true})
-	staff.Fields.Add(&core.TextField{Name: "status"})
-	staff.Fields.Add(&core.BoolField{Name: "bunk_staff"})
-	staff.Fields.Add(&core.NumberField{Name: "year", Required: true})
-	staff.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
-	if err := app.Save(staff); err != nil {
-		t.Fatalf("create staff: %v", err)
-	}
+	addStaffCollection(t, app)
 }
 
 // bunkAssignmentsForYear returns every bunk_assignments row for the given

--- a/pocketbase/sync/bunk_assignments_protection_test.go
+++ b/pocketbase/sync/bunk_assignments_protection_test.go
@@ -70,38 +70,15 @@ func setupBunkAssignmentProtectionCollections(t *testing.T, app core.App) {
 		t.Fatalf("create persons: %v", err)
 	}
 
+	// bunks, staff and bunk_assignments are kindred#2300's shared fixture
+	// builder (sync_testsupport_test.go) -- widened there specifically so
+	// this file's copies didn't keep drifting from production on their own.
 	// bunk is part of the bunk_assignments grain alongside person and
 	// session (kindred#2259) -- protectNonActiveStaffAssignments and
 	// deleteOrphans both resolve it into their composite keys.
-	bunks := core.NewBaseCollection("bunks")
-	bunks.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
-	if err := app.Save(bunks); err != nil {
-		t.Fatalf("create bunks: %v", err)
-	}
-
-	assignments := core.NewBaseCollection("bunk_assignments")
-	assignments.Fields.Add(&core.RelationField{Name: "person", CollectionId: persons.Id, MaxSelect: 1})
-	assignments.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
-	assignments.Fields.Add(&core.RelationField{Name: "bunk", CollectionId: bunks.Id, MaxSelect: 1})
-	assignments.Fields.Add(&core.NumberField{Name: "year", Required: true})
-	// PaginateRecords sorts by "-created" unconditionally, and deleteOrphans's
-	// call to BuildRecordCMIDMappings goes through it.
-	assignments.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
-	if err := app.Save(assignments); err != nil {
-		t.Fatalf("create bunk_assignments: %v", err)
-	}
-
-	staff := core.NewBaseCollection("staff")
-	staff.Fields.Add(&core.NumberField{Name: "person_id", Required: true})
-	staff.Fields.Add(&core.TextField{Name: "status"})
-	staff.Fields.Add(&core.BoolField{Name: "bunk_staff"})
-	staff.Fields.Add(&core.NumberField{Name: "year", Required: true})
-	// PaginateRecords sorts by "-created" unconditionally, so the staff
-	// collection needs it even though nothing else in this test reads it.
-	staff.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
-	if err := app.Save(staff); err != nil {
-		t.Fatalf("create staff: %v", err)
-	}
+	bunks := addBunksCollection(t, app)
+	addBunkAssignmentsCollection(t, app, persons, sessions, bunks, nil)
+	addStaffCollection(t, app)
 }
 
 // TestProtectNonActiveStaffAssignments_ProtectsDismissedStaff is a regression
@@ -183,21 +160,11 @@ func setupBunkAssignmentSweepCollections(t *testing.T, app core.App) {
 		t.Fatalf("create persons: %v", err)
 	}
 
-	bunks := core.NewBaseCollection("bunks")
-	bunks.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
-	if err := app.Save(bunks); err != nil {
-		t.Fatalf("create bunks: %v", err)
-	}
-
-	assignments := core.NewBaseCollection("bunk_assignments")
-	assignments.Fields.Add(&core.RelationField{Name: "person", CollectionId: persons.Id, MaxSelect: 1})
-	assignments.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
-	assignments.Fields.Add(&core.RelationField{Name: "bunk", CollectionId: bunks.Id, MaxSelect: 1})
-	assignments.Fields.Add(&core.NumberField{Name: "year", Required: true})
-	assignments.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
-	if err := app.Save(assignments); err != nil {
-		t.Fatalf("create bunk_assignments: %v", err)
-	}
+	// See setupBunkAssignmentProtectionCollections above: bunks/bunk_assignments
+	// come from kindred#2300's shared fixture builder. The absent `staff`
+	// collection is the deliberate difference this helper exists for.
+	bunks := addBunksCollection(t, app)
+	addBunkAssignmentsCollection(t, app, persons, sessions, bunks, nil)
 }
 
 // newTestCampMinderClient builds a real *campminder.Client for tests that only

--- a/pocketbase/sync/lodging_alias_resolver_test.go
+++ b/pocketbase/sync/lodging_alias_resolver_test.go
@@ -16,7 +16,7 @@ import (
 // any year, not about one unit id surviving across years.
 func TestAliasResolverUnboundedWindows(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	years := []int{2017, 2022, 2025, 2026, 2030}
 	ridgeAByYear := make(map[int]string, len(years))
 	for _, year := range years {
@@ -49,7 +49,7 @@ func TestAliasResolverUnboundedWindows(t *testing.T) {
 // across camp, and nothing downstream would notice.
 func TestAliasResolverRespectsRenameWindows(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	// Every building here gets a row in EVERY year the test resolves against,
 	// including the years its own alias window excludes. A rename retires the
 	// STRING, not the building, and the registry is year-scoped (migration
@@ -139,7 +139,7 @@ func TestAliasResolverRespectsRenameWindows(t *testing.T) {
 // merge of that many rooms (spec 3.4). Six seeded aliases are of this shape.
 func TestAliasResolverMergeDenotingAlias(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	tioga1 := addUnit(t, app, "gt-tioga-1", 2025)
 	tioga2 := addUnit(t, app, "gt-tioga-2", 2025)
 	addAlias(t, app, "Golden Triangle - Tioga 1and2", []string{tioga1, tioga2}, 0, 0)
@@ -170,7 +170,7 @@ func TestAliasResolverMergeDenotingAlias(t *testing.T) {
 // and must not panic or error.
 func TestAliasResolverUnresolvedIsNotAnError(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	addUnit(t, app, "ridge-a", 2022)
 
 	r, err := NewAliasResolver(app)
@@ -198,7 +198,7 @@ func TestAliasResolverUnresolvedIsNotAnError(t *testing.T) {
 // whitespace; inner spacing stays significant because the seed relies on it.
 func TestAliasResolverToleratesWhitespaceAndCase(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	dsA := addUnit(t, app, "hc-downstairs-a", 2025)
 	addAlias(t, app, "Health Center Downstairs  - Room A", []string{dsA}, 0, 0)
 
@@ -229,7 +229,7 @@ func TestAliasResolverToleratesWhitespaceAndCase(t *testing.T) {
 // windows are a data problem for staff, not something to resolve arbitrarily.
 func TestAliasResolverFlagsOverlappingWindows(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	a := addUnit(t, app, "ridge-a", 2025)
 	b := addUnit(t, app, "ridge-b", 2025)
 	addAlias(t, app, "Ridge A", []string{a}, 0, 0)
@@ -256,7 +256,7 @@ func TestAliasResolverFlagsOverlappingWindows(t *testing.T) {
 // hand back 2026's ids.
 func TestResolveReturnsTheRequestedYearsUnitIDs(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	id2026 := addUnit(t, app, "test-unit-a", 2026)
 	id2027 := addUnit(t, app, "test-unit-a", 2027)
 	addAlias(t, app, "Test Building A", []string{id2026}, 0, 0)
@@ -284,7 +284,7 @@ func TestResolveReturnsTheRequestedYearsUnitIDs(t *testing.T) {
 // rooms, which is worse than a name that does not resolve.
 func TestResolveIsUnresolvedWhenAMemberIsMissingThatYear(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	a2026 := addUnit(t, app, "test-unit-a", 2026)
 	b2026 := addUnit(t, app, "test-unit-b", 2026)
 	// "test-unit-a" has a 2027 row; "test-unit-b" does not -- a member code with
@@ -317,7 +317,7 @@ func TestResolveIsUnresolvedWhenAMemberIsMissingThatYear(t *testing.T) {
 // here means only real ids ever reach that write, and the failure vanishes.
 func TestResolveIsUnresolvedWhenAMemberIsDangling(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	a2027 := addUnit(t, app, "test-unit-a", 2027)
 	addAliasWithDanglingMember(t, app, "Test Pair", []string{a2027, "missingunit0001"}, 0, 0)
 

--- a/pocketbase/sync/lodging_assignments_sync_test.go
+++ b/pocketbase/sync/lodging_assignments_sync_test.go
@@ -42,7 +42,7 @@ func TestLodgingAssignmentsSyncName(t *testing.T) {
 // TestLodgingAssignmentsSyncHouseholdGrain: the whole happy path end to end.
 func TestLodgingAssignmentsSyncHouseholdGrain(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	sessionID, unitID := seedOneWeekendHousehold(t, app)
 
 	s := NewLodgingAssignmentsSync(app)
@@ -119,7 +119,7 @@ func TestLodgingAssignmentsSyncHouseholdGrain(t *testing.T) {
 // happens to store.
 func TestLodgingAssignmentsSyncWritesTheSyncedYearsUnitIDs(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	id2026 := addUnit(t, app, "test-unit-a", 2026)
 	id2027 := addUnit(t, app, "test-unit-a", 2027)
 	addAlias(t, app, "Test Building A", []string{id2026}, 0, 0)
@@ -158,7 +158,7 @@ func TestLodgingAssignmentsSyncWritesTheSyncedYearsUnitIDs(t *testing.T) {
 // assignment or append a spurious history row.
 func TestLodgingAssignmentsSyncIsIdempotent(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	seedOneWeekendHousehold(t, app)
 
 	for pass := 0; pass < 2; pass++ {
@@ -184,7 +184,7 @@ func TestLodgingAssignmentsSyncIsIdempotent(t *testing.T) {
 // CampMinder overwrote.
 func TestLodgingAssignmentsSyncAppendsHistoryOnChange(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	seedOneWeekendHousehold(t, app)
 	ridgeB := addUnit(t, app, "ridge-b", 2025)
 	addAlias(t, app, "Ridge B", []string{ridgeB}, 0, 0)
@@ -236,7 +236,7 @@ func TestLodgingAssignmentsSyncAppendsHistoryOnChange(t *testing.T) {
 // the board is not reverted by the next CampMinder sync.
 func TestLodgingAssignmentsSyncRespectsStaffTouched(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	seedOneWeekendHousehold(t, app)
 	ridgeB := addUnit(t, app, "ridge-b", 2025)
 	addAlias(t, app, "Ridge B", []string{ridgeB}, 0, 0)
@@ -274,7 +274,7 @@ func TestLodgingAssignmentsSyncRespectsStaffTouched(t *testing.T) {
 // queue item and must not be dropped, and must not stop the run.
 func TestLodgingAssignmentsSyncQueuesUnresolvedAlias(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
 	// Unrelated to "Tuolumne 7" below -- this only gives 2025 a registry, so
@@ -322,7 +322,7 @@ func TestLodgingAssignmentsSyncQueuesUnresolvedAlias(t *testing.T) {
 // them for manual entry.
 func TestLodgingAssignmentsSyncQueuesAmbiguousSession(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	fc1 := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
 	winter := addSession(t, app, cmIDWinterFamily, "Winter Family Camp", "family",
@@ -366,7 +366,7 @@ func TestLodgingAssignmentsSyncQueuesAmbiguousSession(t *testing.T) {
 // A merged slot is the alias's own member set, not a row pointing at it.
 func TestIngestWritesAMultiRoomPlacementAsOneRow(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
 	bldg := addContainerUnit(t, app, "gt-tioga", 2025)
@@ -414,7 +414,7 @@ const testAdultSessionEnd = "2025-10-19 07:00:00.000Z"
 // the placement keys on person_cm_id and household_cm_id stays 0.
 func TestLodgingAssignmentsSyncPersonGrain(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	womens := addSession(t, app, cmIDWomensWeekend, "Women's Weekend", "adult",
 		testAdultSessionStart, testAdultSessionEnd, 2025)
 	unit := addUnit(t, app, "river-c", 2025)
@@ -458,7 +458,7 @@ func TestLodgingAssignmentsSyncPersonGrain(t *testing.T) {
 // ONE could exist.
 func TestLodgingAssignmentsSyncPersonGrainManyPerSession(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	womens := addSession(t, app, cmIDWomensWeekend, "Women's Weekend", "adult",
 		testAdultSessionStart, testAdultSessionEnd, 2025)
 	unit := addUnit(t, app, "river-c", 2025)
@@ -489,7 +489,7 @@ func TestLodgingAssignmentsSyncPersonGrainManyPerSession(t *testing.T) {
 // enrollment. Queue them; never drop them.
 func TestLodgingAssignmentsSyncPersonGrainNoEnrolment(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	addSession(t, app, cmIDWomensWeekend, "Women's Weekend", "adult",
 		testAdultSessionStart, testAdultSessionEnd, 2025)
 	unit := addUnit(t, app, "river-c", 2025)
@@ -593,7 +593,7 @@ func TestPlacementForPassesTheAliasSetThrough(t *testing.T) {
 // even though it never mentions it.
 func TestLodgingAssignmentsSyncDryRunWritesNothing(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
 	t1 := addUnit(t, app, "gt-tioga-1", 2025)
@@ -641,7 +641,7 @@ func TestLodgingAssignmentsSyncDryRunWritesNothing(t *testing.T) {
 // detector; it is not the change detector.
 func TestLodgingAssignmentsSyncUpdatesPartySizeInSameCabin(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	seedOneWeekendHousehold(t, app)
 
 	s := NewLodgingAssignmentsSync(app)
@@ -691,7 +691,7 @@ func TestLodgingAssignmentsSyncUpdatesPartySizeInSameCabin(t *testing.T) {
 // the field_zero_values warning stays quiet.
 func TestLodgingAssignmentsSyncQueuesUnknownHousehold(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
 	unit := addUnit(t, app, "ridge-a", 2025)
@@ -724,7 +724,7 @@ func TestLodgingAssignmentsSyncQueuesUnknownHousehold(t *testing.T) {
 // TestLodgingAssignmentsSyncQueuesUnknownHousehold.
 func TestLodgingAssignmentsSyncQueuesUnknownPerson(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	addSession(t, app, cmIDWomensWeekend, "Women's Weekend", "adult",
 		testAdultSessionStart, testAdultSessionEnd, 2025)
 	unit := addUnit(t, app, "ridge-a", 2025)
@@ -762,7 +762,7 @@ func TestLodgingAssignmentsSyncQueuesUnknownPerson(t *testing.T) {
 // that never left its cabin.
 func TestLodgingAssignmentsSyncMergeLabelIgnoresMemberOrder(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
 	bldg := addContainerUnit(t, app, "gt-tioga", 2025)
@@ -834,7 +834,7 @@ func TestLodgingAssignmentsSyncMergeLabelIgnoresMemberOrder(t *testing.T) {
 // already entitled to hold is not one.
 func TestLodgingAssignmentsSyncLabelDropsUnresolvableUnits(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
 	ridge := addUnit(t, app, "ridge-a", 2025)
@@ -959,7 +959,7 @@ func TestActiveSeasonYearFieldOverridesEnv(t *testing.T) {
 // this pass.
 func TestLodgingAssignmentsSyncDeletesOrphanedHouseholdMirrorRow(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
 	unit := addUnit(t, app, "ridge-a", 2025)
@@ -998,7 +998,7 @@ func TestLodgingAssignmentsSyncDeletesOrphanedHouseholdMirrorRow(t *testing.T) {
 // obvious regression the sweep must not cause.
 func TestLodgingAssignmentsSyncKeepsMirrorRowForStillEnrolledHousehold(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
 	unit := addUnit(t, app, "ridge-a", 2025)
@@ -1033,7 +1033,7 @@ func TestLodgingAssignmentsSyncKeepsMirrorRowForStillEnrolledHousehold(t *testin
 // so its placements are left untouched rather than swept.
 func TestLodgingAssignmentsSyncSkipsMirrorDeletionWhenSessionHasZeroEnrolled(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
 	unit := addUnit(t, app, "ridge-a", 2025)
@@ -1060,7 +1060,7 @@ func TestLodgingAssignmentsSyncSkipsMirrorDeletionWhenSessionHasZeroEnrolled(t *
 // weekend twin: the sweep must treat person-grain rows the same way.
 func TestLodgingAssignmentsSyncDeletesOrphanedPersonGrainMirrorRow(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	sess := addSession(t, app, cmIDWomensWeekend, "Women's Weekend", "adult",
 		testAdultSessionStart, testAdultSessionEnd, 2025)
 	unit := addUnit(t, app, "river-c", 2025)
@@ -1096,7 +1096,7 @@ func TestLodgingAssignmentsSyncDeletesOrphanedPersonGrainMirrorRow(t *testing.T)
 // stranded_assignment_cleanup.go.
 func TestLodgingAssignmentsSyncDeletesStaffTouchedOrphanedMirrorRow(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
 	unit := addUnit(t, app, "ridge-a", 2025)
@@ -1128,7 +1128,7 @@ func TestLodgingAssignmentsSyncDeletesStaffTouchedOrphanedMirrorRow(t *testing.T
 // does not write, full stop -- including the delete path.
 func TestLodgingAssignmentsSyncDryRunDoesNotDeleteOrphans(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
 	unit := addUnit(t, app, "ridge-a", 2025)
@@ -1173,7 +1173,7 @@ func TestLodgingAssignmentsSyncDryRunDoesNotDeleteOrphans(t *testing.T) {
 // happened must never read as "everyone cancelled".
 func TestLodgingAssignmentsSyncSkipsOrphanSweepForHistoricalYear(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 
 	// ...but this sync targets 2024, a season that already happened.
 	const historicalYear = 2024
@@ -1227,7 +1227,7 @@ func TestLodgingAssignmentsSyncSkipsOrphanSweepForHistoricalYear(t *testing.T) {
 // Serial, not t.Parallel(): t.Setenv panics under Parallel.
 func TestLodgingAssignmentsSyncSkipsOrphanSweepWhenSeasonUnresolvable(t *testing.T) {
 	t.Setenv("CAMPMINDER_SEASON_ID", "")
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
 	unit := addUnit(t, app, "ridge-a", 2025)
@@ -1273,7 +1273,7 @@ func TestLodgingAssignmentsSyncSkipsOrphanSweepWhenSeasonUnresolvable(t *testing
 // Serial, not t.Parallel(): t.Setenv panics under Parallel.
 func TestLodgingAssignmentsSyncDeletesOrphansViaEnvFallback(t *testing.T) {
 	t.Setenv("CAMPMINDER_SEASON_ID", "2025")
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
 	unit := addUnit(t, app, "ridge-a", 2025)
@@ -1316,7 +1316,7 @@ func TestLodgingAssignmentsSyncWritesHistoryOnOrphanDelete(t *testing.T) {
 	// call and the history assertion below in step, and avoids adding a 3rd/4th
 	// hardcoded occurrence of the string across this file (goconst).
 	const unitCode = "ridge-a"
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
 	unit := addUnit(t, app, unitCode, 2025)
@@ -1390,7 +1390,7 @@ func TestLodgingAssignmentsSyncWritesHistoryOnOrphanDelete(t *testing.T) {
 // it stands in for the record the placement was written against.
 func TestFindAssignmentMatchesOnTheCampMinderSessionID(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	sessOld := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
 	sessRecreated := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
@@ -1425,7 +1425,7 @@ func TestFindAssignmentMatchesOnTheCampMinderSessionID(t *testing.T) {
 // same household, and asking for one must never return the other's row.
 func TestFindAssignmentStillSeparatesWeekends(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	sessA := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
 	sessB := addSession(t, app, cmIDFamilyCamp6, "Family Camp 6", "family",

--- a/pocketbase/sync/lodging_fields_test.go
+++ b/pocketbase/sync/lodging_fields_test.go
@@ -70,7 +70,7 @@ func TestLodgingRequestFieldsAreWellFormed(t *testing.T) {
 // from silently disconnecting an answer from its column.
 func TestLodgingRequestFieldNamesResolveThroughCMID(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 
 	renamed := addFieldDef(t, app, cmIDShareCabinsRegistration, "FC Cabin Sharing 2027")
 	untouched := addFieldDef(t, app, cmIDSharedRequest, "Shared-request")
@@ -97,7 +97,7 @@ func TestLodgingRequestFieldNamesResolveThroughCMID(t *testing.T) {
 // would never match; the mapping must still be found.
 func TestLodgingFieldDefIDsMapsByCMID(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 
 	cabinDefID := addFieldDef(t, app, cmIDFamilyCampCabin, "Renamed By Staff In 2027")
 	reportableDefID := addFieldDef(t, app, cmIDReportableFamilyCampCabin, "Reportable Family Camp Cabin")
@@ -124,7 +124,7 @@ func TestLodgingFieldDefIDsMapsByCMID(t *testing.T) {
 // stop reading that field.
 func TestLodgingFieldDefIDsHonoursDisabledMapping(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	cabinDefID := addFieldDef(t, app, cmIDFamilyCampCabin, "Family Camp Cabin")
 
 	saveRecord(t, app, "lodging_field_mappings", map[string]any{
@@ -147,7 +147,7 @@ func TestLodgingFieldDefIDsHonoursDisabledMapping(t *testing.T) {
 // this year may simply have a form that hasn't been sent yet."
 func TestUpsertFieldMappingStatusIsIdempotentAndNeverAutoDisables(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	addFieldDef(t, app, cmIDFamilyCampCabin, "Family Camp Cabin")
 
 	// Year with zero values for the cabin field, 464 the year before.
@@ -189,7 +189,7 @@ func TestUpsertFieldMappingStatusIsIdempotentAndNeverAutoDisables(t *testing.T) 
 // in 2025". last_seen_* means MOST RECENT, so an older run must leave it alone.
 func TestUpsertFieldMappingStatusDoesNotRegressOnOlderYearBackfill(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	addFieldDef(t, app, cmIDFamilyCampCabin, "Family Camp Cabin")
 
 	// The current season's daily sync: no values yet this year, 171 last year.
@@ -232,7 +232,7 @@ func TestUpsertFieldMappingStatusDoesNotRegressOnOlderYearBackfill(t *testing.T)
 // happened to run first.
 func TestUpsertFieldMappingStatusAdvancesOnNewerYear(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	addFieldDef(t, app, cmIDFamilyCampCabin, "Family Camp Cabin")
 
 	if err := UpsertFieldMappingStatus(app, 2025,

--- a/pocketbase/sync/lodging_grain_test.go
+++ b/pocketbase/sync/lodging_grain_test.go
@@ -82,7 +82,7 @@ func TestValidateAssignmentGrainRejectsEmptyUnits(t *testing.T) {
 // invariant has no database backing.
 func TestAssignmentGrainIllegalStatesReallySaveInPocketBase(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
 

--- a/pocketbase/sync/lodging_issues_test.go
+++ b/pocketbase/sync/lodging_issues_test.go
@@ -42,7 +42,7 @@ func TestIssueKindsMatchTheMigration(t *testing.T) {
 // occurrence count -- not five rows to wade through.
 func TestIssueRecorderCollapsesRepeats(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	r := NewIssueRecorder(app, 2022)
 
 	// Five different households hit the same unmapped string.
@@ -89,7 +89,7 @@ func TestIssueRecorderCollapsesRepeats(t *testing.T) {
 // counts or add rows. occurrences is SET to what this run observed, not added to.
 func TestIssueRecorderFlushIsIdempotent(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 
 	for pass := 0; pass < 2; pass++ {
 		r := NewIssueRecorder(app, 2022)
@@ -130,7 +130,7 @@ func TestIssueRecorderFlushIsIdempotent(t *testing.T) {
 // raw value and source field are identical.
 func TestIssueRecorderKeepsPerHouseholdIssuesSeparate(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	r := NewIssueRecorder(app, 2025)
 
 	r.Record(Issue{Kind: issueAmbiguousSession, RawValue: "Ridge A",
@@ -156,7 +156,7 @@ func TestIssueRecorderKeepsPerHouseholdIssuesSeparate(t *testing.T) {
 // emptiness over an open queue item takes its one-click confirmation with it.
 func TestIssueRecorderFlushKeepsAnEarlierSuggestion(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	sess := addSession(t, app, 1309514, "Family Camp 1", "family",
 		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
 
@@ -198,7 +198,7 @@ func TestIssueRecorderFlushKeepsAnEarlierSuggestion(t *testing.T) {
 // exactly the class of bug that made Plan 1's alias verifier unable to pass.
 func TestIssueRecorderHandlesApostrophes(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	r := NewIssueRecorder(app, 2024)
 	r.Record(Issue{Kind: issueUnresolvedAlias, RawValue: "Golden Triangle - Doctor's House",
 		SourceField: fieldNameFamilyCampCabin, Year: 2024})

--- a/pocketbase/sync/lodging_replay_test.go
+++ b/pocketbase/sync/lodging_replay_test.go
@@ -22,7 +22,7 @@ func seedIssue(t *testing.T, app core.App, values map[string]any) string {
 // queue look busier while nothing was repaired.
 func TestReplayIssueRefusesAnUnresolvedRow(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	id := seedIssue(t, app, map[string]any{
 		"kind":            issueWriteFailed,
 		"raw_value":       "Ridge 1and2",
@@ -41,7 +41,7 @@ func TestReplayIssueRefusesAnUnresolvedRow(t *testing.T) {
 // replayed, because ingestValue has nothing to attribute the placement to.
 func TestReplayIssueRefusesARowWithNoParty(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	id := seedIssue(t, app, map[string]any{
 		"kind":            issueWriteFailed,
 		"raw_value":       "Ridge 1and2",
@@ -61,7 +61,7 @@ func TestReplayIssueRefusesARowWithNoParty(t *testing.T) {
 // queue a no_session item -- a repair that reports itself as a fresh problem.
 func TestReplayIssueRefusesARowWithNoYear(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	id := seedIssue(t, app, map[string]any{
 		"kind":            issueWriteFailed,
 		"raw_value":       "Ridge 1and2",
@@ -81,7 +81,7 @@ func TestReplayIssueRefusesARowWithNoYear(t *testing.T) {
 // rebuilt here for one household.
 func TestReplayIssuePlacesAHouseholdWithoutASync(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	sessionID, unitID := seedOneWeekendHousehold(t, app)
 
 	id := seedIssue(t, app, map[string]any{
@@ -138,7 +138,7 @@ func TestReplayIssuePlacesAHouseholdWithoutASync(t *testing.T) {
 // and queue a no_session item -- the repair reporting itself as a new problem.
 func TestReplayIssuePlacesAPersonOnAnAdultWeekend(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	womens := addSession(t, app, cmIDWomensWeekend, "Women's Weekend", "adult",
 		testAdultSessionStart, testAdultSessionEnd, 2025)
 	unit := addUnit(t, app, "river-c", 2025)
@@ -187,7 +187,7 @@ func TestReplayIssuePlacesAPersonOnAnAdultWeekend(t *testing.T) {
 // resolver, unit tree and placementFor all reached from a replay.
 func TestReplayIssuePlacesAMultiRoomAliasAsOneRow(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		testSessionStart, testSessionEnd, 2025)
 	building := addContainerUnit(t, app, "ridge", 2025)
@@ -237,7 +237,7 @@ func TestReplayIssuePlacesAMultiRoomAliasAsOneRow(t *testing.T) {
 // straight back into the queue.
 func TestReplayIssueLeavesAPlacedRowResolved(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	seedOneWeekendHousehold(t, app)
 
 	id := seedIssue(t, app, map[string]any{
@@ -303,7 +303,7 @@ func seedThreeWeekendHousehold(
 // reproduces the sync's answer: the weekend the real last_updated points at.
 func TestReplayIssueKeepsTheSuggestionTheSyncWouldHaveMade(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	// Edited between the first and second weekends, so the sync suggests the
 	// second. Now would suggest the third; a zero timestamp would suggest none.
 	first, second, third := seedThreeWeekendHousehold(t, app,
@@ -345,7 +345,7 @@ func TestReplayIssueKeepsTheSuggestionTheSyncWouldHaveMade(t *testing.T) {
 // when last_updated stops parsing.
 func TestReplayIssuePreservesTheSuggestionWhenTheObservationIsGone(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	first, _, _ := seedThreeWeekendHousehold(t, app,
 		"Ridge A", "2025-06-10T09:00:00.0000000+00:00")
 
@@ -385,7 +385,7 @@ func TestReplayIssuePreservesTheSuggestionWhenTheObservationIsGone(t *testing.T)
 // did not finish the job.
 func TestReplayIssueTicksARowWhoseBlockerIsGoneAndOpensTheNewOne(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	fc1 := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
 	fc6 := addSession(t, app, cmIDFamilyCamp6, "Family Camp 6", "family",
@@ -473,7 +473,7 @@ func TestReplayIssueTicksARowWhoseBlockerIsGoneAndOpensTheNewOne(t *testing.T) {
 // directly rather than waiting for that caller to discover it.
 func TestFindExistingMatchesOnTheWholeDedupTuple(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	stored := Issue{
 		Kind: issueWriteFailed, RawValue: "Ridge 1and2",
 		SourceField: fieldNameFamilyCampCabin, Year: 2025, HouseholdCMID: 9001,
@@ -543,7 +543,7 @@ func TestFindExistingMatchesOnTheWholeDedupTuple(t *testing.T) {
 // which is the invariant this whole wave exists to establish.
 func TestReplayIssueReopensAnotherTickedRowItRehit(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	fc1 := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
 	fc6 := addSession(t, app, cmIDFamilyCamp6, "Family Camp 6", "family",
@@ -682,7 +682,7 @@ func seedFanOutWithOneAmbiguousHousehold(
 // place" from "this row was never replayable in the first place".
 func TestReplayPartylessIssueRefusesRowsItCannotFanOut(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 
 	cases := []struct {
 		name   string
@@ -771,7 +771,7 @@ func TestReplayPartylessIssueRefusesRowsItCannotFanOut(t *testing.T) {
 // strength of a mapping nobody restored.
 func TestReplayPartylessIssueRefusesARowWhoseSourceFieldIsDisabled(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	seedTwoHouseholdsSharingACabinString(t, app, "Ridge Cabin 9", 2026)
 	addAlias(t, app, "Ridge Cabin 9", []string{addUnit(t, app, "ridge-9", 2026)}, 0, 0)
 	saveRecord(t, app, "lodging_field_mappings", map[string]any{
@@ -805,7 +805,7 @@ func TestReplayPartylessIssueRefusesARowWhoseSourceFieldIsDisabled(t *testing.T)
 // that fails if the function silently does nothing.
 func TestReplayPartylessIssueFansOutToEveryPartyThatWroteTheString(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	sessionID, parties := seedTwoHouseholdsSharingACabinString(t, app, "Ridge Cabin 9", 2026)
 	// The staff repair this replay follows: the string now has an alias.
 	unitID := addUnit(t, app, "ridge-9", 2026)
@@ -868,7 +868,7 @@ func TestReplayPartylessIssueFansOutToEveryPartyThatWroteTheString(t *testing.T)
 // 1-household one.
 func TestReplayPartylessIssueReopensARowWhoseStringStillDoesNotResolve(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	seedTwoHouseholdsSharingACabinString(t, app, "Nowhere Cabin", 2026)
 	// A REAL mapping exists -- resolved_alias is set, as production always
 	// sets it on a genuine map (#1899: mapUnresolvedAlias never leaves it
@@ -926,7 +926,7 @@ func TestReplayPartylessIssueReopensARowWhoseStringStillDoesNotResolve(t *testin
 // wrote the string must not undo that decision.
 func TestReplayPartylessIssueDoesNotReopenAnIgnoredRow(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	seedTwoHouseholdsSharingACabinString(t, app, "Not A Cabin", 2026)
 	// No alias, and none is coming: staff said this string is not a cabin
 	// name, which is exactly what resolved_alias staying empty records.
@@ -963,7 +963,7 @@ func TestReplayPartylessIssueDoesNotReopenAnIgnoredRow(t *testing.T) {
 // row it was meant to touch.
 func TestReopenRecordedDoesNotReopenAnUnrelatedIgnoredRowDuringAPartyScopedReplay(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	_, parties := seedTwoHouseholdsSharingACabinString(t, app, "Not A Cabin", 2026)
 	// Nobody ever mapped "Not A Cabin" -- staff ignored it once, and it is
 	// exactly as unmapped now as it was then.
@@ -1010,7 +1010,7 @@ func TestReopenRecordedDoesNotReopenAnUnrelatedIgnoredRowDuringAPartyScopedRepla
 // household in the queue.
 func TestReplayPartylessIssueCountsOnlyThePartiesItPlaced(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	_, _, _, parties := seedFanOutWithOneAmbiguousHousehold(t, app, "Ridge Cabin 9")
 	addAlias(t, app, "Ridge Cabin 9", []string{addUnit(t, app, "ridge-9", 2025)}, 0, 0)
 
@@ -1079,7 +1079,7 @@ func TestReplayPartylessIssueCountsOnlyThePartiesItPlaced(t *testing.T) {
 // TestFindExistingMatchesOnTheWholeDedupTuple pins the lookup itself.
 func TestReplayPartylessIssueLeavesAnotherHouseholdsTickedRowAlone(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	_, _, _, parties := seedFanOutWithOneAmbiguousHousehold(t, app, "Ridge Cabin 9")
 	addAlias(t, app, "Ridge Cabin 9", []string{addUnit(t, app, "ridge-9", 2025)}, 0, 0)
 
@@ -1144,7 +1144,7 @@ func TestReplayPartylessIssueLeavesAnotherHouseholdsTickedRowAlone(t *testing.T)
 // order-independent where a stranger row is not.
 func TestReplayPartylessIssueReopensEveryBlockedPartysRow(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	_, parties := seedTwoHouseholdsSharingACabinString(t, app, "Ridge Cabin 9", 2025)
 	// The string resolves, so the alias row's own blocker is genuinely gone and
 	// the only thing this pass can record is the two attribution failures.
@@ -1220,7 +1220,7 @@ func TestReplayPartylessIssueReopensEveryBlockedPartysRow(t *testing.T) {
 // the damage lands in the database.
 func TestReplayPartylessIssueAttributesWithTheObservationTimestamp(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	_, second, third, _ := seedFanOutWithOneAmbiguousHousehold(t, app, "Ridge Cabin 9")
 	addAlias(t, app, "Ridge Cabin 9", []string{addUnit(t, app, "ridge-9", 2025)}, 0, 0)
 
@@ -1261,7 +1261,7 @@ func TestReplayPartylessIssueAttributesWithTheObservationTimestamp(t *testing.T)
 // successful replay of nothing.
 func TestReplayPartylessIssueFansOutAcrossThePersonGrain(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	womens := addSession(t, app, cmIDWomensWeekend, "Women's Weekend", "adult",
 		testAdultSessionStart, testAdultSessionEnd, 2025)
 	unitID := addUnit(t, app, "river-c", 2025)

--- a/pocketbase/sync/lodging_session_attribution_test.go
+++ b/pocketbase/sync/lodging_session_attribution_test.go
@@ -36,7 +36,7 @@ func TestParseCampMinderTimestamp(t *testing.T) {
 // against it -- so it must be read via GetDateTime, not ParseDate.
 func TestLoadSessionWindowsReadsDateFields(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	addSession(t, app, 1309514, "Family Camp 1", "family",
 		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
 	addSession(t, app, 1335115, "Women's Weekend", "adult",
@@ -69,7 +69,7 @@ func TestLoadSessionWindowsReadsDateFields(t *testing.T) {
 // manufacture ambiguity where there is none.
 func TestBuildHouseholdSessionIndexUsesActiveEnrolmentOnly(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	fc1 := addSession(t, app, 1309514, "Family Camp 1", "family",
 		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
 	fc6 := addSession(t, app, 1309519, "Family Camp 6", "family",
@@ -96,7 +96,7 @@ func TestBuildHouseholdSessionIndexUsesActiveEnrolmentOnly(t *testing.T) {
 // household attending the same weekend is ONE household-weekend, not two.
 func TestBuildHouseholdSessionIndexDedupesSiblings(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	fc1 := addSession(t, app, 1309514, "Family Camp 1", "family",
 		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
 
@@ -121,7 +121,7 @@ func TestBuildHouseholdSessionIndexDedupesSiblings(t *testing.T) {
 // index holds for that party -- not merely non-empty.
 func TestBuildSessionIndexFilteredToOnePartyMatchesTheFullIndex(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	fc1 := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
 	fc6 := addSession(t, app, cmIDFamilyCamp6, "Family Camp 6", "family",

--- a/pocketbase/sync/lodging_testsupport_fixture_test.go
+++ b/pocketbase/sync/lodging_testsupport_fixture_test.go
@@ -20,7 +20,7 @@ import (
 // this package's did not.
 func TestLodgingUnitsFixtureRejectsDuplicateCodeYear(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	addUnit(t, app, "dup-code", 2026)
 
 	col, err := app.FindCollectionByNameOrId("lodging_units")
@@ -46,7 +46,7 @@ func TestLodgingUnitsFixtureRejectsDuplicateCodeYear(t *testing.T) {
 // the real database would reject.
 func TestLodgingUnitsFixtureRejectsYearOutsideProductionRange(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	col, err := app.FindCollectionByNameOrId("lodging_units")
 	if err != nil {
 		t.Fatalf("find collection lodging_units: %v", err)
@@ -214,7 +214,7 @@ func TestLoadProductionSchema(t *testing.T) {
 
 // TestLodgingTestsupportFixtureFieldsExistInProductionSchema is kindred#1921's
 // guard against the bug class migration 1500000132 hit once already: this
-// package's fixtures (newLodgingTestApp, lodging_testsupport_test.go) build
+// package's fixtures (newSyncTestApp, sync_testsupport_test.go) build
 // every collection by hand, so a column a migration drops or renames stays
 // present in the fixture -- every filter naming it keeps resolving here while
 // production starts rejecting the write with "unknown field ...". Nothing
@@ -223,7 +223,7 @@ func TestLoadProductionSchema(t *testing.T) {
 //
 // Drop/rename direction ONLY: this fails on a field the fixture declares that
 // production's real schema does not have. The reverse -- production has a
-// field the fixture lacks -- is deliberately out of scope. newLodgingTestApp's
+// field the fixture lacks -- is deliberately out of scope. newSyncTestApp's
 // own doc comment says the fixtures are minimal on purpose, carrying only the
 // fields the code under test touches, not a full mirror of every production
 // column.
@@ -252,8 +252,8 @@ func TestLodgingTestsupportFixtureFieldsExistInProductionSchema(t *testing.T) {
 	// A bare, un-fixtured app carries tests.NewTestApp()'s own bundled
 	// testdata -- e.g. a demo "users" collection with username/file/rel,
 	// unrelated to production's staff-auth "users" collection. Diffing
-	// newLodgingTestApp's collections against THIS baseline -- rather than a
-	// hardcoded list of names newLodgingTestApp happens to build today -- is
+	// newSyncTestApp's collections against THIS baseline -- rather than a
+	// hardcoded list of names newSyncTestApp happens to build today -- is
 	// what keeps this test honest as that function grows: a collection added
 	// there later is picked up automatically, with no allowlist to remember
 	// to update. Iterating app.FindAllCollections() without this diff would
@@ -272,7 +272,7 @@ func TestLodgingTestsupportFixtureFieldsExistInProductionSchema(t *testing.T) {
 		baselineNames[c.Name] = true
 	}
 
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	fixtureCols, err := app.FindAllCollections()
 	if err != nil {
 		t.Fatalf("list fixture collections: %v", err)
@@ -281,7 +281,7 @@ func TestLodgingTestsupportFixtureFieldsExistInProductionSchema(t *testing.T) {
 	checked := 0
 	for _, col := range fixtureCols {
 		if baselineNames[col.Name] {
-			continue // part of tests.NewTestApp()'s own bundled testdata, not something newLodgingTestApp added
+			continue // part of tests.NewTestApp()'s own bundled testdata, not something newSyncTestApp added
 		}
 		prodFields, ok := prod[col.Name]
 		if !ok {
@@ -296,13 +296,13 @@ func TestLodgingTestsupportFixtureFieldsExistInProductionSchema(t *testing.T) {
 			}
 			t.Errorf("collection %q: fixture declares field %q, which the real "+
 				"pb_migrations schema does not have -- dropped or renamed? "+
-				"update newLodgingTestApp in lodging_testsupport_test.go",
+				"update newSyncTestApp in sync_testsupport_test.go",
 				col.Name, fieldName)
 		}
 	}
 
 	if checked == 0 {
-		t.Fatalf("compared zero collections against %s -- newLodgingTestApp and the "+
+		t.Fatalf("compared zero collections against %s -- newSyncTestApp and the "+
 			"baseline test app collection sets came out identical", schemaPath)
 	}
 }

--- a/pocketbase/sync/stranded_assignment_cleanup_test.go
+++ b/pocketbase/sync/stranded_assignment_cleanup_test.go
@@ -143,13 +143,10 @@ func setupStrandedCollections(t *testing.T, app core.App) {
 		t.Fatalf("create camp_sessions: %v", err)
 	}
 
-	bunks := core.NewBaseCollection("bunks")
-	bunks.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
-	bunks.Fields.Add(&core.TextField{Name: "name"})
-	bunks.Fields.Add(&core.NumberField{Name: "year"})
-	if err := app.Save(bunks); err != nil {
-		t.Fatalf("create bunks: %v", err)
-	}
+	// bunks and bunk_plans are kindred#2300's shared fixture builder
+	// (sync_testsupport_test.go) -- widened there so this file's copies
+	// didn't keep drifting from production on their own.
+	bunks := addBunksCollection(t, app)
 
 	persons := core.NewBaseCollection("persons")
 	persons.Fields.Add(&core.NumberField{Name: "cm_id", Required: true})
@@ -161,13 +158,7 @@ func setupStrandedCollections(t *testing.T, app core.App) {
 		t.Fatalf("create persons: %v", err)
 	}
 
-	plans := core.NewBaseCollection("bunk_plans")
-	plans.Fields.Add(&core.RelationField{Name: "bunk", CollectionId: bunks.Id, MaxSelect: 1})
-	plans.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
-	plans.Fields.Add(&core.NumberField{Name: "year"})
-	if err := app.Save(plans); err != nil {
-		t.Fatalf("create bunk_plans: %v", err)
-	}
+	plans := addBunkPlansCollection(t, app, bunks, sessions)
 
 	scenarios := core.NewBaseCollection("saved_scenarios")
 	scenarios.Fields.Add(&core.TextField{Name: "name"})
@@ -188,14 +179,8 @@ func setupStrandedCollections(t *testing.T, app core.App) {
 		t.Fatalf("create bunk_assignments_draft: %v", err)
 	}
 
-	prod := core.NewBaseCollection("bunk_assignments")
-	prod.Fields.Add(&core.RelationField{Name: "person", CollectionId: persons.Id, MaxSelect: 1})
-	prod.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
-	prod.Fields.Add(&core.RelationField{Name: "bunk", CollectionId: bunks.Id, MaxSelect: 1})
-	prod.Fields.Add(&core.NumberField{Name: "year"})
-	if err := app.Save(prod); err != nil {
-		t.Fatalf("create bunk_assignments: %v", err)
-	}
+	// bunk_assignments too -- see the addBunksCollection comment above.
+	addBunkAssignmentsCollection(t, app, persons, sessions, bunks, plans)
 
 	attendees := core.NewBaseCollection("attendees")
 	attendees.Fields.Add(&core.RelationField{Name: "person", CollectionId: persons.Id, MaxSelect: 1})

--- a/pocketbase/sync/stranded_assignment_cleanup_test.go
+++ b/pocketbase/sync/stranded_assignment_cleanup_test.go
@@ -209,7 +209,7 @@ func setupStrandedCollections(t *testing.T, app core.App) {
 		t.Fatalf("create attendees: %v", err)
 	}
 
-	// --- lodging: #2028's tables, minimal shape (mirrors newLodgingTestApp) ---
+	// --- lodging: #2028's tables, minimal shape (mirrors newSyncTestApp) ---
 
 	units := core.NewBaseCollection("lodging_units")
 	units.Fields.Add(&core.TextField{Name: "code"})

--- a/pocketbase/sync/sync_testsupport_test.go
+++ b/pocketbase/sync/sync_testsupport_test.go
@@ -495,3 +495,22 @@ func TestAliasResolverHasAnyUnitsFalseWhenEmpty(t *testing.T) {
 		t.Error("HasUnitsForYear(2027) = true, want false")
 	}
 }
+
+// TestNewLodgingTestAppCoversBunkAssignmentGrain is kindred#2300: the shared
+// fixture builder was lodging-only, so bunk_assignments/staff/bunks/bunk_plans
+// only ever got hand-built copies scattered across
+// bunk_assignments_protection_test.go, bunk_assignments_grain_test.go and
+// stranded_assignment_cleanup_test.go -- none of them covered by
+// TestLodgingTestsupportFixtureFieldsExistInProductionSchema, which only
+// walks whatever newSyncTestApp builds. This pins that those four
+// collections are now built by the shared app, so the drift check picks
+// them up with NO edit to the check itself.
+func TestNewLodgingTestAppCoversBunkAssignmentGrain(t *testing.T) {
+	t.Parallel()
+	app := newSyncTestApp(t)
+	for _, name := range []string{"bunk_assignments", "staff", "bunks", "bunk_plans"} {
+		if _, err := app.FindCollectionByNameOrId(name); err != nil {
+			t.Errorf("newSyncTestApp does not build %q: %v", name, err)
+		}
+	}
+}

--- a/pocketbase/sync/sync_testsupport_test.go
+++ b/pocketbase/sync/sync_testsupport_test.go
@@ -650,6 +650,7 @@ func TestAddBunkPlansCollectionRequiresYear(t *testing.T) {
 	rec.Set("cm_id", 12345)
 	// Deliberately not setting "year".
 	if err := app.Save(rec); err == nil {
-		t.Error("Save(bunk_plans without year) succeeded, want error -- year must be Required to match production migration 1500000017")
+		t.Error("Save(bunk_plans without year) succeeded, want error -- " +
+			"year must be Required to match production migration 1500000017")
 	}
 }

--- a/pocketbase/sync/sync_testsupport_test.go
+++ b/pocketbase/sync/sync_testsupport_test.go
@@ -249,6 +249,11 @@ func addBunksCollection(t *testing.T, app core.App) *core.Collection {
 	bunks := core.NewBaseCollection("bunks")
 	bunks.Fields.Add(&core.NumberField{Name: "cm_id", Required: true, OnlyInt: true})
 	bunks.Fields.Add(&core.TextField{Name: "name"})
+	// year is left optional despite production requiring it (migration
+	// 1500000006): setupBunkAssignmentProtectionCollections
+	// (bunk_assignments_protection_test.go) seeds bunks with no year set,
+	// and a Required field here would fail every one of those saves
+	// (verified: making it Required fails 8 TestProtect* tests).
 	bunks.Fields.Add(&core.NumberField{Name: "year"})
 	// PaginateRecords sorts by "-created" unconditionally (bunk_assignments.go's
 	// BuildRecordCMIDMappings goes through it), so every caller needs this even
@@ -275,19 +280,24 @@ func addStaffCollection(t *testing.T, app core.App) *core.Collection {
 	return staff
 }
 
-// addBunkPlansCollection builds `bunk_plans`. cm_id and year are left
-// optional despite production requiring both (migration 1500000017):
+// addBunkPlansCollection builds `bunk_plans`. cm_id is left optional despite
+// production requiring it (migration 1500000017):
 // stranded_assignment_cleanup_test.go's fixtures never set cm_id on a
 // bunk_plans row, and a Required field here would fail every one of those
 // saves -- the drift check only asserts a field NAME exists in production,
-// not that this fixture matches its Required-ness.
+// not that this fixture matches its Required-ness. year, unlike cm_id, IS
+// Required here, matching production: base_sync.go auto-appends
+// "year = <season>" to every PaginateRecords/LookupRelation call against
+// bunk_plans, so a row saved without year would silently land at year 0,
+// invisible to every year-scoped lookup -- exactly the drift this shared
+// builder exists to close.
 func addBunkPlansCollection(t *testing.T, app core.App, bunks, sessions *core.Collection) *core.Collection {
 	t.Helper()
 	plans := core.NewBaseCollection("bunk_plans")
 	plans.Fields.Add(&core.NumberField{Name: "cm_id", OnlyInt: true})
 	plans.Fields.Add(&core.RelationField{Name: "bunk", CollectionId: bunks.Id, MaxSelect: 1})
 	plans.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
-	plans.Fields.Add(&core.NumberField{Name: "year"})
+	plans.Fields.Add(&core.NumberField{Name: "year", Required: true, OnlyInt: true})
 	plans.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
 	saveCollection(t, app, plans)
 	return plans
@@ -617,5 +627,29 @@ func TestNewLodgingTestAppCoversBunkAssignmentGrain(t *testing.T) {
 		if _, err := app.FindCollectionByNameOrId(name); err != nil {
 			t.Errorf("newSyncTestApp does not build %q: %v", name, err)
 		}
+	}
+}
+
+// TestAddBunkPlansCollectionRequiresYear pins kindred#2300 review finding
+// #2: production requires bunk_plans.year (migration 1500000017), and
+// base_sync.go auto-appends "year = <season>" to every PaginateRecords/
+// LookupRelation call against bunk_plans. A shared fixture that leaves year
+// optional lets a bunk_plans row get saved with no year (silently stored at
+// year 0), invisible to every year-scoped lookup -- the exact silent-drift
+// failure mode kindred#2300's shared builder exists to close. This asserts
+// the fixture rejects that save the same way production would.
+func TestAddBunkPlansCollectionRequiresYear(t *testing.T) {
+	t.Parallel()
+	app := newSyncTestApp(t)
+	plans, err := app.FindCollectionByNameOrId("bunk_plans")
+	if err != nil {
+		t.Fatalf("find bunk_plans: %v", err)
+	}
+
+	rec := core.NewRecord(plans)
+	rec.Set("cm_id", 12345)
+	// Deliberately not setting "year".
+	if err := app.Save(rec); err == nil {
+		t.Error("Save(bunk_plans without year) succeeded, want error -- year must be Required to match production migration 1500000017")
 	}
 }

--- a/pocketbase/sync/sync_testsupport_test.go
+++ b/pocketbase/sync/sync_testsupport_test.go
@@ -24,7 +24,7 @@ const (
 const testSessionStart = "2025-05-23 07:00:00.000Z"
 const testSessionEnd = "2025-05-26 07:00:00.000Z"
 
-// newLodgingTestApp returns a throwaway PocketBase app carrying every collection
+// newSyncTestApp returns a throwaway PocketBase app carrying every collection
 // the lodging ingest reads or writes, shaped like production's.
 //
 // It deliberately builds collections in Go rather than replaying pb_migrations:
@@ -33,7 +33,7 @@ const testSessionEnd = "2025-05-26 07:00:00.000Z"
 // cannot apply them. Schema fidelity against the real migrations is the job of
 // scripts/dev/verify-lodging-schema.sh; these fixtures only need the fields the
 // code under test touches.
-func newLodgingTestApp(t *testing.T) core.App {
+func newSyncTestApp(t *testing.T) core.App {
 	t.Helper()
 	app, err := tests.NewTestApp()
 	if err != nil {
@@ -404,7 +404,7 @@ func assertLodgingCollectionsEmpty(t *testing.T, app core.App) {
 // portion and return nil, not fail the whole run.
 func TestLodgingAssignmentsSyncSkipsWhenRegistryNeverLoaded(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	// No addUnit call anywhere: lodging_units is empty for every year.
 
 	sessionID := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
@@ -435,7 +435,7 @@ func TestLodgingAssignmentsSyncSkipsWhenRegistryNeverLoaded(t *testing.T) {
 // first.
 func TestLodgingAssignmentsSyncSkipsWhenSeasonNotRolledForward(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	priorYearUnit := addUnit(t, app, "ridge-a", 2026)
 	addAlias(t, app, "Ridge A", []string{priorYearUnit}, 0, 0)
 	// No lodging_units row for 2027: roll-forward has not run yet.
@@ -460,7 +460,7 @@ func TestLodgingAssignmentsSyncSkipsWhenSeasonNotRolledForward(t *testing.T) {
 // depends on, distinguishing "never loaded" from "not this year".
 func TestAliasResolverHasUnitsForYear(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 	addUnit(t, app, "ridge-a", 2026)
 
 	r, err := NewAliasResolver(app)
@@ -482,7 +482,7 @@ func TestAliasResolverHasUnitsForYear(t *testing.T) {
 // no registry loaded for any season at all.
 func TestAliasResolverHasAnyUnitsFalseWhenEmpty(t *testing.T) {
 	t.Parallel()
-	app := newLodgingTestApp(t)
+	app := newSyncTestApp(t)
 
 	r, err := NewAliasResolver(app)
 	if err != nil {

--- a/pocketbase/sync/sync_testsupport_test.go
+++ b/pocketbase/sync/sync_testsupport_test.go
@@ -25,7 +25,11 @@ const testSessionStart = "2025-05-23 07:00:00.000Z"
 const testSessionEnd = "2025-05-26 07:00:00.000Z"
 
 // newSyncTestApp returns a throwaway PocketBase app carrying every collection
-// the lodging ingest reads or writes, shaped like production's.
+// the lodging ingest reads or writes, shaped like production's, plus (as of
+// kindred#2300) bunks/staff/bunk_plans/bunk_assignments -- the grain the
+// sync package's bunk-assignment tests need. Despite the name, this is the
+// sync package's shared fixture builder generally, not lodging-specific;
+// "Sync" is what it has meant since before that name existed.
 //
 // It deliberately builds collections in Go rather than replaying pb_migrations:
 // `pocketbase migrate up` silently skips JS migrations (jsvm captures its
@@ -220,7 +224,108 @@ func newSyncTestApp(t *testing.T) core.App {
 	mappings.Fields.Add(&core.TextField{Name: "note"})
 	saveCollection(t, app, mappings)
 
+	// kindred#2300 widened this from lodging-only: bunks/staff/bunk_plans/
+	// bunk_assignments were hand-built, separately, in
+	// bunk_assignments_protection_test.go, bunk_assignments_grain_test.go
+	// and stranded_assignment_cleanup_test.go, none of which
+	// TestLodgingTestsupportFixtureFieldsExistInProductionSchema could see --
+	// it only walks whatever THIS function builds. Exposed as addXCollection
+	// helpers rather than inlined so those three files, which each also need
+	// OTHER collections this function does not build (attendees,
+	// saved_scenarios, bunk_assignments_draft, lodging_*), can call the same
+	// field definitions onto their own narrower app instead of duplicating
+	// them.
+	bunks := addBunksCollection(t, app)
+	bunkPlans := addBunkPlansCollection(t, app, bunks, sessions)
+	addStaffCollection(t, app)
+	addBunkAssignmentsCollection(t, app, persons, sessions, bunks, bunkPlans)
+
 	return app
+}
+
+// addBunksCollection builds `bunks`. See newSyncTestApp's kindred#2300 comment.
+func addBunksCollection(t *testing.T, app core.App) *core.Collection {
+	t.Helper()
+	bunks := core.NewBaseCollection("bunks")
+	bunks.Fields.Add(&core.NumberField{Name: "cm_id", Required: true, OnlyInt: true})
+	bunks.Fields.Add(&core.TextField{Name: "name"})
+	bunks.Fields.Add(&core.NumberField{Name: "year"})
+	// PaginateRecords sorts by "-created" unconditionally (bunk_assignments.go's
+	// BuildRecordCMIDMappings goes through it), so every caller needs this even
+	// when its own test never reads it.
+	bunks.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
+	saveCollection(t, app, bunks)
+	return bunks
+}
+
+// addStaffCollection builds `staff`, matching production's person_id/status/
+// bunk_staff/year shape (migration 1500000030) minus the lookup-table
+// relations (position, division, ...) nothing under test reads.
+func addStaffCollection(t *testing.T, app core.App) *core.Collection {
+	t.Helper()
+	staff := core.NewBaseCollection("staff")
+	staff.Fields.Add(&core.NumberField{Name: "person_id", Required: true, OnlyInt: true})
+	staff.Fields.Add(&core.TextField{Name: "status"})
+	staff.Fields.Add(&core.BoolField{Name: "bunk_staff"})
+	staff.Fields.Add(&core.NumberField{Name: "year", Required: true, OnlyInt: true})
+	// PaginateRecords sorts by "-created" unconditionally, so staff needs it
+	// even in tests that never read it directly (see addBunksCollection).
+	staff.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
+	saveCollection(t, app, staff)
+	return staff
+}
+
+// addBunkPlansCollection builds `bunk_plans`. cm_id and year are left
+// optional despite production requiring both (migration 1500000017):
+// stranded_assignment_cleanup_test.go's fixtures never set cm_id on a
+// bunk_plans row, and a Required field here would fail every one of those
+// saves -- the drift check only asserts a field NAME exists in production,
+// not that this fixture matches its Required-ness.
+func addBunkPlansCollection(t *testing.T, app core.App, bunks, sessions *core.Collection) *core.Collection {
+	t.Helper()
+	plans := core.NewBaseCollection("bunk_plans")
+	plans.Fields.Add(&core.NumberField{Name: "cm_id", OnlyInt: true})
+	plans.Fields.Add(&core.RelationField{Name: "bunk", CollectionId: bunks.Id, MaxSelect: 1})
+	plans.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
+	plans.Fields.Add(&core.NumberField{Name: "year"})
+	plans.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
+	saveCollection(t, app, plans)
+	return plans
+}
+
+// addBunkAssignmentsCollection builds `bunk_assignments`, including
+// production's post-kindred#2259 unique index from migration 1500000155
+// (year, person, session, bunk -- see that migration's own comment for why
+// the grain widened). bunkPlans may be nil: a caller that has no bunk_plans
+// collection built (e.g. bunk_assignments_protection_test.go) gets a
+// bunk_assignments without the bunk_plan relation, matching what that
+// fixture already builds today.
+//
+// `bunk` is deliberately NOT required, unlike production: this collection's
+// own TestProtectNonActiveStaffAssignments_MissingBunkIsNonDestructiveSkip
+// fixture (bunk_assignments_protection_test.go) depends on saving a row with
+// no bunk set, to exercise the non-destructive-skip path when a bunk
+// relation cannot resolve.
+func addBunkAssignmentsCollection(
+	t *testing.T, app core.App, persons, sessions, bunks, bunkPlans *core.Collection,
+) *core.Collection {
+	t.Helper()
+	assignments := core.NewBaseCollection("bunk_assignments")
+	assignments.Fields.Add(&core.NumberField{Name: "cm_id"})
+	assignments.Fields.Add(&core.RelationField{Name: "person", CollectionId: persons.Id, MaxSelect: 1})
+	assignments.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
+	assignments.Fields.Add(&core.RelationField{Name: "bunk", CollectionId: bunks.Id, MaxSelect: 1})
+	if bunkPlans != nil {
+		assignments.Fields.Add(&core.RelationField{Name: "bunk_plan", CollectionId: bunkPlans.Id, MaxSelect: 1})
+	}
+	assignments.Fields.Add(&core.NumberField{Name: "year", Required: true, OnlyInt: true})
+	assignments.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
+	assignments.Indexes = []string{
+		"CREATE UNIQUE INDEX `idx_bunk_assignments_person_session_bunk_year` " +
+			"ON `bunk_assignments` (`year`, `person`, `session`, `bunk`)",
+	}
+	saveCollection(t, app, assignments)
+	return assignments
 }
 
 func saveCollection(t *testing.T, app core.App, col *core.Collection) {


### PR DESCRIPTION
## What

Widens the shared PocketBase test-fixture builder in `pocketbase/sync/` to cover four more
collections, and migrates the three files that were hand-building them separately over to it —
so kindred#1921's schema-agreement check (`TestLodgingTestsupportFixtureFieldsExistInProductionSchema`)
covers them automatically, with **no edit to the check itself**.

- **Renamed** `newLodgingTestApp` → `newSyncTestApp`, and its file
  `pocketbase/sync/lodging_testsupport_test.go` → `sync_testsupport_test.go`. Pure rename, its
  own commit, no behavior change (`test(sync): rename the lodging fixture builder to newSyncTestApp`).
- **Widened** `newSyncTestApp` with `bunks`, `staff`, `bunk_plans`, `bunk_assignments` (the last
  including production's post-kindred#2259 unique index from migration `1500000155`), exposed as
  four `addXCollection(t, app, ...)` helpers rather than inlined, so callers that also need other,
  out-of-scope collections can still reuse the same field definitions.
- **Migrated** the three files that hand-built these four collections separately:
  `bunk_assignments_protection_test.go`, `bunk_assignments_grain_test.go`,
  `stranded_assignment_cleanup_test.go` — one commit per file, so a wrong migration is revertible
  alone. `persons`/`camp_sessions`/`attendees`/`saved_scenarios`/`bunk_assignments_draft`/
  `lodging_*` stay hand-built in those files; only the four in-scope collections moved.

## Scope, deliberately narrowed (per the issue)

Four collections only: `bunk_assignments`, `staff`, `bunks`, `bunk_plans`. `staff_vehicle_info_test.go`
is **untouched** — its own `staff` fixture stays hand-built; kindred#2277 is editing that file in a
parallel branch and this PR does not touch it. No production `.go` file is touched.

## Issue body was stale — corrected before implementing

Per this campaign's rule, corrected `kindred#2300`'s body (edit + comment on the issue) before
starting:

1. The CI anchor had drifted a **second** time. The 2026-08-14 triage pass's own replacement
   (`ci.yml:611-613`/`:802-806`) no longer measured out — PR #2373 shifted lines after that pass
   ran. Re-derived against `main`@`41dca920`: job `tests-migrations` at `ci.yml:701`, step
   "Fixture schema agreement (kindred#1921)" at `:891`.
2. The "five test-local builders" survey (both the original body and the triage correction) cited
   `camper_history_test.go:658` (deleted outright by kindred#2366) and `api_test.go:2620` (no
   `core.NewBaseCollection(<variable>)` call there in either `lodging/` or `sync/`'s `api_test.go`).
   Re-derived by grep: **5** such call sites exist today (`lodging/hooks_test.go:113`,
   `sync/normalize_geographic_test.go:2361`, `sync/orphan_guard_test.go:768`,
   `sync/orphan_sweep_test.go:30`, `sync/sync_runs_test.go:41`), and **none of them build any of
   this round's four target collections** — the survey doesn't bear on this round's scope
   regardless of count, so it wasn't pursued further.

## Verification

The whole deliverable is that the check picks up the four new collections automatically. Booted a
real PocketBase locally against this repo's own `pb_migrations` (build + `serve --automigrate` +
superuser + `/api/collections?perPage=1000`, 72 collections) to reproduce what CI's Migration
Smoke Test job produces, and ran the check exactly as CI's "Fixture schema agreement" step does:

```
KINDRED_PROD_SCHEMA_JSON=/tmp/pb2300_collections.json go test -count=1 ./sync/... \
  -run TestLodgingTestsupportFixtureFieldsExistInProductionSchema -v
--- PASS: TestLodgingTestsupportFixtureFieldsExistInProductionSchema (0.76s)
```

**No edit to the check was needed** — the "no allowlist" property held; the four new collections
were picked up automatically by the existing diff-against-baseline logic.

**Mutation-check** (the actual deliverable — confirms the widening bought real coverage, not just
a passing test): added a field to `bunks` that does not exist in production
(`mutation_check_field_that_does_not_exist_in_prod`), re-ran the same command:

```
KINDRED_PROD_SCHEMA_JSON=/tmp/pb2300_collections.json go test -count=1 ./sync/... \
  -run TestLodgingTestsupportFixtureFieldsExistInProductionSchema -v
    lodging_testsupport_fixture_test.go:297: collection "bunks": fixture declares field
    "mutation_check_field_that_does_not_exist_in_prod", which the real pb_migrations schema does
    not have -- dropped or renamed? update newSyncTestApp in sync_testsupport_test.go
--- FAIL: TestLodgingTestsupportFixtureFieldsExistInProductionSchema (0.65s)
FAIL   (exit 1)
```

RED as expected, then reverted (working tree confirmed clean against the commit).

**No drift surfaced in the three migrated files** — all their tests still pass unchanged, which is
itself worth noting: it means these three files' hand-built fixtures for these four collections
were already schema-accurate; the value here is that a *future* drift (a migration renaming a
field these fixtures use) will now be caught, where before it silently wouldn't have been.

Full suite:

```
go build ./...                    # clean
go vet ./...                      # clean
go test ./...                     # ok, all packages
go test -race ./sync/             # ok  github.com/camp/kindred/pocketbase/sync  200.893s
bash scripts/pre-push-verify.sh   # ALL CHECKS PASSED
```

## What I deliberately did not do

- Did not touch `staff_vehicle_info_test.go` (owned by kindred#2277, in flight) — its `staff`
  fixture stays hand-built, uncommented by this PR since the file itself is off-limits this round.
- Did not rename `lodging_testsupport_fixture_test.go` or the check function
  `TestLodgingTestsupportFixtureFieldsExistInProductionSchema` — only the *builder*
  (`newLodgingTestApp`/its file) was called out for renaming in the issue; renaming the check too
  would also require touching `.github/workflows/ci.yml`'s `-run` flag, which is outside this
  round's stated scope.
- Did not pursue the "five test-local builders using a variable name" survey further, once
  re-derived: none of the five touch this round's four collections (see "Issue body was stale"
  above).
- Did not widen the shared builder beyond the four named collections, and did not touch any
  production `.go` file.

Closes #2300.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved consistency and reliability across synchronization test scenarios by using shared, production-aligned fixtures.
  * Expanded validation for bunk-related data, required fields, relationships, indexes, and timestamps.
  * Added coverage confirming fixture completeness and required-year validation.
  * Updated migration and fixture checks to use the appropriate synchronization setup.

* **Documentation**
  * Corrected outdated fixture references and comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->