### PR TITLE
feat(pb,api): move write-in occupancy to its own table and switch the read (#2382, 2 of 4)

### DIFF
--- a/api/routers/lodging.py
+++ b/api/routers/lodging.py
@@ -265,16 +265,24 @@ async def set_availability(
     request: AvailabilityWriteRequest,
     user: AuthUser = Depends(require_permission(Permission.BUNKING_MANAGE)),
 ) -> LodgingWriteResponse:
-    """Reserve or release one unit for this weekend.
+    """Write somebody into one unit for this weekend, or release one to families.
 
-    Takes NO scenario, unlike every other write on this router. Availability is
-    a fact about the weekend rather than about the plan -- a burst pipe closes
-    a cabin in every scenario for that weekend -- so 1500000135 deleted the
-    dimension. Requiring one is what made this endpoint uncallable.
+    ONE ENDPOINT, TWO TABLES since kindred#2382. `family_available` answers two
+    unrelated questions and each is stored where it belongs: `false` is an
+    OCCUPANCY and goes to `lodging_write_ins`, `true` is a staff<->family ROLE
+    override for the weekend and stays in `lodging_availability`. The request
+    model, the URL and everything a staff member sees are unchanged -- the
+    split is behind them. `set_availability` carries the reasoning.
+
+    Takes NO scenario, unlike every other write on this router. The role half
+    is a fact about the weekend rather than about the plan, so 1500000135
+    deleted its dimension; the occupancy half writes the LIVE board, which is a
+    scope in its own right rather than the absence of one. Requiring a scenario
+    is what made this endpoint uncallable.
 
     `family_available: null` clears the override, which is spelled as the
-    ABSENCE of a row: there is no value meaning "normal", and writing one would
-    pin the unit against a later change to its role.
+    ABSENCE of a row -- in BOTH tables. There is no value meaning "normal", and
+    writing one would pin the unit against a later change to its role.
     """
     try:
         return await _writes().set_availability(request)

--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -158,9 +158,11 @@ class WriteInCover(BaseModel):
     Resolved on READ, never cascaded on write. A row per leaf would duplicate
     one fact across rows that then drift -- clear one room and the others still
     close the space -- and would strand orphans behind a re-merge. There is
-    still exactly one `lodging_availability` row; this says which units it
-    covers, and `unit_id` is the row it belongs to, so a card that inherited
-    the write-in can still clear it at the source rather than dead-ending.
+    still exactly one `lodging_write_ins` row (kindred#2382 moved occupancy off
+    `lodging_availability`, which now answers only the staff<->family role);
+    this says which units it covers, and `unit_id` is the row it belongs to, so
+    a card that inherited the write-in can still clear it at the source rather
+    than dead-ending.
     """
 
     # The unit the row actually names -- NOT necessarily the unit carrying this
@@ -249,9 +251,20 @@ class LodgingUnitSummary(BaseModel):
     # CampMinder has no sub-room concept for every building. Measured over
     # 2022-2025, resolving down instead would raise 36 false alarms.
     shareability: Shareability = "unknown"
-    # None when no lodging_availability row exists for this unit this weekend,
-    # i.e. the unit's ROLE decides. None and False are different answers and
-    # must not be flattened into one: False is "closed this weekend".
+    # None when NEITHER a `lodging_availability` row nor a `lodging_write_ins`
+    # row exists for this unit this weekend, i.e. the unit's ROLE decides. None
+    # and False are different answers and must not be flattened into one: False
+    # is "closed this weekend".
+    #
+    # TWO SOURCES since kindred#2382 split the boolean's two questions apart:
+    # True comes from the availability row (a staff cabin opened to families
+    # for the weekend), and False from a write-in row (somebody is in it),
+    # which outranks the role when a unit somehow carries both. It still spells
+    # an occupancy as False deliberately -- `is_family_available`, and through
+    # it every count on the stats bar, is derived from this one field, and the
+    # board's open-tint reads False as a proxy for "is somebody in it".
+    # Disentangling the two axes on the wire is PR 4 of kindred#2382; ask
+    # `write_in` "is somebody in this space" in the meantime.
     #
     # Stated explicitly rather than implied. The rejected encoding was a row
     # meaning "the opposite of this unit's current default", which an ordinary
@@ -260,17 +273,19 @@ class LodgingUnitSummary(BaseModel):
     # WHO is in the room. A hold IS a write-in (owner ruling, kindred#2078):
     # staff do not reserve an empty cabin, they record an occupant the system
     # does not know about -- most often non-rostered weekend staff. Read
-    # straight off the availability row's `occupant_name` column, which unlike
-    # `note`/`reason` below carries the SAME name on both sides, so there is
-    # no second translation to keep in step.
+    # straight off the write-in row's `occupant_name` column (kindred#2382;
+    # the availability row's is what a RELEASE carries, which is always
+    # blank), a column that unlike `note`/`reason` below carries the SAME name
+    # on both sides, so there is no second translation to keep in step.
     #
     # Display only, like `reason`. The rule never branches on it: what closes
     # a cabin is `family_available_override`, and an occupant with no override
     # is not a state any writer can produce.
     occupant_name: str = ""
-    # Display only. The rule never branches on it. Read from the availability
-    # row's `note` column -- see the migration header on why `note` was kept
-    # rather than renamed.
+    # Display only. The rule never branches on it. Read from the `note` column
+    # of whichever row supplied the decision -- the write-in row for an
+    # occupancy, the availability row for a release -- see 1500000118's header
+    # on why `note` was kept rather than renamed.
     #
     # OPTIONAL since kindred#2078, and empty on every historical row by
     # construction: 1500000148 moved each existing note into `occupant_name`

--- a/api/services/lodging_repository.py
+++ b/api/services/lodging_repository.py
@@ -383,9 +383,10 @@ class LodgingRepository:
         write-ins come from `fetch_draft_write_ins` and REPLACE these; there
         is no overlay.
 
-        NOTHING READS THIS YET. PR 1 of kindred#2382 lands the tables and this
-        CRUD dark; `write_in_covers` still resolves write-ins out of
-        `lodging_availability` until PR 2 switches it.
+        `build_roster` and `build_summary` both read this, and `_build_units`
+        is where a row becomes the occupancy half of a unit's answer. PR 2 of
+        kindred#2382 switched them over and 1500000162 moved the rows; the
+        DRAFT sibling below is still dark until PR 3.
         """
         return await self._page(
             LODGING_WRITE_INS,
@@ -411,6 +412,12 @@ class LodgingRepository:
         writes, so a shared tier costs nothing. A write-in is an occupancy,
         the same kind of fact as a placement, so it follows the placement
         rule.
+
+        NOTHING READS THIS YET, unlike its live sibling above. PR 2 of
+        kindred#2382 moved the rows and switched the readers over to the LIVE
+        table at behavioural parity; giving write-ins their scenario dimension
+        -- this read, and the seed copies in both `copy_from_mirror` and
+        `copy_scenario_to_scenario` -- is PR 3.
 
         `scenario_id` is client-supplied and escaped, for the reason
         `fetch_draft_assignments` spells out. The weekend is named by

--- a/api/services/lodging_repository.py
+++ b/api/services/lodging_repository.py
@@ -240,15 +240,27 @@ class LodgingRepository:
         )
 
     async def fetch_availability(self, year: int, session_cm_id: int) -> list[Any]:
-        """Staff reservations and releases for one session.
+        """Staff RELEASES for one session -- the staff<->family role override.
+
+        HALF WHAT IT USED TO BE. `family_available` answered two unrelated
+        questions through one boolean, and kindred#2382 split them: `true` is a
+        staff cabin OPENED to families for this weekend, an operational fact
+        that stays here, and `false` was an OCCUPANCY -- somebody is in the
+        room -- which 1500000162 moved to `lodging_write_ins`. A reservation is
+        therefore NOT in this table any more; `fetch_write_ins` is the read for
+        it, and every `family_available = 0` row was moved out. Reading a
+        surviving one as a write-in is the mistake `write_in_covers` documents
+        at length.
 
         ONE layer, read identically with or without a scenario. 1500000135
-        dropped this table's `scenario` column: availability is a fact about
-        the WEEKEND rather than about the plan, so a burst pipe closes a cabin
-        in every scenario for that weekend and there is nothing for a scenario
+        dropped this table's `scenario` column, and that reasoning is exactly
+        right for the half that is left: a role move is a fact about the
+        WEEKEND rather than about the plan, so there is nothing for a scenario
         to disagree about. There is no companion `fetch_scenario_availability`
         to overlay on top of this, and adding one back would reintroduce the
-        last overlay in the lodging model.
+        last overlay in the lodging model. The occupancy half scopes
+        differently -- see `fetch_draft_write_ins` -- which is why it needed a
+        table rather than this one growing a column back.
         """
         return await self._page(
             LODGING_AVAILABILITY,

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -132,6 +132,18 @@ def _b(record: Any, field: str) -> bool:
     return bool(getattr(record, field, False))
 
 
+def _maybe_bool(record: Any, field: str) -> bool | None:
+    """A stored boolean, or None when there is no ROW to read it off.
+
+    NOT `_b` with a default. `_b` flattens a missing row to False, which is the
+    right answer for a column that is always present on a row that always
+    exists; here the absence of a row is a THIRD state -- "no override for this
+    weekend, so the unit's own role decides" -- and collapsing it into False
+    would close every cabin nobody has said anything about.
+    """
+    return None if record is None else _b(record, field)
+
+
 def _f(record: Any, field: str) -> float | None:
     value = getattr(record, field, None)
     try:
@@ -466,7 +478,18 @@ def resolve_combined(*, default: bool, override: bool | None, session_override: 
     return default
 
 
-def write_in_covers(units: list[LodgingUnitSummary]) -> dict[str, WriteInCover]:
+def written_in_unit_ids(write_ins: list[Any]) -> frozenset[str]:
+    """The unit ids `lodging_write_ins` names, for `write_in_covers` to walk.
+
+    Built ONCE per request and threaded, rather than re-derived inside the
+    cover walk: `_build_units` already consumes the same rows on the way to the
+    payload, and two derivations of "which units hold a write-in" are two
+    things that can disagree about one cabin.
+    """
+    return frozenset(_s(row, "unit") for row in write_ins)
+
+
+def write_in_covers(units: list[LodgingUnitSummary], write_in_unit_ids: frozenset[str]) -> dict[str, WriteInCover]:
     """Which units each write-in closes, keyed by unit code.
 
     THE UNIT A ROW NAMES IS NOT THE ONLY SPACE IT CLOSES. A write-in is a fact
@@ -489,9 +512,18 @@ def write_in_covers(units: list[LodgingUnitSummary]) -> dict[str, WriteInCover]:
     building does not then close B, because that would take a lettable room off
     the board for no reason.
 
-    Only a write-in travels. `True` is a staff cabin OPENED to families for the
-    weekend: it names no occupant and closes nothing, so inheriting it would
-    silently open every room beneath a released building.
+    Only a write-in travels. A ROLE release is a staff cabin OPENED to families
+    for the weekend: it names no occupant and closes nothing, so inheriting it
+    would silently open every room beneath a released building.
+
+    WHICH UNITS HOLD ONE IS AN INPUT, not something read off the summary
+    (kindred#2382). It used to be `family_available_override is False`, which
+    was the only spelling occupancy had while it shared
+    `lodging_availability.family_available` with the staff<->family role. The
+    two are separate tables now, so this walks the OCCUPANCY source directly and
+    a bare `false` surviving on a role row -- which names nobody, and which
+    1500000162 leaves none of -- can no longer masquerade as somebody sleeping
+    in a cabin.
 
     Cycle-guarded on both walks. The server refuses to write a parent cycle
     (#1899), but one already in the data must not spin the roster build --
@@ -511,7 +543,7 @@ def write_in_covers(units: list[LodgingUnitSummary]) -> dict[str, WriteInCover]:
         bucket.sort(key=lambda child: child.code)
 
     def _is_written_in(unit: LodgingUnitSummary) -> bool:
-        return unit.family_available_override is False
+        return unit.unit_id in write_in_unit_ids
 
     def _nearest_ancestor(unit: LodgingUnitSummary) -> LodgingUnitSummary | None:
         seen = {unit.code}
@@ -558,14 +590,14 @@ def write_in_covers(units: list[LodgingUnitSummary]) -> dict[str, WriteInCover]:
     return covers
 
 
-def _resolve_write_in_covers(units: list[LodgingUnitSummary]) -> None:
+def _resolve_write_in_covers(units: list[LodgingUnitSummary], write_in_unit_ids: frozenset[str]) -> None:
     """Attach each unit's resolved write-in cover, in place.
 
     The mutating counterpart to `write_in_covers`, mirroring
     `_resolve_power_coverage`: the pure function is what the tests reason
     about, and this is the one line the response path calls.
     """
-    covers = write_in_covers(units)
+    covers = write_in_covers(units, write_in_unit_ids)
     for unit in units:
         unit.write_in = covers.get(unit.code)
 
@@ -950,6 +982,12 @@ class LodgingRosterService:
         async with asyncio.TaskGroup() as tg:
             units_task = tg.create_task(self.repository.fetch_units(year))
             availability_task = tg.create_task(self.repository.fetch_availability(year, session_cm_id))
+            # THE OCCUPANCY HALF, split out of availability by kindred#2382.
+            # Read with NO scenario predicate, and that is not the old shape
+            # coming back: the live board is a scope in its own right, exactly
+            # as `lodging_assignments` is, and the draft twin behind this table
+            # stays dark until PR 3 gives write-ins their scenario dimension.
+            write_ins_task = tg.create_task(self.repository.fetch_write_ins(year, session_cm_id))
             attendees_task = tg.create_task(self.repository.fetch_attendees_for_session(year, session_pb_id))
             households_task = tg.create_task(self.repository.fetch_households(year))
             prior_task = tg.create_task(self.repository.fetch_prior_household_cm_ids(year))
@@ -995,9 +1033,11 @@ class LodgingRosterService:
 
         households = await self._resolve_households(session_type, attendees_task.result(), households_task.result())
 
+        write_ins = write_ins_task.result()
         unit_summaries = self._build_units(
             units_task.result(),
             availability_task.result(),
+            write_ins,
             merges_task.result(),
         )
         # ONE index, threaded to both consumers below -- see `_BathroomIndex`'s
@@ -1018,7 +1058,7 @@ class LodgingRosterService:
         # but its `WeekendSummaryEntry` carries no `units`, so resolving covers
         # there would be work no response can read -- once per weekend, across
         # every weekend of the year, on every lander request.
-        _resolve_write_in_covers(unit_summaries)
+        _resolve_write_in_covers(unit_summaries, written_in_unit_ids(write_ins))
         parties = self._build_parties(
             session_type=session_type,
             session_start=_as_date(_s(session, "start_date")),
@@ -1127,6 +1167,14 @@ class LodgingRosterService:
             entry_cm_id = _i(session, "cm_id")
             async with entry_gate, asyncio.TaskGroup() as inner:
                 availability_task = inner.create_task(self.repository.fetch_availability(year, entry_cm_id))
+                # Exactly as build_roster reads it, and separately, because
+                # this is a DIFFERENT TaskGroup -- wiring one and leaving the
+                # other is the half-fix the guards in this file's tests exist
+                # to catch. The lander keeps only counts, and every count on it
+                # goes through `is_family_available`, so a weekend card that
+                # never read this table would report a written-into cabin as
+                # open beside a board that draws it closed.
+                write_ins_task = inner.create_task(self.repository.fetch_write_ins(year, entry_cm_id))
                 attendees_task = inner.create_task(self.repository.fetch_attendees_for_session(year, session_pb_id))
                 # One placement source, exactly as build_roster chooses it.
                 placements_task = inner.create_task(
@@ -1157,6 +1205,7 @@ class LodgingRosterService:
             unit_summaries = self._build_units(
                 units,
                 availability_task.result(),
+                write_ins_task.result(),
                 merges_task.result(),
             )
             # Same one-index-per-call rule `build_roster` follows -- see the
@@ -1312,25 +1361,25 @@ class LodgingRosterService:
 
     # ---------------------------------------------------------------- units
 
-    def _build_units(self, units: list[Any], availability: list[Any], merges: list[Any]) -> list[LodgingUnitSummary]:
-        # ONE layer. The scenario overlay is gone (1500000135) -- availability
-        # is a fact about the weekend, so a scenario has nothing to overlay.
-        # `family_available` is stored EXPLICITLY, so the row IS the answer and
-        # the absence of a row falls through to the unit's role. A unit with no
-        # row must therefore map to None and not to False: those are different
-        # answers, and `bool(...)` on a missing row would silently close every
-        # cabin nobody has said anything about.
-        override_by_unit = {_s(row, "unit"): _b(row, "family_available") for row in availability}
-        # Display text travels BESIDE the decision, never into it. Stored in the
-        # `note` column (the migration header says why `note` was kept rather
-        # than renamed to `reason`); surfaced to the API as `reason`. This and
-        # `set_availability` are the only two places that translate.
-        reason_by_unit = {_s(row, "unit"): _s(row, "note") for row in availability}
-        # WHO is in the room (kindred#2078). Travels BESIDE the decision like
-        # `reason`, and translated nowhere: the column and the API field share
-        # one name, so unlike `note`/`reason` there is nothing here that can
-        # drift out of step with a writer.
-        occupant_by_unit = {_s(row, "unit"): _s(row, "occupant_name") for row in availability}
+    def _build_units(
+        self, units: list[Any], availability: list[Any], write_ins: list[Any], merges: list[Any]
+    ) -> list[LodgingUnitSummary]:
+        # TWO SOURCES, ONE FIELD, and the split between them is kindred#2382.
+        #
+        # `lodging_availability` answers the staff<->family ROLE question --
+        # "a staff cabin opened to families for this weekend" -- and keeps its
+        # no-scenario shape, because that is an operational fact about the
+        # WEEKEND and 1500000135's reasoning is exactly right for it.
+        # `lodging_write_ins` answers OCCUPANCY: somebody is in the room. That
+        # is a modelling fact (not every write-in is non-rostered staff -- some
+        # are paper registrations for families arriving with no children), so it
+        # got a table of its own with a draft twin waiting behind it.
+        #
+        # ONE layer each. There is still no scenario overlay: a scenario reads
+        # the same live rows it does today, and PR 3 of kindred#2382 is what
+        # gives the occupancy half its scenario dimension.
+        role_row_by_unit = {_s(row, "unit"): row for row in availability}
+        write_in_row_by_unit = {_s(row, "unit"): row for row in write_ins}
 
         # id -> code, so the parent relation can be published as a code.
         code_by_id = {_s(unit, "id"): _s(unit, "code") for unit in units}
@@ -1364,10 +1413,43 @@ class LodgingRosterService:
             group = _s(unit, "bathroom_group")
             area = (getattr(unit, "expand", None) or {}).get("area")
             inventory_class = _s(unit, "inventory_class")
-            override = override_by_unit.get(_s(unit, "id"))
+            unit_id = _s(unit, "id")
+            role_row = role_row_by_unit.get(unit_id)
+            write_in_row = write_in_row_by_unit.get(unit_id)
+            # `family_available_override` STILL SPELLS AN OCCUPANCY AS False,
+            # and that is deliberate rather than left over. Every count on the
+            # stats bar goes through `is_family_available`, which is derived
+            # from this one field, and the board's own open-tint reads `false`
+            # as a proxy for "is somebody in it" -- so a write-in that stopped
+            # spelling itself here would silently return an occupied cabin to
+            # the open count. Disentangling the two axes on the wire is PR 4 of
+            # kindred#2382; this PR moves the STORAGE and nothing a user can
+            # see.
+            #
+            # Occupancy OUTRANKS the role when a unit somehow carries both.
+            # No writer produces that pair -- `set_availability` clears the
+            # other fact on every write -- but two staff racing on one cabin
+            # can, and the safe answer is the closed one: reading the release
+            # instead would open a cabin with somebody sleeping in it.
+            #
+            # A unit with NEITHER row maps to None, never False: those are
+            # different answers, and `bool(...)` on a missing row would close
+            # every cabin nobody has said anything about.
+            override = False if write_in_row is not None else _maybe_bool(role_row, "family_available")
+            # Display text travels BESIDE the decision, never into it, and it
+            # comes from whichever row supplied the decision. Stored in the
+            # `note` column (1500000118's header says why `note` was kept
+            # rather than renamed to `reason`); surfaced to the API as
+            # `reason`. This and `set_availability` are the only two places
+            # that translate.
+            #
+            # WHO is in the room (kindred#2078) is translated nowhere: the
+            # column and the API field share one name, so unlike `note`/`reason`
+            # there is nothing here that can drift out of step with a writer.
+            source_row = write_in_row if write_in_row is not None else role_row
             summaries.append(
                 LodgingUnitSummary(
-                    unit_id=_s(unit, "id"),
+                    unit_id=unit_id,
                     code=code,
                     name=_s(unit, "name"),
                     area_code=_s(area, "code") if area is not None else "",
@@ -1405,8 +1487,8 @@ class LodgingRosterService:
                     parent_code=code_by_id.get(_s(unit, "parent_unit"), ""),
                     is_combined=resolve_combined(
                         default=_b(unit, "default_combined"),
-                        override=scenario_merge_by_unit.get(_s(unit, "id")),
-                        session_override=session_merge_by_unit.get(_s(unit, "id")),
+                        override=scenario_merge_by_unit.get(unit_id),
+                        session_override=session_merge_by_unit.get(unit_id),
                     ),
                     inventory_class=inventory_class,
                     # cast, not a re-derivation: `unit_shareability` is total
@@ -1415,8 +1497,12 @@ class LodgingRosterService:
                     # to the Literal on its own.
                     shareability=cast(Shareability, unit_shareability(_s(unit, "shareability"))),
                     family_available_override=override,
-                    occupant_name=occupant_by_unit.get(_s(unit, "id"), ""),
-                    reason=reason_by_unit.get(_s(unit, "id"), ""),
+                    # `_s` is total over a missing row -- `getattr(None, ..., "")`
+                    # -- so "no row at either source" reads as blank without a
+                    # second branch. `_maybe_bool` above needs its own, because
+                    # blank is not one of the three answers the decision has.
+                    occupant_name=_s(source_row, "occupant_name"),
+                    reason=_s(source_row, "note"),
                     is_family_available=is_family_available(inventory_class, override),
                     map_x=map_x,
                     map_y=map_y,

--- a/api/services/lodging_write_service.py
+++ b/api/services/lodging_write_service.py
@@ -1,7 +1,10 @@
 """Writes for the weekend lodging board.
 
-EVERY write here targets the DRAFT grain, or `lodging_availability`. No write
-in this module can reach `lodging_assignments`, `lodging_assignment_history` or
+EVERY write here targets the DRAFT grain, `lodging_availability`, or
+`lodging_write_ins` -- the occupancy table kindred#2382 split out of
+availability, whose LIVE rows the board writes directly, because the live board
+is a scope in its own right rather than the absence of one. No write in this
+module can reach `lodging_assignments`, `lodging_assignment_history` or
 `lodging_field_mappings`: those belong to the CampMinder ingest, stay
 `is_admin` in PocketBase (1500000132), and are the reason the draft tables
 exist at all. Summer draws the identical line and has never crossed it.
@@ -36,6 +39,7 @@ is choosing, which is the board. Not here, and not in the ingest.
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
 from pocketbase.client import ClientResponseError  # type: ignore[attr-defined]
@@ -558,70 +562,174 @@ class LodgingWriteService:
         )
         return LodgingCopyResponse(copied=copied, skipped=skipped)
 
+    async def _clear_row(self, existing: Any | None, delete: Callable[[str], Awaitable[None]]) -> tuple[str, bool]:
+        """Drop one row if it is there, and say what happened.
+
+        The find above sees the row, but it can vanish before the delete
+        reaches PocketBase -- two staff clearing the same unit, or a
+        double-click. ONLY 404 is swallowed, exactly as `unplace_party`'s
+        delete swallows it; any other failure keeps its status through
+        `pb_error_to_http`, because "the delete was refused" must not read as
+        "there was nothing to delete".
+
+        Shared by both halves of `set_availability` since kindred#2382 split
+        the table in two. Two copies of a swallow-only-404 rule is two chances
+        to widen one of them.
+        """
+        if existing is None:
+            return "", False
+        record_id = str(existing.id)
+        try:
+            await delete(record_id)
+        except ClientResponseError as exc:
+            if exc.status == 404:
+                return record_id, False
+            raise pb_error_to_http(exc) from exc
+        return record_id, True
+
+    async def _upsert_row(
+        self,
+        *,
+        what: str,
+        existing: Any | None,
+        data: dict[str, Any],
+        find: Callable[[], Awaitable[Any | None]],
+        create: Callable[[dict[str, Any]], Awaitable[Any]],
+        update: Callable[[str, dict[str, Any]], Awaitable[Any]],
+        **context: Any,
+    ) -> Any:
+        """Create or update one row, recovering a lost unique-index race.
+
+        The find and the create are two round trips, so they RACE: two staff
+        writing the same unit for the same weekend both find no row, both
+        create, and the unique index rejects the loser. Unguarded that is a
+        400 out of `pb_error_to_http` for a write the board is entitled to
+        make, so the loser re-reads and updates the winner's row -- which by
+        construction is the row this call wanted, same weekend and same unit.
+
+        `REFUSAL_STATUSES` are re-raised rather than retried: a 401/403 is an
+        answer, not a race, and re-reading would turn "you may not" into a
+        second failure with a worse message.
+
+        The recovery's own two calls are guarded the same way `place_party`'s
+        are, and for the same reason: a failure inside the except block is the
+        very 500 the block exists to prevent.
+
+        ONE implementation for both halves of the split (kindred#2382). The
+        occupancy row and the role row live in different tables with the same
+        race, and duplicating twenty lines of recovery is how the two come to
+        answer a lost race differently.
+        """
+        if existing is not None:
+            try:
+                return await update(str(existing.id), data)
+            except ClientResponseError as exc:
+                raise pb_error_to_http(exc) from exc
+        try:
+            return await create(data)
+        except ClientResponseError as exc:
+            if exc.status in REFUSAL_STATUSES:
+                raise pb_error_to_http(exc) from exc
+            try:
+                raced = await find()
+                if raced is None:
+                    raise pb_error_to_http(exc) from exc
+                record = await update(str(raced.id), data)
+                self._log_recovered_race(what, exc, **context)
+                return record
+            except ClientResponseError as retry_exc:
+                raise pb_error_to_http(retry_exc) from retry_exc
+
     async def set_availability(self, request: AvailabilityWriteRequest) -> LodgingWriteResponse:
-        """Reserve or release one unit for this weekend.
+        """Write somebody into one unit for this weekend, or release one to families.
 
-        NO SCENARIO. 1500000135 deleted this table's scenario dimension --
-        availability is a fact about the weekend, not about the plan, since a
-        burst pipe closes a cabin in every scenario for that weekend.
+        ONE ENDPOINT, TWO TABLES since kindred#2382, and which one it writes
+        depends on which question the body is answering:
 
-        `family_available: null` DELETES the row rather than writing a value
-        meaning "normal". There is no such value: the absence of a row is what
-        "whatever this unit's role says" is spelled as, and writing a value
-        that happens to agree with the role would pin the unit against a later
-        change to it.
+        | `family_available` | fact      | table                          |
+        |--------------------|-----------|--------------------------------|
+        | `false`            | OCCUPANCY | `lodging_write_ins`            |
+        | `true`             | ROLE      | `lodging_availability`         |
+        | `null`             | clear     | both -- delete whichever exist |
+
+        The column used to answer both through one boolean. `true` on a staff
+        cabin is a staff<->family ROLE override for the weekend, which the
+        owner ruled is NOT scenario-scoped -- "that's more of a known 'were
+        moving staff to X for weekend Y'" -- and 1500000135's "availability is
+        a fact about the WEEKEND, not about the plan" is exactly right for it,
+        which is why that half stays put and keeps its no-scenario shape.
+        `false` was an OCCUPANCY, and that IS scenario-scoped: not every
+        write-in is non-rostered staff, some are paper registrations for
+        families arriving with no children, and a modelling choice belongs to
+        the scenario that made it.
+
+        NO SCENARIO ON THE REQUEST, still. The live board is a scope in its own
+        right (owner, 2026-08-15: staff must be able to record a write-in on
+        the real board, not only inside a modelling sandbox), so this writes
+        the LIVE occupancy table with no scenario predicate, exactly as
+        `lodging_assignments` has none. The draft twin behind it stays dark
+        until PR 3 of kindred#2382.
+
+        ONE FACT AT A TIME, and this is the promise the split has to keep
+        deliberately. A single row could only ever hold one of the two, so
+        writing an occupancy over a release replaced it; with two tables
+        nothing removes the loser unless this does. Hence the drop after each
+        write.
+
+        ORDER: the new fact is written BEFORE the old one is dropped. There is
+        no transaction across two PocketBase tables, and a failure between the
+        steps has to leave the board saying something true. Write-then-drop
+        leaves both rows present for that window, and `_build_units` resolves
+        occupancy over role -- so a half-applied write-in still reads "somebody
+        is in it", the safe half. Drop-then-write would leave a window with
+        NEITHER fact, opening a cabin nobody meant to open.
+
+        `family_available: null` DELETES rather than writing a value meaning
+        "normal". There is no such value: the absence of a row is how "whatever
+        this unit's role says" is spelled, and writing a value that happens to
+        agree with the role would pin the unit against a later change to it.
+        With two tables it deletes BOTH, or a clear would silently do nothing
+        to whichever fact it missed.
 
         `reason` is written to the `note` COLUMN. This and `_build_units` are
-        the only two places that translate between the two names -- see
-        AvailabilityWriteRequest.
+        still the only two places that translate -- the fact moved tables and
+        did not gain a third translation site.
 
         `occupant_name` is written UNTRANSLATED, because a hold IS a write-in
         (owner ruling, kindred#2078) and the column was added for it under the
         name the API already wanted. It is required through the control and
         optional here; see the schema for why the requirement lives there.
-
-        Both the delete and the create below race the same way the placement
-        writes do, and are guarded the same two ways.
-
-        The delete: the find above sees the row, but it can vanish before the
-        delete reaches PocketBase -- two staff releasing the same unit, or a
-        double-click. ONLY 404 is swallowed, exactly as unplace_party's
-        delete is; any other failure keeps its status through pb_error_to_http.
-
-        The create: `idx_lodging_avail_unique` is UNIQUE on (session_cm_id,
-        year, unit) since 1500000147, so two staff reserving the same unit for
-        the same weekend both
-        find no override, both create, and the index rejects the loser. That is
-        exactly the race place_party guards on the draft's own partial unique
-        index, guarded the identical way -- the loser re-reads and updates the
-        winner's row, which is by construction the row this call wanted: same
-        session, same year, same unit. The recovery's own two calls are guarded
-        the same way place_party's are, for the same reason: a failure inside
-        the except block is the very 500 the block exists to prevent.
         """
         session_pb_id = await self._resolve_session_pb_id(request.year, request.session_cm_id)
 
-        existing = await self.repository.find_availability_override(
+        # BOTH lookups on every call, because every branch has to know about
+        # the fact it is NOT writing: an occupancy has a release to drop, a
+        # release has an occupancy to drop, and a clear has both.
+        existing_role = await self.repository.find_availability_override(
             request.year, request.session_cm_id, request.unit_id
         )
+        existing_write_in = await self.repository.find_write_in(request.year, request.session_cm_id, request.unit_id)
 
         if request.family_available is None:
-            if existing is None:
-                return LodgingWriteResponse(deleted=False)
-            try:
-                await self.repository.delete_availability(str(existing.id))
-            except ClientResponseError as exc:
-                if exc.status == 404:
-                    return LodgingWriteResponse(record_id=str(existing.id), deleted=False)
-                raise pb_error_to_http(exc) from exc
-            return LodgingWriteResponse(record_id=str(existing.id), deleted=True)
+            write_in_id, write_in_deleted = await self._clear_row(existing_write_in, self.repository.delete_write_in)
+            role_id, role_deleted = await self._clear_row(existing_role, self.repository.delete_availability)
+            # The occupancy id is reported in preference to the role id when
+            # both were there. It is the one the board was almost certainly
+            # looking at -- every row this split moved was an occupancy -- and
+            # a response can only name one.
+            return LodgingWriteResponse(
+                record_id=write_in_id or role_id,
+                deleted=write_in_deleted or role_deleted,
+            )
 
+        # The fields both tables share. `family_available` is deliberately NOT
+        # among them: on the occupancy table the ROW is the fact, and a column
+        # restating it would be the conflation growing back.
         data: dict[str, Any] = {
             "session": session_pb_id,
             "session_cm_id": request.session_cm_id,
             "year": request.year,
             "unit": request.unit_id,
-            "family_available": request.family_available,
             # WHO is in the room (kindred#2078). No translation: the API field
             # and the column share one name, so this is the whole of it.
             "occupant_name": request.occupant_name,
@@ -630,35 +738,40 @@ class LodgingWriteService:
             "note": request.reason,
         }
 
-        if existing is not None:
-            # Same shape as `place_party`'s update branch above, and refused
-            # the same way -- see the note there.
-            try:
-                record = await self.repository.update_availability(str(existing.id), data)
-            except ClientResponseError as exc:
-                raise pb_error_to_http(exc) from exc
+        # `is True`, never truthiness. `None` is already handled above, so a
+        # bare test would in fact be correct here -- and this file's own rule
+        # is that the three values of this field are never read for
+        # truthiness, because the one place that starts is the place a later
+        # edit folds a write-in into a clear.
+        if request.family_available is True:
+            record = await self._upsert_row(
+                what="availability",
+                existing=existing_role,
+                data={**data, "family_available": True},
+                find=lambda: self.repository.find_availability_override(
+                    request.year, request.session_cm_id, request.unit_id
+                ),
+                create=self.repository.create_availability,
+                update=self.repository.update_availability,
+                year=request.year,
+                session_cm_id=request.session_cm_id,
+                unit_id=request.unit_id,
+            )
+            await self._clear_row(existing_write_in, self.repository.delete_write_in)
         else:
-            try:
-                record = await self.repository.create_availability(data)
-            except ClientResponseError as exc:
-                if exc.status in REFUSAL_STATUSES:
-                    raise pb_error_to_http(exc) from exc
-                try:
-                    raced = await self.repository.find_availability_override(
-                        request.year, request.session_cm_id, request.unit_id
-                    )
-                    if raced is None:
-                        raise pb_error_to_http(exc) from exc
-                    record = await self.repository.update_availability(str(raced.id), data)
-                    self._log_recovered_race(
-                        "availability",
-                        exc,
-                        year=request.year,
-                        session_cm_id=request.session_cm_id,
-                        unit_id=request.unit_id,
-                    )
-                except ClientResponseError as retry_exc:
-                    raise pb_error_to_http(retry_exc) from retry_exc
+            record = await self._upsert_row(
+                what="write-in",
+                existing=existing_write_in,
+                data=data,
+                find=lambda: self.repository.find_write_in(request.year, request.session_cm_id, request.unit_id),
+                create=self.repository.create_write_in,
+                update=self.repository.update_write_in,
+                year=request.year,
+                session_cm_id=request.session_cm_id,
+                unit_id=request.unit_id,
+            )
+            await self._clear_row(existing_role, self.repository.delete_availability)
+
         return LodgingWriteResponse(record_id=str(getattr(record, "id", "")))
 
     async def set_slot_merge(self, request: SlotMergeRequest) -> LodgingWriteResponse:

--- a/frontend/src/components/weekend/UnitAvailabilityControl.tsx
+++ b/frontend/src/components/weekend/UnitAvailabilityControl.tsx
@@ -61,11 +61,12 @@ export interface UnitAvailabilityWrite {
    *
    * A write-in covers a space and the board draws whichever level the unit
    * tree resolves to, so a room can inherit its building's write-in and a
-   * merged building one of its rooms'. There is one `lodging_availability` row
-   * either way, and clearing it has to target the unit that HOLDS it — the
-   * card's own id would delete nothing, and the unit holding the row has no
-   * card to offer the clear from. `availabilityAction` resolves which; this
-   * only carries it.
+   * merged building one of its rooms'. There is one `lodging_write_ins` row
+   * either way (kindred#2382 moved occupancy off `lodging_availability`, which
+   * now answers only the staff↔family role), and clearing it has to target the
+   * unit that HOLDS it — the card's own id would delete nothing, and the unit
+   * holding the row has no card to offer the clear from. `availabilityAction`
+   * resolves which; this only carries it.
    */
   unitId: string
   /** That unit's name, for the confirmation toast. */

--- a/frontend/src/components/weekend/rosterAttention.ts
+++ b/frontend/src/components/weekend/rosterAttention.ts
@@ -248,9 +248,10 @@ export function indexUnitsByCode(units: LodgingUnitRow[]): Map<string, LodgingUn
  * `is_family_available` and drops a cabin somebody has been written into this
  * weekend. `units_capacity_unknown` asks about the planning inventory, which
  * includes that cabin because it returns next weekend. They diverge the moment
- * anything is written into — and things are: `lodging_availability` DOES hold
- * rows in production, which the old claim here ("has never held a row") got
- * wrong. It was measured against a development database and never re-checked.
+ * anything is written into — and things are: the write-in table DOES hold rows
+ * in production (all 21, moved out of `lodging_availability` by 1500000162),
+ * which the old claim here ("has never held a row") got wrong. It was measured
+ * against a development database and never re-checked.
  *
  * It sits beside the BED count on the stats bar, and beds there are
  * `beds_family_available`, so the available-only reading is the one that

--- a/frontend/src/components/weekend/unitBadges.ts
+++ b/frontend/src/components/weekend/unitBadges.ts
@@ -249,8 +249,10 @@ export interface AvailabilityAction {
    *
    * A write-in covers a space, and the board draws whichever level the tree
    * resolves to — so a room can inherit its building's write-in, and a merged
-   * building one of its rooms'. There is exactly one `lodging_availability`
-   * row either way, and clearing it has to target the unit that HOLDS it:
+   * building one of its rooms'. There is exactly one `lodging_write_ins` row
+   * either way (kindred#2382 split occupancy off `lodging_availability`, which
+   * now answers only the staff↔family role), and clearing it has to target the
+   * unit that HOLDS it:
    * sending the card's own id would delete nothing, and the unit holding the
    * row has no card to offer the clear from. Every other action names the
    * card's own unit.

--- a/frontend/src/components/weekend/writeIn.test.ts
+++ b/frontend/src/components/weekend/writeIn.test.ts
@@ -7,8 +7,8 @@
  * `held`, and a rename alone would have left the tint keyed on a spelling
  * rather than on the fact.
  *
- * Fictional data throughout. Production `lodging_availability` notes are real
- * family and staff names; nothing here is dumped from any database.
+ * Fictional data throughout. Production write-in notes are real family and
+ * staff names; nothing here is dumped from any database.
  */
 import { describe, expect, it } from 'vitest'
 

--- a/frontend/src/components/weekend/writeIn.ts
+++ b/frontend/src/components/weekend/writeIn.ts
@@ -61,7 +61,7 @@ export function writeInOccupant(unit: LodgingUnitRow): WriteInOccupant | null {
 
 /** Where a unit's write-in is recorded, or `null` if none covers it. */
 export interface WriteInSource {
-  /** The unit the `lodging_availability` row belongs to — a clear's target. */
+  /** The unit the `lodging_write_ins` row belongs to — a clear's target. */
   unitId: string
   unitCode: string
   unitName: string

--- a/frontend/src/services/lodgingApi.ts
+++ b/frontend/src/services/lodgingApi.ts
@@ -164,7 +164,11 @@ export async function unplaceParty(
 export interface AvailabilityWrite {
   year: number
   sessionCmId: number
-  /** The unit's PocketBase id, which is what `lodging_availability.unit` relates to. */
+  /**
+   * The unit's PocketBase id, which is what the `unit` relation on whichever
+   * table receives this write points at — `lodging_write_ins` for a write-in,
+   * `lodging_availability` for a release (kindred#2382).
+   */
   unitId: string
   /**
    * THREE values, not two. `false` closes the unit for this weekend, `true`
@@ -187,9 +191,15 @@ export interface AvailabilityWrite {
 }
 
 /**
- * Reserve or release one unit for one weekend.
+ * Write somebody into one unit for one weekend, or release one to families.
  *
- * Takes NO scenario, unlike every other write on this client. Availability is
+ * ONE ENDPOINT, TWO TABLES behind it since kindred#2382, and the request shape
+ * is unchanged by that: `false` is an OCCUPANCY and is stored in
+ * `lodging_write_ins`, `true` is a staff↔family ROLE override for the weekend
+ * and stays in `lodging_availability`, and `null` clears both. The server
+ * decides; nothing here has to.
+ *
+ * Takes NO scenario, unlike every other write on this client. The role half is
  * a fact about the WEEKEND rather than about the plan — a burst pipe closes a
  * cabin in every scenario for that weekend — so 1500000135 deleted the
  * dimension and `AvailabilityWriteRequest` stopped extending

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -7179,9 +7179,11 @@ export type WeeklyDataPoint = {
  * Resolved on READ, never cascaded on write. A row per leaf would duplicate
  * one fact across rows that then drift -- clear one room and the others still
  * close the space -- and would strand orphans behind a re-merge. There is
- * still exactly one `lodging_availability` row; this says which units it
- * covers, and `unit_id` is the row it belongs to, so a card that inherited
- * the write-in can still clear it at the source rather than dead-ending.
+ * still exactly one `lodging_write_ins` row (kindred#2382 moved occupancy off
+ * `lodging_availability`, which now answers only the staff<->family role);
+ * this says which units it covers, and `unit_id` is the row it belongs to, so
+ * a card that inherited the write-in can still clear it at the source rather
+ * than dead-ending.
  */
 export type WriteInCover = {
   /**

--- a/pocketbase/pb_migrations/1500000162_lodging_write_ins_backfill.js
+++ b/pocketbase/pb_migrations/1500000162_lodging_write_ins_backfill.js
@@ -1,0 +1,145 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Move write-in OCCUPANCY out of lodging_availability — kindred#2382, PR 2 of 4.
+ *
+ * 1500000161 created `lodging_write_ins` and `lodging_write_ins_draft` empty
+ * and dark. This is the migration that moves the rows, and the same change
+ * switches every reader and the write path over to them. After it,
+ * `lodging_availability` holds ONLY the staff<->family role override.
+ *
+ * ── WHAT MOVES, AND WHAT IS LEFT BEHIND ─────────────────────────────────────
+ *
+ * `family_available` answered two unrelated questions through one boolean:
+ *
+ *   true  -> a staff cabin OPENED to families for this weekend. A ROLE
+ *            override. Names no occupant. NOT scenario-scoped (owner ruling,
+ *            2026-08-15: "that's more of a known 'were moving staff to X for
+ *            weekend Y'"). STAYS.
+ *   false -> somebody is in the room. An OCCUPANCY. The write-in. Scenario-
+ *            scoped, because not every write-in is non-rostered staff — some
+ *            are paper registrations for families arriving with no children,
+ *            and a modelling choice belongs to the scenario that made it.
+ *            MOVES.
+ *   no row -> the unit's own role decides. Nothing to move.
+ *
+ * The predicate below is therefore `family_available = 0`, and every column it
+ * carries across (unit, session, session_cm_id, year, occupant_name, note)
+ * exists on the destination with the same name, type and limits — 1500000161
+ * mirrored the source schema deliberately so this step has no per-column
+ * judgement to make.
+ *
+ * ⚠️ MEASURED, AND THE MEASUREMENT IS THE REASON THIS IS SAFE. All 21 rows in
+ * `lodging_availability` in the production snapshot are `family_available = 0`
+ * — every one an occupancy, none a role. So the split moves all 21 and leaves
+ * the table EMPTY. Stated plainly rather than described as a partition,
+ * because pretending it splits a populated table two ways would misdescribe
+ * what a reviewer will see afterwards: no ROLE row exists in production today,
+ * and the role half of the table is live capability with no current rows, not
+ * a preserved population.
+ *
+ * ── IDEMPOTENT, AND NON-DESTRUCTIVE IN THAT ORDER ───────────────────────────
+ *
+ * Two guarded statements, and the order is the whole safety argument:
+ *
+ *   1. INSERT the occupancy rows that are not already there, keyed on the
+ *      destination's own unique index (session_cm_id, year, unit) so a re-run
+ *      matches nothing and a half-applied run can still finish. The row's `id`
+ *      travels with it, which keeps the move traceable and means a second run
+ *      cannot mint a duplicate under a fresh id.
+ *   2. DELETE from the source ONLY the rows a copy provably exists for. A row
+ *      that failed to insert for any reason is still in `lodging_availability`
+ *      afterwards, where the read path still understands it, rather than gone.
+ *
+ * This satisfies the standing "no destructive data migrations" rule: nothing
+ * is removed before it is proven saved somewhere else.
+ *
+ * ── WHY RAW SQL ─────────────────────────────────────────────────────────────
+ *
+ * Same idiom as 1500000148's own backfill, and for the same reasons: a
+ * predicate over the table names nobody, so it cannot leak a camper or staff
+ * name into this directory (which `verify-no-hardcoded-lodging.sh` scans) and
+ * cannot go stale as rows arrive. It also carries `created`/`updated` across
+ * unchanged, so the moved row keeps the day staff actually recorded it instead
+ * of reporting itself as written by the migration.
+ *
+ * `family_available` is a PocketBase boolean, which SQLite stores as 0/1; the
+ * production snapshot holds 0 on all 21 rows.
+ *
+ * ── DOWN ────────────────────────────────────────────────────────────────────
+ *
+ * The exact inverse, in the mirrored order: put the rows back as
+ * `family_available = 0`, then drop the ones proven copied. It moves EVERY
+ * live write-in back, not only the ones this migration brought in, and that is
+ * correct — down means "occupancy lives in `lodging_availability` again", so a
+ * write-in recorded after this migration has to travel back with the rest or
+ * it would vanish from a board that still expects to find it.
+ *
+ * `lodging_write_ins_draft` is deliberately untouched by both directions. It is
+ * still dark in this PR — nothing writes it and nothing reads it — and it has a
+ * `scenario` column `lodging_availability` has nowhere to put. PR 3, which
+ * starts filling it, owns its down path.
+ */
+
+migrate(
+  (app) => {
+    // 1 — the occupancy rows move. Guarded on the destination's unique key so
+    // a re-run inserts nothing, and a run that was interrupted part-way can
+    // still finish the remainder.
+    app
+      .db()
+      .newQuery(
+        'INSERT INTO lodging_write_ins ' +
+          '(id, created, updated, unit, session, session_cm_id, year, occupant_name, note) ' +
+          'SELECT a.id, a.created, a.updated, a.unit, a.session, a.session_cm_id, a.year, ' +
+          'a.occupant_name, a.note ' +
+          'FROM lodging_availability a ' +
+          'WHERE a.family_available = 0 AND NOT EXISTS (' +
+          'SELECT 1 FROM lodging_write_ins w ' +
+          'WHERE w.session_cm_id = a.session_cm_id AND w.year = a.year AND w.unit = a.unit)'
+      )
+      .execute();
+
+    // 2 — and only then does the source row go. EXISTS is the proof the string
+    // is already saved somewhere else; a row whose insert did not land keeps
+    // its home rather than being deleted into nothing.
+    app
+      .db()
+      .newQuery(
+        'DELETE FROM lodging_availability ' +
+          'WHERE family_available = 0 AND EXISTS (' +
+          'SELECT 1 FROM lodging_write_ins w ' +
+          'WHERE w.session_cm_id = lodging_availability.session_cm_id ' +
+          'AND w.year = lodging_availability.year AND w.unit = lodging_availability.unit)'
+      )
+      .execute();
+  },
+  (app) => {
+    // The inverse, in the mirrored order: restore first, prove, then remove.
+    app
+      .db()
+      .newQuery(
+        'INSERT INTO lodging_availability ' +
+          '(id, created, updated, unit, session, session_cm_id, year, family_available, ' +
+          'occupant_name, note) ' +
+          'SELECT w.id, w.created, w.updated, w.unit, w.session, w.session_cm_id, w.year, 0, ' +
+          'w.occupant_name, w.note ' +
+          'FROM lodging_write_ins w ' +
+          'WHERE NOT EXISTS (' +
+          'SELECT 1 FROM lodging_availability a ' +
+          'WHERE a.session_cm_id = w.session_cm_id AND a.year = w.year AND a.unit = w.unit)'
+      )
+      .execute();
+
+    app
+      .db()
+      .newQuery(
+        'DELETE FROM lodging_write_ins ' +
+          'WHERE EXISTS (' +
+          'SELECT 1 FROM lodging_availability a ' +
+          'WHERE a.session_cm_id = lodging_write_ins.session_cm_id ' +
+          'AND a.year = lodging_write_ins.year AND a.unit = lodging_write_ins.unit ' +
+          'AND a.family_available = 0)'
+      )
+      .execute();
+  }
+);

--- a/scripts/dev/test-verify-consolidation.sh
+++ b/scripts/dev/test-verify-consolidation.sh
@@ -54,17 +54,47 @@ if [[ ${#migrations[@]} -eq 0 ]]; then
   exit 1
 fi
 cp "${migrations[@]}" "$SCRATCH/modified/"
-# Produce reliable structural drift by omitting the LAST migration
-# (lexicographically highest .js file). Bash globs sort alphabetically,
-# so the array's last element is the tail file. Picked dynamically so
-# this test survives consolidation rounds that absorb the previous tail.
-# Caveat: this assumes the tail migration produces some structural diff
-# when removed. If a future tail migration is purely a no-op-on-fresh-DB
-# (e.g. fully overwritten by a later mutation), this test could go green
-# spuriously — the harness's smoke check still guarantees something was
-# applied, but the drift signal would be weak.
-LAST_MIGRATION=$(basename "${migrations[-1]}")
-rm "$SCRATCH/modified/$LAST_MIGRATION"
+# Produce reliable structural drift by truncating the migration list at the
+# newest migration that actually CHANGES THE SCHEMA, dropping it and
+# everything after it.
+#
+# Two constraints force that shape, and each one broke a simpler version:
+#
+#  1. The tail is not necessarily structural. Bash globs sort alphabetically
+#     so `migrations[-1]` is the newest file, but 1500000162 is a pure DATA
+#     backfill -- it moves rows between two collections that already exist
+#     and alters no schema. Dropping it leaves byte-identical schemas, the
+#     verifier correctly exits 0, and this test fails while nothing is wrong.
+#     (The previous revision predicted exactly this in a caveat, unhandled.)
+#
+#  2. A migration cannot be removed from the MIDDLE. Dropping 1500000161 --
+#     which creates `lodging_write_ins` -- while leaving 1500000162, which
+#     backfills into it, makes the chain error out: the harness reports
+#     exit 2 rather than the exit 1 this test asserts.
+#
+# Removing a SUFFIX is always chain-safe, because a prefix of an ordered
+# migration set is exactly what a younger database has already applied. The
+# remaining set applies cleanly, and the dropped structural migration
+# guarantees the schema differs. This keeps the end-to-end "drift in a REAL
+# migration" intent -- these are unmodified repo migrations -- while
+# surviving any number of data-only migrations landing on the tail.
+structural_re='new Collection\(|deleteCollection|fields\.add|fields\.remove|addIndex|removeIndex|\.indexes'
+cut_index=-1
+for (( i=${#migrations[@]}-1; i>=0; i-- )); do
+  if grep -Eq "$structural_re" "${migrations[i]}"; then
+    cut_index=$i
+    break
+  fi
+done
+if [[ $cut_index -lt 1 ]]; then
+  echo "FAIL: no structural migration found after index 0 in $MIGRATIONS_DIR;" >&2
+  echo "      cannot truncate to produce drift while leaving a non-empty set" >&2
+  exit 1
+fi
+for (( i=cut_index; i<${#migrations[@]}; i++ )); do
+  rm "$SCRATCH/modified/$(basename "${migrations[i]}")"
+done
+echo "  (dropped $(( ${#migrations[@]} - cut_index )) migration(s) from $(basename "${migrations[cut_index]}") onward -- newest schema change and its dependents)"
 set +e
 "$VERIFY_SCRIPT" "$SCRATCH/modified" "$MIGRATIONS_DIR" >/dev/null 2>"$SCRATCH/t2.err"
 rc=$?

--- a/scripts/dev/verify-writein-table-backfill.sh
+++ b/scripts/dev/verify-writein-table-backfill.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Proves 1500000162's write-in SPLIT against a REAL PocketBase boot.
+#
+# kindred#2382: `lodging_availability.family_available` answered two unrelated
+# questions through one boolean. `true` is a staff<->family ROLE override for
+# the weekend and stays; `false` was an OCCUPANCY -- somebody is in the room --
+# and moves to `lodging_write_ins`, which 1500000161 created empty.
+#
+# A green `go test ./...` never proves the PocketBase binary boots, and a
+# fresh-DB schema check can never prove a backfill PRESERVES anything -- there
+# is nothing in a fresh DB to preserve. So this boots twice: once WITHOUT
+# 1500000162 to get a pre-split pair of tables, seeds synthetic rows into the
+# source, then boots again WITH the migration and asserts what happened to each
+# row. A third boot runs a copy of the migration under a later filename, which
+# is the only honest way to test re-runnability when `_migrations` keys on the
+# filename.
+#
+# Every seeded value is FICTIONAL. Production occupant names are real family
+# and staff names and must never be dumped into a fixture (CLAUDE.md section 4).
+#
+# Exit codes: 0 = all assertions passed. 1 = one or more FAILED. 2 = could not
+# run the check at all. Assertions do not short-circuit.
+set -euo pipefail
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib/pb-harness.sh
+source "$HERE/lib/pb-harness.sh"
+
+pb_harness_require_tools
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+PB_BIN="$REPO_ROOT/pocketbase/pocketbase"
+MIG_DIR="$REPO_ROOT/pocketbase/pb_migrations"
+MIGRATION="1500000162_lodging_write_ins_backfill.js"
+CREATE_MIGRATION="1500000161_lodging_write_ins.js"
+
+for f in "$MIGRATION" "$CREATE_MIGRATION"; do
+  [[ -f "$MIG_DIR/$f" ]] || { echo "error: $f not found in $MIG_DIR" >&2; exit 2; }
+done
+
+# The registry loader (pocketbase/main.go) runs as a serve hook and ABORTS THE
+# BOOT with "lodging registry file present but no season is resolvable" when it
+# finds ./config/lodging_registry.json and no season. Every dev checkout that
+# ran setup-local-config.sh has that symlink, so running this from the repo
+# root -- the normal thing -- would make the boot fail and this script exit 2
+# without testing anything. Nothing here reads the registry; the year only has
+# to exist. Defaulted rather than forced, so a caller's own season still wins.
+export CAMPMINDER_SEASON_ID="${CAMPMINDER_SEASON_ID:-2026}"
+
+echo ">> building pocketbase binary..."
+pb_harness_build_binary "$REPO_ROOT/pocketbase" "$PB_BIN"
+
+SCRATCH=$(mktemp -d)
+# shellcheck disable=SC2016  # deliberate: $SCRATCH expands when the trap fires, not here
+pb_harness_install_trap 'rm -rf "$SCRATCH"'
+
+# The migration set as it stood BEFORE this change: everything but 162. 161 is
+# kept, because the destination tables have to exist for a "before" state to be
+# the state this migration actually meets.
+BEFORE_DIR="$SCRATCH/pb_migrations_before"
+mkdir -p "$BEFORE_DIR"
+cp "$MIG_DIR"/*.js "$BEFORE_DIR/"
+rm -f "$BEFORE_DIR/$MIGRATION"
+
+DB_DIR="$SCRATCH/data/pb_data"
+DB="$DB_DIR/data.db"
+
+echo ">> booting WITHOUT $MIGRATION..."
+pb_harness_boot "$PB_BIN" "$DB_DIR" "$BEFORE_DIR" "$SCRATCH/boot-before.log"
+
+fail=0
+note() { echo "FAIL: $*" >&2; fail=1; }
+
+# The destination must exist and be EMPTY, or "the rows moved" is not what the
+# assertions below would be measuring.
+pre=$(sqlite3 "$DB" "SELECT COUNT(*) FROM lodging_write_ins")
+[[ "$pre" == "0" ]] \
+  || { echo "error: lodging_write_ins already holds $pre row(s) without $MIGRATION" >&2; exit 2; }
+
+# Four synthetic rows, standing in for the shapes production actually holds: an
+# occupancy with a name only (all 21 production rows carry one), an occupancy
+# with a name AND a prospective note (3 of the 21), a ROLE release naming
+# nobody, and a second weekend so the move cannot be keyed on one session.
+# `unit` and `session` are plain TEXT relation columns; nothing here joins them,
+# so bare ids keep the fixture free of registry coupling.
+sqlite3 "$DB" <<'SQL'
+INSERT INTO lodging_availability
+  (id, created, updated, session, session_cm_id, year, unit, family_available, occupant_name, note)
+VALUES
+  ('wi000000000001', '2026-08-01 10:00:00.000Z', '2026-08-01 10:00:00.000Z',
+   'sess0000000001', 1000001, 2026, 'unit0000000001', 0, 'Emma Johnson', ''),
+  ('wi000000000002', '2026-08-02 10:00:00.000Z', '2026-08-03 11:00:00.000Z',
+   'sess0000000001', 1000001, 2026, 'unit0000000002', 0, 'Liam Garcia', 'Back Monday'),
+  ('wi000000000003', '2026-08-04 10:00:00.000Z', '2026-08-04 10:00:00.000Z',
+   'sess0000000001', 1000001, 2026, 'unit0000000003', 1, '', 'Director away'),
+  ('wi000000000004', '2026-08-05 10:00:00.000Z', '2026-08-05 10:00:00.000Z',
+   'sess0000000002', 1000002, 2026, 'unit0000000001', 0, 'Ava Martinez', '');
+SQL
+
+echo ">> booting WITH $MIGRATION..."
+pb_harness_boot "$PB_BIN" "$DB_DIR" "$MIG_DIR" "$SCRATCH/boot-after.log"
+
+# ── WHAT MOVED ──────────────────────────────────────────────────────────────
+
+moved() {
+  sqlite3 "$DB" "SELECT id || '|' || unit || '|' || session || '|' || session_cm_id || '|' || year
+                 || '|' || occupant_name || '|' || note || '|' || created || '|' || updated
+                 FROM lodging_write_ins WHERE id = '$1'"
+}
+
+# 1 -- an occupancy with a name only. Every column travels, INCLUDING the
+# timestamps: a moved row must keep the day staff actually recorded it rather
+# than reporting itself as written by the migration.
+got=$(moved wi000000000001)
+want='wi000000000001|unit0000000001|sess0000000001|1000001|2026|Emma Johnson||2026-08-01 10:00:00.000Z|2026-08-01 10:00:00.000Z'
+[[ "$got" == "$want" ]] || note "row 1 moved as '$got' (expected '$want')"
+
+# 2 -- an occupancy with a prospective note beside the name. Two different
+# facts about one write-in, and both have to arrive.
+got=$(moved wi000000000002)
+want='wi000000000002|unit0000000002|sess0000000001|1000001|2026|Liam Garcia|Back Monday|2026-08-02 10:00:00.000Z|2026-08-03 11:00:00.000Z'
+[[ "$got" == "$want" ]] || note "row 2 moved as '$got' (expected '$want')"
+
+# 4 -- a second weekend, same unit. The unique index is keyed on
+# (session_cm_id, year, unit), so this row must move alongside row 1 rather
+# than colliding with it.
+got=$(moved wi000000000004)
+want='wi000000000004|unit0000000001|sess0000000002|1000002|2026|Ava Martinez||2026-08-05 10:00:00.000Z|2026-08-05 10:00:00.000Z'
+[[ "$got" == "$want" ]] || note "row 4 moved as '$got' (expected '$want')"
+
+# ── WHAT STAYED ─────────────────────────────────────────────────────────────
+
+# 3 -- the ROLE release. Not scenario-scoped, names no occupant, and must be
+# exactly where it was: this is the half of the column the owner ruled stays.
+left=$(sqlite3 "$DB" "SELECT id || '|' || family_available || '|' || note FROM lodging_availability ORDER BY id")
+[[ "$left" == 'wi000000000003|1|Director away' ]] \
+  || note "lodging_availability holds '$left' (expected only the release, 'wi000000000003|1|Director away')"
+
+# Nothing was lost between the two tables.
+total=$(sqlite3 "$DB" "SELECT (SELECT COUNT(*) FROM lodging_availability) + (SELECT COUNT(*) FROM lodging_write_ins)")
+[[ "$total" == "4" ]] || note "4 rows went in and $total came out"
+
+# The DRAFT twin is untouched: still dark in this PR, and it has a `scenario`
+# column `lodging_availability` has nowhere to put.
+draft=$(sqlite3 "$DB" "SELECT COUNT(*) FROM lodging_write_ins_draft")
+[[ "$draft" == "0" ]] || note "lodging_write_ins_draft holds $draft row(s); this migration must not write it"
+
+# ── RE-RUNNABILITY, AGAINST THE STATE THAT ACTUALLY NEEDS IT ────────────────
+#
+# `_migrations` keys on FILENAME, so PocketBase will not re-run 162 on a second
+# boot -- which is also the lever that lets this test it honestly. A byte-for-
+# byte COPY under a later filename runs the shipped statements a second time.
+# Copying the file rather than re-typing the SQL here is the point: a
+# duplicated query in this script would still pass if the migration's own
+# guards were deleted.
+#
+# A plain second run is a WEAK test and was measured to be one: after run 1 the
+# source rows are gone, so the INSERT selects nothing whether or not it is
+# guarded, and deleting the `NOT EXISTS` clause still passes. The state the
+# guard is actually for is a HALF-APPLIED run -- the insert landed, the delete
+# did not -- so that is the state this stage builds.
+RERUN_DIR="$SCRATCH/pb_migrations_rerun"
+mkdir -p "$RERUN_DIR"
+cp "$MIG_DIR"/*.js "$RERUN_DIR/"
+cp "$MIG_DIR/$MIGRATION" "$RERUN_DIR/1599999999_writein_table_backfill_rerun_probe.js"
+
+# Row 5: an occupancy written the way the application writes one AFTER the
+# split, with no source row behind it at all. The re-run must leave it exactly
+# alone -- a guard keyed on the wrong side would delete or duplicate it.
+#
+# Row 6: the half-applied residue. Same (session_cm_id, year, unit) as row 1,
+# which already moved, under a DIFFERENT id -- the shape an interrupted run or
+# a re-created row leaves behind, and the one the unique index would reject.
+# Guarded, the INSERT skips it and the DELETE clears it, so the table converges.
+# Unguarded, the INSERT collides and the migration fails the boot.
+sqlite3 "$DB" <<'SQL'
+INSERT INTO lodging_write_ins
+  (id, created, updated, session, session_cm_id, year, unit, occupant_name, note)
+VALUES ('wi000000000005', '2026-08-06 10:00:00.000Z', '2026-08-06 10:00:00.000Z',
+        'sess0000000001', 1000001, 2026, 'unit0000000009', 'Noah Rivera', '');
+
+INSERT INTO lodging_availability
+  (id, created, updated, session, session_cm_id, year, unit, family_available, occupant_name, note)
+VALUES ('wi000000000006', '2026-08-07 10:00:00.000Z', '2026-08-07 10:00:00.000Z',
+        'sess0000000001', 1000001, 2026, 'unit0000000001', 0, 'Emma Johnson', '');
+SQL
+
+write_ins_snapshot() {
+  sqlite3 "$DB" "SELECT id || '=' || unit || '|' || occupant_name || '|' || note
+                 FROM lodging_write_ins ORDER BY id"
+}
+before_write_ins=$(write_ins_snapshot)
+
+echo ">> booting again with a re-run probe copy of $MIGRATION..."
+pb_harness_boot "$PB_BIN" "$DB_DIR" "$RERUN_DIR" "$SCRATCH/boot-rerun.log"
+
+# Nothing in the destination moved: not the four already there, and not the
+# post-split row that never had a source.
+after_write_ins=$(write_ins_snapshot)
+[[ "$before_write_ins" == "$after_write_ins" ]]   || note "the re-run changed lodging_write_ins; it must be a no-op there.
+before:
+$before_write_ins
+after:
+$after_write_ins"
+
+# And the residue is gone, because a copy of it provably exists. The release is
+# still the only thing left in the source table.
+left=$(sqlite3 "$DB" "SELECT id || '|' || family_available FROM lodging_availability ORDER BY id")
+[[ "$left" == 'wi000000000003|1' ]]   || note "after the re-run lodging_availability holds '$left' (expected only the release)"
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "verify-writein-table-backfill: FAILED" >&2
+  exit 1
+fi
+echo "verify-writein-table-backfill: OK ($PB_HARNESS_JS_MIGRATION_COUNT js migrations applied)"

--- a/tests/unit/api/routers/test_lodging_endpoints.py
+++ b/tests/unit/api/routers/test_lodging_endpoints.py
@@ -1400,20 +1400,29 @@ class TestAvailabilityWrites:
         assert response.status_code == 403
 
     def test_losing_the_availability_upsert_race_updates_instead_of_500ing(self, mock_pb: MagicMock) -> None:
-        """Two staff reserving the same unit for one weekend at the same
+        """Two staff writing into the same unit for one weekend at the same
         moment.
 
-        `idx_lodging_avail_unique` is UNIQUE on (session, year, unit), as
-        1500000135 rebuilt it -- exactly the race `place_party` guards on the
-        draft's
-        own partial unique index. Both staff find no override, both create,
-        and the index rejects the loser. Left alone that is a bare
+        `idx_lodging_write_in_unique` is UNIQUE on (session_cm_id, year, unit),
+        as 1500000161 declared it -- exactly the race `place_party` guards on
+        the draft's own partial unique index. Both staff find no row, both
+        create, and the index rejects the loser. Left alone that is a bare
         ClientResponseError into the catch-all handler in api/main.py -- a 500
-        for a reservation the board is entitled to make. The row the winner
-        just wrote is exactly what this call wanted to write, so the loser
-        adopts it and updates.
+        for a write-in the board is entitled to make. The row the winner just
+        wrote is exactly what this call wanted to write, so the loser adopts it
+        and updates.
+
+        THREE staged reads, not two, since kindred#2382 split the table:
+        `set_availability` looks up BOTH facts -- the role row and the
+        occupancy row -- before it writes either, and only the THIRD read is
+        the recovery's own re-read. Staged two-deep this test went vacuous
+        rather than red: the winner's row was consumed as `existing_write_in`,
+        the upsert took its plain update branch, and the create that has to
+        lose the race never ran. Measured -- deleting the whole recovery block
+        from `_upsert_row` left it green. `create.assert_called_once()` below
+        is what stops that happening silently a second time.
         """
-        reads: list[list[Any]] = [[], [_rec(id="avail_raced")]]
+        reads: list[list[Any]] = [[], [], [_rec(id="write_in_raced")]]
 
         def staged(**kwargs: Any) -> list[Any]:
             query_filter = kwargs.get("query_params", {}).get("filter", "")
@@ -1439,8 +1448,12 @@ class TestAvailabilityWrites:
             )
 
         assert response.status_code == 200, response.text
+        # The race really happened: the create ran, lost, and the recovery
+        # adopted the winner. Without this the test passes on the ordinary
+        # "row already there, update it" path, which guards nothing.
+        mock_pb.collection.return_value.create.assert_called_once()
         mock_pb.collection.return_value.update.assert_called_once()
-        assert mock_pb.collection.return_value.update.call_args[0][0] == "avail_raced"
+        assert mock_pb.collection.return_value.update.call_args[0][0] == "write_in_raced"
 
     def test_an_availability_create_failure_that_is_not_a_race_still_errors(self, mock_pb: MagicMock) -> None:
         """The retry is for a lost race, not a blanket swallow.
@@ -1513,8 +1526,12 @@ class TestAvailabilityWrites:
         assert response.status_code == 403
 
     def test_a_failed_update_after_a_lost_availability_race_keeps_its_status(self, mock_pb: MagicMock) -> None:
-        """The winner's override is found, then the update onto it fails."""
-        reads: list[list[Any]] = [[], [_rec(id="avail_raced")]]
+        """The winner's row is found, then the update onto it fails.
+
+        Three staged reads for the reason the test above spells out: the role
+        lookup, the occupancy lookup, then the recovery's re-read.
+        """
+        reads: list[list[Any]] = [[], [], [_rec(id="write_in_raced")]]
 
         def staged(**kwargs: Any) -> list[Any]:
             query_filter = kwargs.get("query_params", {}).get("filter", "")
@@ -1543,3 +1560,6 @@ class TestAvailabilityWrites:
             )
 
         assert response.status_code == 403
+        # Same guard as the sibling above: the recovery path must actually
+        # have been walked, not skipped by a lookup that answered too early.
+        mock_pb.collection.return_value.create.assert_called_once()

--- a/tests/unit/api/routers/test_lodging_endpoints.py
+++ b/tests/unit/api/routers/test_lodging_endpoints.py
@@ -7,7 +7,7 @@ produces spurious 401s elsewhere in the suite.
 
 from collections.abc import Generator
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from fastapi import FastAPI
@@ -1224,7 +1224,7 @@ class TestCopyFromMirror:
 
 
 class TestAvailabilityWrites:
-    def test_holding_a_cabin_creates_a_weekend_scoped_row(self, mock_pb: MagicMock) -> None:
+    def test_writing_somebody_in_creates_a_weekend_scoped_occupancy_row(self, mock_pb: MagicMock) -> None:
         with patch("api.routers.lodging.pb", mock_pb):
             client = _write_client(_manage_user(), mock_pb)
             response = client.put(
@@ -1239,16 +1239,20 @@ class TestAvailabilityWrites:
             )
 
         assert response.status_code == 200
-        mock_pb.collection.assert_any_call("lodging_availability")
+        # THE OCCUPANCY TABLE since kindred#2382. `family_available = false`
+        # was never a role value -- it was a write-in sharing the role
+        # column's boolean -- so it moved to a table of its own, where the ROW
+        # is the fact and no column restates it.
+        mock_pb.collection.assert_any_call("lodging_write_ins")
         payload = mock_pb.collection.return_value.create.call_args[0][0]
         assert payload["unit"] == "u1"
-        assert payload["family_available"] is False
+        assert "family_available" not in payload
         # The reason is display text and lives in the `note` COLUMN; the API
         # field is `reason`. See AvailabilityWriteRequest.
         assert payload["note"] == "Burst pipe"
-        # WEEKEND-scoped, not scenario-scoped. 1500000135 deleted the dimension
-        # -- a burst pipe closes a cabin in every plan for that weekend -- and
-        # writing one anyway would recreate the overlay from the write side.
+        # WEEKEND-scoped, and still no scenario: the live board is a scope in
+        # its own right, so this table has no scenario column at all. The
+        # draft twin behind it stays dark until PR 3 of kindred#2382.
         assert "scenario" not in payload
         assert "state" not in payload
 
@@ -1291,9 +1295,16 @@ class TestAvailabilityWrites:
 
         assert response.status_code == 200, response.text
 
-    def test_clearing_the_override_deletes_the_row(self, mock_pb: MagicMock) -> None:
+    def test_clearing_the_override_deletes_the_row_in_both_tables(self, mock_pb: MagicMock) -> None:
         """Back to whatever the unit's ROLE says, which is not the same as
-        writing an override that happens to agree with it."""
+        writing an override that happens to agree with it.
+
+        TWO tables since kindred#2382 -- the staff<->family role in
+        `lodging_availability`, the occupancy in `lodging_write_ins` -- so a
+        clear has to reach both or it silently does nothing to whichever fact
+        it missed. This fixture hands every collection the same row, so the two
+        deletes name the same id; what is pinned here is that BOTH tables are
+        addressed and BOTH are cleared."""
 
         def reads(**kwargs: Any) -> list[Any]:
             query_filter = kwargs.get("query_params", {}).get("filter", "")
@@ -1315,7 +1326,9 @@ class TestAvailabilityWrites:
             )
 
         assert response.status_code == 200
-        mock_pb.collection.return_value.delete.assert_called_once_with("avail_1")
+        mock_pb.collection.assert_any_call("lodging_write_ins")
+        mock_pb.collection.assert_any_call("lodging_availability")
+        assert mock_pb.collection.return_value.delete.call_args_list == [call("avail_1"), call("avail_1")]
 
     def test_an_availability_delete_race_is_not_an_error(self, mock_pb: MagicMock) -> None:
         """The override is found, then vanishes before the delete lands.
@@ -1464,7 +1477,11 @@ class TestAvailabilityWrites:
         catch-all handler in api/main.py -- a 500, the outcome this guard is
         for.
         """
-        reads: list[list[Any]] = [[]]
+        # TWO empty reads, not one: `set_availability` looks up BOTH facts --
+        # the role row and the occupancy row -- before it writes either
+        # (kindred#2382). The next read is the recovery's own re-read, and that
+        # is the one this test makes fail.
+        reads: list[list[Any]] = [[], []]
 
         def staged(**kwargs: Any) -> list[Any]:
             query_filter = kwargs.get("query_params", {}).get("filter", "")

--- a/tests/unit/api/services/test_lodging_repository.py
+++ b/tests/unit/api/services/test_lodging_repository.py
@@ -704,10 +704,11 @@ class TestWriteInReads:
     live+draft pair sitting beside `lodging_assignments`/`_draft`. These
     reads are that pair's half of the repository.
 
-    NOTHING READS THEM YET. PR 1 lands the tables and the CRUD dark; the
-    switch of `write_in_covers`, `set_availability` and the frontend is PR 2
-    onward. What these tests pin is the shape the later PRs will read
-    through, not any behaviour the running application has today.
+    THE LIVE HALF IS LIVE. PR 2 moved the 21 rows (1500000162) and switched
+    `write_in_covers` and `set_availability` onto them. The DRAFT half is
+    still dark -- nothing reads or writes it until PR 3 gives write-ins their
+    scenario dimension -- so what its tests pin is the shape that PR will read
+    through, not behaviour the running application has today.
     """
 
     @pytest.mark.asyncio

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -26,7 +26,7 @@ import logging
 from datetime import date
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -4449,16 +4449,62 @@ class TestWriteInsResolveFromTheirOwnTable:
         the two methods hold parallel blocks that must be edited separately --
         and it would put a cabin's write-in on the board while the weekend card
         linking to it still counted the cabin as open.
+
+        THE ARGUMENTS ARE PINNED, not only the count. `build_summary` holds the
+        one `year` for the whole sweep and each weekend's OWN CampMinder id, and
+        a read keyed on the PocketBase id instead would still be awaited twice
+        -- kindred#2042 is exactly the mistake a bare `await_count` waves
+        through. `test_the_lander_counts_a_written_into_cabin_as_reserved`
+        below is the other half: this pins that the table is ASKED, that one
+        pins that the answer is USED.
         """
         repo = _repo(fetch_weekend_sessions=[FAMILY_SESSION, ADULT_SESSION])
 
         await LodgingRosterService(repo).build_summary(2026)
 
-        assert repo.fetch_write_ins.await_count == 2
+        assert repo.fetch_write_ins.await_args_list == [call(2026, 1000001), call(2026, 1000002)]
         # And no scenario dimension here either -- the same line
         # `test_no_scenario_dimension_is_read_yet` holds for the roster. Two
         # TaskGroups, two places to get it wrong.
         assert repo.fetch_draft_write_ins.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_the_lander_counts_a_written_into_cabin_as_reserved(self) -> None:
+        """The rows the lander fetches have to REACH `_build_units`.
+
+        Awaiting `fetch_write_ins` and then dropping its result on the floor is
+        a half-fix a call-count assertion cannot see, and it is the exact
+        failure the comment at that fetch site names: a weekend card reporting
+        a written-into cabin as open beside a board that draws it closed.
+        Measured -- passing `[]` in place of `write_ins_task.result()` left every
+        other test in this file green.
+
+        Pinned against `build_roster`'s own counts rather than against
+        literals alone, which is how the lander's contract is already stated in
+        `TestBuildSummary` -- the two endpoints link to each other and must
+        never disagree about one weekend. The literals are kept beside it so a
+        failure says WHICH number moved rather than only that the two differ.
+        """
+        repo = _repo(
+            fetch_weekend_sessions=[FAMILY_SESSION],
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("u1", "ridge-a", "Ridge A", sleeps=5),
+                _unit("u2", "ridge-b", "Ridge B", sleeps=4),
+            ],
+            fetch_write_ins=[_rec(unit="u1", occupant_name="Liam Garcia", note="")],
+        )
+        service = LodgingRosterService(repo)
+
+        summary = await service.build_summary(2026)
+        roster = await service.build_roster(2026, 1000001)
+
+        counts = summary.weekends[0].counts
+        assert counts.units_reserved == 1
+        assert counts.units_family_available == 1
+        # The written-into cabin's five beds are NOT on offer; only Ridge B's.
+        assert counts.beds_family_available == 4
+        assert counts == roster.counts
 
     @pytest.mark.asyncio
     async def test_no_scenario_dimension_is_read_yet(self) -> None:

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -106,6 +106,14 @@ def _repo(**overrides: Any) -> MagicMock:
         "fetch_session": None,
         "fetch_units": [],
         "fetch_availability": [],
+        # Write-in OCCUPANCY, split out of `lodging_availability` by
+        # kindred#2382. Empty by default -- most weekends have no write-in at
+        # all, and that must be the shape the board sees.
+        "fetch_write_ins": [],
+        # The scenario half of the same split. Dark: nothing reads it until
+        # PR 3 of kindred#2382 gives write-ins their scenario dimension, and
+        # `test_no_scenario_dimension_is_read_yet` is what pins that.
+        "fetch_draft_write_ins": [],
         "fetch_assignments": [],
         # The scenario layer. Only read when a scenario is asked for, which is
         # itself asserted below -- no scenario must cost no extra fetches.
@@ -1039,9 +1047,10 @@ class TestUnitsAndCounts:
                 _unit("u1", "house", "House", is_container=True, default_combined=True),
                 _unit("u2", "house-a", "House A", sleeps=4, parent_unit="u1"),
             ],
-            fetch_availability=[
-                _rec(unit="u1", family_available=False, occupant_name="Liam Garcia", note="Back Monday")
-            ],
+            # kindred#2382: occupancy lives in `lodging_write_ins` now. The row
+            # is the same row -- unit, occupant, note -- moved out of the
+            # boolean it used to share with the staff<->family role.
+            fetch_write_ins=[_rec(unit="u1", occupant_name="Liam Garcia", note="Back Monday")],
         )
         roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
 
@@ -1068,7 +1077,7 @@ class TestUnitsAndCounts:
                 _unit("u1", "house", "House", is_container=True, default_combined=True),
                 _unit("u2", "house-a", "House A", sleeps=4, parent_unit="u1"),
             ],
-            fetch_availability=[_rec(unit="u2", family_available=False, occupant_name="Ava Martinez")],
+            fetch_write_ins=[_rec(unit="u2", occupant_name="Ava Martinez", note="")],
         )
         roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
 
@@ -4142,6 +4151,18 @@ class TestWriteInCovers:
     def _unit(code: str, **kwargs: Any) -> LodgingUnitSummary:
         return LodgingUnitSummary(unit_id=f"id-{code}", code=code, name=code.title(), **kwargs)
 
+    @staticmethod
+    def _written(*codes: str) -> frozenset[str]:
+        """The `lodging_write_ins` rows, as the ids the walk is handed.
+
+        WHICH UNITS HOLD A WRITE-IN IS AN INPUT since kindred#2382, not a value
+        read off the summary. It used to be `family_available_override is
+        False`, which was the only spelling occupancy had while it shared one
+        boolean with the staff<->family role; the two are separate tables now,
+        so the walk is given the occupancy source directly.
+        """
+        return frozenset(f"id-{code}" for code in codes)
+
     def test_a_room_inherits_the_write_in_of_the_building_above_it(self) -> None:
         # The SPLIT case. Staff wrote into the whole house while it was merged,
         # then split it back to rooms: the row still names the house, which now
@@ -4149,13 +4170,12 @@ class TestWriteInCovers:
         house = self._unit(
             "house",
             is_container=True,
-            family_available_override=False,
             occupant_name="Liam Garcia",
             reason="Back Monday",
         )
         room = self._unit("house-a", parent_code="house")
 
-        covers = write_in_covers([house, room])
+        covers = write_in_covers([house, room], self._written("house"))
 
         assert covers["house-a"].unit_code == "house"
         assert covers["house-a"].occupant_name == "Liam Garcia"
@@ -4165,12 +4185,10 @@ class TestWriteInCovers:
         # The MERGE case, and the mirror of the one above: the row names a room
         # that stopped being drawn when staff merged the building over it.
         house = self._unit("house", is_container=True, is_combined=True)
-        written_room = self._unit(
-            "house-a", parent_code="house", family_available_override=False, occupant_name="Liam Garcia"
-        )
+        written_room = self._unit("house-a", parent_code="house", occupant_name="Liam Garcia")
         other_room = self._unit("house-b", parent_code="house")
 
-        covers = write_in_covers([house, written_room, other_room])
+        covers = write_in_covers([house, written_room, other_room], self._written("house-a"))
 
         assert covers["house"].unit_code == "house-a"
         assert covers["house"].occupant_name == "Liam Garcia"
@@ -4182,53 +4200,68 @@ class TestWriteInCovers:
         # reaching B, because each unit resolves from OWN rows only -- never
         # transitively through a cover it just computed for somebody else.
         house = self._unit("house", is_container=True)
-        written_room = self._unit(
-            "house-a", parent_code="house", family_available_override=False, occupant_name="Liam Garcia"
-        )
+        written_room = self._unit("house-a", parent_code="house", occupant_name="Liam Garcia")
         other_room = self._unit("house-b", parent_code="house")
 
-        covers = write_in_covers([house, written_room, other_room])
+        covers = write_in_covers([house, written_room, other_room], self._written("house-a"))
 
         assert "house-b" not in covers
         assert covers["house"].unit_code == "house-a"
 
     def test_a_units_own_write_in_beats_an_inherited_one(self) -> None:
-        house = self._unit("house", is_container=True, family_available_override=False, occupant_name="Liam Garcia")
-        room = self._unit("house-a", parent_code="house", family_available_override=False, occupant_name="Ava Martinez")
+        house = self._unit("house", is_container=True, occupant_name="Liam Garcia")
+        room = self._unit("house-a", parent_code="house", occupant_name="Ava Martinez")
 
-        covers = write_in_covers([house, room])
+        covers = write_in_covers([house, room], self._written("house", "house-a"))
 
         assert covers["house-a"].unit_code == "house-a"
         assert covers["house-a"].occupant_name == "Ava Martinez"
 
     def test_the_nearest_ancestor_wins(self) -> None:
-        block = self._unit("block", is_container=True, family_available_override=False, occupant_name="Ava Martinez")
+        block = self._unit("block", is_container=True, occupant_name="Ava Martinez")
         house = self._unit(
             "house",
             parent_code="block",
             is_container=True,
-            family_available_override=False,
             occupant_name="Liam Garcia",
         )
         room = self._unit("house-a", parent_code="house")
 
-        covers = write_in_covers([block, house, room])
+        covers = write_in_covers([block, house, room], self._written("block", "house"))
 
         assert covers["house-a"].unit_code == "house"
 
     def test_a_release_is_not_a_write_in(self) -> None:
-        # `True` is a staff cabin OPENED to families for the weekend. It names
-        # no occupant and closes nothing, so it must not travel: inheriting it
-        # would silently open every room beneath a released building.
+        # A ROLE release is a staff cabin OPENED to families for the weekend. It
+        # names no occupant and closes nothing, so it must not travel:
+        # inheriting it would silently open every room beneath a released
+        # building. It lives in `lodging_availability` and never appears in the
+        # occupancy set at all, which is what makes that structural rather than
+        # a branch somebody can forget.
         house = self._unit("house", is_container=True, inventory_class="staff_default", family_available_override=True)
         room = self._unit("house-a", parent_code="house")
 
-        covers = write_in_covers([house, room])
+        covers = write_in_covers([house, room], self._written())
 
         assert covers == {}
 
+    def test_a_bare_false_override_with_no_write_in_row_covers_nothing(self) -> None:
+        """The classification guard, and the reason the walk stopped reading it.
+
+        `family_available_override is False` was the old predicate. After
+        kindred#2382's split it means only "this unit is closed this weekend",
+        which a ROLE row can say without naming anybody -- and a cover built
+        from one would have the board print an occupant that exists in no row.
+        1500000162 leaves no such row behind and no writer creates another, so
+        this is bad data meeting the rule, not a state the product can reach.
+        """
+        house = self._unit("house", is_container=True, family_available_override=False)
+        room = self._unit("house-a", parent_code="house")
+
+        assert write_in_covers([house, room], self._written()) == {}
+
     def test_a_unit_with_nothing_on_its_path_is_absent(self) -> None:
-        assert write_in_covers([self._unit("cedar-1")]) == {}
+        assert write_in_covers([self._unit("cedar-1")], self._written()) == {}
 
     def test_a_parent_cycle_does_not_hang(self) -> None:
         # The server guards against writing one (#1899), but a cycle already in
@@ -4236,7 +4269,11 @@ class TestWriteInCovers:
         a = self._unit("a", parent_code="b", is_container=True)
         b = self._unit("b", parent_code="a", is_container=True)
 
-        assert write_in_covers([a, b]) == {}
+        # Nobody is written in, so every cover the walks could return is the
+        # product of the cycle rather than of a row -- an empty map is the only
+        # right answer, and reaching it at all means both guards fired. Without
+        # them this hangs rather than failing.
+        assert write_in_covers([a, b], self._written()) == {}
 
     def test_a_blank_coded_unit_never_lends_its_cover_to_another(self) -> None:
         # "" is the same key `parent_code == ""` uses for "no parent", which is
@@ -4246,22 +4283,249 @@ class TestWriteInCovers:
         #
         # A blank code is a valid if unfortunate registry value, so this is bad
         # data meeting a collision, not a state the schema forbids.
-        written = self._unit("", family_available_override=False, occupant_name="Liam Garcia")
+        written = self._unit("", occupant_name="Liam Garcia")
         other = LodgingUnitSummary(unit_id="id-other", code="", name="Other")
 
-        assert write_in_covers([written, other]) == {}
+        assert write_in_covers([written, other], self._written("")) == {}
 
     def test_several_written_rooms_pick_one_deterministically(self) -> None:
         # A building over two written-into rooms is closed either way; the
         # point is that two identical payloads never disagree about WHICH row
         # the card names, which a set-ordered walk would not guarantee.
         house = self._unit("house", is_container=True, is_combined=True)
-        room_b = self._unit(
-            "house-b", parent_code="house", family_available_override=False, occupant_name="Ava Martinez"
-        )
-        room_a = self._unit(
-            "house-a", parent_code="house", family_available_override=False, occupant_name="Liam Garcia"
+        room_b = self._unit("house-b", parent_code="house", occupant_name="Ava Martinez")
+        room_a = self._unit("house-a", parent_code="house", occupant_name="Liam Garcia")
+        written = self._written("house-a", "house-b")
+
+        assert write_in_covers([house, room_b, room_a], written)["house"].unit_code == "house-a"
+        assert write_in_covers([house, room_a, room_b], written)["house"].unit_code == "house-a"
+
+
+class TestWriteInsResolveFromTheirOwnTable:
+    """Write-in OCCUPANCY is read from `lodging_write_ins`, not from availability.
+
+    kindred#2382, PR 2 of 4. `lodging_availability.family_available` answered
+    two unrelated questions through one boolean: `true` on a staff cabin is a
+    staff<->family ROLE override for the weekend, `false` was an occupancy --
+    somebody is in the room. The owner ruled the ROLE is NOT scenario-scoped
+    while an occupancy IS, so the two facts are split apart and each scoped on
+    its own terms.
+
+    This class pins the READ half of the split at BEHAVIOURAL PARITY: after it,
+    the board looks and behaves exactly as it did, and the only thing that moved
+    is which table the occupancy came out of. `family_available_override` is
+    still `False` on a written-into unit, and deliberately so -- it is what
+    `is_family_available`, and through it every count on the stats bar, is
+    derived from. Disentangling that boolean is PR 4.
+
+    Fictional data throughout.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_write_in_row_closes_the_unit_and_names_its_occupant(self) -> None:
+        """The whole read, on one unit, with availability holding nothing.
+
+        The row that used to live in `lodging_availability` with
+        `family_available = false` now lives here, and every field the card
+        reads still arrives: the unit is closed, the occupant is named, and the
+        note travels beside it under the API's `reason` name.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[_unit("u1", "ridge-a", "Ridge A", sleeps=5)],
+            fetch_availability=[],
+            fetch_write_ins=[_rec(unit="u1", occupant_name="Liam Garcia", note="Back Monday")],
         )
 
-        assert write_in_covers([house, room_b, room_a])["house"].unit_code == "house-a"
-        assert write_in_covers([house, room_a, room_b])["house"].unit_code == "house-a"
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        unit = roster.units[0]
+        assert unit.occupant_name == "Liam Garcia"
+        assert unit.reason == "Back Monday"
+        # The compat half, and it is load-bearing rather than leftover: every
+        # count on the stats bar goes through `is_family_available`, which is
+        # derived from this. PR 4 re-points it; until then a write-in still
+        # spells itself here.
+        assert unit.family_available_override is False
+        assert unit.is_family_available is False
+        assert unit.write_in is not None
+        assert unit.write_in.unit_id == "u1"
+        assert unit.write_in.occupant_name == "Liam Garcia"
+
+    @pytest.mark.asyncio
+    async def test_a_stale_availability_occupancy_row_no_longer_writes_anybody_in(self) -> None:
+        """The other side of the split, and the one a half-fix would miss.
+
+        1500000162 moves every `family_available = false` row out, and no
+        writer creates another -- `set_availability` sends an occupancy to the
+        write-in table now. So a `false` row surviving in `lodging_availability`
+        names nobody: it is a bare ROLE value with no occupant behind it, and
+        reading it as a write-in would have the board report an occupant who
+        exists in no row anywhere.
+
+        It still CLOSES the unit, because that is what a `false` role says and
+        flattening it would silently open a cabin. What it must not do is
+        produce a cover.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[_unit("u1", "ridge-a", "Ridge A", sleeps=5)],
+            fetch_availability=[_rec(unit="u1", family_available=False, occupant_name="", note="")],
+            fetch_write_ins=[],
+        )
+
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.units[0].is_family_available is False
+        assert roster.units[0].write_in is None
+
+    @pytest.mark.asyncio
+    async def test_a_role_release_still_comes_from_availability(self) -> None:
+        """The half that does NOT move, stated so a sweep cannot take it too.
+
+        "we're moving staff to X for weekend Y" is an operational fact about
+        the weekend, not a modelling choice, so `lodging_availability` keeps it
+        and keeps its no-scenario shape -- 1500000135's original reasoning,
+        which turns out to be exactly right for this half.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[_unit("u1", "le-shack", "Le Shack", sleeps=4, inventory_class="staff_default")],
+            fetch_availability=[_rec(unit="u1", family_available=True, occupant_name="", note="Director away")],
+            fetch_write_ins=[],
+        )
+
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        unit = roster.units[0]
+        assert unit.family_available_override is True
+        assert unit.is_family_available is True
+        assert unit.reason == "Director away"
+        # A release names no occupant and closes nothing, so it must never
+        # resolve to a cover -- inheriting one would silently open every room
+        # beneath a released building.
+        assert unit.write_in is None
+
+    @pytest.mark.asyncio
+    async def test_a_write_in_outranks_a_release_on_the_same_unit(self) -> None:
+        """Two rows, two tables, one unit -- and occupancy wins.
+
+        No writer produces this pair (`set_availability` clears the other fact
+        on every write), but two staff racing on one cabin can, and the answer
+        has to be the safe one: somebody is in the room, so the room is closed.
+        Reading the release instead would open a cabin with an occupant in it.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[_unit("u1", "le-shack", "Le Shack", sleeps=4, inventory_class="staff_default")],
+            fetch_availability=[_rec(unit="u1", family_available=True, occupant_name="", note="Director away")],
+            fetch_write_ins=[_rec(unit="u1", occupant_name="Ava Martinez", note="")],
+        )
+
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        unit = roster.units[0]
+        assert unit.family_available_override is False
+        assert unit.is_family_available is False
+        assert unit.occupant_name == "Ava Martinez"
+        assert unit.write_in is not None
+
+    @pytest.mark.asyncio
+    async def test_the_roster_reads_the_write_in_table_for_this_weekend(self) -> None:
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[_unit("u1", "ridge-a", "Ridge A", sleeps=5)],
+        )
+
+        await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        repo.fetch_write_ins.assert_awaited_once_with(2026, 1000001)
+
+    @pytest.mark.asyncio
+    async def test_the_lander_reads_the_write_in_table_once_per_weekend(self) -> None:
+        """`build_summary` carries its OWN TaskGroup, which is the whole point.
+
+        Wiring `build_roster` and leaving the lander is the obvious half-fix --
+        the two methods hold parallel blocks that must be edited separately --
+        and it would put a cabin's write-in on the board while the weekend card
+        linking to it still counted the cabin as open.
+        """
+        repo = _repo(fetch_weekend_sessions=[FAMILY_SESSION, ADULT_SESSION])
+
+        await LodgingRosterService(repo).build_summary(2026)
+
+        assert repo.fetch_write_ins.await_count == 2
+        # And no scenario dimension here either -- the same line
+        # `test_no_scenario_dimension_is_read_yet` holds for the roster. Two
+        # TaskGroups, two places to get it wrong.
+        assert repo.fetch_draft_write_ins.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_no_scenario_dimension_is_read_yet(self) -> None:
+        """PR 2 moves the rows; PR 3 gives them a scenario.
+
+        The draft table exists (1500000161) and its repository read exists, but
+        nothing may call it yet: the draft is EMPTY, and a scenario's write-ins
+        REPLACE the live ones rather than overlaying them, so reading it now
+        would empty every write-in off every scenario board. Behavioural parity
+        is the acceptance criterion for this PR, and this is the assertion that
+        holds the line.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[_unit("u1", "ridge-a", "Ridge A", sleeps=5)],
+            fetch_write_ins=[_rec(unit="u1", occupant_name="Liam Garcia", note="")],
+        )
+
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001, scenario="scn_1")
+
+        assert repo.fetch_draft_write_ins.await_count == 0
+        repo.fetch_write_ins.assert_awaited_once_with(2026, 1000001)
+        # And the live rows are what a scenario sees, unchanged from today.
+        assert roster.units[0].write_in is not None
+
+    @pytest.mark.asyncio
+    async def test_a_written_into_cabin_is_still_counted_as_reserved(self) -> None:
+        """The stats bar must not move. `units_reserved` is the number staff read.
+
+        It is derived from `is_family_available`, which is derived from
+        `family_available_override` -- so a write-in that stopped spelling
+        itself there would silently return a closed cabin to the open count and
+        to `beds_family_available`.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("u1", "ridge-a", "Ridge A", sleeps=5),
+                _unit("u2", "ridge-b", "Ridge B", sleeps=4),
+            ],
+            fetch_write_ins=[_rec(unit="u1", occupant_name="Liam Garcia", note="")],
+        )
+
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.counts.units_total == 2
+        assert roster.counts.units_family_available == 1
+        assert roster.counts.units_reserved == 1
+        assert roster.counts.beds_family_available == 4
+
+    @pytest.mark.asyncio
+    async def test_a_write_in_on_a_building_still_reaches_the_rooms_beneath_it(self) -> None:
+        """The tree walk is unchanged; only its input moved tables."""
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("u1", "house", "House", is_container=True, default_combined=True),
+                _unit("u2", "house-a", "House A", sleeps=4, parent_unit="u1"),
+            ],
+            fetch_write_ins=[_rec(unit="u1", occupant_name="Liam Garcia", note="Back Monday")],
+        )
+
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        by_code = {u.code: u for u in roster.units}
+        assert by_code["house-a"].family_available_override is None
+        assert by_code["house-a"].write_in is not None
+        assert by_code["house-a"].write_in.unit_id == "u1"
+        assert by_code["house-a"].write_in.occupant_name == "Liam Garcia"
+        assert by_code["house-a"].write_in.note == "Back Monday"

