### PR TITLE
fix(sync): the persons orphan sweep deleted staff who were never campers

### DIFF
--- a/pocketbase/pb_migrations/1500000158_person_custom_values_cascade.js
+++ b/pocketbase/pb_migrations/1500000158_person_custom_values_cascade.js
@@ -1,0 +1,80 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: person_custom_values.person cascades instead of blanking.
+ *
+ * kindred#2394, part (b). Part (a) is the fix -- persons.go now tracks a
+ * staff-only person as processed, so the nightly sweep stops nominating 26
+ * people it deliberately fetched. This migration is defence in depth: it makes
+ * a GENUINELY correct orphan delete behave properly instead of erroring.
+ *
+ * What went wrong. `person` is declared cascadeDelete: false
+ * (1500000028_person_custom_values.js), so deleting a person does not delete
+ * their custom values -- PocketBase CLEARS the relation and re-saves the rows.
+ * Those rows are covered by
+ *
+ *   CREATE UNIQUE INDEX idx_person_cf_vals_unique
+ *     ON person_custom_values (year, person, field_definition)
+ *
+ * so the moment a SECOND person's rows are blanked for the same
+ * (year, field_definition), the blanked rows collide on ('', year, def) and the
+ * re-save is rejected. That rejection aborts the parent delete and surfaces as
+ * `field_definition: Value must be unique; person: Value must be unique; year:
+ * Value must be unique.` on a DELETE, which is not an error a DELETE should
+ * ever produce.
+ *
+ * A custom-field value is meaningless without the person it describes, so
+ * cascading is the honest answer here: the row goes with its person rather than
+ * surviving as an answer belonging to nobody.
+ *
+ * ⛔ The 152 rows already blanked in production are LEFT IN PLACE, deliberately.
+ * This table has no person_id column -- only the `person` relation -- so once
+ * blanked there is no surviving pointer to who the answer belonged to and they
+ * cannot be re-linked. Deleting them is the only other option, and this repo
+ * does not run destructive data migrations. They stay as inert residue.
+ * (Production snapshot: 152 rows, 116 in year 2023 and 36 in 2026.)
+ *
+ * ⛔ Only this relation is changed. Five other relations to `persons` also sit
+ * inside a unique index and would also collide when blanked --
+ * staff (year, person), financial_aid_applications (person, year),
+ * bunk_assignments (year, person, session),
+ * bunk_assignments_draft (year, session, person, scenario) and
+ * normalized_mappings (person, session, category). They are NOT flipped, for
+ * two reasons. First, deleting a staff record or a financial-aid application
+ * because a person row went away is a product decision nobody has made, and it
+ * is a very different proposition from deleting a custom-field answer -- the
+ * issue says so explicitly. Second, their collision is currently the only thing
+ * that makes such a delete fail loudly; converting that into a silent severed
+ * row would be a downgrade, not a hardening. person_custom_values is the one
+ * collection that both fails today and has an unambiguous answer.
+ *
+ * Idempotent: setting cascadeDelete to a value it already holds is a no-op, so
+ * a re-run (see the renumbering trap in docs/reference/pocketbase-migrations.md)
+ * converges rather than diverging. No guard, though: a missing `person` relation
+ * is the one state this migration must not shrug at, since clearing that field's
+ * blanking behaviour is its whole purpose.
+ */
+
+migrate(
+  (app) => {
+    const col = app.findCollectionByNameOrId('person_custom_values');
+
+    const rel = col.fields.getByName('person');
+    if (!rel) {
+      throw new Error('person_custom_values: expected an existing "person" relation field');
+    }
+    rel.cascadeDelete = true;
+
+    app.save(col);
+  },
+  (app) => {
+    const col = app.findCollectionByNameOrId('person_custom_values');
+
+    const rel = col.fields.getByName('person');
+    if (!rel) {
+      throw new Error('person_custom_values: expected an existing "person" relation field');
+    }
+    rel.cascadeDelete = false;
+
+    app.save(col);
+  }
+);

