### PR TITLE
fix(sync): give wrapper sites a typed error to classify their own rejections

### DIFF
--- a/pocketbase/main_test_parallelism_test.go
+++ b/pocketbase/main_test_parallelism_test.go
@@ -105,7 +105,13 @@ var serialGroups = []struct {
 		// test needs for GetSeasonID() costs a t.Setenv.
 		pkg:    "sync",
 		reason: "t.Setenv: campminder.NewClient reads CAMPMINDER_PRIMARY_KEY",
-		tests:  []string{"TestAttendeesLogStatusChangeDryRunWritesNothing"},
+		tests: []string{
+			"TestAttendeesLogStatusChangeDryRunWritesNothing",
+			"TestProcessAssignment_MissingPersonID_IsRejected",
+			"TestProcessAssignment_SaveFailure_IsInfraError",
+			"TestProcessEnrollment_MissingSessionID_IsRejected",
+			"TestProcessEnrollment_SaveFailure_IsInfraError",
+		},
 	},
 	{
 		// These four drive deleteOrphans, which reads the season through

--- a/pocketbase/sync/attendees.go
+++ b/pocketbase/sync/attendees.go
@@ -3,6 +3,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -209,25 +210,34 @@ func (s *AttendeesSync) processAttendee(
 		}
 
 		if err := s.processEnrollment(personCMID, enrollment, existingAttendees); err != nil {
-			// duplicateSessions is keyed by SessionID and holds every entry that shares a
-			// SessionID with another entry in this attendee's array — first, second, or
-			// later; it doesn't identify which one is "the duplicate". So this only tells
-			// us the group fact: this SessionID appears more than once. A (person, session)
-			// key collision — overwriting the first entry on an idempotent upsert, or, on a
-			// first-ever sync before existingAttendees has an entry for the key, taking the
-			// create branch and hitting idx_attendees_unique — is one plausible cause of
-			// this failure, but not the only one; this entry could equally be failing for a
-			// reason unrelated to the collision. Tag it so the possible collision is legible
-			// in the logs rather than the error reading as an unexplained local DB fault.
-			if sessionIDFloat, ok := enrollment["SessionID"].(float64); ok &&
+			// processEnrollment now distinguishes its two failure classes with
+			// errRejectedRecord (kindred#2292): a malformed enrollment (e.g. a
+			// missing SessionID) never reaches App.Save, so the idx_attendees_unique
+			// collision diagnostic below -- which is specifically about a DB write
+			// colliding -- only applies to the non-rejection branch.
+			if errors.Is(err, errRejectedRecord) {
+				slog.Warn("Rejected enrollment", "person_cm_id", personCMID, "error", err)
+				s.Stats.Rejected++
+			} else if sessionIDFloat, ok := enrollment["SessionID"].(float64); ok &&
 				duplicateSessions[int(sessionIDFloat)] != nil {
+				// duplicateSessions is keyed by SessionID and holds every entry that shares a
+				// SessionID with another entry in this attendee's array — first, second, or
+				// later; it doesn't identify which one is "the duplicate". So this only tells
+				// us the group fact: this SessionID appears more than once. A (person, session)
+				// key collision — overwriting the first entry on an idempotent upsert, or, on a
+				// first-ever sync before existingAttendees has an entry for the key, taking the
+				// create branch and hitting idx_attendees_unique — is one plausible cause of
+				// this failure, but not the only one; this entry could equally be failing for a
+				// reason unrelated to the collision. Tag it so the possible collision is legible
+				// in the logs rather than the error reading as an unexplained local DB fault.
 				slog.Error("Error processing enrollment (this SessionID appears more than "+
 					"once in this attendee's SessionProgramStatus — see kindred#2263)",
 					"person_cm_id", personCMID, "session_cm_id", int(sessionIDFloat), "error", err)
+				s.Stats.Errors++
 			} else {
 				slog.Error("Error processing enrollment", "person_cm_id", personCMID, "error", err)
+				s.Stats.Errors++
 			}
-			s.Stats.Errors++
 		}
 	}
 