--- a/tests/unit/api/services/test_lodging_write_service.py
+++ b/tests/unit/api/services/test_lodging_write_service.py
@@ -54,6 +54,13 @@ def _repo(**overrides: Any) -> MagicMock:
         "create_availability": SimpleNamespace(id="avail_new"),
         "update_availability": SimpleNamespace(id="avail_existing"),
         "delete_availability": None,
+        # Write-in OCCUPANCY, split out of `lodging_availability` by
+        # kindred#2382. `lodging_availability` keeps only the staff<->family
+        # ROLE override; somebody being IN a room is written here.
+        "find_write_in": None,
+        "create_write_in": SimpleNamespace(id="write_in_new"),
+        "update_write_in": SimpleNamespace(id="write_in_existing"),
+        "delete_write_in": None,
         "find_slot_merge": None,
         "create_slot_merge": SimpleNamespace(id="merge_new"),
         "update_slot_merge": SimpleNamespace(id="merge_existing"),
@@ -845,8 +852,12 @@ class TestARefusedWriteIsNeverReportedAsSuccess:
         )
         repo.find_availability_override = AsyncMock(side_effect=[None, SimpleNamespace(id="avail_other")])
 
+        # A RELEASE, because that is the half still stored in
+        # `lodging_availability` after kindred#2382 split occupancy out of it.
+        # The write-in half is guarded identically over its own table in
+        # `TestAWriteInIsStoredAsAnOccupancyNotAnAvailability`.
         with pytest.raises(HTTPException) as exc_info:
