### PR TITLE
refactor(frontend): drop the areas drawer's unusable Map centre inputs

### DIFF
--- a/frontend/src/components/admin/lodging/LodgingAreasDrawer.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingAreasDrawer.test.tsx
@@ -18,6 +18,20 @@ const AREAS = [
   { id: 'a2', name: 'South Zone', code: 'SOUTH', map_x: 0.6, map_y: 0.7, sort_order: 3 },
 ]
 
+// PocketBase stores an unset centroid as 0, never null (see mapModel.ts's
+// hasCoordinates). This is the shape #2397's "must stay unset" guarantee is
+// about. Kept out of the shared AREAS fixture — several tests above assert
+// on exact sort_order arithmetic derived from AREAS, and a third row would
+// shift every one of them.
+const UNSET_CENTROID_AREA = {
+  id: 'a3',
+  name: 'Unset Zone',
+  code: 'UNSET',
+  map_x: 0,
+  map_y: 0,
+  sort_order: 5,
+}
+
 // Module-scoped so `vi.mock` can close over them, so call records and resolved
 // values outlive the test that set them unless cleared here.
 beforeEach(() => {
@@ -151,22 +165,42 @@ describe('LodgingAreasDrawer', () => {
     expect(screen.queryByRole('button', { name: 'Move North Zone up' })).not.toBeInTheDocument()
   })
 
-  it('saves a map centroid, which the later map view renders from', async () => {
-    updateLodgingArea.mockResolvedValue({})
-    const user = userEvent.setup()
+  it('renders no Map centre inputs — there is no map to place them against (#2397)', async () => {
     render(<LodgingAreasDrawer open onClose={vi.fn()} />, { wrapper })
     await waitFor(() => {
       expect(screen.getByDisplayValue('North Zone')).toBeInTheDocument()
     })
 
-    const x = screen.getByLabelText('North Zone map X')
-    await user.clear(x)
-    await user.type(x, '0.45')
+    expect(screen.queryByLabelText('North Zone map X')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('North Zone map Y')).not.toBeInTheDocument()
+    expect(screen.queryByText('Map centre')).not.toBeInTheDocument()
+  })
+
+  it('leaves an unset centroid unset when a different field is edited', async () => {
+    // The centroid inputs are gone, so nothing in this drawer should ever
+    // put map_x/map_y on a write again. An area whose centroid is unset
+    // (map_x: 0, map_y: 0 — PocketBase's convention, not null) must stay
+    // that way rather than getting overwritten as a side effect of editing
+    // its name.
+    listLodgingAreas.mockResolvedValue([...AREAS, UNSET_CENTROID_AREA])
+    updateLodgingArea.mockResolvedValue({})
+    const user = userEvent.setup()
+    render(<LodgingAreasDrawer open onClose={vi.fn()} />, { wrapper })
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Unset Zone')).toBeInTheDocument()
+    })
+
+    const name = screen.getByLabelText('Unset Zone name')
+    await user.clear(name)
+    await user.type(name, 'Renamed Zone')
     await user.tab()
 
     await waitFor(() => {
-      expect(updateLodgingArea).toHaveBeenCalledWith('a1', { map_x: 0.45 })
+      expect(updateLodgingArea).toHaveBeenCalledWith('a3', { name: 'Renamed Zone' })
     })
+    const [, payload] = updateLodgingArea.mock.calls[0] as [string, Record<string, unknown>]
+    expect(payload).not.toHaveProperty('map_x')
+    expect(payload).not.toHaveProperty('map_y')
   })
 
   it('derives a new area sort_order from the highest in use, not the list length', async () => {
@@ -254,48 +288,6 @@ describe('LodgingAreasDrawer — a rejected edit', () => {
     })
     await waitFor(() => {
       expect(screen.getByLabelText('North Zone name')).toHaveValue('North Zone')
-    })
-  })
-
-  it('restores the stored centroid when the field is cleared rather than retyped', async () => {
-    // The early return on an unparseable value skipped the write, correctly —
-    // but left the empty box on screen. Same failure as a rejected write: the
-    // field disagrees with what is stored and survives every refetch, and here
-    // it reads as "this area has no map position", which is a real state.
-    const user = userEvent.setup()
-    render(<LodgingAreasDrawer open onClose={vi.fn()} />, { wrapper })
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('North Zone')).toBeInTheDocument()
-    })
-
-    const x = screen.getByLabelText('North Zone map X')
-    await user.clear(x)
-    await user.tab()
-
-    expect(updateLodgingArea).not.toHaveBeenCalled()
-    await waitFor(() => {
-      expect(screen.getByLabelText('North Zone map X')).toHaveValue(0.2)
-    })
-  })
-
-  it('restores the stored centroid when the save is rejected', async () => {
-    updateLodgingArea.mockRejectedValue(new Error('nope'))
-    const user = userEvent.setup()
-    render(<LodgingAreasDrawer open onClose={vi.fn()} />, { wrapper })
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('North Zone')).toBeInTheDocument()
-    })
-
-    const x = screen.getByLabelText('North Zone map X')
-    await user.clear(x)
-    await user.type(x, '0.99')
-    await user.tab()
-
-    await waitFor(() => {
-      expect(updateLodgingArea).toHaveBeenCalled()
-    })
-    await waitFor(() => {
-      expect(screen.getByLabelText('North Zone map X')).toHaveValue(0.2)
     })
   })
 })

