### PR TITLE
fix(sync): adopt SkippedValues at the last two mechanism-C sites

### DIFF
--- a/pocketbase/sync/household_demographics.go
+++ b/pocketbase/sync/household_demographics.go
@@ -562,9 +562,31 @@ func (s *HouseholdDemographicsSync) aggregateToRows(
 	}
 
 	// Process person custom values (HH- fields) -> _summer columns
+	//
+	// unmappedCounts tracks discard events: an HH- field accepted by IsHHField
+	// (the prefix test) that has no case in MapHHFieldToColumn (kindred#2257,
+	// adopting the mechanism shipped for camper_transportation.go and
+	// staff_vehicle_info.go at kindred#2356/#2277).
+	unmappedCounts := make(map[string]int)
 	for _, v := range personValues {
 		rec := getRecord(v)
-		s.mapPersonFieldToRecord(rec, v.fieldName, v.value)
+		if column := s.mapPersonFieldToRecord(rec, v.fieldName, v.value); column == "" {
+			unmappedCounts[v.fieldName]++
+		}
+	}
+	if len(unmappedCounts) > 0 {
+		total := 0
+		for _, n := range unmappedCounts {
+			total += n
+		}
+		s.Stats.SkippedValues += total
+
+		// One aggregated warning per run, not one per discarded value.
+		slog.Warn("Household demographics: discarding values for unmapped HH-* fields",
+			"year", year,
+			"discard_events", total,
+			"unmapped_fields", unmappedCounts,
+		)
 	}
 
 	// Process household custom values -> _family columns