-            await write_service.set_availability(_availability_request())
+            await write_service.set_availability(_availability_request(family_available=True))
 
         assert exc_info.value.status_code == 403
         repo.update_availability.assert_not_called()
@@ -862,11 +873,11 @@ class TestARefusedWriteIsNeverReportedAsSuccess:
         )
         repo.find_availability_override = AsyncMock(side_effect=[None, SimpleNamespace(id="avail_winner")])
 
-        response = await write_service.set_availability(_availability_request())
+        response = await write_service.set_availability(_availability_request(family_available=True))
 
         record_id, data = repo.update_availability.call_args[0]
         assert record_id == "avail_winner"
-        assert data["family_available"] is False
+        assert data["family_available"] is True
         assert response.record_id == "avail_existing"
 
 
@@ -939,7 +950,7 @@ class TestARecoveredRaceLogsTheErrorItSwallowed:
         repo.find_availability_override = AsyncMock(side_effect=[None, SimpleNamespace(id="avail_winner")])
 
         with caplog.at_level(logging.WARNING, logger="api.services.lodging_write_service"):
-            await write_service.set_availability(_availability_request())
+            await write_service.set_availability(_availability_request(family_available=True))
 
         output = self._formatted(caplog.records)
         assert "status=500" in output
@@ -1055,9 +1066,12 @@ class TestTheAvailabilityWriteShape:
         """
         await write_service.set_availability(_availability_request())
 
-        data = repo.create_availability.call_args[0][0]
+        # The OCCUPANCY table since kindred#2382 -- `family_available = false`
+        # was never a value, it was a write-in wearing the role column's
+        # clothes. The translation moved with the fact and did not gain a
+        # third site.
+        data = repo.create_write_in.call_args[0][0]
         assert data["note"] == "Burst pipe"
-        assert data["family_available"] is False
         assert "scenario" not in data
         assert "state" not in data
 
@@ -1087,7 +1101,7 @@ class TestTheAvailabilityWriteShape:
         """
         await write_service.set_availability(_availability_request(occupant_name="Emma Johnson"))
 