--- a/pocketbase/sync/persons.go
+++ b/pocketbase/sync/persons.go
@@ -57,9 +57,6 @@ type personHouseholdIDs struct {
 type gatherPersonIDsResult struct {
 	personIDs    []int        // All unique person IDs (from attendees + staff)
 	camperIDsSet map[int]bool // IDs from attendees (true campers)
-	// staffFetchFailed is true when the CampMinder staff feed could not be read
-	// and the run fell back to attendees only.
-	staffFetchFailed bool
 }
 
 // NewPersonsSync creates a new persons sync service
@@ -139,7 +136,6 @@ func (s *PersonsSync) Sync(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	s.staffFetchFailed = gatherResult.staffFetchFailed
 	if len(gatherResult.personIDs) == 0 {
 		slog.Info("No attendees or staff found, skipping persons sync", "year", year)
 		s.SyncSuccessful = true
@@ -199,11 +195,13 @@ func (s *PersonsSync) gatherPersonIDs(year int) (*gatherPersonIDsResult, error) 
 	}
 
 	staffPersonIDs, err := s.getPersonIDsFromStaff()
-	staffFetchFailed := false
 	if err != nil {
 		slog.Warn("Error getting staff person IDs, continuing with attendees only", "error", err)
 		staffPersonIDs = nil
-		staffFetchFailed = true
+		// Set on the service here rather than returned and copied across by the
+		// caller: one writer, one reader, and no assignment a later refactor can
+		// drop without the compiler noticing. Sync clears it per run.
+		s.staffFetchFailed = true
 	}
 
 	personIDs := s.mergePersonIDs(attendeePersonIDs, staffPersonIDs)
@@ -214,9 +212,8 @@ func (s *PersonsSync) gatherPersonIDs(year int) (*gatherPersonIDsResult, error) 
 		"year", year)
 
 	return &gatherPersonIDsResult{
-		personIDs:        personIDs,
-		camperIDsSet:     camperIDsSet,
-		staffFetchFailed: staffFetchFailed,
+		personIDs:    personIDs,
+		camperIDsSet: camperIDsSet,
 	}, nil
 }
 
@@ -1163,6 +1160,29 @@ func (s *PersonsSync) printDataQualitySummary() {
 }
 
 // deleteOrphans deletes persons that exist in PocketBase but weren't processed from CampMinder
