### PR TITLE
fix(sync): normalise family camp adult date_of_birth and relationship_to_camper

### DIFF
--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/pocketbase/pocketbase/core"
 )
@@ -761,6 +762,18 @@ func (s *FamilyCampDerivedSync) loadPersonCustomValues(
 // this per-attribute merge policy, and that is kindred#2275's subject.
 // Today's behavior for those fields is pinned by test instead of changed on
 // a guess.
+//
+// NORMALISED, separately from the merge (kindred#2275 phase D, owner ruling
+// 2026-08-16): date_of_birth and relationship_to_camper are rewritten into a
+// canonical form BEFORE they are stored -- see normalizeDateOfBirth and
+// normalizeRelationshipToCamper. This is not a merge policy and does not
+// change which sibling wins; it removes the disagreements that were only ever
+// two spellings of one answer. Measured against the production snapshot, all
+// years: date_of_birth divergence falls from 1,124 (household, year, adult
+// slot) groups to 541, and relationship_to_camper from 315 to 169. The 710
+// that survive are real -- 360 different birth YEARS and 92 Mother-vs-Father
+// slot collisions -- and that residual is what the grain decision on
+// kindred#2275 now rests on.
 func (s *FamilyCampDerivedSync) processAdults(
 	householdValues []customValueEntry, personValues []customValueEntry,
 ) []*adultData {
@@ -829,9 +842,13 @@ func (s *FamilyCampDerivedSync) processAdults(
 		case strings.Contains(v.fieldName, "Gender") && adult.gender == "":
 			adult.gender = v.value
 		case strings.Contains(v.fieldName, "DOB") && adult.dateOfBirth == "":
-			adult.dateOfBirth = v.value
+			// Normalised, not merged: see normalizeDateOfBirth. Which sibling
+			// wins is still load order (kindred#2275); what changes is that
+			// the winner is stored in one canonical form, so two siblings who
+			// typed the SAME birthday two ways no longer read as a conflict.
+			adult.dateOfBirth = normalizeDateOfBirth(v.value)
 		case strings.Contains(v.fieldName, "Relationship") && adult.relationship == "":
-			adult.relationship = v.value
+			adult.relationship = normalizeRelationshipToCamper(v.value)
 		}
 	}
 
@@ -851,6 +868,215 @@ func (s *FamilyCampDerivedSync) processAdults(
 	}
 
 	return result
+}
+
+// ---------------------------------------------------------------------------
+// date_of_birth and relationship_to_camper normalisation (kindred#2275)
+//
+// These are FORMAT normalisers, not merge policy and not validators. The
+// merge below is still first-non-empty-wins and the record grain is still
+// (household, year, adult_number); both remain kindred#2275's open subject.
+// What normalisation buys is that the column becomes COMPARABLE, so the
+// residual disagreement between two siblings answering for the same adult is
+// a real disagreement rather than two spellings of one answer.
+// ---------------------------------------------------------------------------
+
+// dobTwoDigitYearPivot is the century rule for a two-digit year, stated
+// explicitly because the value is genuinely ambiguous: YY >= 30 means 19YY,
+// YY < 30 means 20YY.
+//
+// The pivot is placed at 30 because it lands in a gap that is empty in the
+// production snapshot. The two-digit years actually stored in the family camp
+// DOB fields are 01-24 (52 answers -- children's birthdays typed into an adult
+// field) and 43-99 (2,188 answers -- the adults). Nothing occupies 25-42, so
+// no value present today can be misclassified by this choice.
+const dobTwoDigitYearPivot = 30
+
+// The accepted input shapes for normalizeDateOfBirth. Every one of them
+// occurs in the production snapshot; the whole point of the list is that a
+// parser accepting only the most common shape (M/D/YYYY, 10,418 of 13,823
+// answers) reports the other 3,243 readable ones as junk, which is exactly how
+// kindred#2275
+// was mis-measured twice before.
+var (
+	// M/D/YY(YY) with any of / - . or space as the separator, and tolerant of
+	// the two separators differing (`05-02/1972` occurs).
+	dobNumericPattern = regexp.MustCompile(`^(\d{1,2})[/.\- ](\d{1,2})[/.\- ](\d{2}|\d{4})$`)
+	// YYYY-M-D, already canonical or nearly so.
+	dobISOPattern = regexp.MustCompile(`^(\d{4})-(\d{1,2})-(\d{1,2})$`)
+	// MMDDYYYY and MMDDYY, typed with the separators left out.
+	dobDigits8Pattern = regexp.MustCompile(`^(\d{2})(\d{2})(\d{4})$`)
+	dobDigits6Pattern = regexp.MustCompile(`^(\d{2})(\d{2})(\d{2})$`)
+	// `October 28, 1981`, `Oct 6, 1981`, `Nov. 1 1966`.
+	dobMonthNamePattern = regexp.MustCompile(`^([A-Za-z]{3,9})\.? (\d{1,2})(?:st|nd|rd|th)?,? (\d{4})$`)
+	// `28 Nov 1967`, `9-Oct-1974`.
+	dobDayMonthNamePattern = regexp.MustCompile(`^(\d{1,2})(?:st|nd|rd|th)?[ \-]([A-Za-z]{3,9})\.?[ \-,]+(\d{4})$`)
+)
+
+// dobMonthNames maps the long and abbreviated English month names, lowercased,
+// to their number. `sept` is included because parents type it.
+var dobMonthNames = map[string]int{
+	"january": 1, "jan": 1,
+	"february": 2, "feb": 2,
+	"march": 3, "mar": 3,
+	"april": 4, "apr": 4,
+	"may":  5,
+	"june": 6, "jun": 6,
+	"july": 7, "jul": 7,
+	"august": 8, "aug": 8,
+	"september": 9, "sept": 9, "sep": 9,
+	"october": 10, "oct": 10,
+	"november": 11, "nov": 11,
+	"december": 12, "dec": 12,
+}
+
+// normalizeDateOfBirth rewrites a free-text CampMinder date answer into the
+// single canonical form YYYY-MM-DD.
+//
+// It NORMALISES, it does not discard: a value it cannot read comes back
+// unchanged, never blanked. 162 of the 13,823 stored family camp DOB answers
+// (1.2%) land there -- `11/13`, `6274`, `1974`, `None`, `na` -- and each is a
+// real answer a staff member typed, so a "cleanup" that emptied them would be
+// data loss. Nor does it judge plausibility: a mistyped year (2986, 9171) is a
+// well-formed date and is rewritten like any other, because rejecting it would
+// put it straight back in the junk bucket the earlier measurements inflated.
+//
+// It is idempotent, which the sync's compare-before-write depends on: a
+// normaliser whose output re-normalised differently would rewrite every
+// family_camp_adults row on every run.
+func normalizeDateOfBirth(raw string) string {
+	trimmed := strings.Join(strings.Fields(raw), " ")
+	if trimmed == "" {
+		return ""
+	}
+
+	if m := dobISOPattern.FindStringSubmatch(trimmed); m != nil {
+		if out, ok := canonicalDate(atoiOrZero(m[1]), atoiOrZero(m[2]), atoiOrZero(m[3])); ok {
+			return out
+		}
+	}
+	if m := dobNumericPattern.FindStringSubmatch(trimmed); m != nil {
+		if out, ok := canonicalDate(expandTwoDigitYear(m[3]), atoiOrZero(m[1]), atoiOrZero(m[2])); ok {
+			return out
+		}
+	}
+	if m := dobDigits8Pattern.FindStringSubmatch(trimmed); m != nil {
+		if out, ok := canonicalDate(atoiOrZero(m[3]), atoiOrZero(m[1]), atoiOrZero(m[2])); ok {
+			return out
+		}
+	}
+	if m := dobDigits6Pattern.FindStringSubmatch(trimmed); m != nil {
+		if out, ok := canonicalDate(expandTwoDigitYear(m[3]), atoiOrZero(m[1]), atoiOrZero(m[2])); ok {
+			return out
+		}
+	}
+	if m := dobMonthNamePattern.FindStringSubmatch(trimmed); m != nil {
+		if month, ok := dobMonthNames[strings.ToLower(m[1])]; ok {
+			if out, ok := canonicalDate(atoiOrZero(m[3]), month, atoiOrZero(m[2])); ok {
+				return out
+			}
+		}
+	}
+	if m := dobDayMonthNamePattern.FindStringSubmatch(trimmed); m != nil {
+		if month, ok := dobMonthNames[strings.ToLower(m[2])]; ok {
+			if out, ok := canonicalDate(atoiOrZero(m[3]), month, atoiOrZero(m[1])); ok {
+				return out
+			}
+		}
+	}
+
+	return raw
+}
+
+// expandTwoDigitYear applies dobTwoDigitYearPivot. A year already written with
+// three or more digits is returned as-is.
+func expandTwoDigitYear(year string) int {
+	y := atoiOrZero(year)
+	if len(year) > 2 {
+		return y
+	}
+	if y >= dobTwoDigitYearPivot {
+		return 1900 + y
+	}
+	return 2000 + y
+}
+
+// canonicalDate renders YYYY-MM-DD, reporting false when the parts are not a
+// real calendar date (February 30, month 13). time.Date silently rolls those
+// over, so the round-trip check is what actually rejects them.
+func canonicalDate(year, month, day int) (string, bool) {
+	if year <= 0 || month <= 0 || day <= 0 {
+		return "", false
+	}
+	t := time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
+	if t.Year() != year || int(t.Month()) != month || t.Day() != day {
+		return "", false
+	}
+	return fmt.Sprintf("%04d-%02d-%02d", year, month, day), true
+}
+
+// atoiOrZero converts a regex-captured digit run. The patterns guarantee the
+// input is digits, so the error case is unreachable and is folded to 0, which
+// canonicalDate then rejects.
+func atoiOrZero(s string) int {
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// relationshipSynonyms folds the only two synonym pairs the vocabulary
+// supports. Mother and Father are deliberately NOT folded into each other:
+// 92 of the groups that still disagree after normalisation are exactly that
+// pair, and they are two children naming two DIFFERENT PEOPLE into one adult
+// slot -- the signal kindred#2275 exists to measure.
+//
+// The lookup is exact-match on the whole value, never a substring, which is
+// what keeps the small step-parent population (~21 answers: `Step Father`,
+// `step mother`, `Stepmom`, `Dad/Stepdad`) out of it.
+var relationshipSynonyms = map[string]string{
+	"mom":    "Mother",
+	"mother": "Mother",
+	"dad":    "Father",
+	"father": "Father",
+}
+
+// normalizeRelationshipToCamper folds case and the two synonym pairs on a
+// relationship answer, and leaves everything else exactly as the parent typed
+// it.
+//
+// Case folding applies only to a SINGLE all-letters token, so `mother` becomes
+// `Mother` and `spouse` becomes `Spouse`, while free text (`mother of Emma and
+// Liam`) and punctuated answers (`N/A`, `Dad/Stepdad`) keep their own
+// capitalisation. Re-casing free text would buy 2 more collapsed groups out of
+// 315 and rewrite 100 more stored values, which is not a trade worth making.
+func normalizeRelationshipToCamper(raw string) string {
+	trimmed := strings.Join(strings.Fields(raw), " ")
+	if trimmed == "" {
+		return ""
+	}
+
+	if canonical, ok := relationshipSynonyms[strings.ToLower(trimmed)]; ok {
+		return canonical
+	}
+
+	if !isSingleAlphabeticToken(trimmed) {
+		return trimmed
+	}
+
+	runes := []rune(trimmed)
+	return string(unicode.ToUpper(runes[0])) + strings.ToLower(string(runes[1:]))
+}
+
+// isSingleAlphabeticToken reports whether s is one word made only of letters.
+func isSingleAlphabeticToken(s string) bool {
+	for _, r := range s {
+		if !unicode.IsLetter(r) {
+			return false
+		}
+	}
+	return s != ""
 }
 
 // emailFormatPattern is a narrow, defensible notion of "well-formed enough

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -2405,3 +2405,329 @@ func TestProcessAdultsEmailGapFillStillWins(t *testing.T) {
 		})
 	}
 }
