### PR TITLE
fix(frontend): delete dead role=status/aria-live AT scaffolding

### DIFF
--- a/frontend/src/components/FullPageSpinner.tsx
+++ b/frontend/src/components/FullPageSpinner.tsx
@@ -1,5 +1,10 @@
 import { Loader2 } from 'lucide-react'
 
+// KEPT — deliberately NOT deleted by kindred#2379, despite that issue naming
+// this exact line: `role="status"` is not an AT announcement here (no AT
+// users, per frontend/CLAUDE.md), it is the query handle `ProtectedRoute`,
+// `AdminRoute`, and `RequirePermission`'s tests use for "still loading" — see
+// this file's own regression test (kindred#2348) and its comment.
 export const FullPageSpinner = () => (
   <div className="flex min-h-screen items-center justify-center" role="status">
     <Loader2 className="text-primary h-12 w-12 animate-spin" />

--- a/frontend/src/components/MergeRequestsModal.tsx
+++ b/frontend/src/components/MergeRequestsModal.tsx
@@ -189,6 +189,11 @@ export default function MergeRequestsModal({
                     : 'border-border hover:border-primary/50'
                 }`}
               >
+                {/* KEPT (kindred#2379): a real native radio, not AT
+                    scaffolding — `sr-only` hides its default browser
+                    rendering while the card `<label>` stays the visible,
+                    clickable control. Deleting the class puts a raw radio
+                    button next to the card. */}
                 <input
                   type="radio"
                   name="targetRequest"

--- a/frontend/src/components/SocialNetworkGraph.test.ts
+++ b/frontend/src/components/SocialNetworkGraph.test.ts
@@ -112,4 +112,10 @@ describe('SocialNetworkGraph header layout — slim single row', () => {
     // EdgeFilters import should be removed since the component is no longer used
     expect(source).not.toMatch(/\bEdgeFilters\b/)
   })
+
+  it('has no aria-live/role="status" scaffolding on the degrade banner (kindred#2379)', () => {
+    // Nobody here uses AT (frontend/CLAUDE.md "Accessibility — deliberately
+    // minimal") — the banner's visible text is the whole story.
+    expect(source).not.toContain('role="status"')
+  })
 })

--- a/frontend/src/components/SocialNetworkGraph.test.ts
+++ b/frontend/src/components/SocialNetworkGraph.test.ts
@@ -117,5 +117,6 @@ describe('SocialNetworkGraph header layout — slim single row', () => {
     // Nobody here uses AT (frontend/CLAUDE.md "Accessibility — deliberately
     // minimal") — the banner's visible text is the whole story.
     expect(source).not.toContain('role="status"')
+    expect(source).not.toContain('aria-live')
   })
 })

--- a/frontend/src/components/SocialNetworkGraph.tsx
+++ b/frontend/src/components/SocialNetworkGraph.tsx
@@ -837,10 +837,7 @@ export default function SocialNetworkGraph({ sessionCmId }: SocialNetworkGraphPr
             </div>
 
             {degradeBanner && (
-              <div
-                role="status"
-                className="border-border flex items-center gap-2 border-b bg-amber-50 px-4 py-2 text-sm text-amber-800 dark:bg-amber-950/30 dark:text-amber-200"
-              >
+              <div className="border-border flex items-center gap-2 border-b bg-amber-50 px-4 py-2 text-sm text-amber-800 dark:bg-amber-950/30 dark:text-amber-200">
                 <span aria-hidden>⚠</span>
                 {degradeBanner}
               </div>

--- a/frontend/src/components/admin/lodging/BedInventoryEditor.tsx
+++ b/frontend/src/components/admin/lodging/BedInventoryEditor.tsx
@@ -95,9 +95,9 @@ export function BedInventoryEditor({ beds, onChange }: BedInventoryEditorProps) 
       {/* In the same wrap as the chips, so adding a bed reads as extending the
           set rather than operating a separate control below it. */}
       <li className="inline-flex items-center gap-1.5">
-        <label className="sr-only" htmlFor="bed-type-picker">
-          Add a bed type
-        </label>
+        {/* No standalone <label> — redundant with the select's own
+            aria-label below, which is already the query handle tests use
+            (kindred#2379). */}
         <select
           id="bed-type-picker"
           aria-label="Add a bed type"

--- a/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
@@ -627,6 +627,15 @@ describe('LodgingUnitForm — the parent picker reflects a live allocation chang
 })
 
 describe('LodgingUnitForm — beds', () => {
+  it('names the bed-type picker with aria-label alone, no separate sr-only label (kindred#2379)', () => {
+    const { container } = render(
+      <LodgingUnitForm areas={AREAS} units={[]} year={2026} onSaved={vi.fn()} onCancel={vi.fn()} />
+    )
+
+    expect(container.querySelector('label[for="bed-type-picker"]')).toBeNull()
+    expect(screen.getByLabelText('Add a bed type')).toBeInTheDocument()
+  })
+
   it('shows the suggested occupancy from the bed inventory', async () => {
     const user = userEvent.setup()
     render(
@@ -778,59 +787,29 @@ describe('LodgingUnitForm — capacity flag', () => {
     expect(screen.getByRole('button', { name: 'Use suggested' })).toBeInTheDocument()
   })
 
-  it('keeps the live region mounted even with nothing to announce', () => {
-    // THE LOAD-BEARING ONE. A live region is only announced when its contents
-    // change while it is ALREADY in the document. Rendering the region and its
-    // text together — the obvious one-liner — is missed by several screen
-    // readers, so the region has to outlive the advisory it carries. A unit
-    // with nothing to say is exactly the state a staffer is in just BEFORE
-    // typing the number that creates the conflict.
-    renderUnit({ ...BUNKED, sleeps: 3 })
+  it('has no live region on the capacity advisory (kindred#2379)', () => {
+    // Nobody here uses AT (frontend/CLAUDE.md "Accessibility — deliberately
+    // minimal"), so an aria-live announcement never reaches anyone. The
+    // visible text is the whole story now — asserted directly below.
+    const { container } = renderUnit(CONFLICTED)
 
-    const region = screen.getByRole('status', { name: 'Capacity advisory' })
-    expect(region).toBeInTheDocument()
-    expect(region).toHaveAttribute('aria-live', 'polite')
-    expect(region).toHaveTextContent('')
+    expect(container.querySelector('[role="status"]')).toBeNull()
+    expect(container.querySelector('[aria-live]')).toBeNull()
   })
 
-  it('announces the conflict rather than only drawing it', () => {
-    // Focus stays in the Sleeps field when this appears, so without a live
-    // region a screen-reader user is never told. The flag's whole job is to be
-    // noticed; drawing it in amber does that for one class of user only.
+  it('shows the conflict as soon as the form renders, not only after an edit', () => {
+    // Previously guaranteed by a live region announcing on mount; with no AT
+    // users (frontend/CLAUDE.md "Accessibility — deliberately minimal") the
+    // requirement is just that the visible text is there from the start.
     renderUnit(CONFLICTED)
 
-    expect(screen.getByRole('status', { name: 'Capacity advisory' })).toHaveTextContent(
-      'Beds account for 4, but sleeps says 8.'
-    )
-  })
-
-  it('announces the suggestion too', () => {
-    renderUnit({ ...BUNKED, sleeps: 0 })
-
-    expect(screen.getByRole('status', { name: 'Capacity advisory' })).toHaveTextContent(
-      /Suggested: sleeps 4/i
-    )
+    expect(screen.getByText('Beds account for 4, but sleeps says 8.')).toBeInTheDocument()
   })
 
   it('carries the conflict once, not as a second hidden copy', () => {
-    // The other obvious implementation is an sr-only duplicate beside the
-    // visible text. It makes anyone navigating the form linearly meet the same
-    // sentence twice, so the region WRAPS the visible text instead.
     renderUnit(CONFLICTED)
 
     expect(screen.getAllByText(/beds account for 4/i)).toHaveLength(1)
-  })
-
-  it('leaves the conflict readable on mount, not only when it changes', () => {
-    // A live region announces on CHANGE and never on mount. Hiding the visible
-    // text in favour of an sr-only announcement therefore reports an ALREADY
-    // conflicting unit to nobody — the staffer who opens the form rather than
-    // creating the conflict by typing gets silence and an invisible warning.
-    renderUnit(CONFLICTED)
-
-    const text = screen.getByText(/beds account for 4, but sleeps says 8/i)
-    expect(text).not.toHaveAttribute('aria-hidden')
-    expect(screen.getByRole('status', { name: 'Capacity advisory' })).toContainElement(text)
   })
 
   it('never shows the sheet capacity, which is not a corroborating number', () => {

--- a/frontend/src/components/admin/lodging/UnitAmenityFieldset.tsx
+++ b/frontend/src/components/admin/lodging/UnitAmenityFieldset.tsx
@@ -297,14 +297,10 @@ export function UnitAmenityFieldset({
           <option value="shareable">Two or more families may share</option>
           <option value="single_party">One family only</option>
         </select>
-        {/* ALWAYS MOUNTED, and wrapping the visible text rather than duplicating
-            it — the same two constraints `UnitCapacityFields` documents at
-            length for its own advisory. A live region is only announced when
-            its contents change while it is already in the document, so
-            rendering the region together with its text is missed by several
-            screen readers; and an sr-only second copy would be read twice by
-            anyone navigating the form linearly. */}
-        <div role="status" aria-live="polite" aria-label="Sharing advisory">
+        {/* No AT users here (frontend/CLAUDE.md "Accessibility —
+            deliberately minimal"), so this stays plain text — no
+            aria-live/role="status" (kindred#2379). */}
+        <div>
           {drift && (
             <p className="mt-1.5 text-xs text-amber-700 dark:text-amber-400">
               {`This is set to ${SHAREABILITY_WORDING[drift.stored]}, but the unit as edited reads ${SHAREABILITY_WORDING[drift.derived]}.`}

--- a/frontend/src/components/admin/lodging/UnitCapacityFields.tsx
+++ b/frontend/src/components/admin/lodging/UnitCapacityFields.tsx
@@ -114,27 +114,10 @@ export function UnitCapacityFields({
             onChange({ ...value, beds })
           }}
         />
-        {/* ALWAYS MOUNTED, and that is the whole point: a live region is only
-            announced when its contents change while it is ALREADY in the
-            document. Rendering the region together with its text — the obvious
-            one-liner — is missed by several screen readers, so this one has to
-            outlive the advisory it carries.
-
-            It WRAPS the visible text rather than duplicating it into an
-            sr-only copy. Two copies would be read twice by anyone navigating
-            the form linearly, and hiding the visible one is worse still: a
-            region announces on CHANGE, never on mount, so a form opened on an
-            existing conflict would then report it to nobody at all.
-
-            The button lives inside, which is the one compromise. Keeping it
-            out would mean breaking the text and its action onto separate rows;
-            the cost is that the announcement ends with the control's label. */}
-        {/* NAMED, because this form now has two live regions (the sharing
-            advisory in UnitAmenityFieldset is the other). Two unnamed `status`
-            regions are indistinguishable to a screen-reader user moving
-            between landmarks — the announcement arrives with no indication of
-            which control it belongs to. */}
-        <div role="status" aria-live="polite" aria-label="Capacity advisory">
+        {/* No AT users here (frontend/CLAUDE.md "Accessibility —
+            deliberately minimal"), so this stays plain text — no
+            aria-live/role="status" (kindred#2379). */}
+        <div>
           {flag.kind === 'suggestion' && (
             <div className="text-muted-foreground mt-1.5 flex items-center gap-2 text-xs">
               <span>Suggested: sleeps {flag.derived}</span>

--- a/frontend/src/components/weekend/FriendGroupActionBar.tsx
+++ b/frontend/src/components/weekend/FriendGroupActionBar.tsx
@@ -72,7 +72,17 @@ export interface FriendGroupActionBarProps {
   isAddingToGroup: boolean
 }
 
-/** A colour swatch as a real radio, so the palette is reachable without sight. */
+/**
+ * A colour swatch as a real radio behind a styled span.
+ *
+ * KEPT (kindred#2379): `sr-only` on the `<input>` hides its default browser
+ * radio rendering while the coloured `<span>` is the visible, clickable
+ * affordance — delete the class and a raw grey radio button appears next to
+ * every swatch. The `<span className="sr-only">` naming span is the input's
+ * only accessible name, which is also `WeekendFriendGroups.test.tsx`'s query
+ * handle (`getByRole('radio', { name: 'Indigo' })`) for its own copy of this
+ * pattern — kept here too, for the same reason and for consistency.
+ */
 function ColorSwatch({
   color,
   checked,
@@ -166,6 +176,9 @@ export function FriendGroupActionBar({
             <div className="bg-border h-6 w-px" aria-hidden="true" />
 
             <fieldset className="flex items-center gap-1.5">
+              {/* KEPT (kindred#2379): frontend/CLAUDE.md's own trap note
+                  groups `sr-only` on a `<legend>` with `<input>` as a native-
+                  control case, not AT scaffolding to sweep. */}
               <legend className="sr-only">Group colour</legend>
               {FRIEND_GROUP_COLORS.map((candidate) => (
                 <ColorSwatch

--- a/frontend/src/components/weekend/WeekendFriendGroups.tsx
+++ b/frontend/src/components/weekend/WeekendFriendGroups.tsx
@@ -353,9 +353,17 @@ function FriendGroupCard({
             className="bg-background focus:ring-primary/50 w-44 rounded-lg border px-3 py-1.5 text-sm focus:ring-2 focus:outline-none"
           />
           <fieldset className="flex items-center gap-1.5">
+            {/* KEPT (kindred#2379): frontend/CLAUDE.md's own trap note groups
+                `sr-only` on a `<legend>` with `<input>` as a native-control
+                case, not AT scaffolding to sweep. */}
             <legend className="sr-only">Group colour</legend>
             {FRIEND_GROUP_COLORS.map((candidate) => (
               <label key={candidate} className="cursor-pointer">
+                {/* KEPT (kindred#2379): a real native radio — `sr-only`
+                    hides its default browser rendering while the coloured
+                    span below is the visible, clickable affordance. Delete
+                    the class and a raw grey radio button appears next to
+                    every swatch. */}
                 <input
                   type="radio"
                   name={`friend-group-color-${group.group_id}`}
@@ -374,6 +382,9 @@ function FriendGroupCard({
                   )}
                   style={{ backgroundColor: candidate }}
                 />
+                {/* KEPT (kindred#2379): this is the radio's only accessible
+                    name and `WeekendFriendGroups.test.tsx`'s query handle —
+                    `within(card).getByRole('radio', { name: 'Indigo' })`. */}
                 <span className="sr-only">{FRIEND_GROUP_COLOR_NAMES[candidate] ?? candidate}</span>
               </label>
             ))}


### PR DESCRIPTION
## Summary

Deletes the remaining `aria-live`/`role="status"` AT-announcement scaffolding
and one genuine `sr-only` duplicate, per owner ruling: `frontend/CLAUDE.md`
§ "Accessibility — deliberately minimal" — three users, mouse and keyboard,
no AT and none planned. Where the tree contradicted the issue body, this PR
follows the tree and says so below.

## Part A — `role="status"`/`aria-live`

Deleted, visible text left untouched and verified with a new test each:

- `components/admin/lodging/UnitCapacityFields.tsx` — the "Capacity advisory"
  `role="status" aria-live="polite"` wrapper, plus its now-obsolete
  live-region rationale comment.
- `components/admin/lodging/UnitAmenityFieldset.tsx` — the "Sharing advisory"
  wrapper, same treatment.
- `components/SocialNetworkGraph.tsx` — `role="status"` on the graph's
  degrade banner (line moved to 841 from the issue's 830; four PRs landed on
  `main` since the issue was filed).

**Kept, deliberately deviating from the issue: `components/FullPageSpinner.tsx:4`.**
The issue named this line for deletion, but the tree disagrees with the
issue: this file's own regression test (added in kindred#2348, and still
present) documents `role="status"` as the deliberate query handle
`ProtectedRoute.test.tsx`, `AdminRoute.test.ts`, and
`RequirePermission.test.ts` use for "still loading" — three test files, four
assertions, all of them the *only* handle those tests have for this state.
This is exactly the "test's only query handle" case the same issue's own
MUST-NOT-TOUCH list protects. Added a comment on the component recording why,
so a future sweep doesn't re-open it.

## Part B — the 11 files still carrying `sr-only`

Read all 11. Only **4 files carry an actual `sr-only` className** — the
other 7 hits are prose comments (`Tooltip.tsx`, `FamilyCard.tsx`,
`LodgingBoard.tsx`, `LodgingMap.tsx`, plus the two lodging-advisory files
already touched in Part A) narrating *removed* `sr-only` text from prior PRs
(kindred#2219, kindred#2348) — nothing to delete there.

Of the 4 real sites (8 individual `className="sr-only"` occurrences):

| File | Kept/Deleted | Why |
|---|---|---|
| `admin/lodging/BedInventoryEditor.tsx` | **Deleted** | A standalone `<label className="sr-only" htmlFor="bed-type-picker">`, fully redundant with the adjacent `<select aria-label="Add a bed type">` — the `aria-label` alone already satisfies `getByLabelText('Add a bed type')` (7 call sites in `LodgingUnitForm.test.tsx`), confirmed by a new test and a mutation-check (temporarily restored the label, watched the new test fail, removed it again). |
| `MergeRequestsModal.tsx` | Kept | A real native radio hidden behind a styled card `<label>` — `frontend/CLAUDE.md`'s own trap note (`sr-only` on `<input>` is a visually-hidden native control). Deleting the class puts a raw grey radio next to the card. |
| `weekend/FriendGroupActionBar.tsx` (×3: input, name span, legend) | Kept | Same native-radio pattern as `MergeRequestsModal`, plus a `<legend>` — the trap note groups `<legend>` with `<input>` explicitly. |
| `weekend/WeekendFriendGroups.tsx` (×3: input, name span, legend) | Kept | Same pattern, second copy (not shared code). The name span here is also `WeekendFriendGroups.test.tsx`'s literal query handle: `within(card).getByRole('radio', { name: 'Indigo' })`. |

Every kept site now carries a one-line "KEPT (kindred#2379): ..." comment
explaining why, so the next sweep doesn't have to re-derive it.

**Net: 1 of 11 files had real scaffolding to delete.** The other 10 either
had nothing but prose mentioning a long-since-deleted announcement, or held
real native-control markup / test-query handles the issue's own policy
protects. The achievable win here was smaller than the issue's "11 files"
framing suggested — reported honestly rather than manufacturing scope.

## Part C — arrow-key handling

Narrowed the issue's ~15-file grep (which matched lucide `Arrow*` icon
imports and unrelated `tabIndex` hits) down to real
`onKeyDown` + `Arrow*` key handlers: 3 files.

- `weekend/PlaceFamilyPicker.tsx` — a real combobox/listbox typeahead
  (owner ruling, kindred#2080). Arrow-key navigation here is ordinary
  desktop keyboard behavior for a search-select, explicitly built for
  "pointer or keyboard" per its own doc comment — not AT scaffolding.
- `pipeline-debug/PipelineBatchList.tsx` — its `Arrow` grep hits are lucide
  sort-icon imports (`ArrowDown`/`ArrowUp`/`ArrowUpDown`), not keyboard
  handling. Its `onKeyDown` is Enter/Space on a clickable virtualized row —
  not arrow-key navigation, out of this issue's Part C scope.
- `BunkRequestRow.tsx` — same Enter/Space-on-clickable-div shape, no
  arrow-key handling. This *is* the `<div role="button" tabIndex={0}
  onKeyDown={…}>` → `<button>` simplification `frontend/CLAUDE.md`
  separately prefers, but that's a distinct, larger change (event
  propagation, native button styling) this issue didn't ask for — left
  alone rather than expanding scope.

**No roving-tabindex or arrow-key-navigation-as-AT-scaffionding found.**
Part C is a no-op in this PR, as the issue anticipated it might be.

## Verification

- `cd frontend && ./node_modules/.bin/vitest run` — 450 files, 6881 tests,
  all passing.
- `bash scripts/pre-push-verify.sh` — prettier/eslint/tsc/vitest all PASS.
- New tests added: a `role="status"`/`aria-live` absence check on the
  capacity advisory, a source-grep absence check on `SocialNetworkGraph`'s
  degrade banner, a visible-text-on-mount test replacing the deleted
  live-region assertions, and a query-handle test for the bed-type picker
  (mutation-checked).

Closes #2379.
