### PR TITLE
fix(sync): compare before writing in staff_applications, staff_vehicle_info, camper_transportation

### DIFF
--- a/pocketbase/sync/camper_transportation.go
+++ b/pocketbase/sync/camper_transportation.go
@@ -234,9 +234,13 @@ func (s *CamperTransportationSync) Sync(ctx context.Context) error {
 	slog.Info("Loaded existing records", "count", len(existingRecords))
 
 	// Step 5: Upsert records
-	created, updated, errors := s.upsertRecords(ctx, records, existingRecords, year)
+	created, updated, skipped, errors := s.upsertRecords(ctx, records, existingRecords, year)
 	s.Stats.Created = created
 	s.Stats.Updated = updated
+	// Stats.Skipped counts records that needed no write (kindred#2384). This
+	// service has no field-level staff-gate skip like the two staff syncs, so
+	// unlike them Skipped carries exactly one meaning here.
+	s.Stats.Skipped += skipped
 	s.Stats.Errors = errors
 
 	// Step 6: Delete orphans
@@ -706,6 +710,32 @@ func makeTransportationKey(personID, sessionID, year int) string {
 	return fmt.Sprintf("%d:%d|%d", personID, sessionID, year)
 }
 
+// camperTransportationCompareFields lists the fields to compare for
+// idempotency checks (kindred#2384). Excludes the unique key fields
+// (person_id, session_id, year) since loadExistingRecords already matched on
+// them, and PocketBase-managed fields. Includes `attendee` even though it is
+// not part of the key -- unlike person_id/session_id/year, it can change
+// independently of the key if the attendee mapping is rebuilt.
+var camperTransportationCompareFields = []string{
+	"attendee",
+	colToCampMethod, colFromCampMethod,
+	colDropoffName, colDropoffPhone, colDropoffRelationship,
+	colPickupName, colPickupPhone, colPickupRelationship,
+	colAltPickup1Name, colAltPickup1Phone, colAltPickup1Relationship,
+	colAltPickup2Name, colAltPickup2Phone,
+	"used_legacy_fields",
+}
+
+// recordNeedsUpdate checks if any compared field differs between existing
+// record and new data. Uses compareFields (inclusion list): only the listed
+// fields are checked for changes. Delegates to the shared
+// compareRecordNeedsUpdate in base_sync.go.
+func (s *CamperTransportationSync) recordNeedsUpdate(
+	existing *core.Record, newData map[string]any, compareFields []string,
+) bool {
+	return compareRecordNeedsUpdate(existing, newData, compareFields)
+}
+
 // loadExistingRecords loads existing camper_transportation records for a year
 func (s *CamperTransportationSync) loadExistingRecords(ctx context.Context, year int) (map[string]string, error) {
 	result := make(map[string]string) // compositeKey -> PB ID
@@ -748,22 +778,44 @@ func (s *CamperTransportationSync) upsertRecords(
 	records map[string]*camperTransportationRecord,
 	existingRecords map[string]string,
 	year int,
-) (created, updated, errors int) {
+) (created, updated, skipped, errors int) {
 	col, err := s.App.FindCollectionByNameOrId("camper_transportation")
 	if err != nil {
 		slog.Error("Error finding camper_transportation collection", "error", err)
-		return 0, 0, len(records)
+		return 0, 0, 0, len(records)
 	}
 
 	for _, rec := range records {
 		select {
 		case <-ctx.Done():
-			return created, updated, errors
+			return created, updated, skipped, errors
 		default:
 		}
 
 		key := makeTransportationKey(rec.personID, rec.sessionID, year)
 		existingID, exists := existingRecords[key]
+
+		// Build data map for comparison and for the eventual write.
+		data := map[string]any{
+			"attendee":                rec.attendeeID,
+			"person_id":               rec.personID,
+			"session_id":              rec.sessionID,
+			"year":                    rec.year,
+			colToCampMethod:           rec.toCampMethod,
+			colFromCampMethod:         rec.fromCampMethod,
+			colDropoffName:            rec.dropoffName,
+			colDropoffPhone:           rec.dropoffPhone,
+			colDropoffRelationship:    rec.dropoffRelation,
+			colPickupName:             rec.pickupName,
+			colPickupPhone:            rec.pickupPhone,
+			colPickupRelationship:     rec.pickupRelation,
+			colAltPickup1Name:         rec.altPickup1Name,
+			colAltPickup1Phone:        rec.altPickup1Phone,
+			colAltPickup1Relationship: rec.altPickup1Rel,
+			colAltPickup2Name:         rec.altPickup2Name,
+			colAltPickup2Phone:        rec.altPickup2Phone,
+			"used_legacy_fields":      rec.usedLegacyFields,
+		}
 
 		var record *core.Record
 		if exists {
@@ -773,29 +825,23 @@ func (s *CamperTransportationSync) upsertRecords(
 				errors++
 				continue
 			}
+
+			// Check if update is actually needed (kindred#2384). An unchanged
+			// record counts as a skip, not an update -- see the file-level
+			// comment on Stats.Skipped in Sync() for why that unit is safe here.
+			if !s.recordNeedsUpdate(record, data, camperTransportationCompareFields) {
+				s.DebugLog("Skipping unchanged transportation record",
+					"person_id", rec.personID, "session_id", rec.sessionID, "year", year)
+				skipped++
+				continue
+			}
 		} else {
 			record = core.NewRecord(col)
 		}
 
-		// Set all fields
-		record.Set("attendee", rec.attendeeID)
-		record.Set("person_id", rec.personID)
-		record.Set("session_id", rec.sessionID)
-		record.Set("year", rec.year)
-		record.Set("to_camp_method", rec.toCampMethod)
-		record.Set("from_camp_method", rec.fromCampMethod)
-		record.Set("dropoff_name", rec.dropoffName)
-		record.Set("dropoff_phone", rec.dropoffPhone)
-		record.Set("dropoff_relationship", rec.dropoffRelation)
-		record.Set("pickup_name", rec.pickupName)
-		record.Set("pickup_phone", rec.pickupPhone)
-		record.Set("pickup_relationship", rec.pickupRelation)
-		record.Set("alt_pickup_1_name", rec.altPickup1Name)
-		record.Set("alt_pickup_1_phone", rec.altPickup1Phone)
-		record.Set("alt_pickup_1_relationship", rec.altPickup1Rel)
-		record.Set("alt_pickup_2_name", rec.altPickup2Name)
-		record.Set("alt_pickup_2_phone", rec.altPickup2Phone)
-		record.Set("used_legacy_fields", rec.usedLegacyFields)
+		for field, value := range data {
+			record.Set(field, value)
+		}
 
 		if err := s.App.Save(record); err != nil {
 			slog.Error("Error saving camper_transportation record",
@@ -815,7 +861,7 @@ func (s *CamperTransportationSync) upsertRecords(
 		}
 	}
 
-	return created, updated, errors
+	return created, updated, skipped, errors
 }
 
 // deleteOrphans removes records that exist in DB but not in computed set.

--- a/pocketbase/sync/camper_transportation_test.go
+++ b/pocketbase/sync/camper_transportation_test.go
@@ -779,6 +779,27 @@ func addPersonCustomValue(t *testing.T, app core.App, fieldDefID, personPBID, va
 	}
 }
 
+// updatePersonCustomValue mutates the value of an existing person_custom_values
+// row in place -- simulating a genuine CampMinder edit between two sync runs,
+// as opposed to addPersonCustomValue's always-insert. Used by the *IsIdempotent
+// tests' third run to pin the update direction: recordNeedsUpdate must not
+// just report false forever (kindred#2384 review finding 1).
+func updatePersonCustomValue(t *testing.T, app core.App, fieldDefID, personPBID, value string, year int) {
+	t.Helper()
+	filter := fmt.Sprintf("field_definition = '%s' && person = '%s' && year = %d", fieldDefID, personPBID, year)
+	recs, err := app.FindRecordsByFilter("person_custom_values", filter, "", 1, 0)
+	if err != nil {
+		t.Fatalf("find person_custom_values row to update: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("found %d person_custom_values rows for update, want 1", len(recs))
+	}
+	recs[0].Set("value", value)
+	if saveErr := app.Save(recs[0]); saveErr != nil {
+		t.Fatalf("save updated person_custom_values row: %v", saveErr)
+	}
+}
+
 // TestLoadPersonCustomValuesCountsAndLogsUnmappedFields is the end-to-end pin
 // for kindred#2272's actual fix: before this, a "BUS-*" field accepted by
 // isCamperTransportationField but missing a case in
@@ -1062,5 +1083,31 @@ func TestCamperTransportationSyncSecondRunIsIdempotent(t *testing.T) {
 	}
 	if s.Stats.Skipped != 1 {
 		t.Errorf("second run: skipped=%d, want 1 (the unchanged record)", s.Stats.Skipped)
+	}
+
+	// Third run: a genuine edit (kindred#2384 review finding 1) must still be
+	// written. Without this, a mutant that makes recordNeedsUpdate always
+	// return false passes every assertion above -- the record would never
+	// be updated again, silently.
+	const editedValue = "Liam Garcia"
+	updatePersonCustomValue(t, app, dropoffDefID, personPBID, editedValue, year)
+
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("third Sync: %v", err)
+	}
+	if s.Stats.Created != 0 || s.Stats.Updated != 1 || s.Stats.Errors != 0 {
+		t.Fatalf("third run: created=%d updated=%d errors=%d, want created=0 updated=1 errors=0",
+			s.Stats.Created, s.Stats.Updated, s.Stats.Errors)
+	}
+
+	saved, err := app.FindRecordsByFilter("camper_transportation", "year = 2026", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query after third run: %v", err)
+	}
+	if len(saved) != 1 {
+		t.Fatalf("%d rows persisted after third run, want 1", len(saved))
+	}
+	if got := saved[0].GetString("dropoff_name"); got != editedValue {
+		t.Errorf("dropoff_name = %q after third run, want %q", got, editedValue)
 	}
 }

--- a/pocketbase/sync/camper_transportation_test.go
+++ b/pocketbase/sync/camper_transportation_test.go
@@ -973,3 +973,94 @@ func TestLoadPersonCustomValuesDropsAPersonWithNoAttendeeRow(t *testing.T) {
 		t.Errorf("computed set has %d records, want exactly 1 (only the still-enrolled camper)", len(records))
 	}
 }
+
+// ---------------------------------------------------------------------------
+// kindred#2384: idempotency -- a second run against unchanged source data
+// must report Updated == 0 and Skipped == <record count>, not rewrite every
+// row it already wrote.
+// ---------------------------------------------------------------------------
+
+// addCamperTransportationCollection adds the camper_transportation collection
+// on top of an app built by newSyncTestApp, with every column upsertRecords
+// writes plus the compareFields it will be checked against. A column missing
+// from this list would make compareRecordNeedsUpdate see a permanent nil ->
+// value diff on every run, which would make the idempotency assertion below
+// pass for the wrong reason (nothing was ever comparable) rather than the
+// right one (the comparison found no difference).
+func addCamperTransportationCollection(t *testing.T, app core.App) {
+	t.Helper()
+	attendees, err := app.FindCollectionByNameOrId("attendees")
+	if err != nil {
+		t.Fatalf("find attendees: %v", err)
+	}
+
+	col := core.NewBaseCollection("camper_transportation")
+	col.Fields.Add(&core.RelationField{Name: "attendee", CollectionId: attendees.Id, MaxSelect: 1})
+	col.Fields.Add(&core.NumberField{Name: "person_id"})
+	col.Fields.Add(&core.NumberField{Name: "session_id"})
+	col.Fields.Add(&core.NumberField{Name: "year"})
+	col.Fields.Add(&core.TextField{Name: colToCampMethod, Max: 5000})
+	col.Fields.Add(&core.TextField{Name: colFromCampMethod, Max: 5000})
+	col.Fields.Add(&core.TextField{Name: colDropoffName, Max: 5000})
+	col.Fields.Add(&core.TextField{Name: colDropoffPhone, Max: 5000})
+	col.Fields.Add(&core.TextField{Name: colDropoffRelationship, Max: 5000})
+	col.Fields.Add(&core.TextField{Name: colPickupName, Max: 5000})
+	col.Fields.Add(&core.TextField{Name: colPickupPhone, Max: 5000})
+	col.Fields.Add(&core.TextField{Name: colPickupRelationship, Max: 5000})
+	col.Fields.Add(&core.TextField{Name: colAltPickup1Name, Max: 5000})
+	col.Fields.Add(&core.TextField{Name: colAltPickup1Phone, Max: 5000})
+	col.Fields.Add(&core.TextField{Name: colAltPickup1Relationship, Max: 5000})
+	col.Fields.Add(&core.TextField{Name: colAltPickup2Name, Max: 5000})
+	col.Fields.Add(&core.TextField{Name: colAltPickup2Phone, Max: 5000})
+	col.Fields.Add(&core.BoolField{Name: "used_legacy_fields"})
+	if saveErr := app.Save(col); saveErr != nil {
+		t.Fatalf("save camper_transportation: %v", saveErr)
+	}
+}
+
+// TestCamperTransportationSyncSecondRunIsIdempotent drives the real Sync()
+// entry point (kindred#2384), not upsertRecords directly: asserting on the
+// helper proves the comparison function works, not that Sync() actually
+// calls it before writing. Two identical runs against the same source data
+// must produce Created=1/Updated=0 then Created=0/Updated=0/Skipped=1 -- a
+// no-op run must be visible AS a no-op, not indistinguishable from a rewrite.
+func TestCamperTransportationSyncSecondRunIsIdempotent(t *testing.T) {
+	t.Parallel()
+	app := newSyncTestApp(t)
+	addCamperTransportationCollection(t, app)
+
+	const year = 2026
+	toCampDefID := addFieldDef(t, app, 90001, "BUS-to camp")
+	dropoffDefID := addFieldDef(t, app, 90002, "BUS-who is dropping off")
+
+	sessionPBID := addSession(t, app, 5001, "Session A", "resident",
+		"2026-06-20 07:00:00.000Z", "2026-07-01 07:00:00.000Z", year)
+	householdPBID := addHousehold(t, app, 6001, year)
+	personPBID := addPerson(t, app, 7001, 6001, year, householdPBID)
+	addAttendee(t, app, personPBID, sessionPBID, 7001, 2, year)
+
+	addPersonCustomValue(t, app, toCampDefID, personPBID, "Bus", year)
+	addPersonCustomValue(t, app, dropoffDefID, personPBID, "Emma Johnson", year)
+
+	s := NewCamperTransportationSync(app)
+	s.SetYear(year)
+
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("first Sync: %v", err)
+	}
+	if s.Stats.Created != 1 || s.Stats.Updated != 0 || s.Stats.Errors != 0 {
+		t.Fatalf("first run: created=%d updated=%d errors=%d, want created=1 updated=0 errors=0",
+			s.Stats.Created, s.Stats.Updated, s.Stats.Errors)
+	}
+
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("second Sync: %v", err)
+	}
+	if s.Stats.Created != 0 || s.Stats.Updated != 0 || s.Stats.Errors != 0 {
+		t.Fatalf("second run: created=%d updated=%d errors=%d, want created=0 updated=0 errors=0",
+			s.Stats.Created, s.Stats.Updated, s.Stats.Errors)
+	}
+	if s.Stats.Skipped != 1 {
+		t.Errorf("second run: skipped=%d, want 1 (the unchanged record)", s.Stats.Skipped)
+	}
+}

