### PR TITLE
feat(frontend): flag single-parent families on the family card

### DIFF
--- a/frontend/src/components/weekend/FamilyCard.test.tsx
+++ b/frontend/src/components/weekend/FamilyCard.test.tsx
@@ -644,6 +644,97 @@ describe('FamilyCard — what it shows', () => {
     render(<FamilyCard party={party()} onOpen={vi.fn()} />)
     expect(screen.queryByText('Whole building')).not.toBeInTheDocument()
   })
+
+  describe('single-parent flag (kindred#2254 half 2)', () => {
+    // #2072's own scoping ruling replaces only the two need chips
+    // (`Private bathroom`/`Power`) with the glyph gutter — `Whole building`,
+    // the warn chips and the share chips, including this one, stay as
+    // words. So this reuses the muted `Near another family` chip's exact
+    // grammar rather than inventing a new visual channel, and does not wait
+    // on #2072.
+    it('flags a household with exactly one attending adult', () => {
+      // The default fixture already has one adult (`Emma Johnson`).
+      render(<FamilyCard party={party()} onOpen={vi.fn()} />)
+      expect(screen.getByText('Single parent')).toBeInTheDocument()
+    })
+
+    it('matches the muted "Near another family" chip\'s classes exactly — no new tone invented', () => {
+      render(
+        <FamilyCard
+          party={party({
+            share: {
+              preference: 'yes_share',
+              proximity: ['near'],
+              request_text: '',
+              needs_resolution: false,
+            },
+          })}
+          onOpen={vi.fn()}
+        />
+      )
+      const singleParentChip = screen.getByText('Single parent')
+      const nearChip = screen.getByText('Near another family')
+      expect(singleParentChip.className).toBe(nearChip.className)
+    })
+
+    it('says nothing when two adults are attending', () => {
+      render(
+        <FamilyCard
+          party={party({
+            adults: [
+              { adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' },
+              { adult_number: 2, display_name: 'Liam Johnson', relationship: 'Father' },
+            ],
+          })}
+          onOpen={vi.fn()}
+        />
+      )
+      expect(screen.queryByText('Single parent')).not.toBeInTheDocument()
+    })
+
+    // A placeholder slot ("NA", "-", ...) is not an attending adult
+    // (`isAttendingAdultName`, kindred#1925) — a household with ONE real
+    // adult and four placeholder slots is still one attending adult, and a
+    // household with ZERO real adults is a data gap, not a single parent.
+    it('does not count a placeholder slot as a second parent', () => {
+      render(
+        <FamilyCard
+          party={party({
+            adults: [
+              { adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' },
+              { adult_number: 2, display_name: 'NA', relationship: '' },
+            ],
+          })}
+          onOpen={vi.fn()}
+        />
+      )
+      expect(screen.getByText('Single parent')).toBeInTheDocument()
+    })
+
+    it('says nothing when no adult is named at all — a data gap, not a single parent', () => {
+      render(<FamilyCard party={party({ adults: [] })} onOpen={vi.fn()} />)
+      expect(screen.queryByText('Single parent')).not.toBeInTheDocument()
+    })
+
+    // Person-grain parties (adult weekend guests) ARE their own identity —
+    // there is no separate "attending adults" list to be short one of.
+    // `attendingAdults` already returns `[]` for this grain, so the
+    // household-composition question does not apply.
+    it('never flags an adult weekend guest (person grain) as a single parent', () => {
+      render(
+        <FamilyCard
+          party={party({
+            grain: 'person',
+            display_name: 'Priya Patel',
+            adults: [{ adult_number: 1, display_name: 'Priya Patel' }],
+            children: [],
+          })}
+          onOpen={vi.fn()}
+        />
+      )
+      expect(screen.queryByText('Single parent')).not.toBeInTheDocument()
+    })
+  })
 })
 
 describe('FamilyCard — spec §3.8, what must stay off it', () => {

--- a/frontend/src/components/weekend/FamilyCard.tsx
+++ b/frontend/src/components/weekend/FamilyCard.tsx
@@ -478,6 +478,14 @@ function FamilyCardChips({
   const wantsToShare = proximity.includes('with') || proximity.includes('similar_ages')
   const wantsNear = proximity.includes('near')
   const conflictDetail = answersConflictDetail(party.share)
+  // kindred#2254 half 2: single-parent, derived from the ATTENDING adult
+  // list, not `party.adults.length` or `party_size` -- both of those count
+  // listed-but-not-attending adults (kindred#1925/#2046) and would
+  // false-positive a two-parent household where one adult never RSVP'd for
+  // this session. `computeAttendingAdults` already grain-gates to household
+  // parties (an adult weekend guest IS its own identity, not a household of
+  // one), so no separate `isHousehold` check is needed here.
+  const isSingleParent = computeAttendingAdults(party).length === 1
 
   return (
     <span className="flex flex-wrap gap-1">
@@ -520,6 +528,11 @@ function FamilyCardChips({
       {/* NEAR and WITH are different requests: NEAR is satisfied by map
             distance between units, WITH by putting both in one room. */}
       {wantsNear && <Chip label="Near another family" tone="muted" />}
+      {/* #2072's own scoping ruling replaces only the two NEED chips
+            (`Private bathroom`/`Power`) with its glyph gutter -- this is not
+            a housing-need flag, so it stays a word, reusing this same
+            `Near another family` muted grammar rather than a new one. */}
+      {isSingleParent && <Chip label="Single parent" tone="muted" />}
 
       {party.is_returning === true && (
         <span className="text-forest-700 dark:text-forest-300 inline-flex items-center gap-0.5 text-xs font-semibold">


### PR DESCRIPTION
## Context

Item #2254 half 2. Half 1 (youngest-first child ordering) already shipped
in #2319 (`044eeac1`) and is untouched by this PR — only the single-parent
flag is new here.

Staff read the family card while deciding cabin placement. A single-parent
family "definitely affects housing," but the card gave no way to see it at
a glance: the adults line already renders and truncates, so the count was
present but not salient.

## What changed

`FamilyCard.tsx` gains a muted `Single parent` chip, shown when exactly one
attending adult is on the household party.

- **Derivation**: `attendingAdults(party).length === 1`, reusing the same
  household-filtered, placeholder-stripped adult list `FamilyCardIdentity`
  already computes for the grey adults line — not `party.adults.length` or
  `party_size`, both of which count listed-but-not-attending adults
  (kindred#1925/#2046) and would false-positive a two-parent household
  where one adult never RSVP'd for this session. `attendingAdults` is also
  grain-gated to household parties, so an adult weekend guest (person
  grain, which IS its own identity) is never flagged.
- **Style**: reuses the existing muted `Near another family` chip's exact
  classes (`tone="muted"`) — no new chip color, token, or icon.

## Why the deferral in the issue no longer applies

The issue originally said to prefer resolving #2072 first, in case its
glyph gutter would absorb this chip. The 2026-08-16 triage pass struck that
sentence: #2072's own scoping ruling replaces only the two NEED chips
(`Private bathroom`/`Power`) with the gutter — `Whole building`, the warn
chips, and the share chips (including the `Near another family` precedent
this PR copies) all stay as words. A single-parent flag is not a housing-need
chip, so the gutter can never absorb it, and this PR does not touch, open,
or depend on #2072/#2212/#2275/#2332.

## Deliberately not done

- No change to the already-shipped youngest-first sort (half 1).
- No gutter/glyph integration — out of scope per the struck deferral above.
- No new chip tone, color, or icon — the ask was to reuse the existing
  muted grammar, not invent a new visual channel.

## Testing

`frontend/src/components/weekend/FamilyCard.test.tsx` — TDD: 3 new
assertions (renders the chip, matches the `Near another family` chip's
classes exactly, filters out placeholder adult slots) failed red before
the implementation; 4 more (two adults, zero named adults, adult weekend
guest) were true from the start and stay green as regression guards.

- `vitest run src/components/weekend/FamilyCard.test.tsx` — 73/73 passed
- `vitest run` (full frontend suite) — 450 files / 6887 tests passed
- `tsc --noEmit` — clean
- `eslint src/components/weekend/FamilyCard.tsx src/components/weekend/FamilyCard.test.tsx` — 0 errors (2 pre-existing warnings from the already-shipped sort code, untouched by this diff)
- `scripts/pre-push-verify.sh` — ALL CHECKS PASSED (prettier, eslint, tsc, vitest)

Closes #2254.
