### PR TITLE
feat(sync): record discarded family-camp adult answers in attribute_conflicts

### DIFF
--- a/docs/reference/tables.md
+++ b/docs/reference/tables.md
@@ -652,6 +652,7 @@ Family camp adult attendees extracted from custom values.
 | `gender` | text | Gender |
 | `date_of_birth` | text | Date of birth |
 | `relationship_to_camper` | text | Relationship |
+| `attribute_conflicts` | json | Answers the merge DISCARDED, as `{column: [other values]}`. NULL when the slot's answers agreed. The winner stays in its own column; this holds only losers, and only where they differ by more than case or whitespace (kindred#2275) |
 
 **Unique**: `(household, year, adult_number)`
 

--- a/frontend/src/types/pocketbase-types.ts
+++ b/frontend/src/types/pocketbase-types.ts
@@ -611,8 +611,9 @@ export type EnrollmentSnapshotsRecord = {
   year: number
 }
 
-export type FamilyCampAdultsRecord = {
+export type FamilyCampAdultsRecord<Tattribute_conflicts = unknown> = {
   adult_number: number
+  attribute_conflicts?: null | Tattribute_conflicts
   created: IsoAutoDateString
   date_of_birth?: string
   email?: string
@@ -1788,7 +1789,9 @@ export type DivisionsResponse<Texpand = unknown> = Required<DivisionsRecord> &
   BaseSystemFields<Texpand>
 export type EnrollmentSnapshotsResponse<Texpand = unknown> = Required<EnrollmentSnapshotsRecord> &
   BaseSystemFields<Texpand>
-export type FamilyCampAdultsResponse<Texpand = unknown> = Required<FamilyCampAdultsRecord> &
+export type FamilyCampAdultsResponse<Tattribute_conflicts = unknown, Texpand = unknown> = Required<
+  FamilyCampAdultsRecord<Tattribute_conflicts>
+> &
   BaseSystemFields<Texpand>
 export type FamilyCampMedicalResponse<Texpand = unknown> = Required<FamilyCampMedicalRecord> &
   BaseSystemFields<Texpand>

--- a/pocketbase/pb_migrations/1500000160_family_camp_adults_attribute_conflicts.js
+++ b/pocketbase/pb_migrations/1500000160_family_camp_adults_attribute_conflicts.js
@@ -1,0 +1,80 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: add `attribute_conflicts` to family_camp_adults. kindred#2275.
+ *
+ * ONE ADDITIVE JSON COLUMN. The row grain is UNCHANGED and stays
+ * (household, year, adult_number) -- see "what this is not" below.
+ *
+ * Shape: {column: [other values]} -- the family_camp_adults column that
+ * received more than one answer, mapped to the answers the merge DISCARDED.
+ * The answer that won is still in the column itself, so a reader shows the
+ * column value and this map's values side by side. NULL when the slot's
+ * answers agreed, which is ~94% of rows.
+ *
+ *   {"date_of_birth":["1981-09-02"],"relationship_to_camper":["Mother"]}
+ *
+ * WHY ONE ADULT SLOT RECEIVES TWO ANSWERS -- read this before proposing a
+ * re-grain, because the obvious reading is wrong. It is NOT two children
+ * reporting on their parents. CampMinder asks the family-camp questions on a
+ * per-CAMPER form that covers all of a household's summer and family sessions,
+ * so one parent fills the same family-camp section once per child, on a form
+ * where that section should have been skipped after the first. A divergence is
+ * therefore one person being less careful the second or third time -- a
+ * data-entry artifact of form design, not two independent observers disagreeing
+ * about a fact, and not evidence that the row is keyed at the wrong grain.
+ *
+ * WHAT THIS IS NOT: the camper re-grain. It was proposed (a 2026-08-15 ruling),
+ * then DECLINED by the owner on 2026-08-17 in favour of this column, on the
+ * reading above. So NOTHING here touches the grain triple -- not the write key
+ * in pocketbase/sync/family_camp_derived.go, not TrackProcessedCompositeKey,
+ * not idx_fc_adults_unique. The merge policy is also unchanged:
+ * first-non-empty-wins still decides which answer is stored, and preferEmail
+ * (kindred#1945) still breaks the email tie on well-formedness.
+ *
+ * ONLY THE RESIDUAL LIGHTS UP. The kindred#2405 normalisers run first, so the
+ * 583 date_of_birth and 146 relationship_to_camper divergences that were only
+ * ever two spellings of one answer (`09-02-1979` vs `9/2/1979`; `mother` vs
+ * `Mom`) collapse before the comparison and record nothing.
+ *
+ * NO DATA BACKFILL. The column is written by the family_camp_derived sync,
+ * which recomputes every row it touches; until that runs the column is NULL,
+ * which reads correctly as "not yet computed".
+ *
+ * maxSize 50000: the map holds at most the seven person-sourced columns, each
+ * with at most four discarded answers (five campers is the observed maximum on
+ * one household form), each bounded by its own column's width -- the widest is
+ * `email` at 500 characters. Roughly 14 KB worst case, and PocketBase REJECTS
+ * an over-cap write rather than truncating it, so the headroom is deliberate.
+ *
+ * PocketBase v0.23 syntax: fields.add(new Field({...})) with properties
+ * DIRECT, not inside an options{} wrapper -- a plain object, or a wrapped
+ * property, is silently ignored. The add is guarded so a re-run (or a
+ * re-applied migration after consolidation) is a no-op.
+ */
+
+migrate(
+  (app) => {
+    const col = app.findCollectionByNameOrId('family_camp_adults');
+
+    if (!col.fields.getByName('attribute_conflicts')) {
+      col.fields.add(
+        new Field({
+          type: 'json',
+          name: 'attribute_conflicts',
+          required: false,
+          presentable: false,
+          maxSize: 50000,
+        })
+      );
+    }
+
+    app.save(col);
+  },
+  (app) => {
+    const col = app.findCollectionByNameOrId('family_camp_adults');
+
+    col.fields.removeByName('attribute_conflicts');
+
+    app.save(col);
+  }
+);

--- a/pocketbase/pb_migrations/1500000160_family_camp_adults_attribute_conflicts.js
+++ b/pocketbase/pb_migrations/1500000160_family_camp_adults_attribute_conflicts.js
@@ -9,7 +9,12 @@
  * received more than one answer, mapped to the answers the merge DISCARDED.
  * The answer that won is still in the column itself, so a reader shows the
  * column value and this map's values side by side. NULL when the slot's
- * answers agreed, which is ~94% of rows.
+ * answers agreed. Measured by replaying processAdults over data-prod.db:
+ * 1,240 of 9,789 slots carry a map all years (12.7%), 92 of 834 in 2026
+ * (11.0%) -- so ~87% of rows are NULL, not the ~94% an earlier draft of this
+ * comment carried. That 94% was the residual of the two NORMALISED columns
+ * only; this column records every person-sourced attribute that merges, which
+ * is a larger population.
  *
  *   {"date_of_birth":["1981-09-02"],"relationship_to_camper":["Mother"]}
  *
@@ -34,7 +39,11 @@
  * ONLY THE RESIDUAL LIGHTS UP. The kindred#2405 normalisers run first, so the
  * 583 date_of_birth and 146 relationship_to_camper divergences that were only
  * ever two spellings of one answer (`09-02-1979` vs `9/2/1979`; `mother` vs
- * `Mom`) collapse before the comparison and record nothing.
+ * `Mom`) collapse before the comparison and record nothing. The free-text
+ * columns have no normaliser, so sameAnswer() in family_camp_derived.go folds
+ * case and whitespace at the COMPARISON only -- `Amy Johnson` vs
+ * `amy johnson` is one answer. Without it 189 of 1,429 lit slots, and 32 of
+ * 2026's 124, were nothing but capitalisation.
  *
  * NO DATA BACKFILL. The column is written by the family_camp_derived sync,
  * which recomputes every row it touches; until that runs the column is NULL,

--- a/pocketbase/sync/attendees.go
+++ b/pocketbase/sync/attendees.go
@@ -365,7 +365,12 @@ func (s *AttendeesSync) processEnrollment(
 		lastUpdatedUTC = ParseDate(lu)
 	}
 
-	// Note: CampMinder attendee ID exists in enrollment["ID"] but we don't need it in PocketBase
+	// CampMinder returns NO per-enrollment ID: there is no enrollment["ID"] key.
+	// An enrollment is identified only by (PersonID, SessionID), which is why
+	// this sync's composite key is what it is -- it could not be refined even
+	// if someone wanted to. Measured 2026-08-17 over the whole season: 2,315
+	// attendees, 2,904 SessionProgramStatus entries, 0 carrying an "ID" key
+	// (kindred#2263). The comment this replaces asserted the key existed.
 
 	// Prepare record data
 	recordData := map[string]any{

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -148,7 +149,120 @@ type adultData struct {
 	gender        string
 	dateOfBirth   string
 	relationship  string
+
+	// conflicts holds the answers this merge DISCARDED, keyed by the
+	// family_camp_adults column they were destined for. It is written to the
+	// additive `attribute_conflicts` JSON column and nothing else: the merge
+	// policy is unchanged (kindred#2275, owner ruling 2026-08-17 -- Option B,
+	// a conflict flag, NOT the camper re-grain).
+	//
+	// WHY A SLOT CAN HOLD TWO ANSWERS AT ALL, because getting this wrong sends
+	// the next reader back toward the declined re-grain: it is NOT two children
+	// reporting on their parents. CampMinder asks the family-camp questions on
+	// a per-CAMPER form covering all of a household's summer and family
+	// sessions, so one parent fills the same family-camp section once per
+	// child, on a form where that section should have been skipped after the
+	// first. A divergence is therefore one person being less careful the second
+	// time -- a data-entry artifact of form design, not evidence that the row
+	// is keyed at the wrong grain.
+	conflicts map[string][]string
 }
+
+// noteConflict records other as an answer this adult slot received and the
+// merge discarded, for the given family_camp_adults column. Duplicates are
+// dropped: three campers on one form who typed the same losing answer twice
+// are one conflicting answer, not two.
+func (a *adultData) noteConflict(column, other string) {
+	if other == "" {
+		return
+	}
+	if a.conflicts == nil {
+		a.conflicts = make(map[string][]string, 1)
+	}
+	if slices.Contains(a.conflicts[column], other) {
+		return
+	}
+	a.conflicts[column] = append(a.conflicts[column], other)
+}
+
+// mergeFirstNonEmpty applies the UNCHANGED first-non-empty-wins rule for one
+// attribute and records the residual conflict when a later answer disagrees
+// with the one already held. It returns the value to store, which is always
+// what the pre-kindred#2275 code would have stored.
+//
+// candidate must already be normalised (kindred#2405) where the column has a
+// normaliser, so that two spellings of one answer never reach this comparison.
+func (a *adultData) mergeFirstNonEmpty(column, current, candidate string) string {
+	if candidate == "" || candidate == current {
+		return current
+	}
+	if current == "" {
+		return candidate
+	}
+	a.noteConflict(column, candidate)
+	return current
+}
+
+// conflictsJSON renders the discarded answers in the canonical form stored in
+// the attribute_conflicts column -- `{"column":["other value",...]}` -- or ""
+// when the slot's answers all agreed.
+//
+// Both the keys (encoding/json sorts map keys) and the values are sorted, so
+// the rendering does not depend on map iteration order or on the record id
+// order the values happened to load in. The sync compares before it writes;
+// an unstable rendering would rewrite every conflicted row on every run.
+func (a *adultData) conflictsJSON() string {
+	if len(a.conflicts) == 0 {
+		return ""
+	}
+	sorted := make(map[string][]string, len(a.conflicts))
+	for column, others := range a.conflicts {
+		values := slices.Clone(others)
+		slices.Sort(values)
+		sorted[column] = values
+	}
+	encoded, err := json.Marshal(sorted)
+	if err != nil {
+		// Unreachable: the map holds only strings and string slices.
+		slog.Error("Error encoding adult attribute conflicts", "household", a.householdPBID, "error", err)
+		return ""
+	}
+	return string(encoded)
+}
+
+// storedAttributeConflicts reads a family_camp_adults row's attribute_conflicts
+// column back in the same canonical form conflictsJSON produces, so the two
+// are directly comparable.
+//
+// A PocketBase json column is a types.JSONRaw ([]byte), not a map, and an
+// unset one renders as the literal string "null" rather than "". Every empty
+// shape PocketBase can hand back collapses to "" here; anything else is
+// returned verbatim, because conflictsJSON wrote it verbatim.
+func storedAttributeConflicts(record *core.Record) string {
+	if record == nil {
+		return ""
+	}
+	raw := strings.TrimSpace(record.GetString(attributeConflictsColumn))
+	switch raw {
+	case "", "null", "{}", `""`:
+		return ""
+	}
+	return raw
+}
+
+// setAttributeConflicts writes the canonical rendering onto a record, storing
+// SQL NULL rather than an empty object when there is nothing to report.
+func setAttributeConflicts(record *core.Record, adult *adultData) {
+	if encoded := adult.conflictsJSON(); encoded != "" {
+		record.Set(attributeConflictsColumn, encoded)
+		return
+	}
+	record.Set(attributeConflictsColumn, nil)
+}
+
+// attributeConflictsColumn is the additive JSON column kindred#2275 Option B
+// adds to family_camp_adults (migration 1500000160).
+const attributeConflictsColumn = "attribute_conflicts"
 
 // registrationData holds extracted registration information
 type registrationData struct {
@@ -772,8 +886,23 @@ func (s *FamilyCampDerivedSync) loadPersonCustomValues(
 // years: date_of_birth divergence falls from 1,124 (household, year, adult
 // slot) groups to 541, and relationship_to_camper from 315 to 169. The 710
 // that survive are real -- 360 different birth YEARS and 92 Mother-vs-Father
-// slot collisions -- and that residual is what the grain decision on
-// kindred#2275 now rests on.
+// slot collisions.
+//
+// RECORDED, also separately from the merge (kindred#2275 Option B, owner
+// ruling 2026-08-17): what survives normalisation is written to the additive
+// attribute_conflicts column instead of vanishing -- see adultData.conflicts
+// and mergeFirstNonEmpty. Which answer wins is still first-non-empty over
+// load order for every attribute, and still preferEmail for email; the only
+// change is that the discarded answers are kept, keyed by column, so staff
+// can see that a slot was answered twice.
+//
+// THE GRAIN QUESTION IS CLOSED. A 2026-08-15 ruling to re-key this table to
+// camper grain was REVERSED on 2026-08-17; the column above is what replaced
+// it, on the reading recorded on adultData.conflicts -- two answers in one
+// slot are one parent filling a per-camper form once per child, not two
+// children disagreeing. Nothing here should be re-keyed on the strength of the
+// residual; the grain triple (this write key, TrackProcessedCompositeKey,
+// idx_fc_adults_unique) stays as it is.
 func (s *FamilyCampDerivedSync) processAdults(
 	householdValues []customValueEntry, personValues []customValueEntry,
 ) []*adultData {
@@ -826,29 +955,41 @@ func (s *FamilyCampDerivedSync) processAdults(
 
 		adult := adultMap[v.householdPBID][adultNum]
 
-		// Only set if empty (first non-empty wins for deduplication), EXCEPT
-		// email: see preferEmail for the kindred#1945 validity-preferring rule.
+		// First non-empty wins, unchanged, EXCEPT email: see preferEmail for
+		// the kindred#1945 validity-preferring rule. What mergeFirstNonEmpty
+		// adds (kindred#2275 Option B) is that the answers it discards are
+		// RECORDED on adult.conflicts instead of vanishing -- see that field's
+		// comment for why one adult slot receives two answers at all.
 		switch {
-		case strings.Contains(v.fieldName, "First Name") && adult.firstName == "":
-			adult.firstName = v.value
-		case strings.Contains(v.fieldName, "Last Name") && adult.lastName == "":
-			adult.lastName = v.value
+		case strings.Contains(v.fieldName, "First Name"):
+			adult.firstName = adult.mergeFirstNonEmpty("first_name", adult.firstName, v.value)
+		case strings.Contains(v.fieldName, "Last Name"):
+			adult.lastName = adult.mergeFirstNonEmpty("last_name", adult.lastName, v.value)
 		case strings.Contains(v.fieldName, "Email"):
 			if preferEmail(adult.email, v.value) {
+				// The DISPLACED value is the conflict, not the candidate:
+				// preferEmail has just ruled the candidate the better answer.
+				adult.noteConflict("email", adult.email)
 				adult.email = v.value
+			} else if v.value != adult.email {
+				adult.noteConflict("email", v.value)
 			}
-		case strings.Contains(v.fieldName, "Pronouns") && adult.pronouns == "":
-			adult.pronouns = v.value
-		case strings.Contains(v.fieldName, "Gender") && adult.gender == "":
-			adult.gender = v.value
-		case strings.Contains(v.fieldName, "DOB") && adult.dateOfBirth == "":
-			// Normalised, not merged: see normalizeDateOfBirth. Which sibling
-			// wins is still load order (kindred#2275); what changes is that
-			// the winner is stored in one canonical form, so two siblings who
-			// typed the SAME birthday two ways no longer read as a conflict.
-			adult.dateOfBirth = normalizeDateOfBirth(v.value)
-		case strings.Contains(v.fieldName, "Relationship") && adult.relationship == "":
-			adult.relationship = normalizeRelationshipToCamper(v.value)
+		case strings.Contains(v.fieldName, "Pronouns"):
+			adult.pronouns = adult.mergeFirstNonEmpty("pronouns", adult.pronouns, v.value)
+		case strings.Contains(v.fieldName, "Gender"):
+			adult.gender = adult.mergeFirstNonEmpty("gender", adult.gender, v.value)
+		case strings.Contains(v.fieldName, "DOB"):
+			// Normalised BEFORE the merge and before the comparison: see
+			// normalizeDateOfBirth. Which answer wins is still load order
+			// (unchanged); what normalisation buys is that two spellings of
+			// one birthday neither swap the stored value nor raise a
+			// conflict. 583 of the 1,124 diverging production groups are
+			// exactly that, and they must stay silent.
+			adult.dateOfBirth = adult.mergeFirstNonEmpty(
+				"date_of_birth", adult.dateOfBirth, normalizeDateOfBirth(v.value))
+		case strings.Contains(v.fieldName, "Relationship"):
+			adult.relationship = adult.mergeFirstNonEmpty(
+				"relationship_to_camper", adult.relationship, normalizeRelationshipToCamper(v.value))
 		}
 	}
 
@@ -1897,7 +2038,8 @@ func (s *FamilyCampDerivedSync) adultNeedsUpdate(existing *core.Record, adult *a
 		existing.GetString("pronouns") != adult.pronouns ||
 		existing.GetString("gender") != adult.gender ||
 		existing.GetString("date_of_birth") != adult.dateOfBirth ||
-		existing.GetString("relationship_to_camper") != adult.relationship
+		existing.GetString("relationship_to_camper") != adult.relationship ||
+		storedAttributeConflicts(existing) != adult.conflictsJSON()
 }
 
 // registrationNeedsUpdate checks if a registration record needs updating
@@ -2019,6 +2161,7 @@ func (s *FamilyCampDerivedSync) upsertAdults(
 				existingRecord.Set("gender", adult.gender)
 				existingRecord.Set("date_of_birth", adult.dateOfBirth)
 				existingRecord.Set("relationship_to_camper", adult.relationship)
+				setAttributeConflicts(existingRecord, adult)
 
 				if err := s.App.Save(existingRecord); err != nil {
 					slog.Error("Error updating adult record", "household", adult.householdPBID, "error", err)
@@ -2043,6 +2186,7 @@ func (s *FamilyCampDerivedSync) upsertAdults(
 			record.Set("gender", adult.gender)
 			record.Set("date_of_birth", adult.dateOfBirth)
 			record.Set("relationship_to_camper", adult.relationship)
+			setAttributeConflicts(record, adult)
 
 			if err := s.App.Save(record); err != nil {
 				slog.Error("Error creating adult record", "household", adult.householdPBID, "error", err)

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -199,8 +199,33 @@ func (a *adultData) mergeFirstNonEmpty(column, current, candidate string) string
 	if current == "" {
 		return candidate
 	}
-	a.noteConflict(column, candidate)
+	if !sameAnswer(current, candidate) {
+		a.noteConflict(column, candidate)
+	}
 	return current
+}
+
+// sameAnswer reports whether two answers to one question differ only in
+// SPELLING -- letter case, or how much whitespace the typist left.
+//
+// It gates what is RECORDED, never what is stored: every return value in
+// mergeFirstNonEmpty and every assignment in the email arm is byte-identical
+// with or without this check, so the first-non-empty and preferEmail merges
+// are untouched. It exists because the free-text columns have no
+// kindred#2405 normaliser and a badge that fires on `Amy Johnson` vs
+// `amy johnson` is a badge staff learn to ignore. Measured by replaying
+// processAdults over data-prod.db, all years: 232 recorded losers and 189 of
+// 1,429 lit slots -- 32 of 2026's 124 -- differed from the winner in nothing
+// but case.
+//
+// Deliberately narrow. It folds case and collapses whitespace runs; it does
+// NOT strip punctuation, reorder tokens, or fold nicknames. `Amy Johnson` vs
+// `Amy R Johnson` is still two answers, because it is.
+func sameAnswer(a, b string) bool {
+	return strings.EqualFold(
+		strings.Join(strings.Fields(a), " "),
+		strings.Join(strings.Fields(b), " "),
+	)
 }
 
 // conflictsJSON renders the discarded answers in the canonical form stored in
@@ -894,7 +919,9 @@ func (s *FamilyCampDerivedSync) loadPersonCustomValues(
 // and mergeFirstNonEmpty. Which answer wins is still first-non-empty over
 // load order for every attribute, and still preferEmail for email; the only
 // change is that the discarded answers are kept, keyed by column, so staff
-// can see that a slot was answered twice.
+// can see that a slot was answered twice. What is NOT kept is a discarded
+// answer that differs from the winner only in case or whitespace -- see
+// sameAnswer, which gates the recording and nothing else.
 //
 // THE GRAIN QUESTION IS CLOSED. A 2026-08-15 ruling to re-key this table to
 // camper grain was REVERSED on 2026-08-17; the column above is what replaced
@@ -969,9 +996,15 @@ func (s *FamilyCampDerivedSync) processAdults(
 			if preferEmail(adult.email, v.value) {
 				// The DISPLACED value is the conflict, not the candidate:
 				// preferEmail has just ruled the candidate the better answer.
-				adult.noteConflict("email", adult.email)
+				// This branch needs the sameAnswer guard as much as the other
+				// one does: a leading space fails emailFormatPattern, so
+				// " amy@example.com" is displaced by "amy@example.com" and
+				// would otherwise be recorded as conflicting with itself.
+				if !sameAnswer(adult.email, v.value) {
+					adult.noteConflict("email", adult.email)
+				}
 				adult.email = v.value
-			} else if v.value != adult.email {
+			} else if !sameAnswer(adult.email, v.value) {
 				adult.noteConflict("email", v.value)
 			}
 		case strings.Contains(v.fieldName, "Pronouns"):

--- a/pocketbase/sync/family_camp_derived_replay_test.go
+++ b/pocketbase/sync/family_camp_derived_replay_test.go
@@ -78,6 +78,11 @@ func newFamilyCampReplayTestApp(t *testing.T) core.App {
 	adults.Fields.Add(&core.NumberField{Name: "adult_number"})
 	text(adults, "household", "name", "first_name", "last_name", "email",
 		"pronouns", "gender", "date_of_birth", "relationship_to_camper")
+	// JSON, not text: attribute_conflicts is a json column in production
+	// (migration 1500000160), and PocketBase hands a json column back as a
+	// types.JSONRaw whose empty form renders "null" -- a text stand-in would
+	// hide exactly the round-trip this scaffolding is here to exercise.
+	adults.Fields.Add(&core.JSONField{Name: "attribute_conflicts"})
 	save(adults)
 
 	regs := core.NewBaseCollection("family_camp_registrations")

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"context"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 	"testing"
@@ -2728,6 +2729,320 @@ func TestNormalizeDateOfBirthIsIdempotent(t *testing.T) {
 		relOnce := normalizeRelationshipToCamper(raw)
 		if relTwice := normalizeRelationshipToCamper(relOnce); relTwice != relOnce {
 			t.Errorf("normalizeRelationshipToCamper(%q) = %q but re-normalises to %q", raw, relOnce, relTwice)
+		}
+	}
+}
+
+// ============================================================================
+// kindred#2275 Option B -- attribute_conflicts.
+//
+// OWNER RULING 2026-08-17: the grain change is DECLINED. family_camp_adults
+// stays at (household, year, adult_number) and first-non-empty-wins is
+// UNCHANGED for every attribute. What is additive is that the answers the
+// merge discards are now RECORDED, keyed by the column they were destined
+// for, instead of vanishing.
+//
+// The divergent answers are not two children reporting on their parents.
+// They are one parent filling in the family-camp section of a per-camper form
+// once per camper, on a form where that section should have been skipped
+// after the first child -- so a divergence is one person being less careful
+// the second time. Tests below are written against that reading: a conflict
+// is a data-entry artifact worth showing staff, not evidence that the row is
+// keyed wrong.
+// ============================================================================
+
+// TestProcessAdultsRecordsResidualAttributeConflicts is the core of Option B:
+// only the RESIDUAL lights up. The 583 date_of_birth and 146
+// relationship_to_camper divergences that the kindred#2405 normalisers
+// already collapse must stay silent, or the badge fires on 1,439 slots
+// instead of the ~700 that are real.
+func TestProcessAdultsRecordsResidualAttributeConflicts(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		fieldName     string
+		values        []string
+		wantStored    string
+		wantConflicts string
+	}{
+		{
+			name:      "identical answers record nothing",
+			fieldName: "Family Camp DOB 1",
+			values:    []string{"9/2/1979", "9/2/1979"},
+			// The merged value is still the first-non-empty winner, normalised.
+			wantStored:    "1979-09-02",
+			wantConflicts: "",
+		},
+		{
+			name:          "normalisation collapses the disagreement -- stays silent",
+			fieldName:     "Family Camp DOB 1",
+			values:        []string{"9/2/1979", "09-02-79"},
+			wantStored:    "1979-09-02",
+			wantConflicts: "",
+		},
+		{
+			name:          "a different birth YEAR is a real conflict",
+			fieldName:     "Family Camp DOB 1",
+			values:        []string{"9/2/1979", "9/2/1981"},
+			wantStored:    "1979-09-02",
+			wantConflicts: `{"date_of_birth":["1981-09-02"]}`,
+		},
+		{
+			name:          "relationship case and synonym folding stays silent",
+			fieldName:     "Family Camp-Relationship to 1",
+			values:        []string{"mother", "Mom"},
+			wantStored:    "Mother",
+			wantConflicts: "",
+		},
+		{
+			name:          "Mother vs Father is a real conflict",
+			fieldName:     "Family Camp-Relationship to 1",
+			values:        []string{"Father", "Mother"},
+			wantStored:    "Father",
+			wantConflicts: `{"relationship_to_camper":["Mother"]}`,
+		},
+		{
+			name:          "gap-fill is not a conflict",
+			fieldName:     "Family Camp DOB 1",
+			values:        []string{"", "9/2/1979"},
+			wantStored:    "1979-09-02",
+			wantConflicts: "",
+		},
+		{
+			name:          "first name disagreement is recorded",
+			fieldName:     "Family Camp-P1 First Name",
+			values:        []string{"Amy Johnson", "Amy R Johnson"},
+			wantStored:    "Amy Johnson",
+			wantConflicts: `{"first_name":["Amy R Johnson"]}`,
+		},
+		{
+			name:      "the same losing answer twice is recorded once",
+			fieldName: "Family Camp Gender 1",
+			values:    []string{"Female", "F", "F"},
+			// Three campers on the form, two of them typed the same
+			// second answer. The tooltip must not show it twice.
+			wantStored:    "Female",
+			wantConflicts: `{"gender":["F"]}`,
+		},
+		{
+			name:          "two distinct losing answers are both kept, sorted",
+			fieldName:     "Family Camp Gender 1",
+			values:        []string{"Female", "Nonbinary", "F"},
+			wantStored:    "Female",
+			wantConflicts: `{"gender":["F","Nonbinary"]}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := &FamilyCampDerivedSync{}
+			householdValues := []customValueEntry{
+				{householdPBID: "hh_1", fieldName: "Family Camp Adult 1", value: "Amy Johnson"},
+			}
+			var personValues []customValueEntry
+			for _, v := range tc.values {
+				personValues = append(personValues, customValueEntry{
+					householdPBID: "hh_1", fieldName: tc.fieldName, value: v,
+				})
+			}
+
+			adults := s.processAdults(householdValues, personValues)
+
+			if len(adults) != 1 {
+				t.Fatalf("expected 1 merged adult, got %d", len(adults))
+			}
+			if got := adults[0].conflictsJSON(); got != tc.wantConflicts {
+				t.Errorf("attribute_conflicts = %s, want %s", got, tc.wantConflicts)
+			}
+			stored := map[string]string{
+				"Family Camp DOB 1":             adults[0].dateOfBirth,
+				"Family Camp-Relationship to 1": adults[0].relationship,
+				"Family Camp-P1 First Name":     adults[0].firstName,
+				"Family Camp Gender 1":          adults[0].gender,
+			}[tc.fieldName]
+			if stored != tc.wantStored {
+				t.Errorf("merged value = %q, want %q -- the merge policy must NOT change", stored, tc.wantStored)
+			}
+		})
+	}
+}
+
+// TestProcessAdultsConflictsLeaveTheMergedValueUnchanged is the guard the
+// owner ruling turns on: recording a conflict must not change WHICH answer
+// wins. First-non-empty-wins over load order is unchanged, so reversing the
+// input order must reverse both the winner AND the recorded loser, with the
+// stored attribute matching what the pre-Option-B code produced.
+func TestProcessAdultsConflictsLeaveTheMergedValueUnchanged(t *testing.T) {
+	t.Parallel()
+
+	const early = "1979-09-02"
+	const late = "1981-09-02"
+
+	for _, order := range [][2]string{{early, late}, {late, early}} {
+		t.Run(order[0]+"_then_"+order[1], func(t *testing.T) {
+			t.Parallel()
+			s := &FamilyCampDerivedSync{}
+			householdValues := []customValueEntry{
+				{householdPBID: "hh_1", fieldName: "Family Camp Adult 1", value: "Amy Johnson"},
+			}
+			personValues := []customValueEntry{
+				{householdPBID: "hh_1", fieldName: "Family Camp DOB 1", value: order[0]},
+				{householdPBID: "hh_1", fieldName: "Family Camp DOB 1", value: order[1]},
+			}
+
+			adults := s.processAdults(householdValues, personValues)
+
+			if len(adults) != 1 {
+				t.Fatalf("expected 1 merged adult, got %d", len(adults))
+			}
+			if adults[0].dateOfBirth != order[0] {
+				t.Errorf("first-non-empty-wins must still pick %q, got %q", order[0], adults[0].dateOfBirth)
+			}
+			want := `{"date_of_birth":["` + order[1] + `"]}`
+			if got := adults[0].conflictsJSON(); got != want {
+				t.Errorf("attribute_conflicts = %s, want %s", got, want)
+			}
+		})
+	}
+}
+
+// TestProcessAdultsEmailConflictRecordsTheDisplacedValue covers the one
+// attribute that already had a tie-break (kindred#1945's preferEmail). When
+// validity displaces the first-loaded answer, the DISPLACED value is the one
+// that has to be recorded -- recording the candidate instead would report the
+// winner as the conflict.
+func TestProcessAdultsEmailConflictRecordsTheDisplacedValue(t *testing.T) {
+	t.Parallel()
+
+	const wellFormed = "amy.johnson@example.com"
+	const malformed = "amy.johnson@examplecom"
+
+	for _, order := range [][2]string{{malformed, wellFormed}, {wellFormed, malformed}} {
+		t.Run(order[0]+"_then_"+order[1], func(t *testing.T) {
+			t.Parallel()
+			s := &FamilyCampDerivedSync{}
+			householdValues := []customValueEntry{
+				{householdPBID: "hh_1", fieldName: "Family Camp Adult 1", value: "Amy Johnson"},
+			}
+			personValues := []customValueEntry{
+				{householdPBID: "hh_1", fieldName: "Family Camp Adult 1 Email", value: order[0]},
+				{householdPBID: "hh_1", fieldName: "Family Camp Adult 1 Email", value: order[1]},
+			}
+
+			adults := s.processAdults(householdValues, personValues)
+
+			if len(adults) != 1 {
+				t.Fatalf("expected 1 merged adult, got %d", len(adults))
+			}
+			if adults[0].email != wellFormed {
+				t.Errorf("validity still decides the merge: got %q, want %q", adults[0].email, wellFormed)
+			}
+			want := `{"email":["` + malformed + `"]}`
+			if got := adults[0].conflictsJSON(); got != want {
+				t.Errorf("attribute_conflicts = %s, want %s", got, want)
+			}
+		})
+	}
+}
+
+// TestAdultConflictsJSONIsCanonical pins the stored form. The sync compares
+// before it writes, so a rendering that depended on map iteration order would
+// rewrite every conflicted row on every run.
+func TestAdultConflictsJSONIsCanonical(t *testing.T) {
+	t.Parallel()
+
+	empty := &adultData{}
+	if got := empty.conflictsJSON(); got != "" {
+		t.Errorf("no conflicts must render as the empty string, got %q", got)
+	}
+
+	a := &adultData{}
+	a.noteConflict("relationship_to_camper", "Mother")
+	a.noteConflict("date_of_birth", "1981-09-02")
+	a.noteConflict("date_of_birth", "1975-01-04")
+	a.noteConflict("date_of_birth", "1981-09-02")
+
+	const want = `{"date_of_birth":["1975-01-04","1981-09-02"],"relationship_to_camper":["Mother"]}`
+	first := a.conflictsJSON()
+	if first != want {
+		t.Fatalf("conflictsJSON() = %s, want %s", first, want)
+	}
+	for i := 0; i < 20; i++ {
+		if again := a.conflictsJSON(); again != first {
+			t.Fatalf("conflictsJSON() is not stable: %s then %s", first, again)
+		}
+	}
+}
+
+// TestUpsertAdultsPersistsAttributeConflicts is the round trip through a real
+// record: the column is written, an unchanged re-run does not rewrite it, and
+// a changed conflict set does.
+func TestUpsertAdultsPersistsAttributeConflicts(t *testing.T) {
+	t.Parallel()
+
+	app := newFamilyCampReplayTestApp(t)
+	s := &FamilyCampDerivedSync{App: app, ProcessedAdultKeys: map[string]bool{}}
+
+	conflicted := &adultData{householdPBID: "hh_1", adultNumber: 1, name: "Amy Johnson", dateOfBirth: "1979-09-02"}
+	conflicted.noteConflict("date_of_birth", "1981-09-02")
+
+	created, _, _, errCount := s.upsertAdults(
+		context.Background(), []*adultData{conflicted}, 2026, map[string]*core.Record{})
+	if created != 1 || errCount != 0 {
+		t.Fatalf("create: got created=%d errors=%d, want 1/0", created, errCount)
+	}
+
+	existing, err := s.preloadExistingAdults(2026)
+	if err != nil {
+		t.Fatalf("preloadExistingAdults: %v", err)
+	}
+	stored := existing[familyCampAdultKey("hh_1", 2026, 1)]
+	if stored == nil {
+		t.Fatal("the created adult did not come back from preloadExistingAdults")
+	}
+	if got := storedAttributeConflicts(stored); got != `{"date_of_birth":["1981-09-02"]}` {
+		t.Fatalf("stored attribute_conflicts = %s", got)
+	}
+
+	// An identical second pass must not rewrite the row.
+	_, updated, skipped, errCount := s.upsertAdults(context.Background(), []*adultData{conflicted}, 2026, existing)
+	if updated != 0 || skipped != 1 || errCount != 0 {
+		t.Errorf("idempotent re-run: got updated=%d skipped=%d errors=%d, want 0/1/0", updated, skipped, errCount)
+	}
+
+	// A row whose conflict has been resolved upstream must clear the column.
+	resolved := &adultData{householdPBID: "hh_1", adultNumber: 1, name: "Amy Johnson", dateOfBirth: "1979-09-02"}
+	if !s.adultNeedsUpdate(stored, resolved) {
+		t.Fatal("clearing a conflict must count as a change, or the badge never goes away")
+	}
+	_, updated, _, errCount = s.upsertAdults(context.Background(), []*adultData{resolved}, 2026, existing)
+	if updated != 1 || errCount != 0 {
+		t.Fatalf("clearing pass: got updated=%d errors=%d, want 1/0", updated, errCount)
+	}
+	cleared, err := s.preloadExistingAdults(2026)
+	if err != nil {
+		t.Fatalf("preloadExistingAdults after clear: %v", err)
+	}
+	if got := storedAttributeConflicts(cleared[familyCampAdultKey("hh_1", 2026, 1)]); got != "" {
+		t.Errorf("resolved row still carries attribute_conflicts = %s", got)
+	}
+}
+
+// TestAdultsCollectionHasAttributeConflictsColumn is the schema half. The Go
+// writer above is inert without the migration, and a Go-only PR would ship a
+// Set() against a column PocketBase would reject.
+func TestAdultsCollectionHasAttributeConflictsColumn(t *testing.T) {
+	t.Parallel()
+
+	source, err := os.ReadFile("../pb_migrations/1500000160_family_camp_adults_attribute_conflicts.js")
+	if err != nil {
+		t.Fatalf("the attribute_conflicts migration must exist: %v", err)
+	}
+	for _, want := range []string{"family_camp_adults", "attribute_conflicts", "new Field(", "type: 'json'"} {
+		if !strings.Contains(string(source), want) {
+			t.Errorf("migration is missing %q -- a plain fields.add({...}) is silently ignored in PB v0.23", want)
 		}
 	}
 }

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -2817,6 +2817,34 @@ func TestProcessAdultsRecordsResidualAttributeConflicts(t *testing.T) {
 			wantConflicts: `{"first_name":["Amy R Johnson"]}`,
 		},
 		{
+			// The free-text columns have no kindred#2405 normaliser, so the
+			// only thing standing between staff and 232 badges that say
+			// "Amy Johnson vs amy johnson" is the conflict comparison itself.
+			// Measured over data-prod.db, all years: 189 of 1,429 lit slots
+			// (32 of 2026's 124) light up on nothing but letter case.
+			name:          "a case-only difference is one answer, not two",
+			fieldName:     "Family Camp-P1 First Name",
+			values:        []string{"Amy Johnson", "amy johnson"},
+			wantStored:    "Amy Johnson",
+			wantConflicts: "",
+		},
+		{
+			// CampMinder does not trim these values and the loader does not
+			// either, so a stray space is a spelling, not an answer.
+			name:          "a whitespace-only difference is one answer, not two",
+			fieldName:     "Family Camp-P1 First Name",
+			values:        []string{"Amy Johnson", "Amy  Johnson "},
+			wantStored:    "Amy Johnson",
+			wantConflicts: "",
+		},
+		{
+			name:          "case folding applies to every merged column",
+			fieldName:     "Family Camp Gender 1",
+			values:        []string{"Female", "female"},
+			wantStored:    "Female",
+			wantConflicts: "",
+		},
+		{
 			name:      "the same losing answer twice is recorded once",
 			fieldName: "Family Camp Gender 1",
 			values:    []string{"Female", "F", "F"},
@@ -2947,6 +2975,75 @@ func TestProcessAdultsEmailConflictRecordsTheDisplacedValue(t *testing.T) {
 	}
 }
 
+// TestProcessAdultsEmailCaseVariantIsNotAConflict covers the column with the
+// highest case-noise rate in production: 111 of 325 recorded email conflicts,
+// before this guard, were one address typed with a capitalised first letter.
+// A mail domain is case-insensitive by RFC 1035 and every provider treats the
+// local part that way in practice, so `Amy@example.com` and `amy@example.com`
+// are one answer -- staff cannot act on the difference.
+//
+// The second case is the one that needs the guard on BOTH branches: a leading
+// space makes the value fail emailFormatPattern, so preferEmail DISPLACES it
+// with the trimmed spelling. Without the guard the displaced value is recorded
+// as a conflicting answer against itself.
+func TestProcessAdultsEmailCaseVariantIsNotAConflict(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		values     []string
+		wantStored string
+	}{
+		{
+			name:       "capitalisation only",
+			values:     []string{"Amy.Johnson@example.com", "amy.johnson@example.com"},
+			wantStored: "Amy.Johnson@example.com",
+		},
+		{
+			name:       "capitalisation only, reversed",
+			values:     []string{"amy.johnson@example.com", "Amy.Johnson@example.com"},
+			wantStored: "amy.johnson@example.com",
+		},
+		{
+			// preferEmail displaces the untrimmed spelling because the leading
+			// space fails emailFormatPattern. The merge is unchanged; what must
+			// not happen is a conflict against the same address.
+			name:       "leading space displaced by the trimmed spelling",
+			values:     []string{" amy.johnson@example.com", "amy.johnson@example.com"},
+			wantStored: "amy.johnson@example.com",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := &FamilyCampDerivedSync{}
+			householdValues := []customValueEntry{
+				{householdPBID: "hh_1", fieldName: "Family Camp Adult 1", value: "Amy Johnson"},
+			}
+			var personValues []customValueEntry
+			for _, v := range tc.values {
+				personValues = append(personValues, customValueEntry{
+					householdPBID: "hh_1", fieldName: "Family Camp Adult 1 Email", value: v,
+				})
+			}
+
+			adults := s.processAdults(householdValues, personValues)
+
+			if len(adults) != 1 {
+				t.Fatalf("expected 1 merged adult, got %d", len(adults))
+			}
+			if adults[0].email != tc.wantStored {
+				t.Errorf("merged email = %q, want %q -- the merge policy must NOT change",
+					adults[0].email, tc.wantStored)
+			}
+			if got := adults[0].conflictsJSON(); got != "" {
+				t.Errorf("attribute_conflicts = %s, want none -- one address in two spellings", got)
+			}
+		})
+	}
+}
+
 // TestAdultConflictsJSONIsCanonical pins the stored form. The sync compares
 // before it writes, so a rendering that depended on map iteration order would
 // rewrite every conflicted row on every run.
@@ -3040,7 +3137,13 @@ func TestAdultsCollectionHasAttributeConflictsColumn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("the attribute_conflicts migration must exist: %v", err)
 	}
-	for _, want := range []string{"family_camp_adults", "attribute_conflicts", "new Field(", "type: 'json'"} {
+	// maxSize is in the list because PB v0.23 accepts the field without it and
+	// silently applies its own default (1 MB for json, per
+	// docs/reference/pocketbase-migrations.md) -- the cap this column's comment
+	// justifies would then exist nowhere.
+	for _, want := range []string{
+		"family_camp_adults", "attribute_conflicts", "new Field(", "type: 'json'", "maxSize: 50000",
+	} {
 		if !strings.Contains(string(source), want) {
 			t.Errorf("migration is missing %q -- a plain fields.add({...}) is silently ignored in PB v0.23", want)
 		}


### PR DESCRIPTION
Adds one additive JSON column, `family_camp_adults.attribute_conflicts`, and has
`processAdults` write the answers its merge discards into it — keyed by the column they
were destined for, so a reader can say *which* attribute was answered twice and *what*
the other answer was.

```json
{"date_of_birth": ["1981-09-02"], "relationship_to_camper": ["Mother"]}
```

The winning answer stays in its own column; this map holds only the losers. NULL when a
slot's answers agreed.

## The grain change was DECLINED, and this PR deliberately does not touch the grain triple

A 2026-08-15 ruling on #2275 said to re-key `family_camp_adults` to camper grain. The owner
**reversed** that on 2026-08-17 in favour of this column (Option B), after correcting the
framing the campaign had been carrying:

> the divergent adult rows are **not two children reporting on their parents**. They are the
> same parent filling in the family-camp section of a per-camper form, once per camper, on a
> form where that section should have been skipped after the first child.

So a divergence is one person being less careful the second time — a **data-entry artifact of
form design**, not a grain problem. That reading is written into the migration comment and into
`adultData.conflicts`, because getting it wrong is what sends the next reader back toward the
re-key that was just declined.

Nothing here moves the grain triple: not the write key (`familyCampAdultKey`), not
`TrackProcessedCompositeKey`, not `idx_fc_adults_unique`. Verified against a scratch DB built
from `pb_migrations/` alone — the unique index is still `(household, year, adult_number)` and
row counts are unchanged. Fanning out would have inflated `party_size` (`beds` in
`api/services/lodging_roster_service.py` counts `family_camp_adults` rows) and left 9,143
historical rows permanently at the old grain.

## The merge policy is unchanged

First-non-empty-wins still decides which answer is stored, for every attribute, and
`preferEmail` (#1945) still breaks the email tie on well-formedness. `mergeFirstNonEmpty`
returns exactly what the previous code returned; the only change is that the discarded
value is kept instead of vanishing. Pinned by a test that asserts the stored value in both
load orders, and by the existing first-loaded-sibling tests, which are untouched.

Proved rather than asserted: replaying `processAdults` over every row of
`pocketbase/pb_data/data-prod.db`, all years, and hashing the eight stored attributes of all
9,789 resulting slots gives the **same fingerprint** (`24d14af8cf6baba38b43b537`) before and
after every change in this PR, including the spelling guard below.

## Two spellings of one answer must stay silent

The #2405 normalisers run **before** the comparison, so the 583 `date_of_birth` and 146
`relationship_to_camper` divergences that were only ever two spellings of one answer
(`09-02-1979` vs `9/2/1979`; `mother` vs `Mom`) never reach it.

The free-text columns have no normaliser, and that gap was loud. Measured on the snapshot,
**189 of 1,429 lit slots — and 32 of 2026's 124, a quarter of the year staff actually look
at — differed from the winner in nothing but letter case**: `Amy Johnson` vs `amy johnson`,
`Amy@example.com` vs `amy@example.com`. Email was the worst column at 111 of 325, `first_name`
118 of 791.

`sameAnswer` folds case and collapses whitespace runs **at the comparison only**. It gates
what is recorded and nothing else — which is what the identical fingerprint above certifies.
It is deliberately narrow: no punctuation stripping, no token reordering, no nickname folding.
`Amy Johnson` vs `Amy R Johnson` is still two answers, because it is.

The email arm needs the guard on **both** branches, and that is the non-obvious half: a leading
space fails `emailFormatPattern`, so `" a@x.com"` is *displaced* by `"a@x.com"` and was being
recorded as conflicting with itself.

Normalisation itself is still not changed — nothing stored is re-cased, and `Mother`/`Father`
are not folded into each other.

## Scale, re-measured — and it is larger than the ruling's figure

The ruling quoted 46 of 788 slots in 2026 (5.8%) and 619 of 9,629 all-years (6.4%). That was
measured on the residual of the **two normalised columns only**. The column as specified is
`{column: [other values]}`, so this implementation records every person-sourced attribute that
merges — which is a bigger population. Re-measured by replaying this branch's `processAdults`
over every row of `pocketbase/pb_data/data-prod.db`, all years, no roster filter:

| scope | slots | ≥1 conflict | of which DOB/relationship |
|---|---|---|---|
| 2026 | 834 | **92 (11.0%)** | 45 |
| all years | 9,789 | **1,240 (12.7%)** | 610 |

**The DOB/relationship subset lands one row under the ruling's 2026 figure (45 vs 46) and
within nine all-years (610 vs 619).** The one 2026 row is a `relationship_to_camper` answer
whose two spellings differ only in capitalisation, which `sameAnswer` now silences; the
all-years gap is mostly the denominator — the ruling counted `(household, year, adult_slot)`
groups present in `person_custom_values`, this counts the `family_camp_adults` rows those
groups actually produce, which the nameless-row admission filter (#1946) trims.

Per column, all years, slots lighting up on that column:

| column | recorded | before the spelling guard | independently measured "answers lost" in #2275's body |
|---|---|---|---|
| `first_name` | 673 | 791 | 791 colliding groups |
| `date_of_birth` | 536 | 536 | 541 post-normalisation residual |
| `gender` | 507 | 507 | 511 |
| `email` | 214 | 325 | 326 |
| `relationship_to_camper` | 166 | 168 | 169 |
| `pronouns` | 75 | 75 | 76 |
| `last_name` | 11 | 15 | 15 |

The middle column is the corroboration: **before folding spellings, every column lands within a
handful of the figure #2275 derived independently by SQL**, which is what shows this records
exactly the answers the merge was already discarding. The drop from the middle column to the
first is entirely capitalisation, and it is concentrated in the three columns that have no
normaliser. `date_of_birth`, `gender` and `pronouns` are unchanged by folding — there was no
case noise in them at all.

`first_name` is still the biggest contributor and is worth knowing about: it is a **mislabeled
full name** (773 of 788 2026 values contain a space), so its remaining conflicts are things like
`Amy Johnson` vs `Amy R Johnson`. If the badge should be narrowed to the two normalised
columns, that is a one-line change to the arms in `processAdults`.

## Bundled rider — a false comment in `sync/attendees.go`, closes nothing

```go
// Note: CampMinder attendee ID exists in enrollment["ID"] but we don't need it in PocketBase
```

**There is no `ID` key.** Measured across the entire season: 2,315 attendees, 2,904
`SessionProgramStatus` entries, **0** carrying one — the evidence recorded when #2263 closed on
2026-08-17. The conclusion ("we don't need it") was fine; the premise would send someone hunting
for a stable per-enrollment identifier down a dead end. That absence is load-bearing — the vendor
exposes no identity below `(PersonID, SessionID)`, so the composite key could not be refined even
if someone wanted to. Comment-only: `processEnrollment` and every key are untouched. This closes
no issue.

## Not in scope

- **No badge or tooltip.** This PR is the column plus the writer. The frontend surfacing is
  the remaining half of Option B and would make this a GUI PR.
- **No backfill.** `family_camp_derived` recomputes every row it touches, so the column fills
  on the next sync run and reads correctly as "not yet computed" until then.
- **No change to what is stored, to the merge, or to the grain.**

## Tests

TDD — every assertion below was written and watched fail before the implementation existed,
and the ones that could have passed vacuously were mutation-checked (drop the value sort;
record a conflict on agreeing answers; drop the dedup guard; stop collapsing PocketBase's
`"null"`; drop the `adultNeedsUpdate` clause; drop `sameAnswer` from each of its three call
sites; drop `maxSize` from the migration — each turns the corresponding test red).

- `TestProcessAdultsRecordsResidualAttributeConflicts` — silent when the answers agree, silent
  when normalisation collapses them, silent on gap-fill, silent when the difference is only
  case or whitespace; recorded (with the losing value, keyed by column) when they genuinely
  differ; duplicate losers deduped; multiple losers sorted.
- `TestProcessAdultsConflictsLeaveTheMergedValueUnchanged` — both load orders: the stored value
  is still the first-non-empty winner, and reversing the input reverses winner *and* loser.
- `TestProcessAdultsEmailConflictRecordsTheDisplacedValue` — when `preferEmail` displaces the
  first-loaded answer, the **displaced** value is the conflict, not the candidate.
- `TestProcessAdultsEmailCaseVariantIsNotAConflict` — one address in two capitalisations is one
  answer, in both load orders, and the untrimmed spelling `preferEmail` displaces does not get
  recorded as conflicting with itself.
- `TestAdultConflictsJSONIsCanonical` — stable rendering, so the compare-before-write does not
  rewrite conflicted rows on every run.
- `TestUpsertAdultsPersistsAttributeConflicts` — real record round trip: written on create, an
  identical re-run skips, and a resolved conflict clears the column.
- `TestAdultsCollectionHasAttributeConflictsColumn` — the Go writer is inert without the
  migration, and the migration keeps its `maxSize: 50000` rather than falling back to
  PocketBase's 1 MB json default.

Gates: `pre-push-verify.sh` all green (go build, golangci-lint, full Go suite, prettier,
eslint, tsc, vitest, migration headers, `options:{}` anti-pattern scan, pb-js-lint). Migration
applied, reverted and re-applied against a scratch DB; `maxSize: 50000` verified present in the
live schema rather than silently defaulted. A pre-migration row whose column is SQL NULL reads
back as "no conflicts" and is **not** rewritten, so the first sync after deploy touches only
rows that genuinely changed. `frontend/src/types/pocketbase-types.ts` regenerated from that
scratch DB — +5/-2 lines, no formatting churn, and the table has no frontend consumers today.

**Deliberately closes nothing.** kindred#2275 stays OPEN to carry the remaining half of Option B —
the badge and tooltip that read this column. Owner ruling, 2026-08-17: keep **all seven** columns
recording for now ("more data doesn't hurt while we're still landing the GUI and tweaking the
backend"), so the wide reading in this PR is the intended scope and the narrowing option is
declined. Do not add a closing keyword here until the badge ships.