--- a/pocketbase/sync/staff_applications.go
+++ b/pocketbase/sync/staff_applications.go
@@ -203,9 +203,15 @@ func (s *StaffApplicationsSync) Sync(ctx context.Context) error {
 	slog.Info("Loaded existing records", "count", len(existingRecords))
 
 	// Step 5: Upsert records
-	created, updated, upsertErrors := s.upsertRecords(ctx, records, existingRecords, year)
+	created, updated, upsertSkipped, upsertErrors := s.upsertRecords(ctx, records, existingRecords, year)
 	s.Stats.Created = created
 	s.Stats.Updated = updated
+	// Stats.Skipped now carries TWO record-level meanings, same as
+	// staff_vehicle_info.go: the staff-row gate drop counted above in
+	// loadPersonCustomValues (kindred#2277) and, added here, a record that
+	// needed no write (kindred#2384). Both count RECORDS, so the unit stays
+	// consistent -- but += (not =) preserves the earlier count.
+	s.Stats.Skipped += upsertSkipped
 	s.Stats.Errors = upsertErrors
 
 	// Step 6: Delete orphans
@@ -936,6 +942,39 @@ func makeStaffAppKey(personID, year int) string {
 	return fmt.Sprintf("%d|%d", personID, year)
 }
 
+// staffApplicationsCompareFields lists the fields to compare for idempotency
+// checks (kindred#2384). Excludes the unique key fields (person_id, year)
+// since loadExistingRecords already matched on them, and PocketBase-managed
+// fields. Includes `staff` even though it is not part of the key -- unlike
+// person_id/year, it can change independently of the key if the
+// person-to-staff mapping is rebuilt.
+var staffApplicationsCompareFields = []string{
+	"staff",
+	"can_work_dates", "cant_work_explain", "work_dates_supervisor",
+	"work_dates_wild", "work_dates_driver",
+	"work_expectations", "qualifications", "qualification_changes",
+	"position_pref_1", "position_pref_2", "position_pref_3",
+	"why_tawonga", "why_work_again", "jewish_community", "three_rules",
+	"autobiography", "community_means", "working_across_differences",
+	"languages", "dietary_needs", "dietary_needs_other", "over_21",
+	"ref_1_name", "ref_1_phone", "ref_1_email", "ref_1_relationship", "ref_1_years",
+	"stress_situation", "stress_response", "spiritual_moment", "activity_program",
+	"someone_admire", "since_camp", "wish_knew", "last_summer_learned",
+	"favorite_camper_moment", "closest_friend", "tawonga_makes_think",
+	"advice_would_give", "how_look_at_camp",
+	"over_18", "work_dates_kitchen_supervisor", "jedi_returner", "jedi_new_staff",
+}
+
+// recordNeedsUpdate checks if any compared field differs between existing
+// record and new data. Uses compareFields (inclusion list): only the listed
+// fields are checked for changes. Delegates to the shared
+// compareRecordNeedsUpdate in base_sync.go.
+func (s *StaffApplicationsSync) recordNeedsUpdate(
+	existing *core.Record, newData map[string]any, compareFields []string,
+) bool {
+	return compareRecordNeedsUpdate(existing, newData, compareFields)
+}
+
 // loadExistingRecords loads existing staff_applications records for a year
 func (s *StaffApplicationsSync) loadExistingRecords(ctx context.Context, year int) (map[string]string, error) {
 	result := make(map[string]string)
@@ -977,22 +1016,88 @@ func (s *StaffApplicationsSync) upsertRecords(
 	records map[string]*staffApplicationRecord,
 	existingRecords map[string]string,
 	year int,
-) (created, updated, errCount int) {
+) (created, updated, skipped, errCount int) {
 	col, err := s.App.FindCollectionByNameOrId("staff_applications")
 	if err != nil {
 		slog.Error("Error finding staff_applications collection", "error", err)
-		return 0, 0, len(records)
+		return 0, 0, 0, len(records)
 	}
 
 	for _, rec := range records {
 		select {
 		case <-ctx.Done():
-			return created, updated, errCount
+			return created, updated, skipped, errCount
 		default:
 		}
 
 		key := makeStaffAppKey(rec.personID, year)
 		existingID, exists := existingRecords[key]
+
+		data := map[string]any{
+			"staff":     rec.staffID,
+			"person_id": rec.personID,
+			"year":      rec.year,
+
+			// Work availability
+			"can_work_dates":        rec.canWorkDates,
+			"cant_work_explain":     rec.cantWorkExplain,
+			"work_dates_supervisor": rec.workDatesSupervisor,
+			"work_dates_wild":       rec.workDatesWild,
+			"work_dates_driver":     rec.workDatesDriver,
+
+			// Qualifications
+			"work_expectations":     rec.workExpectations,
+			"qualifications":        rec.qualifications,
+			"qualification_changes": rec.qualificationChanges,
+
+			// Position preferences
+			"position_pref_1": rec.positionPref1,
+			"position_pref_2": rec.positionPref2,
+			"position_pref_3": rec.positionPref3,
+
+			// Essays
+			"why_tawonga":                rec.whyTawonga,
+			"why_work_again":             rec.whyWorkAgain,
+			"jewish_community":           rec.jewishCommunity,
+			"three_rules":                rec.threeRules,
+			"autobiography":              rec.autobiography,
+			"community_means":            rec.communityMeans,
+			"working_across_differences": rec.workingAcrossDifferences,
+
+			// Personal info
+			"languages":           rec.languages,
+			"dietary_needs":       rec.dietaryNeeds,
+			"dietary_needs_other": rec.dietaryOther,
+			"over_21":             rec.over21,
+
+			// Reference
+			"ref_1_name":         rec.ref1Name,
+			"ref_1_phone":        rec.ref1Phone,
+			"ref_1_email":        rec.ref1Email,
+			"ref_1_relationship": rec.ref1Relationship,
+			"ref_1_years":        rec.ref1Years,
+
+			// Reflection prompts
+			"stress_situation":       rec.stressSituation,
+			"stress_response":        rec.stressResponse,
+			"spiritual_moment":       rec.spiritualMoment,
+			"activity_program":       rec.activityProgram,
+			"someone_admire":         rec.someoneAdmire,
+			"since_camp":             rec.sinceCamp,
+			"wish_knew":              rec.wishKnew,
+			"last_summer_learned":    rec.lastSummerLearned,
+			"favorite_camper_moment": rec.favoriteCamperMoment,
+			"closest_friend":         rec.closestFriend,
+			"tawonga_makes_think":    rec.tawongaMakesThink,
+			"advice_would_give":      rec.adviceWouldGive,
+			"how_look_at_camp":       rec.howLookAtCamp,
+
+			// Live 2026 fields (kindred#2271, owner ruling 2026-08-14)
+			"over_18":                       rec.over18,
+			"work_dates_kitchen_supervisor": rec.workDatesKitchenSupervisor,
+			"jedi_returner":                 rec.jediReturner,
+			"jedi_new_staff":                rec.jediNewStaff,
+		}
 
 		var record *core.Record
 		if exists {
@@ -1002,74 +1107,26 @@ func (s *StaffApplicationsSync) upsertRecords(
 				errCount++
 				continue
 			}
+
+			// Check if update is actually needed (kindred#2384). An unchanged
+			// record counts as a skip, not an update. Stats.Skipped here counts
+			// records that needed no write, distinct from Stats.SkippedValues
+			// (individual unmapped App-* answers, tracked in
+			// loadPersonCustomValues above) -- both count something, but not
+			// the same thing, per kindred#2356.
+			if !s.recordNeedsUpdate(record, data, staffApplicationsCompareFields) {
+				s.DebugLog("Skipping unchanged staff_applications record",
+					"person_id", rec.personID, "year", year)
+				skipped++
+				continue
+			}
 		} else {
 			record = core.NewRecord(col)
 		}
 
-		// Set all fields
-		record.Set("staff", rec.staffID)
-		record.Set("person_id", rec.personID)
-		record.Set("year", rec.year)
-
-		// Work availability
-		record.Set("can_work_dates", rec.canWorkDates)
-		record.Set("cant_work_explain", rec.cantWorkExplain)
-		record.Set("work_dates_supervisor", rec.workDatesSupervisor)
-		record.Set("work_dates_wild", rec.workDatesWild)
-		record.Set("work_dates_driver", rec.workDatesDriver)
-
-		// Qualifications
-		record.Set("work_expectations", rec.workExpectations)
-		record.Set("qualifications", rec.qualifications)
-		record.Set("qualification_changes", rec.qualificationChanges)
-
-		// Position preferences
-		record.Set("position_pref_1", rec.positionPref1)
-		record.Set("position_pref_2", rec.positionPref2)
-		record.Set("position_pref_3", rec.positionPref3)
-
-		// Essays
-		record.Set("why_tawonga", rec.whyTawonga)
-		record.Set("why_work_again", rec.whyWorkAgain)
-		record.Set("jewish_community", rec.jewishCommunity)
-		record.Set("three_rules", rec.threeRules)
-		record.Set("autobiography", rec.autobiography)
-		record.Set("community_means", rec.communityMeans)
-		record.Set("working_across_differences", rec.workingAcrossDifferences)
-
-		// Personal info
-		record.Set("languages", rec.languages)
-		record.Set("dietary_needs", rec.dietaryNeeds)
-		record.Set("dietary_needs_other", rec.dietaryOther)
-		record.Set("over_21", rec.over21)
-
-		// Reference
-		record.Set("ref_1_name", rec.ref1Name)
-		record.Set("ref_1_phone", rec.ref1Phone)
-		record.Set("ref_1_email", rec.ref1Email)
-		record.Set("ref_1_relationship", rec.ref1Relationship)
-		record.Set("ref_1_years", rec.ref1Years)
-
-		// Reflection prompts
-		record.Set("stress_situation", rec.stressSituation)
-		record.Set("stress_response", rec.stressResponse)
-		record.Set("spiritual_moment", rec.spiritualMoment)
-		record.Set("activity_program", rec.activityProgram)
-		record.Set("someone_admire", rec.someoneAdmire)
-		record.Set("since_camp", rec.sinceCamp)
-		record.Set("wish_knew", rec.wishKnew)
-		record.Set("last_summer_learned", rec.lastSummerLearned)
-		record.Set("favorite_camper_moment", rec.favoriteCamperMoment)
-		record.Set("closest_friend", rec.closestFriend)
-		record.Set("tawonga_makes_think", rec.tawongaMakesThink)
-		record.Set("advice_would_give", rec.adviceWouldGive)
-		record.Set("how_look_at_camp", rec.howLookAtCamp)
-
-		// Live 2026 fields (kindred#2271, owner ruling 2026-08-14)
-		record.Set("over_18", rec.over18)
-		record.Set("work_dates_kitchen_supervisor", rec.workDatesKitchenSupervisor)
-		record.Set("jedi_returner", rec.jediReturner)
-		record.Set("jedi_new_staff", rec.jediNewStaff)
+		for field, value := range data {
+			record.Set(field, value)
+		}
 
 		if err := s.App.Save(record); err != nil {
 			slog.Error("Error saving staff_applications record",
@@ -1088,7 +1145,7 @@ func (s *StaffApplicationsSync) upsertRecords(
 		}
 	}
 
-	return created, updated, errCount
+	return created, updated, skipped, errCount
 }
 
 // deleteOrphans removes records that exist in DB but not in computed set.

--- a/pocketbase/sync/staff_applications_test.go
+++ b/pocketbase/sync/staff_applications_test.go
@@ -1169,7 +1169,7 @@ func TestUpsertRecordsWritesTheFourLive2026Columns(t *testing.T) {
 		},
 	}
 
-	created, updated, errCount := s.upsertRecords(
+	created, updated, _, errCount := s.upsertRecords(
 		context.Background(), records, map[string]string{}, year)
 	if errCount != 0 {
 		t.Fatalf("upsertRecords reported %d errors, want 0", errCount)
@@ -1235,5 +1235,107 @@ func TestStaffApplicationsDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
 	}
 	if len(remaining) != 1 {
 		t.Errorf("%d rows survived, want 1", len(remaining))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// kindred#2384: idempotency -- a second run against unchanged source data
+// must report Updated == 0 and Skipped == <record count>, not rewrite every
+// row it already wrote.
+// ---------------------------------------------------------------------------
+
+// staffApplicationsTextColumns lists the string-valued columns
+// staffApplicationsCompareFields compares, matching upsertRecords' Set()
+// calls exactly. The three bool columns (over_21, over_18,
+// work_dates_kitchen_supervisor) are added separately below.
+var staffApplicationsTextColumns = []string{
+	"can_work_dates", "cant_work_explain", "work_dates_supervisor",
+	"work_dates_wild", "work_dates_driver",
+	"work_expectations", "qualifications", "qualification_changes",
+	"position_pref_1", "position_pref_2", "position_pref_3",
+	"why_tawonga", "why_work_again", "jewish_community", "three_rules",
+	"autobiography", "community_means", "working_across_differences",
+	"languages", "dietary_needs", "dietary_needs_other",
+	"ref_1_name", "ref_1_phone", "ref_1_email", "ref_1_relationship", "ref_1_years",
+	"stress_situation", "stress_response", "spiritual_moment", "activity_program",
+	"someone_admire", "since_camp", "wish_knew", "last_summer_learned",
+	"favorite_camper_moment", "closest_friend", "tawonga_makes_think",
+	"advice_would_give", "how_look_at_camp",
+	"jedi_returner", "jedi_new_staff",
+}
+
+// addStaffApplicationsFullCollection adds the staff_applications collection
+// on top of an app built by newSyncTestApp, with every column upsertRecords
+// writes plus the compareFields it will be checked against. A column missing
+// from this list would make compareRecordNeedsUpdate see a permanent nil ->
+// value diff on every run, which would make the idempotency assertion below
+// pass for the wrong reason (nothing was ever comparable) rather than the
+// right one (the comparison found no difference).
+func addStaffApplicationsFullCollection(t *testing.T, app core.App) {
+	t.Helper()
+	staff, err := app.FindCollectionByNameOrId("staff")
+	if err != nil {
+		t.Fatalf("find staff: %v", err)
+	}
+
+	col := core.NewBaseCollection("staff_applications")
+	col.Fields.Add(&core.RelationField{Name: "staff", CollectionId: staff.Id, MaxSelect: 1})
+	col.Fields.Add(&core.NumberField{Name: "person_id"})
+	col.Fields.Add(&core.NumberField{Name: "year"})
+	col.Fields.Add(&core.BoolField{Name: "over_21"})
+	col.Fields.Add(&core.BoolField{Name: "over_18"})
+	col.Fields.Add(&core.BoolField{Name: "work_dates_kitchen_supervisor"})
+	for _, name := range staffApplicationsTextColumns {
+		col.Fields.Add(&core.TextField{Name: name, Max: 5000})
+	}
+	if saveErr := app.Save(col); saveErr != nil {
+		t.Fatalf("save staff_applications: %v", saveErr)
+	}
+}
+
+// TestStaffApplicationsSyncSecondRunIsIdempotent drives the real Sync() entry
+// point (kindred#2384), not upsertRecords directly: asserting on the helper
+// proves the comparison function works, not that Sync() actually calls it
+// before writing. Two identical runs against the same source data must
+// produce Created=1/Updated=0 then Created=0/Updated=0/Skipped=1 -- a no-op
+// run must be visible AS a no-op, not indistinguishable from a rewrite.
+func TestStaffApplicationsSyncSecondRunIsIdempotent(t *testing.T) {
+	t.Parallel()
+	app := newSyncTestApp(t)
+	addStaffApplicationsFullCollection(t, app)
+
+	const year = 2026
+	tawongaDefID := addFieldDef(t, app, 92001, "App-Why Tawonga?")
+	over21DefID := addFieldDef(t, app, 92002, "App-Over 21")
+
+	householdPBID := addHousehold(t, app, 9001, year)
+	personPBID := addPerson(t, app, 9101, 9001, year, householdPBID)
+	saveRecord(t, app, "staff", map[string]any{
+		"person_id": 9101, "year": year,
+	})
+
+	addPersonCustomValue(t, app, tawongaDefID, personPBID, "Because it's home.", year)
+	addPersonCustomValue(t, app, over21DefID, personPBID, "Yes", year)
+
+	s := NewStaffApplicationsSync(app)
+	s.SetYear(year)
+
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("first Sync: %v", err)
+	}
+	if s.Stats.Created != 1 || s.Stats.Updated != 0 || s.Stats.Errors != 0 {
+		t.Fatalf("first run: created=%d updated=%d errors=%d, want created=1 updated=0 errors=0",
+			s.Stats.Created, s.Stats.Updated, s.Stats.Errors)
+	}
+
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("second Sync: %v", err)
+	}
+	if s.Stats.Created != 0 || s.Stats.Updated != 0 || s.Stats.Errors != 0 {
+		t.Fatalf("second run: created=%d updated=%d errors=%d, want created=0 updated=0 errors=0",
+			s.Stats.Created, s.Stats.Updated, s.Stats.Errors)
+	}
+	if s.Stats.Skipped != 1 {
+		t.Errorf("second run: skipped=%d, want 1 (the unchanged record)", s.Stats.Skipped)
 	}
 }

--- a/pocketbase/sync/staff_applications_test.go
+++ b/pocketbase/sync/staff_applications_test.go
@@ -1338,4 +1338,30 @@ func TestStaffApplicationsSyncSecondRunIsIdempotent(t *testing.T) {
 	if s.Stats.Skipped != 1 {
 		t.Errorf("second run: skipped=%d, want 1 (the unchanged record)", s.Stats.Skipped)
 	}
+
+	// Third run: a genuine edit (kindred#2384 review finding 1) must still be
+	// written. Without this, a mutant that makes recordNeedsUpdate always
+	// return false passes every assertion above -- the record would never
+	// be updated again, silently.
+	const editedValue = "Because it's the best place on earth."
+	updatePersonCustomValue(t, app, tawongaDefID, personPBID, editedValue, year)
+
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("third Sync: %v", err)
+	}
+	if s.Stats.Created != 0 || s.Stats.Updated != 1 || s.Stats.Errors != 0 {
+		t.Fatalf("third run: created=%d updated=%d errors=%d, want created=0 updated=1 errors=0",
+			s.Stats.Created, s.Stats.Updated, s.Stats.Errors)
+	}
+
+	saved, err := app.FindRecordsByFilter("staff_applications", "year = 2026", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query after third run: %v", err)
+	}
+	if len(saved) != 1 {
+		t.Fatalf("%d rows persisted after third run, want 1", len(saved))
+	}
+	if got := saved[0].GetString("why_tawonga"); got != editedValue {
+		t.Errorf("why_tawonga = %q after third run, want %q", got, editedValue)
+	}
 }

--- a/pocketbase/sync/staff_vehicle_info.go
+++ b/pocketbase/sync/staff_vehicle_info.go
@@ -183,9 +183,14 @@ func (s *StaffVehicleInfoSync) Sync(ctx context.Context) error {
 	slog.Info("Loaded existing records", "count", len(existingRecords))
 
 	// Step 5: Upsert records
-	created, updated, upsertErrors := s.upsertRecords(ctx, records, existingRecords, year)
+	created, updated, upsertSkipped, upsertErrors := s.upsertRecords(ctx, records, existingRecords, year)
 	s.Stats.Created = created
 	s.Stats.Updated = updated
+	// Stats.Skipped now carries TWO record-level meanings (kindred#2384): the
+	// staff-row gate drop counted above in loadPersonCustomValues (kindred#2277)
+	// and, added here, a record that needed no write. Both count RECORDS, so
+	// the unit stays consistent -- but += (not =) preserves the earlier count.
+	s.Stats.Skipped += upsertSkipped
 	s.Stats.Errors = upsertErrors
 
 	// Step 6: Delete orphans
@@ -379,7 +384,12 @@ func (s *StaffVehicleInfoSync) loadPersonCustomValues(
 		if !hasStaff {
 			// Structurally correct -- `staff` is a required relation, so a row
 			// cannot be written without one -- but it must not be silent
-			// (kindred#2273, kindred#2277).
+			// (kindred#2273, kindred#2277). Once aggregated below, this joins
+			// a DIFFERENT meaning of Stats.Skipped from upsertRecords further
+			// down (kindred#2384): this counts a person dropped before a
+			// record was ever built, upsertRecords counts a built record that
+			// needed no write. Both are record-level counts, so the unit
+			// stays consistent.
 			gatedPeople[entry.personID] = true
 			continue
 		}
@@ -569,6 +579,29 @@ func makeStaffVehicleKey(personID, year int) string {
 	return fmt.Sprintf("%d|%d", personID, year)
 }
 
+// staffVehicleInfoCompareFields lists the fields to compare for idempotency
+// checks (kindred#2384). Excludes the unique key fields (person_id, year)
+// since loadExistingRecords already matched on them, and PocketBase-managed
+// fields. Includes `staff` even though it is not part of the key -- unlike
+// person_id/year, it can change independently of the key if the
+// person-to-staff mapping is rebuilt.
+var staffVehicleInfoCompareFields = []string{
+	"staff",
+	colDrivingToCamp, "how_getting_to_camp", colCanBringOthers,
+	"driver_name", "which_friend", "vehicle_make", "vehicle_model",
+	"license_plate", "ride_from", "transport_notes",
+}
+
+// recordNeedsUpdate checks if any compared field differs between existing
+// record and new data. Uses compareFields (inclusion list): only the listed
+// fields are checked for changes. Delegates to the shared
+// compareRecordNeedsUpdate in base_sync.go.
+func (s *StaffVehicleInfoSync) recordNeedsUpdate(
+	existing *core.Record, newData map[string]any, compareFields []string,
+) bool {
+	return compareRecordNeedsUpdate(existing, newData, compareFields)
+}
+
 // loadExistingRecords loads existing staff_vehicle_info records for a year
 func (s *StaffVehicleInfoSync) loadExistingRecords(ctx context.Context, year int) (map[string]string, error) {
 	result := make(map[string]string)
@@ -610,22 +643,38 @@ func (s *StaffVehicleInfoSync) upsertRecords(
 	records map[string]*staffVehicleInfoRecord,
 	existingRecords map[string]string,
 	year int,
-) (created, updated, errCount int) {
+) (created, updated, skipped, errCount int) {
 	col, err := s.App.FindCollectionByNameOrId("staff_vehicle_info")
 	if err != nil {
 		slog.Error("Error finding staff_vehicle_info collection", "error", err)
-		return 0, 0, len(records)
+		return 0, 0, 0, len(records)
 	}
 
 	for _, rec := range records {
 		select {
 		case <-ctx.Done():
-			return created, updated, errCount
+			return created, updated, skipped, errCount
 		default:
 		}
 
 		key := makeStaffVehicleKey(rec.personID, year)
 		existingID, exists := existingRecords[key]
+
+		data := map[string]any{
+			"staff":               rec.staffID,
+			"person_id":           rec.personID,
+			"year":                rec.year,
+			colDrivingToCamp:      rec.drivingToCamp,
+			"how_getting_to_camp": rec.howGettingToCamp,
+			colCanBringOthers:     rec.canBringOthers,
+			"driver_name":         rec.driverName,
+			"which_friend":        rec.whichFriend,
+			"vehicle_make":        rec.vehicleMake,
+			"vehicle_model":       rec.vehicleModel,
+			"license_plate":       rec.licensePlate,
+			"ride_from":           rec.rideFrom,
+			"transport_notes":     rec.transportNotes,
+		}
 
 		var record *core.Record
 		if exists {
@@ -635,24 +684,27 @@ func (s *StaffVehicleInfoSync) upsertRecords(
 				errCount++
 				continue
 			}
+
+			// Check if update is actually needed (kindred#2384). An unchanged
+			// record counts as a skip, not an update. Stats.Skipped here can
+			// also carry a SEPARATE meaning from loadPersonCustomValues above
+			// (a person dropped at the staff-row gate, kindred#2277) -- both
+			// are record-level counts, so the unit is still consistent, but a
+			// reader of the final number cannot tell which happened without
+			// this comment.
+			if !s.recordNeedsUpdate(record, data, staffVehicleInfoCompareFields) {
+				s.DebugLog("Skipping unchanged staff_vehicle_info record",
+					"person_id", rec.personID, "year", year)
+				skipped++
+				continue
+			}
 		} else {
 			record = core.NewRecord(col)
 		}
 
-		// Set all fields
-		record.Set("staff", rec.staffID)
-		record.Set("person_id", rec.personID)
-		record.Set("year", rec.year)
-		record.Set("driving_to_camp", rec.drivingToCamp)
-		record.Set("how_getting_to_camp", rec.howGettingToCamp)
-		record.Set("can_bring_others", rec.canBringOthers)
-		record.Set("driver_name", rec.driverName)
-		record.Set("which_friend", rec.whichFriend)
-		record.Set("vehicle_make", rec.vehicleMake)
-		record.Set("vehicle_model", rec.vehicleModel)
-		record.Set("license_plate", rec.licensePlate)
-		record.Set("ride_from", rec.rideFrom)
-		record.Set("transport_notes", rec.transportNotes)
+		for field, value := range data {
+			record.Set(field, value)
+		}
 
 		if err := s.App.Save(record); err != nil {
 			slog.Error("Error saving staff_vehicle_info record",
@@ -671,7 +723,7 @@ func (s *StaffVehicleInfoSync) upsertRecords(
 		}
 	}
 
-	return created, updated, errCount
+	return created, updated, skipped, errCount
 }
 
 // deleteOrphans removes records that exist in DB but not in computed set.

--- a/pocketbase/sync/staff_vehicle_info_test.go
+++ b/pocketbase/sync/staff_vehicle_info_test.go
@@ -728,4 +728,30 @@ func TestStaffVehicleInfoSyncSecondRunIsIdempotent(t *testing.T) {
 	if s.Stats.Skipped != 1 {
 		t.Errorf("second run: skipped=%d, want 1 (the unchanged record)", s.Stats.Skipped)
 	}
+
+	// Third run: a genuine edit (kindred#2384 review finding 1) must still be
+	// written. Without this, a mutant that makes recordNeedsUpdate always
+	// return false passes every assertion above -- the record would never
+	// be updated again, silently.
+	const editedValue = "The bus station"
+	updatePersonCustomValue(t, app, rideFromDefID, personPBID, editedValue, year)
+
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("third Sync: %v", err)
+	}
+	if s.Stats.Created != 0 || s.Stats.Updated != 1 || s.Stats.Errors != 0 {
+		t.Fatalf("third run: created=%d updated=%d errors=%d, want created=0 updated=1 errors=0",
+			s.Stats.Created, s.Stats.Updated, s.Stats.Errors)
+	}
+
+	saved, err := app.FindRecordsByFilter("staff_vehicle_info", "year = 2026", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query after third run: %v", err)
+	}
+	if len(saved) != 1 {
+		t.Fatalf("%d rows persisted after third run, want 1", len(saved))
+	}
+	if got := saved[0].GetString("ride_from"); got != editedValue {
+		t.Errorf("ride_from = %q after third run, want %q", got, editedValue)
+	}
 }

--- a/pocketbase/sync/staff_vehicle_info_test.go
+++ b/pocketbase/sync/staff_vehicle_info_test.go
@@ -643,3 +643,89 @@ func TestSVIRoutingReportAgainstRealFieldNames(t *testing.T) {
 		t.Errorf("unmapped fields = %v, want %v", unmapped, wantUnmapped)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// kindred#2384: idempotency -- a second run against unchanged source data
+// must report Updated == 0 and Skipped == <record count>, not rewrite every
+// row it already wrote.
+// ---------------------------------------------------------------------------
+
+// addStaffVehicleInfoCollection adds the staff_vehicle_info collection on top
+// of an app built by newSyncTestApp, with every column upsertRecords writes
+// plus the compareFields it will be checked against. A column missing from
+// this list would make compareRecordNeedsUpdate see a permanent nil -> value
+// diff on every run, which would make the idempotency assertion below pass
+// for the wrong reason (nothing was ever comparable) rather than the right
+// one (the comparison found no difference).
+func addStaffVehicleInfoCollection(t *testing.T, app core.App) {
+	t.Helper()
+	staff, err := app.FindCollectionByNameOrId("staff")
+	if err != nil {
+		t.Fatalf("find staff: %v", err)
+	}
+
+	col := core.NewBaseCollection("staff_vehicle_info")
+	col.Fields.Add(&core.RelationField{Name: "staff", CollectionId: staff.Id, MaxSelect: 1})
+	col.Fields.Add(&core.NumberField{Name: "person_id"})
+	col.Fields.Add(&core.NumberField{Name: "year"})
+	col.Fields.Add(&core.BoolField{Name: colDrivingToCamp})
+	col.Fields.Add(&core.TextField{Name: "how_getting_to_camp", Max: 5000})
+	col.Fields.Add(&core.TextField{Name: colCanBringOthers, Max: 5000})
+	col.Fields.Add(&core.TextField{Name: "driver_name", Max: 5000})
+	col.Fields.Add(&core.TextField{Name: "which_friend", Max: 5000})
+	col.Fields.Add(&core.TextField{Name: "vehicle_make", Max: 5000})
+	col.Fields.Add(&core.TextField{Name: "vehicle_model", Max: 5000})
+	col.Fields.Add(&core.TextField{Name: "license_plate", Max: 5000})
+	col.Fields.Add(&core.TextField{Name: "ride_from", Max: 5000})
+	col.Fields.Add(&core.TextField{Name: "transport_notes", Max: 5000})
+	if saveErr := app.Save(col); saveErr != nil {
+		t.Fatalf("save staff_vehicle_info: %v", saveErr)
+	}
+}
+
+// TestStaffVehicleInfoSyncSecondRunIsIdempotent drives the real Sync() entry
+// point (kindred#2384), not upsertRecords directly: asserting on the helper
+// proves the comparison function works, not that Sync() actually calls it
+// before writing. Two identical runs against the same source data must
+// produce Created=1/Updated=0 then Created=0/Updated=0/Skipped=1 -- a no-op
+// run must be visible AS a no-op, not indistinguishable from a rewrite.
+func TestStaffVehicleInfoSyncSecondRunIsIdempotent(t *testing.T) {
+	t.Parallel()
+	app := newSyncTestApp(t)
+	addStaffVehicleInfoCollection(t, app)
+
+	const year = 2026
+	drivingDefID := addFieldDef(t, app, 91001, "SVI-are you driving to camp")
+	rideFromDefID := addFieldDef(t, app, 91002, "SVI- Where do you need a ride from")
+
+	householdPBID := addHousehold(t, app, 8001, year)
+	personPBID := addPerson(t, app, 8101, 8001, year, householdPBID)
+	saveRecord(t, app, "staff", map[string]any{
+		"person_id": 8101, "year": year,
+	})
+
+	addPersonCustomValue(t, app, drivingDefID, personPBID, "Yes", year)
+	addPersonCustomValue(t, app, rideFromDefID, personPBID, "The airport", year)
+
+	s := NewStaffVehicleInfoSync(app)
+	s.SetYear(year)
+
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("first Sync: %v", err)
+	}
+	if s.Stats.Created != 1 || s.Stats.Updated != 0 || s.Stats.Errors != 0 {
+		t.Fatalf("first run: created=%d updated=%d errors=%d, want created=1 updated=0 errors=0",
+			s.Stats.Created, s.Stats.Updated, s.Stats.Errors)
+	}
+
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("second Sync: %v", err)
+	}
+	if s.Stats.Created != 0 || s.Stats.Updated != 0 || s.Stats.Errors != 0 {
+		t.Fatalf("second run: created=%d updated=%d errors=%d, want created=0 updated=0 errors=0",
+			s.Stats.Created, s.Stats.Updated, s.Stats.Errors)
+	}
+	if s.Stats.Skipped != 1 {
+		t.Errorf("second run: skipped=%d, want 1 (the unchanged record)", s.Stats.Skipped)
+	}
+}


### PR DESCRIPTION
## The defect

`staff_applications.go`, `staff_vehicle_info.go` and `camper_transportation.go` all fetched each
existing record, called `record.Set(...)` for every field unconditionally, saved, and incremented
`Stats.Updated` — with no comparison against stored values anywhere in any of the three. A run
against completely unchanged CampMinder data rewrote and reported every row as "updated," every
single time.

Re-measured against the production snapshot (`pocketbase/pb_data/data-prod.db`, read-only) for the
2026 season:

```sql
select year, count(*) from staff_applications group by year order by year;
select year, count(*) from staff_vehicle_info group by year order by year;
select year, count(*) from camper_transportation group by year order by year;
```

- `staff_applications`: **274** rows for 2026 — matches the issue's figure.
- `staff_vehicle_info`: **200** rows for 2026 — matches the issue's figure.
- `camper_transportation`: **1,667** rows for 2026 — the issue said "likewise" without a number;
  this is the real one. Before this fix a no-op nightly sync on this table alone rewrote all 1,667
  rows.

## What changed

Reused the existing shared helper, per the spec — no fourth comparison implementation:

- **`base_sync.go`**: `compareRecordNeedsUpdate(existing, newData, compareFields)` (already used by
  `staff_skills.go` and `camper_dietary.go`) is now also the comparison for these three.
- **`staff_applications.go`**: added `staffApplicationsCompareFields` (44 App-*/Position-Preference
  columns plus `staff`, excluding the `person_id`/`year` key), a `recordNeedsUpdate` delegate, and
  rebuilt `upsertRecords` around a `data map[string]any` so the same map both drives the comparison
  and the write. `upsertRecords` now returns `(created, updated, skipped, errCount)`.
- **`staff_vehicle_info.go`**: same shape — `staffVehicleInfoCompareFields` (10 SVI-* columns plus
  `staff`), same `data`-map refactor, same 4-value return.
- **`camper_transportation.go`**: same shape — `camperTransportationCompareFields` (13 BUS-* columns
  plus `attendee` and `used_legacy_fields`, excluding the `person_id`/`session_id`/`year` key).

**An unchanged record now counts as `Stats.Skipped`**, matching both existing comparing siblings
(`camper_dietary.go` and `staff_skills.go`) — this is the settled decision from the spec, not
re-litigated here. Consequence, stated plainly, and corrected from an earlier draft of this body
that undercounted the two staff syncs (see PR review): `Stats.Skipped` in `staff_applications.go`
and `staff_vehicle_info.go` is `+=`'d twice per run — once for the kindred#2277 staff-row gate
(`gatedPeople`) and once for this PR's no-write count (`upsertSkipped`) — so a no-op run flips
from `274 updated` to `0 updated, 296 skipped` for staff applications (274 no-write + 22 gated,
both re-measured against the production snapshot) and from `200 updated` to `0 updated, 206
skipped` for staff vehicles (200 + 6 gated). `camper_transportation.go` has no second
`Stats.Skipped` writer, so it is the one place the naive `1,667 updated` -> `0 updated, 1,667
skipped` holds exactly. That is the point either way: a run that changed nothing is now
distinguishable from one that rewrote everything.

**`Stats.Skipped` carries two record-level meanings in the two staff syncs**, and this PR is not the
first thing to add a second meaning to it — `staff_applications.go`/`staff_vehicle_info.go` already
gained a staff-row-gate meaning under kindred#2277 (merged as this PR was rebasing onto it, see
below). Both meanings count whole records, so the unit stays consistent, and a comment sits at each
site saying so. `camper_transportation.go` has no gate-drop counter, so `Stats.Skipped` carries
exactly one meaning there.

## Rebase note

PR #2380 (kindred#2277 + kindred#2383) merged to `main` while this branch was in progress and
touches the same two files (`staff_applications.go`, `staff_vehicle_info.go`) — it restructured the
staff-row-gate skip counting from a bare `continue`/`s.Stats.Skipped++` into a `gatedPeople` set
counted once per person. Rebased onto `origin/main` after it merged; the one resulting conflict (in
`staff_vehicle_info.go`, both branches touching the same gate `continue` block) was resolved by
keeping #2380's `gatedPeople` structure and updating this PR's comment to describe the two Skipped
meanings against the new code shape rather than the old one.

## Deliberately NOT done

- Did not write a fourth comparison helper — reused `compareRecordNeedsUpdate` per the spec.
- Did not touch `camper_dietary.go` or `staff_skills.go` (already idempotent) beyond reading them as
  the reuse targets.
- Did not touch the staff-row gate itself, RBAC, or any other sync service.

## Tests

Per service, one test drives the real `Sync()` entry point twice against a fixed fixture (not
`upsertRecords` directly — spec is explicit that driving the helper "proves nothing"):
`TestStaffApplicationsSyncSecondRunIsIdempotent`,
`TestStaffVehicleInfoSyncSecondRunIsIdempotent`,
`TestCamperTransportationSyncSecondRunIsIdempotent`. Each builds on the shared `newSyncTestApp`
fixture (custom_field_defs, persons, person_custom_values, staff, attendees) plus a local collection
builder carrying every column the comparison checks — a column missing from that builder would make
every field read back as `nil`, which would make the assertion pass for the wrong reason (nothing
comparable) instead of the right one.

First run: `Created=1, Updated=0, Errors=0`. Second run against the identical fixture:
`Created=0, Updated=0, Errors=0, Skipped=1`.

### Mutation-check evidence (`go test ./sync/ -run <test>`, restored after each)

| File | Mutation | Test | Result |
|---|---|---|---|
| `camper_transportation.go` | replaced the `recordNeedsUpdate` branch with `if false` | `TestCamperTransportationSyncSecondRunIsIdempotent` | RED — `created=0 updated=1 errors=0, want ... updated=0` |
| `staff_vehicle_info.go` | same | `TestStaffVehicleInfoSyncSecondRunIsIdempotent` | RED — same shape |
| `staff_applications.go` | same | `TestStaffApplicationsSyncSecondRunIsIdempotent` | RED — same shape |

All three restored; full suite green afterward.

**Review follow-up (kindred#2384 PR review):** the three tests above only pinned the skip
direction — nothing asserted that a genuinely changed record still gets written, so a mutant that
makes `recordNeedsUpdate` always return `false` (i.e. never update again) passed the full suite.
Added a third run to each test that edits the seeded `person_custom_values` row via a new
`updatePersonCustomValue` helper and asserts `Updated=1` plus the new value on the re-fetched
record. Mutation-checked the same way — `if false` in place of each `recordNeedsUpdate` body — and
confirmed RED before restoring:

| File | Mutation | Test | Result |
|---|---|---|---|
| `staff_applications.go` | `recordNeedsUpdate` -> `return false` | third run of `TestStaffApplicationsSyncSecondRunIsIdempotent` | RED — `created=0 updated=0 errors=0, want ... updated=1` |
| `staff_vehicle_info.go` | same | third run of `TestStaffVehicleInfoSyncSecondRunIsIdempotent` | RED — same shape |
| `camper_transportation.go` | same | third run of `TestCamperTransportationSyncSecondRunIsIdempotent` | RED — same shape |

All three restored; `go test ./sync/ -run 'IsIdempotent$'` green afterward.

## Verification

```
$ go build ./...                # exit=0
$ go vet ./...                  # exit=0
$ go test ./...                 # ok, all packages
$ go test -race ./sync/         # ok  github.com/camp/kindred/pocketbase/sync  238.123s
$ go test . -run 'Parallel|Serial|Exempt'   # PASS (my three new tests call t.Parallel()
                                             # and touch no process globals, so no
                                             # serialGroups entry needed)
```

Pushed and rebased onto `origin/main` (post-#2380); remote ref confirmed moved via
`git fetch -q && git rev-list --count origin/feature/sync-idempotency-2384..HEAD` = `0`.

## GUI impact

These counts render in the admin Sync tab toast and the per-service badges
(`useSyncCompletionToasts.ts`, `useSyncStatusAPI.ts`). After this PR, a no-op nightly run on a
season with no CampMinder changes will show these three services' badges reading **0 updated** with
a nonzero **skipped** count, instead of the previous behavior of reporting every stored row as
"updated" on every run regardless of whether anything actually changed. Concretely, for the 2026
season as re-measured against the production snapshot: staff applications shows **0 updated, 296
skipped** (not 274 — see the corrected figure above), staff vehicles **0 updated, 206 skipped**
(not 200), and camper transportation **0 updated, 1,667 skipped**.

Closes #2384.

