### PR TITLE
fix(pb): stop lodging roll-forward from carrying is_confirmed across seasons

### DIFF
--- a/pocketbase/lodging/rollforward.go
+++ b/pocketbase/lodging/rollforward.go
@@ -27,9 +27,17 @@ import (
 //	year                   — set explicitly to the target
 //	area / parent_unit     — relations, re-resolved into the target year by the
 //	                         two later passes
+//	is_confirmed           — asserts a human physically walked THIS season's
+//	                         cabin (docs/reference/lodging-registry.md:377), not
+//	                         a fact that outlives the season it was checked in.
+//	                         Carrying it would let a roll-forward -- including a
+//	                         BACKWARD one onto a season nobody has walked -- stamp
+//	                         is_confirmed = true on a row nobody confirmed
+//	                         (kindred#2392).
 var notCarried = map[string]bool{
 	"id": true, "created": true, "updated": true,
 	"year": true, "area": true, "parent_unit": true,
+	"is_confirmed": true,
 }
 
 // carriedFields returns every field on the collection that should travel to the

--- a/pocketbase/lodging/rollforward.go
+++ b/pocketbase/lodging/rollforward.go
@@ -8,9 +8,10 @@ import (
 	"github.com/pocketbase/pocketbase/core"
 )
 
-// Columns copied verbatim onto the new season's row. `code` is here and is
-// NEVER regenerated: a building renamed next season keeps its code, and the
-// code is the only thing linking its years together.
+// Columns copied verbatim onto the new season's row, on EVERY roll regardless
+// of direction. `code` is here and is NEVER regenerated: a building renamed
+// next season keeps its code, and the code is the only thing linking its
+// years together.
 //
 // `id`, `created` and `updated` are excluded — the new row is a new record.
 // `area` and `parent_unit` are excluded because they are relations that must be
@@ -27,27 +28,43 @@ import (
 //	year                   — set explicitly to the target
 //	area / parent_unit     — relations, re-resolved into the target year by the
 //	                         two later passes
-//	is_confirmed           — asserts a human physically walked THIS season's
-//	                         cabin (docs/reference/lodging-registry.md:377), not
-//	                         a fact that outlives the season it was checked in.
-//	                         Carrying it would let a roll-forward -- including a
-//	                         BACKWARD one onto a season nobody has walked -- stamp
-//	                         is_confirmed = true on a row nobody confirmed
-//	                         (kindred#2392).
+//
+// `is_confirmed` is NOT here — see carriedFields's direction-dependent
+// exclusion below. It cannot be a blanket entry in this map: #2029 made
+// confirmation a permanent staff attestation that deliberately carries
+// forward ("Confirmation carries forward... a yearly re-confirm is
+// unnecessary", docs/reference/lodging-registry.md:368-373;
+// SeasonRollForwardPanel.tsx's doc comment says the same), and that is the
+// ONLY direction the Season panel exposes today (fromYear = currentYear-1,
+// toYear = currentYear). A blanket exclusion would silently un-confirm every
+// already-verified cabin the next time staff advance the season.
 var notCarried = map[string]bool{
 	"id": true, "created": true, "updated": true,
 	"year": true, "area": true, "parent_unit": true,
-	"is_confirmed": true,
 }
 
-// carriedFields returns every field on the collection that should travel to the
-// next season, so a column added tomorrow rides along without editing this file.
-func carriedFields(col *core.Collection) []string {
+// carriedFields returns every field on the collection that should travel to
+// the target season, so a column added tomorrow rides along without editing
+// this file.
+//
+// backward reports whether this roll copies from a LATER season onto an
+// EARLIER one (`to < from`) — the direction kindred#2392 proposes for
+// backfilling lodging_units into years that predate the confirmed registry.
+// `is_confirmed` is excluded ONLY on that direction: a backward roll would
+// otherwise stamp is_confirmed = true on a season nobody has ever walked, in
+// a field the docs describe as a permanent staff attestation (see
+// notCarried's comment for the forward case this must not break).
+func carriedFields(col *core.Collection, backward bool) []string {
 	out := make([]string, 0, len(col.Fields))
 	for _, f := range col.Fields {
-		if !notCarried[f.GetName()] {
-			out = append(out, f.GetName())
+		name := f.GetName()
+		if notCarried[name] {
+			continue
 		}
+		if backward && name == "is_confirmed" {
+			continue
+		}
+		out = append(out, name)
 	}
 	return out
 }
@@ -184,6 +201,7 @@ func copyAreas(app core.App, from, to int, write bool, plan *RollForwardPlan) (m
 	if err != nil {
 		return nil, fmt.Errorf("lodging_areas collection: %w", err)
 	}
+	backward := to < from
 
 	for _, src := range source {
 		code := src.GetString("code")
@@ -201,7 +219,7 @@ func copyAreas(app core.App, from, to int, write bool, plan *RollForwardPlan) (m
 			continue
 		}
 		rec := core.NewRecord(col)
-		for _, f := range carriedFields(col) {
+		for _, f := range carriedFields(col, backward) {
 			rec.Set(f, src.Get(f))
 		}
 		rec.Set("year", to)
@@ -227,6 +245,7 @@ func copyUnits(app core.App, from, to int, write bool, areaIDs map[string]string
 	if err != nil {
 		return fmt.Errorf("lodging_units collection: %w", err)
 	}
+	backward := to < from
 
 	for _, src := range source {
 		code := src.GetString("code")
@@ -246,7 +265,7 @@ func copyUnits(app core.App, from, to int, write bool, areaIDs map[string]string
 		}
 
 		rec := core.NewRecord(col)
-		for _, f := range carriedFields(col) {
+		for _, f := range carriedFields(col, backward) {
 			rec.Set(f, src.Get(f))
 		}
 		rec.Set("year", to)

--- a/pocketbase/lodging/rollforward_test.go
+++ b/pocketbase/lodging/rollforward_test.go
@@ -27,8 +27,8 @@ func newRollForwardTestApp(t *testing.T) core.App {
 
 // seedYear seeds one self-contained season: 2 areas and 3 units, one of which
 // (test-unit-a-room-1) has a parent (test-unit-a) — the minimum shape that
-// exercises the area-index pass, the parent-relink pass, and a deny-list
-// field (is_confirmed) that must copy verbatim.
+// exercises the area-index pass, the parent-relink pass, and a deny-listed
+// field (is_confirmed) that must NOT copy across a roll-forward (kindred#2392).
 func seedYear(t *testing.T, app core.App, year int) {
 	t.Helper()
 
@@ -99,13 +99,32 @@ func TestApplyRollForwardCopiesEveryUnitAndArea(t *testing.T) {
 	if plan.UnitsToCreate != 3 || plan.AreasToCreate != 2 {
 		t.Errorf("plan = %+v, want 3 units and 2 areas", plan)
 	}
+}
+
+// TestApplyRollForwardDoesNotCarryIsConfirmedForward pins kindred#2392's fix.
+// `is_confirmed` asserts a human physically walked the cabin for THIS season
+// (docs/reference/lodging-registry.md:377) -- it is not a fact about the
+// building that outlives the season it was checked in. Before this fix
+// `notCarried` held only `year`, `area` and `parent_unit`, so is_confirmed
+// rode along with every other ordinary column through carriedFields, and
+// any roll-forward -- including a BACKWARD one onto a season nobody has
+// walked -- stamped is_confirmed = true on a row nobody confirmed.
+func TestApplyRollForwardDoesNotCarryIsConfirmedForward(t *testing.T) {
+	t.Parallel()
+	app := newRollForwardTestApp(t)
+	seedYear(t, app, 2026) // parent unit test-unit-a seeds with is_confirmed = true
+
+	if _, err := ApplyRollForward(app, 2026, 2027); err != nil {
+		t.Fatalf("ApplyRollForward: %v", err)
+	}
 
 	rec, err := findByCodeAndYear(app, "lodging_units", "test-unit-a", 2027)
 	if err != nil || rec == nil {
 		t.Fatalf("unit not carried forward: %v", err)
 	}
-	if !rec.GetBool("is_confirmed") {
-		t.Error("is_confirmed did not carry forward")
+	if rec.GetBool("is_confirmed") {
+		t.Error("is_confirmed carried forward from the source season; want false -- " +
+			"a new season's registry starts unconfirmed until staff walk it")
 	}
 }
 

--- a/pocketbase/lodging/rollforward_test.go
+++ b/pocketbase/lodging/rollforward_test.go
@@ -27,8 +27,9 @@ func newRollForwardTestApp(t *testing.T) core.App {
 
 // seedYear seeds one self-contained season: 2 areas and 3 units, one of which
 // (test-unit-a-room-1) has a parent (test-unit-a) — the minimum shape that
-// exercises the area-index pass, the parent-relink pass, and a deny-listed
-// field (is_confirmed) that must NOT copy across a roll-forward (kindred#2392).
+// exercises the area-index pass, the parent-relink pass, and is_confirmed's
+// direction-dependent carry behavior (kindred#2392): forward, it travels like
+// any ordinary column; backward, it must not.
 func seedYear(t *testing.T, app core.App, year int) {
 	t.Helper()
 
@@ -101,15 +102,16 @@ func TestApplyRollForwardCopiesEveryUnitAndArea(t *testing.T) {
 	}
 }
 
-// TestApplyRollForwardDoesNotCarryIsConfirmedForward pins kindred#2392's fix.
-// `is_confirmed` asserts a human physically walked the cabin for THIS season
-// (docs/reference/lodging-registry.md:377) -- it is not a fact about the
-// building that outlives the season it was checked in. Before this fix
-// `notCarried` held only `year`, `area` and `parent_unit`, so is_confirmed
-// rode along with every other ordinary column through carriedFields, and
-// any roll-forward -- including a BACKWARD one onto a season nobody has
-// walked -- stamped is_confirmed = true on a row nobody confirmed.
-func TestApplyRollForwardDoesNotCarryIsConfirmedForward(t *testing.T) {
+// TestApplyRollForwardCarriesIsConfirmedOnAForwardRoll pins the #2029 design
+// this PR must not silently reverse: "Confirmation carries forward... a
+// yearly re-confirm is unnecessary" (docs/reference/lodging-registry.md:368-373)
+// and SeasonRollForwardPanel.tsx's own doc comment ("Values, is_confirmed and
+// code all carry forward"). The Season panel only ever calls this direction
+// (fromYear = currentYear-1, toYear = currentYear) -- it is the ONLY roll
+// staff perform today. A blanket exclusion of is_confirmed from notCarried
+// would silently un-confirm every previously-verified cabin on ordinary
+// season advance, forcing staff to re-walk buildings nothing changed about.
+func TestApplyRollForwardCarriesIsConfirmedOnAForwardRoll(t *testing.T) {
 	t.Parallel()
 	app := newRollForwardTestApp(t)
 	seedYear(t, app, 2026) // parent unit test-unit-a seeds with is_confirmed = true
@@ -122,9 +124,34 @@ func TestApplyRollForwardDoesNotCarryIsConfirmedForward(t *testing.T) {
 	if err != nil || rec == nil {
 		t.Fatalf("unit not carried forward: %v", err)
 	}
+	if !rec.GetBool("is_confirmed") {
+		t.Error("is_confirmed did not carry forward on a FORWARD roll; want true -- " +
+			"confirmation is a permanent staff attestation per #2029, not a per-season flag")
+	}
+}
+
+// TestApplyRollForwardDoesNotCarryIsConfirmedOnABackwardRoll pins kindred#2392's
+// concern: a BACKWARD roll -- the mechanism proposed for backfilling
+// lodging_units into 2022-2025 -- must not stamp is_confirmed = true onto a
+// season nobody has ever walked. `is_confirmed` is excluded from carriedFields
+// only in this direction (`to < from`); see carriedFields's doc comment for
+// why the exclusion cannot be direction-blind without breaking the test above.
+func TestApplyRollForwardDoesNotCarryIsConfirmedOnABackwardRoll(t *testing.T) {
+	t.Parallel()
+	app := newRollForwardTestApp(t)
+	seedYear(t, app, 2027) // parent unit test-unit-a seeds with is_confirmed = true
+
+	if _, err := ApplyRollForward(app, 2027, 2026); err != nil {
+		t.Fatalf("ApplyRollForward: %v", err)
+	}
+
+	rec, err := findByCodeAndYear(app, "lodging_units", "test-unit-a", 2026)
+	if err != nil || rec == nil {
+		t.Fatalf("unit not carried backward: %v", err)
+	}
 	if rec.GetBool("is_confirmed") {
-		t.Error("is_confirmed carried forward from the source season; want false -- " +
-			"a new season's registry starts unconfirmed until staff walk it")
+		t.Error("is_confirmed carried backward from the source season; want false -- " +
+			"a historical backfill row nobody has walked must start unconfirmed")
 	}
 }
 


### PR DESCRIPTION
## Defect

`notCarried` in `pocketbase/lodging/rollforward.go` denied only `year`, `area`
and `parent_unit`. Every other column -- including `is_confirmed` -- rode
along verbatim through `carriedFields`, because a new column is carried by
default (deny-list, not allow-list) unless it is explicitly excluded.

`is_confirmed` is a permanent staff attestation, not a per-season flag: #2029
made it deliberately carry forward on a roll ("Confirmation carries
forward... a yearly re-confirm is unnecessary",
`docs/reference/lodging-registry.md:368-373`; `SeasonRollForwardPanel.tsx`'s
own doc comment says the same). That is correct for the FORWARD direction --
the only one the Season panel exposes today (`fromYear = currentYear-1,
toYear = currentYear`). It is wrong for a BACKWARD roll -- the mechanism
kindred#2392 proposes for backfilling `lodging_units` into 2022-2025 -- which
would stamp `is_confirmed = true` onto historical rows nobody has ever
checked against a physical cabin, in a field the docs describe as permanent.

## Fix

`carriedFields` now takes a `backward` flag (`to < from`, computed once per
pass in `copyAreas`/`copyUnits`) and excludes `is_confirmed` **only** on a
backward roll. A forward roll -- today's only real usage -- still carries
`is_confirmed`, matching #2029's design and every doc/comment that describes
it; a backward roll starts every carried unit unconfirmed, closing the gap
kindred#2392 raised.

An earlier version of this PR added `is_confirmed` to `notCarried`
unconditionally, which is direction-blind and would have silently
un-confirmed every already-verified cabin on the very next ordinary season
advance -- reversing #2029's design rather than fixing the backward-roll gap.
Caught and corrected during independent review; kindred#2392's ruled plan
(step 1) has been corrected to match.

Test-first: `TestApplyRollForwardCarriesIsConfirmedOnAForwardRoll` (red
against the unconditional-exclusion version, mutation-checked) pins that a
forward roll still carries `is_confirmed`.
`TestApplyRollForwardDoesNotCarryIsConfirmedOnABackwardRoll` pins that a
backward roll does not. Both replace the single direction-blind test the PR
originally shipped with.

`go build ./... && go test ./lodging/...` (full package), `go vet`,
`gofmt -l`, and `golangci-lint run` are all clean on the two touched files.

## What this deliberately does NOT do

- **Does not run the roll.** Rolling 2026 -> 2025 -> ... -> 2022 to backfill
  the historical registry is an operator task against production, called out
  explicitly in kindred#2392, and is not performed by this PR.
- **Does not add a direction guard** to `PreviewRollForward`/`ApplyRollForward`
  rejecting `from > to` -- kindred#2392 asks for that to be verified with a
  `Preview` call before the real roll runs, which is part of the operator
  task, not this code change. (This PR's `backward` flag makes carry-forward
  behavior correct either way; it does not restrict which directions are
  callable.)
- **Does not touch `pocketbase/lodging/registry.go`** -- owned by a sibling
  PR (kindred#2390).
- **Does not close kindred#2392.** That issue's plan has three more steps
  (direction-guard verification, the actual roll, and the per-year sync run)
  that are explicitly operator tasks, not agent work.

Related to kindred#2392 (step 1 of its ruled plan).