+// skipSweepForStaffFetchFailure reports whether a sweep must be abandoned because
+// this run could not read the CampMinder staff feed, and logs why when it must.
+//
+// The consequence differs per sweep -- persons loses the staff-only people
+// themselves, households loses whatever is reachable only through them -- so the
+// caller supplies that half of the message; everything else is shared.
+//
+// It warns rather than returning an error on purpose. updateRelationsAndCleanup
+// turns a deleteOrphans error into Stats.Errors++, and a deliberate skip is not an
+// operational failure. That is the same verdict OrphanSweepGuard.SkipReason gives a
+// rejection, and it carries the same accepted cost, stated there: a run that keeps
+// skipping lets genuine orphans accumulate, and the signal to go fix the upstream is
+// the warning repeating night after night rather than a separate alerting path.
+func (s *PersonsSync) skipSweepForStaffFetchFailure(entity, consequence string, year int) bool {
+	if !s.staffFetchFailed {
+		return false
+	}
+
+	slog.Warn("Orphan sweep skipped: the CampMinder staff feed could not be read, so "+consequence,
+		"entity", entity, "year", year)
+	return true
+}
+
 func (s *PersonsSync) deleteOrphans(year int) error {
 	// A swallowed staff-feed failure makes the computed set known-incomplete, so
 	// abandon the sweep rather than narrow it (kindred#2394). gatherPersonIDs
@@ -1179,11 +1199,9 @@ func (s *PersonsSync) deleteOrphans(year int) error {
 	// people" -- so it skips without failing the run: updateRelationsAndCleanup
 	// turns a returned error into Stats.Errors++, and a deliberate skip is not an
 	// operational error.
-	if s.staffFetchFailed {
-		slog.Warn("Orphan sweep skipped: the CampMinder staff feed could not be read, "+
-			"so every staff-only person is missing from the computed set and their stored "+
-			"rows would be read as orphans",
-			"entity", "persons", "year", year)
+	if s.skipSweepForStaffFetchFailure("persons",
+		"every staff-only person is missing from the computed set and their stored rows "+
+			"would be read as orphans", year) {
 		return nil
 	}
 
@@ -1718,10 +1736,8 @@ func (s *PersonsSync) updatePersonHouseholdRelations(
 // feed failed, and this sweep would delete it. Hence the one guard this function
 // does take.
 func (s *PersonsSync) deleteHouseholdOrphans(year int, processedIDs map[int]bool) error {
-	if s.staffFetchFailed {
-		slog.Warn("Household orphan sweep skipped: the CampMinder staff feed could not be read, "+
-			"so households reachable only through staff are missing from the computed set",
-			"entity", "households", "year", year)
+	if s.skipSweepForStaffFetchFailure("households",
+		"households reachable only through staff are missing from the computed set", year) {
 		return nil
 	}
 

--- a/pocketbase/sync/persons.go
+++ b/pocketbase/sync/persons.go
@@ -35,6 +35,11 @@ type PersonsSync struct {
 	missingDataStats map[string]int
 	skippedStaff     int
 
+	// staffFetchFailed records that this run could not read the CampMinder staff
+	// feed, so its computed set is known-incomplete and the orphan sweep must not
+	// run. Set from gatherPersonIDs, read by deleteOrphans. See kindred#2394.
+	staffFetchFailed bool
+
 	// Sub-entity stats for combined sync (households)
 	// Note: person_tags removed - tags are now a multi-select relation on persons
 	householdStats *Stats
@@ -52,6 +57,9 @@ type personHouseholdIDs struct {
 type gatherPersonIDsResult struct {
 	personIDs    []int        // All unique person IDs (from attendees + staff)
 	camperIDsSet map[int]bool // IDs from attendees (true campers)
+	// staffFetchFailed is true when the CampMinder staff feed could not be read
+	// and the run fell back to attendees only.
+	staffFetchFailed bool
 }
 
 // NewPersonsSync creates a new persons sync service
@@ -121,6 +129,7 @@ func (s *PersonsSync) Sync(ctx context.Context) error {
 	s.LogSyncStart("persons (combined: persons + households)")
 	s.Stats = Stats{}
 	s.SyncSuccessful = false
+	s.staffFetchFailed = false
 	s.ClearProcessedKeys()
 
 	year := s.Client.GetSeasonID()
@@ -130,6 +139,7 @@ func (s *PersonsSync) Sync(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	s.staffFetchFailed = gatherResult.staffFetchFailed
 	if len(gatherResult.personIDs) == 0 {
 		slog.Info("No attendees or staff found, skipping persons sync", "year", year)
 		s.SyncSuccessful = true
@@ -189,9 +199,11 @@ func (s *PersonsSync) gatherPersonIDs(year int) (*gatherPersonIDsResult, error) 
 	}
 
 	staffPersonIDs, err := s.getPersonIDsFromStaff()
+	staffFetchFailed := false
 	if err != nil {
 		slog.Warn("Error getting staff person IDs, continuing with attendees only", "error", err)
 		staffPersonIDs = nil
+		staffFetchFailed = true
 	}
 
 	personIDs := s.mergePersonIDs(attendeePersonIDs, staffPersonIDs)
@@ -202,8 +214,9 @@ func (s *PersonsSync) gatherPersonIDs(year int) (*gatherPersonIDsResult, error) 
 		"year", year)
 
 	return &gatherPersonIDsResult{
-		personIDs:    personIDs,
-		camperIDsSet: camperIDsSet,
+		personIDs:        personIDs,
+		camperIDsSet:     camperIDsSet,
+		staffFetchFailed: staffFetchFailed,
 	}, nil
 }
 
@@ -1151,6 +1164,29 @@ func (s *PersonsSync) printDataQualitySummary() {
 
 // deleteOrphans deletes persons that exist in PocketBase but weren't processed from CampMinder
 func (s *PersonsSync) deleteOrphans(year int) error {
+	// A swallowed staff-feed failure makes the computed set known-incomplete, so
+	// abandon the sweep rather than narrow it (kindred#2394). gatherPersonIDs
+	// deliberately continues with attendees only when getPersonIDsFromStaff errors
+	// -- the campers still need syncing -- but on such a run every staff-only
+	// person is missing from ProcessedKeys and reads as an orphan, which is the
+	// very defect the tracking in processPerson exists to prevent.
+	//
+	// Neither existing guard covers this. OrphanSweepGuard.Check compares a
+	// computed set still holding ~90% of the rows on disk against a 50% floor, and
+	// skipSweepForRejections reads Stats.Rejected, which a swallowed fetch error
+	// never bumps. This is the same verdict SkipReason gives a rejection -- the
+	// computed set is short for a reason that is not "CampMinder lost these
+	// people" -- so it skips without failing the run: updateRelationsAndCleanup
+	// turns a returned error into Stats.Errors++, and a deliberate skip is not an
+	// operational error.
+	if s.staffFetchFailed {
+		slog.Warn("Orphan sweep skipped: the CampMinder staff feed could not be read, "+
+			"so every staff-only person is missing from the computed set and their stored "+
+			"rows would be read as orphans",
+			"entity", "persons", "year", year)
+		return nil
+	}
+
 	filter := fmt.Sprintf("year = %d", year)
 
 	return s.DeleteOrphansGuarded(
@@ -1672,7 +1708,23 @@ func (s *PersonsSync) updatePersonHouseholdRelations(
 // The property is not free — it holds only while the tracking stays above the
 // transform, which is what TestPersonsTracksEveryHouseholdItWillLaterTransform
 // pins. Move it below and persons silently joins the other twelve.
+//
+// All of that is about REJECTIONS, and a MISSING UPSTREAM FEED is a different
+// fact that the tracking's position cannot help with (kindred#2394).
+// extractUniqueHouseholds reads `Households` straight off the CampMinder payload
+// with no reference to CamperDetails, and processBatchPersons calls it for every
+// person in the batch -- staff-only people included. So a household reachable only
+// through staff is tracked on a healthy run and simply absent on a run whose staff
+// feed failed, and this sweep would delete it. Hence the one guard this function
+// does take.
 func (s *PersonsSync) deleteHouseholdOrphans(year int, processedIDs map[int]bool) error {
+	if s.staffFetchFailed {
+		slog.Warn("Household orphan sweep skipped: the CampMinder staff feed could not be read, "+
+			"so households reachable only through staff are missing from the computed set",
+			"entity", "households", "year", year)
+		return nil
+	}
+
 	slog.Info("Checking for orphaned households")
 
 	filter := fmt.Sprintf("year = %d", year)

--- a/pocketbase/sync/persons.go
+++ b/pocketbase/sync/persons.go
@@ -478,6 +478,22 @@ func (s *PersonsSync) processPerson(
 	if pbData == nil {
 		s.skippedStaff++
 		s.Stats.Skipped++
+
+		// ...but still track the key (kindred#2394). These are people the run
+		// fetched from CampMinder ON PURPOSE -- getPersonIDsFromStaff pulls staff
+		// person IDs in so staff.person can be populated -- who then get no row
+		// because they have never been a camper. Returning here without tracking
+		// left their stored row untracked, and deleteOrphans reads untracked as
+		// "CampMinder no longer returns this person" and deletes it. That is the
+		// opposite of what the run observed: it saw them. 26 staff a night, every
+		// night, each delete blanking staff.person as it went.
+		//
+		// Skipped stays as it was, deliberately: no row was written, and that is
+		// what Skipped counts. Skipped and orphaned are different facts, and this
+		// branch only ever meant the first one.
+		if personID, ok := personData["ID"].(float64); ok {
+			s.TrackProcessedKey(int(personID), year)
+		}
 		return nil
 	}
 

--- a/pocketbase/sync/persons_test.go
+++ b/pocketbase/sync/persons_test.go
@@ -1978,3 +1978,161 @@ func seedSweepPerson(t *testing.T, app core.App, cmID, year int, first, last str
 		t.Fatalf("seed person %d: %v", cmID, saveErr)
 	}
 }
+
+// TestOrphanSweepSkippedWhenStaffFetchFailed pins the other half of kindred#2394.
+//
+// Tracking a staff-only person (above) only protects them while the run actually
+// SEES them. gatherPersonIDs swallows a getPersonIDsFromStaff failure --
+// `slog.Warn(...); staffPersonIDs = nil` -- and carries on with attendees only, so
+// on such a run every staff-only person is absent from the computed set and reads
+// as an orphan again. Neither existing guard catches it: OrphanSweepGuard.Check
+// compares a computed set still holding ~90% of the rows on disk against a 50%
+// floor, and skipSweepForRejections needs Stats.Rejected, which a swallowed fetch
+// error never bumps.
+//
+// That mattered less while person_custom_values.person blanked-and-collided,
+// because the collision aborted most of those deletes. Migration 1500000158 makes
+// that relation cascade, so the deletes would now succeed silently -- which is
+// exactly why the skip has to exist in the same change as the cascade.
+//
+// The second case is what stops the first from being vacuous: with the flag clear,
+// a genuinely untracked row is still swept.
+func TestOrphanSweepSkippedWhenStaffFetchFailed(t *testing.T) {
+	t.Parallel()
+
+	const (
+		camperCMID = 1001
+		staffCMID  = 2001
+		year       = 2026
+	)
+
+	for _, tc := range []struct {
+		name             string
+		staffFetchFailed bool
+		wantSwept        bool
+	}{
+		{
+			name:             "staff fetch failed: the sweep is abandoned, not narrowed",
+			staffFetchFailed: true,
+			wantSwept:        false,
+		},
+		{
+			name:             "staff fetch succeeded: a genuine orphan is still swept",
+			staffFetchFailed: false,
+			wantSwept:        true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := newPersonsTestApp(t)
+			seedSweepPerson(t, app, camperCMID, year, testFirstName, "Johnson")
+			seedSweepPerson(t, app, staffCMID, year, "Noah", "Martinez")
+
+			s := NewPersonsSync(app, nil)
+			s.SyncSuccessful = true
+			s.staffFetchFailed = tc.staffFetchFailed
+
+			// Only the camper is tracked -- the staff-only person never reached
+			// processPerson at all, because the run never learned they existed.
+			s.TrackProcessedKey(camperCMID, year)
+
+			if err := s.deleteOrphans(year); err != nil {
+				t.Fatalf("deleteOrphans: %v", err)
+			}
+
+			_, err := app.FindFirstRecordByFilter("persons", "cm_id = 2001")
+			swept := err != nil
+
+			if swept != tc.wantSwept {
+				t.Errorf("row swept = %v, want %v (lookup err: %v)", swept, tc.wantSwept, err)
+			}
+
+			// The skip must not fail the run: updateRelationsAndCleanup turns a
+			// deleteOrphans error into Stats.Errors++, and a deliberate skip is not
+			// an error. (deleteOrphans returning nil is asserted above.)
+			if _, err := app.FindFirstRecordByFilter("persons", "cm_id = 1001"); err != nil {
+				t.Errorf("the tracked camper was swept: %v", err)
+			}
+		})
+	}
+}
+
+// TestHouseholdOrphanSweepSkippedWhenStaffFetchFailed covers the sweep sitting
+// three lines below the persons one in updateRelationsAndCleanup, which has the
+// identical exposure.
+//
+// extractUniqueHouseholds reads `Households` off the raw CampMinder payload, with
+// no reference to CamperDetails, and processBatchPersons calls it for EVERY person
+// in the batch -- staff-only people included. So a staff-only person's households
+// are tracked on a healthy run and missing on a run whose staff feed failed, and
+// any household reachable only through staff is then deleted as an orphan.
+//
+// deleteHouseholdOrphans is deliberately unguarded, but that reasoning is about
+// REJECTIONS: it builds its key set upstream of the transform that rejects, so a
+// rejection can never remove a key from it. A missing upstream feed removes keys
+// regardless of where the tracking sits, which is why this one needs the skip.
+func TestHouseholdOrphanSweepSkippedWhenStaffFetchFailed(t *testing.T) {
+	t.Parallel()
+
+	const (
+		camperHouseholdCMID = 3001
+		staffHouseholdCMID  = 3002
+		year                = 2026
+	)
+
+	for _, tc := range []struct {
+		name             string
+		staffFetchFailed bool
+		wantSwept        bool
+	}{
+		{name: "staff fetch failed: the sweep is abandoned", staffFetchFailed: true, wantSwept: false},
+		{name: "staff fetch succeeded: a genuine orphan is still swept", staffFetchFailed: false, wantSwept: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := newHouseholdsTestApp(t)
+			seedSweepHousehold(t, app, camperHouseholdCMID, year)
+			seedSweepHousehold(t, app, staffHouseholdCMID, year)
+
+			s := NewPersonsSync(app, nil)
+			s.SyncSuccessful = true
+			s.staffFetchFailed = tc.staffFetchFailed
+
+			// Only the camper's household was reachable this run.
+			processed := map[int]bool{camperHouseholdCMID: true}
+
+			if err := s.deleteHouseholdOrphans(year, processed); err != nil {
+				t.Fatalf("deleteHouseholdOrphans: %v", err)
+			}
+
+			_, err := app.FindFirstRecordByFilter("households", "cm_id = 3002")
+			swept := err != nil
+
+			if swept != tc.wantSwept {
+				t.Errorf("household swept = %v, want %v (lookup err: %v)", swept, tc.wantSwept, err)
+			}
+			if _, err := app.FindFirstRecordByFilter("households", "cm_id = 3001"); err != nil {
+				t.Errorf("the tracked household was swept: %v", err)
+			}
+		})
+	}
+}
+
+// seedSweepHousehold writes one households row for the sweep test above.
+func seedSweepHousehold(t *testing.T, app core.App, cmID, year int) {
+	t.Helper()
+
+	col, err := app.FindCollectionByNameOrId("households")
+	if err != nil {
+		t.Fatalf("find households: %v", err)
+	}
+
+	rec := core.NewRecord(col)
+	rec.Set("cm_id", cmID)
+	rec.Set("year", year)
+	if saveErr := app.Save(rec); saveErr != nil {
+		t.Fatalf("seed household %d: %v", cmID, saveErr)
+	}
+}

--- a/pocketbase/sync/persons_test.go
+++ b/pocketbase/sync/persons_test.go
@@ -3,6 +3,8 @@ package sync
 import (
 	"strings"
 	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
 )
 
 const testAlumniTagID = "rec_alumni_001"
@@ -1839,5 +1841,140 @@ func TestTransformPersonToPB_ParentNamesClearedOnParseFail(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// kindred#2394: a staff-only person is not an orphan
+//
+// getPersonIDsFromStaff pulls staff person IDs into the run ON PURPOSE, so that
+// staff.person can be populated. transformPersonToPB then returns nil for
+// anyone whose CampMinder record carries no CamperDetails block -- someone who
+// has never been a camper -- and processPerson returns at that nil before it
+// reaches TrackProcessedKey. deleteOrphans reads every untracked (cm_id, year)
+// in `persons` as absent from CampMinder and deletes it, so the sync fetched
+// these people deliberately and then deleted them for not being campers.
+// ---------------------------------------------------------------------------
+
+// staffOnlyPersonData returns the CampMinder payload shape that produces the
+// defect: a real person with no CamperDetails block. Deliberately distinct from
+// validPersonData (rejection_wrapper_test.go), whose CamperDetails is what makes
+// it transform into a row.
+func staffOnlyPersonData(cmID int, first, last string) map[string]any {
+	return map[string]any{
+		"ID":   float64(cmID),
+		"Name": map[string]any{"First": first, "Last": last},
+	}
+}
+
+// TestProcessPersonTracksStaffOnlyPersonAsProcessed pins the tracking itself.
+// The skip accounting must be untouched: no row was written, so the record
+// really was skipped -- it simply must not also read as missing from CampMinder.
+func TestProcessPersonTracksStaffOnlyPersonAsProcessed(t *testing.T) {
+	t.Parallel()
+
+	const (
+		staffCMID = 2001
+		year      = 2026
+	)
+
+	s := &PersonsSync{
+		BaseSyncService:  BaseSyncService{ProcessedKeys: map[string]bool{}},
+		missingDataStats: map[string]int{},
+	}
+
+	if err := s.processPerson(
+		staffOnlyPersonData(staffCMID, testFirstName, "Johnson"),
+		false, map[int]*core.Record{}, map[string]string{}, map[int]string{}, year,
+	); err != nil {
+		t.Fatalf("processPerson: %v", err)
+	}
+
+	if !s.IsKeyProcessed(staffCMID, year) {
+		t.Errorf("ProcessedKeys is missing %q -- a person this run fetched from CampMinder "+
+			"on purpose reads as absent from it, and deleteOrphans deletes their row",
+			CompositeKey(staffCMID, year))
+	}
+
+	if s.skippedStaff != 1 {
+		t.Errorf("skippedStaff = %d, want 1 -- tracking must not change the skip accounting", s.skippedStaff)
+	}
+	if s.Stats.Skipped != 1 {
+		t.Errorf("Stats.Skipped = %d, want 1 -- tracking must not change the skip accounting", s.Stats.Skipped)
+	}
+}
+
+// TestStaffOnlyPersonSurvivesOrphanSweep drives the whole path the nightly run
+// takes: two campers processed, one staff-only person fetched and written off,
+// then the real deleteOrphans against a real persons collection. Three rows is
+// under OrphanSweepMinRows, so the collapse guard's ratio arm does not fire and
+// what the sweep does is decided by ProcessedKeys alone -- which is the point.
+func TestStaffOnlyPersonSurvivesOrphanSweep(t *testing.T) {
+	t.Parallel()
+
+	const (
+		camperOneCMID = 1001
+		camperTwoCMID = 1002
+		staffCMID     = 2001
+		year          = 2026
+	)
+
+	// Reuses the fixture from rejection_wrapper_test.go: same collection, same fields.
+	app := newPersonsTestApp(t)
+	seedSweepPerson(t, app, camperOneCMID, year, testFirstName, "Johnson")
+	seedSweepPerson(t, app, camperTwoCMID, year, "Liam", "Garcia")
+	seedSweepPerson(t, app, staffCMID, year, "Noah", "Martinez") // staff, never a camper
+
+	s := NewPersonsSync(app, nil)
+	s.SyncSuccessful = true
+
+	// The two campers came through the write path this run.
+	s.TrackProcessedKey(camperOneCMID, year)
+	s.TrackProcessedKey(camperTwoCMID, year)
+
+	// The staff-only person comes through the real path: fetched, transformed to
+	// nil, no row written.
+	if err := s.processPerson(
+		staffOnlyPersonData(staffCMID, "Noah", "Martinez"),
+		false, map[int]*core.Record{}, map[string]string{}, map[int]string{}, year,
+	); err != nil {
+		t.Fatalf("processPerson: %v", err)
+	}
+
+	if err := s.deleteOrphans(year); err != nil {
+		t.Fatalf("deleteOrphans: %v", err)
+	}
+
+	if _, err := app.FindFirstRecordByFilter("persons", "cm_id = 2001"); err != nil {
+		t.Errorf("the staff-only person's row was swept as an orphan (%v) -- "+
+			"the run fetched them from CampMinder, so they are not missing from it. "+
+			"In production this is 26 staff a night, and it severs staff.person", err)
+	}
+
+	// The campers are untouched, so the assertion above is about the tracking and
+	// not about a sweep that did nothing at all.
+	for _, filter := range []string{"cm_id = 1001", "cm_id = 1002"} {
+		if _, err := app.FindFirstRecordByFilter("persons", filter); err != nil {
+			t.Errorf("a tracked camper was swept (%s): %v", filter, err)
+		}
+	}
+}
+
+// seedSweepPerson writes one persons row for the sweep tests above.
+func seedSweepPerson(t *testing.T, app core.App, cmID, year int, first, last string) {
+	t.Helper()
+
+	col, err := app.FindCollectionByNameOrId("persons")
+	if err != nil {
+		t.Fatalf("find persons: %v", err)
+	}
+
+	rec := core.NewRecord(col)
+	rec.Set("cm_id", cmID)
+	rec.Set("year", year)
+	rec.Set("first_name", first)
+	rec.Set("last_name", last)
+	if saveErr := app.Save(rec); saveErr != nil {
+		t.Fatalf("seed person %d: %v", cmID, saveErr)
 	}
 }


### PR DESCRIPTION
The `persons` sync has failed every night in its recorded history. `sync_runs`
shows `errors_count = 26, deleted_count = 0` on 2026-08-14, -15 and -16 — 26
orphan deletes, all of them failing, while created/updated moved normally
(4/85, 1/111, 1/103). Each failure was a uniqueness violation raised by a
`DELETE`, which is not an error a delete should ever be able to produce.

## The defect: the delete should never have been attempted

`getPersonIDsFromStaff` pulls staff person IDs into the run **on purpose**, so
`staff.person` can be populated. `transformPersonToPB` then returns `nil` for
anyone whose CampMinder record carries no `CamperDetails` block — someone who
has never been a camper — and `processPerson` returned at that `nil` *before*
`TrackProcessedKey`. `deleteOrphans` reads every untracked `(cm_id, year)` in
`persons` as "CampMinder no longer returns this person", so the sync fetched
these people deliberately and then nominated them for deletion for not being
campers.

The uniqueness error was the symptom, not the defect. `person_custom_values.person`
is `cascadeDelete: false`, so PocketBase blanks the relation and re-saves the
dependent rows instead of deleting them; those rows are covered by
`UNIQUE (year, person, field_definition)`, so the second person blanked for the
same `(year, field_definition)` collides on `('', year, def)`, the re-save is
rejected, and that rejection aborts the parent delete. **The collision was the
only thing stopping a wrong delete from succeeding.**

Measured on the production snapshot:

| | |
|---|---:|
| `persons` rows for 2026 with `is_camper = 0` | 299 |
| ...of those, referenced by `staff.person` | 277 |
| `person_custom_values` rows already blanked | 152 (116 in 2023, 36 in 2026) |
| `staff` rows already blanked | 1 |
| `person_custom_values` rows belonging to a non-camper 2026 person | 12,269 |

## The fix

**(a) `processPerson` now tracks the key in the `pbData == nil` branch.** A
person the run fetched from CampMinder is by definition not absent from
CampMinder, which is the only thing an orphan sweep is entitled to conclude.
`skippedStaff` and `Stats.Skipped` are deliberately unchanged — no row was
written, and that is what "skipped" counts. Skipped and orphaned are different
facts, and that branch only ever meant the first one.

**(b) Migration `1500000158` flips `person_custom_values.person` to
`cascadeDelete: true`**, so a genuinely-correct *future* orphan delete cascades
instead of blanking-and-colliding. A custom-field value is meaningless without
the person it describes. This is defence in depth, not the fix, and it lands in
the same change as (a) on purpose: shipping it alone would have removed the
safety net and let the sync start *successfully* deleting ~26 staff
person-records a night.

**(c) Both orphan sweeps are abandoned when the CampMinder staff feed cannot be
read.** (a) only protects a staff-only person while the run actually *sees*
them, and `gatherPersonIDs` swallows a `getPersonIDsFromStaff` failure —
`slog.Warn(...); staffPersonIDs = nil` — then carries on with attendees only.
On such a run every staff-only person is absent from `ProcessedKeys` and reads
as an orphan again. Neither existing guard catches it: `OrphanSweepGuard.Check`
compares a computed set still holding ~90% of the rows on disk against a 50%
floor, and `skipSweepForRejections` reads `Stats.Rejected`, which a swallowed
fetch error never bumps. That mattered less while the relation
blanked-and-collided, because the collision aborted most of those deletes —
which is precisely why the skip has to land in the same change as (b) rather
than after it.

`deleteHouseholdOrphans` has the identical exposure and is fixed alongside:
`extractUniqueHouseholds` reads `Households` straight off the CampMinder
payload with no reference to `CamperDetails`, and `processBatchPersons` calls it
for every person in the batch, staff included, so a household reachable only
through staff vanishes from the computed set on the same run. Its existing "no
guard needed" note is about *rejections*, which its tracking position above the
transform genuinely does cover; a missing upstream feed removes keys wherever
the tracking sits. Both skip rather than error, because
`updateRelationsAndCleanup` turns a returned error into `Stats.Errors++` and a
deliberate skip is not an operational error — the same verdict `SkipReason`
already gives a rejection.

## Deliberately not done

- **The 152 already-blanked `person_custom_values` rows are left in place.**
  That table has no `person_id` column — only the `person` relation — so once
  blanked there is no surviving pointer to whom the answer belonged. Re-linking
  is impossible and deleting is destructive; this repo does not run destructive
  data migrations. They stay as inert residue.
- **The other five collision-prone relations to `persons` are not flipped** —
  `staff (year, person)`, `financial_aid_applications (person, year)`,
  `bunk_assignments (year, person, session)`,
  `bunk_assignments_draft (year, session, person, scenario)` and
  `normalized_mappings (person, session, category)`. Deleting a staff record or
  a financial-aid application because a person row went away is a product
  decision nobody has made, and their collision is currently what makes such a
  delete fail *loudly*; converting that into a silently severed row would be a
  downgrade.
- **`financial_transactions` is untouched.** Its 124,088 blank-`person` rows are
  household-level by design — 122,824 carry a `household`, and only 1,264 have
  both keys blank.
- **The 75 blanked `attendees` rows are not re-linked.** `person_id` survives on
  all of them and 16 still resolve against `persons`, so recovery is possible,
  but it is a separate piece of work.
- **`base_sync.go` is unchanged.** Its counting was already right: it bumps
  `Stats.Errors` per failed `App.Delete` and only reaches `orphanCount++` on
  success, which is exactly why 26 errors showed up against 0 deletions.

## Verification

- New `TestStaffOnlyPersonSurvivesOrphanSweep` drives the real path against a
  real `persons` collection — two campers processed, one staff-only person
  fetched and written off, then the real `deleteOrphans`. Before the fix it
  failed with the production log line verbatim
  (`Deleting orphaned record entity=person ... id=2001|2026`); after it, the row
  survives and the tracked campers still do too. Three rows sits under
  `OrphanSweepMinRows`, so the collapse guard's ratio arm cannot be what saves
  the row.
- New `TestProcessPersonTracksStaffOnlyPersonAsProcessed` pins the tracking
  itself and pins that the skip accounting did not move.
- New `TestOrphanSweepSkippedWhenStaffFetchFailed` and
  `TestHouseholdOrphanSweepSkippedWhenStaffFetchFailed` pin (c). Each is a pair:
  with the flag set the untracked row survives, and with it clear a genuine
  orphan is still swept, so neither case can pass by the sweep doing nothing.
- `go build ./...`, `go test ./...` and `golangci-lint run` all clean.
- The migration was boot-checked against a **fresh** database with the real
  PocketBase binary (`scripts/dev/lib/pb-harness.sh`): 118 JS migrations apply,
  the server reaches `/api/health`, and `person_custom_values.person` reads
  `cascadeDelete: true` while `field_definition` correctly stays `false`.

Closes #2394.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Related custom person data is now automatically removed when its associated person is deleted.
  - Staff-only people are preserved during synchronization, even when camper details are unavailable.
  - Person and household records are no longer mistakenly removed when staff data cannot be retrieved.
  - Genuine orphaned records continue to be cleaned up when synchronization data is complete.
- **Tests**
  - Added coverage for staff-only records, failed staff retrieval, and orphan cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->