### PR TITLE
feat(sync): wire the remaining 12 default sync jobs to DryRunnable

### DIFF
--- a/pocketbase/main_test_parallelism_test.go
+++ b/pocketbase/main_test_parallelism_test.go
@@ -95,6 +95,14 @@ var serialGroups = []struct {
 		tests:  []string{"TestBuildNormalizationLookupCompositeKeyDedup"},
 	},
 	{
+		// campminder.NewClient reads CAMPMINDER_PRIMARY_KEY from the environment
+		// (same reason as the block below), so building the real client this
+		// test needs for GetSeasonID() costs a t.Setenv.
+		pkg:    "sync",
+		reason: "t.Setenv: campminder.NewClient reads CAMPMINDER_PRIMARY_KEY",
+		tests:  []string{"TestAttendeesLogStatusChangeDryRunWritesNothing"},
+	},
+	{
 		// These four drive deleteOrphans, which reads the season through
 		// s.Client.GetSeasonID(). Client is a concrete *campminder.Client and
 		// campminder.NewClient reads CAMPMINDER_PRIMARY_KEY from the

--- a/pocketbase/main_test_parallelism_test.go
+++ b/pocketbase/main_test_parallelism_test.go
@@ -170,6 +170,7 @@ var serialGroups = []struct {
 			"TestLoadPersonCustomValuesNoDiscardsMeansNoWarnAppLog",
 			"TestLoadPersonCustomValuesNoDiscardsMeansNoWarnLog",
 			"TestLoadPersonCustomValuesRoutesTheFourLive2026FieldsAndDoesNotSkipThem",
+			"TestStrandedAssignmentCleanupDryRunLodgingLogReportsSimulatedSweep",
 		},
 	},
 	{

--- a/pocketbase/main_test_parallelism_test.go
+++ b/pocketbase/main_test_parallelism_test.go
@@ -91,6 +91,11 @@ var serialGroups = []struct {
 	},
 	{
 		pkg:    "sync",
+		reason: "t.Setenv: IS_DOCKER drives ResolveUnifiedSyncServices' process_requests append",
+		tests:  []string{"TestCurrentYearDefaultSyncStillRejectsDryRun"},
+	},
+	{
+		pkg:    "sync",
 		reason: "t.Setenv: API_URL points at a per-test httptest server",
 		tests:  []string{"TestBuildNormalizationLookupCompositeKeyDedup"},
 	},

--- a/pocketbase/sync/attendees.go
+++ b/pocketbase/sync/attendees.go
@@ -41,6 +41,14 @@ func (s *AttendeesSync) Name() string {
 	return "attendees"
 }
 
+// SetDryRun implements the orchestrator's DryRunnable interface (kindred#2351). Declared
+// explicitly rather than inherited by embedding BaseSyncService -- see that field's doc
+// comment on BaseSyncService for why a promoted setter is not safe. Setting it also gates
+// logStatusChange's own App.Save call below, which is outside BaseSyncService's write sites.
+func (s *AttendeesSync) SetDryRun(dryRun bool) {
+	s.DryRun = dryRun
+}
+
 // Sync performs the attendees sync
 func (s *AttendeesSync) Sync(ctx context.Context) error {
 	s.LogSyncStart("attendees")
@@ -413,6 +421,10 @@ func (s *AttendeesSync) logStatusChange(
 	}
 	if personPBID, ok := recordData["person"]; ok {
 		record.Set("person", personPBID)
+	}
+
+	if s.DryRun {
+		return nil
 	}
 
 	if err := s.App.Save(record); err != nil {

--- a/pocketbase/sync/attendees_dryrun_test.go
+++ b/pocketbase/sync/attendees_dryrun_test.go
@@ -1,0 +1,55 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+
+	"github.com/camp/kindred/pocketbase/campminder"
+)
+
+// TestAttendeesLogStatusChangeDryRunWritesNothing proves logStatusChange's own
+// App.Save call -- the one write site AttendeesSync has outside
+// BaseSyncService.ProcessCompositeRecord -- is gated by DryRun (kindred#2351).
+func TestAttendeesLogStatusChangeDryRunWritesNothing(t *testing.T) {
+	// Not t.Parallel(): t.Setenv below panics if the test may run in parallel.
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	col := core.NewBaseCollection("attendee_status_history")
+	col.Fields.Add(&core.NumberField{Name: "person_id"})
+	col.Fields.Add(&core.TextField{Name: "old_status"})
+	col.Fields.Add(&core.TextField{Name: "new_status"})
+	col.Fields.Add(&core.TextField{Name: "detected_at"})
+	col.Fields.Add(&core.NumberField{Name: "year"})
+	if saveErr := app.Save(col); saveErr != nil {
+		t.Fatalf("create attendee_status_history: %v", saveErr)
+	}
+
+	// GetSeasonID is a pure getter -- no network call -- so a real *campminder.Client built
+	// from a fake key is sufficient here.
+	t.Setenv("CAMPMINDER_PRIMARY_KEY", "test-subscription-key")
+	client, err := campminder.NewClient(&campminder.Config{APIKey: "test-key", ClientID: "test-client", SeasonID: 2026})
+	if err != nil {
+		t.Fatalf("campminder.NewClient: %v", err)
+	}
+
+	s := NewAttendeesSync(app, client)
+	s.SetDryRun(true)
+
+	if callErr := s.logStatusChange(5001, 6001, "waitlisted", "enrolled", map[string]any{}); callErr != nil {
+		t.Fatalf("logStatusChange: %v", callErr)
+	}
+
+	rows, err := app.FindRecordsByFilter("attendee_status_history", "", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("dry run wrote %d rows to attendee_status_history; want 0", len(rows))
+	}
+}

--- a/pocketbase/sync/base_sync.go
+++ b/pocketbase/sync/base_sync.go
@@ -57,6 +57,25 @@ type BaseSyncService struct {
 	ProcessedKeys  map[string]bool // Track processed composite keys for orphan detection
 	FieldDiffStats map[string]int  // Track which fields cause updates (for debugging)
 	Debug          bool            // Enable verbose debug logging
+	// DryRun, when true, makes every write helper below (ProcessSimpleRecord,
+	// ProcessSimpleRecordGlobal, ProcessCompositeRecord, deleteOrphans,
+	// DeleteOrphansFromPreloaded) compute its result and update Stats exactly as
+	// a normal run would, but skip the App.Save / App.Delete call that would
+	// persist it (kindred#2351). Gating lives at those eight call sites.
+	//
+	// Deliberately NOT paired with a promoted SetDryRun method here. BaseSyncService is
+	// embedded by several services outside kindred#2351's twelve -- bunk_requests (which
+	// ResolveUnifiedSyncServices appends to "all" for the current year, so it IS reachable
+	// through the unified dry_run endpoint) and request_processor (whose Sync() delegates to
+	// a remote FastAPI call this field cannot gate at all) among them. An exported SetDryRun
+	// on this type would be PROMOTED to every one of those embedders automatically, making
+	// each silently satisfy DryRunnable whether or not its own writes are actually gated --
+	// the exact "compiles, therefore looks safe, but still runs wet" trap kindred#2334 was
+	// about, discovered here by TestEmbeddingBaseSyncServiceDoesNotLeakDryRunnable. Every
+	// service this issue actually wires declares its OWN three-line SetDryRun that sets this
+	// field directly (e.g. session_groups.go); a service that does not declare one stays
+	// correctly unsupported and gets the honest 400.
+	DryRun bool
 }
 
 // NewBaseSyncService creates a new base sync service
@@ -339,6 +358,11 @@ func (b *BaseSyncService) deleteOrphans(
 
 		slog.Info("Deleting orphaned record", "entity", entityName, "name", candidate.name, "id", candidate.key)
 
+		if b.DryRun {
+			orphanCount++
+			continue
+		}
+
 		// Counted AFTER the delete lands. A failed delete leaves the row on disk,
 		// and reporting it as deleted tells an operator the opposite of the truth.
 		if err := b.App.Delete(record); err != nil {
@@ -482,6 +506,11 @@ func (b *BaseSyncService) DeleteOrphansFromPreloaded(
 		if !b.ProcessedKeys[keyStr] {
 			name := b.getRecordName(record, entityName)
 			slog.Info("Deleting orphaned record", "entity", entityName, "name", name, "key", keyStr)
+
+			if b.DryRun {
+				orphanCount++
+				continue
+			}
 
 			// Counted AFTER the delete lands. A failed delete leaves the row on disk,
 			// and reporting it as deleted tells an operator the opposite of the truth.
@@ -713,6 +742,11 @@ func (b *BaseSyncService) ProcessSimpleRecord(
 				existing.Set(field, value)
 			}
 
+			if b.DryRun {
+				b.Stats.Updated++
+				return nil
+			}
+
 			if err := b.App.Save(existing); err != nil {
 				return fmt.Errorf("updating record: %w", err)
 			}
@@ -730,6 +764,11 @@ func (b *BaseSyncService) ProcessSimpleRecord(
 		record := core.NewRecord(col)
 		for field, value := range recordData {
 			record.Set(field, value)
+		}
+
+		if b.DryRun {
+			b.Stats.Created++
+			return nil
 		}
 
 		if err := b.App.Save(record); err != nil {
@@ -784,6 +823,11 @@ func (b *BaseSyncService) ProcessSimpleRecordGlobal(
 				existing.Set(field, value)
 			}
 
+			if b.DryRun {
+				b.Stats.Updated++
+				return nil
+			}
+
 			if err := b.App.Save(existing); err != nil {
 				return fmt.Errorf("updating record: %w", err)
 			}
@@ -801,6 +845,11 @@ func (b *BaseSyncService) ProcessSimpleRecordGlobal(
 		record := core.NewRecord(col)
 		for field, value := range recordData {
 			record.Set(field, value)
+		}
+
+		if b.DryRun {
+			b.Stats.Created++
+			return nil
 		}
 
 		if err := b.App.Save(record); err != nil {
@@ -912,6 +961,11 @@ func (b *BaseSyncService) ProcessCompositeRecord(
 				existing.Set(field, value)
 			}
 
+			if b.DryRun {
+				b.Stats.Updated++
+				return nil
+			}
+
 			if err := b.App.Save(existing); err != nil {
 				return fmt.Errorf("updating record: %w", err)
 			}
@@ -929,6 +983,11 @@ func (b *BaseSyncService) ProcessCompositeRecord(
 		record := core.NewRecord(col)
 		for field, value := range recordData {
 			record.Set(field, value)
+		}
+
+		if b.DryRun {
+			b.Stats.Created++
+			return nil
 		}
 
 		if err := b.App.Save(record); err != nil {

--- a/pocketbase/sync/base_sync_dryrun_test.go
+++ b/pocketbase/sync/base_sync_dryrun_test.go
@@ -1,0 +1,221 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+)
+
+// newBaseSyncDryRunTestApp returns a test app holding one collection shaped
+// like a year-scoped CampMinder table, for exercising BaseSyncService's write
+// helpers directly against a real database.
+func newBaseSyncDryRunTestApp(t *testing.T, collection string) core.App {
+	t.Helper()
+
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	col := core.NewBaseCollection(collection)
+	col.Fields.Add(&core.TextField{Name: "cm_id"})
+	col.Fields.Add(&core.TextField{Name: "name"})
+	col.Fields.Add(&core.NumberField{Name: "year"})
+	if saveErr := app.Save(col); saveErr != nil {
+		t.Fatalf("save %s: %v", collection, saveErr)
+	}
+
+	return app
+}
+
+// TestBaseSyncServiceProcessSimpleRecordDryRunWritesNothing proves the actual
+// production entry point 12 of the 24 default unified sync jobs share for
+// every create/update they perform (kindred#2351): with DryRun set, neither
+// branch of ProcessSimpleRecord calls App.Save, so record counts and the
+// row's own fields are untouched. This is the same shared helper
+// ProcessSimpleRecordGlobal and ProcessCompositeRecord mirror; those two are
+// covered by the sibling tests below rather than repeated here.
+func TestBaseSyncServiceProcessSimpleRecordDryRunWritesNothing(t *testing.T) {
+	t.Parallel()
+	app := newBaseSyncDryRunTestApp(t, "dryrun_simple")
+
+	col, findErr := app.FindCollectionByNameOrId("dryrun_simple")
+	if findErr != nil {
+		t.Fatalf("FindCollectionByNameOrId: %v", findErr)
+	}
+	existing := core.NewRecord(col)
+	existing.Set("cm_id", "1")
+	existing.Set("name", "Original")
+	existing.Set("year", 2025)
+	if saveErr := app.Save(existing); saveErr != nil {
+		t.Fatalf("seed existing record: %v", saveErr)
+	}
+
+	b := &BaseSyncService{App: app, Stats: Stats{}, DryRun: true, FieldDiffStats: make(map[string]int)}
+
+	existingRecords := map[any]*core.Record{
+		CompositeKey(1, 2025): existing,
+	}
+
+	// Update branch: field differs, so a real run would call App.Save.
+	if updateErr := b.ProcessSimpleRecord("dryrun_simple", 1,
+		map[string]any{"cm_id": "1", "name": "Changed", "year": 2025},
+		existingRecords, []string{"name"}); updateErr != nil {
+		t.Fatalf("ProcessSimpleRecord (update): %v", updateErr)
+	}
+
+	// Create branch: key 2 has no existing record, so a real run would call
+	// App.Save on a brand new record.
+	if createErr := b.ProcessSimpleRecord("dryrun_simple", 2,
+		map[string]any{"cm_id": "2", "name": "New", "year": 2025},
+		existingRecords, []string{"name"}); createErr != nil {
+		t.Fatalf("ProcessSimpleRecord (create): %v", createErr)
+	}
+
+	rows, queryErr := app.FindRecordsByFilter("dryrun_simple", "", "", 0, 0)
+	if queryErr != nil {
+		t.Fatalf("re-query: %v", queryErr)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("dry run wrote %d rows; want 1 (only the seeded one)", len(rows))
+	}
+	if rows[0].GetString("name") != "Original" {
+		t.Fatalf("dry run persisted a name change: got %q, want %q (unchanged)",
+			rows[0].GetString("name"), "Original")
+	}
+}
+
+// TestBaseSyncServiceDeleteOrphansDryRunDeletesNothing proves DeleteOrphans'
+// App.Delete call site is gated: with DryRun set, an unprocessed (orphaned)
+// row survives the sweep.
+func TestBaseSyncServiceDeleteOrphansDryRunDeletesNothing(t *testing.T) {
+	t.Parallel()
+	app := newBaseSyncDryRunTestApp(t, "dryrun_orphans")
+
+	col, findErr := app.FindCollectionByNameOrId("dryrun_orphans")
+	if findErr != nil {
+		t.Fatalf("FindCollectionByNameOrId: %v", findErr)
+	}
+	orphan := core.NewRecord(col)
+	orphan.Set("cm_id", "99")
+	orphan.Set("name", "Orphan")
+	orphan.Set("year", 2025)
+	if saveErr := app.Save(orphan); saveErr != nil {
+		t.Fatalf("seed orphan record: %v", saveErr)
+	}
+
+	b := &BaseSyncService{
+		App:            app,
+		Stats:          Stats{},
+		DryRun:         true,
+		SyncSuccessful: true,
+		ProcessedKeys:  map[string]bool{}, // nothing processed -> everything is an orphan
+	}
+
+	if sweepErr := b.DeleteOrphans("dryrun_orphans", func(r *core.Record) (string, bool) {
+		return r.GetString("cm_id"), true
+	}, "dryrun_orphan", ""); sweepErr != nil {
+		t.Fatalf("DeleteOrphans: %v", sweepErr)
+	}
+
+	rows, queryErr := app.FindRecordsByFilter("dryrun_orphans", "", "", 0, 0)
+	if queryErr != nil {
+		t.Fatalf("re-query: %v", queryErr)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("dry run deleted %d rows; want 1 (the orphan survives)", len(rows))
+	}
+}
+
+// TestBaseSyncServiceDeleteOrphansFromPreloadedDryRunDeletesNothing mirrors
+// the test above for the preloaded-map sweep entry point used by the
+// higher-volume services.
+func TestBaseSyncServiceDeleteOrphansFromPreloadedDryRunDeletesNothing(t *testing.T) {
+	t.Parallel()
+	app := newBaseSyncDryRunTestApp(t, "dryrun_preloaded_orphans")
+
+	col, findErr := app.FindCollectionByNameOrId("dryrun_preloaded_orphans")
+	if findErr != nil {
+		t.Fatalf("FindCollectionByNameOrId: %v", findErr)
+	}
+	orphan := core.NewRecord(col)
+	orphan.Set("cm_id", "77")
+	orphan.Set("year", 2025)
+	if saveErr := app.Save(orphan); saveErr != nil {
+		t.Fatalf("seed orphan record: %v", saveErr)
+	}
+
+	b := &BaseSyncService{
+		App:            app,
+		Stats:          Stats{},
+		DryRun:         true,
+		SyncSuccessful: true,
+		ProcessedKeys:  map[string]bool{},
+	}
+
+	preloaded := map[any]*core.Record{"77|2025": orphan}
+	if sweepErr := b.DeleteOrphansFromPreloaded(preloaded, "dryrun_preloaded_orphan"); sweepErr != nil {
+		t.Fatalf("DeleteOrphansFromPreloaded: %v", sweepErr)
+	}
+
+	rows, queryErr := app.FindRecordsByFilter("dryrun_preloaded_orphans", "", "", 0, 0)
+	if queryErr != nil {
+		t.Fatalf("re-query: %v", queryErr)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("dry run deleted %d rows; want 1 (the orphan survives)", len(rows))
+	}
+}
+
+// TestBaseSyncServiceProcessCompositeRecordDryRunWritesNothing proves
+// ProcessCompositeRecord's two App.Save call sites (used by attendees,
+// bunk_plans, bunk_assignments, and the two custom-field-value services)
+// are gated the same way ProcessSimpleRecord's are.
+func TestBaseSyncServiceProcessCompositeRecordDryRunWritesNothing(t *testing.T) {
+	t.Parallel()
+	app := newBaseSyncDryRunTestApp(t, "dryrun_composite")
+
+	col, findErr := app.FindCollectionByNameOrId("dryrun_composite")
+	if findErr != nil {
+		t.Fatalf("FindCollectionByNameOrId: %v", findErr)
+	}
+	existing := core.NewRecord(col)
+	existing.Set("cm_id", "1:2")
+	existing.Set("name", "Original")
+	existing.Set("year", 2025)
+	if saveErr := app.Save(existing); saveErr != nil {
+		t.Fatalf("seed existing record: %v", saveErr)
+	}
+
+	b := &BaseSyncService{App: app, Stats: Stats{}, DryRun: true}
+
+	existingRecords := map[string]*core.Record{
+		"1:2|2025": existing,
+	}
+
+	if updateErr := b.ProcessCompositeRecord("dryrun_composite", "1:2",
+		map[string]any{"cm_id": "1:2", "name": "Changed", "year": 2025},
+		existingRecords, nil); updateErr != nil {
+		t.Fatalf("ProcessCompositeRecord (update): %v", updateErr)
+	}
+
+	if createErr := b.ProcessCompositeRecord("dryrun_composite", "3:4",
+		map[string]any{"cm_id": "3:4", "name": "New", "year": 2025},
+		existingRecords, nil); createErr != nil {
+		t.Fatalf("ProcessCompositeRecord (create): %v", createErr)
+	}
+
+	rows, queryErr := app.FindRecordsByFilter("dryrun_composite", "", "", 0, 0)
+	if queryErr != nil {
+		t.Fatalf("re-query: %v", queryErr)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("dry run wrote %d rows; want 1 (only the seeded one)", len(rows))
+	}
+	if rows[0].GetString("name") != "Original" {
+		t.Fatalf("dry run persisted a name change: got %q, want %q (unchanged)",
+			rows[0].GetString("name"), "Original")
+	}
+}

--- a/pocketbase/sync/base_sync_dryrun_test.go
+++ b/pocketbase/sync/base_sync_dryrun_test.go
@@ -7,6 +7,12 @@ import (
 	pbtests "github.com/pocketbase/pocketbase/tests"
 )
 
+// dryRunTestOriginalName is the seeded value every dry-run write test in this
+// file asserts survives untouched -- pulled into a constant (goconst) once a
+// third test pushed the literal's occurrence count past golangci-lint's
+// threshold.
+const dryRunTestOriginalName = "Original"
+
 // newBaseSyncDryRunTestApp returns a test app holding one collection shaped
 // like a year-scoped CampMinder table, for exercising BaseSyncService's write
 // helpers directly against a real database.
@@ -55,7 +61,7 @@ func TestBaseSyncServiceProcessSimpleRecordDryRunWritesNothing(t *testing.T) {
 	}
 	existing := core.NewRecord(col)
 	existing.Set("cm_id", "1")
-	existing.Set("name", "Original")
+	existing.Set("name", dryRunTestOriginalName)
 	existing.Set("year", 2025)
 	if saveErr := app.Save(existing); saveErr != nil {
 		t.Fatalf("seed existing record: %v", saveErr)
@@ -89,9 +95,9 @@ func TestBaseSyncServiceProcessSimpleRecordDryRunWritesNothing(t *testing.T) {
 	if len(rows) != 1 {
 		t.Fatalf("dry run wrote %d rows; want 1 (only the seeded one)", len(rows))
 	}
-	if rows[0].GetString("name") != "Original" {
+	if rows[0].GetString("name") != dryRunTestOriginalName {
 		t.Fatalf("dry run persisted a name change: got %q, want %q (unchanged)",
-			rows[0].GetString("name"), "Original")
+			rows[0].GetString("name"), dryRunTestOriginalName)
 	}
 }
 
@@ -113,7 +119,7 @@ func TestBaseSyncServiceProcessSimpleRecordGlobalDryRunWritesNothing(t *testing.
 	}
 	existing := core.NewRecord(col)
 	existing.Set("cm_id", "1")
-	existing.Set("name", "Original")
+	existing.Set("name", dryRunTestOriginalName)
 	if saveErr := app.Save(existing); saveErr != nil {
 		t.Fatalf("seed existing record: %v", saveErr)
 	}
@@ -146,9 +152,9 @@ func TestBaseSyncServiceProcessSimpleRecordGlobalDryRunWritesNothing(t *testing.
 	if len(rows) != 1 {
 		t.Fatalf("dry run wrote %d rows; want 1 (only the seeded one)", len(rows))
 	}
-	if rows[0].GetString("name") != "Original" {
+	if rows[0].GetString("name") != dryRunTestOriginalName {
 		t.Fatalf("dry run persisted a name change: got %q, want %q (unchanged)",
-			rows[0].GetString("name"), "Original")
+			rows[0].GetString("name"), dryRunTestOriginalName)
 	}
 }
 
@@ -248,7 +254,7 @@ func TestBaseSyncServiceProcessCompositeRecordDryRunWritesNothing(t *testing.T) 
 	}
 	existing := core.NewRecord(col)
 	existing.Set("cm_id", "1:2")
-	existing.Set("name", "Original")
+	existing.Set("name", dryRunTestOriginalName)
 	existing.Set("year", 2025)
 	if saveErr := app.Save(existing); saveErr != nil {
 		t.Fatalf("seed existing record: %v", saveErr)
@@ -279,8 +285,8 @@ func TestBaseSyncServiceProcessCompositeRecordDryRunWritesNothing(t *testing.T) 
 	if len(rows) != 1 {
 		t.Fatalf("dry run wrote %d rows; want 1 (only the seeded one)", len(rows))
 	}
-	if rows[0].GetString("name") != "Original" {
+	if rows[0].GetString("name") != dryRunTestOriginalName {
 		t.Fatalf("dry run persisted a name change: got %q, want %q (unchanged)",
-			rows[0].GetString("name"), "Original")
+			rows[0].GetString("name"), dryRunTestOriginalName)
 	}
 }

--- a/pocketbase/sync/base_sync_dryrun_test.go
+++ b/pocketbase/sync/base_sync_dryrun_test.go
@@ -34,9 +34,17 @@ func newBaseSyncDryRunTestApp(t *testing.T, collection string) core.App {
 // production entry point 12 of the 24 default unified sync jobs share for
 // every create/update they perform (kindred#2351): with DryRun set, neither
 // branch of ProcessSimpleRecord calls App.Save, so record counts and the
-// row's own fields are untouched. This is the same shared helper
-// ProcessSimpleRecordGlobal and ProcessCompositeRecord mirror; those two are
-// covered by the sibling tests below rather than repeated here.
+// row's own fields are untouched. ProcessCompositeRecord's identically-shaped
+// guards are covered by the sibling test below.
+//
+// ProcessSimpleRecordGlobal (base_sync.go's other App.Save-guarded write
+// helper) is deliberately NOT covered here or below: none of kindred#2351's
+// twelve wired services call it -- its only callers (custom_field_definitions,
+// divisions, financial_lookups, person_tag_definitions, staff_lookups) declare
+// no SetDryRun and stay rejected with a 400, so the guard is currently dead
+// code from a coverage standpoint. TestBaseSyncServiceProcessSimpleRecordGlobalDryRunWritesNothing
+// pins it anyway, on the same "shared helper, one gap breaks every future
+// caller silently" reasoning as the other three helpers in this file.
 func TestBaseSyncServiceProcessSimpleRecordDryRunWritesNothing(t *testing.T) {
 	t.Parallel()
 	app := newBaseSyncDryRunTestApp(t, "dryrun_simple")
@@ -75,6 +83,63 @@ func TestBaseSyncServiceProcessSimpleRecordDryRunWritesNothing(t *testing.T) {
 	}
 
 	rows, queryErr := app.FindRecordsByFilter("dryrun_simple", "", "", 0, 0)
+	if queryErr != nil {
+		t.Fatalf("re-query: %v", queryErr)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("dry run wrote %d rows; want 1 (only the seeded one)", len(rows))
+	}
+	if rows[0].GetString("name") != "Original" {
+		t.Fatalf("dry run persisted a name change: got %q, want %q (unchanged)",
+			rows[0].GetString("name"), "Original")
+	}
+}
+
+// TestBaseSyncServiceProcessSimpleRecordGlobalDryRunWritesNothing mirrors
+// TestBaseSyncServiceProcessSimpleRecordDryRunWritesNothing above for
+// ProcessSimpleRecordGlobal, base_sync.go's write helper for entities that
+// are NOT year-scoped (divisions, custom_field_defs, staff_lookups,
+// financial_lookups, person_tag_defs). None of those callers are wired to
+// DryRunnable today, so this guard is currently unreachable in production --
+// pinned regardless, so a future service that wires one of those five
+// callers doesn't inherit a silently-broken guard.
+func TestBaseSyncServiceProcessSimpleRecordGlobalDryRunWritesNothing(t *testing.T) {
+	t.Parallel()
+	app := newBaseSyncDryRunTestApp(t, "dryrun_global")
+
+	col, findErr := app.FindCollectionByNameOrId("dryrun_global")
+	if findErr != nil {
+		t.Fatalf("FindCollectionByNameOrId: %v", findErr)
+	}
+	existing := core.NewRecord(col)
+	existing.Set("cm_id", "1")
+	existing.Set("name", "Original")
+	if saveErr := app.Save(existing); saveErr != nil {
+		t.Fatalf("seed existing record: %v", saveErr)
+	}
+
+	b := &BaseSyncService{App: app, Stats: Stats{}, DryRun: true}
+
+	existingRecords := map[any]*core.Record{
+		"1": existing,
+	}
+
+	// Update branch: field differs, so a real run would call App.Save.
+	if updateErr := b.ProcessSimpleRecordGlobal("dryrun_global", "1",
+		map[string]any{"cm_id": "1", "name": "Changed"},
+		existingRecords, []string{"name"}); updateErr != nil {
+		t.Fatalf("ProcessSimpleRecordGlobal (update): %v", updateErr)
+	}
+
+	// Create branch: key "2" has no existing record, so a real run would
+	// call App.Save on a brand new record.
+	if createErr := b.ProcessSimpleRecordGlobal("dryrun_global", "2",
+		map[string]any{"cm_id": "2", "name": "New"},
+		existingRecords, []string{"name"}); createErr != nil {
+		t.Fatalf("ProcessSimpleRecordGlobal (create): %v", createErr)
+	}
+
+	rows, queryErr := app.FindRecordsByFilter("dryrun_global", "", "", 0, 0)
 	if queryErr != nil {
 		t.Fatalf("re-query: %v", queryErr)
 	}

--- a/pocketbase/sync/bunk_assignments.go
+++ b/pocketbase/sync/bunk_assignments.go
@@ -57,6 +57,13 @@ func (s *BunkAssignmentsSync) Name() string {
 	return "bunk_assignments"
 }
 
+// SetDryRun implements the orchestrator's DryRunnable interface (kindred#2351). Declared
+// explicitly rather than inherited by embedding BaseSyncService -- see that field's doc
+// comment for why a promoted setter is not safe here.
+func (s *BunkAssignmentsSync) SetDryRun(dryRun bool) {
+	s.DryRun = dryRun
+}
+
 // Sync performs the bunk assignments synchronization
 func (s *BunkAssignmentsSync) Sync(ctx context.Context) error {
 	s.LogSyncStart("bunk assignments")

--- a/pocketbase/sync/bunk_plans.go
+++ b/pocketbase/sync/bunk_plans.go
@@ -58,6 +58,13 @@ func (s *BunkPlansSync) Name() string {
 	return "bunk_plans"
 }
 
+// SetDryRun implements the orchestrator's DryRunnable interface (kindred#2351). Declared
+// explicitly rather than inherited by embedding BaseSyncService -- see that field's doc
+// comment for why a promoted setter is not safe here.
+func (s *BunkPlansSync) SetDryRun(dryRun bool) {
+	s.DryRun = dryRun
+}
+
 // Sync performs the bunk plans synchronization
 func (s *BunkPlansSync) Sync(ctx context.Context) error {
 	s.LogSyncStart("bunk plans")

--- a/pocketbase/sync/bunks.go
+++ b/pocketbase/sync/bunks.go
@@ -28,6 +28,13 @@ func (s *BunksSync) Name() string {
 	return "bunks"
 }
 
+// SetDryRun implements the orchestrator's DryRunnable interface (kindred#2351). Declared
+// explicitly rather than inherited by embedding BaseSyncService -- see that field's doc
+// comment for why a promoted setter is not safe here.
+func (s *BunksSync) SetDryRun(dryRun bool) {
+	s.DryRun = dryRun
+}
+
 // Sync performs the bunks synchronization
 func (s *BunksSync) Sync(ctx context.Context) error {
 	// Use StandardSync with a custom preload filter for current year

--- a/pocketbase/sync/custom_field_values_dryrun_test.go
+++ b/pocketbase/sync/custom_field_values_dryrun_test.go
@@ -1,0 +1,170 @@
+package sync
+
+// TestPersonCustomFieldValuesDryRunWritesNothing and its household twin prove
+// processPersonCustomFieldValue/processHouseholdCustomFieldValue's own two
+// App.Save call sites -- a fast-path upsert that does not go through
+// BaseSyncService.ProcessSimpleRecord -- are gated by DryRun (kindred#2351).
+// Modeled on TestPersonCustomFieldValuesDuplicateInRunGuard in
+// custom_field_values_duplicate_guard_test.go, which established that these
+// functions are directly testable against the real implementation.
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// testDietValueVegetarian is reused across the create/seed/update steps below
+// (goconst wants a shared name once the same literal appears three times).
+const testDietValueVegetarian = "Vegetarian"
+
+func TestPersonCustomFieldValuesDryRunWritesNothing(t *testing.T) {
+	t.Parallel()
+
+	app := newOrphanSweepTestApp(t, "person_custom_values",
+		"person", "field_definition", "value", "last_updated")
+
+	s := &PersonCustomFieldValuesSync{
+		BaseSyncService: BaseSyncService{
+			App:           app,
+			ProcessedKeys: map[string]bool{},
+			Stats:         Stats{},
+		},
+	}
+	s.SetDryRun(true)
+
+	fieldDefMapping := map[int]string{100: testFieldDefPBIDPerson}
+	existingRecords := map[string]*core.Record{}
+
+	// Create branch: no existing record for this key.
+	if createErr := s.processPersonCustomFieldValue(
+		map[string]any{"id": float64(100), "value": testDietValueVegetarian},
+		12345, testPersonPBID, 2025, fieldDefMapping, existingRecords); createErr != nil {
+		t.Fatalf("processPersonCustomFieldValue (create): %v", createErr)
+	}
+
+	rows, err := app.FindRecordsByFilter("person_custom_values", "", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("dry run wrote %d rows to person_custom_values; want 0", len(rows))
+	}
+	if s.Stats.Created != 1 {
+		t.Errorf("Stats.Created = %d, want 1 (the create that would have happened)", s.Stats.Created)
+	}
+
+	// Update branch: fresh service (fresh ProcessedKeys, so the duplicate-in-run guard
+	// does not fire) seeds a real row wet, then dry-runs a change to it.
+	seed := &PersonCustomFieldValuesSync{
+		BaseSyncService: BaseSyncService{App: app, ProcessedKeys: map[string]bool{}, Stats: Stats{}},
+	}
+	seedExisting := map[string]*core.Record{}
+	if seedErr := seed.processPersonCustomFieldValue(
+		map[string]any{"id": float64(100), "value": testDietValueVegetarian},
+		99999, testPersonPBID, 2025, fieldDefMapping, seedExisting); seedErr != nil {
+		t.Fatalf("processPersonCustomFieldValue (seed): %v", seedErr)
+	}
+	seeded, seedQueryErr := app.FindRecordsByFilter("person_custom_values", "", "", 0, 0)
+	if seedQueryErr != nil || len(seeded) != 1 {
+		t.Fatalf("seed: got %d rows, err=%v", len(seeded), seedQueryErr)
+	}
+
+	update := &PersonCustomFieldValuesSync{
+		BaseSyncService: BaseSyncService{App: app, ProcessedKeys: map[string]bool{}, Stats: Stats{}},
+	}
+	update.SetDryRun(true)
+	updateExisting := map[string]*core.Record{"pb_person_123:pb_field_100|2025": seeded[0]}
+	if updateErr := update.processPersonCustomFieldValue(
+		map[string]any{"id": float64(100), "value": "Vegan"},
+		99999, testPersonPBID, 2025, fieldDefMapping, updateExisting); updateErr != nil {
+		t.Fatalf("processPersonCustomFieldValue (update): %v", updateErr)
+	}
+
+	reloaded, reloadErr := app.FindRecordById("person_custom_values", seeded[0].Id)
+	if reloadErr != nil {
+		t.Fatalf("reload: %v", reloadErr)
+	}
+	if reloaded.GetString("value") != testDietValueVegetarian {
+		t.Errorf("dry run persisted a value change: got %q, want unchanged %q",
+			reloaded.GetString("value"), testDietValueVegetarian)
+	}
+	if update.Stats.Updated != 1 {
+		t.Errorf("Stats.Updated = %d, want 1 (the update that would have happened)", update.Stats.Updated)
+	}
+}
+
+func TestHouseholdCustomFieldValuesDryRunWritesNothing(t *testing.T) {
+	t.Parallel()
+
+	app := newOrphanSweepTestApp(t, "household_custom_values",
+		"household", "field_definition", "value", "last_updated")
+
+	s := &HouseholdCustomFieldValuesSync{
+		BaseSyncService: BaseSyncService{
+			App:           app,
+			ProcessedKeys: map[string]bool{},
+			Stats:         Stats{},
+		},
+	}
+	s.SetDryRun(true)
+
+	fieldDefMapping := map[int]string{100: testFieldDefPBID}
+	existingRecords := map[string]*core.Record{}
+
+	if createErr := s.processHouseholdCustomFieldValue(
+		map[string]any{"id": float64(100), "value": "3-bedroom"},
+		54321, testHouseholdPBID, 2025, fieldDefMapping, existingRecords); createErr != nil {
+		t.Fatalf("processHouseholdCustomFieldValue (create): %v", createErr)
+	}
+
+	rows, err := app.FindRecordsByFilter("household_custom_values", "", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("dry run wrote %d rows to household_custom_values; want 0", len(rows))
+	}
+	if s.Stats.Created != 1 {
+		t.Errorf("Stats.Created = %d, want 1 (the create that would have happened)", s.Stats.Created)
+	}
+
+	// Update branch: fresh service (fresh ProcessedKeys, so the duplicate-in-run guard
+	// does not fire) seeds a real row wet, then dry-runs a change to it.
+	seed := &HouseholdCustomFieldValuesSync{
+		BaseSyncService: BaseSyncService{App: app, ProcessedKeys: map[string]bool{}, Stats: Stats{}},
+	}
+	seedExisting := map[string]*core.Record{}
+	if seedErr := seed.processHouseholdCustomFieldValue(
+		map[string]any{"id": float64(100), "value": "3-bedroom"},
+		99999, testHouseholdPBID, 2025, fieldDefMapping, seedExisting); seedErr != nil {
+		t.Fatalf("processHouseholdCustomFieldValue (seed): %v", seedErr)
+	}
+	seeded, seedQueryErr := app.FindRecordsByFilter("household_custom_values", "", "", 0, 0)
+	if seedQueryErr != nil || len(seeded) != 1 {
+		t.Fatalf("seed: got %d rows, err=%v", len(seeded), seedQueryErr)
+	}
+
+	update := &HouseholdCustomFieldValuesSync{
+		BaseSyncService: BaseSyncService{App: app, ProcessedKeys: map[string]bool{}, Stats: Stats{}},
+	}
+	update.SetDryRun(true)
+	updateExisting := map[string]*core.Record{"pb_household_123:pb_field_100|2025": seeded[0]}
+	if updateErr := update.processHouseholdCustomFieldValue(
+		map[string]any{"id": float64(100), "value": "4-bedroom"},
+		99999, testHouseholdPBID, 2025, fieldDefMapping, updateExisting); updateErr != nil {
+		t.Fatalf("processHouseholdCustomFieldValue (update): %v", updateErr)
+	}
+
+	reloaded, reloadErr := app.FindRecordById("household_custom_values", seeded[0].Id)
+	if reloadErr != nil {
+		t.Fatalf("reload: %v", reloadErr)
+	}
+	if reloaded.GetString("value") != "3-bedroom" {
+		t.Errorf("dry run persisted a value change: got %q, want unchanged %q",
+			reloaded.GetString("value"), "3-bedroom")
+	}
+	if update.Stats.Updated != 1 {
+		t.Errorf("Stats.Updated = %d, want 1 (the update that would have happened)", update.Stats.Updated)
+	}
+}

--- a/pocketbase/sync/financial_transactions.go
+++ b/pocketbase/sync/financial_transactions.go
@@ -43,6 +43,13 @@ func (s *FinancialTransactionsSync) Name() string {
 	return serviceNameFinancialTransactions
 }
 
+// SetDryRun implements the orchestrator's DryRunnable interface (kindred#2351). Declared
+// explicitly rather than inherited by embedding BaseSyncService -- see that field's doc
+// comment for why a promoted setter is not safe here.
+func (s *FinancialTransactionsSync) SetDryRun(dryRun bool) {
+	s.DryRun = dryRun
+}
+
 // Sync performs the year-scoped financial transactions sync
 func (s *FinancialTransactionsSync) Sync(ctx context.Context) error {
 	return s.SyncForYear(ctx, s.Client.GetSeasonID())

--- a/pocketbase/sync/household_custom_field_values.go
+++ b/pocketbase/sync/household_custom_field_values.go
@@ -43,6 +43,15 @@ func (s *HouseholdCustomFieldValuesSync) Name() string {
 	return serviceNameHouseholdCustomValues
 }
 
+// SetDryRun implements the orchestrator's DryRunnable interface (kindred#2351). Declared
+// explicitly rather than inherited by embedding BaseSyncService -- see that field's doc
+// comment on BaseSyncService for why a promoted setter is not safe. Setting it also gates
+// processHouseholdCustomFieldValue's own two App.Save call sites (a fast-path upsert that
+// does not go through BaseSyncService.ProcessSimpleRecord).
+func (s *HouseholdCustomFieldValuesSync) SetDryRun(dryRun bool) {
+	s.DryRun = dryRun
+}
+
 // SetSession sets the session filter for this sync (e.g., "1", "2", "2a", "all")
 func (s *HouseholdCustomFieldValuesSync) SetSession(session string) {
 	s.Session = session
@@ -419,6 +428,10 @@ func (s *HouseholdCustomFieldValuesSync) processHouseholdCustomFieldValue(
 			for key, val := range pbData {
 				existing.Set(key, val)
 			}
+			if s.DryRun {
+				s.Stats.Updated++
+				return nil
+			}
 			if err := s.App.Save(existing); err != nil {
 				valueStr, _ := pbData["value"].(string)
 				slog.Error("Error updating household custom field value",
@@ -442,6 +455,11 @@ func (s *HouseholdCustomFieldValuesSync) processHouseholdCustomFieldValue(
 		record := core.NewRecord(collection)
 		for key, val := range pbData {
 			record.Set(key, val)
+		}
+
+		if s.DryRun {
+			s.Stats.Created++
+			return nil
 		}
 
 		if err := s.App.Save(record); err != nil {

--- a/pocketbase/sync/orchestrator_test.go
+++ b/pocketbase/sync/orchestrator_test.go
@@ -4455,3 +4455,39 @@ func TestEmbeddingBaseSyncServiceDoesNotLeakDryRunnable(t *testing.T) {
 			"package cannot gate with a local flag at all")
 	}
 }
+
+// TestCurrentYearDefaultSyncStillRejectsDryRun pins the residue kindred#2351 deliberately left
+// out of scope: `dry_run=true` against the default `service=all` for the CURRENT year still
+// gets HTTP 400, because ResolveUnifiedSyncServices appends "reconcile_request_lifecycle" and
+// "bunk_requests" to the 24 default jobs whenever isCurrentYear is true, and neither
+// implements DryRunnable. #2351's own scope table names only the 24 default jobs; these two
+// were never on it (see the issue body's "Scope" section) -- wiring them is future work, not a
+// gap in this PR. Without this test, the PR body's "What" paragraph reading as "the 400 is
+// fixed" would go unchecked: a historical-replay request (year != current) genuinely gets a
+// 200 now, but the most natural invocation -- the current year, with no service specified --
+// does not.
+func TestCurrentYearDefaultSyncStillRejectsDryRun(t *testing.T) {
+	// Not t.Parallel(): t.Setenv forbids it.
+	o := NewOrchestrator(nil)
+
+	// Only the two services responsible for the residual 400 need to be registered as their
+	// real (un-wired) types -- UnsupportedDryRunServices silently skips any name in the list
+	// that isn't registered on this orchestrator instance (see TestUnsupportedDryRunServices),
+	// so the 24 default jobs themselves don't need registering to prove this specific residue.
+	o.RegisterService("reconcile_request_lifecycle", NewReconcileLifecycleSync(nil))
+	o.RegisterService("bunk_requests", NewBunkRequestsSync(nil, nil))
+
+	t.Setenv("IS_DOCKER", "")
+	services := ResolveUnifiedSyncServices(DefaultService, true, true)
+
+	got := o.UnsupportedDryRunServices(services)
+	want := []string{"reconcile_request_lifecycle", "bunk_requests"}
+	if len(got) != len(want) {
+		t.Fatalf("UnsupportedDryRunServices(current-year default) = %v, want %v", got, want)
+	}
+	for i, name := range want {
+		if got[i] != name {
+			t.Errorf("UnsupportedDryRunServices(current-year default)[%d] = %q, want %q", i, got[i], name)
+		}
+	}
+}

--- a/pocketbase/sync/orchestrator_test.go
+++ b/pocketbase/sync/orchestrator_test.go
@@ -1917,11 +1917,31 @@ func TestUnsupportedDryRunServices(t *testing.T) {
 // 400. This list -- and the compile-time assertions below -- exist so a future
 // service losing its SetDryRun method (e.g. during a refactor) fails a test instead of silently
 // falling back to rejection.
+//
+// kindred#2351 added the next twelve. All twelve embed BaseSyncService and route their writes
+// through some mix of its eight gated App.Save/App.Delete call sites (see that field's doc
+// comment in base_sync.go) and, for four of them, write sites of their own: attendees'
+// attendee_status_history insert; persons' person/household upserts, attendee-relation and
+// household-relation backfills, and household-orphan delete; the two custom-values services'
+// fast-path upsert. Every one of the twelve declares its OWN explicit three-line SetDryRun
+// rather than inheriting one from BaseSyncService -- discovered the hard way: an exported
+// SetDryRun on BaseSyncService itself is PROMOTED to every embedder, including services this
+// issue never touches (bunk_requests, reachable through a current-year `service=all` request
+// via ResolveUnifiedSyncServices; request_processor, whose Sync() delegates to a remote FastAPI
+// call this field cannot gate at all), so it would make those silently claim DryRunnable
+// whether or not their own writes are gated -- exactly the "200 dry_run:true, runs wet anyway"
+// failure kindred#2334 was about. TestEmbeddingBaseSyncServiceDoesNotLeakDryRunnable pins that
+// bunk_requests and request_processor stay correctly unsupported. stranded_assignment_cleanup
+// does not embed BaseSyncService at all -- it is a from-scratch DryRun field and two gated
+// app.Save calls threaded through reconcileStrandedAssignments/reconcileLodgingOrphans.
 var dryRunCapableRealServices = []string{
 	"camper_dietary", "quest_registrations", "household_demographics",
 	"financial_aid_applications", "lodging_assignments", "camper_transportation",
 	"staff_vehicle_info", "enrollment_snapshots", "normalize_geographic", "family_camp_derived",
 	"staff_applications", "staff_skills",
+	"session_groups", "sessions", "bunks", "bunk_plans", "bunk_assignments", "staff",
+	"financial_transactions", "attendees", "persons", "person_custom_values",
+	"household_custom_values", "stranded_assignment_cleanup",
 }
 
 // Compile-time guarantee that the real production types stay wired to DryRunnable. If any of
@@ -1940,12 +1960,31 @@ var (
 	_ DryRunnable = (*FamilyCampDerivedSync)(nil)
 	_ DryRunnable = (*StaffApplicationsSync)(nil)
 	_ DryRunnable = (*StaffSkillsSync)(nil)
+	_ DryRunnable = (*SessionGroupsSync)(nil)
+	_ DryRunnable = (*SessionsSync)(nil)
+	_ DryRunnable = (*BunksSync)(nil)
+	_ DryRunnable = (*BunkPlansSync)(nil)
+	_ DryRunnable = (*BunkAssignmentsSync)(nil)
+	_ DryRunnable = (*StaffSync)(nil)
+	_ DryRunnable = (*FinancialTransactionsSync)(nil)
+	_ DryRunnable = (*AttendeesSync)(nil)
+	_ DryRunnable = (*PersonsSync)(nil)
+	_ DryRunnable = (*PersonCustomFieldValuesSync)(nil)
+	_ DryRunnable = (*HouseholdCustomFieldValuesSync)(nil)
+	_ DryRunnable = (*StrandedAssignmentCleanupSync)(nil)
 )
 
 // TestRealServicesHonorDryRunThroughUnifiedEndpoint proves the wiring against the actual
 // registered production types (not dryRunAwareService test doubles): every service in
 // dryRunCapableRealServices must be absent from UnsupportedDryRunServices' verdict on that
-// list, while a service known to have no such logic (session_groups) must still be rejected.
+// list, while a service known to have no such logic (bunk_requests) must still be rejected.
+// bunk_requests is the exemplar rather than persons or session_groups (both now wired) because
+// it embeds BaseSyncService -- like every service in dryRunCapableRealServices below does --
+// and still correctly stays unsupported, which is the whole point of not putting a promoted
+// SetDryRun on BaseSyncService itself (see that field's doc comment). It is also not a
+// hypothetical: ResolveUnifiedSyncServices appends bunk_requests to "all" whenever the
+// requested year is the current one, so it is genuinely reachable through the unified
+// dry_run=true endpoint, not just a name picked for the test.
 // Without this, TestUnsupportedDryRunServices above could stay green forever while every real
 // service in production silently lost its DryRunnable implementation.
 //
@@ -1968,20 +2007,32 @@ func TestRealServicesHonorDryRunThroughUnifiedEndpoint(t *testing.T) {
 	o.RegisterService("family_camp_derived", NewFamilyCampDerivedSync(nil))
 	o.RegisterService("staff_applications", NewStaffApplicationsSync(nil))
 	o.RegisterService("staff_skills", NewStaffSkillsSync(nil))
+	o.RegisterService(serviceNameSessionGroups, NewSessionGroupsSync(nil, nil))
+	o.RegisterService("sessions", NewSessionsSync(nil, nil))
+	o.RegisterService("bunks", NewBunksSync(nil, nil))
+	o.RegisterService("bunk_plans", NewBunkPlansSync(nil, nil))
+	o.RegisterService("bunk_assignments", NewBunkAssignmentsSync(nil, nil))
+	o.RegisterService("staff", NewStaffSync(nil, nil))
+	o.RegisterService("financial_transactions", NewFinancialTransactionsSync(nil, nil))
+	o.RegisterService("attendees", NewAttendeesSync(nil, nil))
+	o.RegisterService("persons", NewPersonsSync(nil, nil))
+	o.RegisterService("person_custom_values", NewPersonCustomFieldValuesSync(nil, nil))
+	o.RegisterService("household_custom_values", NewHouseholdCustomFieldValuesSync(nil, nil))
+	o.RegisterService("stranded_assignment_cleanup", NewStrandedAssignmentCleanupSync(nil))
 	// The real production type, not a double: the rejection path has to be proven against a
 	// service that genuinely has no dry-run support, or nothing in the suite shows that a
-	// wet-only service is actually caught. If session_groups ever gains a real SetDryRun and
-	// a skip-write branch, this failing is the correct signal to move it into
+	// wet-only service is actually caught. If bunk_requests ever gains a real SetDryRun and a
+	// skip-write branch of its own, this failing is the correct signal to move it into
 	// dryRunCapableRealServices rather than to swap a double back in here.
-	o.RegisterService(serviceNameSessionGroups, NewSessionGroupsSync(nil, nil))
+	o.RegisterService("bunk_requests", NewBunkRequestsSync(nil, nil))
 
 	if got := o.UnsupportedDryRunServices(dryRunCapableRealServices); len(got) != 0 {
 		t.Errorf("expected every real dry-run-capable service to be supported, got unsupported=%v", got)
 	}
 
-	got := o.UnsupportedDryRunServices(append(append([]string{}, dryRunCapableRealServices...), serviceNameSessionGroups))
-	if len(got) != 1 || got[0] != serviceNameSessionGroups {
-		t.Errorf("expected only [%s] unsupported alongside the real services, got %v", serviceNameSessionGroups, got)
+	got := o.UnsupportedDryRunServices(append(append([]string{}, dryRunCapableRealServices...), "bunk_requests"))
+	if len(got) != 1 || got[0] != "bunk_requests" {
+		t.Errorf("expected only [bunk_requests] unsupported alongside the real services, got %v", got)
 	}
 }
 
@@ -2065,18 +2116,30 @@ func TestRealServicesSetDryRunStoresTheFlag(t *testing.T) {
 	t.Parallel()
 
 	services := map[string]DryRunnable{
-		"camper_dietary":             NewCamperDietarySync(nil),
-		"quest_registrations":        NewQuestRegistrationsSync(nil),
-		"household_demographics":     NewHouseholdDemographicsSync(nil),
-		"financial_aid_applications": NewFinancialAidApplicationsSync(nil),
-		"lodging_assignments":        NewLodgingAssignmentsSync(nil),
-		"camper_transportation":      NewCamperTransportationSync(nil),
-		"staff_vehicle_info":         NewStaffVehicleInfoSync(nil),
-		"enrollment_snapshots":       NewEnrollmentSnapshotsSync(nil),
-		"normalize_geographic":       NewNormalizeGeographicSync(nil),
-		"family_camp_derived":        NewFamilyCampDerivedSync(nil),
-		"staff_applications":         NewStaffApplicationsSync(nil),
-		"staff_skills":               NewStaffSkillsSync(nil),
+		"camper_dietary":              NewCamperDietarySync(nil),
+		"quest_registrations":         NewQuestRegistrationsSync(nil),
+		"household_demographics":      NewHouseholdDemographicsSync(nil),
+		"financial_aid_applications":  NewFinancialAidApplicationsSync(nil),
+		"lodging_assignments":         NewLodgingAssignmentsSync(nil),
+		"camper_transportation":       NewCamperTransportationSync(nil),
+		"staff_vehicle_info":          NewStaffVehicleInfoSync(nil),
+		"enrollment_snapshots":        NewEnrollmentSnapshotsSync(nil),
+		"normalize_geographic":        NewNormalizeGeographicSync(nil),
+		"family_camp_derived":         NewFamilyCampDerivedSync(nil),
+		"staff_applications":          NewStaffApplicationsSync(nil),
+		"staff_skills":                NewStaffSkillsSync(nil),
+		"session_groups":              NewSessionGroupsSync(nil, nil),
+		"sessions":                    NewSessionsSync(nil, nil),
+		"bunks":                       NewBunksSync(nil, nil),
+		"bunk_plans":                  NewBunkPlansSync(nil, nil),
+		"bunk_assignments":            NewBunkAssignmentsSync(nil, nil),
+		"staff":                       NewStaffSync(nil, nil),
+		"financial_transactions":      NewFinancialTransactionsSync(nil, nil),
+		"attendees":                   NewAttendeesSync(nil, nil),
+		"persons":                     NewPersonsSync(nil, nil),
+		"person_custom_values":        NewPersonCustomFieldValuesSync(nil, nil),
+		"household_custom_values":     NewHouseholdCustomFieldValuesSync(nil, nil),
+		"stranded_assignment_cleanup": NewStrandedAssignmentCleanupSync(nil),
 	}
 
 	// Every name the orchestrator will hand SetDryRun(true) must be covered here, or a
@@ -4365,5 +4428,30 @@ func TestCustomFieldValuesHandlersReserveBeforeMutatingSharedState(t *testing.T)
 					"request A's in-flight run would silently narrow to it", sessionBefore, sessionAfter)
 			}
 		})
+	}
+}
+
+// TestEmbeddingBaseSyncServiceDoesNotLeakDryRunnable proves that BaseSyncService's write-site
+// gating does NOT automatically hand DryRunnable to every service that embeds it. This is the
+// blast-radius trap kindred#2351 found empirically: giving BaseSyncService itself an exported
+// SetDryRun method makes it PROMOTED to every embedder, including services outside this
+// issue's twelve that ResolveUnifiedSyncServices reaches for a current-year `service=all`
+// request (bunk_requests, appended whenever isCurrentYear is true) and services that delegate
+// their actual write to a remote HTTP call this package cannot gate at all
+// (RequestProcessor.Sync -> callAPIProcessor). A service must declare its OWN SetDryRun to be
+// dry-run-capable; embedding BaseSyncService alone must not be enough.
+func TestEmbeddingBaseSyncServiceDoesNotLeakDryRunnable(t *testing.T) {
+	t.Parallel()
+
+	if _, ok := any(NewBunkRequestsSync(nil, nil)).(DryRunnable); ok {
+		t.Error("BunkRequestsSync satisfies DryRunnable by embedding BaseSyncService alone " +
+			"-- it is reachable via a current-year service=all dry_run=true request " +
+			"(ResolveUnifiedSyncServices appends it) but its own six App.Save/App.Delete " +
+			"call sites are not gated")
+	}
+	if _, ok := any(NewRequestProcessor(nil)).(DryRunnable); ok {
+		t.Error("RequestProcessor satisfies DryRunnable by embedding BaseSyncService alone " +
+			"-- its Sync() delegates to a remote FastAPI call (callAPIProcessor) that this " +
+			"package cannot gate with a local flag at all")
 	}
 }

--- a/pocketbase/sync/person_custom_field_values.go
+++ b/pocketbase/sync/person_custom_field_values.go
@@ -43,6 +43,15 @@ func (s *PersonCustomFieldValuesSync) Name() string {
 	return serviceNamePersonCustomValues
 }
 
+// SetDryRun implements the orchestrator's DryRunnable interface (kindred#2351). Declared
+// explicitly rather than inherited by embedding BaseSyncService -- see that field's doc
+// comment on BaseSyncService for why a promoted setter is not safe. Setting it also gates
+// processPersonCustomFieldValue's own two App.Save call sites (a fast-path upsert that does
+// not go through BaseSyncService.ProcessSimpleRecord).
+func (s *PersonCustomFieldValuesSync) SetDryRun(dryRun bool) {
+	s.DryRun = dryRun
+}
+
 // SetSession sets the session filter for this sync (e.g., "1", "2", "2a", "all")
 func (s *PersonCustomFieldValuesSync) SetSession(session string) {
 	s.Session = session
@@ -428,6 +437,10 @@ func (s *PersonCustomFieldValuesSync) processPersonCustomFieldValue(
 			for key, val := range pbData {
 				existing.Set(key, val)
 			}
+			if s.DryRun {
+				s.Stats.Updated++
+				return nil
+			}
 			if err := s.App.Save(existing); err != nil {
 				valueStr, _ := pbData["value"].(string)
 				slog.Error("Error updating custom field value",
@@ -452,6 +465,11 @@ func (s *PersonCustomFieldValuesSync) processPersonCustomFieldValue(
 		record := core.NewRecord(collection)
 		for key, val := range pbData {
 			record.Set(key, val)
+		}
+
+		if s.DryRun {
+			s.Stats.Created++
+			return nil
 		}
 
 		if err := s.App.Save(record); err != nil {

--- a/pocketbase/sync/persons.go
+++ b/pocketbase/sync/persons.go
@@ -66,6 +66,16 @@ func (s *PersonsSync) Name() string {
 	return personsCollection
 }
 
+// SetDryRun implements the orchestrator's DryRunnable interface (kindred#2351). Declared
+// explicitly rather than inherited by embedding BaseSyncService -- see that field's doc
+// comment on BaseSyncService for why a promoted setter is not safe. Setting it also gates
+// this file's own App.Save/App.Delete call sites (the person and household upserts, the
+// attendee-relation and household-relation backfills, and deleteHouseholdOrphans), all of
+// which are outside BaseSyncService's write sites.
+func (s *PersonsSync) SetDryRun(dryRun bool) {
+	s.DryRun = dryRun
+}
+
 // GetStats returns stats for this sync, including sub-entity stats for combined sync
 func (s *PersonsSync) GetStats() Stats {
 	stats := s.Stats
@@ -531,6 +541,11 @@ func (s *PersonsSync) processPerson(
 				existing.Set(field, value)
 			}
 
+			if s.DryRun {
+				s.Stats.Updated++
+				return nil
+			}
+
 			if err := s.App.Save(existing); err != nil {
 				return fmt.Errorf("updating person %d: %w", personIDInt, err)
 			}
@@ -548,6 +563,11 @@ func (s *PersonsSync) processPerson(
 		record := core.NewRecord(collection)
 		for field, value := range pbData {
 			record.Set(field, value)
+		}
+
+		if s.DryRun {
+			s.Stats.Created++
+			return nil
 		}
 
 		if err := s.App.Save(record); err != nil {
@@ -1158,6 +1178,10 @@ func (s *PersonsSync) updateAttendeeRelations(year int) error {
 			personRecords, err := s.App.FindRecordsByFilter("persons", personFilter, "", 1, 0)
 			if err == nil && len(personRecords) > 0 {
 				attendee.Set("person", personRecords[0].Id)
+				if s.DryRun {
+					updated++
+					continue
+				}
 				if err := s.App.Save(attendee); err != nil {
 					slog.Error("Error updating attendee relation", "personCMID", int(personCMID), "error", err)
 					errors++
@@ -1473,6 +1497,10 @@ func (s *PersonsSync) processHouseholdRecord(
 			for field, value := range pbData {
 				existing.Set(field, value)
 			}
+			if s.DryRun {
+				stats.Updated++
+				return nil
+			}
 			if err := s.App.Save(existing); err != nil {
 				return fmt.Errorf("updating household: %w", err)
 			}
@@ -1490,6 +1518,11 @@ func (s *PersonsSync) processHouseholdRecord(
 		record := core.NewRecord(collection)
 		for field, value := range pbData {
 			record.Set(field, value)
+		}
+
+		if s.DryRun {
+			stats.Created++
+			return nil
 		}
 
 		if err := s.App.Save(record); err != nil {
@@ -1580,6 +1613,10 @@ func (s *PersonsSync) updatePersonHouseholdRelations(
 		}
 
 		if needsSave {
+			if s.DryRun {
+				updated++
+				continue
+			}
 			if err := s.App.Save(person); err != nil {
 				slog.Error("Error updating person household relations", "personID", person.Id, "error", err)
 				errCount++
@@ -1627,6 +1664,10 @@ func (s *PersonsSync) deleteHouseholdOrphans(year int, processedIDs map[int]bool
 		}
 
 		if !processedIDs[int(cmID)] {
+			if s.DryRun {
+				deleted++
+				continue
+			}
 			if err := s.App.Delete(record); err != nil {
 				slog.Error("Error deleting orphaned household", "cm_id", int(cmID), "error", err)
 				s.Stats.Errors++

--- a/pocketbase/sync/persons_dryrun_test.go
+++ b/pocketbase/sync/persons_dryrun_test.go
@@ -1,0 +1,281 @@
+package sync
+
+// This file proves DryRun gates all five of persons.go's own write sites
+// (kindred#2351) -- the ones outside BaseSyncService's eight already-covered
+// call sites: the person upsert (processPerson), the household upsert
+// (processHouseholdRecord), the attendee-relation backfill
+// (updateAttendeeRelations), the household-relation backfill
+// (updatePersonHouseholdRelations), and the household-orphan delete
+// (deleteHouseholdOrphans). It reuses newHouseholdsTestApp/seedHousehold from
+// orphan_rejection_test.go and newMinimalPersonsTestApp from
+// persons_delete_orphans_wrapper_test.go where their shape fits, rather than
+// redefining fixtures.
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+)
+
+// TestDeleteHouseholdOrphansDryRunDeletesNothing proves the delete site is
+// gated: a household that would be swept as an orphan survives a dry run.
+func TestDeleteHouseholdOrphansDryRunDeletesNothing(t *testing.T) {
+	t.Parallel()
+
+	app := newHouseholdsTestApp(t)
+	seedHousehold(t, app, 900, 2026) // not in processedIDs below -- a genuine orphan
+
+	s := &PersonsSync{BaseSyncService: BaseSyncService{App: app}}
+	s.SetDryRun(true)
+
+	if sweepErr := s.deleteHouseholdOrphans(2026, map[int]bool{}); sweepErr != nil {
+		t.Fatalf("deleteHouseholdOrphans: %v", sweepErr)
+	}
+
+	rows, queryErr := app.FindRecordsByFilter("households", "", "", 0, 0)
+	if queryErr != nil {
+		t.Fatalf("re-query: %v", queryErr)
+	}
+	if len(rows) != 1 {
+		t.Errorf("dry run deleted %d households; want 1 (the orphan survives)", len(rows))
+	}
+}
+
+// TestProcessHouseholdRecordDryRunWritesNothing proves processHouseholdRecord's
+// own two App.Save call sites are gated.
+func TestProcessHouseholdRecordDryRunWritesNothing(t *testing.T) {
+	t.Parallel()
+
+	app := newHouseholdsTestApp(t)
+	seedHousehold(t, app, 900, 2026)
+	existing, findErr := app.FindFirstRecordByFilter("households", "cm_id = 900")
+	if findErr != nil {
+		t.Fatalf("find seeded household: %v", findErr)
+	}
+
+	s := &PersonsSync{BaseSyncService: BaseSyncService{App: app}}
+	s.SetDryRun(true)
+	stats := &Stats{}
+
+	// Update branch.
+	if updateErr := s.processHouseholdRecord(900,
+		map[string]any{"greeting": "changed this run"},
+		map[int]*core.Record{900: existing},
+		[]string{"greeting"}, stats); updateErr != nil {
+		t.Fatalf("processHouseholdRecord (update): %v", updateErr)
+	}
+	reloaded, reloadErr := app.FindRecordById("households", existing.Id)
+	if reloadErr != nil {
+		t.Fatalf("reload: %v", reloadErr)
+	}
+	if reloaded.GetString("greeting") != "stored last run" {
+		t.Errorf("dry run persisted a greeting change: got %q, want unchanged %q",
+			reloaded.GetString("greeting"), "stored last run")
+	}
+	if stats.Updated != 1 {
+		t.Errorf("Stats.Updated = %d, want 1", stats.Updated)
+	}
+
+	// Create branch: a household ID not in existingHouseholds.
+	if createErr := s.processHouseholdRecord(901,
+		map[string]any{"greeting": "brand new", "cm_id": 901, "year": 2026},
+		map[int]*core.Record{900: existing},
+		[]string{"greeting"}, stats); createErr != nil {
+		t.Fatalf("processHouseholdRecord (create): %v", createErr)
+	}
+	rows, queryErr := app.FindRecordsByFilter("households", "", "", 0, 0)
+	if queryErr != nil {
+		t.Fatalf("re-query: %v", queryErr)
+	}
+	if len(rows) != 1 {
+		t.Errorf("dry run wrote %d households; want 1 (only the seeded one)", len(rows))
+	}
+	if stats.Created != 1 {
+		t.Errorf("Stats.Created = %d, want 1", stats.Created)
+	}
+}
+
+// TestProcessPersonDryRunWritesNothing proves processPerson's own two
+// App.Save call sites -- the main person upsert -- are gated.
+func TestProcessPersonDryRunWritesNothing(t *testing.T) {
+	t.Parallel()
+
+	app, appErr := pbtests.NewTestApp()
+	if appErr != nil {
+		t.Fatalf("NewTestApp: %v", appErr)
+	}
+	t.Cleanup(app.Cleanup)
+
+	col := core.NewBaseCollection("persons")
+	col.Fields.Add(&core.NumberField{Name: "cm_id"})
+	col.Fields.Add(&core.TextField{Name: "first_name"})
+	col.Fields.Add(&core.TextField{Name: "last_name"})
+	col.Fields.Add(&core.NumberField{Name: "year"})
+	col.Fields.Add(&core.BoolField{Name: "is_camper"})
+	if saveErr := app.Save(col); saveErr != nil {
+		t.Fatalf("create persons: %v", saveErr)
+	}
+
+	existingPerson := core.NewRecord(col)
+	existingPerson.Set("cm_id", 5001)
+	existingPerson.Set("first_name", testFirstName) // "Emma" -- shared with persons_test.go
+	existingPerson.Set("last_name", "Johnson")
+	existingPerson.Set("year", 2026)
+	if seedErr := app.Save(existingPerson); seedErr != nil {
+		t.Fatalf("seed existing person: %v", seedErr)
+	}
+
+	s := &PersonsSync{
+		BaseSyncService:  BaseSyncService{App: app, ProcessedKeys: map[string]bool{}},
+		missingDataStats: make(map[string]int),
+	}
+	s.SetDryRun(true)
+
+	personData := func(id float64, first string) map[string]any {
+		return map[string]any{
+			"ID":            id,
+			"CamperDetails": map[string]any{},
+			"Name":          map[string]any{"First": first, "Last": "Johnson"},
+		}
+	}
+
+	// Update branch.
+	if updateErr := s.processPerson(personData(5001, "Emmaline"), true,
+		map[int]*core.Record{5001: existingPerson}, map[string]string{}, map[int]string{}, 2026); updateErr != nil {
+		t.Fatalf("processPerson (update): %v", updateErr)
+	}
+	reloaded, reloadErr := app.FindRecordById("persons", existingPerson.Id)
+	if reloadErr != nil {
+		t.Fatalf("reload: %v", reloadErr)
+	}
+	if reloaded.GetString("first_name") != testFirstName {
+		t.Errorf("dry run persisted a name change: got %q, want unchanged %q",
+			reloaded.GetString("first_name"), testFirstName)
+	}
+	if s.Stats.Updated != 1 {
+		t.Errorf("Stats.Updated = %d, want 1", s.Stats.Updated)
+	}
+
+	// Create branch: a person ID not in existingPersons.
+	if createErr := s.processPerson(personData(5002, "Liam"), true,
+		map[int]*core.Record{5001: existingPerson}, map[string]string{}, map[int]string{}, 2026); createErr != nil {
+		t.Fatalf("processPerson (create): %v", createErr)
+	}
+	rows, queryErr := app.FindRecordsByFilter("persons", "", "", 0, 0)
+	if queryErr != nil {
+		t.Fatalf("re-query: %v", queryErr)
+	}
+	if len(rows) != 1 {
+		t.Errorf("dry run wrote %d persons; want 1 (only the seeded one)", len(rows))
+	}
+	if s.Stats.Created != 1 {
+		t.Errorf("Stats.Created = %d, want 1", s.Stats.Created)
+	}
+}
+
+// TestUpdatePersonHouseholdRelationsDryRunWritesNothing proves the
+// household-relation backfill's App.Save call is gated: a person eligible for
+// the backfill is left with its household relation unset by a dry run.
+func TestUpdatePersonHouseholdRelationsDryRunWritesNothing(t *testing.T) {
+	t.Parallel()
+
+	app := newMinimalPersonsTestApp(t)
+
+	personsCol, findErr := app.FindCollectionByNameOrId("persons")
+	if findErr != nil {
+		t.Fatalf("find persons: %v", findErr)
+	}
+	person := core.NewRecord(personsCol)
+	person.Set("cm_id", 5001)
+	person.Set("year", 2026)
+	if saveErr := app.Save(person); saveErr != nil {
+		t.Fatalf("seed person: %v", saveErr)
+	}
+
+	householdsCol := core.NewBaseCollection("households")
+	householdsCol.Fields.Add(&core.NumberField{Name: "cm_id"})
+	if createErr := app.Save(householdsCol); createErr != nil {
+		t.Fatalf("create households: %v", createErr)
+	}
+	household := core.NewRecord(householdsCol)
+	household.Set("cm_id", 7001)
+	if seedErr := app.Save(household); seedErr != nil {
+		t.Fatalf("seed household: %v", seedErr)
+	}
+
+	s := &PersonsSync{BaseSyncService: BaseSyncService{App: app}}
+	s.SetDryRun(true)
+
+	householdsByID := map[int]*core.Record{7001: household}
+	personHouseholdMap := map[int]personHouseholdIDs{5001: {PrincipalID: 7001}}
+
+	if updateErr := s.updatePersonHouseholdRelations(2026, householdsByID, personHouseholdMap); updateErr != nil {
+		t.Fatalf("updatePersonHouseholdRelations: %v", updateErr)
+	}
+
+	reloaded, reloadErr := app.FindRecordById("persons", person.Id)
+	if reloadErr != nil {
+		t.Fatalf("reload: %v", reloadErr)
+	}
+	if reloaded.GetString("household") != "" {
+		t.Errorf("dry run persisted the household relation: got %q, want unset",
+			reloaded.GetString("household"))
+	}
+}
+
+// TestUpdateAttendeeRelationsDryRunWritesNothing proves the attendee-relation
+// backfill's App.Save call is gated: an attendee eligible for the backfill is
+// left with its person relation unset by a dry run.
+func TestUpdateAttendeeRelationsDryRunWritesNothing(t *testing.T) {
+	t.Parallel()
+
+	app, appErr := pbtests.NewTestApp()
+	if appErr != nil {
+		t.Fatalf("NewTestApp: %v", appErr)
+	}
+	t.Cleanup(app.Cleanup)
+
+	personsCol := core.NewBaseCollection("persons")
+	personsCol.Fields.Add(&core.NumberField{Name: "cm_id"})
+	personsCol.Fields.Add(&core.NumberField{Name: "year"})
+	if createErr := app.Save(personsCol); createErr != nil {
+		t.Fatalf("create persons: %v", createErr)
+	}
+	person := core.NewRecord(personsCol)
+	person.Set("cm_id", 5001)
+	person.Set("year", 2026)
+	if seedErr := app.Save(person); seedErr != nil {
+		t.Fatalf("seed person: %v", seedErr)
+	}
+
+	attendeesCol := core.NewBaseCollection("attendees")
+	attendeesCol.Fields.Add(&core.NumberField{Name: "person_id"})
+	attendeesCol.Fields.Add(&core.TextField{Name: "person"})
+	attendeesCol.Fields.Add(&core.NumberField{Name: "year"})
+	if createAttendeesErr := app.Save(attendeesCol); createAttendeesErr != nil {
+		t.Fatalf("create attendees: %v", createAttendeesErr)
+	}
+	attendee := core.NewRecord(attendeesCol)
+	attendee.Set("person_id", 5001)
+	attendee.Set("year", 2026)
+	if seedAttendeeErr := app.Save(attendee); seedAttendeeErr != nil {
+		t.Fatalf("seed attendee: %v", seedAttendeeErr)
+	}
+
+	s := &PersonsSync{BaseSyncService: BaseSyncService{App: app}}
+	s.SetDryRun(true)
+
+	if updateErr := s.updateAttendeeRelations(2026); updateErr != nil {
+		t.Fatalf("updateAttendeeRelations: %v", updateErr)
+	}
+
+	reloaded, reloadErr := app.FindRecordById("attendees", attendee.Id)
+	if reloadErr != nil {
+		t.Fatalf("reload: %v", reloadErr)
+	}
+	if reloaded.GetString("person") != "" {
+		t.Errorf("dry run persisted the person relation: got %q, want unset",
+			reloaded.GetString("person"))
+	}
+}

--- a/pocketbase/sync/session_groups.go
+++ b/pocketbase/sync/session_groups.go
@@ -30,6 +30,13 @@ func (s *SessionGroupsSync) Name() string {
 	return serviceNameSessionGroups
 }
 
+// SetDryRun implements the orchestrator's DryRunnable interface (kindred#2351). Declared
+// explicitly rather than inherited by embedding BaseSyncService -- see that field's doc
+// comment for why a promoted setter is not safe here.
+func (s *SessionGroupsSync) SetDryRun(dryRun bool) {
+	s.DryRun = dryRun
+}
+
 // Sync performs the session groups sync
 func (s *SessionGroupsSync) Sync(ctx context.Context) error {
 	year := s.Client.GetSeasonID()

--- a/pocketbase/sync/sessions.go
+++ b/pocketbase/sync/sessions.go
@@ -59,6 +59,13 @@ func (s *SessionsSync) Name() string {
 	return serviceNameSessions
 }
 
+// SetDryRun implements the orchestrator's DryRunnable interface (kindred#2351). Declared
+// explicitly rather than inherited by embedding BaseSyncService -- see that field's doc
+// comment for why a promoted setter is not safe here.
+func (s *SessionsSync) SetDryRun(dryRun bool) {
+	s.DryRun = dryRun
+}
+
 // Sync performs the session sync
 func (s *SessionsSync) Sync(ctx context.Context) error {
 	// Use custom implementation like bunks for idempotency

--- a/pocketbase/sync/staff.go
+++ b/pocketbase/sync/staff.go
@@ -49,6 +49,13 @@ func (s *StaffSync) Name() string {
 	return serviceNameStaff
 }
 
+// SetDryRun implements the orchestrator's DryRunnable interface (kindred#2351). Declared
+// explicitly rather than inherited by embedding BaseSyncService -- see that field's doc
+// comment for why a promoted setter is not safe here.
+func (s *StaffSync) SetDryRun(dryRun bool) {
+	s.DryRun = dryRun
+}
+
 // Sync performs the year-scoped staff sync
 func (s *StaffSync) Sync(ctx context.Context) error {
 	s.LogSyncStart(serviceNameStaff)

--- a/pocketbase/sync/stranded_assignment_cleanup.go
+++ b/pocketbase/sync/stranded_assignment_cleanup.go
@@ -228,6 +228,12 @@ type StrandedAssignmentCleanupSync struct {
 	Year  int
 	Debug bool
 	Stats Stats
+	// DryRun, when true, computes the same stranded/orphan sets and updates
+	// Stats exactly as a normal run would, but skips both app.Save calls in
+	// reconcileStrandedAssignments/reconcileLodgingOrphans that null bunk/units
+	// on a draft (kindred#2351). The two production audits are read-only
+	// already and are unaffected either way.
+	DryRun bool
 }
 
 // NewStrandedAssignmentCleanupSync constructs the service.
@@ -246,6 +252,9 @@ func (s *StrandedAssignmentCleanupSync) SetDebug(debug bool) { s.Debug = debug }
 
 // SetYear sets the year for this run (orchestrator hook).
 func (s *StrandedAssignmentCleanupSync) SetYear(year int) { s.Year = year }
+
+// SetDryRun implements the orchestrator's DryRunnable interface (kindred#2351).
+func (s *StrandedAssignmentCleanupSync) SetDryRun(dryRun bool) { s.DryRun = dryRun }
 
 // WasSuccessful indicates whether the last run encountered no errors.
 func (s *StrandedAssignmentCleanupSync) WasSuccessful() bool { return s.Stats.Errors == 0 }
@@ -269,10 +278,10 @@ func (s *StrandedAssignmentCleanupSync) Sync(_ context.Context) error {
 			return fmt.Errorf("stranded_assignment_cleanup: year resolution failed: %w", err)
 		}
 	}
-	if err := reconcileStrandedAssignments(s.App, year, &s.Stats); err != nil {
+	if err := reconcileStrandedAssignments(s.App, year, &s.Stats, s.DryRun); err != nil {
 		return err
 	}
-	return reconcileLodgingOrphans(s.App, year, &s.Stats)
+	return reconcileLodgingOrphans(s.App, year, &s.Stats, s.DryRun)
 }
 
 // reconcileStrandedAssignments is the integration logic:
@@ -289,7 +298,7 @@ func (s *StrandedAssignmentCleanupSync) Sync(_ context.Context) error {
 //     Unassigned pool (a cancelled camper falls out of the scenario entirely).
 //  4. Audit bunk_assignments (production): log flagged rows — but do NOT
 //     delete. The bunk_assignments sync's own deleteOrphans() owns prod.
-func reconcileStrandedAssignments(app core.App, year int, stats *Stats) error {
+func reconcileStrandedAssignments(app core.App, year int, stats *Stats, dryRun bool) error {
 	yearFilter := fmt.Sprintf("year = %d", year)
 
 	plans, err := app.FindRecordsByFilter("bunk_plans", yearFilter, "", 0, 0)
@@ -349,6 +358,10 @@ func reconcileStrandedAssignments(app core.App, year int, stats *Stats) error {
 		rec := draftByID[c.RecordID]
 		rec.Set("bunk", "")
 		rec.Set("bunk_plan", "")
+		if dryRun {
+			stats.Updated++
+			continue
+		}
 		if saveErr := app.Save(rec); saveErr != nil {
 			stats.Errors++
 			slog.Error("stranded_assignment_cleanup: save draft", "id", c.RecordID, "error", saveErr)
@@ -428,7 +441,7 @@ func reconcileStrandedAssignments(app core.App, year int, stats *Stats) error {
 //     deletes. Deletion belongs to LodgingAssignmentsSync.deleteLodgingOrphans,
 //     driven by absence from the CampMinder cabin value -- the same split of
 //     responsibility bunk_assignments already has with the pass above.
-func reconcileLodgingOrphans(app core.App, year int, stats *Stats) error {
+func reconcileLodgingOrphans(app core.App, year int, stats *Stats, dryRun bool) error {
 	householdIndex, err := BuildHouseholdSessionIndex(app, year, []string{sessionTypeFamily})
 	if err != nil {
 		stats.Errors++
@@ -455,6 +468,10 @@ func reconcileLodgingOrphans(app core.App, year int, stats *Stats) error {
 	for _, c := range orphanDrafts {
 		rec := draftByID[c.RecordID]
 		rec.Set("units", []string{})
+		if dryRun {
+			stats.Updated++
+			continue
+		}
 		if saveErr := app.Save(rec); saveErr != nil {
 			stats.Errors++
 			slog.Error("stranded_assignment_cleanup: save lodging draft", "id", c.RecordID, "error", saveErr)

--- a/pocketbase/sync/stranded_assignment_cleanup.go
+++ b/pocketbase/sync/stranded_assignment_cleanup.go
@@ -464,12 +464,23 @@ func reconcileLodgingOrphans(app core.App, year int, stats *Stats, dryRun bool) 
 	draftByID, draftCandidates := lodgingCandidatesFromRecords(drafts)
 	orphanDrafts := findLodgingEnrollmentOrphans(householdIndex, personIndex, draftCandidates)
 
+	// writes counts only persisted App.Save calls (gates the WAL checkpoint below,
+	// which has nothing to flush on a dry run). swept counts what this pass DID or
+	// WOULD sweep -- real or simulated -- and is what the completion log reports,
+	// so an operator previewing a dry run sees the household this pass found, not
+	// a misleading 0. Deliberately local rather than stats.Updated: Sync() runs
+	// reconcileStrandedAssignments before this function against the same shared
+	// *Stats, so stats.Updated already carries the bunk pass's own count by the
+	// time this one logs -- reading it here would double-count that into this
+	// pass's number.
 	writes := 0
+	swept := 0
 	for _, c := range orphanDrafts {
 		rec := draftByID[c.RecordID]
 		rec.Set("units", []string{})
 		if dryRun {
 			stats.Updated++
+			swept++
 			continue
 		}
 		if saveErr := app.Save(rec); saveErr != nil {
@@ -478,6 +489,7 @@ func reconcileLodgingOrphans(app core.App, year int, stats *Stats, dryRun bool) 
 			continue
 		}
 		writes++
+		swept++
 		stats.Updated++
 	}
 
@@ -512,7 +524,7 @@ func reconcileLodgingOrphans(app core.App, year int, stats *Stats, dryRun bool) 
 	slog.Info("stranded_assignment_cleanup lodging pass complete",
 		"year", year,
 		"orphaned_drafts", len(orphanDrafts),
-		"drafts_swept", writes,
+		"drafts_swept", swept,
 		"lodging_prod_audit_warnings", stats.LodgingProdAuditWarnings,
 		"errors", stats.Errors,
 	)

--- a/pocketbase/sync/stranded_assignment_cleanup_dryrun_test.go
+++ b/pocketbase/sync/stranded_assignment_cleanup_dryrun_test.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	pbtests "github.com/pocketbase/pocketbase/tests"
@@ -120,5 +121,69 @@ func TestStrandedAssignmentCleanupDryRunLeavesLodgingDraftUntouched(t *testing.T
 	stats := svc.GetStats()
 	if stats.Updated != 1 {
 		t.Errorf("Stats.Updated = %d, want 1 (the lodging sweep that would have happened)", stats.Updated)
+	}
+}
+
+// TestStrandedAssignmentCleanupDryRunLodgingLogReportsSimulatedSweep proves
+// reconcileLodgingOrphans' completion log tells an operator what a dry run
+// WOULD sweep, not what it actually wrote (CodeRabbit finding on #2386):
+// the log line's "drafts_swept" field used to read the local `writes`
+// counter, which only increments on a real `app.Save`, so a dry run always
+// logged `drafts_swept=0` even when `orphaned_drafts` was nonzero --
+// silently contradicting the very household this test seeds as an orphan.
+// reconcileStrandedAssignments' sibling log line (the bunk sweep, a few
+// lines up in this same file) already gets this right by logging
+// stats.Updated instead -- but that field accumulates across BOTH
+// reconcile passes sharing one Stats struct (Sync() calls
+// reconcileStrandedAssignments then reconcileLodgingOrphans with the same
+// &s.Stats), so copying that exact fix here would double-count the bunk
+// sweep into the lodging log line. This test seeds only a lodging orphan
+// (no bunk_plans, so the bunk pass sweeps nothing), isolating the two.
+//
+// Not t.Parallel(): captureSweepLogs swaps the process-global slog default
+// (see main_test_parallelism_test.go's serialTests entry for this test).
+func TestStrandedAssignmentCleanupDryRunLodgingLogReportsSimulatedSweep(t *testing.T) {
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupStrandedCollections(t, app)
+
+	sess := addLodgingSession(t, app, 100, "family", 2026)
+	unit := addLodgingUnit(t, app, "ridge-a")
+	scenario := saveRec(t, app, "saved_scenarios", map[string]any{"name": "April", "session": sess.Id, "year": 2026})
+
+	cancelled := saveRec(t, app, "persons", map[string]any{"cm_id": 9001, "household_id": 5001, "year": 2026})
+	enrolledPerson := saveRec(t, app, "persons", map[string]any{"cm_id": 9002, "household_id": 5002, "year": 2026})
+	saveRec(t, app, "attendees", map[string]any{
+		"person": cancelled.Id, "person_id": 9001, "session": sess.Id, "status_id": 32, "year": 2026,
+	})
+	saveRec(t, app, "attendees", map[string]any{
+		"person": enrolledPerson.Id, "person_id": 9002, "session": sess.Id, "status_id": 2, "year": 2026,
+	})
+	saveRec(t, app, "lodging_assignments_draft", map[string]any{
+		"session": sess.Id, "session_cm_id": 100, "year": 2026, "scenario": scenario.Id,
+		"units": []string{unit.Id}, "household_cm_id": 5001, "source": "campminder_sync", "staff_touched": false,
+	})
+
+	buf := captureSweepLogs(t)
+
+	svc := NewStrandedAssignmentCleanupSync(app)
+	svc.SetYear(2026)
+	svc.SetDryRun(true)
+	if syncErr := svc.Sync(context.Background()); syncErr != nil {
+		t.Fatalf("Sync: %v", syncErr)
+	}
+
+	logs := buf.String()
+	if !strings.Contains(logs, "stranded_assignment_cleanup lodging pass complete") {
+		t.Fatalf("lodging completion log not found; got:\n%s", logs)
+	}
+	if strings.Contains(logs, "drafts_swept=0") {
+		t.Errorf("dry run logged drafts_swept=0 despite one simulated lodging sweep; got:\n%s", logs)
+	}
+	if !strings.Contains(logs, "drafts_swept=1") {
+		t.Errorf("want drafts_swept=1 (the simulated sweep an operator would act on); got:\n%s", logs)
 	}
 }

--- a/pocketbase/sync/stranded_assignment_cleanup_dryrun_test.go
+++ b/pocketbase/sync/stranded_assignment_cleanup_dryrun_test.go
@@ -1,0 +1,62 @@
+package sync
+
+import (
+	"context"
+	"testing"
+
+	pbtests "github.com/pocketbase/pocketbase/tests"
+)
+
+// TestStrandedAssignmentCleanupDryRunLeavesDraftUntouched proves both of
+// reconcileStrandedAssignments' write sites are gated (kindred#2351): a
+// draft that a wet run would null out survives a dry run byte-for-byte, and
+// Stats.Updated still reports what WOULD have been swept so an operator's
+// preview is accurate.
+//
+// Deliberately a new file rather than an addition to
+// stranded_assignment_cleanup_test.go: that file's fixtures are being
+// rewritten in a parallel branch (kindred#2300), so this test borrows its
+// setupStrandedCollections/saveRec helpers rather than editing it.
+func TestStrandedAssignmentCleanupDryRunLeavesDraftUntouched(t *testing.T) {
+	t.Parallel()
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupStrandedCollections(t, app)
+
+	sess := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": 100, "year": 2026})
+	keptBunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 1, "name": "B-1", "year": 2026})
+	goneBunk := saveRec(t, app, "bunks", map[string]any{"cm_id": 2, "name": "G-5", "year": 2026})
+	person := saveRec(t, app, "persons", map[string]any{"cm_id": 9001})
+	keptPlan := saveRec(t, app, "bunk_plans", map[string]any{"bunk": keptBunk.Id, "session": sess.Id, "year": 2026})
+	scenario := saveRec(t, app, "saved_scenarios", map[string]any{"name": "April", "session": sess.Id, "year": 2026})
+	draft := saveRec(t, app, "bunk_assignments_draft", map[string]any{
+		"scenario": scenario.Id, "person": person.Id, "session": sess.Id,
+		"bunk": goneBunk.Id, "bunk_plan": keptPlan.Id, "year": 2026,
+	})
+
+	svc := NewStrandedAssignmentCleanupSync(app)
+	svc.SetYear(2026)
+	svc.SetDryRun(true)
+	if syncErr := svc.Sync(context.Background()); syncErr != nil {
+		t.Fatalf("Sync: %v", syncErr)
+	}
+
+	got, err := app.FindRecordById("bunk_assignments_draft", draft.Id)
+	if err != nil {
+		t.Fatalf("reload draft: %v", err)
+	}
+	if got.GetString("bunk") != goneBunk.Id {
+		t.Errorf("dry run cleared bunk: got %q, want unchanged %q", got.GetString("bunk"), goneBunk.Id)
+	}
+	if got.GetString("bunk_plan") != keptPlan.Id {
+		t.Errorf("dry run cleared bunk_plan: got %q, want unchanged %q", got.GetString("bunk_plan"), keptPlan.Id)
+	}
+
+	stats := svc.GetStats()
+	if stats.Updated != 1 {
+		t.Errorf("Stats.Updated = %d, want 1 (the sweep that would have happened)", stats.Updated)
+	}
+}

--- a/pocketbase/sync/stranded_assignment_cleanup_dryrun_test.go
+++ b/pocketbase/sync/stranded_assignment_cleanup_dryrun_test.go
@@ -13,10 +13,15 @@ import (
 // Stats.Updated still reports what WOULD have been swept so an operator's
 // preview is accurate.
 //
+// reconcileStrandedAssignments is one of TWO functions StrandedAssignmentCleanupSync's
+// DryRun guards -- see TestStrandedAssignmentCleanupDryRunLeavesLodgingDraftUntouched below
+// for the second, reconcileLodgingOrphans' units write.
+//
 // Deliberately a new file rather than an addition to
 // stranded_assignment_cleanup_test.go: that file's fixtures are being
 // rewritten in a parallel branch (kindred#2300), so this test borrows its
-// setupStrandedCollections/saveRec helpers rather than editing it.
+// setupStrandedCollections/saveRec/addLodgingSession/addLodgingUnit helpers
+// rather than editing it.
 func TestStrandedAssignmentCleanupDryRunLeavesDraftUntouched(t *testing.T) {
 	t.Parallel()
 	app, err := pbtests.NewTestApp()
@@ -58,5 +63,62 @@ func TestStrandedAssignmentCleanupDryRunLeavesDraftUntouched(t *testing.T) {
 	stats := svc.GetStats()
 	if stats.Updated != 1 {
 		t.Errorf("Stats.Updated = %d, want 1 (the sweep that would have happened)", stats.Updated)
+	}
+}
+
+// TestStrandedAssignmentCleanupDryRunLeavesLodgingDraftUntouched proves the second of
+// StrandedAssignmentCleanupSync's two write sites is gated: reconcileLodgingOrphans' `units`
+// clear on a lodging_assignments_draft row for a household no longer enrolled (kindred#2028's
+// weekend twin of the bunk sweep above). Fixture mirrors
+// TestStrandedAssignmentCleanup_SweepsLodgingEnrollmentOrphanDraftHousehold in
+// stranded_assignment_cleanup_test.go, the wet-run test that proves this same household would
+// actually be swept -- this one proves a dry run leaves it alone.
+func TestStrandedAssignmentCleanupDryRunLeavesLodgingDraftUntouched(t *testing.T) {
+	t.Parallel()
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupStrandedCollections(t, app)
+
+	sess := addLodgingSession(t, app, 100, "family", 2026)
+	unit := addLodgingUnit(t, app, "ridge-a")
+	scenario := saveRec(t, app, "saved_scenarios", map[string]any{"name": "April", "session": sess.Id, "year": 2026})
+
+	cancelled := saveRec(t, app, "persons", map[string]any{"cm_id": 9001, "household_id": 5001, "year": 2026})
+	enrolledPerson := saveRec(t, app, "persons", map[string]any{"cm_id": 9002, "household_id": 5002, "year": 2026})
+	saveRec(t, app, "attendees", map[string]any{
+		"person": cancelled.Id, "person_id": 9001, "session": sess.Id, "status_id": 32, "year": 2026,
+	})
+	// Keeps the session's enrolled set non-empty so the per-session guard passes.
+	saveRec(t, app, "attendees", map[string]any{
+		"person": enrolledPerson.Id, "person_id": 9002, "session": sess.Id, "status_id": 2, "year": 2026,
+	})
+
+	draft := saveRec(t, app, "lodging_assignments_draft", map[string]any{
+		"session": sess.Id, "session_cm_id": 100, "year": 2026, "scenario": scenario.Id,
+		"units": []string{unit.Id}, "household_cm_id": 5001, "source": "campminder_sync", "staff_touched": false,
+	})
+
+	svc := NewStrandedAssignmentCleanupSync(app)
+	svc.SetYear(2026)
+	svc.SetDryRun(true)
+	if syncErr := svc.Sync(context.Background()); syncErr != nil {
+		t.Fatalf("Sync: %v", syncErr)
+	}
+
+	got, err := app.FindRecordById("lodging_assignments_draft", draft.Id)
+	if err != nil {
+		t.Fatalf("reload draft: %v", err)
+	}
+	if len(got.GetStringSlice("units")) == 0 {
+		t.Errorf("dry run cleared units for a cancelled household: got %v, want unchanged [%s]",
+			got.GetStringSlice("units"), unit.Id)
+	}
+
+	stats := svc.GetStats()
+	if stats.Updated != 1 {
+		t.Errorf("Stats.Updated = %d, want 1 (the lodging sweep that would have happened)", stats.Updated)
 	}
 }


### PR DESCRIPTION
## What

`dry_run=true` on `/api/custom/sync/run` with the default `service=all` returned **HTTP 400**
because 12 of the 24 default unified jobs (corrected from the issue's stale count of 25 --
see the issue comment) did not implement `DryRunnable`. This wires all 12: `session_groups`,
`sessions`, `attendees`, `persons`, `bunks`, `bunk_plans`, `bunk_assignments`, `staff`,
`financial_transactions`, `person_custom_values`, `household_custom_values`,
`stranded_assignment_cleanup` -- exactly #2351's scope table, no more.

**This does not make the default `service=all` fully dry-run-able for the current year.**
`ResolveUnifiedSyncServices` appends `reconcile_request_lifecycle` and `bunk_requests` (and,
under `IS_DOCKER`, `process_requests`) to the 24 defaults whenever the requested year is the
current one -- none of those three were ever in #2351's scope (see the issue's own "Scope"
table), and none implement `DryRunnable`. So a current-year `service=all&dry_run=true` request
still gets HTTP 400 after this PR; only a historical replay (an explicit past `year`) actually
reaches 200 now. `TestCurrentYearDefaultSyncStillRejectsDryRun` (new, `orchestrator_test.go`)
pins the residue so it stays visible rather than reappearing as a surprise. Wiring those three
is future work, tracked by #2351's own successor note, not a gap in this PR.

## Architecture

11 of the 12 embed `BaseSyncService`. Every write those services perform routes through one of
eight call sites inside `BaseSyncService`'s shared helpers (`ProcessSimpleRecord`,
`ProcessSimpleRecordGlobal`, `ProcessCompositeRecord`, `deleteOrphans`,
`DeleteOrphansFromPreloaded`), so the fix lives mostly in one place: a `DryRun bool` field on
`BaseSyncService`, and a guard at each of those eight `App.Save`/`App.Delete` calls that skips
the write and still updates `Stats` as if it had happened.

**A blast-radius bug this uncovered and fixed along the way:** the first version of this change
gave `BaseSyncService` itself an exported `SetDryRun` method, reasoning that 7 of the 12 (the
ones with *no* write sites of their own) would then get `DryRunnable` "for free" through Go's
method promotion. That is true, but promotion doesn't stop at those 7 -- it silently hands
`DryRunnable` to **every** service that embeds `BaseSyncService`, including two outside this
issue entirely: `bunk_requests` (which `ResolveUnifiedSyncServices` appends to a *current-year*
`service=all` request, so it is genuinely reachable through the endpoint this issue is about)
and `request_processor` (whose `Sync()` delegates to a remote FastAPI call that a local bool
cannot gate at all). Both would have compiled as dry-run-safe while running fully wet -- the
exact "200 `dry_run:true`, writes anyway" failure #2334 was about, just relocated. Caught before
it shipped by a new test, `TestEmbeddingBaseSyncServiceDoesNotLeakDryRunnable`.

The fix: `BaseSyncService` keeps the `DryRun` field and the eight gated call sites, but does
**not** export a promoted `SetDryRun`. Each of the 12 wired services declares its own
three-line `SetDryRun` that sets the (possibly-promoted) field directly. A service that embeds
`BaseSyncService` but doesn't declare this method -- `bunk_requests`, `process_requests`,
`custom_field_definitions`, `financial_lookups`, `multi_workbook_export`, `divisions`,
`person_tag_definitions`, `staff_lookups` -- correctly stays unsupported and gets the honest
400. `bunk_requests` is now the test suite's negative-control exemplar in place of the two
services (`session_groups`, `persons`) that used to fill that role before this PR wired them.

Five of the 12 also have write sites of their own, outside those eight shared call sites, gated
individually in their own files:
- `attendees.go`: `logStatusChange`'s `attendee_status_history` insert.
- `persons.go`: the person upsert (`processPerson`), the household upsert
  (`processHouseholdRecord`), an attendee-relation backfill (`updateAttendeeRelations`), a
  household-relation backfill (`updatePersonHouseholdRelations`), and a household-orphan delete
  (`deleteHouseholdOrphans`) -- five independent write areas, each gated and each covered by its
  own real-app test in `persons_dryrun_test.go` (`persons` carries PII across every downstream
  join, so this is the one file in the PR where "same pattern as everywhere else" wasn't
  treated as license to skip a dedicated test).
- `person_custom_field_values.go` / `household_custom_field_values.go`: a fast-path upsert
  (`processPersonCustomFieldValue` / `processHouseholdCustomFieldValue`) that bypasses
  `ProcessSimpleRecord` for a `last_updated`-comparison shortcut.
- `stranded_assignment_cleanup.go` doesn't embed `BaseSyncService` at all -- it's a from-scratch
  `DryRun` field and `dryRun bool` parameter threaded through
  `reconcileStrandedAssignments`/`reconcileLodgingOrphans`, gating the two `app.Save` calls that
  null out a stranded draft's `bunk`/`bunk_plan` or `units`. The issue flagged this one as
  possibly having "no meaningful skip-write branch" -- on inspection it does (two clean,
  independent gate points), so it's wired rather than left out.

## What I deliberately did not do

- **No promoted `SetDryRun` on `BaseSyncService`.** Explained above -- would have silently
  exposed `bunk_requests`/`process_requests` (and six other embedders) as falsely dry-run-safe.
- **No full end-to-end `Sync()` dry-run test for the 11 CampMinder-backed services.** `Sync()`
  on all of them (except `stranded_assignment_cleanup`) makes a live HTTP call via
  `campminder.Client`, and this package has no mock CampMinder server. Instead, each wired
  write site is driven directly (its own function, not through `Sync()`) against a real
  PocketBase test app, asserting real record counts before/after -- the same production code
  `Sync()` calls, just without the network hop `Sync()` adds on top. `stranded_assignment_cleanup`
  needs no CampMinder client, so its test *does* drive the real `Sync()` end-to-end.
- **Did not touch `orchestrator.go`.** Everything needed lived in `base_sync.go`, the 12
  service files, and `orchestrator_test.go` -- no need to enter the `Stats` sub-struct region
  PR #2378 is also touching.

## Issue body correction

Filed a comment and edited #2351's body: it claimed 25 default unified jobs (24 is correct --
9 + 2 custom-value jobs + 13), and its "Collides with" list named three issues (#2347, #2259,
#2264) that are all now closed, plus `staff.go` as overlapping #2277, which #2277's own PR
(#2380) shows is false (#2277 only ever touched `staff_applications.go`/`staff_vehicle_info.go`).

## Mutation-check evidence

Two required by the task, plus every write-guard this PR added was mutation-checked the same
way (confirmed RED, then restored to GREEN):

1. **No-op setter** (`session_groups.go`): replaced `SetDryRun`'s body with `_ = dryRun`.
   `TestRealServicesSetDryRunStoresTheFlag/session_groups` failed:
   `session_groups.SetDryRun(true) left DryRun false -- the unified endpoint would report
   dry_run=true and the service would write for real`.
2. **Write-guard removed** (`base_sync.go`'s `ProcessSimpleRecord` update branch): deleted the
   `if b.DryRun { ...; return nil }` block. `TestBaseSyncServiceProcessSimpleRecordDryRunWritesNothing`
   failed: `dry run persisted a name change: got "Changed", want "Original"`.

Nine more write-guard mutations were run the same way and all went RED: `base_sync.go`'s
`DeleteOrphans`/`DeleteOrphansFromPreloaded`/`ProcessCompositeRecord` guards,
`stranded_assignment_cleanup.go`'s draft-sweep guard, `attendees.go`'s `logStatusChange` guard,
both `person_custom_field_values.go` guards (create+update), `household_custom_field_values.go`'s
update guard, and `persons.go`'s `deleteHouseholdOrphans` / `processHouseholdRecord` /
`processPerson` / `updateAttendeeRelations` guards.

**Review round found two guards this original list missed entirely** -- no test drove either,
so deleting them stayed green:
- `stranded_assignment_cleanup.go`'s `reconcileLodgingOrphans` `units`-clear guard (the lodging
  twin of the draft-sweep guard above, on a *different* write site in the same file). The only
  existing dry-run test seeded zero `lodging_assignments_draft` rows, so the loop it guards
  never ran. Added `TestStrandedAssignmentCleanupDryRunLeavesLodgingDraftUntouched` with a real
  household-orphan fixture; mutation-checked by deleting the guard -- failed with `dry run
  cleared units for a cancelled household: got [], want unchanged [...]`; restored.
- `base_sync.go`'s `ProcessSimpleRecordGlobal` create+update guards -- the file's own header
  comment claimed these were "covered by the sibling tests below," which was false; no sibling
  test exercises this helper. Added
  `TestBaseSyncServiceProcessSimpleRecordGlobalDryRunWritesNothing` (currently pins dead code --
  none of this helper's five callers are wired to `DryRunnable` yet -- so a future service that
  wires one of them doesn't inherit a silently-broken guard) and corrected the comment;
  mutation-checked by commenting out both guards in isolation -- failed with `dry run wrote 2
  rows; want 1`; restored.

Both are now covered, so "every write-guard this PR added was mutation-checked" is accurate as
of this revision.

## Tests

13 new tests across 5 new files (`base_sync_dryrun_test.go`,
`stranded_assignment_cleanup_dryrun_test.go`, `attendees_dryrun_test.go`,
`custom_field_values_dryrun_test.go`, `persons_dryrun_test.go`), plus
`TestEmbeddingBaseSyncServiceDoesNotLeakDryRunnable` in `orchestrator_test.go`, plus the
required extension of `TestRealServicesSetDryRunStoresTheFlag` /
`TestRealServicesHonorDryRunThroughUnifiedEndpoint` / `dryRunCapableRealServices` to the 12
newly-wired names. **Review round added 3 more** to the same files (no new files):
`TestStrandedAssignmentCleanupDryRunLeavesLodgingDraftUntouched` and
`TestBaseSyncServiceProcessSimpleRecordGlobalDryRunWritesNothing` (the two coverage gaps above),
plus `TestCurrentYearDefaultSyncStillRejectsDryRun` in `orchestrator_test.go` (pins the
current-year 400 residue described in "What"). 16 new tests total.

- `cd pocketbase && go build ./...` -- clean
- `go vet ./...` -- clean
- `go test ./sync/...` -- green
- `go test -race ./sync/` -- green (171s)
- `bash scripts/pre-push-verify.sh` -- green after adding two new serial-test entries to
  `main_test_parallelism_test.go`: `TestAttendeesLogStatusChangeDryRunWritesNothing` needs
  `t.Setenv` for `campminder.NewClient` (same reason four existing entries in that file already
  give), and the review-round `TestCurrentYearDefaultSyncStillRejectsDryRun` needs `t.Setenv`
  for `IS_DOCKER`.
- `gofmt -l .` -- clean

## Scope locks respected

- Did not touch `bunk_assignments_protection_test.go`, `bunk_assignments_grain_test.go`, or
  `stranded_assignment_cleanup_test.go` (owned by the parallel #2300-derived work, currently PR
  #2385) -- new fixtures for `stranded_assignment_cleanup` and `bunk_assignments` live in
  `stranded_assignment_cleanup_dryrun_test.go` and `base_sync_dryrun_test.go` instead.
- Did not touch `camper_transportation.go`, `staff_applications.go`, `staff_vehicle_info.go`.
- Did not touch `orchestrator.go`'s `Stats` sub-struct region (PR #2378).

Closes #2351.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded dry-run support across synchronization processes, including people, households, attendees, assignments, sessions, staff, financial data, and custom fields.
  - Dry runs now report expected creates, updates, and cleanup actions without changing stored records.
  - Status history and assignment cleanup operations remain unchanged during dry runs.

- **Bug Fixes**
  - Prevented unintended database writes during dry-run synchronization.
  - Improved validation for unsupported dry-run operations.

- **Tests**
  - Added comprehensive coverage for simulated results and preserved data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->