### PR TITLE
refactor(pb): collapse has_kitchenette into has_kitchen

### DIFF
--- a/frontend/src/components/admin/lodging/LodgingAliasForm.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingAliasForm.test.tsx
@@ -44,7 +44,6 @@ function fixtureUnit(over: Partial<LodgingUnitRecord> & { id: string }): Lodging
     has_fridge: false,
     is_accessible: false,
     has_tub: false,
-    has_kitchenette: false,
     has_crib: false,
     has_changing_table: false,
     has_shared_fridge: false,

--- a/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitForm.test.tsx
@@ -50,7 +50,6 @@ const UNIT: LodgingUnitRecord = {
   has_fridge: false,
   is_accessible: false,
   has_tub: false,
-  has_kitchenette: false,
   has_crib: false,
   has_changing_table: false,
   has_shared_fridge: false,

--- a/frontend/src/components/admin/lodging/LodgingUnitsPanel.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitsPanel.test.tsx
@@ -64,7 +64,6 @@ function fixtureUnit(over: Record<string, unknown>) {
     has_fridge: false,
     is_accessible: false,
     has_tub: false,
-    has_kitchenette: false,
     has_crib: false,
     has_changing_table: false,
     has_shared_fridge: false,

--- a/frontend/src/components/admin/lodging/UnitCapacityFields.test.tsx
+++ b/frontend/src/components/admin/lodging/UnitCapacityFields.test.tsx
@@ -29,7 +29,6 @@ function unit(over: Partial<LodgingUnitRecord> & { id: string }): LodgingUnitRec
     has_fridge: false,
     is_accessible: false,
     has_tub: false,
-    has_kitchenette: false,
     has_crib: false,
     has_changing_table: false,
     has_shared_fridge: false,

--- a/frontend/src/components/admin/lodging/UnitMapPositionField.test.tsx
+++ b/frontend/src/components/admin/lodging/UnitMapPositionField.test.tsx
@@ -45,7 +45,6 @@ const UNIT: LodgingUnitRecord = {
   has_fridge: false,
   is_accessible: false,
   has_tub: false,
-  has_kitchenette: false,
   has_crib: false,
   has_changing_table: false,
   has_shared_fridge: false,

--- a/frontend/src/components/admin/lodging/UnresolvedAliasQueue.test.tsx
+++ b/frontend/src/components/admin/lodging/UnresolvedAliasQueue.test.tsx
@@ -28,7 +28,6 @@ function unitFixture(over: Record<string, unknown>) {
     has_fridge: false,
     is_accessible: false,
     has_tub: false,
-    has_kitchenette: false,
     has_crib: false,
     has_changing_table: false,
     has_shared_fridge: false,

--- a/frontend/src/components/admin/lodging/bathroomShare.test.ts
+++ b/frontend/src/components/admin/lodging/bathroomShare.test.ts
@@ -33,7 +33,6 @@ function unit(over: Partial<LodgingUnitRecord> & { id: string }): LodgingUnitRec
     has_fridge: false,
     is_accessible: false,
     has_tub: false,
-    has_kitchenette: false,
     has_crib: false,
     has_changing_table: false,
     has_shared_fridge: false,

--- a/frontend/src/components/admin/lodging/derivedCapacity.test.ts
+++ b/frontend/src/components/admin/lodging/derivedCapacity.test.ts
@@ -31,7 +31,6 @@ function unit(over: Partial<LodgingUnitRecord> & { id: string }): LodgingUnitRec
     has_fridge: false,
     is_accessible: false,
     has_tub: false,
-    has_kitchenette: false,
     has_crib: false,
     has_changing_table: false,
     has_shared_fridge: false,

--- a/frontend/src/components/admin/lodging/unitAmenities.test.ts
+++ b/frontend/src/components/admin/lodging/unitAmenities.test.ts
@@ -8,13 +8,10 @@ import { describe, expect, it } from 'vitest'
 
 import { AMENITY_FLAGS, amenitiesOf, type UnitAmenities } from './unitAmenities'
 
-const NEW_2026_FLAGS = [
-  'has_tub',
-  'has_kitchenette',
-  'has_crib',
-  'has_changing_table',
-  'has_shared_fridge',
-] as const
+// has_kitchenette was one of the original five (narrowing has_kitchen) but was
+// dropped in kindred#2390: 0 production rows disagreed with their parent, so
+// staff ruled the split not worth tracking. See the dedicated test below.
+const NEW_2026_FLAGS = ['has_tub', 'has_crib', 'has_changing_table', 'has_shared_fridge'] as const
 
 describe('AMENITY_FLAGS', () => {
   it('has a unique key, a label and an icon for every entry', () => {
@@ -26,7 +23,7 @@ describe('AMENITY_FLAGS', () => {
     }
   })
 
-  it('carries the five facts the 2026 Master Housing sheet added', () => {
+  it('carries the surviving four of the five facts the 2026 Master Housing sheet added', () => {
     const keys = new Set<string>(AMENITY_FLAGS.map((f) => f.key))
     for (const key of NEW_2026_FLAGS) {
       expect(keys.has(key), `${key} is not in AMENITY_FLAGS`).toBe(true)
@@ -40,6 +37,16 @@ describe('AMENITY_FLAGS', () => {
     for (const flag of AMENITY_FLAGS) {
       expect(flag.key in amenities, `${flag.key} is missing from amenitiesOf()`).toBe(true)
     }
+  })
+
+  it('drops has_kitchenette — collapsed into has_kitchen, kindred#2390', () => {
+    // Every production unit with has_kitchenette=true already had
+    // has_kitchen=true (0 counterexamples), so the split carried no
+    // information staff act on. The column is gone; nothing here should
+    // still offer it.
+    expect(AMENITY_FLAGS.some((f) => (f.key as string) === 'has_kitchenette')).toBe(false)
+    const amenities = amenitiesOf() as unknown as Record<string, unknown>
+    expect('has_kitchenette' in amenities).toBe(false)
   })
 })
 
@@ -55,7 +62,6 @@ describe('amenitiesOf', () => {
   it('carries the new flags off an existing unit', () => {
     const unit = {
       has_tub: true,
-      has_kitchenette: true,
       has_crib: true,
       has_changing_table: true,
       has_shared_fridge: true,

--- a/frontend/src/components/admin/lodging/unitAmenities.ts
+++ b/frontend/src/components/admin/lodging/unitAmenities.ts
@@ -16,7 +16,6 @@ import {
   Baby,
   Bath,
   Footprints,
-  Microwave,
   Plug,
   Refrigerator,
   Snowflake,
@@ -34,7 +33,6 @@ export type AmenityFlag =
   | 'near_bathhouse'
   | 'is_accessible'
   | 'has_tub'
-  | 'has_kitchenette'
   | 'has_crib'
   | 'has_changing_table'
   | 'has_shared_fridge'
@@ -48,11 +46,11 @@ export interface UnitAmenities {
   near_bathhouse: boolean
   is_accessible: boolean
   // Added with the 2026 Master Housing import. Each REFINES a field above
-  // rather than restating it — has_tub under `bathroom`, has_kitchenette under
-  // has_kitchen, has_shared_fridge under has_fridge — so none can contradict
-  // its parent and a surface reading only the parent stays correct.
+  // rather than restating it — has_tub under `bathroom`, has_shared_fridge
+  // under has_fridge — so none can contradict its parent and a surface reading
+  // only the parent stays correct. has_kitchenette (narrowing has_kitchen) was
+  // dropped in kindred#2390: 0 production rows disagreed with their parent.
   has_tub: boolean
-  has_kitchenette: boolean
   has_crib: boolean
   has_changing_table: boolean
   has_shared_fridge: boolean
@@ -60,8 +58,8 @@ export interface UnitAmenities {
 }
 
 // The row glyphs render only the flags that are TRUE
-// (LodgingUnitRow filters on `unit[flag.key]`), so the five below cost a
-// typical row nothing: they are true on 5, 4, 3, 1 and 4 units respectively.
+// (LodgingUnitRow filters on `unit[flag.key]`), so the four below cost a
+// typical row nothing: they are true on 5, 3, 1 and 4 units respectively.
 export const AMENITY_FLAGS: readonly { key: AmenityFlag; label: string; icon: LucideIcon }[] = [
   { key: 'has_power', label: 'Has power', icon: Plug },
   { key: 'has_ac', label: 'Has A/C', icon: Snowflake },
@@ -70,7 +68,6 @@ export const AMENITY_FLAGS: readonly { key: AmenityFlag; label: string; icon: Lu
   { key: 'near_bathhouse', label: 'Near bathhouse', icon: Footprints },
   { key: 'is_accessible', label: 'Accessible', icon: Accessibility },
   { key: 'has_tub', label: 'Has tub', icon: Bath },
-  { key: 'has_kitchenette', label: 'Kitchen is a kitchenette', icon: Microwave },
   // Distinct from has_pack_play_space: a camp-provided crib is not floor space
   // for a family's own pack-and-play, and families with babies ask about both.
   { key: 'has_crib', label: 'Has crib', icon: Baby },
@@ -108,7 +105,6 @@ export function amenitiesOf(unit?: LodgingUnitRecord): UnitAmenities {
     near_bathhouse: unit?.near_bathhouse ?? false,
     is_accessible: unit?.is_accessible ?? false,
     has_tub: unit?.has_tub ?? false,
-    has_kitchenette: unit?.has_kitchenette ?? false,
     has_crib: unit?.has_crib ?? false,
     has_changing_table: unit?.has_changing_table ?? false,
     has_shared_fridge: unit?.has_shared_fridge ?? false,

--- a/frontend/src/components/admin/lodging/unitSort.test.ts
+++ b/frontend/src/components/admin/lodging/unitSort.test.ts
@@ -27,7 +27,6 @@ function unit(over: Partial<LodgingUnitRecord> & { id: string }): LodgingUnitRec
     has_fridge: false,
     is_accessible: false,
     has_tub: false,
-    has_kitchenette: false,
     has_crib: false,
     has_changing_table: false,
     has_shared_fridge: false,

--- a/frontend/src/components/admin/lodging/unitTree.test.ts
+++ b/frontend/src/components/admin/lodging/unitTree.test.ts
@@ -35,7 +35,6 @@ function unit(over: Partial<LodgingUnitRecord> & { id: string }): LodgingUnitRec
     has_fridge: false,
     is_accessible: false,
     has_tub: false,
-    has_kitchenette: false,
     has_crib: false,
     has_changing_table: false,
     has_shared_fridge: false,

--- a/frontend/src/types/lodging.ts
+++ b/frontend/src/types/lodging.ts
@@ -269,11 +269,12 @@ export interface LodgingUnitRecord extends PocketBaseRecordBase {
   has_fridge: boolean
   is_accessible: boolean
   // From the 2026 Master Housing sheet. Each refines a field above rather than
-  // restating it: has_tub under `bathroom`, has_kitchenette under has_kitchen,
-  // has_shared_fridge under has_fridge. has_crib is distinct from
-  // has_pack_play_space — a camp crib is not floor space for a family's own.
+  // restating it: has_tub under `bathroom`, has_shared_fridge under
+  // has_fridge. has_crib is distinct from has_pack_play_space — a camp crib is
+  // not floor space for a family's own. has_kitchenette (narrowing
+  // has_kitchen) was dropped in kindred#2390: 0 production rows disagreed
+  // with their parent.
   has_tub: boolean
-  has_kitchenette: boolean
   has_crib: boolean
   has_changing_table: boolean
   has_shared_fridge: boolean
@@ -431,7 +432,6 @@ export interface LodgingUnitInput {
   has_fridge?: boolean
   is_accessible?: boolean
   has_tub?: boolean
-  has_kitchenette?: boolean
   has_crib?: boolean
   has_changing_table?: boolean
   has_shared_fridge?: boolean

--- a/frontend/src/types/pocketbase-types.ts
+++ b/frontend/src/types/pocketbase-types.ts
@@ -1179,7 +1179,6 @@ export type LodgingUnitsRecord<Tbeds = unknown> = {
   has_fridge?: boolean
   has_heat?: boolean
   has_kitchen?: boolean
-  has_kitchenette?: boolean
   has_lights?: boolean
   has_living_room?: boolean
   has_pack_play_space?: boolean

--- a/pocketbase/lodging/registry.go
+++ b/pocketbase/lodging/registry.go
@@ -186,14 +186,17 @@ type registryUnit struct {
 	HasKitchen       bool `json:"has_kitchen"`
 	HasLights        bool `json:"has_lights"`
 
-	// These five refine an amenity above rather than restating it: HasTub
-	// narrows the Bathroom select, HasKitchenette narrows HasKitchen,
-	// HasSharedFridge narrows HasFridge. None can contradict its parent, so a
-	// consumer reading only the parent stays correct. HasCrib is distinct from
-	// HasPackPlaySpace — a camp-provided crib is not floor space for a family's
-	// own pack-and-play, and families with babies ask about both.
+	// These four refine an amenity above rather than restating it: HasTub
+	// narrows the Bathroom select, HasSharedFridge narrows HasFridge. None can
+	// contradict its parent, so a consumer reading only the parent stays
+	// correct. HasCrib is distinct from HasPackPlaySpace — a camp-provided crib
+	// is not floor space for a family's own pack-and-play, and families with
+	// babies ask about both.
+	//
+	// A fifth refinement, HasKitchenette (narrowing HasKitchen), was dropped in
+	// kindred#2390: production had zero rows where it disagreed with its
+	// parent, and staff ruled the distinction not worth tracking.
 	HasTub           bool `json:"has_tub"`
-	HasKitchenette   bool `json:"has_kitchenette"`
 	HasCrib          bool `json:"has_crib"`
 	HasChangingTable bool `json:"has_changing_table"`
 	HasSharedFridge  bool `json:"has_shared_fridge"`
@@ -684,7 +687,6 @@ func seedUnits(
 		rec.Set("has_kitchen", u.HasKitchen)
 		rec.Set("has_lights", u.HasLights)
 		rec.Set("has_tub", u.HasTub)
-		rec.Set("has_kitchenette", u.HasKitchenette)
 		rec.Set("has_crib", u.HasCrib)
 		rec.Set("has_changing_table", u.HasChangingTable)
 		rec.Set("has_shared_fridge", u.HasSharedFridge)

--- a/pocketbase/pb_migrations/1500000159_drop_has_kitchenette.js
+++ b/pocketbase/pb_migrations/1500000159_drop_has_kitchenette.js
@@ -1,0 +1,36 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: drop the redundant `has_kitchenette` bool from `lodging_units`.
+ *
+ * OWNER RULING (kindred#2390): "staff has decided a kitchen and a kitchenette
+ * are equivalent... kitchens are kitchens. there aren't enough to split hairs,
+ * and they may all be kitchenette's honestly." `has_kitchenette` was added by
+ * 1500000137 to REFINE `has_kitchen` — "narrows has_kitchen" — never to
+ * contradict it, so a consumer reading only `has_kitchen` was already correct.
+ * The column's only remaining job was flagging 4 of the 22 kitchen units as
+ * smaller, a distinction staff no longer act on.
+ *
+ * Verified against production (`pocketbase/pb_data/data-prod.db`,
+ * `lodging_units`, 118 rows): `has_kitchenette = 1` occurs ONLY where
+ * `has_kitchen = 1` (4 rows), and there is no `has_kitchenette = 1 AND
+ * has_kitchen = 0` row. This is a pure column drop — no data migration, no
+ * backfill, because collapsing the two changes zero verdicts.
+ */
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("lodging_units")
+  const field = collection.fields.getByName("has_kitchenette")
+  if (field) {
+    collection.fields.removeById(field.id)
+    app.save(collection)
+  }
+}, (app) => {
+  // Down: re-add the field exactly as 1500000137 defined it.
+  const collection = app.findCollectionByNameOrId("lodging_units")
+  collection.fields.add(new Field({
+    type: "bool",
+    name: "has_kitchenette",
+    required: false,
+    presentable: false,
+  }))
+  app.save(collection)
+})

--- a/scripts/dev/apply_lodging_inventory.py
+++ b/scripts/dev/apply_lodging_inventory.py
@@ -55,11 +55,13 @@ INVENTORY_FIELDS = (
     "max_beds",
     "beds",
     # Each refines a field above rather than restating it: has_tub under the
-    # `bathroom` enum, has_kitchenette under has_kitchen, has_shared_fridge
-    # under has_fridge. None can contradict its parent, so a consumer that reads
-    # only the parent stays correct.
+    # `bathroom` enum, has_shared_fridge under has_fridge. None can contradict
+    # its parent, so a consumer that reads only the parent stays correct.
+    #
+    # has_kitchenette (narrowing has_kitchen) was dropped in kindred#2390: 0
+    # production rows disagreed with their parent, and staff ruled the split
+    # not worth tracking.
     "has_tub",
-    "has_kitchenette",
     "has_crib",
     "has_changing_table",
     "has_shared_fridge",

--- a/tests/unit/scripts/test_apply_lodging_inventory.py
+++ b/tests/unit/scripts/test_apply_lodging_inventory.py
@@ -7,7 +7,17 @@ from typing import Any
 
 import pytest
 
-from scripts.dev.apply_lodging_inventory import main, plan_updates
+from scripts.dev.apply_lodging_inventory import INVENTORY_FIELDS, main, plan_updates
+
+
+def test_has_kitchenette_is_not_in_inventory_fields() -> None:
+    """has_kitchenette was collapsed into has_kitchen and the column dropped.
+
+    All 4 production units with has_kitchenette=true already carry
+    has_kitchen=true (kindred#2390), so the script no longer has anything to
+    carry for a field the schema doesn't have.
+    """
+    assert "has_kitchenette" not in INVENTORY_FIELDS
 
 
 def test_plan_updates_matches_within_one_year() -> None:


### PR DESCRIPTION
## Defect

`lodging_units.has_kitchenette` narrowed `has_kitchen` (added by 1500000137) but carried no independent information: production's 118 rows split has_kitchen=1 into 18 without the child flag and 4 with it, and zero rows had `has_kitchenette=1 AND has_kitchen=0`. Staff ruled the finer split is not worth tracking — a kitchen and a kitchenette are the same thing for placement purposes.

Verified independently against `pocketbase/pb_data/data-prod.db` (opened by name, not the dev `data.db` decoy):

| `has_kitchen` | `has_kitchenette` | units |
|---|---|---|
| 0 | 0 | 96 |
| 1 | 0 | 18 |
| 1 | 1 | 4 |

No row disagrees with its parent, so this is a pure column drop — no backfill.

## Fix

- `pb_migrations/1500000159_drop_has_kitchenette.js` — removes the bool field; down-arm re-adds it exactly as 1500000137 defined it.
- `pocketbase/lodging/registry.go` — drops `HasKitchenette` and its `rec.Set` call.
- `scripts/dev/apply_lodging_inventory.py` — drops it from `INVENTORY_FIELDS`.
- `frontend/src/types/lodging.ts`, `frontend/src/components/admin/lodging/unitAmenities.ts` — drops `AmenityFlag`/`UnitAmenities`/`AMENITY_FLAGS`/`LodgingUnitRecord`/`LodgingUnitInput` surface.
- `frontend/src/types/pocketbase-types.ts` — regenerated against a migrations-only scratch database per the CI freshness-check procedure (`go build && ./pocketbase migrate up --dir ./pb_types_tmp && node generate-types.js --db ./pb_types_tmp/data.db`), not the long-lived dev `data.db`, which would emit unrelated drift. `git diff -w` confirms the change is exactly the one dropped field.
- `config/lodging_registry.json` (private `kindred-local` repo, symlinked into `config/`) — 101 units' `has_kitchenette` key removed in a companion commit, already pushed: `data(lodging): drop has_kitchenette (kindred#2390)`.
- 11 admin-panel test fixtures that spell out every `LodgingUnitRecord` field by hand (`bathroomShare`, `derivedCapacity`, `LodgingAliasForm`, `LodgingUnitForm`, `LodgingUnitsPanel`, `UnitCapacityFields`, `UnitMapPositionField`, `unitSort`, `unitTree`, `UnresolvedAliasQueue`, `unitAmenities`) — TypeScript's excess-property check fails an object literal typed as `LodgingUnitRecord` that still spells out a key the type no longer has, so these were a mechanical, unavoidable consequence of the type change (confirmed with `tsc --noEmit`), not a separate decision. None were claimed by any sibling worktree active in this campaign — checked with `git status` across every `.worktrees/*` entry before touching them.

## Deliberately NOT done

- **No backfill/data migration.** Every `has_kitchenette=1` row already carries `has_kitchen=1`; collapsing the two changes zero verdicts.
- **`has_tub` (narrows `bathroom`) and `has_shared_fridge` (narrows `has_fridge`) are untouched.** This issue is specifically about the kitchen pair, on the strength of the owner's ruling; the sibling narrowing pairs were not ruled on and are unaffected.

## Verification

- `tests/unit/scripts/test_apply_lodging_inventory.py::test_has_kitchenette_is_not_in_inventory_fields` and `unitAmenities.test.ts`'s new `drops has_kitchenette` case were written first and confirmed RED before implementation (AssertionError against the pre-change `INVENTORY_FIELDS`/`AMENITY_FLAGS`).
- `go build ./... && go test ./...` — pass.
- `uv run pytest` (lodging-scoped + full suite via pre-push) — pass.
- `uv run ruff check . && uv run mypy .` — pass.
- `tsc --noEmit` — pass (0 errors).
- `vitest run` (lodging admin folder, 372 tests; full suite via pre-push) — pass. Two unrelated flakes seen on one earlier full-suite run (`LodgingAliasForm` timeout, `WeekendRosterPage.codeSplitting` timeout) were reproduced as passing in isolation on both this branch and a clean stash of `main` — confirmed as full-suite resource contention, not a regression.
- `eslint src --max-warnings=386` — pass, 386 warnings (unchanged), 0 errors.
- `bash scripts/pre-push-verify.sh` — ALL CHECKS PASSED (Go build/test/golangci-lint, Python ruff/mypy/pytest, frontend prettier/eslint/tsc/vitest, migration header + `options:{}` anti-pattern checks, pb-js-lint).

Closes #2390.