-        data = repo.create_availability.call_args[0][0]
+        data = repo.create_write_in.call_args[0][0]
         assert data["occupant_name"] == "Emma Johnson"
         assert data["note"] == "Burst pipe"
 
@@ -1154,8 +1168,11 @@ class TestARefusedUpdateAnswersTheSameWayARefusedCreateDoes:
             )
         )
 
+        # A RELEASE -- the half `lodging_availability` still stores. Its
+        # write-in twin is guarded over `lodging_write_ins` in
+        # `TestAWriteInIsStoredAsAnOccupancyNotAnAvailability`.
         with pytest.raises(HTTPException) as exc_info:
-            await write_service.set_availability(_availability_request())
+            await write_service.set_availability(_availability_request(family_available=True))
 
         assert exc_info.value.status_code == 403
 
@@ -1325,6 +1342,14 @@ class TestEveryLookupIsKeyedOnTheCampMinderSessionId:
         assert placement["session_cm_id"] == self.SESSION_CM_ID
 
         await write_service.set_availability(_availability_request())
+        write_in = repo.create_write_in.call_args[0][0]
+        assert write_in["session"] == "sess_1"
+        assert write_in["session_cm_id"] == self.SESSION_CM_ID
+
+        # BOTH halves of kindred#2382's split, because they are different
+        # tables now and a write that set the keys on only one of them would
+        # pass with either line alone.
+        await write_service.set_availability(_availability_request(family_available=True))
         availability = repo.create_availability.call_args[0][0]
         assert availability["session"] == "sess_1"
         assert availability["session_cm_id"] == self.SESSION_CM_ID
