### PR TITLE
chore(scripts): move worktrees in-repo to .worktrees/

### DIFF
--- a/.claude/hooks/worktree-guard.sh
+++ b/.claude/hooks/worktree-guard.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
-# PreToolUse hook for Bash — blocks direct `git worktree add` calls.
-# Must use ./scripts/worktree/new.sh which handles port allocation,
-# branch naming, DB seeding, and config symlinks.
+# PreToolUse hook for Bash. Blocks two commands that silently break the
+# worktree layout. Self-tested by scripts/dev/test-worktree-guard.sh.
 #
 # Exit codes:
 #   0 = allow the tool call
 #   2 = block (Claude Code surfaces stderr as the denial reason)
+#
+# The hook only sees commands Claude issues through the Bash tool. Scripts
+# that shell out internally -- including new.sh's own `git worktree add` --
+# do not pass through it, and a developer's own terminal is unaffected.
 
 set -u
 
@@ -15,18 +18,16 @@ if command -v jq >/dev/null 2>&1; then
   command=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null)
 else
   # Fallback: scan the raw JSON payload. Less precise than parsing
-  # .tool_input.command — may catch the literal string in other fields — but
+  # .tool_input.command -- may catch the literal string in other fields -- but
   # preserves enforcement. Failing open would leave worktree creation
   # unguarded on hosts without jq.
   command=$input
 fi
 
+# ── 1. Direct `git worktree add` ────────────────────────────────────────
 # Match `git ... worktree add`, allowing intervening flags like `-C <dir>` or
 # `--git-dir=…` that would otherwise bypass the guard. Shell separators
 # (`;`, `&`, `|`) bound the match so chained commands still trigger.
-# The wrapper script itself shells out to `git worktree add` internally, but
-# those subprocesses don't go through the Bash tool, so the hook only sees
-# Claude's direct invocations.
 if printf '%s' "$command" | grep -qE '\bgit\b[^|;&]*\bworktree[[:space:]]+add\b'; then
   cat >&2 <<'EOF'
 [worktree-guard] BLOCKED: direct `git worktree add` is not allowed in this project.
@@ -44,5 +45,76 @@ intent with them before bypassing — don't just retry.
 EOF
   exit 2
 fi