+
+// ============================================================================
+// kindred#2275 phase D -- NORMALISATION of date_of_birth and
+// relationship_to_camper. Format/case only; the merge policy and the record
+// grain are unchanged and remain kindred#2275's open subject.
+// ============================================================================
+
+// TestNormalizeDateOfBirthAcceptsEveryStoredFormat is the guard against the
+// trap that cost the measurement of kindred#2275 three rounds: a date parser
+// that only accepts M/D/YYYY reports the other 3,243 readable production
+// answers as junk. Every case below is a shape that actually occurs in the family camp
+// DOB fields (cm_id 34166/34167), and every one must come out as the single
+// canonical form YYYY-MM-DD.
+func TestNormalizeDateOfBirthAcceptsEveryStoredFormat(t *testing.T) {
+	t.Parallel()
+
+	const want = "1979-09-02"
+
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "M/D/YYYY (10,418 of 13,823)", raw: "9/2/1979", want: want},
+		{name: "MM/DD/YYYY zero padded", raw: "09/02/1979", want: want},
+		{name: "M/D/YY (2,042)", raw: "9/2/79", want: want},
+		{name: "M-D-YYYY (384)", raw: "9-2-1979", want: want},
+		{name: "MM-DD-YYYY zero padded", raw: "09-02-1979", want: want},
+		{name: "M-D-YY (147)", raw: "9-2-79", want: want},
+		{name: "M.D.YYYY (45)", raw: "9.2.1979", want: want},
+		{name: "M.D.YY (49)", raw: "2.13.80", want: "1980-02-13"},
+		{name: "MMDDYYYY (369)", raw: "09021979", want: want},
+		{name: "MMDDYYYY without leading zero month", raw: "10221978", want: "1978-10-22"},
+		{name: "MMDDYY six digits", raw: "090279", want: want},
+		{name: "ISO already canonical (1)", raw: "1979-09-02", want: want},
+		{name: "ISO with single digit parts", raw: "1979-9-2", want: want},
+		{name: "long month name", raw: "October 28, 1981", want: "1981-10-28"},
+		{name: "abbreviated month name", raw: "Oct 6, 1981", want: "1981-10-06"},
+		{name: "month name without comma", raw: "September 2 1979", want: want},
+		{name: "day-first with abbreviated month", raw: "9-Oct-1974", want: "1974-10-09"},
+		{name: "day-first spaced", raw: "28 Nov 1967", want: "1967-11-28"},
+		{name: "space separated numeric", raw: "03 16 1976", want: "1976-03-16"},
+		{name: "mixed separators", raw: "05-02/1972", want: "1972-05-02"},
+		{name: "surrounding whitespace is trimmed", raw: "  9/2/1979  ", want: want},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := normalizeDateOfBirth(tc.raw); got != tc.want {
+				t.Errorf("normalizeDateOfBirth(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNormalizeDateOfBirthNormalisesRatherThanDiscards pins the half of the
+// contract that is easy to get backwards: a value the parser cannot read is
+// returned UNCHANGED, never blanked. Only 162 of 13,823 production answers
+// (1.2%) land here, and every one of them is a real answer a staff member
+// typed -- discarding them would be a data loss dressed up as a cleanup.
+func TestNormalizeDateOfBirthNormalisesRatherThanDiscards(t *testing.T) {
+	t.Parallel()
+
+	// Every one of these is a verbatim shape from the production snapshot.
+	unparseable := []string{
+		"11/13",   // month/day only, no year
+		"6274",    // four bare digits
+		"1974",    // year only
+		"None",    // literal
+		"na",      // literal
+		"N/A",     // literal
+		"July 30", // month and day, no year
+		"2/30/1980",
+		"13/1/1980", // month out of range
+	}
+
+	for _, raw := range unparseable {
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			if got := normalizeDateOfBirth(raw); got != raw {
+				t.Errorf("normalizeDateOfBirth(%q) = %q, want the input back unchanged", raw, got)
+			}
+		})
+	}
+
+	if got := normalizeDateOfBirth(""); got != "" {
+		t.Errorf("normalizeDateOfBirth(%q) = %q, want empty", "", got)
+	}
+	if got := normalizeDateOfBirth("   "); got != "" {
+		t.Errorf("normalizeDateOfBirth(%q) = %q, want empty", "   ", got)
+	}
+}
+
+// TestNormalizeDateOfBirthTwoDigitYearPivot states the century rule
+// explicitly, because a two-digit year is genuinely ambiguous and a silent
+// choice here would be a guess. Rule: YY >= 30 is 19YY, YY < 30 is 20YY.
+// The pivot sits in a gap that is empty in production -- the two-digit years
+// actually stored are 01-24 (52 answers, children's dates typed into an adult
+// field) and 43-99 (2,188 answers), with 25-42 absent -- so it cannot
+// misclassify any value present today.
+func TestNormalizeDateOfBirthTwoDigitYearPivot(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct{ raw, want string }{
+		{raw: "1/2/99", want: "1999-01-02"},
+		{raw: "1/2/58", want: "1958-01-02"},
+		{raw: "1/2/43", want: "1943-01-02"},
+		{raw: "1/2/30", want: "1930-01-02"},
+		{raw: "1/2/29", want: "2029-01-02"},
+		{raw: "1/2/24", want: "2024-01-02"},
+		{raw: "1/2/01", want: "2001-01-02"},
+		{raw: "1/2/00", want: "2000-01-02"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.raw, func(t *testing.T) {
+			t.Parallel()
+			if got := normalizeDateOfBirth(tc.raw); got != tc.want {
+				t.Errorf("normalizeDateOfBirth(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNormalizeDateOfBirthDoesNotValidatePlausibility pins that this is a
+// FORMAT normaliser and not a validator. Production holds mistyped years
+// (2986, 9171, 1073) that are perfectly well-formed dates and hopeless
+// birthdays. Rewriting them into canonical form is lossless and makes them
+// comparable; rejecting them would put them back in the "junk" bucket the
+// earlier measurements wrongly inflated.
+func TestNormalizeDateOfBirthDoesNotValidatePlausibility(t *testing.T) {
+	t.Parallel()
+
+	if got := normalizeDateOfBirth("2/13/2986"); got != "2986-02-13" {
+		t.Errorf("normalizeDateOfBirth(%q) = %q, want %q", "2/13/2986", got, "2986-02-13")
+	}
+}
+
+// TestNormalizeRelationshipToCamperFoldsCaseAndTheTwoSynonymPairs covers the
+// second normalisation. 315 of 5,751 (household, year, adult slot) groups
+// disagree on relationship_to_camper in production, and the largest single
+// cause is case: `Father`/`father`/`FAther`/`FATHER` are four spellings of one
+// answer. Mom<->Mother and Dad<->Father are the only synonym pairs folded.
+func TestNormalizeRelationshipToCamperFoldsCaseAndTheTwoSynonymPairs(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct{ raw, want string }{
+		{raw: "Mother", want: "Mother"},
+		{raw: "mother", want: "Mother"},
+		{raw: "MOther", want: "Mother"},
+		{raw: "MOTHER", want: "Mother"},
+		{raw: "Mom", want: "Mother"},
+		{raw: "mom", want: "Mother"},
+		{raw: "MOM", want: "Mother"},
+		{raw: "Father", want: "Father"},
+		{raw: "father", want: "Father"},
+		{raw: "FAther", want: "Father"},
+		{raw: "Dad", want: "Father"},
+		{raw: "dad", want: "Father"},
+		{raw: "DAD", want: "Father"},
+		{raw: "Parent", want: "Parent"},
+		{raw: "parent", want: "Parent"},
+		{raw: "PArent", want: "Parent"},
+		{raw: "self", want: "Self"},
+		{raw: "Self", want: "Self"},
+		{raw: "grandmother", want: "Grandmother"},
+		{raw: "spouse", want: "Spouse"},
+		{raw: "  Mother  ", want: "Mother"},
+		{raw: "", want: ""},
+		{raw: "   ", want: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run("raw="+tc.raw, func(t *testing.T) {
+			t.Parallel()
+			if got := normalizeRelationshipToCamper(tc.raw); got != tc.want {
+				t.Errorf("normalizeRelationshipToCamper(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNormalizeRelationshipToCamperKeepsDistinctAnswersDistinct is the guard
+// on what must NOT be folded.
+//
+//   - Mother and Father must never collapse into each other. 92 of the 167
+//     groups that still disagree after normalisation are exactly this pair --
+//     two children naming two DIFFERENT PEOPLE into one adult slot. That is
+//     the signal kindred#2275 exists to measure; folding it would delete the
+//     evidence and make the residual look artificially small.
+//   - Step-parents are a real if small population (~21 production answers:
+//     `Step Father`, `step mother`, `Stepmom`, `Dad/Stepdad` ...). Synonym
+//     folding is exact-match on the whole value, never a substring, so none of
+//     them is rewritten into `Mother` or `Father`.
+//   - Free text keeps the capitalisation the parent typed. Only a single
+//     all-letters token is case-folded.
+func TestNormalizeRelationshipToCamperKeepsDistinctAnswersDistinct(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct{ raw, want string }{
+		{raw: "Stepmom", want: "Stepmom"},
+		{raw: "stepmom", want: "Stepmom"},
+		{raw: "Stepmother", want: "Stepmother"},
+		{raw: "Step Father", want: "Step Father"},
+		{raw: "step mother", want: "step mother"},
+		{raw: "Dad/Stepdad", want: "Dad/Stepdad"},
+		{raw: "Grandmother of Emma Johnson", want: "Grandmother of Emma Johnson"},
+		{raw: "mother of Emma and Liam", want: "mother of Emma and Liam"},
+		{raw: "N/A", want: "N/A"},
+		{raw: "Self?", want: "Self?"},
+	}
+
+	for _, tc := range cases {
+		t.Run("raw="+tc.raw, func(t *testing.T) {
+			t.Parallel()
+			if got := normalizeRelationshipToCamper(tc.raw); got != tc.want {
+				t.Errorf("normalizeRelationshipToCamper(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+
+	if normalizeRelationshipToCamper("Mother") == normalizeRelationshipToCamper("Father") {
+		t.Fatal("Mother and Father must never normalise to the same value")
+	}
+}
+
+// TestProcessAdultsNormalisesSiblingDateFormats is the end-to-end half: two
+// enrolled siblings type the SAME birthday in two different formats into the
+// same adult slot. Before normalisation the merge kept whichever row loaded
+// first and the two values compared as different, which is 583 of the 1,124
+// diverging production groups. After it, both orders produce the same stored
+// value and the divergence is gone.
+func TestProcessAdultsNormalisesSiblingDateFormats(t *testing.T) {
+	t.Parallel()
+
+	const wantDOB = "1979-09-02"
+
+	for _, order := range [][2]string{
+		{"9/2/1979", "09-02-79"},
+		{"09-02-79", "9/2/1979"},
+		{"09021979", "September 2, 1979"},
+	} {
+		t.Run(order[0]+"_then_"+order[1], func(t *testing.T) {
+			t.Parallel()
+			s := &FamilyCampDerivedSync{}
+			householdValues := []customValueEntry{
+				{householdPBID: "hh_1", fieldName: "Family Camp Adult 1", value: "Amy Johnson"},
+			}
+			personValues := []customValueEntry{
+				{householdPBID: "hh_1", fieldName: "Family Camp DOB 1", value: order[0]},
+				{householdPBID: "hh_1", fieldName: "Family Camp DOB 1", value: order[1]},
+			}
+
+			adults := s.processAdults(householdValues, personValues)
+
+			if len(adults) != 1 {
+				t.Fatalf("expected 1 merged adult, got %d", len(adults))
+			}
+			if adults[0].dateOfBirth != wantDOB {
+				t.Errorf("got date_of_birth %q, want canonical %q", adults[0].dateOfBirth, wantDOB)
+			}
+		})
+	}
+}
+
+// TestProcessAdultsNormalisesRelationshipCase is the relationship half of the
+// same end-to-end check, plus the negative case: a genuine Mother/Father
+// collision still resolves by load order and is still visible as a
+// disagreement, because normalisation is not a merge policy.
+func TestProcessAdultsNormalisesRelationshipCase(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		first      string
+		second     string
+		wantStored string
+	}{
+		{name: "case variants fold", first: "mother", second: "Mother", wantStored: "Mother"},
+		{name: "synonym folds", first: "Mom", second: "mother", wantStored: "Mother"},
+		{name: "dad folds to father", first: "dad", second: "Father", wantStored: "Father"},
+		{name: "genuine collision keeps first loaded", first: "Father", second: "Mother", wantStored: "Father"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := &FamilyCampDerivedSync{}
+			householdValues := []customValueEntry{
+				{householdPBID: "hh_1", fieldName: "Family Camp Adult 1", value: "Amy Johnson"},
+			}
+			personValues := []customValueEntry{
+				{householdPBID: "hh_1", fieldName: "Family Camp-Relationship to 1", value: tc.first},
+				{householdPBID: "hh_1", fieldName: "Family Camp-Relationship to 1", value: tc.second},
+			}
+
+			adults := s.processAdults(householdValues, personValues)
+
+			if len(adults) != 1 {
+				t.Fatalf("expected 1 merged adult, got %d", len(adults))
+			}
+			if adults[0].relationship != tc.wantStored {
+				t.Errorf("got relationship %q, want %q", adults[0].relationship, tc.wantStored)
+			}
+		})
+	}
+}
+
+// TestNormalizeDateOfBirthIsIdempotent guards the sync's compare-before-write:
+// a normaliser that changed its own output on a second pass would rewrite
+// every family_camp_adults row on every run forever.
+func TestNormalizeDateOfBirthIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{"9/2/1979", "2.13.80", "October 28, 1981", "11/13", "None", ""} {
+		once := normalizeDateOfBirth(raw)
+		if twice := normalizeDateOfBirth(once); twice != once {
+			t.Errorf("normalizeDateOfBirth(%q) = %q but re-normalises to %q", raw, once, twice)
+		}
+		relOnce := normalizeRelationshipToCamper(raw)
+		if relTwice := normalizeRelationshipToCamper(relOnce); relTwice != relOnce {
+			t.Errorf("normalizeRelationshipToCamper(%q) = %q but re-normalises to %q", raw, relOnce, relTwice)
+		}
+	}
+}


### PR DESCRIPTION
`processAdults` stored `date_of_birth` and `relationship_to_camper` exactly as the
parent typed them, so two enrolled siblings answering for the same adult slot
"disagreed" whenever they had merely typed the same answer two different ways.
Measured against the production snapshot, all years, over
`(household, year, adult_slot)` groups: **1,124 of 9,388 DOB groups** and
**315 of 5,751 relationship groups** held two or more distinct values — and over
half of that was formatting and case, not disagreement.

This normalises both columns. It does **not** change the merge and does **not**
change the record grain; both remain kindred#2275's open subject.

## The date parser

`normalizeDateOfBirth` rewrites an answer into the single canonical form
`YYYY-MM-DD`. Accepted shapes, every one of which occurs in production:

| shape | example | answers |
|---|---|---|
| `M/D/YYYY` | `9/2/1979` | 10,418 |
| `M/D/YY` | `9/2/79` | 2,042 |
| `M-D-YYYY` | `09-02-1979` | 384 |
| `MMDDYYYY` | `10221978` | 369 |
| `M-D-YY` | `9-2-79` | 147 |
| `M.D.YY` | `2.13.80` | 49 |
| `M.D.YYYY` | `9.2.1979` | 45 |
| `MMDDYY` | `090279` | 35 |
| `YYYY-M-D` | `1979-09-02` | 1 |
| month name | `October 28, 1981`, `Oct 6, 1981` | in the tail |
| day-first month name | `28 Nov 1967`, `9-Oct-1974` | in the tail |
| space separated | `03 16 1976` | in the tail |
| mixed separators | `05-02/1972` | in the tail |

**Two-digit year century rule, stated explicitly:** `YY >= 30` is `19YY`,
`YY < 30` is `20YY`. The pivot is at 30 because it lands in a gap that is empty
in production — the two-digit years actually stored are 01-24 (52 answers,
children's birthdays typed into an adult field) and 43-99 (2,188 answers), with
25-42 absent — so no value present today can be misclassified by it.

**It normalises, it does not discard.** A value the parser cannot read is
returned unchanged, never blanked. **Residual after parsing: 162 of 13,823
answers (1.17%)** — `11/13`, `6274`, `1974`, `None`, `na`, `N/A`. Each is a real
answer someone typed; emptying them would be data loss dressed as a cleanup.
It also does not judge plausibility: a mistyped year (`2/13/2986`) is a
well-formed date and is canonicalised like any other, because rejecting it would
put it straight back in the junk bucket the two earlier passes at this issue
wrongly inflated.

## The relationship normaliser

`normalizeRelationshipToCamper` folds case on a single all-letters token
(`mother`/`MOther`/`MOTHER` → `Mother`) and the two synonym pairs
Mom↔Mother and Dad↔Father. Nothing else.

- **`Mother` and `Father` are never folded into each other.** 92 of the residual
  groups are exactly that pair, and they are two children naming two different
  people into one adult slot. That is the signal, not noise.
- Synonym lookup is **exact-match on the whole value, never a substring**, which
  is what keeps the small step-parent tail (~21 answers: `Step Father`,
  `step mother`, `Stepmom`, `Dad/Stepdad`) from being rewritten into
  `Mother`/`Father`. A substring implementation is mutation-tested against.
- Free text keeps the capitalisation the parent typed; only a single
  all-letters token is re-cased. Re-casing free text too would collapse 2 more
  groups out of 315 and rewrite 100 more stored values — not a trade worth
  making.

## Residual divergence — the actual deliverable

Re-measured with the shipped Go normalisers replayed over every stored value in
`pocketbase/pb_data/data-prod.db` (all years, no roster filter):

| column | slots | divergent before | divergent after | collapsed |
|---|---|---|---|---|
| `date_of_birth` | 9,388 | 1,124 | **541** | 583 (52%) |
| `relationship_to_camper` | 5,751 | 315 | **169** | 146 (46%) |
| **combined** | 9,629 union slots | **1,439** | **710** | 729 (51%) |

2026 alone: DOB 94 → 43, relationship 17 → 8. 2025: DOB 126 → 61,
relationship 27 → 17.

What survives, and why it is real:

- **`date_of_birth`, 541** — 360 different birth YEAR, 105 same year with a
  different month/day, 70 unparseable on one side, 6 month/day transposed.
- **`relationship_to_camper`, 169** — 92 `Father | Mother`, 11
  `Father | Parent`, 11 `Mother | Parent`, and a 55-group tail of genuinely
  different relations and typos.

So the grain decision now rests on **710 residual divergences over 9,629
(household, year, adult_slot) slots — 7.4%**, of which the hard identity core
(different birth year, plus Mother-vs-Father) is 452 slots, 4.7%. The issue's
§5 estimate of "~259 of 315" relationship divergences collapsing under
normalisation was optimistic: the measured figure is 146 of 315, because it was
extrapolated from the nine largest pair shapes and the tail is mostly genuine.

## Operational note

The first sync after this ships rewrites `date_of_birth` on essentially every
`family_camp_adults` row (13,660 of 13,823 source answers change textual form)
and `relationship_to_camper` on 3,107 of 6,969. These are updates, not deletes,
so the orphan-sweep ratio guard is not involved. Both normalisers are
idempotent — pinned by test — so the run after that one rewrites nothing.

## Deliberately NOT done

- **No grain change and no migration.** Full fan-out to
  `(household, year, person_id, adult_number)` is an open owner decision that
  this re-measure exists to inform.
- **No merge-policy change.** First-non-empty-wins over load order still decides
  which sibling's answer is stored, for every attribute except `email`. A
  recency or validity tie-break for DOB would be a policy call, not a
  normalisation.
- **No plausibility validation, no blanking of junk, no deletion of rows.**
- **No change to `adult_number` 3-5**, which carry no attributes at all.
- **No backfill of the 1,181 person-partition Adult-name values** that
  `processAdults` reads from nothing.

No issue is retired here. kindred#2275 stays open, now holding a measured
residual instead of an estimate.