--- a/frontend/src/components/admin/lodging/LodgingAreasDrawer.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingAreasDrawer.test.tsx
@@ -165,6 +165,24 @@ describe('LodgingAreasDrawer', () => {
     expect(screen.queryByRole('button', { name: 'Move North Zone up' })).not.toBeInTheDocument()
   })
 
+  // The row used to wrap onto two lines: name + reorder arrows on one, Delete
+  // alone on the next — wasted vertical space across eight rows. Delete now
+  // sits in the SAME flex row as the name field and the arrows, so all three
+  // share one parent rather than Delete living in a block of its own below.
+  it('puts delete on the same line as the name and reorder arrows', async () => {
+    render(<LodgingAreasDrawer open onClose={vi.fn()} />, { wrapper })
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('North Zone')).toBeInTheDocument()
+    })
+
+    const name = screen.getByLabelText('North Zone name')
+    const moveDown = screen.getByRole('button', { name: 'Move North Zone down' })
+    const deleteButton = screen.getByRole('button', { name: 'Delete North Zone' })
+
+    expect(moveDown.parentElement).toBe(name.parentElement)
+    expect(deleteButton.parentElement).toBe(name.parentElement)
+  })
+
   it('renders no Map centre inputs — there is no map to place them against (#2397)', async () => {
     render(<LodgingAreasDrawer open onClose={vi.fn()} />, { wrapper })
     await waitFor(() => {

--- a/frontend/src/components/admin/lodging/LodgingAreasDrawer.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingAreasDrawer.test.tsx
@@ -294,8 +294,7 @@ describe('LodgingAreasDrawer — a rejected edit', () => {
 
 describe('LodgingAreasDrawer — deleting an area', () => {
   // The units table deliberately never offers delete (spec §3.8). Areas do,
-  // one click from a numeric input, and an area with no units deletes silently
-  // and unrecoverably.
+  // and an area with no units deletes silently and unrecoverably.
   it('asks before deleting', async () => {
     const user = userEvent.setup()
     render(<LodgingAreasDrawer open onClose={vi.fn()} />, { wrapper })

--- a/frontend/src/components/admin/lodging/LodgingAreasDrawer.tsx
+++ b/frontend/src/components/admin/lodging/LodgingAreasDrawer.tsx
@@ -133,71 +133,64 @@ export function LodgingAreasDrawer({ open, onClose }: LodgingAreasDrawerProps) {
             {areas.map((area, index) => (
               <li
                 key={area.id}
-                className="border-border hover:border-primary/50 flex flex-col gap-2 rounded-lg border p-3 transition-colors"
+                className="border-border hover:border-primary/50 flex items-center gap-2 rounded-lg border p-3 transition-colors"
               >
-                <div className="flex items-center gap-2">
-                  <input
-                    className={`${FIELD} flex-1`}
-                    defaultValue={area.name}
-                    aria-label={`${area.name} name`}
-                    onBlur={(e) => {
-                      if (e.target.value !== area.name) {
-                        const field = e.target
-                        void saveField(
-                          field,
-                          area.name,
-                          () => updateLodgingArea(area.id, { name: field.value }),
-                          'Failed to rename the area'
-                        )
-                      }
-                    }}
-                  />
-                  {index > 0 && (
-                    <button
-                      type="button"
-                      aria-label={`Move ${area.name} up`}
-                      onClick={() => void move(index, -1)}
-                      className="text-muted-foreground hover:text-foreground"
-                    >
-                      <ChevronUp className="h-4 w-4" />
-                    </button>
-                  )}
-                  {index < areas.length - 1 && (
-                    <button
-                      type="button"
-                      aria-label={`Move ${area.name} down`}
-                      onClick={() => void move(index, 1)}
-                      className="text-muted-foreground hover:text-foreground"
-                    >
-                      <ChevronDown className="h-4 w-4" />
-                    </button>
-                  )}
-                </div>
-
-                <div className="flex items-center gap-2 text-xs">
+                <input
+                  className={`${FIELD} flex-1`}
+                  defaultValue={area.name}
+                  aria-label={`${area.name} name`}
+                  onBlur={(e) => {
+                    if (e.target.value !== area.name) {
+                      const field = e.target
+                      void saveField(
+                        field,
+                        area.name,
+                        () => updateLodgingArea(area.id, { name: field.value }),
+                        'Failed to rename the area'
+                      )
+                    }
+                  }}
+                />
+                {index > 0 && (
                   <button
                     type="button"
-                    onClick={() => {
-                      // The units table never offers delete at all (spec §3.8).
-                      // Areas must, since an area with no units is genuinely
-                      // removable — and an empty area deletes silently and
-                      // unrecoverably without this confirmation.
-                      if (
-                        !window.confirm(`Delete the area “${area.name}”? This cannot be undone.`)
-                      ) {
-                        return
-                      }
-                      void run(
-                        () => deleteLodgingArea(area.id),
-                        `Cannot delete ${area.name} while units still belong to it.`
-                      )
-                    }}
-                    aria-label={`Delete ${area.name}`}
-                    className={`text-muted-foreground hover:text-foreground ml-auto ${ACTION_LINK}`}
+                    aria-label={`Move ${area.name} up`}
+                    onClick={() => void move(index, -1)}
+                    className="text-muted-foreground hover:text-foreground"
                   >
-                    Delete
+                    <ChevronUp className="h-4 w-4" />
                   </button>
-                </div>
+                )}
+                {index < areas.length - 1 && (
+                  <button
+                    type="button"
+                    aria-label={`Move ${area.name} down`}
+                    onClick={() => void move(index, 1)}
+                    className="text-muted-foreground hover:text-foreground"
+                  >
+                    <ChevronDown className="h-4 w-4" />
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={() => {
+                    // The units table never offers delete at all (spec §3.8).
+                    // Areas must, since an area with no units is genuinely
+                    // removable — and an empty area deletes silently and
+                    // unrecoverably without this confirmation.
+                    if (!window.confirm(`Delete the area “${area.name}”? This cannot be undone.`)) {
+                      return
+                    }
+                    void run(
+                      () => deleteLodgingArea(area.id),
+                      `Cannot delete ${area.name} while units still belong to it.`
+                    )
+                  }}
+                  aria-label={`Delete ${area.name}`}
+                  className={`text-muted-foreground hover:text-foreground ${ACTION_LINK}`}
+                >
+                  Delete
+                </button>
               </li>
             ))}
           </ul>

--- a/frontend/src/components/admin/lodging/LodgingAreasDrawer.tsx
+++ b/frontend/src/components/admin/lodging/LodgingAreasDrawer.tsx
@@ -1,14 +1,19 @@
 /**
  * Areas, as a slide-in over the units table.
  *
- * Eight rows of name, order and map centroid do not warrant a top-level tab —
- * and areas exist to serve Units, which is where staff already are. Codes are
- * hidden for the same reason unit codes are: they are a back-end join key, not
+ * Eight rows of name and order do not warrant a top-level tab — and areas
+ * exist to serve Units, which is where staff already are. Codes are hidden
+ * for the same reason unit codes are: they are a back-end join key, not
  * something staff think in.
  *
- * The map centroid is not decorative. A later phase renders the actual camp
- * map from these coordinates, which is where "is this family next to a
- * bathhouse" gets answered (spec §7.2b).
+ * This used to also edit each area's map centroid as two bare number inputs
+ * with nothing to compare them against — typing `0.4389` was never a usable
+ * editing affordance (kindred#2397, following the same call `UnitMapPositionField`
+ * already made for units in kindred#2013/#2024). `map_x`/`map_y` are still on
+ * the collection and still read elsewhere; this removed one editing surface,
+ * not the fields. A later phase may render the actual camp map and let a
+ * centroid be dragged onto it the way `UnitMapPositionField` does for units —
+ * that is what "is this family next to a bathhouse" (spec §7.2b) still needs.
  */
 import { Dialog, DialogPanel, DialogTitle } from '@headlessui/react'
 import { useQueryClient } from '@tanstack/react-query'
@@ -24,7 +29,6 @@ import {
   reorderLodgingAreas,
   updateLodgingArea,
 } from '../../../services/lodgingCrud'
-import type { LodgingAreaRecord } from '../../../types/lodging'
 import { invalidateLodgingRegistryQueries } from '../../../utils/queryKeys'
 import { ACTION_LINK, BUTTON_PRIMARY, FIELD_INLINE as FIELD, LABEL } from './lodgingStyles'
 
@@ -108,31 +112,6 @@ export function LodgingAreasDrawer({ open, onClose }: LodgingAreasDrawerProps) {
     await run(() => reorderLodgingAreas(next.map((a) => a.id)), 'Failed to reorder the areas')
   }
 
-  const saveCentroid = async (
-    area: LodgingAreaRecord,
-    axis: 'map_x' | 'map_y',
-    field: HTMLInputElement
-  ) => {
-    const stored = String(area[axis])
-    const value = Number.parseFloat(field.value)
-    // Cleared or unparseable: skip the write, but put the stored value back.
-    // Leaving the empty box is the same failure a rejected write would be —
-    // the field disagrees with what is stored and survives every refetch —
-    // and here it reads as "this area has no map position", a real state that
-    // the later map view would render very differently.
-    if (Number.isNaN(value)) {
-      field.value = stored
-      return
-    }
-    if (value === area[axis]) return
-    await saveField(
-      field,
-      stored,
-      () => updateLodgingArea(area.id, { [axis]: value }),
-      'Failed to save the centroid'
-    )
-  }
-
   return (
     <Dialog open={open} onClose={onClose} className="relative z-50">
       <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
@@ -196,34 +175,13 @@ export function LodgingAreasDrawer({ open, onClose }: LodgingAreasDrawerProps) {
                 </div>
 
                 <div className="flex items-center gap-2 text-xs">
-                  <span className="text-muted-foreground">Map centre</span>
-                  <input
-                    className={`${FIELD} w-20`}
-                    type="number"
-                    step="0.001"
-                    min={0}
-                    max={1}
-                    defaultValue={area.map_x}
-                    aria-label={`${area.name} map X`}
-                    onBlur={(e) => void saveCentroid(area, 'map_x', e.target)}
-                  />
-                  <input
-                    className={`${FIELD} w-20`}
-                    type="number"
-                    step="0.001"
-                    min={0}
-                    max={1}
-                    defaultValue={area.map_y}
-                    aria-label={`${area.name} map Y`}
-                    onBlur={(e) => void saveCentroid(area, 'map_y', e.target)}
-                  />
                   <button
                     type="button"
                     onClick={() => {
                       // The units table never offers delete at all (spec §3.8).
                       // Areas must, since an area with no units is genuinely
-                      // removable — but it sits one click from a numeric input
-                      // and an empty area deletes silently and unrecoverably.
+                      // removable — and an empty area deletes silently and
+                      // unrecoverably without this confirmation.
                       if (
                         !window.confirm(`Delete the area “${area.name}”? This cannot be undone.`)
                       ) {


### PR DESCRIPTION
## The defect

`LodgingAreasDrawer` exposed each area's map centroid (`map_x`/`map_y`) as two bare number
inputs with nothing to compare them against — the file renders no map at all
(`grep -c 'MapBaseLayer\|svg\|canvas\|img'` on it returns `0`). Typing `0.4389` into a normalised
coordinate was never a usable editing affordance. The sibling component, `UnitMapPositionField`,
made this exact call for units already in kindred#2013/#2024 ("Typing `0.4389` was never how a
pin gets placed anyway — dragging it onto the cabin is"); areas never got the follow-through.

## The fix

Removed the two "Map centre" number inputs from `LodgingAreasDrawer.tsx` (`map X` / `map Y`).
Kept the name field, the order (move up/down) controls, and delete. `saveCentroid` — the onBlur
handler that wrote `map_x`/`map_y` from those inputs — had no other caller anywhere in the tree,
so it's deleted in this same PR rather than left as dead code, along with its now-unused
`LodgingAreaRecord` import.

`map_x`/`map_y` stay on the `lodging_areas` collection unchanged; no migration. They're still
read elsewhere (e.g. `mapModel.ts`, `boardLayout.ts`). This removes one editing surface, not the
fields — a later phase can add a real drag-to-place editor on a rendered map, the same shape
`UnitMapPositionField` already uses for units.

The other write paths in this file (`updateLodgingArea` for rename/reorder, `createLodgingArea`
for new areas) never touched `map_x`/`map_y` and still don't — removing the inputs introduces no
new write of `0`/`0` or `null` over an area's existing (possibly unset) centroid.

## Tests

- New: asserts the "Map centre" inputs (`aria-label` `"<name> map X"` / `"<name> map Y"`) and the
  "Map centre" label text are absent from the rendered drawer.
- New: renders an area whose centroid is unset (`map_x: 0, map_y: 0` — PocketBase's convention
  for "unset", not `null`), edits its name, and asserts the resulting `updateLodgingArea` payload
  carries neither `map_x` nor `map_y`.
- Removed: the three tests that exercised the deleted inputs directly (typing/clearing/rejecting
  a centroid edit) — the behavior they pinned no longer exists.
- Mutation-checked: reintroducing a `map_x`/`map_y` write on the rename path turned the new
  "leaves an unset centroid unset" test red before the fix was restored, confirming it actually
  pins the no-write guarantee rather than passing vacuously.

## What this deliberately does NOT do

- No PocketBase migration. `map_x`/`map_y` are untouched on the collection.
- No new centroid editor (drag-on-map). That is explicitly out of scope per the issue and is the
  same shape as the unit-level map editor being tracked separately in kindred#2396.
- No change to `UnitMapPositionField.tsx` or any other file. Its header comment references
  `LodgingAreasDrawer`'s former `saveCentroid` by name as a design precedent; that comment is now
  slightly stale (the function it names no longer exists) but the file is out of this PR's scope
  and the surrounding claim ("same save-on-interaction shape") is still accurate.

Closes #2397.
