### PR TITLE
feat(pb): add the lodging write-in tables, dark (#2382, 1 of 4)

### DIFF
--- a/api/constants/collections.py
+++ b/api/constants/collections.py
@@ -71,6 +71,26 @@ LODGING_ASSIGNMENTS_DRAFT = "lodging_assignments_draft"
 # plan.
 LODGING_SLOT_MERGES = "lodging_slot_merges"
 
+# Write-in OCCUPANCY -- who is in a room that the roster does not otherwise
+# know about (1500000161, kindred#2382). Split out of `lodging_availability`,
+# which conflated two unrelated questions in one boolean: `family_available`
+# true on a staff cabin is a staff<->family ROLE override for the weekend, and
+# false is an occupancy. The owner ruled (2026-08-15) that the ROLE is NOT
+# scenario-scoped -- it is an operational fact, "we're moving staff to X for
+# weekend Y" -- while an occupancy IS, because not every write-in is
+# non-rostered staff: some are paper registrations for families arriving with
+# no children, and that is a modelling choice belonging to the scenario that
+# made it.
+#
+# So availability keeps only the role half, and occupancy gets a live+draft
+# pair beside LODGING_ASSIGNMENTS / LODGING_ASSIGNMENTS_DRAFT -- the same split
+# between record and plan, and for the same reason. A nullable `scenario`
+# sentinel was explicitly rejected: it is the shape lodging_assignments dropped
+# because it "was dead weight that invited a `scenario != \"\"` write rule
+# instead of a draft table."
+LODGING_WRITE_INS = "lodging_write_ins"
+LODGING_WRITE_INS_DRAFT = "lodging_write_ins_draft"
+
 # The single work queue for cabin strings ingest could not resolve. Owned and
 # solely written by the ingest layer; the admin UI reads it filtered to
 # kind = "unresolved_alias". Deliberately NOT a second surfaces-only collection.

--- a/api/services/lodging_repository.py
+++ b/api/services/lodging_repository.py
@@ -49,6 +49,8 @@ from api.constants.collections import (
     LODGING_SESSION_STATUS,
     LODGING_SLOT_MERGES,
     LODGING_UNITS,
+    LODGING_WRITE_INS,
+    LODGING_WRITE_INS_DRAFT,
 )
 from api.constants.filters import ACTIVE_ENROLLED_FILTER
 from api.dependencies import lodging_cache
@@ -358,6 +360,69 @@ class LodgingRepository:
             LODGING_SLOT_MERGES,
             query_params={
                 "filter": (f"session_cm_id = {session_cm_id} && year = {year} && {scenario_clause}"),
+                "sort": STABLE_SORT,
+            },
+        )
+
+    async def fetch_write_ins(self, year: int, session_cm_id: int) -> list[Any]:
+        """The LIVE board's write-ins for one weekend (kindred#2382).
+
+        A write-in is an occupancy the roster does not otherwise know about:
+        non-rostered weekend staff, or a paper registration for a family
+        arriving with no children. It used to be stored as
+        `lodging_availability.family_available = false`, where it shared a
+        column with the staff<->family ROLE override and inherited that
+        column's session-only scope.
+
+        NO SCENARIO PREDICATE, and that is not the old shape coming back. The
+        live board is a scope in its OWN RIGHT -- the owner's second
+        requirement on 2026-08-15, "we need to allow write ins to happen in
+        campminder prod, not just scenarios, for staff to properly evaluate
+        the board" -- so these rows live in their own table with no scenario
+        column at all, exactly as `lodging_assignments` does. A scenario's
+        write-ins come from `fetch_draft_write_ins` and REPLACE these; there
+        is no overlay.
+
+        NOTHING READS THIS YET. PR 1 of kindred#2382 lands the tables and this
+        CRUD dark; `write_in_covers` still resolves write-ins out of
+        `lodging_availability` until PR 2 switches it.
+        """
+        return await self._page(
+            LODGING_WRITE_INS,
+            query_params={
+                "filter": f"session_cm_id = {session_cm_id} && year = {year}",
+                "sort": STABLE_SORT,
+            },
+        )
+
+    async def fetch_draft_write_ins(self, year: int, session_cm_id: int, scenario_id: str) -> list[Any]:
+        """One scenario's write-ins for one session -- ALL of them.
+
+        REPLACE, not overlay, matching `fetch_draft_assignments` under
+        kindred#1974: these rows are the scenario's whole set of write-ins, so
+        a unit with no row here holds no write-in in this scenario, whatever
+        the live board says. A scenario is seeded by an explicit copy (both
+        seed paths, by owner ruling 2026-08-16) rather than by rendering the
+        live board through the gaps.
+
+        `fetch_slot_merges` is the near neighbour that does the opposite --
+        it unions the weekend-level tier in -- and the difference is what the
+        row records. A draw level is a fact about the WEEKEND that no sync
+        writes, so a shared tier costs nothing. A write-in is an occupancy,
+        the same kind of fact as a placement, so it follows the placement
+        rule.
+
+        `scenario_id` is client-supplied and escaped, for the reason
+        `fetch_draft_assignments` spells out. The weekend is named by
+        `session_cm_id`, a number, so there is no literal for an injected `||`
+        to close.
+        """
+        return await self._page(
+            LODGING_WRITE_INS_DRAFT,
+            query_params={
+                "filter": (
+                    f'session_cm_id = {session_cm_id} && year = {year} && scenario = "{pb_escape(scenario_id)}"'
+                ),
                 "sort": STABLE_SORT,
             },
         )
@@ -925,6 +990,71 @@ class LodgingRepository:
 
     async def delete_availability(self, record_id: str) -> None:
         await asyncio.to_thread(self.pb.collection(LODGING_AVAILABILITY).delete, record_id)