@@ -294,7 +304,7 @@ func (s *AttendeesSync) processEnrollment(
 	// Extract session ID
 	sessionID, ok := enrollment["SessionID"].(float64)
 	if !ok {
-		return fmt.Errorf("invalid or missing SessionID")
+		return fmt.Errorf("%w: invalid or missing SessionID", errRejectedRecord)
 	}
 	sessionCMID := int(sessionID)
 

--- a/pocketbase/sync/base_sync.go
+++ b/pocketbase/sync/base_sync.go
@@ -4,6 +4,7 @@ package sync
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"reflect"
@@ -14,6 +15,20 @@ import (
 	"github.com/camp/kindred/pocketbase/campminder"
 	"github.com/pocketbase/pocketbase/core"
 )
+
+// errRejectedRecord is the sentinel kindred#2292 gives to wrapper functions whose
+// callee can fail two different ways -- a per-record transform rejection
+// (malformed or missing upstream data) or an infrastructure failure (a local
+// App.Save/App.Delete that did not complete) -- through the same `error` return.
+//
+// A wrapper marks a rejection by wrapping this sentinel: `fmt.Errorf("%w: reason",
+// errRejectedRecord)`. Its call site then branches on `errors.Is(err,
+// errRejectedRecord)` to choose Stats.Rejected (warn-only, kindred#2284/#2295) over
+// Stats.Errors (zero tolerance). An error that reaches the call site WITHOUT this
+// sentinel is always infrastructure -- that is the default, not an opt-in -- so a
+// wrapper that adds a new failure path is safe by construction unless it
+// deliberately wraps errRejectedRecord.
+var errRejectedRecord = errors.New("record rejected")
 
 // RelationConfig defines configuration for populating a relation field
 type RelationConfig struct {
@@ -669,10 +684,17 @@ func (b *BaseSyncService) ProcessSimpleRecord(
 	existingRecords map[any]*core.Record,
 	compareFields []string, // Optional: specific fields to check for updates
 ) error {
-	// Extract year from recordData - required for year isolation
+	// Extract year from recordData - required for year isolation. A missing or
+	// malformed year means recordData itself is malformed -- a rejection, not an
+	// infrastructure failure -- so it's wrapped in errRejectedRecord for the call
+	// site (kindred#2292). Every one of ProcessSimpleRecord's five callers builds
+	// "year" locally from s.Client.GetSeasonID(), never from raw upstream data, so
+	// this path is defensive today rather than reachable; it is typed correctly
+	// regardless, for the same reason a function's error return is not scoped to
+	// what its current callers happen to pass.
 	yearValue, ok := recordData["year"]
 	if !ok {
-		return fmt.Errorf("recordData missing required 'year' field")
+		return fmt.Errorf("%w: recordData missing required 'year' field", errRejectedRecord)
 	}
 
 	var year int
@@ -682,7 +704,7 @@ func (b *BaseSyncService) ProcessSimpleRecord(
 	case int:
 		year = v
 	default:
-		return fmt.Errorf("'year' field must be numeric, got %T", yearValue)
+		return fmt.Errorf("%w: 'year' field must be numeric, got %T", errRejectedRecord, yearValue)
 	}
 
 	// Use composite key for lookup to ensure year isolation
@@ -913,7 +935,12 @@ func (b *BaseSyncService) ProcessCompositeRecord(
 	existingRecords map[string]*core.Record,
 	skipFields []string, // Fields to skip during comparison (like "year" for idempotency)
 ) error {
-	// Extract year from recordData - required for year isolation
+	// Extract year from recordData - required for year isolation. Deliberately
+	// NOT wrapped in errRejectedRecord: ProcessCompositeRecord is not one of
+	// kindred#2292's five named mixed wrappers (processEnrollment and
+	// processAssignment are, and both call this as their final write step), so
+	// this stays out of scope for this issue and keeps its pre-existing
+	// classification (Errors).
 	yearValue, ok := recordData["year"]
 	if !ok {
 		return fmt.Errorf("recordData missing required 'year' field")

--- a/pocketbase/sync/bunk_assignments.go
+++ b/pocketbase/sync/bunk_assignments.go
@@ -3,6 +3,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -215,8 +216,13 @@ func (s *BunkAssignmentsSync) Sync(ctx context.Context) error {
 				assignmentData["SessionID"] = float64(sessionID)
 
 				if err := s.processAssignment(assignmentData, existingAssignments); err != nil {
-					slog.Error("Error processing assignment", "error", err)
-					s.Stats.Errors++
+					if errors.Is(err, errRejectedRecord) {
+						slog.Warn("Rejected assignment", "error", err)
+						s.Stats.Rejected++
+					} else {
+						slog.Error("Error processing assignment", "error", err)
+						s.Stats.Errors++
+					}
 				}
 			}
 		}
@@ -565,25 +571,26 @@ func (s *BunkAssignmentsSync) processAssignment(
 	assignmentData map[string]any,
 	existingAssignments map[string]*core.Record,
 ) error {
-	// Extract required fields
+	// Extract required fields. A missing field here is malformed upstream data,
+	// not an infrastructure failure -- kindred#2292.
 	personID, ok := assignmentData["PersonID"].(float64)
 	if !ok {
-		return fmt.Errorf("missing PersonID")
+		return fmt.Errorf("%w: missing PersonID", errRejectedRecord)
 	}
 
 	sessionID, ok := assignmentData["SessionID"].(float64)
 	if !ok {
-		return fmt.Errorf("missing SessionID")
+		return fmt.Errorf("%w: missing SessionID", errRejectedRecord)
 	}
 
 	bunkID, ok := assignmentData["BunkID"].(float64)
 	if !ok {
-		return fmt.Errorf("missing BunkID")
+		return fmt.Errorf("%w: missing BunkID", errRejectedRecord)
 	}
 
 	bunkPlanID, ok := assignmentData["BunkPlanID"].(float64)
 	if !ok {
-		return fmt.Errorf("missing BunkPlanID")
+		return fmt.Errorf("%w: missing BunkPlanID", errRejectedRecord)
 	}
 
 	personCMID := int(personID)

--- a/pocketbase/sync/bunk_requests.go
+++ b/pocketbase/sync/bunk_requests.go
@@ -326,6 +326,18 @@ func findOrphanedPersonIDs(csvPersonIDs map[int]bool, existingOBRPersonIDs []int
 // Called after CSV sync to clean up data from campers who have cancelled/unenrolled.
 // Returns the set of OBR person cm_ids (post-purge) for use by the zombie BR sweep.
 func (s *BunkRequestsSync) purgeOrphanedRequests(year int) (map[int]bool, error) {
+	// This sweep is hand-rolled rather than routed through
+	// BaseSyncService.DeleteOrphansGuarded, so it does not pick up
+	// OrphanSweepGuard's Rejected arm for free -- orphan_guard.go's own doc
+	// warns this is exactly the gap a hand-rolled sweep falls into. A row
+	// this run's processRow rejected (kindred#2292) never reaches
+	// s.csvPersonIDs, which makes its still-current requester look identical
+	// to one who genuinely cancelled. Skip explicitly rather than purge on an
+	// incomplete set (kindred#2295's precondition, applied by hand here).
+	if s.skipSweepForRejections("bunk_requests", nil) {
+		return nil, nil
+	}
+
 	if len(s.csvPersonIDs) == 0 {
 		slog.Info("No CSV persons tracked, skipping orphan purge")
 		return nil, nil

--- a/pocketbase/sync/bunk_requests.go
+++ b/pocketbase/sync/bunk_requests.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5" //nolint:gosec // G501: MD5 used for change detection, not security
 	"encoding/csv"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -138,8 +139,13 @@ func (s *BunkRequestsSync) RunSync(csvPath string, _ int) error {
 
 		// Process row
 		if rowErr := s.processRow(row, columnIndex, currentYear); rowErr != nil {
-			slog.Error("Error processing row", "row", rowNumber, "error", rowErr)
-			s.Stats.Errors++
+			if errors.Is(rowErr, errRejectedRecord) {
+				slog.Warn("Rejected bunk request row", "row", rowNumber, "error", rowErr)
+				s.Stats.Rejected++
+			} else {
+				slog.Error("Error processing row", "row", rowNumber, "error", rowErr)
+				s.Stats.Errors++
+			}
 		}
 	}
 
@@ -202,15 +208,16 @@ func (s *BunkRequestsSync) loadValidPersonIDs() error {
 
 // processRow processes a single CSV row
 func (s *BunkRequestsSync) processRow(row []string, columnIndex map[string]int, year int) error {
-	// Extract PersonID
+	// Extract PersonID. A missing or malformed value here is a bad CSV row, not
+	// an infrastructure failure -- kindred#2292.
 	personIDStr := s.getColumn(row, columnIndex, "PersonID")
 	if personIDStr == "" {
-		return fmt.Errorf("missing PersonID")
+		return fmt.Errorf("%w: missing PersonID", errRejectedRecord)
 	}
 
 	personID, err := strconv.Atoi(personIDStr)
 	if err != nil {
-		return fmt.Errorf("invalid PersonID: %s", personIDStr)
+		return fmt.Errorf("%w: invalid PersonID: %s", errRejectedRecord, personIDStr)
 	}
 
 	// Validate person is enrolled and get their PocketBase ID

--- a/pocketbase/sync/bunk_requests_rejection_sweep_test.go
+++ b/pocketbase/sync/bunk_requests_rejection_sweep_test.go
@@ -1,0 +1,146 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+)
+
+// This file pins the kindred#2295 safety precondition against
+// BunkRequestsSync's two hand-rolled sweeps.
+//
+// purgeOrphanedRequests / purgeZombieBRs predate kindred#2292 and were never
+// migrated onto BaseSyncService.DeleteOrphansGuarded, so they never picked up
+// OrphanSweepGuard's Rejected arm. Before #2292, a malformed CSV row bumped
+// Stats.Errors, which fails the whole run via applyCompletionStatus -- so an
+// operator saw the deletion. #2292 reclassifies that same row into
+// Stats.Rejected (warn-only, deliberately absent from applyCompletionStatus),
+// which means the same person's real, still-valid original_bunk_requests rows
+// now get silently purged as "orphaned" (their PersonID never made it into
+// s.csvPersonIDs) and the run reports success. orphan_guard.go's own doc
+// predicted exactly this: "a future reclassification into one of [the
+// hand-rolled sweeps] gets ... no rejection protection and no warning."
+
+// newBunkRequestsPurgeTestApp builds persons + a real relation-typed
+// original_bunk_requests.requester (unlike newBunkRequestsTestApp's plain
+// TextField, which purgeOrphanedRequests' ExpandedOne("requester") can't
+// read) + bunk_requests, the three collections the two sweeps touch.
+func newBunkRequestsPurgeTestApp(t *testing.T) core.App {
+	t.Helper()
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	persons := core.NewBaseCollection("persons")
+	persons.Fields.Add(&core.NumberField{Name: "cm_id"})
+	if saveErr := app.Save(persons); saveErr != nil {
+		t.Fatalf("save persons: %v", saveErr)
+	}
+
+	obr := core.NewBaseCollection("original_bunk_requests")
+	obr.Fields.Add(&core.RelationField{Name: "requester", CollectionId: persons.Id, MaxSelect: 1})
+	obr.Fields.Add(&core.NumberField{Name: "year"})
+	obr.Fields.Add(&core.TextField{Name: "field"})
+	obr.Fields.Add(&core.TextField{Name: "content"})
+	if saveErr := app.Save(obr); saveErr != nil {
+		t.Fatalf("save original_bunk_requests: %v", saveErr)
+	}
+
+	brs := core.NewBaseCollection("bunk_requests")
+	brs.Fields.Add(&core.NumberField{Name: "requester_id"})
+	brs.Fields.Add(&core.NumberField{Name: "year"})
+	if saveErr := app.Save(brs); saveErr != nil {
+		t.Fatalf("save bunk_requests: %v", saveErr)
+	}
+
+	return app
+}
+
+// seedOBR writes one original_bunk_requests row for personCMID, relating it
+// to a freshly created persons row.
+func seedOBR(t *testing.T, app core.App, personCMID, year int) {
+	t.Helper()
+
+	personsCol, err := app.FindCollectionByNameOrId("persons")
+	if err != nil {
+		t.Fatalf("find persons: %v", err)
+	}
+	person := core.NewRecord(personsCol)
+	person.Set("cm_id", personCMID)
+	if saveErr := app.Save(person); saveErr != nil {
+		t.Fatalf("seed person %d: %v", personCMID, saveErr)
+	}
+
+	obrCol, err := app.FindCollectionByNameOrId("original_bunk_requests")
+	if err != nil {
+		t.Fatalf("find original_bunk_requests: %v", err)
+	}
+	obr := core.NewRecord(obrCol)
+	obr.Set("requester", person.Id)
+	obr.Set("year", year)
+	obr.Set("field", "bunk_request_form")
+	obr.Set("content", "wants to bunk with Olivia Martinez")
+	if saveErr := app.Save(obr); saveErr != nil {
+		t.Fatalf("seed OBR for person %d: %v", personCMID, saveErr)
+	}
+}
+
+// TestPurgeOrphanedRequests_SkipsWhenRunHadRejections is the failing-first
+// test for the fix: a run that rejected at least one CSV row must not treat
+// that row's absence from csvPersonIDs as proof the person left camp.
+func TestPurgeOrphanedRequests_SkipsWhenRunHadRejections(t *testing.T) {
+	t.Parallel()
+
+	app := newBunkRequestsPurgeTestApp(t)
+	seedOBR(t, app, 9001, 2026)
+
+	s := NewBunkRequestsSync(app, nil)
+	// 9001's row is real and current, but its own CSV row was rejected this run
+	// (e.g. an Excel-mangled PersonID cell), so it never reached csvPersonIDs --
+	// even though other rows in the same CSV processed fine (9002).
+	s.csvPersonIDs = map[int]bool{9002: true}
+	s.Stats.Rejected = 1
+
+	if _, err := s.purgeOrphanedRequests(2026); err != nil {
+		t.Fatalf("purgeOrphanedRequests: %v", err)
+	}
+
+	rows, findErr := app.FindRecordsByFilter("original_bunk_requests", "", "", 0, 0)
+	if findErr != nil {
+		t.Fatalf("re-query OBRs: %v", findErr)
+	}
+	if len(rows) != 1 {
+		t.Errorf("purgeOrphanedRequests deleted the row of a run that had rejections: got %d OBRs, want 1", len(rows))
+	}
+}
+
+// TestPurgeOrphanedRequests_StillPurgesWithoutRejections is the regression
+// guard: a clean run (Rejected == 0) with a genuinely orphaned person must
+// still purge, so the fix cannot be a blanket "never delete".
+func TestPurgeOrphanedRequests_StillPurgesWithoutRejections(t *testing.T) {
+	t.Parallel()
+
+	app := newBunkRequestsPurgeTestApp(t)
+	seedOBR(t, app, 9001, 2026)
+
+	s := NewBunkRequestsSync(app, nil)
+	// 9001 genuinely absent from this year's CSV; 9002 is present so the
+	// pre-existing "empty CSV" fresh-deploy guard doesn't also explain a pass.
+	s.csvPersonIDs = map[int]bool{9002: true}
+	s.Stats.Rejected = 0
+
+	if _, err := s.purgeOrphanedRequests(2026); err != nil {
+		t.Fatalf("purgeOrphanedRequests: %v", err)
+	}
+
+	rows, findErr := app.FindRecordsByFilter("original_bunk_requests", "", "", 0, 0)
+	if findErr != nil {
+		t.Fatalf("re-query OBRs: %v", findErr)
+	}
+	if len(rows) != 0 {
+		t.Errorf("a clean run's genuine orphan survived: got %d OBRs, want 0", len(rows))
+	}
+}

--- a/pocketbase/sync/bunks.go
+++ b/pocketbase/sync/bunks.go
@@ -3,6 +3,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -112,8 +113,13 @@ func (s *BunksSync) Sync(ctx context.Context) error {
 		// Process the record - specify fields to compare (excluding year for idempotency)
 		compareFields := []string{"cm_id", "name", "gender", "is_active", "sort_order", "area_id"}
 		if err := s.ProcessSimpleRecord("bunks", key, pbData, existingRecords, compareFields); err != nil {
-			slog.Error("Error processing bunk", "error", err)
-			s.Stats.Errors++
+			if errors.Is(err, errRejectedRecord) {
+				slog.Warn("Rejected bunk", "error", err)
+				s.Stats.Rejected++
+			} else {
+				slog.Error("Error processing bunk", "error", err)
+				s.Stats.Errors++
+			}
 		}
 	}
 

--- a/pocketbase/sync/financial_transactions.go
+++ b/pocketbase/sync/financial_transactions.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -152,8 +153,13 @@ func (s *FinancialTransactionsSync) SyncForYear(ctx context.Context, year int) e
 		err = s.ProcessSimpleRecord(
 			"financial_transactions", txnKey, pbData, existingRecords, compareFields)
 		if err != nil {
-			slog.Error("Error processing transaction", "cm_id", cmID, "amount", amount, "error", err)
-			s.Stats.Errors++
+			if errors.Is(err, errRejectedRecord) {
+				slog.Warn("Rejected transaction", "cm_id", cmID, "amount", amount, "error", err)
+				s.Stats.Rejected++
+			} else {
+				slog.Error("Error processing transaction", "cm_id", cmID, "amount", amount, "error", err)
+				s.Stats.Errors++
+			}
 		}
 	}
 

--- a/pocketbase/sync/persons.go
+++ b/pocketbase/sync/persons.go
@@ -4,6 +4,7 @@ package sync
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -344,8 +345,13 @@ func (s *PersonsSync) processBatchPersons(
 		isCamper := hasID && camperIDsSet[int(personID)]
 
 		if err := s.processPerson(personData, isCamper, existingPersons, tagDefsByName, divisionsByID, year); err != nil {
-			slog.Error("Error processing person", "error", err)
-			s.Stats.Errors++
+			if errors.Is(err, errRejectedRecord) {
+				slog.Warn("Rejected person", "error", err)
+				s.Stats.Rejected++
+			} else {
+				slog.Error("Error processing person", "error", err)
+				s.Stats.Errors++
+			}
 		}
 
 		batchHouseholds := s.extractUniqueHouseholds([]map[string]any{personData})
@@ -490,10 +496,11 @@ func (s *PersonsSync) processPerson(
 	// Remove temporary field
 	delete(pbData, "division_cm_id")
 
-	// Get person ID
+	// Get person ID. Missing here is malformed upstream data, not an
+	// infrastructure failure -- kindred#2292.
 	personID, ok := personData["ID"].(float64)
 	if !ok {
-		return fmt.Errorf("missing person ID")
+		return fmt.Errorf("%w: missing person ID", errRejectedRecord)
 	}
 	personIDInt := int(personID)
 
@@ -1169,7 +1176,9 @@ func (s *PersonsSync) updateAttendeeRelations(year int) error {
 	}
 
 	updated := 0
-	errors := 0
+	// Named errCount, not errors -- kindred#2292 added the errors package import to
+	// this file, and gocritic's importShadow flags a local var shadowing it.
+	errCount := 0
 	for _, attendee := range records {
 		personCMID, _ := attendee.Get("person_id").(float64)
 		if personCMID > 0 {
@@ -1184,7 +1193,7 @@ func (s *PersonsSync) updateAttendeeRelations(year int) error {
 				}
 				if err := s.App.Save(attendee); err != nil {
 					slog.Error("Error updating attendee relation", "personCMID", int(personCMID), "error", err)
-					errors++
+					errCount++
 				} else {
 					updated++
 				}
@@ -1192,7 +1201,7 @@ func (s *PersonsSync) updateAttendeeRelations(year int) error {
 		}
 	}
 
-	slog.Info("Updated attendee person relations", "updated", updated, "errors", errors)
+	slog.Info("Updated attendee person relations", "updated", updated, "errors", errCount)
 	return nil
 }
 

--- a/pocketbase/sync/rejection_sites_test.go
+++ b/pocketbase/sync/rejection_sites_test.go
@@ -47,21 +47,42 @@ type rejectSite struct {
 //     SQLite operations that did not complete: infrastructure, zero tolerance.
 //   - household_demographics.go's sweep refusal -- a refusal is not a counted
 //     failure at all; kindred#2283 moves it onto the returned-error channel.
-//   - wrapper sites whose callee returns both a transform rejection and an
-//     App.Save error through one return value, so the call site cannot tell them
-//     apart: processEnrollment (attendees.go), processAssignment
-//     (bunk_assignments.go), processRow (bunk_requests.go), processPerson
-//     (persons.go) and ProcessSimpleRecord (base_sync.go). They stay loud until
-//     kindred#2292 gives them typed errors. processAttendee is NOT one of them,
-//     despite an earlier revision of this comment saying so: it returns only
-//     `invalid or missing PersonID` or nil, counting and swallowing
-//     processEnrollment's errors itself, so its call site is a pure rejection
-//     that needs no sentinel.
+//   - processAttendee (attendees.go) is NOT a mixed wrapper, despite an earlier
+//     revision of this comment saying so: it returns only `invalid or missing
+//     PersonID` or nil, counting and swallowing processEnrollment's errors
+//     itself, so its call site is a pure rejection that needs no sentinel.
+//
+// kindred#2292 gave the five wrapper sites whose callee could return EITHER a
+// transform rejection or an App.Save error through one return value --
+// processEnrollment (attendees.go), processAssignment (bunk_assignments.go),
+// processRow (bunk_requests.go), processPerson (persons.go), and
+// ProcessSimpleRecord (base_sync.go, reached by five call sites: bunks.go,
+// financial_transactions.go, session_groups.go, staff.go, sessions.go) -- a
+// shared sentinel, errRejectedRecord. Each wrapper wraps it on its own
+// pre-App.Save validation paths only; every App.Save/FindCollectionByNameOrId
+// failure inside them stays unwrapped and therefore Errors. Their call sites
+// branch on errors.Is(err, errRejectedRecord), which is why their "Rejected ..."
+// messages below are new entries rather than reclassified old ones.
 func expectedRejectSites() []rejectSite {
 	return []rejectSite{
+		// kindred#2292: processEnrollment's sentinel-wrapped validation failure,
+		// reported at its call site in processAttendee.
+		{"attendees.go", "Rejected enrollment"},
+		// kindred#2292: processAssignment's sentinel-wrapped validation failures,
+		// reported at its call site in Sync.
+		{"bunk_assignments.go", "Rejected assignment"},
+		// kindred#2292: processRow's sentinel-wrapped validation failures,
+		// reported at its call site in RunSync.
+		{"bunk_requests.go", "Rejected bunk request row"},
 		{"bunks.go", "Error transforming bunk"},
 		{"bunks.go", "Invalid bunk ID type"},
 		{"bunks.go", "Invalid year type in pbData"},
+		// kindred#2292: ProcessSimpleRecord's sentinel-wrapped year validation,
+		// reported at its call site in Sync. Defensive today -- bunks.go always
+		// builds "year" as a valid int before calling in -- but typed correctly
+		// regardless of what current callers happen to pass (base_sync.go's
+		// errRejectedRecord doc comment explains why).
+		{"bunks.go", "Rejected bunk"},
 		{"custom_field_definitions.go", "Error transforming custom field definition"},
 		{"custom_field_definitions.go", "Invalid custom field definition cm_id"},
 		{"divisions.go", "Error transforming division"},
@@ -72,6 +93,10 @@ func expectedRejectSites() []rejectSite {
 		{"financial_lookups.go", "Invalid payment method cm_id"},
 		{"financial_transactions.go", "Error transforming transaction"},
 		{"financial_transactions.go", "Invalid transaction cm_id"},
+		// kindred#2292: ProcessSimpleRecord's sentinel-wrapped year validation,
+		// reported at its call site in SyncForYear. See the "Rejected bunk" note
+		// above.
+		{"financial_transactions.go", "Rejected transaction"},
 		{"household_custom_field_values.go", "Invalid or missing field id in custom field value"},
 		{"person_custom_field_values.go", "Invalid or missing field id in custom field value"},
 		// kindred#2270: a second API entry for a (person|household, field_definition, year)
@@ -85,12 +110,25 @@ func expectedRejectSites() []rejectSite {
 		{"person_tag_definitions.go", "Error transforming person tag definition"},
 		{"person_tag_definitions.go", "Invalid person tag definition name"},
 		{"persons.go", "Error transforming household"},
+		// kindred#2292: processPerson's sentinel-wrapped validation failure,
+		// reported at its call site in processBatchPersons.
+		{"persons.go", "Rejected person"},
 		{"session_groups.go", "Error transforming session group"},
 		{"session_groups.go", "Invalid session group ID type"},
+		// kindred#2292: ProcessSimpleRecord's sentinel-wrapped year validation,
+		// reported at its call site in Sync. See the "Rejected bunk" note above.
+		{"session_groups.go", "Rejected session group"},
 		{"sessions.go", "Error transforming session"},
 		{"sessions.go", "Invalid session ID type"},
 		{"sessions.go", "Invalid year type in pbData"},
+		// kindred#2292: ProcessSimpleRecord's sentinel-wrapped year validation,
+		// reported at its call site in Sync. See the "Rejected bunk" note above.
+		{"sessions.go", "Rejected session"},
 		{"staff.go", "Error transforming staff record"},
+		// kindred#2292: ProcessSimpleRecord's sentinel-wrapped year validation,
+		// reported at its call site in syncStaff. See the "Rejected bunk" note
+		// above.
+		{"staff.go", "Rejected staff record"},
 		// The three kindred#2295 additions. Their `Error transforming ...` siblings
 		// three lines up were reclassified in the first pass and these were missed,
 		// even though they are the same per-record validation failure -- and the

--- a/pocketbase/sync/rejection_wrapper_test.go
+++ b/pocketbase/sync/rejection_wrapper_test.go
@@ -1,0 +1,407 @@
+package sync
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+
+	"github.com/camp/kindred/pocketbase/campminder"
+)
+
+// The tests in this file pin kindred#2292: the five wrapper functions whose
+// callee returns both a transform rejection and an infrastructure (App.Save)
+// error through one return value now distinguish them with errRejectedRecord,
+// so the call site's errors.Is check routes to the right Stats counter.
+//
+// Each wrapper gets two cases: a malformed-input case that must return an error
+// satisfying errors.Is(err, errRejectedRecord), and a valid-input-but-failed-save
+// case (via failingSaveApp) that must return an error that does NOT satisfy it.
+// That is the classification the call site's errors.Is branch depends on --
+// rejection_sites_test.go's structural census then pins that each call site
+// routes the right literal message to the right counter.
+
+// failingSaveApp wraps a core.App and fails every App.Save for one named
+// collection, delegating everything else. Models an infrastructure (SQLite)
+// failure the way flakyCollectionApp models one for FindRecordsByFilter.
+type failingSaveApp struct {
+	core.App
+	collection string
+}
+
+func (a *failingSaveApp) Save(model core.Model) error {
+	if record, ok := model.(*core.Record); ok && record.Collection().Name == a.collection {
+		return fmt.Errorf("simulated save failure for %s", a.collection)
+	}
+	if err := a.App.Save(model); err != nil {
+		return fmt.Errorf("delegating Save: %w", err)
+	}
+	return nil
+}
+
+// newRejectionTestClient returns a real *campminder.Client -- GetSeasonID is a
+// pure getter, so a fake key is sufficient, matching attendees_dryrun_test.go.
+func newRejectionTestClient(t *testing.T) *campminder.Client {
+	t.Helper()
+	t.Setenv("CAMPMINDER_PRIMARY_KEY", "test-subscription-key")
+	client, err := campminder.NewClient(&campminder.Config{APIKey: "test-key", ClientID: "test-client", SeasonID: 2026})
+	if err != nil {
+		t.Fatalf("campminder.NewClient: %v", err)
+	}
+	return client
+}
+
+func assertRejected(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("got nil error, want an error wrapping errRejectedRecord")
+	}
+	if !errors.Is(err, errRejectedRecord) {
+		t.Errorf("err = %v, want errors.Is(err, errRejectedRecord) == true", err)
+	}
+}
+
+func assertInfraError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("got nil error, want a non-rejection error")
+	}
+	if errors.Is(err, errRejectedRecord) {
+		t.Errorf("err = %v, want errors.Is(err, errRejectedRecord) == false", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// processEnrollment (attendees.go)
+// ---------------------------------------------------------------------------
+
+func newAttendeesTestApp(t *testing.T) core.App {
+	t.Helper()
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	sessions := core.NewBaseCollection("camp_sessions")
+	sessions.Fields.Add(&core.NumberField{Name: "cm_id"})
+	sessions.Fields.Add(&core.NumberField{Name: "year"})
+	if saveErr := app.Save(sessions); saveErr != nil {
+		t.Fatalf("save camp_sessions: %v", saveErr)
+	}
+
+	persons := core.NewBaseCollection("persons")
+	persons.Fields.Add(&core.NumberField{Name: "cm_id"})
+	persons.Fields.Add(&core.NumberField{Name: "year"})
+	if saveErr := app.Save(persons); saveErr != nil {
+		t.Fatalf("save persons: %v", saveErr)
+	}
+
+	attendees := core.NewBaseCollection("attendees")
+	attendees.Fields.Add(&core.NumberField{Name: "person_id"})
+	attendees.Fields.Add(&core.TextField{Name: "status"})
+	attendees.Fields.Add(&core.NumberField{Name: "status_id"})
+	attendees.Fields.Add(&core.TextField{Name: "enrollment_date"})
+	attendees.Fields.Add(&core.TextField{Name: "effective_date"})
+	attendees.Fields.Add(&core.TextField{Name: "last_updated_utc"})
+	attendees.Fields.Add(&core.NumberField{Name: "year"})
+	attendees.Fields.Add(&core.TextField{Name: "session"})
+	attendees.Fields.Add(&core.TextField{Name: "person"})
+	if saveErr := app.Save(attendees); saveErr != nil {
+		t.Fatalf("save attendees: %v", saveErr)
+	}
+
+	return app
+}
+
+func TestProcessEnrollment_MissingSessionID_IsRejected(t *testing.T) {
+	app := newAttendeesTestApp(t)
+	s := NewAttendeesSync(app, newRejectionTestClient(t))
+
+	err := s.processEnrollment(9001, map[string]any{}, map[string]*core.Record{})
+	assertRejected(t, err)
+}
+
+func TestProcessEnrollment_SaveFailure_IsInfraError(t *testing.T) {
+	app := newAttendeesTestApp(t)
+
+	// Seed a session and a person so PopulateRelations succeeds.
+	sessionsCol, err := app.FindCollectionByNameOrId("camp_sessions")
+	if err != nil {
+		t.Fatalf("find camp_sessions: %v", err)
+	}
+	sessionRec := core.NewRecord(sessionsCol)
+	sessionRec.Set("cm_id", 501)
+	sessionRec.Set("year", 2026)
+	if saveErr := app.Save(sessionRec); saveErr != nil {
+		t.Fatalf("seed session: %v", saveErr)
+	}
+
+	personsCol, err := app.FindCollectionByNameOrId("persons")
+	if err != nil {
+		t.Fatalf("find persons: %v", err)
+	}
+	personRec := core.NewRecord(personsCol)
+	personRec.Set("cm_id", 9001)
+	personRec.Set("year", 2026)
+	if saveErr := app.Save(personRec); saveErr != nil {
+		t.Fatalf("seed person: %v", saveErr)
+	}
+
+	failing := &failingSaveApp{App: app, collection: "attendees"}
+	s := NewAttendeesSync(failing, newRejectionTestClient(t))
+	s.sessionCMIDs = map[string]bool{"501": true}
+
+	enrollment := map[string]any{"SessionID": float64(501), "StatusID": float64(2)}
+	err = s.processEnrollment(9001, enrollment, map[string]*core.Record{})
+	assertInfraError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// processAssignment (bunk_assignments.go)
+// ---------------------------------------------------------------------------
+
+func newBunkAssignmentsTestApp(t *testing.T) core.App {
+	t.Helper()
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	for _, name := range []string{"persons", "camp_sessions", "bunks"} {
+		col := core.NewBaseCollection(name)
+		col.Fields.Add(&core.NumberField{Name: "cm_id"})
+		col.Fields.Add(&core.NumberField{Name: "year"})
+		if saveErr := app.Save(col); saveErr != nil {
+			t.Fatalf("save %s: %v", name, saveErr)
+		}
+	}
+
+	assignments := core.NewBaseCollection("bunk_assignments")
+	assignments.Fields.Add(&core.NumberField{Name: "year"})
+	assignments.Fields.Add(&core.NumberField{Name: "cm_id"})
+	assignments.Fields.Add(&core.TextField{Name: "person"})
+	assignments.Fields.Add(&core.TextField{Name: "session"})
+	assignments.Fields.Add(&core.TextField{Name: "bunk"})
+	if saveErr := app.Save(assignments); saveErr != nil {
+		t.Fatalf("save bunk_assignments: %v", saveErr)
+	}
+
+	return app
+}
+
+func TestProcessAssignment_MissingPersonID_IsRejected(t *testing.T) {
+	app := newBunkAssignmentsTestApp(t)
+	s := NewBunkAssignmentsSync(app, newRejectionTestClient(t))
+
+	err := s.processAssignment(map[string]any{}, map[string]*core.Record{})
+	assertRejected(t, err)
+}
+
+func TestProcessAssignment_SaveFailure_IsInfraError(t *testing.T) {
+	app := newBunkAssignmentsTestApp(t)
+
+	seed := func(collection string, cmID int) {
+		t.Helper()
+		col, colErr := app.FindCollectionByNameOrId(collection)
+		if colErr != nil {
+			t.Fatalf("find %s: %v", collection, colErr)
+		}
+		rec := core.NewRecord(col)
+		rec.Set("cm_id", cmID)
+		rec.Set("year", 2026)
+		if saveErr := app.Save(rec); saveErr != nil {
+			t.Fatalf("seed %s: %v", collection, saveErr)
+		}
+	}
+	seed("persons", 9001)
+	seed("camp_sessions", 501)
+	seed("bunks", 701)
+
+	failing := &failingSaveApp{App: app, collection: "bunk_assignments"}
+	s := NewBunkAssignmentsSync(failing, newRejectionTestClient(t))
+	s.validPersonCMIDs = map[int]bool{9001: true}
+	s.validSessionCMIDs = map[int]bool{501: true}
+	s.validBunkCMIDs = map[int]bool{701: true}
+
+	assignmentData := map[string]any{
+		"PersonID":   float64(9001),
+		"SessionID":  float64(501),
+		"BunkID":     float64(701),
+		"BunkPlanID": float64(0),
+	}
+	err := s.processAssignment(assignmentData, map[string]*core.Record{})
+	assertInfraError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// processRow (bunk_requests.go)
+// ---------------------------------------------------------------------------
+
+func newBunkRequestsTestApp(t *testing.T) core.App {
+	t.Helper()
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	col := core.NewBaseCollection("original_bunk_requests")
+	col.Fields.Add(&core.TextField{Name: "requester"})
+	col.Fields.Add(&core.NumberField{Name: "year"})
+	col.Fields.Add(&core.TextField{Name: "field"})
+	col.Fields.Add(&core.TextField{Name: "content"})
+	col.Fields.Add(&core.TextField{Name: "content_hash"})
+	col.Fields.Add(&core.TextField{Name: "processed"})
+	if saveErr := app.Save(col); saveErr != nil {
+		t.Fatalf("save original_bunk_requests: %v", saveErr)
+	}
+
+	return app
+}
+
+func TestProcessRow_MissingPersonID_IsRejected(t *testing.T) {
+	t.Parallel()
+	app := newBunkRequestsTestApp(t)
+	s := NewBunkRequestsSync(app, nil)
+
+	columnIndex := map[string]int{"PersonID": 0}
+	err := s.processRow([]string{""}, columnIndex, 2026)
+	assertRejected(t, err)
+}
+
+func TestProcessRow_InvalidPersonID_IsRejected(t *testing.T) {
+	t.Parallel()
+	app := newBunkRequestsTestApp(t)
+	s := NewBunkRequestsSync(app, nil)
+
+	columnIndex := map[string]int{"PersonID": 0}
+	err := s.processRow([]string{"not-a-number"}, columnIndex, 2026)
+	assertRejected(t, err)
+}
+
+func TestProcessRow_SaveFailure_IsInfraError(t *testing.T) {
+	t.Parallel()
+	app := newBunkRequestsTestApp(t)
+	failing := &failingSaveApp{App: app, collection: "original_bunk_requests"}
+	s := NewBunkRequestsSync(failing, nil)
+	s.validPersonIDs = map[int]string{9001: "somepbid00000001"}
+
+	columnIndex := map[string]int{"PersonID": 0, "Share Bunk With": 1}
+	err := s.processRow([]string{"9001", "bunk with Emma Johnson"}, columnIndex, 2026)
+	assertInfraError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// processPerson (persons.go)
+// ---------------------------------------------------------------------------
+
+func newPersonsTestApp(t *testing.T) core.App {
+	t.Helper()
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	col := core.NewBaseCollection("persons")
+	col.Fields.Add(&core.NumberField{Name: "cm_id"})
+	col.Fields.Add(&core.TextField{Name: "first_name"})
+	col.Fields.Add(&core.TextField{Name: "last_name"})
+	col.Fields.Add(&core.NumberField{Name: "year"})
+	col.Fields.Add(&core.BoolField{Name: "is_camper"})
+	if saveErr := app.Save(col); saveErr != nil {
+		t.Fatalf("save persons: %v", saveErr)
+	}
+
+	return app
+}
+
+func validPersonData(id float64) map[string]any {
+	return map[string]any{
+		"ID":            id,
+		"CamperDetails": map[string]any{},
+		"Name":          map[string]any{"First": "Emma", "Last": "Johnson"},
+	}
+}
+
+func TestProcessPerson_MissingID_IsRejected(t *testing.T) {
+	t.Parallel()
+	app := newPersonsTestApp(t)
+	s := NewPersonsSync(app, nil)
+
+	personData := map[string]any{
+		"CamperDetails": map[string]any{},
+		"Name":          map[string]any{"First": "Emma", "Last": "Johnson"},
+	}
+	err := s.processPerson(personData, true, map[int]*core.Record{}, map[string]string{}, map[int]string{}, 2026)
+	assertRejected(t, err)
+}
+
+func TestProcessPerson_SaveFailure_IsInfraError(t *testing.T) {
+	t.Parallel()
+	app := newPersonsTestApp(t)
+	failing := &failingSaveApp{App: app, collection: "persons"}
+	s := NewPersonsSync(failing, nil)
+
+	err := s.processPerson(
+		validPersonData(9001), true, map[int]*core.Record{}, map[string]string{}, map[int]string{}, 2026)
+	assertInfraError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// ProcessSimpleRecord (base_sync.go)
+// ---------------------------------------------------------------------------
+
+func newSimpleRecordTestApp(t *testing.T) core.App {
+	t.Helper()
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	col := core.NewBaseCollection("simple_records")
+	col.Fields.Add(&core.NumberField{Name: "cm_id"})
+	col.Fields.Add(&core.TextField{Name: "name"})
+	col.Fields.Add(&core.NumberField{Name: "year"})
+	if saveErr := app.Save(col); saveErr != nil {
+		t.Fatalf("save simple_records: %v", saveErr)
+	}
+
+	return app
+}
+
+func TestProcessSimpleRecord_MissingYear_IsRejected(t *testing.T) {
+	t.Parallel()
+	app := newSimpleRecordTestApp(t)
+	b := BaseSyncService{App: app}
+
+	recordData := map[string]any{"cm_id": 9001, "name": "widget"}
+	err := b.ProcessSimpleRecord("simple_records", 9001, recordData, map[any]*core.Record{}, nil)
+	assertRejected(t, err)
+}
+
+func TestProcessSimpleRecord_InvalidYearType_IsRejected(t *testing.T) {
+	t.Parallel()
+	app := newSimpleRecordTestApp(t)
+	b := BaseSyncService{App: app}
+
+	recordData := map[string]any{"cm_id": 9001, "name": "widget", "year": "not-a-number"}
+	err := b.ProcessSimpleRecord("simple_records", 9001, recordData, map[any]*core.Record{}, nil)
+	assertRejected(t, err)
+}
+
+func TestProcessSimpleRecord_SaveFailure_IsInfraError(t *testing.T) {
+	t.Parallel()
+	app := newSimpleRecordTestApp(t)
+	failing := &failingSaveApp{App: app, collection: "simple_records"}
+	b := BaseSyncService{App: failing}
+
+	recordData := map[string]any{"cm_id": 9001, "name": "widget", "year": 2026}
+	err := b.ProcessSimpleRecord("simple_records", 9001, recordData, map[any]*core.Record{}, nil)
+	assertInfraError(t, err)
+}

--- a/pocketbase/sync/sentinel_branch_polarity_test.go
+++ b/pocketbase/sync/sentinel_branch_polarity_test.go
@@ -1,0 +1,165 @@
+package sync
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// This file pins the OTHER half of kindred#2292's classification, the half
+// rejection_sites_test.go's census cannot see.
+//
+// TestPerRecordRejectionsUseTheRejectedCounter proves a "Rejected ..." slog
+// line sits directly above a Stats.Rejected++ bump. It does not look at the
+// `if errors.Is(err, errRejectedRecord)` condition that sends control to that
+// bump at all -- it only reads the statement immediately preceding the
+// counter. So a polarity swap at one of the nine call sites this issue added
+// -- `if errors.Is(...)` flipped to `if !errors.Is(...)` -- moves BOTH
+// branches' bodies (log line and counter bump together) to the opposite
+// condition, and the census reads whichever line still sits above
+// Rejected++ as correct. It stays green.
+//
+// Verified by hand against bunks.go's call site: inverting its condition
+// alone leaves `go test ./sync/` green without this file.
+//
+// This test reads the branch condition directly instead: every `if
+// errors.Is(_, errRejectedRecord)` (or its negation) in the package must
+// route its own body to Rejected and the sibling branch to Errors, with the
+// bodies on the correct side of the negation.
+func TestSentinelBranchesRouteToTheRightCounter(t *testing.T) {
+	t.Parallel()
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+
+	var mismatches []string
+	var sawAny bool
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		fset := token.NewFileSet()
+		parsed, parseErr := parser.ParseFile(fset, filepath.Join(".", name), nil, 0)
+		if parseErr != nil {
+			t.Fatalf("parse %s: %v", name, parseErr)
+		}
+
+		ast.Inspect(parsed, func(n ast.Node) bool {
+			ifStmt, ok := n.(*ast.IfStmt)
+			if !ok {
+				return true
+			}
+			negated, isSentinelCheck := sentinelCondition(ifStmt.Cond)
+			if !isSentinelCheck {
+				return true
+			}
+			sawAny = true
+			line := fset.Position(ifStmt.Pos()).Line
+
+			// errors.Is(...) true means rejected; !errors.Is(...) true means
+			// NOT rejected -- i.e. it means infra. Map "then" and "else" onto
+			// "rejected branch" / "errors branch" accordingly.
+			//
+			// ifStmt.Else is walked as a plain ast.Node rather than required to
+			// be a *ast.BlockStmt: attendees.go's call site chains a second
+			// `else if` onto the infra-error side (an idx_attendees_unique
+			// collision diagnostic) before its final `else`, and Errors++ can
+			// live in either arm of that chain.
+			var thenNode, elseNode ast.Node = ifStmt.Body, ifStmt.Else
+			if elseNode == nil {
+				mismatches = append(mismatches, name+":"+strconv.Itoa(line)+
+					": errors.Is(_, errRejectedRecord) branch has no else at all "+
+					"to hold the infra-error counter")
+				return true
+			}
+
+			rejectedNode, errorsNode := thenNode, elseNode
+			if negated {
+				rejectedNode, errorsNode = elseNode, thenNode
+			}
+
+			if !nodeBumpsCounter(rejectedNode, counterRejected) {
+				mismatches = append(mismatches, name+":"+strconv.Itoa(line)+
+					": the errors.Is(_, errRejectedRecord)-true branch does not bump Stats.Rejected")
+			}
+			if !nodeBumpsCounter(errorsNode, counterErrors) {
+				mismatches = append(mismatches, name+":"+strconv.Itoa(line)+
+					": the errors.Is(_, errRejectedRecord)-false branch does not bump Stats.Errors")
+			}
+			return true
+		})
+	}
+
+	if !sawAny {
+		t.Fatal("found no `errors.Is(_, errRejectedRecord)` branch in the package -- " +
+			"has the sentinel been renamed or removed out from under this test?")
+	}
+
+	sort.Strings(mismatches)
+	if len(mismatches) > 0 {
+		t.Errorf("%d sentinel branch(es) route to the wrong counter (or a polarity-inverted "+
+			"one has swapped which side is which):\n  %s",
+			len(mismatches), strings.Join(mismatches, "\n  "))
+	}
+}
+
+// sentinelCondition reports whether cond is `errors.Is(x, errRejectedRecord)`
+// or its negation `!errors.Is(x, errRejectedRecord)`, and if so, whether it
+// was negated.
+func sentinelCondition(cond ast.Expr) (negated, ok bool) {
+	if unary, isUnary := cond.(*ast.UnaryExpr); isUnary && unary.Op == token.NOT {
+		_, inner := sentinelCondition(unary.X)
+		if inner {
+			return true, true
+		}
+		return false, false
+	}
+
+	call, isCall := cond.(*ast.CallExpr)
+	if !isCall || len(call.Args) != 2 {
+		return false, false
+	}
+	sel, isSel := call.Fun.(*ast.SelectorExpr)
+	if !isSel || sel.Sel.Name != "Is" {
+		return false, false
+	}
+	pkgIdent, isIdent := sel.X.(*ast.Ident)
+	if !isIdent || pkgIdent.Name != "errors" {
+		return false, false
+	}
+	secondArg, isIdent := call.Args[1].(*ast.Ident)
+	if !isIdent || secondArg.Name != "errRejectedRecord" {
+		return false, false
+	}
+	return false, true
+}
+
+// nodeBumpsCounter reports whether node contains a `x.<counter>++` bump
+// anywhere within it (not just as a direct statement, so it also sees one
+// nested inside a further if/else the wrapper's branch might add).
+func nodeBumpsCounter(node ast.Node, counter string) bool {
+	found := false
+	ast.Inspect(node, func(n ast.Node) bool {
+		inc, isInc := n.(*ast.IncDecStmt)
+		if !isInc || inc.Tok != token.INC {
+			return true
+		}
+		sel, isSel := inc.X.(*ast.SelectorExpr)
+		if !isSel || sel.Sel.Name != counter {
+			return true
+		}
+		found = true
+		return true
+	})
+	return found
+}

--- a/pocketbase/sync/session_groups.go
+++ b/pocketbase/sync/session_groups.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -106,8 +107,13 @@ func (s *SessionGroupsSync) Sync(ctx context.Context) error {
 		// Process the record
 		compareFields := []string{"cm_id", "name", "description", "is_active", "sort_order"}
 		if err := s.ProcessSimpleRecord("session_groups", key, pbData, existingRecords, compareFields); err != nil {
-			slog.Error("Error processing session group", "error", err)
-			s.Stats.Errors++
+			if errors.Is(err, errRejectedRecord) {
+				slog.Warn("Rejected session group", "error", err)
+				s.Stats.Rejected++
+			} else {
+				slog.Error("Error processing session group", "error", err)
+				s.Stats.Errors++
+			}
 		}
 	}
 

--- a/pocketbase/sync/sessions.go
+++ b/pocketbase/sync/sessions.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -254,8 +255,13 @@ func (s *SessionsSync) Sync(ctx context.Context) error {
 			"start_grade_id", "end_grade_id", "gender_id",
 		}
 		if err := s.ProcessSimpleRecord("camp_sessions", key, pbData, existingRecords, compareFields); err != nil {
-			slog.Error("Error processing session", "error", err)
-			s.Stats.Errors++
+			if errors.Is(err, errRejectedRecord) {
+				slog.Warn("Rejected session", "error", err)
+				s.Stats.Rejected++
+			} else {
+				slog.Error("Error processing session", "error", err)
+				s.Stats.Errors++
+			}
 		}
 	}
 

--- a/pocketbase/sync/staff.go
+++ b/pocketbase/sync/staff.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -176,8 +177,13 @@ func (s *StaffSync) syncStaff(ctx context.Context) error {
 					"international", "years", "salary",
 				}
 				if err := s.ProcessSimpleRecord("staff", personPBID, pbData, existingRecords, compareFields); err != nil {
-					slog.Error("Error processing staff record", "person_pb_id", personPBID, "error", err)
-					s.Stats.Errors++
+					if errors.Is(err, errRejectedRecord) {
+						slog.Warn("Rejected staff record", "person_pb_id", personPBID, "error", err)
+						s.Stats.Rejected++
+					} else {
+						slog.Error("Error processing staff record", "person_pb_id", personPBID, "error", err)
+						s.Stats.Errors++
+					}
 				}
 
 				statusCounts[status]++


### PR DESCRIPTION
## What

kindred#2284 split `Stats.Errors` (infrastructure, zero tolerance) from `Stats.Rejected`
(per-record data quality, warn-only). Five wrapper functions couldn't participate: their
callee returns both classes of failure through one `error`, so the call site's single
counter bump could not tell a locked database from a malformed record.

This gives each of the five a shared sentinel, `errRejectedRecord` (`base_sync.go`), and
wraps it on the wrapper's own pre-write validation paths. Every `App.Save` /
`FindCollectionByNameOrId` failure inside the wrapper stays unwrapped, so it is still
`Errors` by default -- a wrapper that grows a new failure path is safe unless it
deliberately opts a check into the sentinel. Call sites branch with
`errors.Is(err, errRejectedRecord)`.

**All 5 mixed callees and all 9 call sites are done:**

- `processEnrollment` (attendees.go) -- 1 call site, in `processAttendee`
- `processAssignment` (bunk_assignments.go) -- 1 call site, in `Sync`
- `processRow` (bunk_requests.go) -- 1 call site, in `RunSync`
- `processPerson` (persons.go) -- 1 call site, in `processBatchPersons`
- `ProcessSimpleRecord` (base_sync.go) -- 5 call sites: bunks.go (`Sync`),
  financial_transactions.go (`SyncForYear`), session_groups.go (`Sync`), staff.go
  (`syncStaff`), sessions.go (`Sync`)

(The issue's census said "10 counting call sites" for these five; this PR's own earlier
drafts of this section also said 10 in two places despite the reconciliation paragraph
right here saying 9 -- both were wrong. It's 9: 4 singular + 5 for `ProcessSimpleRecord`.)

`rejection_sites_test.go`'s stale comment is corrected: it previously said the mixed
wrappers were `processAttendee, ProcessSimpleRecord`, which was wrong on both counts --
`processAttendee` does not return both classes (it counts and swallows
`processEnrollment`'s errors itself and is a pure rejection needing no sentinel), and
`processPerson`, `processAssignment`, `processRow` were missing entirely.

## What is, and is NOT, wrapped as a rejection

Wrapped (`errRejectedRecord`) -- the wrapper's own pre-write validation of raw
per-record data, matching the issue's worked example:

- `processEnrollment`: missing/invalid `SessionID`
- `processAssignment`: missing `PersonID` / `SessionID` / `BunkID` / `BunkPlanID`
- `processRow`: missing/invalid `PersonID` in the CSV row
- `processPerson`: missing person `ID`
- `ProcessSimpleRecord`: missing/non-numeric `year` in `recordData`

Left unwrapped (stays `Errors`) -- deliberately, not by omission:

- Every `App.Save` / `App.Delete` / `FindCollectionByNameOrId` failure in all five wrappers
  and in the sibling helper `ProcessCompositeRecord` (used by `processEnrollment` and
  `processAssignment`, not itself one of the five). These are local SQLite operations,
  the census's existing zero-tolerance rule.
- `PopulateRelations`' "required relation not found" (`attendees.go`,
  `bunk_assignments.go`). Both call sites reach it only after already confirming the
  referenced session/person/bunk exists via a `valid*CMIDs` check, so a miss here means
  an internal inconsistency between that check and the live `LookupRelation` lookup, not
  routine upstream data quality -- closer to an invariant violation than a rejection.
- `ProcessSimpleRecord`'s two `year`-validation errors are wrapped for correctness, but
  are defensive rather than currently reachable: all five call sites build `year` locally
  from `s.Client.GetSeasonID()`, never from raw upstream data, before calling in. Typed
  correctly regardless -- a function's error classification isn't scoped to what its
  current callers happen to pass.

## Verification

- Failing test first for every wrapper (compile failure on the undefined sentinel, then a
  real assertion failure), then implementation, then green. `pocketbase/sync/rejection_wrapper_test.go`
  is new, 12 tests: two tests per wrapper driving the wrapper function itself -- the real
  entry point, not a helper -- with (a) malformed input, asserting
  `errors.Is(err, errRejectedRecord)`, and (b) valid input against a `failingSaveApp` that
  forces `App.Save` to fail, asserting the opposite. Two wrappers get a third test:
  `processRow` for its separately-validated invalid-vs-missing `PersonID` cases, and
  `ProcessSimpleRecord` for its non-numeric-year branch.
- Mutation-checked all 5: reverted each sentinel wrap in turn, confirmed the matching test
  went RED with the expected message, restored, confirmed GREEN.
- `rejection_sites_test.go`'s structural AST census (`TestPerRecordRejectionsUseTheRejectedCounter`,
  `TestNoUnexpectedSiteUsesTheRejectedCounter`) scans every literal `.Errors++`/`.Rejected++`
  in the package and classifies it by the `slog` call directly above it. All 9 new call
  sites are literal `if/else` blocks (no shared helper -- a helper would make the AST
  scanner report the bump as unclassifiable) with new `"Rejected ..."` messages added to
  `expectedRejectSites()`. This proves each call site's counter bump sits under the right
  log line -- but not that the `errors.Is` condition sending control to it has the right
  polarity (see "Review fixes" below for why that's a separate, and real, gap).
- `go build ./...`, `go vet ./...`, `gofmt -l`: clean.
- `golangci-lint run ./...` (CI-only, not in pre-push, run directly since this diff touches
  ten files): caught two real issues from the new imports -- persons.go had a pre-existing
  local `errors := 0` counter that the new `errors` package import now shadowed (renamed to
  `errCount`), and the test file's `failingSaveApp.Save` delegate returned the pocketbase
  interface's error unwrapped (`wrapcheck`; now `fmt.Errorf("delegating Save: %w", err)`,
  matching the existing `flakyCollectionApp` pattern in
  `bunk_assignments_protection_test.go`). Both fixed; 0 issues now.
- `go test ./...`: full suite green, including `TestSyncAndLodgingTestsRunInParallel` /
  `TestSerialTestExemptionsAreAllStillNeeded` (package main) -- the 4 new tests that build a
  real `*campminder.Client` via `t.Setenv` were added to the existing
  `"t.Setenv: campminder.NewClient reads CAMPMINDER_PRIMARY_KEY"` serial group in
  `main_test_parallelism_test.go`, alphabetically; the other 8 run parallel.
- `go test -race ./sync/`: clean.

## Safety precondition (kindred#2295, confirmed before relying on it)

`BaseSyncService.skipSweepForRejections` (base_sync.go ~252) and the `guard.Rejected`
accounting (~332) are present on `main` -- a rejected record no longer costs its row to
the orphan sweep for every sweep that routes through `DeleteOrphans` /
`DeleteOrphansGuarded`, which is what makes routing genuine data-quality failures to
`Stats.Rejected` safe for those sweeps.

`BunkRequestsSync`'s two sweeps, `purgeOrphanedRequests` and `purgeZombieBRs`, do not --
they predate #2292 and are hand-rolled rather than routed through that machinery, so they
never picked up the `Rejected` guard for free. Before this PR's `processRow` change, a
malformed CSV row (e.g. an Excel-mangled `PersonID` cell) bumped `Stats.Errors`, which
`applyCompletionStatus` fails the whole run on -- so an operator saw the deletion that
followed. Reclassifying that same row onto `Stats.Rejected` (warn-only, deliberately
absent from `applyCompletionStatus`) removed that visibility: the rejected row's person
never reaches `s.csvPersonIDs`, so `purgeOrphanedRequests` reads their still-current,
still-valid `original_bunk_requests` rows as orphaned and deletes them, and the run
reports success. `orphan_guard.go`'s own doc predicted exactly this failure mode for a
"future reclassification into one of [the hand-rolled sweeps]." Fixed here by gating
`purgeOrphanedRequests` on `s.skipSweepForRejections("bunk_requests", nil)`, the same
check the guarded sweeps get automatically; `purgeZombieBRs` is already gated
transitively, since `RunSync` only calls it when `purgeOrphanedRequests` returned a
non-nil person set. Pinned by two new tests in `bunk_requests_rejection_sweep_test.go`:
one seeding a real, current OBR row and asserting it survives a run with
`Stats.Rejected > 0`, and a regression guard proving a clean run's genuine orphan is
still purged. Mutation-checked: reverting the guard reproduces the deletion and the skip
test fails with the exact expected message; restored, both tests green.

A second, independent gap: the AST census above (`rejection_sites_test.go`) proves a
`"Rejected ..."` log line sits above a `Stats.Rejected++` bump, but never reads the
`if errors.Is(err, errRejectedRecord)` condition that sends control there -- so a
polarity swap (`if errors.Is(...)` flipped to `if !errors.Is(...)`) moves both branches'
bodies together and the census stays green reading whichever line still sits above the
bump. Measured: inverting the condition at `bunks.go`'s call site alone left
`go test ./sync/` green with only this PR's existing tests. New file
`sentinel_branch_polarity_test.go` adds `TestSentinelBranchesRouteToTheRightCounter`,
which walks every `errors.Is(_, errRejectedRecord)` branch in the package via AST and
asserts the true side bumps `Rejected` and the false side bumps `Errors` (or vice versa
under negation) -- independent of message text, so it also catches a swap at
`attendees.go`, `persons.go` and `bunk_requests.go`, all three verified the same way.

Closes #2292.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization reporting by distinguishing rejected or invalid records from processing failures.
  * Rejected records now appear as warnings and are counted separately, while operational failures remain errors.
  * Added validation handling for missing or malformed enrollment, assignment, request, person, session, staff, and transaction data.
  * Prevented orphan-request cleanup when rejected records make the imported data incomplete.
* **Tests**
  * Added coverage to verify rejection tracking, failure classification, and safe orphan cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->