@@ -623,11 +645,16 @@ func (s *HouseholdDemographicsSync) setColumn(rec *householdDemographicsRecord, 
 // The four boolean arms are unchanged. They are logical ORs over the
 // contributing values, never first-wins, so they were never part of the defect;
 // at this grain they OR over one camper's answers instead of the household's.
-func (s *HouseholdDemographicsSync) mapPersonFieldToRecord(rec *householdDemographicsRecord, fieldName, value string) {
+// It returns the resolved column name, or "" if fieldName has no case in
+// MapHHFieldToColumn -- the caller (aggregateToRows) uses this to count
+// discarded values (kindred#2257).
+func (s *HouseholdDemographicsSync) mapPersonFieldToRecord(
+	rec *householdDemographicsRecord, fieldName, value string,
+) string {
 	// Use MapHHFieldToColumn for the field mapping
 	column := MapHHFieldToColumn(fieldName)
 	if column == "" {
-		return // Unknown field
+		return "" // Unknown field
 	}
 
 	switch column {
@@ -677,6 +704,8 @@ func (s *HouseholdDemographicsSync) mapPersonFieldToRecord(rec *householdDemogra
 	case "form_filler":
 		s.setColumn(rec, &rec.formFiller, column, value)
 	}
+
+	return column
 }
 
 // mapHouseholdFieldToRecord maps a household custom field onto the

--- a/pocketbase/sync/household_demographics_test.go
+++ b/pocketbase/sync/household_demographics_test.go
@@ -407,6 +407,62 @@ func TestAggregateKeepsEveryPersonAnswer(t *testing.T) {
 	}
 }
 
+// TestAggregateToRowsCountsUnmappedPersonFields pins the kindred#2257
+// mechanism-C fix in this file: an HH- field admitted by IsHHField (the
+// prefix test) but missing a case in MapHHFieldToColumn used to be discarded
+// by mapPersonFieldToRecord's `if column == "" { return }` with no counter
+// and no log line -- the same silent drop already fixed at
+// camper_transportation.go and staff_vehicle_info.go (kindred#2356/#2277).
+// The record itself is still created from the routed field on the same row --
+// this is a VALUE discard, not a record one, so it must land on
+// Stats.SkippedValues, not Stats.Skipped.
+func TestAggregateToRowsCountsUnmappedPersonFields(t *testing.T) {
+	t.Parallel()
+	s := NewHouseholdDemographicsSync(nil)
+
+	values := []hhCustomValueEntry{
+		hhPersonEntry("hh1", "p1", 101, "HH-Jewish Affiliation", testAffiliation),
+		hhPersonEntry("hh1", "p1", 101, "HH-Not A Real Field", "some answer"),
+	}
+
+	rows := s.aggregateToRows(values, nil, 2026)
+
+	rec := rows[MakeCompositeKey("hh1", 101, 2026)]
+	if rec == nil {
+		t.Fatalf("expected a row for person 101, got none: %v", rowKeys(rows))
+	}
+	if rec.jewishAffiliation != testAffiliation {
+		t.Errorf("routed field was not written: jewishAffiliation = %q, want %q", rec.jewishAffiliation, testAffiliation)
+	}
+
+	if s.Stats.SkippedValues != 1 {
+		t.Errorf("Stats.SkippedValues = %d, want 1 -- the unmapped HH- field is a discarded value, not a record",
+			s.Stats.SkippedValues)
+	}
+	if s.Stats.Skipped != 0 {
+		t.Errorf("Stats.Skipped = %d, want 0 -- a discarded field value is not a skipped record", s.Stats.Skipped)
+	}
+}
+
+// TestMapPersonFieldToRecordReturnsTheResolvedColumn pins
+// mapPersonFieldToRecord's return value directly, at the single-field level --
+// the same shape mapTransportFieldToRecord already has in
+// camper_transportation.go, which aggregateToRows' unmapped-count loop above
+// depends on.
+func TestMapPersonFieldToRecordReturnsTheResolvedColumn(t *testing.T) {
+	t.Parallel()
+	s := NewHouseholdDemographicsSync(nil)
+	rec := &householdDemographicsRecord{}
+
+	const wantJewishAffiliationCol = "jewish_affiliation"
+	if got := s.mapPersonFieldToRecord(rec, "HH-Jewish Affiliation", testAffiliation); got != wantJewishAffiliationCol {
+		t.Errorf("mapPersonFieldToRecord routed field returned %q, want %q", got, wantJewishAffiliationCol)
+	}
+	if got := s.mapPersonFieldToRecord(rec, "HH-Not A Real Field", "some answer"); got != "" {
+		t.Errorf("mapPersonFieldToRecord unmapped field returned %q, want \"\"", got)
+	}
+}
+
 // TestAggregateIsOrderIndependent pins the property the old code could not
 // hold. loadPersonCustomValues pages with no ORDER BY, so the input order is an
 // artifact of whichever index the planner picked; the same input supplied in a

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -301,13 +301,14 @@ type Stats struct {
 	Deleted int `json:"deleted,omitempty"` // For tracking deletions (e.g., removed bunk requests)
 	Skipped int `json:"skipped"`
 	// SkippedValues counts discarded custom-field VALUES, not records (kindred#2356).
-	// camper_transportation.go, staff_applications.go, and staff_vehicle_info.go all
-	// discard individual unmapped BUS-*/App-*/SVI-* answers while still creating the
+	// camper_transportation.go, staff_applications.go, staff_vehicle_info.go,
+	// quest_registrations.go, and household_demographics.go all discard individual
+	// unmapped BUS-*/App-*/SVI-*/Quest-*/Q-*/HH-* answers while still creating the
 	// record they belong to (see the routed-field cases in their own
-	// loadPersonCustomValues tests) -- before this counter existed, those discards
-	// were folded into Skipped, so a toast reading "274 created, 557 skipped" looked
-	// like 557 records were dropped when it was really 557 individual answers across
-	// some subset of the 274 rows that WERE created.
+	// loadPersonCustomValues / aggregateToRows tests) -- before this counter existed,
+	// those discards were folded into Skipped, so a toast reading "274 created, 557
+	// skipped" looked like 557 records were dropped when it was really 557 individual
+	// answers across some subset of the 274 rows that WERE created.
 	//
 	// staff_applications.go also has a second flavor (kindred#2277): the answers
 	// belonging to a person gated out entirely by the staff-row requirement, whose
@@ -316,8 +317,9 @@ type Stats struct {
 	// discarded answers regardless of whether the record they'd have populated was
 	// created or not; Skipped is what counts the row.
 	//
-	// Nothing but those three services increments this; every other Skipped site in
-	// this package counts a whole record, and must keep doing so.
+	// Nothing but those five services increments this (kindred#2257 adopted the
+	// mechanism at the last two, closing out its mechanism-C sweep); every other
+	// Skipped site in this package counts a whole record, and must keep doing so.
 	SkippedValues int `json:"skipped_values,omitempty"`
 	// Errors counts INFRASTRUCTURE failures only — local SQLite operations that did not
 	// complete (App.Save, App.Delete, App.Create, FindRecordsByFilter). There is no healthy

--- a/pocketbase/sync/quest_registrations.go
+++ b/pocketbase/sync/quest_registrations.go
@@ -551,7 +551,26 @@ func (s *QuestRegistrationsSync) loadPersonCustomValues(
 		page++
 	}
 
-	return aggregateQuestEntries(entries, year, personHasAttendee), nil
+	records, unmappedCounts := aggregateQuestEntries(entries, year, personHasAttendee)
+
+	if len(unmappedCounts) > 0 {
+		total := 0
+		for _, n := range unmappedCounts {
+			total += n
+		}
+		s.Stats.SkippedValues += total
+
+		// One aggregated warning per run, not one per discarded value
+		// (kindred#2257, adopting the mechanism shipped for
+		// camper_transportation.go/staff_applications.go at kindred#2272/#2271).
+		slog.Warn("Quest registrations: discarding values for unmapped Quest-*/Q-* fields",
+			"year", year,
+			"discard_events", total,
+			"unmapped_fields", unmappedCounts,
+		)
+	}
+
+	return records, nil
 }
 
 // aggregateQuestEntries folds Quest custom values into one record per person-year.
@@ -564,10 +583,19 @@ func (s *QuestRegistrationsSync) loadPersonCustomValues(
 // `personHasAttendee` is an ADMISSION filter and nothing more -- see
 // loadPersonsWithAttendee. Because it is a set rather than a chosen row, the
 // result cannot depend on the order entries arrive in.
+//
+// The second return value counts discarded field VALUES, keyed by field name,
+// for a Quest-*/Q-* field admitted by isQuestRegistrationField but missing a
+// case in MapQuestFieldToColumn (kindred#2257). It stays a plain return here
+// rather than folding into Stats directly, so this function keeps the purity
+// the comment above already commits to; the caller (loadPersonCustomValues)
+// owns Stats and does the folding.
 func aggregateQuestEntries(
 	entries []questValueEntry, year int, personHasAttendee map[int]bool,
-) map[string]*questRegistrationRecord {
-	result := make(map[string]*questRegistrationRecord)
+) (records map[string]*questRegistrationRecord, unmappedCounts map[string]int) {
+	records = make(map[string]*questRegistrationRecord)
+	unmappedCounts = make(map[string]int)
+	result := records
 
 	for _, entry := range entries {
 		if !personHasAttendee[entry.personID] {
@@ -584,17 +612,20 @@ func aggregateQuestEntries(
 			result[key] = rec
 		}
 
-		mapQuestFieldToRecord(rec, entry.fieldName, entry.value)
+		if column := mapQuestFieldToRecord(rec, entry.fieldName, entry.value); column == "" {
+			unmappedCounts[entry.fieldName]++
+		}
 	}
 
-	return result
+	return result, unmappedCounts
 }
 
-// mapQuestFieldToRecord maps a Quest-*/Q-* field to the record
-func mapQuestFieldToRecord(rec *questRegistrationRecord, fieldName, value string) {
+// mapQuestFieldToRecord maps a Quest-*/Q-* field to the record and returns the
+// resolved column name, or "" if fieldName has no case in MapQuestFieldToColumn.
+func mapQuestFieldToRecord(rec *questRegistrationRecord, fieldName, value string) string {
 	column := MapQuestFieldToColumn(fieldName)
 	if column == "" {
-		return
+		return ""
 	}
 
 	switch column {
@@ -808,6 +839,8 @@ func mapQuestFieldToRecord(rec *questRegistrationRecord, fieldName, value string
 			rec.busAltPhone = value
 		}
 	}
+
+	return column
 }
 
 // MapQuestFieldToColumn maps CampMinder field names to database column names

--- a/pocketbase/sync/quest_registrations_test.go
+++ b/pocketbase/sync/quest_registrations_test.go
@@ -576,7 +576,7 @@ func TestAggregateQuestEntriesKeepsAdmissionFilter(t *testing.T) {
 	// 100 is enrolled somewhere this year; 200 is not.
 	hasAttendee := map[int]bool{100: true}
 
-	got := aggregateQuestEntries(entries, 2026, hasAttendee)
+	got, _ := aggregateQuestEntries(entries, 2026, hasAttendee)
 
 	if len(got) != 1 {
 		t.Fatalf("expected 1 admitted record, got %d", len(got))
@@ -606,8 +606,8 @@ func TestAggregateQuestEntriesIsOrderIndependent(t *testing.T) {
 	}
 	hasAttendee := map[int]bool{100: true, 200: true}
 
-	a := aggregateQuestEntries(forward, 2026, hasAttendee)
-	b := aggregateQuestEntries(reversed, 2026, hasAttendee)
+	a, _ := aggregateQuestEntries(forward, 2026, hasAttendee)
+	b, _ := aggregateQuestEntries(reversed, 2026, hasAttendee)
 
 	if len(a) != len(b) {
 		t.Fatalf("record count differs by input order: %d vs %d", len(a), len(b))
@@ -740,5 +740,94 @@ func TestLoadQuestSessionIDsPinsTheSchemaIdentifiers(t *testing.T) {
 	}
 	if len(ids) != 1 {
 		t.Errorf("got %d session ids, want exactly 1", len(ids))
+	}
+}
+
+// --- kindred#2257: adopt SkippedValues for mechanism-C -----------------------
+
+// TestQuestLoadPersonCustomValuesCountsUnmappedFields pins the mechanism-C fix
+// for kindred#2257: a Quest-*/Q-* field admitted by isQuestRegistrationField
+// (the prefix test) but missing a case in MapQuestFieldToColumn used to be
+// discarded by mapQuestFieldToRecord's `if column == "" { return }` with no
+// counter and no log line, exactly like the sites already fixed at
+// camper_transportation.go and staff_vehicle_info.go (kindred#2356/#2277).
+// The record itself is still created -- this is a VALUE discard, not a record
+// one, so it must land on Stats.SkippedValues, not Stats.Skipped.
+func TestQuestLoadPersonCustomValuesCountsUnmappedFields(t *testing.T) {
+	t.Parallel()
+	app := newTransportValuesTestApp(t)
+
+	personsCol, err := app.FindCollectionByNameOrId("persons")
+	if err != nil {
+		t.Fatalf("find persons: %v", err)
+	}
+	person := core.NewRecord(personsCol)
+	person.Set("cm_id", 8001)
+	if saveErr := app.Save(person); saveErr != nil {
+		t.Fatalf("save person: %v", saveErr)
+	}
+
+	const year = 2026
+	// One routed field (must still work) and one field admitted by the
+	// "Quest-" prefix that has no case in MapQuestFieldToColumn (simulates a
+	// hypothetical new CampMinder Quest-* definition).
+	addPersonCustomValue(t, app, "fd_routed", person.Id, "adventure", year)
+	addPersonCustomValue(t, app, "fd_unmapped", person.Id, "unexpected value", year)
+
+	fieldNameMap := map[string]string{
+		"fd_routed":   "Q-Why come?",
+		"fd_unmapped": "Quest-Space Camp Interest",
+	}
+	personHasAttendee := map[int]bool{8001: true}
+
+	s := NewQuestRegistrationsSync(app)
+	records, err := s.loadPersonCustomValues(context.Background(), year, fieldNameMap, personHasAttendee)
+	if err != nil {
+		t.Fatalf("loadPersonCustomValues: %v", err)
+	}
+
+	key := makeQuestRegistrationKey(8001, year)
+	rec, ok := records[key]
+	if !ok {
+		t.Fatalf("no record for key %q; got %d records", key, len(records))
+	}
+	if rec.whyCome != "adventure" {
+		t.Errorf("routed field was not written: whyCome = %q, want %q", rec.whyCome, "adventure")
+	}
+
+	if s.Stats.SkippedValues != 1 {
+		t.Errorf("Stats.SkippedValues = %d, want 1 -- the unmapped Quest field is a discarded value, not a record",
+			s.Stats.SkippedValues)
+	}
+	if s.Stats.Skipped != 0 {
+		t.Errorf("Stats.Skipped = %d, want 0 -- a discarded field value is not a skipped record", s.Stats.Skipped)
+	}
+}
+
+// TestAggregateQuestEntriesReturnsUnmappedCounts pins aggregateQuestEntries'
+// second return value directly, at the pure-function level the rest of this
+// file's kindred#2261 tests already use -- see the package comment on why the
+// production aggregation, not a test-local reimplementation, must be driven.
+func TestAggregateQuestEntriesReturnsUnmappedCounts(t *testing.T) {
+	t.Parallel()
+	entries := []questValueEntry{
+		{personID: 100, fieldName: "Q-Why come?", value: "adventure"},
+		{personID: 100, fieldName: "Quest-Space Camp Interest", value: "yes please"},
+	}
+	hasAttendee := map[int]bool{100: true}
+
+	records, unmapped := aggregateQuestEntries(entries, 2026, hasAttendee)
+
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+	if got := records[makeQuestRegistrationKey(100, 2026)].whyCome; got != "adventure" {
+		t.Errorf("whyCome = %q, want %q", got, "adventure")
+	}
+	if unmapped["Quest-Space Camp Interest"] != 1 {
+		t.Errorf("unmapped[%q] = %d, want 1", "Quest-Space Camp Interest", unmapped["Quest-Space Camp Interest"])
+	}
+	if len(unmapped) != 1 {
+		t.Errorf("unmapped has %d entries, want 1: %v", len(unmapped), unmapped)
 	}
 }


### PR DESCRIPTION
## Defect

`quest_registrations.go` and `household_demographics.go` each had one more
"mechanism-C" silent drop from kindred#2257's inventory: a custom-field
VALUE admitted by a prefix filter but missing a case in the exact-match
column mapper was discarded with no counter and no log line.

- `mapQuestFieldToRecord` (quest_registrations.go): `isQuestRegistrationField`
  admits by prefix (`Quest-`/`Q-`/`Quest `), but `MapQuestFieldToColumn` is
  a finite 45-case exact-match switch — any admitted field outside that
  switch vanished silently.
- `mapPersonFieldToRecord` (household_demographics.go): `IsHHField` admits
  by the `HH-` prefix, but `MapHHFieldToColumn` is a finite 17-case
  exact-match switch — same gap.

Both are the exact shape already fixed at `camper_transportation.go`
(kindred#2356), `staff_applications.go`, and `staff_vehicle_info.go`
(kindred#2277) — a prefix-admission filter strictly wider than the
exact-match mapping table underneath it.

## Fix

Both mapping functions (`mapQuestFieldToRecord`, `mapPersonFieldToRecord`)
now return the resolved column name, or `""` when unmapped. Their callers
(`aggregateQuestEntries` / `aggregateToRows`) count discard events by field
name, fold the total into `Stats.SkippedValues`, and emit one aggregated
`slog.Warn` per run — the same shape `camper_transportation.go` and
`staff_applications.go` use, not a per-value log line.

`aggregateQuestEntries` stays a pure, non-method function (its own comment
already commits to that, for testability — see `TestAggregateQuestEntriesIsOrderIndependent`
etc.), so it returns the discard counts as a second named value rather
than reaching into `Stats` directly; the caller, `loadPersonCustomValues`,
owns `Stats` and does the folding.

`orchestrator.go`'s `Stats.SkippedValues` doc comment (the only change in
that file — a doc comment, no logic) is updated so its "nothing but those
services increments this" sentence names all five adopters instead of
three.

## Verified unreachable, left untouched

Per the issue's explicit instruction, and confirmed against the tree
before touching anything:

- `household_demographics.go`'s `mapHouseholdFieldToRecord` has its own
  `column == ""` early return, but its admission filter
  (`isHouseholdDemographicsField`'s non-`HH-` branch: `Synagogue`,
  `Center`, `Custody Issues`, `Board`) and `MapHouseholdFieldToColumn`'s
  4-case switch are the identical 4-name set — that branch is structurally
  unreachable.
- `camper_dietary.go`'s equivalent (`isCamperDietaryField`'s 5 admitted
  `Family Medical-*` names vs. `MapDietaryFieldToColumn`'s 5-case switch)
  is the same identity — also unreachable.

Neither file is touched by this PR.

## What this deliberately did not do

- Did not touch `camper_dietary.go`, `persons.go`, `base_sync.go`,
  `orphan_guard.go`, `staff_applications.go`, or `staff_vehicle_info.go`.
- Did not add the BUS-*/App-* style "known-retired vs. unrecognized"
  field classification `camper_transportation.go`/`staff_applications.go`
  carry — that split rests on domain research (which CampMinder fields
  are retired-but-expected) this item didn't do for Quest-*/HH-* fields.
  The aggregated warning here logs the raw per-field discard counts
  instead; a follow-up can add classification if a real unmapped field
  ever shows up.
- Did not add `t.Parallel()`-incompatible log-content assertions —
  `captureSweepLogs` (used by the three existing adopters' tests) swaps
  slog's process-global default handler and requires a serial-test
  exemption entry in `pocketbase/main_test_parallelism_test.go`, a file
  outside this item's ownership list. Both new tests assert on
  `Stats.SkippedValues` directly instead and run with `t.Parallel()`.
- This retires zero issue numbers. The two sites fixed here were never
  filed as children of kindred#2257 — it stays open as the umbrella
  tracking issue.

## Testing

- New failing-first Go tests (verified red via a real build failure
  before the signature changes landed, then green after):
  `TestQuestLoadPersonCustomValuesCountsUnmappedFields`,
  `TestAggregateQuestEntriesReturnsUnmappedCounts`,
  `TestAggregateToRowsCountsUnmappedPersonFields`,
  `TestMapPersonFieldToRecordReturnsTheResolvedColumn`.
- Mutation-checked: neutering the `Stats.SkippedValues +=` increment in
  both files turned the two DB-backed tests red (confirmed, then
  restored), so they pin real behavior rather than passing vacuously.
- `go build ./...`, `go vet ./...`, `go test ./sync/...` (full package,
  135s and again 92s), and `golangci-lint run --config ../.golangci.yml
  ./sync/...` (0 issues) all pass on the final diff.

Refs kindred#2257.