+
+    async def find_write_in(self, year: int, session_cm_id: int, unit_pb_id: str) -> Any | None:
+        """The one LIVE write-in for a unit this weekend, or None.
+
+        Keyed exactly as `idx_lodging_write_in_unique` is
+        (session_cm_id, year, unit), so the lookup either finds the row the
+        next write would collide with or there is none -- the same argument
+        `find_availability_override` makes for the table this half moves off.
+
+        `unit_pb_id` arrives in the request body and is escaped. Unescaped, an
+        injected `||` would return some OTHER weekend's row, which the caller
+        then updates or deletes.
+        """
+        rows = await self._page(
+            LODGING_WRITE_INS,
+            query_params={
+                "filter": (f'session_cm_id = {session_cm_id} && year = {year} && unit = "{pb_escape(unit_pb_id)}"'),
+                "sort": STABLE_SORT,
+            },
+        )
+        return rows[0] if rows else None
+
+    async def find_draft_write_in(self, year: int, session_cm_id: int, scenario_id: str, unit_pb_id: str) -> Any | None:
+        """The one write-in for a unit in a scenario, or None.
+
+        The live key plus `scenario`, matching
+        `idx_lodging_write_in_draft_unique` -- two scenarios may hold
+        contradicting write-ins for one unit without colliding, which is the
+        whole point of the draft grain.
+
+        TWO client-supplied strings reach this filter, `scenario_id` off the
+        `?scenario=` query parameter and `unit_pb_id` from the request body,
+        and both are escaped: either one unescaped widens the predicate past
+        its own scoping, and on a lookup the caller updates or deletes what
+        comes back.
+        """
+        rows = await self._page(
+            LODGING_WRITE_INS_DRAFT,
+            query_params={
+                "filter": (
+                    f"session_cm_id = {session_cm_id} && year = {year} "
+                    f'&& scenario = "{pb_escape(scenario_id)}" && unit = "{pb_escape(unit_pb_id)}"'
+                ),
+                "sort": STABLE_SORT,
+            },
+        )
+        return rows[0] if rows else None
+
+    async def create_write_in(self, data: dict[str, Any]) -> Any:
+        return await asyncio.to_thread(self.pb.collection(LODGING_WRITE_INS).create, data)
+
+    async def update_write_in(self, record_id: str, data: dict[str, Any]) -> Any:
+        return await asyncio.to_thread(self.pb.collection(LODGING_WRITE_INS).update, record_id, data)
+
+    async def delete_write_in(self, record_id: str) -> None:
+        await asyncio.to_thread(self.pb.collection(LODGING_WRITE_INS).delete, record_id)
+
+    async def create_draft_write_in(self, data: dict[str, Any]) -> Any:
+        return await asyncio.to_thread(self.pb.collection(LODGING_WRITE_INS_DRAFT).create, data)
+
+    async def update_draft_write_in(self, record_id: str, data: dict[str, Any]) -> Any:
+        return await asyncio.to_thread(self.pb.collection(LODGING_WRITE_INS_DRAFT).update, record_id, data)
+
+    async def delete_draft_write_in(self, record_id: str) -> None:
+        await asyncio.to_thread(self.pb.collection(LODGING_WRITE_INS_DRAFT).delete, record_id)
 
     async def find_slot_merge(self, year: int, session_cm_id: int, unit_pb_id: str, scenario: str) -> Any | None:
         """The one merge row for a container at this tier, or None.

--- a/frontend/src/types/pocketbase-types.ts
+++ b/frontend/src/types/pocketbase-types.ts
@@ -56,6 +56,8 @@ export const Collections = {
   LodgingSlotMerges: 'lodging_slot_merges',
   LodgingUnitAliases: 'lodging_unit_aliases',
   LodgingUnits: 'lodging_units',
+  LodgingWriteIns: 'lodging_write_ins',
+  LodgingWriteInsDraft: 'lodging_write_ins_draft',
   NormalizedMappings: 'normalized_mappings',
   OriginalBunkRequests: 'original_bunk_requests',
   PaymentMethods: 'payment_methods',
@@ -1208,6 +1210,31 @@ export type LodgingUnitsRecord<Tbeds = unknown> = {
   year: number
 }
 
+export type LodgingWriteInsRecord = {
+  created: IsoAutoDateString
+  id: string
+  note?: string
+  occupant_name?: string
+  session: RecordIdString
+  session_cm_id: number
+  unit: RecordIdString
+  updated: IsoAutoDateString
+  year: number
+}
+
+export type LodgingWriteInsDraftRecord = {
+  created: IsoAutoDateString
+  id: string
+  note?: string
+  occupant_name?: string
+  scenario: RecordIdString
+  session: RecordIdString
+  session_cm_id: number
+  unit: RecordIdString
+  updated: IsoAutoDateString
+  year: number
+}
+
 export const NormalizedMappingsCategoryOptions = {
   city: 'city',
   school: 'school',
@@ -1842,6 +1869,10 @@ export type LodgingUnitsResponse<Tbeds = unknown, Texpand = unknown> = Required<
   LodgingUnitsRecord<Tbeds>
 > &
   BaseSystemFields<Texpand>
+export type LodgingWriteInsResponse<Texpand = unknown> = Required<LodgingWriteInsRecord> &
+  BaseSystemFields<Texpand>
+export type LodgingWriteInsDraftResponse<Texpand = unknown> = Required<LodgingWriteInsDraftRecord> &
+  BaseSystemFields<Texpand>
 export type NormalizedMappingsResponse<Texpand = unknown> = Required<NormalizedMappingsRecord> &
   BaseSystemFields<Texpand>
 export type OriginalBunkRequestsResponse<Texpand = unknown> = Required<OriginalBunkRequestsRecord> &
@@ -1958,6 +1989,8 @@ export type CollectionRecords = {
   lodging_slot_merges: LodgingSlotMergesRecord
   lodging_unit_aliases: LodgingUnitAliasesRecord
   lodging_units: LodgingUnitsRecord
+  lodging_write_ins: LodgingWriteInsRecord
+  lodging_write_ins_draft: LodgingWriteInsDraftRecord
   normalized_mappings: NormalizedMappingsRecord
   original_bunk_requests: OriginalBunkRequestsRecord
   payment_methods: PaymentMethodsRecord
@@ -2033,6 +2066,8 @@ export type CollectionResponses = {
   lodging_slot_merges: LodgingSlotMergesResponse
   lodging_unit_aliases: LodgingUnitAliasesResponse
   lodging_units: LodgingUnitsResponse
+  lodging_write_ins: LodgingWriteInsResponse
+  lodging_write_ins_draft: LodgingWriteInsDraftResponse
   normalized_mappings: NormalizedMappingsResponse
   original_bunk_requests: OriginalBunkRequestsResponse
   payment_methods: PaymentMethodsResponse

--- a/pocketbase/lodging/hooks.go
+++ b/pocketbase/lodging/hooks.go
@@ -45,6 +45,13 @@ const (
 	collectionIngestIssues     = "lodging_ingest_issues"
 	collectionAvailability     = "lodging_availability"
 	collectionSlotMerges       = "lodging_slot_merges"
+	// The write-in occupancy pair (1500000161, kindred#2382). Separate from
+	// collectionAvailability because the two hold different facts: after the
+	// split, availability carries only the staff<->family ROLE override for
+	// the weekend, and these carry who is actually in the room -- live and
+	// per-scenario respectively.
+	collectionWriteIns      = "lodging_write_ins"
+	collectionWriteInsDraft = "lodging_write_ins_draft"
 )
 
 // yearScopedRef is one relation the year guard follows: the field to read on
@@ -113,6 +120,8 @@ var yearScopedRefs = map[string][]yearScopedRef{
 	collectionAssignments:      {{field: "units", target: collectionUnits}},
 	collectionAssignmentsDraft: {{field: "units", target: collectionUnits}},
 	collectionSlotMerges:       {{field: "unit", target: collectionUnits}},
+	collectionWriteIns:         {{field: "unit", target: collectionUnits}},
+	collectionWriteInsDraft:    {{field: "unit", target: collectionUnits}},
 	collectionUnits: {
 		{field: "area", target: collectionAreas},
 		{field: "parent_unit", target: collectionUnits},
@@ -168,6 +177,13 @@ var yearImmutableRefs = map[string][]dependentRef{
 		{collection: collectionAssignments, filter: "units.id ?= {:id}"},
 		{collection: collectionAssignmentsDraft, filter: "units.id ?= {:id}"},
 		{collection: collectionSlotMerges, filter: "unit = {:id}"},
+		// SINGLE relations (1500000161 declares `unit` MaxSelect 1 on both),
+		// so a plain `=` and no `.id` join -- the same arity as
+		// collectionAvailability and collectionSlotMerges above, NOT the
+		// `units.id ?= {:id}` shape the two placement tables need. See
+		// dependentRef's doc comment for which way that mistake is silent.
+		{collection: collectionWriteIns, filter: "unit = {:id}"},
+		{collection: collectionWriteInsDraft, filter: "unit = {:id}"},
 	},
 }
 

--- a/pocketbase/lodging/hooks_test.go
+++ b/pocketbase/lodging/hooks_test.go
@@ -1794,6 +1794,184 @@ func TestGuardYearImmutableAllowsAYearChangeWithNoDependents(t *testing.T) {
 	}
 }
 
+// newWriteInsTestApp is the lodging_write_ins / lodging_write_ins_draft twin
+// of newSlotMergesTestApp (kindred#2382).
+//
+// Both write-in collections are added as a SEPARATE, later step for the same
+// reason lodging_slot_merges is: TestGuardUnitYearSkipsAnAbsentCollection
+// needs at least one watched collection ABSENT from setupCollections to pin
+// wireHooks's collection-not-found skip path, and a fixture that carried
+// every table would silently retire that test.
+//
+// The shape mirrors the production tables (1500000161) down to the fields any
+// guard actually reads -- unit/session/year, plus `scenario` on the draft --
+// and leaves out session_cm_id, occupant_name and note the same way
+// setupCollections leaves out fields nothing under test reads. `scenario`
+// points at a stand-in saved_scenarios collection rather than being omitted,
+// because it is the one structural difference between the pair and dropping
+// it here would let a draft-only mistake pass unnoticed.
+//
+// Both collections have to exist BEFORE wireHooks runs: its dependent-
+// collection loop pre-filters yearImmutableRefs to collections that exist AT
+// BIND TIME, so creating either afterward would leave it permanently excluded
+// from refs for this app's lifetime.
+func newWriteInsTestApp(t *testing.T) core.App {
+	t.Helper()
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+	setupCollections(t, app)
+
+	unitsCol := mustCollection(t, app, "lodging_units")
+	sessionsCol := mustCollection(t, app, "camp_sessions")
+
+	scenarios := core.NewBaseCollection("saved_scenarios")
+	if err := app.Save(scenarios); err != nil {
+		t.Fatalf("save saved_scenarios: %v", err)
+	}
+	scenariosCol := mustCollection(t, app, "saved_scenarios")
+
+	for _, name := range []string{"lodging_write_ins", "lodging_write_ins_draft"} {
+		writeIns := core.NewBaseCollection(name)
+		writeIns.Fields.Add(&core.RelationField{
+			Name: "unit", CollectionId: unitsCol.Id, MaxSelect: 1,
+		})
+		writeIns.Fields.Add(&core.RelationField{
+			Name: "session", CollectionId: sessionsCol.Id, MaxSelect: 1,
+		})
+		writeIns.Fields.Add(&core.NumberField{Name: "year"})
+		if name == "lodging_write_ins_draft" {
+			writeIns.Fields.Add(&core.RelationField{
+				Name: "scenario", CollectionId: scenariosCol.Id, MaxSelect: 1,
+			})
+		}
+		if err := app.Save(writeIns); err != nil {
+			t.Fatalf("save %s: %v", name, err)
+		}
+	}
+
+	wireHooks(app)
+	return app
+}
+
+// seedWriteIn creates a row in the named write-in collection pointing at unit
+// for the given year, and returns the save error rather than failing the test
+// -- the guard tests below want to assert on both outcomes.
+//
+// The error is wrapped for wrapcheck's benefit, but the wrap is not only
+// linter appeasement: a caller here asserts on PRESENCE, not on message, so
+// context about which collection was written is the only thing that makes a
+// surprise failure readable.
+func seedWriteIn(t *testing.T, app core.App, collection, unit string, year int) error {
+	t.Helper()
+	r := core.NewRecord(mustCollection(t, app, collection))
+	r.Set("unit", unit)
+	r.Set("session", seedSession(t, app))
+	r.Set("year", year)
+	if err := app.Save(r); err != nil {
+		return fmt.Errorf("save %s row for year %d: %w", collection, year, err)
+	}
+	return nil
+}
+
+// TestGuardUnitYearRejectsACrossYearWriteIn is lodging_write_ins's own entry
+// in yearScopedRefs (kindred#2382). It is the third single-relation case
+// (`unit`, MaxSelect 1) alongside lodging_availability and
+// lodging_slot_merges, and nothing about either of those exercises this
+// entry: a write-in table added to the schema but never registered in the map
+// leaves the suite green while a 2027 write-in silently holds a 2026 room.
+func TestGuardUnitYearRejectsACrossYearWriteIn(t *testing.T) {
+	t.Parallel()
+	app := newWriteInsTestApp(t)
+	unit := seedUnit(t, app, "test-unit-a", 2026)
+
+	if err := seedWriteIn(t, app, "lodging_write_ins", unit, 2027); err == nil {
+		t.Fatal("saved a 2027 write-in naming a 2026 unit; want a refusal")
+	}
+}
+
+// TestGuardUnitYearRejectsACrossYearDraftWriteIn is the draft grain's own
+// entry. Separate from the live one above for the same reason
+// TestGuardYearImmutableRejectsAUnitYearChangeWithADraftAssignmentDependent is
+// separate from its confirmed-board sibling: it is a different collection with
+// its own map entry, so a change that registered only the live table would
+// leave this uncovered.
+func TestGuardUnitYearRejectsACrossYearDraftWriteIn(t *testing.T) {
+	t.Parallel()
+	app := newWriteInsTestApp(t)
+	unit := seedUnit(t, app, "test-unit-a", 2026)
+
+	if err := seedWriteIn(t, app, "lodging_write_ins_draft", unit, 2027); err == nil {
+		t.Fatal("saved a 2027 draft write-in naming a 2026 unit; want a refusal")
+	}
+}
+
+// TestGuardUnitYearAllowsAWriteInSharingItsUnitsYear is the positive control
+// for the two refusals above, same shape as
+// TestGuardUnitYearAllowsAMatchingRow: without it, a guard that refused every
+// write to these tables would pass both refusal tests.
+func TestGuardUnitYearAllowsAWriteInSharingItsUnitsYear(t *testing.T) {
+	t.Parallel()
+	app := newWriteInsTestApp(t)
+	unit := seedUnit(t, app, "test-unit-a", 2026)
+
+	for _, collection := range []string{"lodging_write_ins", "lodging_write_ins_draft"} {
+		if err := seedWriteIn(t, app, collection, unit, 2026); err != nil {
+			t.Fatalf("refused a %s row sharing its unit's year: %v", collection, err)
+		}
+	}
+}
+
+// TestGuardYearImmutableRejectsAUnitYearChangeWithAWriteInDependent is
+// lodging_write_ins's REVERSE entry -- yearImmutableRefs[lodging_units].
+// Registering a table in yearScopedRefs alone still gets its own writes
+// checked, so its tests pass while guardYearImmutable quietly stops covering
+// a unit's year edit against it: exactly the omission kindred#2146's
+// TestYearRefMapsAgreeOnEveryRelation exists to make loud, asserted here
+// against the running engine rather than against the maps.
+func TestGuardYearImmutableRejectsAUnitYearChangeWithAWriteInDependent(t *testing.T) {
+	t.Parallel()
+	app := newWriteInsTestApp(t)
+	unit := seedUnit(t, app, "test-unit-a", 2027)
+	if err := seedWriteIn(t, app, "lodging_write_ins", unit, 2027); err != nil {
+		t.Fatalf("seeding a dependent write-in row: %v", err)
+	}
+
+	rec, err := app.FindRecordById(collectionUnits, unit)
+	if err != nil {
+		t.Fatalf("reloading the unit: %v", err)
+	}
+	rec.Set("year", 2028)
+
+	if err := app.Save(rec); err == nil {
+		t.Fatal("re-seasoned a unit with a dependent write-in row; want a refusal")
+	}
+}
+
+// TestGuardYearImmutableRejectsAUnitYearChangeWithADraftWriteInDependent is
+// the draft grain's reverse entry, separate from the live one for the reason
+// its yearScopedRefs sibling above gives.
+func TestGuardYearImmutableRejectsAUnitYearChangeWithADraftWriteInDependent(t *testing.T) {
+	t.Parallel()
+	app := newWriteInsTestApp(t)
+	unit := seedUnit(t, app, "test-unit-a", 2027)
+	if err := seedWriteIn(t, app, "lodging_write_ins_draft", unit, 2027); err != nil {
+		t.Fatalf("seeding a dependent draft write-in row: %v", err)
+	}
+
+	rec, err := app.FindRecordById(collectionUnits, unit)
+	if err != nil {
+		t.Fatalf("reloading the unit: %v", err)
+	}
+	rec.Set("year", 2028)
+
+	if err := app.Save(rec); err == nil {
+		t.Fatal("re-seasoned a unit with a dependent draft write-in row; want a refusal")
+	}
+}
+
 // relationPair is one (dependent -> target) edge, the unit of correspondence
 // between the two maps. yearScopedRefs states the edge from the dependent's
 // side (a key plus a ref.target); yearImmutableRefs states the same edge from

--- a/pocketbase/pb_migrations/1500000161_lodging_write_ins.js
+++ b/pocketbase/pb_migrations/1500000161_lodging_write_ins.js
@@ -95,8 +95,13 @@
  * the single-cover arity lives in four type signatures a storage change does
  * not touch. Do not widen the index here on its behalf.
  *
- * PocketBase v0.23 syntax: field properties are DIRECT, never inside
- * `options: {}`, which is silently ignored.
+ * PocketBase v0.23 syntax: field properties are DIRECT, never nested inside
+ * an `options` wrapper object, which is silently ignored.
+ *
+ * (Spelling it that way round is deliberate. scripts/pre-push-verify.sh greps
+ * changed migrations for the literal wrapper and filters only full-line `//`
+ * comments, so a JSDoc block quoting it fails the check -- 1500000135's header
+ * carries the same sentence and would too, if that file were ever in a diff.)
  */
 
 // VERBATIM from 1500000139:66-71, which took them verbatim from 1500000132.

--- a/pocketbase/pb_migrations/1500000161_lodging_write_ins.js
+++ b/pocketbase/pb_migrations/1500000161_lodging_write_ins.js
@@ -96,12 +96,14 @@
  * not touch. Do not widen the index here on its behalf.
  *
  * PocketBase v0.23 syntax: field properties are DIRECT, never nested inside
- * an `options` wrapper object, which is silently ignored.
+ * `options: {}`, which is silently ignored -- the same sentence 1500000132,
+ * 1500000135 and 1500000146 carry verbatim in their own headers.
  *
- * (Spelling it that way round is deliberate. scripts/pre-push-verify.sh greps
- * changed migrations for the literal wrapper and filters only full-line `//`
- * comments, so a JSDoc block quoting it fails the check -- 1500000135's header
- * carries the same sentence and would too, if that file were ever in a diff.)
+ * (It was worded backwards here at first, to get past scripts/pre-push-verify.sh:
+ * its anti-pattern grep filtered only full-line `//` comments, so a JSDoc block
+ * QUOTING the rule failed the check that enforces it, and the same was true of
+ * the three headers named above. The scan now filters `*` and `/*` continuation
+ * lines too, so the sentence can be written the way everyone else writes it.)
  */
 
 // VERBATIM from 1500000139:66-71, which took them verbatim from 1500000132.
@@ -113,6 +115,10 @@ const AUTHED_READ = '@request.auth.id != ""';
 const BUNKING_MANAGE =
   '@request.auth.is_admin = true || @request.auth.cached_permissions ~ "bunking.manage"';
 
+// Used for the lookups, the skip guards and the down arm. The `name:` inside
+// each `new Collection({...})` below is spelled as a LITERAL rather than as
+// one of these, and that is load-bearing rather than a style slip -- see the
+// comment at each create site.
 const LIVE = 'lodging_write_ins';
 const DRAFT = 'lodging_write_ins_draft';
 
@@ -175,7 +181,17 @@ migrate(
       app.save(
         new Collection({
           type: 'base',
-          name: LIVE,
+          // LITERAL, not `LIVE`. scripts/dev/verify-migration-history.sh's
+          // CHECK 2 -- the load-bearing half of kindred#2245's renumber
+          // detector, per that script's own header -- extracts the
+          // collections a migration CREATEs by regexing
+          // `name: "..."` / `name: '...'` out of the up arm. A constant
+          // reads as no collection at all, so the detector goes SILENTLY
+          // CLEAN on this file: measured against a scratch DB holding both
+          // tables with the _migrations row erased, it exited 0 with no
+          // output. Every other CREATE migration in the tree writes a
+          // literal here; keep it that way.
+          name: 'lodging_write_ins',
           listRule: AUTHED_READ,
           viewRule: AUTHED_READ,
           createRule: BUNKING_MANAGE,
@@ -217,7 +233,8 @@ migrate(
       app.save(
         new Collection({
           type: 'base',
-          name: DRAFT,
+          // LITERAL, for the reason the live create above spells out.
+          name: 'lodging_write_ins_draft',
           listRule: AUTHED_READ,
           viewRule: AUTHED_READ,
           createRule: BUNKING_MANAGE,
@@ -243,11 +260,25 @@ migrate(
     // discards nothing. Once that backfill exists, ITS down path is what
     // restores the rows to lodging_availability — this one must not try to,
     // because it has no idea where they came from.
+    //
+    // THE LOOKUP IS IN THE try, THE DELETE IS NOT -- the shape
+    // docs/reference/pocketbase-migrations.md § "Error Handling in Data
+    // Migrations" requires, and its reason is this exact one. With
+    // `app.delete(...)` inside the try, a genuine failure on the WRITE (a
+    // relation into these tables from a later migration, a permission
+    // fault, the DB gone away) is caught by the same `catch` that means
+    // "already absent", so `migrate down` reports a revert it never
+    // performed and leaves the collections standing. Outside it, the
+    // not-found path stays quiet and a real error propagates.
     for (const name of [DRAFT, LIVE]) {
+      let existing;
       try {
-        app.delete(app.findCollectionByNameOrId(name));
+        existing = app.findCollectionByNameOrId(name);
       } catch {
-        // Already absent.
+        // Already absent -- nothing to revert.
+      }
+      if (existing) {
+        app.delete(existing);
       }
     }
   }

--- a/pocketbase/pb_migrations/1500000161_lodging_write_ins.js
+++ b/pocketbase/pb_migrations/1500000161_lodging_write_ins.js
@@ -1,0 +1,249 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * lodging_write_ins + lodging_write_ins_draft — write-in OCCUPANCY, split out
+ * of lodging_availability and given a scenario dimension.
+ *
+ * Dark on arrival. This migration creates two empty tables and moves NOTHING.
+ * No reader is switched, no row is copied, and `lodging_availability` is not
+ * touched. kindred#2382 is PR 1 of 4; the backfill, the readers and the
+ * frontend follow, and until they land the application behaves exactly as it
+ * did before.
+ *
+ * ── WHY THIS EXISTS: ONE BOOLEAN, TWO QUESTIONS ─────────────────────────────
+ *
+ * `lodging_availability.family_available` answers two unrelated questions:
+ *
+ *   true  on a staff_default unit -> a staff cabin OPENED to families for this
+ *                                    weekend. A ROLE override. Names no
+ *                                    occupant.
+ *   false                         -> somebody is in the room. An OCCUPANCY.
+ *                                    The write-in.
+ *   no row                        -> the unit's own role decides. ROLE again.
+ *
+ * Owner ruling, 2026-08-15 (kindred#2382):
+ *
+ *   "staff vs family_available is not scenario scoped, no, that's more of a
+ *    known 'were moving staff to X for weekend Y'"
+ *
+ * and, separately, that a write-in must be scenario-scoped, because not every
+ * write-in is non-rostered staff — some are paper registrations for families
+ * arriving with no children, which are a MODELLING choice and belong to the
+ * scenario that made them.
+ *
+ * So the two halves scope differently and the fix is a SPLIT, not a twin of
+ * the conflated table: `lodging_availability` keeps ONLY the staff<->family
+ * role override, session-scoped and global, and occupancy moves here.
+ *
+ * ── THIS REVERSES 1500000135'S DECLINED TWIN, ON NEW EVIDENCE ───────────────
+ *
+ * 1500000135 deleted `lodging_availability.scenario` and named the twin it was
+ * declining to build:
+ *
+ *   "Availability is a fact about the WEEKEND, not about the plan: a burst
+ *    pipe closes a cabin in every scenario for that weekend, so there is
+ *    nothing for a scenario to disagree about. The overlay therefore
+ *    disappears by deleting one of its two layers rather than by growing a
+ *    `lodging_availability_draft` twin."
+ *
+ * That reasoning was CORRECT and still is — for availability. It is exactly
+ * why `lodging_availability` keeps its no-scenario shape here and is left
+ * alone. What changed is what the table STORES: kindred#2228 turned it into
+ * the named-global-occupant store and 1500000148 moved the historical notes
+ * into `occupant_name`. A write-in is not a burst pipe, so "there is nothing
+ * for a scenario to disagree about" stopped being true for the occupancy half
+ * of the column.
+ *
+ * This is therefore not a revert. 1500000135's call is untouched on the facts
+ * it was made about; a different fact, which arrived after it, is being given
+ * a home of its own on the owner ruling above.
+ *
+ * ⛔ A NULLABLE `scenario` SENTINEL WAS EXPLICITLY REJECTED. The live+draft
+ * pair below is this repository's established pattern, and the reason is
+ * recorded verbatim in api/services/lodging_repository.py: lodging_assignments
+ * dropped its scenario column because it "was dead weight that invited a
+ * `scenario != ''` write rule instead of a draft table." The live board is a
+ * scope in its own right, not the absence of one.
+ *
+ * ── SHAPE ───────────────────────────────────────────────────────────────────
+ *
+ * The occupancy fields mirror `lodging_availability`'s live schema exactly —
+ * unit, session, session_cm_id, year, occupant_name, note — so the PR 2
+ * backfill is a straight copy with no per-column judgement to make. The draft
+ * adds `scenario`, declared the way lodging_assignments_draft declares it
+ * (required, cascadeDelete true, into saved_scenarios), which is what makes
+ * "the live board is never overridable by a scenario" a schema guarantee and
+ * makes deleting a scenario take its write-ins with it.
+ *
+ * `occupant_name` is NOT required, mirroring 1500000148's own call on the
+ * column it copies from. All 21 rows in production carry one today, so a
+ * required field would in fact accept the backfill — but tightening it here
+ * would make this migration diverge from the source column it is supposed to
+ * mirror, and the API is already the tighter of the two (it caps the field it
+ * accepts at 500, a UI-side judgement about a name).
+ *
+ * `session.cascadeDelete` is FALSE and `unit.cascadeDelete` is TRUE, matching
+ * lodging_availability's live schema and lodging_slot_merges' explicit
+ * reasoning: a camp_session vanishing from one CampMinder response is an
+ * ingest anomaly (kindred#1879) whose correct failure mode is a 400 on the
+ * orphan delete, while a write-in against a building that no longer exists is
+ * meaningless.
+ *
+ * ONE ROW PER (unit, weekend) — and per scenario on the draft. The unique
+ * index mirrors `idx_lodging_avail_unique`, so the arity is unchanged from
+ * what the application enforces today. Whether a container should be able to
+ * hold N write-ins is kindred#2381, which does NOT dissolve into this change:
+ * the single-cover arity lives in four type signatures a storage change does
+ * not touch. Do not widen the index here on its behalf.
+ *
+ * PocketBase v0.23 syntax: field properties are DIRECT, never inside
+ * `options: {}`, which is silently ignored.
+ */
+
+// VERBATIM from 1500000139:66-71, which took them verbatim from 1500000132.
+// Do not paraphrase — the permission is read off `cached_permissions` as a
+// dotted string, and the plausible alternative
+// (`@request.auth.permissions.bunking ?~ "manage"`) matches nothing and denies
+// every write SILENTLY. That failure mode has already shipped once here.
+const AUTHED_READ = '@request.auth.id != ""';
+const BUNKING_MANAGE =
+  '@request.auth.is_admin = true || @request.auth.cached_permissions ~ "bunking.manage"';
+
+const LIVE = 'lodging_write_ins';
+const DRAFT = 'lodging_write_ins_draft';
+
+/**
+ * The occupancy fields, mirrored from lodging_availability's live schema.
+ *
+ * Built per call rather than shared as one array literal: PocketBase mutates
+ * the field objects it is handed (stamping ids), so two collections built from
+ * one literal would collide.
+ */
+function occupancyFields(unitsCol, sessionsCol) {
+  return [
+    {
+      type: 'relation', name: 'unit', required: true, presentable: false,
+      collectionId: unitsCol.id, cascadeDelete: true, minSelect: null, maxSelect: 1,
+    },
+    {
+      type: 'relation', name: 'session', required: true, presentable: false,
+      collectionId: sessionsCol.id, cascadeDelete: false, minSelect: null, maxSelect: 1,
+    },
+    // The CampMinder identity travels BESIDE the PocketBase relation, not in
+    // place of it, and it is what the unique index below keys on
+    // (kindred#2042 / 1500000147 re-keyed every sibling lodging index the same
+    // way): a camp_sessions row recreated rather than updated gets a new
+    // PocketBase id, and rows keyed on the old one become unreachable.
+    { type: 'number', name: 'session_cm_id', required: true, presentable: false, min: 1, max: null, onlyInt: true },
+    // CampMinder reuses session ids across years — every data table carries
+    // the year that disambiguates them.
+    { type: 'number', name: 'year', required: true, presentable: false, min: 2010, max: 2100, onlyInt: true },
+    // max 2000 mirrors lodging_availability.occupant_name (1500000148), which
+    // in turn mirrors `note` (1500000118), so a PR 2 copy cannot be rejected
+    // for length by any value the source column could hold.
+    { type: 'text', name: 'occupant_name', required: false, presentable: false, min: 0, max: 2000, pattern: '' },
+    { type: 'text', name: 'note', required: false, presentable: false, min: 0, max: 2000, pattern: '' },
+    { type: 'autodate', name: 'created', required: false, presentable: false, onCreate: true, onUpdate: false },
+    { type: 'autodate', name: 'updated', required: false, presentable: false, onCreate: true, onUpdate: true },
+  ];
+}
+
+migrate(
+  (app) => {
+    const units = app.findCollectionByNameOrId('lodging_units');
+    const sessions = app.findCollectionByNameOrId('camp_sessions');
+    const scenarios = app.findCollectionByNameOrId('saved_scenarios');
+
+    // Idempotent per collection, and checked per collection rather than once
+    // for the pair: a filename-keyed skip must not attempt a second create,
+    // and a half-applied run must still be able to finish. An idempotent
+    // CREATE is the one shape docs/reference/pocketbase-migrations.md warns
+    // against as a FIX for a renumbered migration — used here only to make a
+    // re-run a no-op, not to accept whatever shape is already present.
+    let liveExists = false;
+    try {
+      app.findCollectionByNameOrId(LIVE);
+      liveExists = true;
+    } catch {
+      // Not present — create it below.
+    }
+    if (!liveExists) {
+      app.save(
+        new Collection({
+          type: 'base',
+          name: LIVE,
+          listRule: AUTHED_READ,
+          viewRule: AUTHED_READ,
+          createRule: BUNKING_MANAGE,
+          updateRule: BUNKING_MANAGE,
+          deleteRule: BUNKING_MANAGE,
+          fields: occupancyFields(units, sessions),
+          indexes: [
+            'CREATE INDEX `idx_lodging_write_in_unit` ON `lodging_write_ins` (`unit`)',
+            'CREATE INDEX `idx_lodging_write_in_session_year` ON `lodging_write_ins` (`session_cm_id`, `year`)',
+            // At most one write-in per unit per weekend, mirroring
+            // idx_lodging_avail_unique. Without it a unit could carry two
+            // contradicting rows and "who is in this cabin?" would stop being
+            // a question with an answer.
+            'CREATE UNIQUE INDEX `idx_lodging_write_in_unique` ON `lodging_write_ins` (`session_cm_id`, `year`, `unit`)',
+          ],
+        })
+      );
+    }
+
+    let draftExists = false;
+    try {
+      app.findCollectionByNameOrId(DRAFT);
+      draftExists = true;
+    } catch {
+      // Not present — create it below.
+    }
+    if (!draftExists) {
+      const draftFields = occupancyFields(units, sessions);
+      // SCENARIO IS A REQUIRED RELATION, NOT TEXT — declared exactly as
+      // lodging_assignments_draft declares it. 1500000132: "Scenario is a
+      // property of PLANNING, not of record, and summer encodes exactly that
+      // by putting the column only on the draft." cascadeDelete means deleting
+      // a scenario takes its write-ins with it, which is the correct answer to
+      // kindred#2382's scenario-delete knock-on.
+      draftFields.push({
+        type: 'relation', name: 'scenario', required: true, presentable: false,
+        collectionId: scenarios.id, cascadeDelete: true, minSelect: null, maxSelect: 1,
+      });
+      app.save(
+        new Collection({
+          type: 'base',
+          name: DRAFT,
+          listRule: AUTHED_READ,
+          viewRule: AUTHED_READ,
+          createRule: BUNKING_MANAGE,
+          updateRule: BUNKING_MANAGE,
+          deleteRule: BUNKING_MANAGE,
+          fields: draftFields,
+          indexes: [
+            'CREATE INDEX `idx_lodging_write_in_draft_unit` ON `lodging_write_ins_draft` (`unit`)',
+            'CREATE INDEX `idx_lodging_write_in_draft_scenario` ON `lodging_write_ins_draft` (`scenario`)',
+            'CREATE INDEX `idx_lodging_write_in_draft_session_year` ON `lodging_write_ins_draft` (`session_cm_id`, `year`)',
+            // The live key plus the scenario, matching how
+            // lodging_assignments_draft keys its own uniqueness: two scenarios
+            // may hold contradicting write-ins for one unit without colliding.
+            'CREATE UNIQUE INDEX `idx_lodging_write_in_draft_unique` ON `lodging_write_ins_draft` (`session_cm_id`, `year`, `unit`, `scenario`)',
+          ],
+        })
+      );
+    }
+  },
+  (app) => {
+    // Safe to drop outright: this migration creates the tables empty and
+    // copies nothing into them, so a down path taken before PR 2's backfill
+    // discards nothing. Once that backfill exists, ITS down path is what
+    // restores the rows to lodging_availability — this one must not try to,
+    // because it has no idea where they came from.
+    for (const name of [DRAFT, LIVE]) {
+      try {
+        app.delete(app.findCollectionByNameOrId(name));
+      } catch {
+        // Already absent.
+      }
+    }
+  }
+);

--- a/scripts/pre-push-verify.sh
+++ b/scripts/pre-push-verify.sh
@@ -305,12 +305,24 @@ if $HAS_MIGRATIONS; then
         # `options: [ ... ]` arrays (e.g. select-option values in config.js) are
         # legitimate and must NOT be flagged — same object-vs-array distinction
         # the eslint no-restricted-syntax rule makes.
-        # Filter only full-line `//` comments. grep -n prefixes each hit with
-        # `LINENUM:`, so anchor on that prefix; a bare `^[[:space:]]*//` would
-        # never match. Keeps real `options: {` hits that carry an inline comment.
-        if grep -n 'options\s*:\s*{' "$file" | grep -vE '^[0-9]+:[[:space:]]*//' | grep -q .; then
+        # Filter COMMENT lines, in every form a migration header uses:
+        # `//`, a JSDoc continuation `*`, and a block opener `/*`. grep -n
+        # prefixes each hit with `LINENUM:`, so anchor on that prefix; a bare
+        # `^[[:space:]]*//` would never match. Keeps real `options: {` hits
+        # that carry an inline comment.
+        #
+        # The `*` arm is not decoration. Four migrations already state the
+        # anti-pattern inside a JSDoc header -- 1500000132, 1500000135,
+        # 1500000146 and 1500000161 all carry the sentence "properties are
+        # DIRECT, never nested inside `options: {}`, which is silently
+        # ignored" -- so a `//`-only filter fails this check on any diff that
+        # touches one of them, purely for quoting the rule it is enforcing.
+        # 1500000161 had to word the sentence backwards to get past it. A
+        # line whose first non-space character is `*` or `/` cannot be
+        # executable JS carrying a field wrapper, so nothing real is hidden.
+        if grep -n 'options\s*:\s*{' "$file" | grep -vE '^[0-9]+:[[:space:]]*(//|/?\*)' | grep -q .; then
             echo "    Found 'options: {}' field wrapper (v0.23+ anti-pattern): $file"
-            grep -n 'options\s*:\s*{' "$file" | grep -vE '^[0-9]+:[[:space:]]*//' | head -5 | while read -r line; do
+            grep -n 'options\s*:\s*{' "$file" | grep -vE '^[0-9]+:[[:space:]]*(//|/?\*)' | head -5 | while read -r line; do
                 echo "      $line"
             done
             OPTIONS_OK=false

--- a/tests/unit/api/services/test_lodging_repository.py
+++ b/tests/unit/api/services/test_lodging_repository.py
@@ -106,6 +106,8 @@ class TestStableSort:
             pytest.param(lambda r: r.fetch_availability(2026, 1000001), id="fetch_availability"),
             pytest.param(lambda r: r.fetch_assignments(2026, 1000001), id="fetch_assignments"),
             pytest.param(lambda r: r.fetch_slot_merges(2026, 1000001, "scn_1"), id="fetch_slot_merges"),
+            pytest.param(lambda r: r.fetch_write_ins(2026, 1000001), id="fetch_write_ins"),
+            pytest.param(lambda r: r.fetch_draft_write_ins(2026, 1000001, "scn_1"), id="fetch_draft_write_ins"),
             pytest.param(lambda r: r.fetch_attendees_for_session(2026, "s1"), id="fetch_attendees"),
             pytest.param(lambda r: r.fetch_households(2026), id="fetch_households"),
             pytest.param(lambda r: r.fetch_prior_household_cm_ids(2026), id="fetch_prior_cm_ids"),
@@ -387,6 +389,26 @@ class TestLodgingReadsKeyOnTheCampMinderSessionId:
                 "lodging_slot_merges",
                 id="find_slot_merge",
             ),
+            pytest.param(
+                lambda r, s: r.fetch_write_ins(2026, s),
+                "lodging_write_ins",
+                id="fetch_write_ins",
+            ),
+            pytest.param(
+                lambda r, s: r.fetch_draft_write_ins(2026, s, "scn_1"),
+                "lodging_write_ins_draft",
+                id="fetch_draft_write_ins",
+            ),
+            pytest.param(
+                lambda r, s: r.find_write_in(2026, s, "u1"),
+                "lodging_write_ins",
+                id="find_write_in",
+            ),
+            pytest.param(
+                lambda r, s: r.find_draft_write_in(2026, s, "scn_1", "u1"),
+                "lodging_write_ins_draft",
+                id="find_draft_write_in",
+            ),
         ],
     )
     async def test_the_session_term_is_the_campminder_id(
@@ -424,6 +446,10 @@ class TestLodgingReadsKeyOnTheCampMinderSessionId:
             pytest.param(lambda r, s: r.find_draft_assignment(2026, s, "scn_1", 2000001, 0), id="find_draft"),
             pytest.param(lambda r, s: r.find_availability_override(2026, s, "u1"), id="find_availability"),
             pytest.param(lambda r, s: r.find_slot_merge(2026, s, "u1", "scn_1"), id="find_slot_merge"),
+            pytest.param(lambda r, s: r.fetch_write_ins(2026, s), id="fetch_write_ins"),
+            pytest.param(lambda r, s: r.fetch_draft_write_ins(2026, s, "scn_1"), id="fetch_draft_write_ins"),
+            pytest.param(lambda r, s: r.find_write_in(2026, s, "u1"), id="find_write_in"),
+            pytest.param(lambda r, s: r.find_draft_write_in(2026, s, "scn_1", "u1"), id="find_draft_write_in"),
         ],
     )
     async def test_the_session_term_is_never_compared_to_a_string(
@@ -583,6 +609,38 @@ class TestClientSuppliedValuesAreEscaped:
         assert '" || id != "' not in filter_str
 
     @pytest.mark.asyncio
+    async def test_fetch_draft_write_ins_escapes_the_scenario(self, repo: LodgingRepository, pb: MagicMock) -> None:
+        await repo.fetch_draft_write_ins(2026, 1000001, self.INJECTION)
+
+        filter_str = _last_query(pb)["filter"]
+        assert f'scenario = "{self.ESCAPED}"' in filter_str
+        assert '" || id != "' not in filter_str
+
+    @pytest.mark.asyncio
+    async def test_find_write_in_escapes_the_unit_id(self, repo: LodgingRepository, pb: MagicMock) -> None:
+        await repo.find_write_in(2026, 1000001, 'u1" || id != "')
+
+        filter_str = _last_query(pb)["filter"]
+        assert 'unit = "u1\\" || id != \\""' in filter_str
+        assert '" || id != "' not in filter_str
+
+    @pytest.mark.asyncio
+    async def test_find_draft_write_in_escapes_both_client_values(self, repo: LodgingRepository, pb: MagicMock) -> None:
+        """TWO client-supplied strings reach this one filter, not one.
+
+        `unit_pb_id` arrives in the request body and `scenario_id` off the
+        `?scenario=` query parameter, and either one unescaped widens the
+        predicate past its own scoping -- which on this lookup means the
+        caller updates or deletes another scenario's write-in.
+        """
+        await repo.find_draft_write_in(2026, 1000001, self.INJECTION, 'u1" || id != "')
+
+        filter_str = _last_query(pb)["filter"]
+        assert f'scenario = "{self.ESCAPED}"' in filter_str
+        assert 'unit = "u1\\" || id != \\""' in filter_str
+        assert '" || id != "' not in filter_str
+
+    @pytest.mark.asyncio
     async def test_find_availability_override_escapes_the_unit_id(self, repo: LodgingRepository, pb: MagicMock) -> None:
         """One client value left, not two: 1500000135 took the scenario.
 