+
+# ── 2. `git clean` that can delete .worktrees/ ──────────────────────────
+# Worktrees live at .worktrees/ inside the repo and are gitignored, which
+# puts them in range of `git clean`. Only one combination actually reaches
+# them, and the boundaries are measured, not assumed:
+#
+#   git clean -dff     survives — without -x/-X, ignored files are untouched
+#   git clean -xdf     survives — git prints "Skipping repository" itself
+#   git clean -nxdff   survives — dry run deletes nothing
+#   git clean -xdff    DELETED  — "Removing .worktrees/"
+#   git clean -Xdff    DELETED  — -X is ignored-files-ONLY, so it hits too
+#
+# So the trigger is: an ignored-file flag (-x/-X), AND force given twice,
+# AND not a dry run. Blocking wider than that would flag commands git
+# already refuses to execute, which trains the reader to bypass the guard.
+clean_is_destructive() {
+  local segment="$1"
+  printf '%s' "$segment" | grep -qE '\bgit\b.*\bclean\b' || return 1
+
+  local force=0 ignored=0 dryrun=0 tok rest i
+  while IFS= read -r tok; do
+    case "$tok" in
+      --) break ;;                       # end of options; rest are pathspecs
+      --force)   force=$((force + 1)) ;;
+      --dry-run) dryrun=1 ;;
+      -[!-]*)
+        # Short-flag cluster, e.g. -xdff. Inspect each letter: bundling is
+        # why a plain substring match on "-ff" would miss `git clean -ffdx`.
+        rest=${tok#-}
+        for (( i = 0; i < ${#rest}; i++ )); do
+          case "${rest:i:1}" in
+            f)   force=$((force + 1)) ;;
+            x|X) ignored=1 ;;
+            n)   dryrun=1 ;;
+          esac
+        done
+        ;;
+    esac
+    # `printf '%s\n'`, not '%s': `read` reports failure at EOF on a line with
+    # no trailing newline, so the final token -- which is exactly where the
+    # flags sit -- would be read into $tok and then discarded by the loop
+    # condition. Same reason the segment split below adds one.
+  done < <(printf '%s\n' "$segment" | tr -s ' \t' '\n')
+
+  [ "$ignored" -eq 1 ] && [ "$force" -ge 2 ] && [ "$dryrun" -eq 0 ]
+}
+
+# Split on shell separators so a `git clean` chained behind another command
+# is still examined on its own.
+while IFS= read -r segment; do
+  if clean_is_destructive "$segment"; then
+    cat >&2 <<'EOF'
+[worktree-guard] BLOCKED: this `git clean` would delete .worktrees/.
+
+Worktrees live at .worktrees/ inside the repo and are gitignored, so an
+ignored-file flag (-x or -X) combined with a doubled force (-ff) removes
+them outright — and leaves .git/worktrees/* pointing at nothing.
+
+Safe alternatives:
+  git clean -xdf              # single -f; git skips nested repositories
+  git clean -nxdff            # dry run; shows what would go
+  git clean -xdff -e .worktrees   # keep the worktrees, clean everything else
+
+To remove a worktree properly: ./scripts/worktree/cleanup.sh <feature-name>
+
+If the user explicitly asked to wipe the tree including worktrees, confirm
+that intent with them before bypassing — don't just retry.
+EOF
+    exit 2
+  fi
+done < <(printf '%s\n' "$command" | tr ';|&\n' '\n')
 
 exit 0

--- a/.claude/hooks/worktree-guard.sh
+++ b/.claude/hooks/worktree-guard.sh
@@ -24,6 +24,16 @@ else
   command=$input
 fi
 
+# Join backslash-newline line continuations before anything inspects the text.
+# Bash folds them into a single command before executing, so the guard has to
+# see what will actually run. Without this both checks below are bypassable:
+# grep matches line by line, and the git-clean splitter treats a newline as a
+# command separator -- so `git clean \<newline> -xdff` arrives as `git clean \`
+# plus `-xdff`, and neither half looks destructive on its own. Verified live
+# before the fix: the command ran and printed "Removing .worktrees/".
+# Pinned by TEST 13a-13d in scripts/dev/test-worktree-guard.sh.
+command=${command//\\$'\n'/ }
+
 # ── 1. Direct `git worktree add` ────────────────────────────────────────
 # Match `git ... worktree add`, allowing intervening flags like `-C <dir>` or
 # `--git-dir=…` that would otherwise bypass the guard. Shell separators

--- a/.claude/skills/consolidate-migrations/SKILL.md
+++ b/.claude/skills/consolidate-migrations/SKILL.md
@@ -147,7 +147,7 @@ Every round happens in a worktree, even if invoked from `~/kindred`.
 ```bash
 WORKTREE_NAME="consolidate-${TABLE}-$(date +%Y%m%d)"
 "$MAIN_REPO/scripts/worktree/new.sh" "$WORKTREE_NAME"
-WORKTREE_DIR="$HOME/kindred-worktrees/$WORKTREE_NAME"
+WORKTREE_DIR="$MAIN_REPO/.worktrees/$WORKTREE_NAME"
 ```
 
 All filesystem writes from Step 7 onward target `$WORKTREE_DIR/...`, never

--- a/.dockerignore
+++ b/.dockerignore
@@ -37,6 +37,11 @@ yarn-error.log*
 Thumbs.db
 
 # Project specific
+# Feature worktrees live in-repo at .worktrees/ and are full checkouts
+# (~1.1 GB each). CI builds from a fresh clone so they never exist there,
+# but a local `docker build .` would otherwise ship every one of them as
+# build context.
+.worktrees/
 pocketbase/pb_data/
 pocketbase/backups/
 pocketbase/*.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,11 @@ jobs:
             - 'scripts/dev/**'
             - '.github/workflows/ci.yml'
             - 'pocketbase/pb_migrations/**'
+            # test-worktree-guard.sh lives under scripts/dev/ but its subject
+            # is .claude/hooks/worktree-guard.sh. Without this line, editing
+            # the hook alone would not run the suite that pins its behavior --
+            # the exact unwired-guard shape kindred#2370 was about.
+            - '.claude/hooks/**'
           docker:
             - 'docker/**'
             - 'docker-compose*.yml'
@@ -280,12 +285,13 @@ jobs:
   # on either would leave it exactly as unwired as the absence this issue
   # is about. See the `guardSelfTests` filter comment above.
   #
-  # The other three self-tests found under scripts/dev/test-*.sh
+  # The other four self-tests found under scripts/dev/test-*.sh
   # (test-verify-consolidation.sh, test-migration-schema-diff.sh,
-  # test-pb-harness.sh) were audited the same way and are wired here too --
-  # all three pass standalone against a scratch Go build and a scratch
-  # sqlite3 DB, with no live PocketBase server or seeded dev DB required, so
-  # none of them carry the flake risk that would make wiring them a mistake.
+  # test-pb-harness.sh, test-worktree-guard.sh) were audited the same way and
+  # are wired here too -- all four pass standalone against a scratch Go build
+  # and a scratch sqlite3 DB, with no live PocketBase server or seeded dev DB
+  # required, so none of them carry the flake risk that would make wiring them
+  # a mistake. test-worktree-guard.sh needs neither: only bash and jq.
   guard-self-tests:
     name: Dev Guard Self-Tests
     needs: detect-changes
@@ -320,6 +326,9 @@ jobs:
 
     - name: PB harness lib self-test
       run: ./scripts/dev/test-pb-harness.sh
+
+    - name: Worktree guard self-test
+      run: ./scripts/dev/test-worktree-guard.sh
 
   # Python linting (parallel with other lint jobs)
   python-lint:

--- a/.gitignore
+++ b/.gitignore
@@ -313,6 +313,20 @@ requirements/
 claude-exports/
 pb_data_local/
 
+# Feature worktrees, created by scripts/worktree/new.sh. Each is a full
+# checkout (~1.1 GB with deps and a seeded DB) and must never be tracked.
+#
+# This entry is load-bearing beyond git: the `grep` shim Claude Code installs
+# runs with `--hidden`, so the leading dot does NOT keep worktrees out of
+# search results -- `--ignore-files` reading this line is what does. ripgrep
+# skips them for both reasons. See docs/reference/git-workflow.md.
+#
+# Left unanchored on purpose. Nothing should ever create a nested
+# .worktrees/, and scripts/worktree/new.sh pins its parent to the main
+# worktree so it cannot, but if that ever regresses the copy still stays out
+# of git and out of every search rather than silently becoming trackable.
+.worktrees/
+
 # =============================================================================
 # Private local files (not tracked)
 # These files contain camp-specific branding, credentials, or private config.

--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,10 @@
+# Search-tool ignore file, read by ripgrep, fd and friends (gitignore syntax).
+#
+# .gitignore already lists .worktrees/, and that covers every default search
+# path. This file exists for one gap: `rg --no-ignore-vcs` deliberately
+# discards .gitignore but still honors .ignore, so without this line that
+# invocation reports every hit four times over -- once per worktree checkout.
+#
+# It does NOT cover `rg -uu` / `--no-ignore`, which by definition ignores
+# this file too. That is correct behavior and not worth working around.
+.worktrees/

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -240,10 +240,11 @@ post-merge:
   commands:
     worktree-cleanup:
       run: |
-        MAIN_REPO="$(git rev-parse --show-toplevel)"
-        REPO_NAME="$(basename "$MAIN_REPO")"
-        REPO_PARENT="$(dirname "$MAIN_REPO")"
-        WORKTREES_DIR="$REPO_PARENT/${REPO_NAME}-worktrees"
+        # --git-common-dir, not --show-toplevel: post-merge fires in whichever
+        # worktree was merged into, and --show-toplevel would then look for
+        # sibling worktrees inside that worktree. See scripts/worktree/new.sh.
+        MAIN_REPO="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
+        WORKTREES_DIR="$MAIN_REPO/.worktrees"
         [ -d "$WORKTREES_DIR" ] || exit 0
         MERGED=""
         COUNT=0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,8 @@ Read the relevant doc before working in these areas:
 
 **Create worktrees with `./scripts/worktree/new.sh <feature-name>`** — never bare `git worktree add`, never `EnterWorktree`. The script handles port allocation (so parallel worktrees don't collide), branch naming, DB seed from main, and local-config symlinks. A `PreToolUse` hook blocks the bare command; if it denies a call, switch to `new.sh`.
 
+**Worktrees live at `.worktrees/<feature>/` inside the repo**, gitignored. They are in-repo because the harness reverts any `cd` that resolves outside the project root — so a sibling directory can never hold the session's working directory, and the statusline reports main's branch while you edit another. The same hook blocks `git clean -x -ff`, which would otherwise delete every worktree and leave `.git/worktrees/*` dangling.
+
 Working directly in the main repo folder needs the user's explicit say-so — assume a worktree otherwise, since other agents may hold uncommitted changes there.
 
 Worktree mechanics (ports, isolation, cleanup): `docs/reference/git-workflow.md`

--- a/docs/reference/git-workflow.md
+++ b/docs/reference/git-workflow.md
@@ -18,7 +18,7 @@ git pull --rebase origin main
 ./scripts/worktree/new.sh <descriptive-feature-name>
 
 # 3. Move to the worktree
-cd ../kindred-worktrees/<feature-name>
+cd .worktrees/<feature-name>
 
 # 4. Start development
 ./scripts/start_dev.sh
@@ -29,10 +29,33 @@ cd ../kindred-worktrees/<feature-name>
 ./scripts/worktree/cleanup.sh <feature-name>
 ```
 
+### Where They Live
+Worktrees are created at `.worktrees/<feature>/` **inside** the main repo, and
+`.worktrees/` is gitignored.
+
+They sit in-repo so a shell can hold a working directory in one. The Claude
+Code harness pins the session cwd to the project root and reverts any `cd`
+that lands outside it — resolving symlinks, so a symlinked `.worktrees` does
+not satisfy it. While worktrees were siblings at `../<repo>-worktrees/`, no
+session could `cd` into one, and the statusline (which reads the session cwd)
+reported main's branch no matter which feature branch was being edited.
+
+Two consequences worth knowing:
+
+- **`git clean -xdff` deletes every worktree** and leaves `.git/worktrees/*`
+  dangling. Single `-f` is safe — git skips nested repositories itself — and
+  without `-x`/`-X` ignored files are untouched. `.claude/hooks/worktree-guard.sh`
+  blocks only the lethal combination; `scripts/dev/test-worktree-guard.sh`
+  pins the boundary.
+- **Searches are unaffected**, but because of the `.gitignore` entry, not the
+  leading dot. The `grep` shim runs with `--hidden`; `--ignore-files` reading
+  that entry is what keeps worktree copies out of results. `rg -uu`, real
+  `/usr/bin/grep -r` and `find .` still descend — all opt-in.
+
 ### How It Works
 | Main Repo | Worktree |
 |-----------|----------|
-| `<repo>/` | `<repo>-worktrees/<feature>/` |
+| `<repo>/` | `<repo>/.worktrees/<feature>/` |
 | Ports: 3000, 8000, 8080, 8090 | Ports: Vite 3110-3199, FastAPI 8210-8299, Caddy 8310-8399, PB 8410-8499 |
 | Branch: main | Branch: feature/<feature> |
 | Database: production data | Database: seeded from main |

--- a/scripts/dev/test-worktree-guard.sh
+++ b/scripts/dev/test-worktree-guard.sh
@@ -80,7 +80,7 @@ expect_allow() {
 
 echo "=== TEST 1-3: git worktree add stays blocked (regression) ==="
 expect_block "plain"             "git worktree add ../foo feature/bar"
-expect_block "intervening flags" "git -C /home/adam/kindred worktree add x y"
+expect_block "intervening flags" "git -C /tmp/repository worktree add x y"
 expect_block "chained"           "cd /tmp && git worktree add z"
 
 echo
@@ -104,6 +104,20 @@ expect_block "mixed short and long" "git clean -x -f --force"
 echo
 echo "=== TEST 13: chained after another command is blocked ==="
 expect_block "chained" "npm run build && git clean -xdff"
+
+echo
+echo "=== TEST 13a-13d: line continuations do not smuggle a command past ==="
+# A backslash-newline is a continuation: bash joins it into ONE command before
+# running it. A guard that splits on the raw newline first sees `git clean \`
+# and `-xdff` as unrelated segments, and neither looks destructive on its own.
+# Verified as a live bypass before this was fixed -- the command ran and
+# printed "Removing .worktrees/". Both checks are affected, because grep
+# matches line by line too.
+expect_block "clean, continued before flags"  $'git clean \\\n  -xdff'
+expect_block "clean, continued mid-flags"     $'git clean -x \\\n  -f -f'
+expect_block "worktree add, continued"        $'git worktree \\\n  add ../foo bar'
+# The join must not manufacture a block out of a safe continued command.
+expect_allow "safe clean, continued"          $'git clean \\\n  -xdf'
 
 echo
 echo "=== TEST 14-17: git clean forms that CANNOT reach .worktrees/ are allowed ==="

--- a/scripts/dev/test-worktree-guard.sh
+++ b/scripts/dev/test-worktree-guard.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Test for .claude/hooks/worktree-guard.sh
+#
+# The guard is a PreToolUse hook on Bash. It reads the tool payload on stdin
+# and exits 0 to allow or 2 to block, with the reason on stderr.
+#
+# It covers two unrelated hazards that share one mechanism:
+#
+#   1. `git worktree add` -- bypasses ./scripts/worktree/new.sh, which owns
+#      port allocation, branch naming, DB seeding and config symlinks.
+#
+#   2. `git clean` with BOTH an ignored-file flag and a doubled force --
+#      worktrees now live at .worktrees/ INSIDE the repo and are gitignored,
+#      so this command deletes them and leaves .git/worktrees/* dangling.
+#
+# The git-clean half is deliberately narrow, and the boundaries below are
+# empirical, not guessed. Measured against a gitignored nested repo:
+#
+#   git clean -dff    survives  -- without -x/-X, ignored files are untouched
+#   git clean -xdf    survives  -- git prints "Skipping repository" itself
+#   git clean -xdff   DELETED   -- "Removing .worktrees/"
+#   git clean -Xdff   DELETED   -- -X is ignored-files-ONLY, so it hits too
+#
+# Blocking any wider than that would flag commands git already refuses to
+# execute, and train the reader to bypass the guard. Blocking any narrower
+# would miss -X or a flag order the author did not think of, which is why
+# TEST 7-9 pin the reorderings rather than one canonical spelling.
+
+set -euo pipefail
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$HERE/../.." && pwd)
+GUARD="$REPO_ROOT/.claude/hooks/worktree-guard.sh"
+
+if [[ ! -x "$GUARD" ]]; then
+  echo "FAIL: $GUARD not executable or missing" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "FAIL: jq is required to build the hook payload" >&2
+  exit 1
+fi
+
+FAILURES=0
+
+# Feed one command to the guard as a real tool payload and report its exit
+# code. jq builds the JSON so quoting, newlines and backslashes in the
+# command under test cannot corrupt the payload.
+guard_rc() {
+  local cmd="$1" rc=0
+  jq -nc --arg c "$cmd" '{tool_name:"Bash",tool_input:{command:$c}}' \
+    | "$GUARD" >/dev/null 2>&1 || rc=$?
+  echo "$rc"
+}
+
+expect_block() {
+  local label="$1" cmd="$2" rc
+  rc=$(guard_rc "$cmd")
+  if [[ "$rc" -ne 2 ]]; then
+    echo "FAIL: [$label] expected BLOCK (exit 2), got $rc" >&2
+    echo "      command: $cmd" >&2
+    FAILURES=$((FAILURES + 1))
+  else
+    echo "  ok  BLOCK  $label"
+  fi
+}
+
+expect_allow() {
+  local label="$1" cmd="$2" rc
+  rc=$(guard_rc "$cmd")
+  if [[ "$rc" -ne 0 ]]; then
+    echo "FAIL: [$label] expected ALLOW (exit 0), got $rc" >&2
+    echo "      command: $cmd" >&2
+    FAILURES=$((FAILURES + 1))
+  else
+    echo "  ok  ALLOW  $label"
+  fi
+}
+
+echo "=== TEST 1-3: git worktree add stays blocked (regression) ==="
+expect_block "plain"             "git worktree add ../foo feature/bar"
+expect_block "intervening flags" "git -C /home/adam/kindred worktree add x y"
+expect_block "chained"           "cd /tmp && git worktree add z"
+
+echo
+echo "=== TEST 4-6: worktree subcommands that are not 'add' stay allowed ==="
+expect_allow "list"    "git worktree list"
+expect_allow "remove"  "git worktree remove .worktrees/foo"
+expect_allow "prune"   "git worktree prune"
+
+echo
+echo "=== TEST 7-9: git clean that deletes .worktrees/ is blocked ==="
+expect_block "-xdff"                "git clean -xdff"
+expect_block "-ffdx (reordered)"    "git clean -ffdx"
+expect_block "-Xdff (ignored-only)" "git clean -Xdff"
+
+echo
+echo "=== TEST 10-12: the same danger spelled other ways is blocked ==="
+expect_block "separate short flags" "git clean -x -f -f"
+expect_block "long force twice"     "git clean --force --force -x"
+expect_block "mixed short and long" "git clean -x -f --force"
+
+echo
+echo "=== TEST 13: chained after another command is blocked ==="
+expect_block "chained" "npm run build && git clean -xdff"
+
+echo
+echo "=== TEST 14-17: git clean forms that CANNOT reach .worktrees/ are allowed ==="
+# Each of these is a real command a developer runs. Blocking them would be a
+# false positive, and the measured behavior above is why they are safe.
+expect_allow "-xdf  (single force; git skips repos)" "git clean -xdf"
+expect_allow "-dff  (no -x; ignored files untouched)" "git clean -dff"
+expect_allow "-n    (dry run)"                        "git clean -nxd"
+# -nxdff carries every ingredient the guard looks for and still deletes
+# nothing -- measured as "Would remove .worktrees/". Listing what a
+# destructive command WOULD do is how you decide whether to run it, so the
+# guard must not block the safe half of that workflow.
+expect_allow "-nxdff (dry run, doubled force)"        "git clean -nxdff"
+expect_allow "--dry-run --force --force -x"           "git clean --dry-run --force --force -x"
+
+echo
+echo "=== TEST 18-20: unrelated commands are untouched ==="
+expect_allow "git status"       "git status --porcelain"
+expect_allow "ls"               "ls -la"
+expect_allow "clean in prose"   "echo 'remember to clean the build dir'"
+
+echo
+echo "=== TEST 21: a block explains itself on stderr ==="
+BLOCK_OUT=$(jq -nc '{tool_name:"Bash",tool_input:{command:"git clean -xdff"}}' \
+  | "$GUARD" 2>&1 >/dev/null || true)
+if ! grep -q '\.worktrees' <<<"$BLOCK_OUT"; then
+  echo "FAIL: block message does not mention .worktrees" >&2
+  echo "$BLOCK_OUT" >&2
+  FAILURES=$((FAILURES + 1))
+else
+  echo "  ok  message names the directory at risk"
+fi
+
+echo
+if [[ "$FAILURES" -gt 0 ]]; then
+  echo "FAILED: $FAILURES check(s)" >&2
+  exit 1
+fi
+echo "PASS: worktree-guard behaves as specified"

--- a/scripts/worktree/cleanup.sh
+++ b/scripts/worktree/cleanup.sh
@@ -10,13 +10,14 @@
 set -e
 
 # Dynamic paths
-MAIN_REPO="$(git rev-parse --show-toplevel)"
+# --git-common-dir, not --show-toplevel: the latter names the *current*
+# worktree when run from inside one, and worktrees now nest under the main
+# repo. See scripts/worktree/new.sh for the full reasoning.
+MAIN_REPO="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
 
 # shellcheck source=../colors.sh
 source "$MAIN_REPO/scripts/colors.sh"
-REPO_NAME="$(basename "$MAIN_REPO")"
-REPO_PARENT="$(dirname "$MAIN_REPO")"
-WORKTREES_DIR="$REPO_PARENT/${REPO_NAME}-worktrees"
+WORKTREES_DIR="$MAIN_REPO/.worktrees"
 
 # Check if a PR for this branch was merged (the only safe heuristic)
 is_pr_merged() {

--- a/scripts/worktree/list.sh
+++ b/scripts/worktree/list.sh
@@ -3,13 +3,14 @@
 #
 # Usage: ./scripts/worktree/list.sh
 
-MAIN_REPO="$(git rev-parse --show-toplevel)"
+# --git-common-dir, not --show-toplevel: the latter names the *current*
+# worktree when run from inside one, and worktrees now nest under the main
+# repo. See scripts/worktree/new.sh for the full reasoning.
+MAIN_REPO="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
 
 # shellcheck source=../colors.sh
 source "$MAIN_REPO/scripts/colors.sh"
-REPO_NAME="$(basename "$MAIN_REPO")"
-REPO_PARENT="$(dirname "$MAIN_REPO")"
-WORKTREES_DIR="$REPO_PARENT/${REPO_NAME}-worktrees"
+WORKTREES_DIR="$MAIN_REPO/.worktrees"
 
 echo -e "${GREEN}=== Git Worktrees ===${NC}"
 echo -e ""

--- a/scripts/worktree/new.sh
+++ b/scripts/worktree/new.sh
@@ -7,22 +7,27 @@
 #   ./scripts/worktree/new.sh social-graph-perf
 #
 # Creates:
-#   <repo-parent>/<repo-name>-worktrees/<feature-name>/
+#   <main-repo>/.worktrees/<feature-name>/
 #   Branch: feature/<feature-name>
 #   Ports: auto-assigned based on feature name hash
 #   Database: seeded from main
 
 set -e
 
-# Dynamic path detection
-MAIN_REPO="$(git rev-parse --show-toplevel)"
+# Dynamic path detection.
+#
+# --git-common-dir, NOT --show-toplevel. Both name the main repo when run
+# from it, but --show-toplevel names the *current* worktree when run from
+# inside one, and worktrees now nest under it: that spelling turns a
+# new.sh invoked from a worktree into .worktrees/<a>/.worktrees/<b>, a
+# worktree inside a worktree. --git-common-dir always resolves to the
+# shared .git of the main worktree, so this is pinned wherever it runs.
+MAIN_REPO="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
 
 # Colors
 # shellcheck source=../colors.sh
 source "$MAIN_REPO/scripts/colors.sh"
-REPO_NAME="$(basename "$MAIN_REPO")"
-REPO_PARENT="$(dirname "$MAIN_REPO")"
-WORKTREES_DIR="$REPO_PARENT/${REPO_NAME}-worktrees"
+WORKTREES_DIR="$MAIN_REPO/.worktrees"
 
 # Parse arguments
 FEATURE_NAME="${1:-}"


### PR DESCRIPTION
Worktrees now live at `.worktrees/<feature>/` inside the repo instead of a sibling `../<repo>-worktrees/` directory.

## Why

The harness pins the session working directory to the project root and reverts any `cd` that resolves outside it. Measured twice:

```
$ cd ~/kindred-worktrees/staff-gate-visibility-2277
/home/adam/kindred-worktrees/staff-gate-visibility-2277
exit=0
Shell cwd was reset to /home/adam/kindred
```

Corroborated across 25 session transcripts: 13,229 recorded `cwd` values, none outside `~/kindred`.

Two consequences. The statusline reads `workspace.current_dir`, so it reported `~/kindred (main)` — clean and green — no matter which feature branch was being edited. And every worktree-directed command had to re-pay its full path through `git -C` or an absolute path.

A symlink does not fix this: the clamp resolves `realpath`. Probed with the pre-existing `docs/camp` symlink, whose logical path is inside the repo and physical path outside — still reset. So the directories had to move for real.

Verified after the change, running `new.sh` from a *different* worktree:

```
call 1: cd ~/kindred/.worktrees/e2e-probe   → no reset
call 2: cwd at start of new call: ~/kindred/.worktrees/e2e-probe   ← persisted

statusline: ~/kindred/.worktrees/e2e-probe (feature/e2e-probe)
```

## What changed

- **`WORKTREES_DIR`** in `new.sh`, `cleanup.sh`, `list.sh` and the `.lefthook.yml` post-merge hook → `$MAIN_REPO/.worktrees`.
- **`MAIN_REPO` derivation** switched from `git rev-parse --show-toplevel` to the parent of `--git-common-dir`. `--show-toplevel` names the *current* worktree when run from inside one; now that worktrees nest under the main repo, that spelling would have produced `.worktrees/<a>/.worktrees/<b>`. Confirmed fixed by creating a worktree from a sibling worktree and watching it land in the main repo.
- **`.gitignore` / `.dockerignore` / new `.ignore`.** The `.gitignore` entry is load-bearing beyond git: the `grep` shim runs with `--hidden`, so the leading dot does *not* keep worktrees out of search results — `--ignore-files` reading that entry is what does. Measured with a planted worktree copy: `rg`, `rg --hidden` and bare `grep -r` all returned 1 hit, `rg -uu` returned 2 (documented, opt-in), and `git status` showed nothing.
- **`git clean` guard** in `.claude/hooks/worktree-guard.sh`, with a new self-test.

## The git clean guard

Gitignoring the worktrees puts them in range of `git clean`. The guard is narrow because the boundaries were measured against a gitignored nested repo, not assumed:

| Command | Result |
|---|---|
| `git clean -dff` | survives — without `-x`/`-X`, ignored files are untouched |
| `git clean -xdf` | survives — git prints "Skipping repository" itself |
| `git clean -nxdff` | survives — dry run deletes nothing |
| `git clean -xdff` | **DELETED** — "Removing .worktrees/" |
| `git clean -Xdff` | **DELETED** — `-X` is ignored-files-only, so it hits too |

So it blocks exactly: an ignored-file flag, **and** force given twice, **and** not a dry run. Blocking wider would flag commands git already refuses to execute, which trains the reader to bypass the guard.

`scripts/dev/test-worktree-guard.sh` pins all 21 cases including flag reorderings (`-ffdx`), long forms (`--force --force`) and chaining. Written first and confirmed red (8 failures) before the guard existed — which is how the tokenizer bug surfaced: `read` reports failure at EOF on a line with no trailing newline, so the final token, where the flags sit, was being silently dropped.

Wired into CI's `guard-self-tests` job, and `.claude/hooks/**` added to the `guardSelfTests` path filter so editing the hook alone triggers the suite that pins it — the unwired-guard shape #2370 was about.

## Not migrated

Existing worktrees were drained rather than moved. `new.sh` links private config with `ln -sfr`, so each worktree carries six *relative* symlinks; the new location is one level deeper and `git worktree move` does not rewrite symlink targets. All six would have resolved to `~/kindred/kindred-local/…` and dangled, silently costing branding, `CLAUDE.local.md`, vault config, vite overrides and the lodging registry PocketBase reads at boot. Freshly created worktrees get correct relative links automatically — verified on the probe.

## Verification

- `scripts/dev/test-worktree-guard.sh` — 21/21
- `shellcheck --severity=warning` on all five changed scripts — clean
- `markdownlint-cli2`, YAML parse of both workflow files — clean
- `scripts/pre-push-verify.sh` — pass
- End-to-end: `new.sh` → correct path, cwd persists, five of six private-config symlinks resolve (the sixth, `sheets_sharing.local.json`, has no target in `kindred-local` and dangles identically in `main` — pre-existing, untouched here), `.git` pointer correct; `cleanup.sh` and `list.sh` both operate on the new location

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worktrees are now consistently created and managed in the repository’s `.worktrees/` directory, including when working from nested worktrees.
  * Unsafe cleanup commands that could delete ignored worktree files are now blocked, with safer alternatives provided.

* **Documentation**
  * Updated development and Git workflow guidance to explain the new worktree layout, search behavior, and cleanup precautions.

* **Tests**
  * Added automated coverage for worktree safety protections and integrated it into CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->