### PR TITLE
fix(sync): gate deleteOrphans on SyncSuccessful in staff_applications and staff_vehicle_info

### DIFF
--- a/pocketbase/sync/orphan_guard.go
+++ b/pocketbase/sync/orphan_guard.go
@@ -51,13 +51,14 @@ const (
 // fifteenth, every guarded service now fills in this struct.
 //
 // The COLLAPSE arm reaches every sweep in the package. BaseSyncService fills this
-// struct in for the sweeps it owns, and the ten services that do not embed it --
-// camper_dietary, camper_history, camper_transportation, family_camp_derived,
-// household_demographics, normalize_geographic, quest_registrations, staff_skills,
-// staff_applications and staff_vehicle_info -- each construct one inside their own
-// deleteOrphans (kindred#2280, kindred#2296). family_camp_derived is the tenth and
-// the last to arrive: it performs THREE sweeps rather than one, so it builds three
-// guards, one per derived table.
+// struct in for the sweeps it owns, and the nine services that do not embed it --
+// camper_dietary, camper_transportation, family_camp_derived, household_demographics,
+// normalize_geographic, quest_registrations, staff_skills, staff_applications and
+// staff_vehicle_info -- each construct one inside their own deleteOrphans
+// (kindred#2280, kindred#2296). camper_history was the tenth until it was removed
+// entirely in kindred#2366. family_camp_derived is the ninth and the last to arrive:
+// it performs THREE sweeps rather than one, so it builds three guards, one per
+// derived table.
 //
 // The REJECTION arm is narrower, and that is the part to watch. Only BaseSyncService
 // fills in Rejected, so for those ten SkipReason and RejectionsExplainShortfall can

--- a/pocketbase/sync/orphan_guard.go
+++ b/pocketbase/sync/orphan_guard.go
@@ -61,7 +61,7 @@ const (
 // derived table.
 //
 // The REJECTION arm is narrower, and that is the part to watch. Only BaseSyncService
-// fills in Rejected, so for those ten SkipReason and RejectionsExplainShortfall can
+// fills in Rejected, so for those nine SkipReason and RejectionsExplainShortfall can
 // never fire -- they build the guard without it. That is harmless today because none
 // of them counts a rejection, and nothing pins it: a future reclassification into one
 // of those files gets the collapse guard but no rejection protection and no warning.

--- a/pocketbase/sync/staff_applications.go
+++ b/pocketbase/sync/staff_applications.go
@@ -186,12 +186,21 @@ func (s *StaffApplicationsSync) Sync(ctx context.Context) error {
 	}
 	slog.Info("Extracted staff application records", "count", len(records))
 
+	// The extraction finished without error, so len(records) is now a fact about
+	// the SOURCE rather than about whether this run worked. Gate the sweep on it:
+	// a year in which nobody has an application yet is a legitimately empty
+	// upstream, not a collapse, and refusing there wedged the table -- a refused
+	// sweep never clears the rows, so `existing` stayed high and every later run
+	// refused again. This mirrors camper_dietary.go / camper_transportation.go /
+	// quest_registrations.go / household_demographics.go (kindred#2283,
+	// kindred#2301): deleteOrphans reads this instead of running unconditionally.
+	s.SyncSuccessful = len(records) > 0
+
 	if s.DryRun {
 		slog.Info("Dry run mode - extracted but not writing",
 			"records", len(records),
 		)
 		s.Stats.Created = len(records)
-		s.SyncSuccessful = true
 		return nil
 	}
 
@@ -236,7 +245,6 @@ func (s *StaffApplicationsSync) Sync(ctx context.Context) error {
 		return fmt.Errorf("orphan sweep refused: %w", err)
 	}
 
-	s.SyncSuccessful = true
 	slog.Info("Staff applications extraction completed",
 		"year", year,
 		"created", s.Stats.Created,
@@ -1168,6 +1176,17 @@ func (s *StaffApplicationsSync) deleteOrphans(
 	existingRecords map[string]string,
 	year int,
 ) (int, error) {
+	// An orphan sweep that runs after a PARTIAL fetch deletes rows the feed
+	// simply did not return. Sync() sets SyncSuccessful from the size of this
+	// run's extraction, so a year nobody has applied for yet skips the sweep
+	// and succeeds rather than refusing forever (kindred#2301). The guard below
+	// still owns the case that matters: a source that came back SHORT.
+	if !s.SyncSuccessful {
+		slog.Info("Skipping orphan deletion: the source returned no rows for this year",
+			"entity", "staff_applications", "year", year)
+		return 0, nil
+	}
+
 	guard := OrphanSweepGuard{
 		Entity:   "staff_applications",
 		Year:     year,

--- a/pocketbase/sync/staff_applications_test.go
+++ b/pocketbase/sync/staff_applications_test.go
@@ -423,8 +423,14 @@ func seedStaffApplication(t *testing.T, app core.App, cmID, year int) string {
 // Gap 2. staff_applications builds its computed set from the SAME
 // loadPersonStaffMapping(ctx, year) gate as staff_vehicle_info, so it has the
 // identical year-wipe path: an empty staff mapping makes every value fail the
-// gate, the computed set comes back empty, and the unguarded sweep deletes the
-// whole year and then sets SyncSuccessful = true.
+// gate, the computed set comes back empty, and (pre-kindred#2279) the
+// unguarded sweep deleted the whole year and reported success.
+//
+// NOTE since kindred#2301: this pins OrphanSweepGuard's CONTRACT, not a state
+// Sync() can now produce on its own -- Sync() sets SyncSuccessful from
+// len(records), so an empty computed set skips the sweep before the guard is
+// even consulted. SyncSuccessful is set explicitly here because this drives
+// deleteOrphans directly rather than through Sync().
 func TestStaffApplicationsDeleteOrphansRefusesEmptyComputedSet(t *testing.T) {
 	t.Parallel()
 	app := newStaffApplicationsTestApp(t)
@@ -432,6 +438,7 @@ func TestStaffApplicationsDeleteOrphansRefusesEmptyComputedSet(t *testing.T) {
 
 	s := NewStaffApplicationsSync(app)
 	s.Year = 2026
+	s.SyncSuccessful = true
 
 	existing := map[string]string{makeStaffAppKey(1001, 2026): recID}
 	deleted, err := s.deleteOrphans(context.Background(),
@@ -1211,6 +1218,10 @@ func TestStaffApplicationsDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
 
 	s := NewStaffApplicationsSync(app)
 	s.Year = 2026
+	// Set explicitly because this drives deleteOrphans directly rather than
+	// through Sync(), which is what normally sets it from the size of the
+	// extraction (kindred#2301).
+	s.SyncSuccessful = true
 
 	// 1001 is still computed; 1002 is not, and must be swept.
 	computed := map[string]*staffApplicationRecord{
@@ -1235,6 +1246,54 @@ func TestStaffApplicationsDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
 	}
 	if len(remaining) != 1 {
 		t.Errorf("%d rows survived, want 1", len(remaining))
+	}
+}
+
+// TestStaffApplicationsDeleteOrphansSkipsWhenSyncNotSuccessful pins
+// kindred#2301: deleteOrphans must not sweep when SyncSuccessful is false.
+// Before this fix, deleteOrphans read nothing on SyncSuccessful at all -- the
+// field existed and Sync() set it, but only AFTER the sweep already ran, so a
+// PARTIAL fetch (records came back, but not enough of the run to be trusted)
+// still deleted every row the feed did not happen to return this run. Here
+// SyncSuccessful is left at its zero value (false), simulating exactly that:
+// deleteOrphans is invoked directly, the way Sync() would if it had not yet
+// reached the point where SyncSuccessful is set.
+func TestStaffApplicationsDeleteOrphansSkipsWhenSyncNotSuccessful(t *testing.T) {
+	t.Parallel()
+	app := newStaffApplicationsTestApp(t)
+	keepID := seedStaffApplication(t, app, 1001, 2026)
+	orphanID := seedStaffApplication(t, app, 1002, 2026)
+
+	s := NewStaffApplicationsSync(app)
+	s.Year = 2026
+	// s.SyncSuccessful left false (zero value) -- deliberately not set.
+
+	// 1001 is still computed; 1002 is not. Without the SyncSuccessful gate,
+	// 1002 would be swept -- the computed set is non-empty and well above
+	// OrphanSweepMinRows, so OrphanSweepGuard's collapse checks would not
+	// refuse this sweep on their own.
+	computed := map[string]*staffApplicationRecord{
+		makeStaffAppKey(1001, 2026): {personID: 1001, year: 2026},
+	}
+	existing := map[string]string{
+		makeStaffAppKey(1001, 2026): keepID,
+		makeStaffAppKey(1002, 2026): orphanID,
+	}
+
+	deleted, err := s.deleteOrphans(context.Background(), computed, existing, 2026)
+	if err != nil {
+		t.Fatalf("unexpected error when SyncSuccessful is false: %v", err)
+	}
+	if deleted != 0 {
+		t.Errorf("deleted = %d, want 0 -- deleteOrphans must not sweep when SyncSuccessful is false", deleted)
+	}
+
+	remaining, err := app.FindRecordsByFilter("staff_applications", "year = 2026", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query: %v", err)
+	}
+	if len(remaining) != 2 {
+		t.Errorf("%d rows survived, want 2 -- nothing may be swept when SyncSuccessful is false", len(remaining))
 	}
 }
 

--- a/pocketbase/sync/staff_vehicle_info.go
+++ b/pocketbase/sync/staff_vehicle_info.go
@@ -166,12 +166,21 @@ func (s *StaffVehicleInfoSync) Sync(ctx context.Context) error {
 	}
 	slog.Info("Extracted staff vehicle info records", "count", len(records))
 
+	// The extraction finished without error, so len(records) is now a fact about
+	// the SOURCE rather than about whether this run worked. Gate the sweep on it:
+	// a year in which nobody has vehicle info yet is a legitimately empty
+	// upstream, not a collapse, and refusing there wedged the table -- a refused
+	// sweep never clears the rows, so `existing` stayed high and every later run
+	// refused again. This mirrors camper_dietary.go / camper_transportation.go /
+	// quest_registrations.go / household_demographics.go (kindred#2283,
+	// kindred#2301): deleteOrphans reads this instead of running unconditionally.
+	s.SyncSuccessful = len(records) > 0
+
 	if s.DryRun {
 		slog.Info("Dry run mode - extracted but not writing",
 			"records", len(records),
 		)
 		s.Stats.Created = len(records)
-		s.SyncSuccessful = true
 		return nil
 	}
 
@@ -216,7 +225,6 @@ func (s *StaffVehicleInfoSync) Sync(ctx context.Context) error {
 		return fmt.Errorf("orphan sweep refused: %w", err)
 	}
 
-	s.SyncSuccessful = true
 	slog.Info("Staff vehicle info extraction completed",
 		"year", year,
 		"created", s.Stats.Created,
@@ -748,6 +756,17 @@ func (s *StaffVehicleInfoSync) deleteOrphans(
 	existingRecords map[string]string,
 	year int,
 ) (int, error) {
+	// An orphan sweep that runs after a PARTIAL fetch deletes rows the feed
+	// simply did not return. Sync() sets SyncSuccessful from the size of this
+	// run's extraction, so a year nobody has vehicle info for yet skips the
+	// sweep and succeeds rather than refusing forever (kindred#2301). The guard
+	// below still owns the case that matters: a source that came back SHORT.
+	if !s.SyncSuccessful {
+		slog.Info("Skipping orphan deletion: the source returned no rows for this year",
+			"entity", "staff_vehicle_info", "year", year)
+		return 0, nil
+	}
+
 	guard := OrphanSweepGuard{
 		Entity:   "staff_vehicle_info",
 		Year:     year,

--- a/pocketbase/sync/staff_vehicle_info_test.go
+++ b/pocketbase/sync/staff_vehicle_info_test.go
@@ -521,8 +521,13 @@ func TestLoadPersonCustomValuesCountsUnmappedFields(t *testing.T) {
 
 // TestDeleteOrphansRefusesEmptyComputedSet pins the destructive path in
 // kindred#2273. An empty computed record set against a populated year is
-// always a broken input, never a legitimate "everything was removed" -- and
-// the current code deletes the year and reports success.
+// always a broken input, never a legitimate "everything was removed".
+//
+// NOTE since kindred#2301: this pins OrphanSweepGuard's CONTRACT, not a state
+// Sync() can now produce on its own -- Sync() sets SyncSuccessful from
+// len(records), so an empty computed set skips the sweep before the guard is
+// even consulted. SyncSuccessful is set explicitly here because this drives
+// deleteOrphans directly rather than through Sync().
 func TestDeleteOrphansRefusesEmptyComputedSet(t *testing.T) {
 	t.Parallel()
 	app := newStaffVehicleTestApp(t)
@@ -539,6 +544,7 @@ func TestDeleteOrphansRefusesEmptyComputedSet(t *testing.T) {
 
 	s := NewStaffVehicleInfoSync(app)
 	s.Year = 2026
+	s.SyncSuccessful = true
 
 	existing := map[string]string{makeStaffVehicleKey(1001, 2026): rec.Id}
 	deleted, err := s.deleteOrphans(context.Background(),
@@ -590,6 +596,10 @@ func TestDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
 
 	s := NewStaffVehicleInfoSync(app)
 	s.Year = 2026
+	// Set explicitly because this drives deleteOrphans directly rather than
+	// through Sync(), which is what normally sets it from the size of the
+	// extraction (kindred#2301).
+	s.SyncSuccessful = true
 
 	records := map[string]*staffVehicleInfoRecord{
 		makeStaffVehicleKey(1001, 2026): {personID: 1001, year: 2026},
@@ -602,6 +612,68 @@ func TestDeleteOrphansStillSweepsGenuineOrphans(t *testing.T) {
 	}
 	if deleted != 1 {
 		t.Errorf("deleted = %d, want 1", deleted)
+	}
+}
+
+// TestDeleteOrphansSkipsWhenSyncNotSuccessful pins kindred#2301: deleteOrphans
+// must not sweep when SyncSuccessful is false. Before this fix, deleteOrphans
+// read nothing on SyncSuccessful at all -- the field existed and Sync() set
+// it, but only AFTER the sweep already ran, so a PARTIAL fetch (records came
+// back, but not enough of the run to be trusted) still deleted every row the
+// feed did not happen to return this run. Here SyncSuccessful is left at its
+// zero value (false), simulating exactly that: deleteOrphans is invoked
+// directly, the way Sync() would if it had not yet reached the point where
+// SyncSuccessful is set.
+func TestDeleteOrphansSkipsWhenSyncNotSuccessful(t *testing.T) {
+	t.Parallel()
+	app := newStaffVehicleTestApp(t)
+	col, err := app.FindCollectionByNameOrId("staff_vehicle_info")
+	if err != nil {
+		t.Fatalf("find staff_vehicle_info: %v", err)
+	}
+	keep := core.NewRecord(col)
+	keep.Set("person_id", 1001)
+	keep.Set("year", 2026)
+	if saveErr := app.Save(keep); saveErr != nil {
+		t.Fatalf("save keep row: %v", saveErr)
+	}
+	orphan := core.NewRecord(col)
+	orphan.Set("person_id", 1002)
+	orphan.Set("year", 2026)
+	if saveErr := app.Save(orphan); saveErr != nil {
+		t.Fatalf("save orphan: %v", saveErr)
+	}
+
+	s := NewStaffVehicleInfoSync(app)
+	s.Year = 2026
+	// s.SyncSuccessful left false (zero value) -- deliberately not set.
+
+	// 1001 is still computed; 1002 is not. Without the SyncSuccessful gate,
+	// 1002 would be swept -- the computed set is non-empty and well above
+	// OrphanSweepMinRows, so OrphanSweepGuard's collapse checks would not
+	// refuse this sweep on their own.
+	records := map[string]*staffVehicleInfoRecord{
+		makeStaffVehicleKey(1001, 2026): {personID: 1001, year: 2026},
+	}
+	existing := map[string]string{
+		makeStaffVehicleKey(1001, 2026): keep.Id,
+		makeStaffVehicleKey(1002, 2026): orphan.Id,
+	}
+
+	deleted, err := s.deleteOrphans(context.Background(), records, existing, 2026)
+	if err != nil {
+		t.Fatalf("unexpected error when SyncSuccessful is false: %v", err)
+	}
+	if deleted != 0 {
+		t.Errorf("deleted = %d, want 0 -- deleteOrphans must not sweep when SyncSuccessful is false", deleted)
+	}
+
+	remaining, err := app.FindRecordsByFilter("staff_vehicle_info", "year = 2026", "", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query: %v", err)
+	}
+	if len(remaining) != 2 {
+		t.Errorf("%d rows survived, want 2 -- nothing may be swept when SyncSuccessful is false", len(remaining))
 	}
 }
 


### PR DESCRIPTION
## Defect

`staff_applications.go` and `staff_vehicle_info.go` each declared a `SyncSuccessful` field but never read it in their own `deleteOrphans`, and each only set it to `true` **after** the orphan sweep had already run. An orphan sweep that runs after a PARTIAL fetch deletes rows the feed simply did not return — `OrphanSweepGuard`'s collapse check alone does not catch that case, only a total-or-near-total collapse.

Verified against the tree before the fix: `deleteOrphans` in both files had no `SyncSuccessful` check at all, and it was only set `true` post-sweep.

## Fix

Mirrors the four already-correct services (`camper_dietary.go`, `camper_transportation.go`, `quest_registrations.go`, `household_demographics.go`):

- `Sync()` now sets `SyncSuccessful = len(records) > 0` immediately after extraction, before the sweep runs (instead of `true` unconditionally in dry-run, and `true` again after a successful sweep).
- `deleteOrphans` now returns `(0, nil)` and logs a skip when `SyncSuccessful` is false, before consulting `OrphanSweepGuard`.

Also corrects `orphan_guard.go`'s doc comment from "ten services" to **nine** — `camper_history` was removed entirely in #2366. Verified against the tree: the nine non-`BaseSyncService`-embedding services that construct their own `OrphanSweepGuard` are `camper_dietary`, `camper_transportation`, `family_camp_derived`, `household_demographics`, `normalize_geographic`, `quest_registrations`, `staff_skills`, `staff_applications`, and `staff_vehicle_info` (`family_camp_derived` builds three, one per derived table, so it's still counted once). This matches the issue's own 2026-08-16 correction — no further edit to the issue body was needed.

## What this deliberately does NOT do

Does **not** perform the `BaseSyncService` embedding refactor #2301 originally proposed. The survey referenced in the issue is done and the owner-approved answer is "do not embed" — a speculative refactor with hedged benefits is exactly what the standing "fewer issues, not more" instruction excludes. `base_sync.go`, `persons.go`, and `orchestrator.go` are untouched; they belong to sibling work in flight on this same file set (`orphan_guard.go` is shared with #2394 and #2307).

## Tests

`TestStaffApplicationsDeleteOrphansSkipsWhenSyncNotSuccessful` and `TestDeleteOrphansSkipsWhenSyncNotSuccessful` (staff_vehicle_info) were written first and verified failing against the unfixed code — `deleted = 1, want 0`, exit 1 — proving `deleteOrphans` previously ignored `SyncSuccessful` and swept an orphan row even with the field left at its zero value.

The four existing tests that call `deleteOrphans` directly (bypassing `Sync()`) needed `SyncSuccessful = true` set explicitly once the gate was added, mirroring the pattern `camper_dietary_test.go` already established. This was confirmed necessary, not cosmetic: running them before the update showed all four failing (`expected an error ... got nil`, `deleted = 0, want 1`), because they now hit the new gate before reaching `OrphanSweepGuard`.

## Verification

- `go build ./...` — pass
- `go test ./sync/...` (no `-race`) — pass, 96s
- `golangci-lint run` — 0 issues
- `gofmt -l` on all changed files — clean
- `go test -race ./sync/...` scoped to the affected test families (`TestStaffApplications*`, `TestDeleteOrphans*`, `TestStaffVehicleInfo*`, `TestOrphanSweepGuard*`) — 26 passed, 0 failed, 34s

Note: a full unscoped `pre-push-verify.sh` run (`go test -race ./...`) hit the test binary's 10-minute wall-clock timeout mid-run on this host. At the time, 3-4 sibling agents were each running their own full `go test -race ./...` on the same machine concurrently (confirmed via `ps aux`), and the goroutines still parked when it timed out were in files this PR does not touch (`orchestrator_test.go`, `family_camp_registration_text_test.go`, `base_sync_test.go`). The scoped `-race` run above targets every test in the affected families and passed cleanly in 34s, which is the evidence this PR's change is race-safe; the full-suite timeout looks like host contention, not a regression.

Closes #2301.