@@ -1485,3 +1510,279 @@ class TestSetSlotMerge:
 
         assert exc_info.value.status_code == 400
         repo.update_slot_merge.assert_not_called()
+
+
+class TestAWriteInIsStoredAsAnOccupancyNotAnAvailability:
+    """kindred#2382, PR 2 of 4 -- the WRITE half of the split.
+
+    `lodging_availability.family_available` answered two unrelated questions
+    through one boolean. `true` on a staff cabin is a staff<->family ROLE
+    override for the weekend -- "we're moving staff to X for weekend Y" -- and
+    the owner ruled it is NOT scenario-scoped, so it stays where it is.
+    `false` was an OCCUPANCY, somebody is in the room, and that IS
+    scenario-scoped, because not every write-in is non-rostered staff: some are
+    paper registrations for families arriving with no children, which is a
+    modelling choice belonging to the scenario that made it.
+
+    So `PUT /api/lodging/availability` now writes to one of TWO tables
+    depending on which question the body is answering. The endpoint, its
+    request model and everything a staff member sees are unchanged -- the split
+    is behind them, and behavioural parity is the acceptance criterion for this
+    PR.
+
+    ONE FACT AT A TIME, exactly as before. A single row per (unit, weekend)
+    could only ever hold one of the two, and writing the other replaced it; two
+    tables have to keep that promise deliberately, so every write drops the
+    other fact.
+
+    Fictional data throughout.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_write_in_creates_a_row_in_the_write_in_table(
+        self, write_service: LodgingWriteService, repo: MagicMock
+    ) -> None:
+        await write_service.set_availability(_availability_request(occupant_name="Emma Johnson", reason="Back Monday"))
+
+        repo.create_availability.assert_not_called()
+        data = repo.create_write_in.call_args[0][0]
+        assert data["unit"] == "u1"
+        assert data["session"] == "sess_1"
+        # The durable weekend key travels beside the relation (kindred#1879),
+        # exactly as it does on every other lodging write.
+        assert data["session_cm_id"] == 1000001
+        assert data["year"] == 2026
+        assert data["occupant_name"] == "Emma Johnson"
+        # The API says `reason`; the COLUMN is `note`. The translation moved
+        # tables with the fact and did not gain a third site.
+        assert data["note"] == "Back Monday"
+        # The boolean is what the split REMOVED. A write-in table row IS the
+        # occupancy; a column restating it would be the conflation coming back.
+        assert "family_available" not in data
+        # No scenario yet -- the draft twin stays dark until PR 3. Writing one
+        # here would put rows in a table nothing reads.
+        assert "scenario" not in data
+
+    @pytest.mark.asyncio
+    async def test_an_existing_write_in_is_updated_not_duplicated(
+        self, write_service: LodgingWriteService, repo: MagicMock
+    ) -> None:
+        """One row per (unit, weekend), as `idx_lodging_write_in_unique` says."""
+        repo.find_write_in = AsyncMock(return_value=SimpleNamespace(id="write_in_1"))
+
+        response = await write_service.set_availability(_availability_request(occupant_name="Emma Johnson"))
+
+        repo.create_write_in.assert_not_called()
+        record_id, data = repo.update_write_in.call_args[0]
+        assert record_id == "write_in_1"
+        assert data["occupant_name"] == "Emma Johnson"
+        assert response.record_id == "write_in_existing"
+
+    @pytest.mark.asyncio
+    async def test_a_write_in_drops_any_release_on_the_same_unit(
+        self, write_service: LodgingWriteService, repo: MagicMock
+    ) -> None:
+        """One fact at a time, unchanged from the single-row world.
+
+        The release row and the write-in row now live in different tables, so
+        nothing removes the loser for us. Left in place, a released staff cabin
+        somebody was then written into would carry both facts at once.
+        """
+        repo.find_availability_override = AsyncMock(return_value=SimpleNamespace(id="avail_1"))
+
+        await write_service.set_availability(_availability_request(occupant_name="Emma Johnson"))
+
+        repo.create_write_in.assert_called_once()
+        repo.delete_availability.assert_awaited_once_with("avail_1")
+
+    @pytest.mark.asyncio
+    async def test_the_new_fact_is_written_before_the_old_one_is_dropped(
+        self, write_service: LodgingWriteService, repo: MagicMock
+    ) -> None:
+        """ORDER, because there is no transaction across two PocketBase tables.
+
+        A failure between the two steps must leave the board saying something
+        true. Writing first and dropping second leaves BOTH facts present, and
+        the read path resolves occupancy over role -- so a half-applied
+        write-in still reads as "somebody is in it", which is the safe half.
+        Dropping first would leave a window with neither fact, opening a cabin
+        nobody meant to open.
+        """
+        calls: list[str] = []
+
+        def record_create(_data: dict[str, Any]) -> SimpleNamespace:
+            calls.append("create_write_in")
+            return SimpleNamespace(id="write_in_new")
+
+        def record_delete(_record_id: str) -> None:
+            calls.append("delete_availability")
+
+        repo.find_availability_override = AsyncMock(return_value=SimpleNamespace(id="avail_1"))
+        repo.create_write_in = AsyncMock(side_effect=record_create)
+        repo.delete_availability = AsyncMock(side_effect=record_delete)
+
+        await write_service.set_availability(_availability_request())
+
+        assert calls == ["create_write_in", "delete_availability"]
+
+    @pytest.mark.asyncio
+    async def test_a_release_still_writes_the_availability_row(
+        self, write_service: LodgingWriteService, repo: MagicMock
+    ) -> None:
+        """The ROLE half does not move. 1500000135's reasoning is right for it.
+
+        "Availability is a fact about the WEEKEND, not about the plan" was
+        correct all along for the staff<->family role; what changed is what
+        else the column had been asked to carry.
+        """
+        await write_service.set_availability(_availability_request(family_available=True, reason="Director away"))
+
+        repo.create_write_in.assert_not_called()
+        data = repo.create_availability.call_args[0][0]
+        assert data["family_available"] is True
+        assert data["note"] == "Director away"
+
+    @pytest.mark.asyncio
+    async def test_a_release_drops_any_write_in_on_the_same_unit(
+        self, write_service: LodgingWriteService, repo: MagicMock
+    ) -> None:
+        """The mirror of the write-in case, and the half a sweep would miss."""
+        repo.find_write_in = AsyncMock(return_value=SimpleNamespace(id="write_in_1"))
+
+        await write_service.set_availability(_availability_request(family_available=True, reason="Director away"))
+
+        repo.create_availability.assert_called_once()
+        repo.delete_write_in.assert_awaited_once_with("write_in_1")
+
+    @pytest.mark.asyncio
+    async def test_clearing_removes_both_facts(self, write_service: LodgingWriteService, repo: MagicMock) -> None:
+        """`family_available: null` restores the unit's standing role.
+
+        It always meant "delete the row", and there is no value meaning
+        "normal". With two tables it means delete BOTH rows: leaving either one
+        would have a clear silently do nothing on whichever fact it missed.
+        """
+        repo.find_write_in = AsyncMock(return_value=SimpleNamespace(id="write_in_1"))
+        repo.find_availability_override = AsyncMock(return_value=SimpleNamespace(id="avail_1"))
+
+        response = await write_service.set_availability(_availability_request(family_available=None))
+
+        repo.delete_write_in.assert_awaited_once_with("write_in_1")
+        repo.delete_availability.assert_awaited_once_with("avail_1")
+        assert response.deleted is True
+
+    @pytest.mark.asyncio
+    async def test_clearing_a_unit_that_holds_neither_fact_is_not_an_error(
+        self, write_service: LodgingWriteService, repo: MagicMock
+    ) -> None:
+        response = await write_service.set_availability(_availability_request(family_available=None))
+
+        repo.delete_write_in.assert_not_called()
+        repo.delete_availability.assert_not_called()
+        assert response.deleted is False
+        assert response.record_id == ""
+
+    @pytest.mark.asyncio
+    async def test_a_write_in_delete_race_is_not_an_error(
+        self, write_service: LodgingWriteService, repo: MagicMock
+    ) -> None:
+        """The row can vanish between the find and the delete.
+
+        Two staff clearing the same cabin, or one double-click. ONLY 404 is
+        swallowed, exactly as it is on every other delete in this module: "the
+        delete was refused" must not read as "there was nothing to delete".
+        """
+        repo.find_write_in = AsyncMock(return_value=SimpleNamespace(id="write_in_1"))
+        repo.delete_write_in = AsyncMock(
+            side_effect=ClientResponseError("gone", status=404, data={}, url="", is_abort=False, original_error=None)
+        )
+
+        response = await write_service.set_availability(_availability_request(family_available=None))
+
+        assert response.record_id == "write_in_1"
+        assert response.deleted is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [401, 403])
+    async def test_a_refused_write_in_delete_keeps_its_status(
+        self, write_service: LodgingWriteService, repo: MagicMock, status: int
+    ) -> None:
+        repo.find_write_in = AsyncMock(return_value=SimpleNamespace(id="write_in_1"))
+        repo.delete_write_in = AsyncMock(
+            side_effect=ClientResponseError(
+                "refused", status=status, data={}, url="", is_abort=False, original_error=None
+            )
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await write_service.set_availability(_availability_request(family_available=None))
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_a_lost_write_in_race_is_still_recovered(
+        self, write_service: LodgingWriteService, repo: MagicMock
+    ) -> None:
+        """`idx_lodging_write_in_unique` rejects the loser, exactly as the
+        availability index used to -- so the loser re-reads and updates the
+        winner's row, which by construction is the row this call wanted."""
+        repo.create_write_in = AsyncMock(
+            side_effect=ClientResponseError(
+                "unique constraint", status=400, data={}, url="", is_abort=False, original_error=None
+            )
+        )
+        repo.find_write_in = AsyncMock(side_effect=[None, SimpleNamespace(id="write_in_winner")])
+
+        response = await write_service.set_availability(_availability_request(occupant_name="Emma Johnson"))
+
+        record_id, data = repo.update_write_in.call_args[0]
+        assert record_id == "write_in_winner"
+        assert data["occupant_name"] == "Emma Johnson"
+        assert response.record_id == "write_in_existing"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [401, 403])
+    async def test_a_refused_write_in_create_keeps_its_status(
+        self, write_service: LodgingWriteService, repo: MagicMock, status: int
+    ) -> None:
+        repo.create_write_in = AsyncMock(
+            side_effect=ClientResponseError(
+                "refused", status=status, data={}, url="", is_abort=False, original_error=None
+            )
+        )
+        repo.find_write_in = AsyncMock(side_effect=[None, SimpleNamespace(id="write_in_other")])
+
+        with pytest.raises(HTTPException) as exc_info:
+            await write_service.set_availability(_availability_request())
+
+        assert exc_info.value.status_code == 403
+        repo.update_write_in.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_refused_write_in_update_keeps_its_status(
+        self, write_service: LodgingWriteService, repo: MagicMock
+    ) -> None:
+        repo.find_write_in = AsyncMock(return_value=SimpleNamespace(id="write_in_1"))
+        repo.update_write_in = AsyncMock(
+            side_effect=ClientResponseError("refused", status=403, data={}, url="", is_abort=False, original_error=None)
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await write_service.set_availability(_availability_request())
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_the_write_in_lookup_is_keyed_by_campminder_session_id(
+        self, write_service: LodgingWriteService, repo: MagicMock
+    ) -> None:
+        """kindred#2042's durable key, on the new table too.
+
+        A camp_sessions row recreated rather than updated gets a new PocketBase
+        id; rows keyed on the old one become unreachable. Every lodging lookup
+        goes through the CampMinder id for that reason, and the split must not
+        quietly introduce one that does not.
+        """
+        await write_service.set_availability(_availability_request())
+
+        repo.find_write_in.assert_awaited_once_with(2026, 1000001, "u1")


### PR DESCRIPTION
Second of four on kindred#2382. **This PR is not the one that finishes that issue** — PR 4 is, and it carries the closing reference. Nothing here does.

Stacked on `feature/phase-e-writein-table` (#2422, "1 of 4"), which created `lodging_write_ins` and `lodging_write_ins_draft` empty and dark. This one **moves the rows and switches the read**, at behavioural parity.

## The model, per the owner's 2026-08-15 clarification

`lodging_availability.family_available` answered two unrelated questions through one boolean:

| value | fact | scenario-scoped? | where it lives after this PR |
|---|---|---|---|
| `true` | staff↔family **ROLE** — a staff cabin opened to families for the weekend | **No** — an operational fact, *"we're moving staff to X for weekend Y"* | `lodging_availability`, unchanged |
| `false` | **OCCUPANCY** — somebody is in it. The write-in | **Yes** — not every write-in is non-rostered staff; some are paper registrations for families arriving with no children, which is a modelling choice | `lodging_write_ins` |
| no row | the unit's own role decides | — | — |

## Measured, and re-verified against `pocketbase/pb_data/data-prod.db`

```
SELECT family_available, count(*) FROM lodging_availability GROUP BY family_available;
0|21
```

**All 21 rows are `family_available = 0` — every one an OCCUPANCY, none a ROLE.** So `1500000162` moves all 21 and leaves `lodging_availability` **empty**. Stated plainly rather than described as a partition: the role half is live capability with no current rows, not a preserved population. There is no risky partition and no ambiguous row.

## What shipped

**Migration `1500000162_lodging_write_ins_backfill.js`** — moves the `family_available = 0` rows, carrying `unit`, `session`, `session_cm_id`, `year`, `occupant_name`, `note`, plus the row's `id` and its `created`/`updated`, so a moved row keeps the day staff actually recorded it. Two guarded statements in a deliberate order: INSERT what is not already there (keyed on the destination's unique index), then DELETE only what a copy provably exists for. Nothing is removed before it is proven saved. Down is the exact inverse.

**Read** — `build_roster` and `build_summary` each fetch `lodging_write_ins` (two separate TaskGroups, both wired; a guard test pins each). `_build_units` now takes two sources and resolves ROLE from availability, OCCUPANCY from write-ins, with occupancy outranking role for the race case no writer can produce. `write_in_covers` / `_resolve_write_in_covers` take the occupancy unit-ids as an **input** instead of re-deriving them from `family_available_override is False`, so a bare `false` on a role row — which names nobody — can no longer masquerade as somebody sleeping in a cabin.

**Write** — `PUT /api/lodging/availability` keeps its URL, its request model and everything a staff member sees, and routes behind them: `false` → `lodging_write_ins`, `true` → `lodging_availability`, `null` → deletes from both. Each write drops the other fact, because a single row used to do that for free and two tables have to keep the promise deliberately. The **new fact is written before the old one is dropped**: there is no transaction across two PocketBase tables, and write-then-drop leaves a window where both rows exist, which the read resolves as "somebody is in it" — the safe half. Drop-then-write would leave a window with neither, opening a cabin nobody meant to open.

## Behavioural parity is the acceptance criterion

`family_available_override` **still spells an occupancy as `False`**, deliberately. Every count on the stats bar (`units_family_available`, `units_reserved`, `beds_family_available`) is derived from it through `is_family_available`, and the board's forest open-tint reads `false` as a proxy for "is somebody in it". A write-in that stopped spelling itself there would silently return an occupied cabin to the open count. Disentangling the two axes **on the wire** is PR 4.

Because of that, **the frontend needs no behavioural change**: `unit.write_in` is still populated by the server, so `coveringWriteIn`, `writeInOccupant`, `writeInSource`, `reservationBadge`, `availabilityAction` and the drop-disable all keep working unmodified. The frontend diff here is table-name corrections in comments that my own change made false, nothing else.

## Deliberately NOT in this PR

- **No scenario dimension.** `lodging_write_ins_draft` stays dark — nothing reads or writes it. `fetch_draft_write_ins` is untouched and `copy_from_mirror` / `copy_scenario_to_scenario` are not opened. Two tests pin it (`test_no_scenario_dimension_is_read_yet`, and the same assertion on the lander). That is **PR 3**.
- **No re-pointing of #2093's forest open-tint proxy** and no edits to the premise comments in `writeIn.ts:1-25`, `unitBadges.ts:302`, `lodging_repository.py:18-22`. That is **PR 4**.
- **No widening of the single-cover arity** to N write-ins per container — still one row per (unit, weekend). That is kindred#2381, which does not dissolve into this.
- **`frontend/src/utils/boardLayout.ts` untouched** (in-flight PR #2404).

## ⚠️ File overlap

PR #2423 (kindred#2330, `feature/phase-e-share-provenance`) is open and also edits `api/schemas/lodging.py` and `api/services/lodging_roster_service.py`, in different regions (request-text provenance, not write-ins). This branch is not based on it and edits are scoped tightly to the write-in regions. **Whichever of the two merges second must rebase.**

## ⚠️ CI does not run on this branch — confirmed, not assumed

`.github/workflows/ci.yml` triggers on `pull_request: branches: [main]`. This PR's base is `feature/phase-e-writein-table`, so **no CI Summary runs and this branch is unverified by CI**. The only checks present are "Validate PR title", a skipped `auto-merge`, and a CodeRabbit check that is green because it says *"Review skipped: automatic reviews are disabled"* — a no-op notice, not a review.

**Its only evidence is the local gate runs below.** Re-check once #2422 merges and this PR's base moves to `main`.

## Evidence

`bash scripts/pre-push-verify.sh` — **ALL CHECKS PASSED**: ruff format, ruff check, mypy, pytest (unit), go build, golangci-lint, go test, prettier, eslint, tsc, vitest, migration headers, `options:{}` anti-pattern scan, pb-js-lint, shellcheck. Pre-push hook additionally green (`6366 passed, 41 skipped`, api-types freshness).

Targeted suites:

```
tests/unit/api/services/test_lodging_{roster,write}_service.py
tests/unit/api/services/test_lodging_repository.py
tests/unit/api/routers/test_lodging_endpoints.py     477 passed
frontend  src/components/weekend + services + types  1359 passed (54 files)
```

**The migration was verified against a real PocketBase boot**, not only against unit tests. `scripts/dev/verify-writein-table-backfill.sh` (new, following `verify-availability-writein-backfill.sh`'s pattern) boots three times — without the migration, with it, then with a byte-for-byte copy under a later filename — and asserts every column and timestamp travels, the ROLE release stays put, the draft twin is untouched, and nothing is lost between the tables. It builds the **half-applied** state (insert landed, delete did not) rather than a plain second run, because a plain second run was measured to be a weak test: the source rows are already gone, so deleting the `NOT EXISTS` guard still passes it.

```
verify-writein-table-backfill: OK (122 js migrations applied)
```

Mutation-checked, three ways: dropping the `family_available = 0` predicate → FAIL ("4 rows went in and 5 came out"); dropping the `NOT EXISTS` idempotency guard → exit 2, boot refused with `UNIQUE constraint failed: lodging_write_ins.session_cm_id, lodging_write_ins.year, lodging_write_ins.unit`; dropping the DELETE's `EXISTS` proof → FAIL (the release row deleted too). Restored → OK.

The read predicate was mutation-checked the same way: reverting `_is_written_in` to `family_available_override is False` turns 8 tests red, restoring turns 197 green.

And **against the real production snapshot** (a scratch copy of `data-prod.db`, never the original): `migrate up` → availability 0 / write-ins 21, all 21 occupant names and all 3 notes preserved; forget-and-re-apply → unchanged; `migrate down 1` → 21 rows back with `family_available = 0`, 21 names, 3 notes; `migrate up` again → moved again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