@@ -635,6 +693,156 @@ class TestFetchAvailability:
         return that the first one does not.
         """
         assert not hasattr(repo, "fetch_scenario_availability")
+
+
+class TestWriteInReads:
+    """`lodging_write_ins` / `lodging_write_ins_draft` — kindred#2382, PR 1 of 4.
+
+    The owner's 2026-08-15 clarification split `family_available` in two:
+    the staff<->family ROLE override stays on `lodging_availability`,
+    session-scoped and global, and write-in OCCUPANCY moves to its own
+    live+draft pair sitting beside `lodging_assignments`/`_draft`. These
+    reads are that pair's half of the repository.
+
+    NOTHING READS THEM YET. PR 1 lands the tables and the CRUD dark; the
+    switch of `write_in_covers`, `set_availability` and the frontend is PR 2
+    onward. What these tests pin is the shape the later PRs will read
+    through, not any behaviour the running application has today.
+    """
+
+    @pytest.mark.asyncio
+    async def test_fetch_write_ins_reads_the_live_table_with_no_scenario_predicate(
+        self, repo: LodgingRepository, pb: MagicMock
+    ) -> None:
+        """The live board is a scope in its own right (owner, 2026-08-15).
+
+        It is not "the absence of a scenario" and it is not `scenario = ""` on
+        a partitioned table -- that sentinel shape is the one 1500000135's
+        own reasoning, quoted in this module's header, rejected. The live
+        rows live in their own table and carry no scenario column at all, so
+        naming one here would name a column that does not exist, which
+        PocketBase rejects at query time rather than ignoring.
+        """
+        await repo.fetch_write_ins(2026, 1000001)
+
+        pb.collection.assert_called_with("lodging_write_ins")
+        params = _last_query(pb)
+        assert "session_cm_id = 1000001" in params["filter"]
+        assert "year = 2026" in params["filter"]
+        assert "scenario" not in params["filter"]
+
+    @pytest.mark.asyncio
+    async def test_fetch_draft_write_ins_returns_only_the_named_scenarios_rows(
+        self, repo: LodgingRepository, pb: MagicMock
+    ) -> None:
+        """REPLACE, not overlay -- the same rule kindred#1974 set for placements.
+
+        `lodging_slot_merges` is the tempting counter-model: it unions the
+        weekend-level tier in (`scenario = ""`) because a draw level is a
+        fact about the weekend. A write-in is not -- it is an occupancy, the
+        same kind of fact as a placement -- so a scenario's write-ins are its
+        whole set, and a scenario is seeded by an explicit copy (PR 3) rather
+        than by rendering the live board through the gaps.
+        """
+        await repo.fetch_draft_write_ins(2026, 1000001, "scn_1")
+
+        pb.collection.assert_called_with("lodging_write_ins_draft")
+        params = _last_query(pb)
+        assert "session_cm_id = 1000001" in params["filter"]
+        assert "year = 2026" in params["filter"]
+        assert 'scenario = "scn_1"' in params["filter"]
+        # No fall-through to the live board's rows.
+        assert 'scenario = ""' not in params["filter"]
+        assert "||" not in params["filter"]
+
+    @pytest.mark.asyncio
+    async def test_find_write_in_keys_the_live_unique_index(self, repo: LodgingRepository, pb: MagicMock) -> None:
+        """Matches `idx_lodging_write_in_unique` (session_cm_id, year, unit).
+
+        Mirrors `find_availability_override` against the table the write-in
+        half moves to: without a lookup of exactly the index's shape a unit
+        could carry two contradicting rows for one weekend and "who is in
+        this cabin?" would stop being a question with an answer.
+        """
+        await repo.find_write_in(2026, 1000001, "u1")
+
+        pb.collection.assert_called_with("lodging_write_ins")
+        filter_str = _last_query(pb)["filter"]
+        assert "session_cm_id = 1000001" in filter_str
+        assert "year = 2026" in filter_str
+        assert 'unit = "u1"' in filter_str
+        assert "scenario" not in filter_str
+
+    @pytest.mark.asyncio
+    async def test_find_draft_write_in_keys_the_draft_unique_index(
+        self, repo: LodgingRepository, pb: MagicMock
+    ) -> None:
+        """The draft index carries `scenario` as a fourth term.
+
+        `lodging_assignments_draft`'s partial indexes do the same
+        (1500000132/1500000147): the draft key is the live key plus the
+        scenario, so two scenarios may hold contradicting rows for one unit
+        and neither collides with the other.
+        """
+        await repo.find_draft_write_in(2026, 1000001, "scn_1", "u1")
+
+        pb.collection.assert_called_with("lodging_write_ins_draft")
+        filter_str = _last_query(pb)["filter"]
+        assert "session_cm_id = 1000001" in filter_str
+        assert "year = 2026" in filter_str
+        assert 'unit = "u1"' in filter_str
+        assert 'scenario = "scn_1"' in filter_str
+
+    @pytest.mark.asyncio
+    async def test_find_write_in_returns_none_when_there_is_no_row(
+        self, repo: LodgingRepository, pb: MagicMock
+    ) -> None:
+        pb.collection.return_value.get_full_list.return_value = []
+
+        assert await repo.find_write_in(2026, 1000001, "u1") is None
+        assert await repo.find_draft_write_in(2026, 1000001, "scn_1", "u1") is None
+
+    @pytest.mark.asyncio
+    async def test_find_write_in_returns_the_single_row(self, repo: LodgingRepository, pb: MagicMock) -> None:
+        row = _record(id="wi_1")
+        pb.collection.return_value.get_full_list.return_value = [row]
+
+        assert await repo.find_write_in(2026, 1000001, "u1") is row
+        assert await repo.find_draft_write_in(2026, 1000001, "scn_1", "u1") is row
+
+
+class TestWriteInWrites:
+    """The write half, live and draft, targets the right table each time.
+
+    A create that reached the wrong grain would record a scenario's modelling
+    choice on the live board -- the exact conflation kindred#2382 exists to
+    undo -- so the collection name is asserted on every one of the six.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("call", "collection"),
+        [
+            pytest.param(lambda r: r.create_write_in({"unit": "u1"}), "lodging_write_ins", id="create_live"),
+            pytest.param(lambda r: r.update_write_in("wi_1", {"note": "x"}), "lodging_write_ins", id="update_live"),
+            pytest.param(lambda r: r.delete_write_in("wi_1"), "lodging_write_ins", id="delete_live"),
+            pytest.param(
+                lambda r: r.create_draft_write_in({"unit": "u1"}), "lodging_write_ins_draft", id="create_draft"
+            ),
+            pytest.param(
+                lambda r: r.update_draft_write_in("wi_1", {"note": "x"}),
+                "lodging_write_ins_draft",
+                id="update_draft",
+            ),
+            pytest.param(lambda r: r.delete_draft_write_in("wi_1"), "lodging_write_ins_draft", id="delete_draft"),
+        ],
+    )
+    async def test_the_write_targets_its_own_grain(
+        self, repo: LodgingRepository, pb: MagicMock, call: Any, collection: str
+    ) -> None:
+        await call(repo)
+
+        pb.collection.assert_called_with(collection)
 
 
 class TestFetchAttendees:

--- a/tests/unit/api/test_lodging_constants.py
+++ b/tests/unit/api/test_lodging_constants.py
@@ -39,6 +39,25 @@ def test_lodging_collection_constants_exist() -> None:
     assert collections.LODGING_ASSIGNMENT_HISTORY == "lodging_assignment_history"
 
 
+def test_lodging_write_in_collection_constants_exist() -> None:
+    """kindred#2382, PR 1 of 4 — the write-in occupancy pair.
+
+    `lodging_availability` conflated two unrelated questions through one
+    boolean: `family_available = true` on a staff cabin is a staff<->family
+    ROLE override for the weekend, and `false` is an OCCUPANCY — somebody is
+    in the room. The owner ruled (2026-08-15) that the ROLE is NOT
+    scenario-scoped and the occupancy IS, so occupancy moves to its own
+    live+draft pair beside `lodging_assignments`/`_draft` and availability
+    keeps only the role half.
+
+    A nullable `scenario` sentinel column was explicitly rejected — see this
+    module's sibling note in `api/services/lodging_repository.py`, which
+    records why `lodging_assignments` dropped its own.
+    """
+    assert collections.LODGING_WRITE_INS == "lodging_write_ins"
+    assert collections.LODGING_WRITE_INS_DRAFT == "lodging_write_ins_draft"
+
+
 def test_weekend_status_constant_exists() -> None:
     """kindred#2092. Its own collection, NOT a column on camp_sessions.
 


### PR DESCRIPTION
`lodging_availability.family_available` answers two unrelated questions through one boolean, and only one of them is scenario-scoped:

| stored | means | question | scenario-scoped? |
|---|---|---|---|
| `true` on a `staff_default` unit | a staff cabin OPENED to families this weekend | **ROLE** | **No** — an operational fact ("we're moving staff to X for weekend Y") |
| `false` | somebody is in it — the write-in | **OCCUPANCY** | **Yes** |
| no row | the unit's own role decides | ROLE (default) | n/a |

Owner ruling, 2026-08-15 (#2382): the ROLE half is **not** scenario-scoped and stays exactly where it is; the OCCUPANCY half is, because not every write-in is non-rostered staff — some are paper registrations for families arriving with no children, and that is a modelling choice belonging to the scenario that made it.

So the fix is a **split**, not a draft twin of the conflated table. This PR lands the receiving half of that split and **nothing else**.

## What this PR does

- **`pocketbase/pb_migrations/1500000161_lodging_write_ins.js`** — creates `lodging_write_ins` and `lodging_write_ins_draft`. The occupancy fields mirror `lodging_availability`'s live schema exactly (`unit`, `session`, `session_cm_id`, `year`, `occupant_name`, `note`), so PR 2's backfill is a straight copy with no per-column judgement. The draft adds `scenario` declared the way `lodging_assignments_draft` declares it — required, `cascadeDelete: true`, into `saved_scenarios` — which makes "the live board is never overridable by a scenario" a schema guarantee and makes deleting a scenario take its write-ins with it. Both `name:` values inside `new Collection({...})` are string **literals**, not the file's `LIVE` / `DRAFT` constants: `scripts/dev/verify-migration-history.sh`'s CHECK 2 — the load-bearing half of #2245's renumber detector, since history-sync erases the `_migrations` evidence CHECK 1 reads — finds the collections a migration CREATEs by regexing `name: "..."` out of the up arm, and a constant reads as no collection at all.
- **`pocketbase/lodging/hooks.go`** — registers both collections in `yearScopedRefs` and in `yearImmutableRefs[lodging_units]`, following `collectionSlotMerges` exactly. Both are single `unit` relations, so the filter is a plain `unit = {:id}` with no `.id` join.
- **`api/services/lodging_repository.py`** + **`api/constants/collections.py`** — the live and draft CRUD, following the `lodging_assignments`/`_draft` pattern already in that file.
- **`frontend/src/types/pocketbase-types.ts`** — regenerated against a migrations-only scratch database. Pure addition, 35 lines, no churn.

## What this PR deliberately does NOT do

**After this PR the application behaves identically. That is the acceptance criterion.**

- **No data migration.** The 21 production rows stay in `lodging_availability`. No backfill, no copy, no delete.
- **No reader is switched.** `write_in_covers` (`lodging_roster_service.py:469`), `LodgingUnitSummary.write_in`, `coveringWriteIn`, `set_availability`, `lodgingApi.ts` and `UnitAvailabilityControl.tsx` are untouched and still resolve write-ins through `family_available`. The new tables are empty and nothing reads them.
- `copy_from_mirror`, `copy_scenario_to_scenario`, `writeIn.ts`, `unitBadges.ts` and `boardLayout.ts` (owned by in-flight #2404) are untouched.

## This does not close anything

⛔ **#2382 stays OPEN until PR 4.** This is PR **1 of 4** and closes no issue. The remaining three:

- **PR 2** — backfill the 21 `family_available = false` rows into `lodging_write_ins`, and switch `write_in_covers` / `set_availability` to read and write them.
- **PR 3** — seed a scenario's write-ins in both copy paths (`copy_from_mirror`, `copy_scenario_to_scenario`), per the owner ruling of 2026-08-16; without it #2247's placement gate would permit dropping a family into a room the live board records as occupied.
- **PR 4** — move the frontend off `family_available_override === false` (`writeIn.ts`, `unitBadges.ts`, #2093's forest open-tint proxy), leave `lodging_availability` holding only the ROLE override, and take #2382 to done.

#2381 is **not** dissolved by this. The single-cover arity survives a storage change because it lives in four type signatures a new table does not touch, so the unique index here deliberately mirrors today's one-row-per-`(unit, weekend)` shape rather than widening on its behalf.

## Why this is not a revert of 1500000135

`1500000135_lodging_availability_no_scenario.js` deleted the scenario column and named the twin it was declining to build:

> Availability is a fact about the WEEKEND, not about the plan: a burst pipe closes a cabin in every scenario for that weekend, so there is nothing for a scenario to disagree about.

That reasoning was correct and still is — for availability, which is exactly why `lodging_availability` keeps its no-scenario shape here and is left alone. What changed is what the table *stores*: #2228 turned it into the named-global-occupant store and 1500000148 moved the historical notes into `occupant_name`. A write-in is not a burst pipe, so "nothing for a scenario to disagree about" stopped being true for the occupancy half. The migration header says all of this and cites the ruling rather than reading as a revert.

⛔ A nullable `scenario` sentinel column was explicitly rejected. `api/services/lodging_repository.py` records why verbatim: `lodging_assignments` dropped its scenario column because it *"was dead weight that invited a `scenario != \"\"` write rule instead of a draft table."* The live+draft pair is this repository's established pattern.

## Measurement

Re-verified against `pocketbase/pb_data/data-prod.db` (opened by name — the sibling `data.db` is the dev copy):

```
SELECT family_available, count(*) FROM lodging_availability GROUP BY family_available;
0|21
```

All 21 rows are OCCUPANCY. **Zero are ROLE** — the role half of the column has never been written. So there is no risky partition and no ambiguous row for PR 2 to adjudicate. All 21 carry a non-empty `occupant_name`, and all 21 are distinct on `(session_cm_id, year, unit)`, so the unique index below holds over them.

## Tests

Written failing first, then implemented.

**Go** (`pocketbase/lodging/hooks_test.go`, +5 tests) — the guards are exercised against the running engine, not asserted against the maps:

- `TestGuardUnitYearRejectsACrossYearWriteIn` / `…DraftWriteIn` — a 2027 write-in naming a 2026 unit is refused, live and draft.
- `TestGuardUnitYearAllowsAWriteInSharingItsUnitsYear` — positive control, so a guard that refused every write to these tables would not pass the two above.
- `TestGuardYearImmutableRejectsAUnitYearChangeWithAWriteInDependent` / `…DraftWriteInDependent` — re-seasoning a unit with a dependent write-in is refused.
- `newWriteInsTestApp` mirrors `newSlotMergesTestApp`, adding both collections *after* `setupCollections`, so `TestGuardUnitYearSkipsAnAbsentCollection` keeps a genuinely absent collection to pin.

Mutation-checked, reading the exit code:

- dropping `collectionWriteInsDraft` from `yearScopedRefs` → RED (the guard test **and** `TestYearRefMapsAgreeOnEveryRelation`, which enforces the two maps stay symmetric);
- replacing either filter with one that compiles but matches zero rows (`unit = {:id} && year = 9999`) → RED on both year-immutable tests. That is the silent failure mode `dependentRef`'s doc comment warns about, and it is caught.

**Python** (`tests/unit/api/services/test_lodging_repository.py`, `tests/unit/api/test_lodging_constants.py`) — the live read carries no scenario predicate; the draft read REPLACES rather than overlays (matching #1974's rule for placements, **not** `lodging_slot_merges`' weekend-level union, because a write-in is an occupancy and not a fact about the weekend); both lookups key their own unique index; every client-supplied string reaching a filter is escaped. All four new reads were added to the two `session_cm_id` lists (keyed-on-the-CampMinder-id, never-compared-to-a-string); the stable-sort list took the two paginated `fetch_*` reads only, because that list holds `fetch_*` reads and no `find_*` — `find_availability_override` and `find_slot_merge` are absent from it too.

## Gates

| Gate | Result |
|---|---|
| `bash scripts/pre-push-verify.sh` | ALL CHECKS PASSED |
| `cd pocketbase && go test ./...` | pass (12 packages) |
| `uv run pytest tests/` | 6367 passed, 23 skipped |
| `golangci-lint run` | 0 issues |
| `scripts/dev/verify-lodging-schema.sh` | OK (120 js migrations applied) |
| `scripts/dev/verify-migration-history.sh` | OK |
| `scripts/dev/verify-no-hardcoded-lodging.sh` | OK |
| `migrate up` → `migrate down 1` → `migrate up` on a scratch DB | clean both ways; re-apply with the collections already present is a no-op |
| field caps read back off the migrated DB | `max: 2000` on both text columns, not the 5000 default — no `options` wrapper trap |

**No GUI impact.** The only file changed under `frontend/` is the generated types file.

### The shared gate that made the migration explain itself

`scripts/pre-push-verify.sh`'s `options: {` scan filtered only full-line `//` comments, so a JSDoc header that *quotes* the anti-pattern failed the check that enforces it. This PR first worked around it by wording the note backwards. That is fixed here instead: the filter now skips `*` and `/*` continuation lines as well, and the migration header states the rule the way 1500000132, 1500000135 and 1500000146 already state it. A line whose first non-space character is `*` or `/` cannot be executable JS carrying a field wrapper, so nothing real is hidden — verified in both directions (the three existing headers yield zero residual hits; a real `{ type: "text", name: "x", options: { max: 100 } }` is still reported).

### Review fixes folded in

- The `new Collection({...})` names became string literals, so `verify-migration-history.sh` CHECK 2 can see them. Measured on a scratch DB holding both tables with the `1500000161` row deleted from `_migrations` — the state a renumber leaves — the detector went from **exit 0 with no output** (silent false CLEAN) to exit 1 naming both collections. That detector is also what makes the up arm's skip-if-exists guard defensible, since `docs/reference/pocketbase-migrations.md` warns an idempotent CREATE otherwise leaves a divergent schema "with nothing left to reveal it".
- The down arm ran `app.delete(...)` **inside** the `try`, so a genuine delete failure was caught by the same `catch` that means "already absent" and `migrate down` would report a revert it never performed. The lookup stays in the `try`; the delete moved out, per that document's "Error Handling in Data Migrations".
