### PR TITLE
feat(api): give write-ins their scenario dimension (#2382, 3 of 4)

### DIFF
--- a/api/services/lodging_repository.py
+++ b/api/services/lodging_repository.py
@@ -396,9 +396,10 @@ class LodgingRepository:
         is no overlay.
 
         `build_roster` and `build_summary` both read this, and `_build_units`
-        is where a row becomes the occupancy half of a unit's answer. PR 2 of
-        kindred#2382 switched them over and 1500000162 moved the rows; the
-        DRAFT sibling below is still dark until PR 3.
+        is where a row becomes the occupancy half of a unit's answer. Both pick
+        THIS read or `fetch_draft_write_ins` below on whether the request named
+        a scenario, exactly as they pick between `fetch_assignments` and
+        `fetch_draft_assignments` -- never both.
         """
         return await self._page(
             LODGING_WRITE_INS,
@@ -425,11 +426,13 @@ class LodgingRepository:
         the same kind of fact as a placement, so it follows the placement
         rule.
 
-        NOTHING READS THIS YET, unlike its live sibling above. PR 2 of
-        kindred#2382 moved the rows and switched the readers over to the LIVE
-        table at behavioural parity; giving write-ins their scenario dimension
-        -- this read, and the seed copies in both `copy_from_mirror` and
-        `copy_scenario_to_scenario` -- is PR 3.
+        `build_roster` and `build_summary` read THIS instead of
+        `fetch_write_ins` whenever the request names a scenario, and the live
+        table is then not read at all. `copy_from_mirror` and
+        `copy_scenario_to_scenario` both seed it, so a fresh scenario starts
+        with the write-ins its source had rather than blank -- without that,
+        kindred#2247's placement gate would let a family be dropped into a room
+        the live board records as occupied.
 
         `scenario_id` is client-supplied and escaped, for the reason
         `fetch_draft_assignments` spells out. The weekend is named by

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -982,12 +982,30 @@ class LodgingRosterService:
         async with asyncio.TaskGroup() as tg:
             units_task = tg.create_task(self.repository.fetch_units(year))
             availability_task = tg.create_task(self.repository.fetch_availability(year, session_cm_id))
-            # THE OCCUPANCY HALF, split out of availability by kindred#2382.
-            # Read with NO scenario predicate, and that is not the old shape
-            # coming back: the live board is a scope in its own right, exactly
-            # as `lodging_assignments` is, and the draft twin behind this table
-            # stays dark until PR 3 gives write-ins their scenario dimension.
-            write_ins_task = tg.create_task(self.repository.fetch_write_ins(year, session_cm_id))
+            # THE OCCUPANCY HALF, split out of availability by kindred#2382,
+            # and chosen exactly the way the placement source below is chosen.
+            # A scenario reads its OWN write-ins and REPLACES the live ones --
+            # it does not read them at all -- matching kindred#1974's
+            # no-fall-through rule for `lodging_assignments_draft`. A unit with
+            # no draft row holds no write-in in that scenario, whatever the
+            # live board says.
+            #
+            # The live board is the other scope, not the absence of one: with
+            # no scenario this reads `lodging_write_ins` with no scenario
+            # predicate, exactly as `lodging_assignments` is read.
+            #
+            # A fresh scenario is seeded by an explicit COPY in both seed paths
+            # (`copy_from_mirror` and `copy_scenario_to_scenario`, owner ruling
+            # 2026-08-16), which is what stops it starting blank -- without it
+            # kindred#2247's placement gate would let a family be dropped into
+            # a room the live board records as occupied. Rendering the live
+            # rows through this read's gaps would be the overlay instead, and
+            # would make two scenarios unable to disagree.
+            write_ins_task = tg.create_task(
+                self.repository.fetch_draft_write_ins(year, session_cm_id, scenario)
+                if scenario
+                else self.repository.fetch_write_ins(year, session_cm_id)
+            )
             attendees_task = tg.create_task(self.repository.fetch_attendees_for_session(year, session_pb_id))
             households_task = tg.create_task(self.repository.fetch_households(year))
             prior_task = tg.create_task(self.repository.fetch_prior_household_cm_ids(year))
@@ -1086,7 +1104,7 @@ class LodgingRosterService:
     async def build_summary(self, year: int, scenario: str = "") -> WeekendSummaryResponse:
         """Every weekend in the year with its counts, in one pass.
 
-        `build_roster` makes TWELVE fetches (11 concurrent + `fetch_session`
+        `build_roster` makes THIRTEEN fetches (12 concurrent + `fetch_session`
         alone before them), of which SEVEN are year-scoped -- the unit
         registry, households, the prior-household set, family-camp adults,
         registrations, the unresolved-alias count and last year's cabins
@@ -1108,16 +1126,19 @@ class LodgingRosterService:
         in `_build_counts` from units already in hand rather than fetched.
 
         So the year-scoped work happens once here, and only the genuinely
-        session-scoped reads run per weekend: availability, attendees and one
-        placement read -- the synced rows, or the scenario's own. The
+        session-scoped reads run per weekend: availability, write-ins,
+        attendees and one placement read -- the synced rows, or the scenario's
+        own. The
         per-weekend numbers then come from the SAME `_build_units` /
         `_build_parties` / `_build_counts` helpers the roster uses, so the
         lander cannot drift from the page it links to, and it resolves a
         scenario the same way: replace, never fall through.
 
-        FOUR session-scoped reads per weekend, with or without a scenario:
-        availability, attendees, one placement source, and slot merges (the
-        last of these unconditional since 1500000140). A `Semaphore` below
+        FIVE session-scoped reads per weekend, with or without a scenario:
+        availability, one write-in source, attendees, one placement source, and
+        slot merges (the last of these unconditional since 1500000140). The two
+        "one source" reads are the scenario-aware pair -- the live table or the
+        scenario's draft, never both. A `Semaphore` below
         bounds how many weekends' worth of those run at once -- kindred#1920,
         which also records why a per-weekend cap was chosen over collapsing
         the placement read to one call for the whole year.
@@ -1167,14 +1188,19 @@ class LodgingRosterService:
             entry_cm_id = _i(session, "cm_id")
             async with entry_gate, asyncio.TaskGroup() as inner:
                 availability_task = inner.create_task(self.repository.fetch_availability(year, entry_cm_id))
-                # Exactly as build_roster reads it, and separately, because
-                # this is a DIFFERENT TaskGroup -- wiring one and leaving the
-                # other is the half-fix the guards in this file's tests exist
-                # to catch. The lander keeps only counts, and every count on it
-                # goes through `is_family_available`, so a weekend card that
-                # never read this table would report a written-into cabin as
-                # open beside a board that draws it closed.
-                write_ins_task = inner.create_task(self.repository.fetch_write_ins(year, entry_cm_id))
+                # Exactly as build_roster reads it, SCENARIO AND ALL, and
+                # separately, because this is a DIFFERENT TaskGroup -- wiring
+                # one and leaving the other is the half-fix the guards in this
+                # file's tests exist to catch. The lander keeps only counts,
+                # and every count on it goes through `is_family_available`, so
+                # a weekend card that read the wrong scope would report a
+                # written-into cabin as open beside a board that draws it
+                # closed.
+                write_ins_task = inner.create_task(
+                    self.repository.fetch_draft_write_ins(year, entry_cm_id, scenario)
+                    if scenario
+                    else self.repository.fetch_write_ins(year, entry_cm_id)
+                )
                 attendees_task = inner.create_task(self.repository.fetch_attendees_for_session(year, session_pb_id))
                 # One placement source, exactly as build_roster chooses it.
                 placements_task = inner.create_task(

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -479,7 +479,12 @@ def resolve_combined(*, default: bool, override: bool | None, session_override: 
 
 
 def written_in_unit_ids(write_ins: list[Any]) -> frozenset[str]:
-    """The unit ids `lodging_write_ins` names, for `write_in_covers` to walk.
+    """The unit ids the chosen write-in source names, for `write_in_covers` to walk.
+
+    WHICHEVER source the request resolved to -- `lodging_write_ins` on the live
+    board, `lodging_write_ins_draft` inside a scenario (kindred#2382). The
+    caller has already made that choice, and a scenario REPLACES, so this walks
+    exactly one scope's rows.
 
     Built ONCE per request and threaded, rather than re-derived inside the
     cover walk: `_build_units` already consumes the same rows on the way to the
@@ -1399,11 +1404,15 @@ class LodgingRosterService:
         # `lodging_write_ins` answers OCCUPANCY: somebody is in the room. That
         # is a modelling fact (not every write-in is non-rostered staff -- some
         # are paper registrations for families arriving with no children), so it
-        # got a table of its own with a draft twin waiting behind it.
+        # got a table of its own with a scenario-scoped draft twin beside it.
         #
-        # ONE layer each. There is still no scenario overlay: a scenario reads
-        # the same live rows it does today, and PR 3 of kindred#2382 is what
-        # gives the occupancy half its scenario dimension.
+        # ONE layer each, and still no overlay -- but since PR 3 of
+        # kindred#2382 the two halves SCOPE differently. The role rows are the
+        # same for every plan (`lodging_availability` has no scenario column).
+        # The write-in rows are whichever table the caller already chose, the
+        # live one or a scenario's own draft, and a scenario REPLACES -- so
+        # what arrives here is the whole occupancy answer for the scope that
+        # was asked for, and nothing below merges a second source into it.
         role_row_by_unit = {_s(row, "unit"): row for row in availability}
         write_in_row_by_unit = {_s(row, "unit"): row for row in write_ins}
 
@@ -1449,8 +1458,8 @@ class LodgingRosterService:
             # as a proxy for "is somebody in it" -- so a write-in that stopped
             # spelling itself here would silently return an occupied cabin to
             # the open count. Disentangling the two axes on the wire is PR 4 of
-            # kindred#2382; this PR moves the STORAGE and nothing a user can
-            # see.
+            # kindred#2382; until it lands this one field still answers both,
+            # whichever table the row came from.
             #
             # Occupancy OUTRANKS the role when a unit somehow carries both.
             # No writer produces that pair -- `set_availability` clears the

--- a/api/services/lodging_write_service.py
+++ b/api/services/lodging_write_service.py
@@ -310,13 +310,23 @@ class LodgingWriteService:
         scenario spans weekends, and placements in one must not refuse a seed
         of another.
 
-        Availability is NOT copied, and since 1500000135 there is nothing it
-        could mean to copy it: the table has no scenario column, so every
-        scenario reads the same rows and a copy would be a row duplicating
-        itself. The earlier reason -- that availability overlaid the live rows,
-        so copying them would pin the scenario against a later change -- has
-        become the stronger one that a scenario cannot disagree about
-        availability at all.
+        THE STAFF<->FAMILY ROLE OVERRIDE IS NOT COPIED, and since 1500000135
+        there is nothing it could mean to copy it: `lodging_availability` has
+        no scenario column, so every scenario reads the same rows and a copy
+        would be a row duplicating itself. The owner ruled that half is not
+        scenario-scoped -- "that's more of a known 'were moving staff to X for
+        weekend Y'" -- so there is nothing there for a scenario to disagree
+        about.
+
+        WRITE-INS ARE COPIED, and that is the opposite call on the other half
+        of the boolean 1500000161 split apart (owner ruling, kindred#2382,
+        2026-08-16). Once a scenario's write-ins REPLACE the live ones rather
+        than falling through, a scenario seeded without them starts with every
+        written-into cabin looking OPEN -- and kindred#2247's placement gate
+        reads exactly that, so it would let a family be dropped into a room the
+        live board records as occupied. That failure mode is one this split
+        CREATES rather than inherits, and this copy is what closes it. See
+        `_seed_write_ins`.
 
         A mirror row is SKIPPED, not failed on, when it names no party grain
         (it would key on nothing, dedupe against nothing, and be exactly the
@@ -395,12 +405,24 @@ class LodgingWriteService:
                 raise await self._seed_failure(exc, request, copied) from exc
             copied += 1
 
+        # The LIVE board's write-ins, because the live board is what this seed
+        # copies FROM. `copy_scenario_to_scenario` reads the source scenario's
+        # own draft rows instead, the same split the placement read above makes
+        # between `fetch_assignments` and `fetch_draft_assignments`.
+        write_ins = await self._seed_write_ins(
+            rows=await self.repository.fetch_write_ins(request.year, request.session_cm_id),
+            session_pb_id=session_pb_id,
+            session_cm_id=request.session_cm_id,
+            year=request.year,
+            scenario=request.scenario,
+        )
+
         # Inlined into the message, not `extra={}` -- see the identical note
         # on `copy_scenario_to_scenario`'s own logger.info call below.
         logger.info(
             f"Seeded lodging scenario from the CampMinder mirror: year={request.year} "
             f"session_cm_id={request.session_cm_id} scenario={request.scenario} "
-            f"copied={copied} skipped={skipped}"
+            f"copied={copied} skipped={skipped} write_ins={write_ins}"
         )
         return LodgingCopyResponse(copied=copied, skipped=skipped)
 
@@ -551,6 +573,22 @@ class LodgingWriteService:
                 }
             )
 
+        # Write-ins: the SOURCE SCENARIO's own, not the live board's. Unlike
+        # `fetch_slot_merges` above there is no weekend-level tier to filter
+        # out -- `fetch_draft_write_ins` returns exactly one scenario's rows --
+        # and unlike the role override there IS something for two scenarios to
+        # disagree about, which is the whole of kindred#2382. Dropping this
+        # would make "copy from Option A" produce a board showing fewer
+        # occupied rooms than Option A does, and kindred#2247's placement gate
+        # would then offer those rooms.
+        write_ins = await self._seed_write_ins(
+            rows=await self.repository.fetch_draft_write_ins(year, session_cm_id, from_scenario),
+            session_pb_id=session_pb_id,
+            session_cm_id=session_cm_id,
+            year=year,
+            scenario=to_scenario,
+        )
+
         # Inlined into the message, not `extra={}` -- `extra` is silently
         # dropped at format time (bunking/logging_config.py's
         # ISO8601Formatter.format only ever renders record.getMessage()),
@@ -558,9 +596,69 @@ class LodgingWriteService:
         # few hundred lines above.
         logger.info(
             f"Copied a lodging scenario into a fresh one: year={year} session_cm_id={session_cm_id} "
-            f"from_scenario={from_scenario} to_scenario={to_scenario} copied={copied} skipped={skipped}"
+            f"from_scenario={from_scenario} to_scenario={to_scenario} copied={copied} skipped={skipped} "
+            f"write_ins={write_ins}"
         )
         return LodgingCopyResponse(copied=copied, skipped=skipped)
+
+    async def _seed_write_ins(
+        self, *, rows: list[Any], session_pb_id: str, session_cm_id: int, year: int, scenario: str
+    ) -> int:
+        """Copy one weekend's write-ins into a scenario, and say how many.
+
+        ONE HELPER, TWO SEED PATHS, and the only thing that differs between
+        them is which read produced `rows`: `copy_from_mirror` hands over the
+        LIVE board's (`fetch_write_ins`), `copy_scenario_to_scenario` the
+        SOURCE scenario's own (`fetch_draft_write_ins`). Everything after that
+        is identical, and two copies of it is two chances for one seed path to
+        start writing a different row shape than the other.
+
+        WHY A SEED COPIES THESE AT ALL is the owner's ruling of 2026-08-16, and
+        it is a safety argument rather than a convenience one. A scenario's
+        write-ins REPLACE the live ones on read (kindred#2382, matching
+        kindred#1974's no-fall-through rule for placements), so a scenario
+        seeded without them shows every written-into cabin as OPEN --
+        kindred#2247's placement gate reads exactly that field, so it would
+        offer a room the live board records as occupied. The split creates that
+        failure mode; this copy is what closes it.
+
+        NO EMPTINESS CHECK AND NO RACE RECOVERY OF ITS OWN, following the
+        `lodging_slot_merges` copy in `copy_scenario_to_scenario` rather than
+        the placement loop above it. Both seed paths have already refused a
+        destination that holds placements, and a create that collides with
+        `idx_lodging_write_in_draft_unique` surfaces through
+        `pb_error_to_http` the same way a colliding merge create does. Adding a
+        second, differently-shaped guard here would give one seed two answers
+        to "this scenario is already populated".
+
+        NOT counted into `LodgingCopyResponse.copied`, again as merges are not:
+        that number is the one a staff member reads as "the board is
+        populated", and it means placements. The count comes back for the log
+        line, where it is the difference between a silent no-op and a visible
+        one.
+
+        `family_available` is deliberately absent from the payload. On the
+        occupancy tables the ROW is the fact; a column restating it would be
+        the conflation kindred#2382 split apart growing back -- the same
+        sentence `set_availability` carries over its own shared payload.
+        """
+        for row in rows:
+            await self.repository.create_draft_write_in(
+                {
+                    "unit": getattr(row, "unit", None),
+                    "session": session_pb_id,
+                    "session_cm_id": session_cm_id,
+                    "year": year,
+                    "scenario": scenario,
+                    "occupant_name": str(getattr(row, "occupant_name", "") or ""),
+                    # The column keeps its own name here, not the API's
+                    # `reason`: this is a table-to-table copy and never passes
+                    # through the schema. `set_availability` and `_build_units`
+                    # remain the only two places the two names meet.
+                    "note": str(getattr(row, "note", "") or ""),
+                }
+            )
+        return len(rows)
 
     async def _clear_row(self, existing: Any | None, delete: Callable[[str], Awaitable[None]]) -> tuple[str, bool]:
         """Drop one row if it is there, and say what happened.

--- a/api/services/lodging_write_service.py
+++ b/api/services/lodging_write_service.py
@@ -625,11 +625,23 @@ class LodgingWriteService:
         NO EMPTINESS CHECK AND NO RACE RECOVERY OF ITS OWN, following the
         `lodging_slot_merges` copy in `copy_scenario_to_scenario` rather than
         the placement loop above it. Both seed paths have already refused a
-        destination that holds placements, and a create that collides with
-        `idx_lodging_write_in_draft_unique` surfaces through
-        `pb_error_to_http` the same way a colliding merge create does. Adding a
-        second, differently-shaped guard here would give one seed two answers
-        to "this scenario is already populated".
+        destination that holds placements, and adding a second,
+        differently-shaped guard here would give one seed two answers to "this
+        scenario is already populated".
+
+        THE CREATE IS STILL CONVERTED, because "no recovery" is not "no
+        handler", and the difference is reachable rather than theoretical. That
+        up-front guard counts PLACEMENTS, so a weekend whose mirror holds
+        nothing copyable -- early season, before CampMinder has assigned any
+        lodging -- passes it on every attempt while the write-ins the first
+        seed wrote are already in the scenario, and the second seed collides on
+        `idx_lodging_write_in_draft_unique`. Nothing on this router catches
+        `ClientResponseError`, so one escaping here unconverted would reach
+        api/main.py's catch-all as a 500: a state the server understands
+        perfectly well, reported as one it does not. `pb_error_to_http` is what
+        every other write on this service raises through, and it keeps a
+        refusal a refusal (401/403 -> 403) rather than folding it into the
+        collision.
 
         NOT counted into `LodgingCopyResponse.copied`, again as merges are not:
         that number is the one a staff member reads as "the board is
@@ -643,21 +655,25 @@ class LodgingWriteService:
         sentence `set_availability` carries over its own shared payload.
         """
         for row in rows:
-            await self.repository.create_draft_write_in(
-                {
-                    "unit": getattr(row, "unit", None),
-                    "session": session_pb_id,
-                    "session_cm_id": session_cm_id,
-                    "year": year,
-                    "scenario": scenario,
-                    "occupant_name": str(getattr(row, "occupant_name", "") or ""),
-                    # The column keeps its own name here, not the API's
-                    # `reason`: this is a table-to-table copy and never passes
-                    # through the schema. `set_availability` and `_build_units`
-                    # remain the only two places the two names meet.
-                    "note": str(getattr(row, "note", "") or ""),
-                }
-            )
+            try:
+                await self.repository.create_draft_write_in(
+                    {
+                        "unit": getattr(row, "unit", None),
+                        "session": session_pb_id,
+                        "session_cm_id": session_cm_id,
+                        "year": year,
+                        "scenario": scenario,
+                        "occupant_name": str(getattr(row, "occupant_name", "") or ""),
+                        # The column keeps its own name here, not the API's
+                        # `reason`: this is a table-to-table copy and never
+                        # passes through the schema. `set_availability` and
+                        # `_build_units` remain the only two places the two
+                        # names meet.
+                        "note": str(getattr(row, "note", "") or ""),
+                    }
+                )
+            except ClientResponseError as exc:
+                raise pb_error_to_http(exc) from exc
         return len(rows)
 
     async def _clear_row(self, existing: Any | None, delete: Callable[[str], Awaitable[None]]) -> tuple[str, bool]:
@@ -765,8 +781,19 @@ class LodgingWriteService:
         right (owner, 2026-08-15: staff must be able to record a write-in on
         the real board, not only inside a modelling sandbox), so this writes
         the LIVE occupancy table with no scenario predicate, exactly as
-        `lodging_assignments` has none. The draft twin behind it stays dark
-        until PR 3 of kindred#2382.
+        `lodging_assignments` has none.
+
+        ⚠️ AND THAT IS NOW A GAP RATHER THAN A RESTING STATE. PR 3 of
+        kindred#2382 made a scenario's write-ins REPLACE the live ones on read,
+        so a staff member working inside a scenario who writes one here lands
+        it on the LIVE board and then does not see it on the board they made it
+        on. It cannot be closed from this side alone -- the frontend has to
+        send the `scenario` it already holds -- so PR 4 owns it:
+        `AvailabilityWriteRequest` gains an optional `scenario` (blank meaning
+        the live board, exactly as `SlotMergeRequest` spells it), the OCCUPANCY
+        half below routes to `find/create/update/delete_draft_write_in` when it
+        is set, and the ROLE half stays on `lodging_availability` whatever the
+        request says, because that half is not scenario-scoped.
 
         ONE FACT AT A TIME, and this is the promise the split has to keep
         deliberately. A single row could only ever hold one of the two, so

--- a/docs/architecture/lodging-occupancy.md
+++ b/docs/architecture/lodging-occupancy.md
@@ -140,6 +140,30 @@ rule: it blocks legitimate work and teaches staff to ignore warnings.
   about the plan — a burst pipe closes a cabin in every scenario for that
   weekend.
 
+  **That boolean answered two questions, and kindred#2382 split them.** `true`
+  is a staff↔family ROLE override — "this staff cabin is released to families
+  this weekend" — which the owner ruled is *not* scenario-scoped, so it stays
+  here and `1500000135`'s reasoning above is exactly right for it. `false` was
+  an OCCUPANCY — somebody is in the room — and that *is* scenario-scoped,
+  because not every write-in is non-rostered staff: some are paper
+  registrations for families arriving with no children, which are a modelling
+  choice belonging to the scenario that made them. Migration `1500000161`
+  created `lodging_write_ins` and `lodging_write_ins_draft` for it and
+  `1500000162` moved the rows.
+
+  The pair behaves exactly as `lodging_assignments` / `lodging_assignments_draft`
+  does: a request naming a scenario reads the DRAFT and **replaces** the live
+  rows rather than falling through to them (kindred#1974's rule), and the live
+  board is a scope in its own right rather than the absence of one — staff must
+  be able to record a write-in on the real board, not only inside a modelling
+  sandbox. A fresh scenario is therefore seeded with the write-ins its source
+  had, in **both** seed paths (`copy_from_mirror` and
+  `copy_scenario_to_scenario`); without that the placement gate below would
+  offer a room the live board records as occupied. Deleting a scenario sweeps
+  its write-ins through the relation's `cascadeDelete`, the same mechanism
+  every other lodging draft table relies on — there is no hook and no
+  client-side pre-delete loop.
+
   ### What a hold represents (owner ruling, 2026-08-09; kindred#2090, kindred#2087)
 
   A hold records **who is in a building** — chiefly non-rostered staff, a

--- a/docs/architecture/lodging-occupancy.md
+++ b/docs/architecture/lodging-occupancy.md
@@ -164,6 +164,17 @@ rule: it blocks legitimate work and teaches staff to ignore warnings.
   every other lodging draft table relies on — there is no hook and no
   client-side pre-delete loop.
 
+  **The READ replaces; the WRITE does not yet choose.** `PUT
+  /api/lodging/availability` takes no `scenario` and writes the live occupancy
+  table, which was right while reads fell through and is a gap now that they
+  replace: a staff member working inside a scenario who records a write-in
+  lands it on the live board and does not see it on the board they made it on.
+  Closing it needs the frontend to send the scenario it already holds, so it
+  belongs with the rest of kindred#2382's frontend work — `set_availability`'s
+  own docstring carries the shape of the fix. Until then, a write-in meant for
+  a scenario has to be recorded on the live board and picked up by seeding the
+  scenario from it.
+
   ### What a hold represents (owner ruling, 2026-08-09; kindred#2090, kindred#2087)
 
   A hold records **who is in a building** — chiefly non-rostered staff, a

--- a/pocketbase/lodging/hooks_test.go
+++ b/pocketbase/lodging/hooks_test.go
@@ -1843,8 +1843,16 @@ func newWriteInsTestApp(t *testing.T) core.App {
 		})
 		writeIns.Fields.Add(&core.NumberField{Name: "year"})
 		if name == "lodging_write_ins_draft" {
+			// CascadeDelete MIRRORS 1500000161, and it is the whole of
+			// kindred#2382's scenario-delete answer: deleting a saved scenario
+			// takes its write-ins with it, exactly as it does for
+			// lodging_assignments_draft (1500000132) and lodging_slot_merges
+			// (1500000139). No hook and no Python pre-delete loop implements
+			// it, so a fixture that left it off would let
+			// TestDeletingAScenarioSweepsItsDraftWriteIns pass or fail on the
+			// fixture rather than on the schema under test.
 			writeIns.Fields.Add(&core.RelationField{
-				Name: "scenario", CollectionId: scenariosCol.Id, MaxSelect: 1,
+				Name: "scenario", CollectionId: scenariosCol.Id, MaxSelect: 1, CascadeDelete: true,
 			})
 		}
 		if err := app.Save(writeIns); err != nil {
@@ -1874,6 +1882,91 @@ func seedWriteIn(t *testing.T, app core.App, collection, unit string, year int) 
 		return fmt.Errorf("save %s row for year %d: %w", collection, year, err)
 	}
 	return nil
+}
+
+// TestDeletingAScenarioSweepsItsDraftWriteIns is kindred#2382's
+// scenario-delete knock-on, asserted against the running engine.
+//
+// WHERE THE CASCADE LIVES, because both plausible homes are wrong and the
+// question gets re-asked: NOT in pocketbase/lodging/hooks.go, which registers
+// these collections only for the year guards, and NOT in Python --
+// `delete_scenario` (api/routers/scenarios.py) sweeps `bunk_assignments_draft`
+// by hand for summer and touches no lodging table at all. It is a SCHEMA
+// property: `scenario` is declared `cascadeDelete: true` in 1500000161,
+// exactly as lodging_assignments_draft declares it (1500000132) and
+// lodging_slot_merges does (1500000139). Adding a pre-delete loop for lodging
+// would re-create the N+1 that bunk_assignments_draft's own flip to
+// cascadeDelete existed to remove.
+//
+// Once a scenario's write-ins REPLACE the live ones rather than falling
+// through (PR 3 of kindred#2382), a row surviving its scenario is not merely
+// litter: `idx_lodging_write_in_draft_unique` keys on the scenario id, so an
+// orphan holds a slot no live board and no other scenario can see or clear.
+//
+// The migration TEXT is pinned separately by
+// TestLodgingWriteInDraftScenarioIsRequiredAndCascades in package main; this
+// half proves the effect a declaration of that shape actually has.
+func TestDeletingAScenarioSweepsItsDraftWriteIns(t *testing.T) {
+	t.Parallel()
+	app := newWriteInsTestApp(t)
+	unit := seedUnit(t, app, "test-unit-a", 2026)
+
+	scenario := core.NewRecord(mustCollection(t, app, "saved_scenarios"))
+	if err := app.Save(scenario); err != nil {
+		t.Fatalf("seed scenario: %v", err)
+	}
+
+	row := core.NewRecord(mustCollection(t, app, "lodging_write_ins_draft"))
+	row.Set("unit", unit)
+	row.Set("session", seedSession(t, app))
+	row.Set("year", 2026)
+	row.Set("scenario", scenario.Id)
+	if err := app.Save(row); err != nil {
+		t.Fatalf("seed draft write-in: %v", err)
+	}
+
+	if err := app.Delete(scenario); err != nil {
+		t.Fatalf("delete scenario: %v", err)
+	}
+
+	if _, err := app.FindRecordById("lodging_write_ins_draft", row.Id); err == nil {
+		t.Fatal("the draft write-in outlived its scenario; want it cascaded away")
+	}
+}
+
+// TestDeletingAScenarioLeavesTheLiveWriteInsAlone is the other half, and the
+// one a cascade written too wide would fail.
+//
+// The live table carries no scenario relation at all, which is what makes the
+// live board a scope in its own right rather than the absence of one. A
+// scenario being deleted must not disturb it -- staff evaluate the real board
+// from these rows (owner, 2026-08-15), and losing them to somebody else's
+// housekeeping would open a cabin with an occupant in it.
+func TestDeletingAScenarioLeavesTheLiveWriteInsAlone(t *testing.T) {
+	t.Parallel()
+	app := newWriteInsTestApp(t)
+	unit := seedUnit(t, app, "test-unit-a", 2026)
+
+	scenario := core.NewRecord(mustCollection(t, app, "saved_scenarios"))
+	if err := app.Save(scenario); err != nil {
+		t.Fatalf("seed scenario: %v", err)
+	}
+
+	live := core.NewRecord(mustCollection(t, app, "lodging_write_ins"))
+	live.Set("unit", unit)
+	live.Set("session", seedSession(t, app))
+	live.Set("year", 2026)
+	if err := app.Save(live); err != nil {
+		t.Fatalf("seed live write-in: %v", err)
+	}
+
+	if err := app.Delete(scenario); err != nil {
+		t.Fatalf("delete scenario: %v", err)
+	}
+
+	if _, err := app.FindRecordById("lodging_write_ins", live.Id); err != nil {
+		t.Fatalf("deleting a scenario took a LIVE write-in with it: %v", err)
+	}
 }
 
 // TestGuardUnitYearRejectsACrossYearWriteIn is lodging_write_ins's own entry

--- a/pocketbase/main_lodging_write_in_cascade_test.go
+++ b/pocketbase/main_lodging_write_in_cascade_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+const lodgingWriteInMigration = "pb_migrations/1500000161_lodging_write_ins.js"
+
+func readLodgingWriteInMigration(t *testing.T) string {
+	t.Helper()
+	content, err := os.ReadFile(lodgingWriteInMigration)
+	if err != nil {
+		t.Fatalf("read migration %s: %v", lodgingWriteInMigration, err)
+	}
+	return string(content)
+}
+
+// TestLodgingWriteInDraftScenarioIsRequiredAndCascades pins the two properties
+// that make lodging_write_ins_draft a draft, the same pair
+// TestLodgingDraftScenarioIsRequiredAndCascades pins for 1500000132's twins.
+//
+// It matters from PR 3 of kindred#2382 onward rather than from the migration
+// that wrote it, which is why it is asserted here and not there. Up to PR 2 the
+// draft table was dark: nothing read it, nothing wrote it, and either property
+// could have drifted without consequence. Now a scenario's write-ins REPLACE
+// the live ones on read, so:
+//
+// REQUIRED: a draft row with no scenario belongs to no board at all. It would
+// be invisible to the live read (which never touches this table) and to every
+// scenario read (which filters on the scenario id), while still holding a slot
+// in idx_lodging_write_in_draft_unique that no board can clear.
+//
+// cascadeDelete: this is the WHOLE of the scenario-delete answer for write-ins.
+// Nothing in pocketbase/lodging/hooks.go and nothing in Python's
+// `delete_scenario` sweeps a lodging draft table -- that router deletes
+// bunk_assignments_draft rows by hand for summer and touches no lodging
+// collection. The lodging tables have always relied on the relation, and
+// bunk_assignments_draft was itself flipped to cascadeDelete purely to delete
+// the N+1 pre-delete loop that compensated for not having it.
+//
+// Asserts on the migration FILE for the reason
+// TestLodgingDraftMigrationUsesTheCanonicalBunkingManageRule gives: applying JS
+// migrations from a Go test needs jsvm bootstrapped against the migrations dir,
+// which tests.NewTestApp() does not do. The EFFECT of a declaration of this
+// shape is asserted against the running engine by
+// TestDeletingAScenarioSweepsItsDraftWriteIns in pocketbase/lodging. Two
+// halves: this one fails when the declaration drifts, that one fails when a
+// declaration of this shape stops doing what it says.
+func TestLodgingWriteInDraftScenarioIsRequiredAndCascades(t *testing.T) {
+	body := readLodgingWriteInMigration(t)
+
+	const scenarioField = `type: 'relation', name: 'scenario', required: true, presentable: false,`
+	if !strings.Contains(body, scenarioField) {
+		t.Errorf("migration %s must declare the draft's scenario relation as required",
+			lodgingWriteInMigration)
+	}
+
+	// Scoped to the draft's own field rather than to the file, which already
+	// carries `cascadeDelete: true` on `unit` in the fields BOTH collections
+	// share -- a bare file-wide Contains would pass with the scenario relation
+	// set to false.
+	scenarioAt := strings.Index(body, scenarioField)
+	if scenarioAt < 0 {
+		return
+	}
+	tail := body[scenarioAt+len(scenarioField):]
+	if end := strings.Index(tail, "});"); end >= 0 {
+		tail = tail[:end]
+	}
+	if !strings.Contains(tail, "cascadeDelete: true") {
+		t.Errorf("migration %s must set cascadeDelete on the DRAFT scenario relation, "+
+			"so deleting a scenario sweeps its write-ins", lodgingWriteInMigration)
+	}
+}
+
+// TestLodgingWriteInLiveTableHasNoScenarioColumn is the property that makes the
+// live board a scope in its own right rather than the absence of one.
+//
+// The owner's second requirement on 2026-08-15 -- "we need to allow write ins
+// to happen in campminder prod, not just scenarios, for staff to properly
+// evaluate the board" -- is what rules out the nullable-`scenario` sentinel
+// this repository has already turned down once (api/services/lodging_repository.py
+// records the reasoning verbatim: lodging_assignments dropped its scenario
+// column because it "was dead weight that invited a `scenario != \"\"` write
+// rule instead of a draft table"). A scenario column growing back onto the live
+// table is that sentinel returning, and it would make `fetch_write_ins`'s
+// unpredicated read silently wrong rather than loudly broken.
+func TestLodgingWriteInLiveTableHasNoScenarioColumn(t *testing.T) {
+	body := readLodgingWriteInMigration(t)
+
+	// The live collection is built from occupancyFields() alone; the draft
+	// pushes `scenario` onto its own copy. Exactly ONE scenario relation may
+	// appear in this file, and it is the draft's.
+	if got := strings.Count(body, `name: 'scenario'`); got != 1 {
+		t.Errorf("migration %s declares %d scenario relations, want exactly 1 (the draft's); "+
+			"the live table is a scope in its own right and must carry none",
+			lodgingWriteInMigration, got)
+	}
+
+	if !strings.Contains(body, "draftFields.push({") {
+		t.Errorf("migration %s must add scenario to the DRAFT's fields only, not to the shared "+
+			"occupancyFields() both collections are built from", lodgingWriteInMigration)
+	}
+}

--- a/tests/unit/api/routers/test_lodging_endpoints.py
+++ b/tests/unit/api/routers/test_lodging_endpoints.py
@@ -1305,8 +1305,9 @@ class TestAvailabilityWrites:
         # field is `reason`. See AvailabilityWriteRequest.
         assert payload["note"] == "Burst pipe"
         # WEEKEND-scoped, and still no scenario: the live board is a scope in
-        # its own right, so this table has no scenario column at all. The
-        # draft twin behind it stays dark until PR 3 of kindred#2382.
+        # its own right, so this table has no scenario column at all. Routing
+        # this write to the draft twin when the caller names a scenario is
+        # PR 4's -- see `set_availability`, which carries the gap.
         assert "scenario" not in payload
         assert "state" not in payload
 

--- a/tests/unit/api/routers/test_lodging_endpoints.py
+++ b/tests/unit/api/routers/test_lodging_endpoints.py
@@ -1129,8 +1129,22 @@ class TestCopyFromMirror:
 
     @staticmethod
     def _mirror_reads(**kwargs: Any) -> list[Any]:
-        query_filter = kwargs.get("query_params", {}).get("filter", "")
-        if "session_cm_id = 1000001" in query_filter:
+        """The synced placements, and nothing else.
+
+        KEYED ON `expand`, not on the filter alone, and it has to be: the seed
+        also reads `lodging_write_ins` (kindred#2382 PR 3) and that read's
+        filter is byte-identical to `fetch_assignments`' -- same weekend, same
+        year. One `mock_pb.collection.return_value` serves every collection
+        here, so a filter-only match would hand a placement row back as a
+        write-in and the seed would copy it into the draft occupancy table.
+        `expand: "units"` is what only the placement read asks for.
+
+        `_mirror_write_in_reads` below is the same trick from the other side,
+        for the test that exercises the write-in half.
+        """
+        params = kwargs.get("query_params", {})
+        query_filter = params.get("filter", "")
+        if "session_cm_id = 1000001" in query_filter and params.get("expand") == "units":
             return [
                 _rec(
                     id="assign_1",
@@ -1141,6 +1155,19 @@ class TestCopyFromMirror:
                     expand={"units": [_rec(id="u1", code="ridge-a", name="Ridge A")]},
                 )
             ]
+        return _session_lookup(**kwargs)
+
+    @staticmethod
+    def _mirror_write_in_reads(**kwargs: Any) -> list[Any]:
+        """One LIVE write-in and no placements -- the mirror image of the above.
+
+        Fictional occupant: a production write-in names a real family or a real
+        staff member.
+        """
+        params = kwargs.get("query_params", {})
+        query_filter = params.get("filter", "")
+        if "session_cm_id = 1000001" in query_filter and params.get("expand") != "units":
+            return [_rec(id="wi_1", unit="u1", occupant_name="Olivia Chen", note="Paper registration")]
         return _session_lookup(**kwargs)
 
     def test_copying_seeds_the_scenario_from_the_synced_placements(self, mock_pb: MagicMock) -> None:
@@ -1159,6 +1186,33 @@ class TestCopyFromMirror:
         assert payload["scenario"] == "scn_1"
         assert payload["units"] == ["u1"]
         assert payload["household_cm_id"] == 2000001
+
+    def test_the_seed_also_carries_the_live_boards_write_ins_into_the_scenario(self, mock_pb: MagicMock) -> None:
+        """Owner ruling, 2026-08-16, asserted at the endpoint rather than only in the service.
+
+        A scenario's write-ins REPLACE the live ones on read (kindred#2382),
+        so a scenario seeded without them shows every written-into cabin as
+        OPEN -- and kindred#2247's placement gate reads exactly that, so it
+        would offer a room the live board records as occupied. The split
+        creates that failure mode; this copy closes it.
+        """
+        with patch("api.routers.lodging.pb", mock_pb):
+            client = _write_client(_manage_user(), mock_pb)
+            mock_pb.collection.return_value.get_full_list.side_effect = self._mirror_write_in_reads
+            response = client.post(
+                "/api/lodging/placements/copy",
+                json={"year": 2026, "session_cm_id": 1000001, "scenario": "scn_1"},
+            )
+
+        assert response.status_code == 200, response.text
+        mock_pb.collection.assert_any_call("lodging_write_ins_draft")
+        payload = mock_pb.collection.return_value.create.call_args[0][0]
+        assert payload["scenario"] == "scn_1"
+        assert payload["unit"] == "u1"
+        assert payload["occupant_name"] == "Olivia Chen"
+        assert payload["note"] == "Paper registration"
+        assert payload["session_cm_id"] == 1000001
+        assert payload["year"] == 2026
 
     def test_copying_into_a_worked_scenario_is_a_409(self, mock_pb: MagicMock) -> None:
         """Refused, not merged: a second copy would overwrite the placements

--- a/tests/unit/api/services/test_lodging_repository.py
+++ b/tests/unit/api/services/test_lodging_repository.py
@@ -704,11 +704,12 @@ class TestWriteInReads:
     live+draft pair sitting beside `lodging_assignments`/`_draft`. These
     reads are that pair's half of the repository.
 
-    THE LIVE HALF IS LIVE. PR 2 moved the 21 rows (1500000162) and switched
-    `write_in_covers` and `set_availability` onto them. The DRAFT half is
-    still dark -- nothing reads or writes it until PR 3 gives write-ins their
-    scenario dimension -- so what its tests pin is the shape that PR will read
-    through, not behaviour the running application has today.
+    BOTH HALVES ARE LIVE. PR 2 moved the 21 rows (1500000162) and switched
+    `write_in_covers` and `set_availability` onto the live table; PR 3 gave the
+    draft its readers, so `build_roster` and `build_summary` read it INSTEAD OF
+    the live one whenever the request names a scenario, and both seed paths
+    write it. `find_`, `update_` and `delete_draft_write_in` are the only ones
+    still dark, because `set_availability` takes no scenario until PR 4.
     """
 
     @pytest.mark.asyncio

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -110,9 +110,10 @@ def _repo(**overrides: Any) -> MagicMock:
         # kindred#2382. Empty by default -- most weekends have no write-in at
         # all, and that must be the shape the board sees.
         "fetch_write_ins": [],
-        # The scenario half of the same split. Dark: nothing reads it until
-        # PR 3 of kindred#2382 gives write-ins their scenario dimension, and
-        # `test_no_scenario_dimension_is_read_yet` is what pins that.
+        # The scenario half of the same split (kindred#2382, PR 3). A request
+        # naming a scenario reads THIS instead of `fetch_write_ins` and
+        # REPLACES it -- see TestAScenariosWriteInsReplaceTheLiveOnes. Empty by
+        # default for the same reason its live sibling is.
         "fetch_draft_write_ins": [],
         "fetch_assignments": [],
         # The scenario layer. Only read when a scenario is asked for, which is
@@ -4463,9 +4464,11 @@ class TestWriteInsResolveFromTheirOwnTable:
         await LodgingRosterService(repo).build_summary(2026)
 
         assert repo.fetch_write_ins.await_args_list == [call(2026, 1000001), call(2026, 1000002)]
-        # And no scenario dimension here either -- the same line
-        # `test_no_scenario_dimension_is_read_yet` holds for the roster. Two
-        # TaskGroups, two places to get it wrong.
+        # The LIVE table, and only it, because this sweep names no scenario --
+        # the same line `test_the_mirror_reads_the_live_table_and_never_the_draft`
+        # holds for the roster. Two TaskGroups, two places to get it wrong;
+        # `test_the_lander_reads_each_weekends_draft_write_ins_in_a_scenario`
+        # is this assertion's mirror image.
         assert repo.fetch_draft_write_ins.await_count == 0
 
     @pytest.mark.asyncio
@@ -4507,15 +4510,14 @@ class TestWriteInsResolveFromTheirOwnTable:
         assert counts == roster.counts
 
     @pytest.mark.asyncio
-    async def test_no_scenario_dimension_is_read_yet(self) -> None:
-        """PR 2 moves the rows; PR 3 gives them a scenario.
+    async def test_the_mirror_reads_the_live_table_and_never_the_draft(self) -> None:
+        """No scenario means the LIVE board, which is a scope in its own right.
 
-        The draft table exists (1500000161) and its repository read exists, but
-        nothing may call it yet: the draft is EMPTY, and a scenario's write-ins
-        REPLACE the live ones rather than overlaying them, so reading it now
-        would empty every write-in off every scenario board. Behavioural parity
-        is the acceptance criterion for this PR, and this is the assertion that
-        holds the line.
+        The other side of `TestAScenariosWriteInsReplaceTheLiveOnes` below: a
+        request naming no scenario must not touch the draft table at all, the
+        same way it reads `fetch_assignments` rather than
+        `fetch_draft_assignments`. Reading both and merging is the overlay
+        kindred#1974 deleted for placements and this table never had.
         """
         repo = _repo(
             fetch_session=FAMILY_SESSION,
@@ -4523,11 +4525,10 @@ class TestWriteInsResolveFromTheirOwnTable:
             fetch_write_ins=[_rec(unit="u1", occupant_name="Liam Garcia", note="")],
         )
 
-        roster = await LodgingRosterService(repo).build_roster(2026, 1000001, scenario="scn_1")
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
 
-        assert repo.fetch_draft_write_ins.await_count == 0
         repo.fetch_write_ins.assert_awaited_once_with(2026, 1000001)
-        # And the live rows are what a scenario sees, unchanged from today.
+        assert repo.fetch_draft_write_ins.await_count == 0
         assert roster.units[0].write_in is not None
 
     @pytest.mark.asyncio
@@ -4575,3 +4576,227 @@ class TestWriteInsResolveFromTheirOwnTable:
         assert by_code["house-a"].write_in.unit_id == "u1"
         assert by_code["house-a"].write_in.occupant_name == "Liam Garcia"
         assert by_code["house-a"].write_in.note == "Back Monday"
+
+
+class TestAScenariosWriteInsReplaceTheLiveOnes:
+    """kindred#2382, PR 3 of 4 -- the occupancy half gains its scenario dimension.
+
+    REPLACE, NOT OVERLAY, and that is the whole rule. A request naming a
+    scenario reads `lodging_write_ins_draft` and does not read the live table
+    at all, exactly as kindred#1974 made a scenario read
+    `lodging_assignments_draft` instead of `lodging_assignments`. A unit with
+    no draft row holds NO write-in in that scenario, whatever the live board
+    says -- the live rows are not consulted, and are not even fetched.
+
+    Two staff members can therefore model the same paper-registered family into
+    two different cabins, which is the requirement the owner stated on
+    2026-08-15 and the thing a single shared table could not express.
+
+    The seed is what stops a fresh scenario losing the live board's write-ins:
+    `copy_from_mirror` and `copy_scenario_to_scenario` both copy them (owner
+    ruling, 2026-08-16). That is asserted in test_lodging_write_service.py; the
+    reason it is not asserted by rendering the live rows through the gaps HERE
+    is that doing so is precisely the fall-through this class forbids.
+
+    Fictional data throughout.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_scenario_reads_the_draft_table_and_not_the_live_one(self) -> None:
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[_unit("u1", "ridge-a", "Ridge A", sleeps=5)],
+            fetch_write_ins=[_rec(unit="u1", occupant_name="Liam Garcia", note="")],
+        )
+
+        await LodgingRosterService(repo).build_roster(2026, 1000001, scenario="scn_1")
+
+        repo.fetch_draft_write_ins.assert_awaited_once_with(2026, 1000001, "scn_1")
+        assert repo.fetch_write_ins.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_a_live_write_in_does_not_fall_through_into_a_scenario(self) -> None:
+        """The live board holds a write-in; the scenario holds none. The scenario is EMPTY.
+
+        This is the assertion a merge implementation would fail, and the one an
+        overlay was always going to get wrong in the safe-looking direction:
+        showing the live occupancy in a scenario that never asked for it is
+        exactly the shared-table behaviour kindred#2382 exists to end.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[_unit("u1", "ridge-a", "Ridge A", sleeps=5)],
+            fetch_write_ins=[_rec(unit="u1", occupant_name="Liam Garcia", note="Back Monday")],
+            fetch_draft_write_ins=[],
+        )
+
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001, scenario="scn_1")
+
+        unit = roster.units[0]
+        assert unit.write_in is None
+        assert unit.family_available_override is None
+        assert unit.is_family_available is True
+        assert unit.occupant_name == ""
+
+    @pytest.mark.asyncio
+    async def test_a_scenarios_own_write_in_closes_the_unit_and_names_its_occupant(self) -> None:
+        """Every field the card reads arrives from the draft row, unchanged.
+
+        The positive control for the two assertions above: without it, a
+        service that read the draft table and then dropped the rows on the
+        floor would pass both.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[_unit("u1", "ridge-a", "Ridge A", sleeps=5)],
+            fetch_write_ins=[],
+            fetch_draft_write_ins=[_rec(unit="u1", occupant_name="Olivia Chen", note="Paper registration")],
+        )
+
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001, scenario="scn_1")
+
+        unit = roster.units[0]
+        assert unit.family_available_override is False
+        assert unit.is_family_available is False
+        assert unit.occupant_name == "Olivia Chen"
+        assert unit.reason == "Paper registration"
+        assert unit.write_in is not None
+        assert unit.write_in.unit_id == "u1"
+
+    @pytest.mark.asyncio
+    async def test_two_scenarios_can_write_the_same_family_into_different_cabins(self) -> None:
+        """The requirement in one test.
+
+        Owner, 2026-08-15: "we do unfortunately need write in to be scenario
+        scoped, not only session scoped, because not all write ins would be for
+        staff, some are paper registrations for families coming with no kids."
+        A shared table could not express this at all -- the second write would
+        collide with the first on `idx_lodging_write_in_unique`.
+        """
+        units = [
+            _unit("u1", "ridge-a", "Ridge A", sleeps=5),
+            _unit("u2", "ridge-b", "Ridge B", sleeps=4),
+        ]
+        service_a = LodgingRosterService(
+            _repo(
+                fetch_session=FAMILY_SESSION,
+                fetch_units=units,
+                fetch_draft_write_ins=[_rec(unit="u1", occupant_name="Olivia Chen", note="")],
+            )
+        )
+        service_b = LodgingRosterService(
+            _repo(
+                fetch_session=FAMILY_SESSION,
+                fetch_units=units,
+                fetch_draft_write_ins=[_rec(unit="u2", occupant_name="Olivia Chen", note="")],
+            )
+        )
+
+        roster_a = await service_a.build_roster(2026, 1000001, scenario="scn_a")
+        roster_b = await service_b.build_roster(2026, 1000001, scenario="scn_b")
+
+        assert {u.code: u.occupant_name for u in roster_a.units} == {"ridge-a": "Olivia Chen", "ridge-b": ""}
+        assert {u.code: u.occupant_name for u in roster_b.units} == {"ridge-a": "", "ridge-b": "Olivia Chen"}
+
+    @pytest.mark.asyncio
+    async def test_a_scenarios_write_in_still_covers_the_rooms_beneath_a_building(self) -> None:
+        """The cover walk takes the scenario's rows, not the live ones.
+
+        `_resolve_write_in_covers` is fed from whichever source the request
+        chose, so a scenario that writes into a building closes the rooms under
+        it in THAT scenario. Wiring the fetch and leaving the cover walk on the
+        live list is the half-fix this catches.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("u1", "house", "House", is_container=True, default_combined=True),
+                _unit("u2", "house-a", "House A", sleeps=4, parent_unit="u1"),
+            ],
+            fetch_write_ins=[],
+            fetch_draft_write_ins=[_rec(unit="u1", occupant_name="Olivia Chen", note="Paper registration")],
+        )
+
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001, scenario="scn_1")
+
+        by_code = {u.code: u for u in roster.units}
+        assert by_code["house-a"].write_in is not None
+        assert by_code["house-a"].write_in.unit_id == "u1"
+        assert by_code["house-a"].write_in.occupant_name == "Olivia Chen"
+
+    @pytest.mark.asyncio
+    async def test_the_role_override_is_still_read_from_the_live_table_in_a_scenario(self) -> None:
+        """The ROLE half does NOT gain a scenario dimension, by owner ruling.
+
+        "staff vs family_available is not scenario scoped, no, that's more of a
+        known 'were moving staff to X for weekend Y'" -- so a release is read
+        from `lodging_availability` with no scenario predicate whether or not
+        the request names one. Scoping this half too is the mistake
+        1500000135's reasoning already argued against.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[_unit("u1", "le-shack", "Le Shack", sleeps=4, inventory_class="staff_default")],
+            fetch_availability=[_rec(unit="u1", family_available=True, occupant_name="", note="Director away")],
+        )
+
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001, scenario="scn_1")
+
+        repo.fetch_availability.assert_awaited_once_with(2026, 1000001)
+        assert roster.units[0].family_available_override is True
+        assert roster.units[0].reason == "Director away"
+
+    @pytest.mark.asyncio
+    async def test_the_lander_reads_each_weekends_draft_write_ins_in_a_scenario(self) -> None:
+        """`build_summary` carries its OWN TaskGroup -- two places to get this wrong.
+
+        The mirror image of the assertion in
+        `test_the_lander_reads_the_write_in_table_once_per_weekend`: wiring
+        `build_roster` and leaving the lander would put a scenario's write-in
+        on the board while the weekend card linking to it still counted from
+        the live table.
+
+        THE ARGUMENTS ARE PINNED, not only the count: the one `year`, each
+        weekend's OWN CampMinder id, and the one scenario for the sweep.
+        """
+        repo = _repo(fetch_weekend_sessions=[FAMILY_SESSION, ADULT_SESSION])
+
+        await LodgingRosterService(repo).build_summary(2026, scenario="scn_1")
+
+        assert repo.fetch_draft_write_ins.await_args_list == [
+            call(2026, 1000001, "scn_1"),
+            call(2026, 1000002, "scn_1"),
+        ]
+        assert repo.fetch_write_ins.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_the_lander_counts_a_scenarios_write_in_as_reserved(self) -> None:
+        """The rows the lander fetches have to REACH `_build_units`.
+
+        Awaiting `fetch_draft_write_ins` and then dropping its result on the
+        floor is a half-fix a call-count assertion cannot see -- the same trap
+        `test_the_lander_counts_a_written_into_cabin_as_reserved` names for the
+        live table. Pinned against `build_roster`'s own counts, because the two
+        endpoints link to each other and must never disagree about one weekend.
+        """
+        repo = _repo(
+            fetch_weekend_sessions=[FAMILY_SESSION],
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("u1", "ridge-a", "Ridge A", sleeps=5),
+                _unit("u2", "ridge-b", "Ridge B", sleeps=4),
+            ],
+            fetch_write_ins=[],
+            fetch_draft_write_ins=[_rec(unit="u1", occupant_name="Olivia Chen", note="")],
+        )
+        service = LodgingRosterService(repo)
+
+        summary = await service.build_summary(2026, scenario="scn_1")
+        roster = await service.build_roster(2026, 1000001, scenario="scn_1")
+
+        counts = summary.weekends[0].counts
+        assert counts.units_reserved == 1
+        assert counts.units_family_available == 1
+        # The written-into cabin's five beds are NOT on offer; only Ridge B's.
+        assert counts.beds_family_available == 4
+        assert counts == roster.counts

--- a/tests/unit/api/services/test_lodging_write_service.py
+++ b/tests/unit/api/services/test_lodging_write_service.py
@@ -61,6 +61,16 @@ def _repo(**overrides: Any) -> MagicMock:
         "create_write_in": SimpleNamespace(id="write_in_new"),
         "update_write_in": SimpleNamespace(id="write_in_existing"),
         "delete_write_in": None,
+        "fetch_write_ins": [],
+        # The scenario grain of the same occupancy fact (kindred#2382, PR 3).
+        # Both seed paths copy into it and a scenario write targets it, so
+        # every one of these has a caller -- an empty default is the shape a
+        # weekend with no write-ins really has.
+        "fetch_draft_write_ins": [],
+        "find_draft_write_in": None,
+        "create_draft_write_in": SimpleNamespace(id="draft_write_in_new"),
+        "update_draft_write_in": SimpleNamespace(id="draft_write_in_existing"),
+        "delete_draft_write_in": None,
         "find_slot_merge": None,
         "create_slot_merge": SimpleNamespace(id="merge_new"),
         "update_slot_merge": SimpleNamespace(id="merge_existing"),
@@ -543,16 +553,25 @@ class TestCopyFromMirror:
         repo.count_draft_assignments.assert_awaited_once_with(2026, 1000001, "scn_1")
 
     @pytest.mark.asyncio
-    async def test_availability_is_not_copied(self, write_service: LodgingWriteService, repo: MagicMock) -> None:
-        """Availability stayed an OVERLAY (kindred#1974 changed placements
-        only), so a scenario already sees the live reservations as its base.
-        Copying them would pin the scenario against a later change to the live
-        plan -- the same argument that makes `state: null` a delete."""
+    async def test_the_staff_to_family_role_override_is_not_copied(
+        self, write_service: LodgingWriteService, repo: MagicMock
+    ) -> None:
+        """`lodging_availability` holds only the ROLE half now, and it is NOT
+        scenario-scoped (owner ruling, kindred#2382: "that's more of a known
+        'were moving staff to X for weekend Y'"). It has carried no scenario
+        column since 1500000135, so every scenario already reads the same rows
+        and a copy would be a row duplicating itself.
+
+        The OCCUPANCY half of that old boolean goes the other way and IS
+        copied -- see TestCopyFromMirrorAlsoCopiesWriteIns. This test is what
+        keeps the two halves from being conflated back together by a seed."""
         repo.fetch_assignments = AsyncMock(return_value=[_mirror_row()])
+        repo.fetch_write_ins = AsyncMock(return_value=[_write_in_row()])
 
         await write_service.copy_from_mirror(PlacementCopyRequest(year=2026, session_cm_id=1000001, scenario="scn_1"))
 
         repo.create_availability.assert_not_called()
+        repo.update_availability.assert_not_called()
 
 
 def _draft_row(**overrides: Any) -> SimpleNamespace:
@@ -770,6 +789,160 @@ class TestCopyScenarioToScenarioAlsoCopiesSlotMerges:
         )
 
         repo.create_slot_merge.assert_not_called()
+
+
+def _write_in_row(**overrides: Any) -> SimpleNamespace:
+    """One occupancy row, as `fetch_write_ins` / `fetch_draft_write_ins` return it.
+
+    Fictional occupant throughout -- a production write-in names a real family
+    or a real staff member (CLAUDE.md section 4).
+    """
+    fields: dict[str, Any] = {
+        "id": "write_in_1",
+        "unit": "u1",
+        "occupant_name": "Olivia Chen",
+        "note": "Paper registration",
+    }
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
+
+
+class TestCopyFromMirrorAlsoCopiesWriteIns:
+    """A fresh scenario inherits the LIVE board's write-ins. Owner ruling, 2026-08-16.
+
+    THE REASON IS SAFETY, not convenience. Once a scenario's write-ins REPLACE
+    the live ones rather than falling through (kindred#2382 PR 3), a scenario
+    seeded without them starts with every written-into cabin looking OPEN --
+    and kindred#2247's placement gate reads exactly that, so it would let a
+    family be dropped into a room the live board records as occupied. The split
+    creates that failure mode; the copy is what closes it.
+
+    Shaped after the `lodging_slot_merges` copy in `copy_scenario_to_scenario`:
+    read the source tier, create the destination's own rows, no emptiness check
+    of its own and no separate count in the response.
+    """
+
+    @pytest.mark.asyncio
+    async def test_each_live_write_in_becomes_a_draft_row_in_the_scenario(
+        self, write_service: LodgingWriteService, repo: MagicMock
+    ) -> None:
+        repo.fetch_write_ins = AsyncMock(return_value=[_write_in_row()])
+
+        await write_service.copy_from_mirror(PlacementCopyRequest(year=2026, session_cm_id=1000001, scenario="scn_1"))
+
+        repo.fetch_write_ins.assert_awaited_once_with(2026, 1000001)
+        repo.create_draft_write_in.assert_awaited_once()
+        data = repo.create_draft_write_in.call_args[0][0]
+        assert data["unit"] == "u1"
+        assert data["scenario"] == "scn_1"
+        assert data["occupant_name"] == "Olivia Chen"
+        assert data["note"] == "Paper registration"
+        assert data["session"] == "sess_1"
+        assert data["session_cm_id"] == 1000001
+        assert data["year"] == 2026
+
+    @pytest.mark.asyncio
+    async def test_every_live_write_in_is_copied_not_only_the_first(
+        self, write_service: LodgingWriteService, repo: MagicMock
+    ) -> None:
+        repo.fetch_write_ins = AsyncMock(
+            return_value=[
+                _write_in_row(),
+                _write_in_row(id="write_in_2", unit="u2", occupant_name="Ava Martinez", note=""),
+            ]
+        )
+
+        await write_service.copy_from_mirror(PlacementCopyRequest(year=2026, session_cm_id=1000001, scenario="scn_1"))
+
+        assert [c[0][0]["unit"] for c in repo.create_draft_write_in.call_args_list] == ["u1", "u2"]
+
+    @pytest.mark.asyncio
+    async def test_no_live_write_ins_means_no_create_calls(
+        self, write_service: LodgingWriteService, repo: MagicMock
+    ) -> None:
+        await write_service.copy_from_mirror(PlacementCopyRequest(year=2026, session_cm_id=1000001, scenario="scn_1"))
+
+        repo.create_draft_write_in.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_the_live_write_in_table_is_not_written(
+        self, write_service: LodgingWriteService, repo: MagicMock
+    ) -> None:
+        """A seed writes the SCENARIO, never the board it copied from.
+
+        `create_write_in` is the live table's create. Reaching it here would
+        mean a scenario seed had edited the live board -- the direction
+        `copy_from_mirror`'s own docstring says the line permits only one way
+        round.
+        """
+        repo.fetch_write_ins = AsyncMock(return_value=[_write_in_row()])
+
+        await write_service.copy_from_mirror(PlacementCopyRequest(year=2026, session_cm_id=1000001, scenario="scn_1"))
+
+        repo.create_write_in.assert_not_called()
+        repo.update_write_in.assert_not_called()
+        repo.delete_write_in.assert_not_called()
+
+
+class TestCopyScenarioToScenarioAlsoCopiesWriteIns:
+    """The source SCENARIO's own write-ins, for the reason the mirror seed copies the live ones.
+
+    `copy_from_mirror` seeds from the live board, so it reads
+    `fetch_write_ins`; this seeds from another scenario, so it reads that
+    scenario's own draft rows -- exactly the split the placement copy already
+    makes between `fetch_assignments` and `fetch_draft_assignments`.
+    "Copy from Option A" that dropped Option A's write-ins would not copy what
+    Option A's board shows.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_source_scenarios_write_ins_are_copied_into_the_destination(
+        self, write_service: LodgingWriteService, repo: MagicMock
+    ) -> None:
+        repo.fetch_draft_write_ins = AsyncMock(return_value=[_write_in_row()])
+
+        await write_service.copy_scenario_to_scenario(
+            year=2026, session_cm_id=1000001, from_scenario="scn_source", to_scenario="scn_dest"
+        )
+
+        repo.fetch_draft_write_ins.assert_awaited_once_with(2026, 1000001, "scn_source")
+        repo.create_draft_write_in.assert_awaited_once()
+        data = repo.create_draft_write_in.call_args[0][0]
+        assert data["unit"] == "u1"
+        assert data["scenario"] == "scn_dest"
+        assert data["occupant_name"] == "Olivia Chen"
+        assert data["note"] == "Paper registration"
+        assert data["session"] == "sess_1"
+        assert data["session_cm_id"] == 1000001
+        assert data["year"] == 2026
+
+    @pytest.mark.asyncio
+    async def test_the_live_board_is_not_the_source_here(
+        self, write_service: LodgingWriteService, repo: MagicMock
+    ) -> None:
+        """Reading `fetch_write_ins` would seed the destination from the LIVE
+        board rather than from the scenario the caller named -- a copy that
+        silently ignores the source, and the one mistake sharing a helper
+        between the two seed paths would make."""
+        repo.fetch_write_ins = AsyncMock(return_value=[_write_in_row(unit="u9", occupant_name="Ava Martinez")])
+        repo.fetch_draft_write_ins = AsyncMock(return_value=[_write_in_row()])
+
+        await write_service.copy_scenario_to_scenario(
+            year=2026, session_cm_id=1000001, from_scenario="scn_source", to_scenario="scn_dest"
+        )
+
+        assert repo.fetch_write_ins.await_count == 0
+        assert [c[0][0]["unit"] for c in repo.create_draft_write_in.call_args_list] == ["u1"]
+
+    @pytest.mark.asyncio
+    async def test_no_source_write_ins_means_no_create_calls(
+        self, write_service: LodgingWriteService, repo: MagicMock
+    ) -> None:
+        await write_service.copy_scenario_to_scenario(
+            year=2026, session_cm_id=1000001, from_scenario="scn_source", to_scenario="scn_dest"
+        )
+
+        repo.create_draft_write_in.assert_not_called()
 
 
 class TestARefusedWriteIsNeverReportedAsSuccess:

--- a/tests/unit/api/services/test_lodging_write_service.py
+++ b/tests/unit/api/services/test_lodging_write_service.py
@@ -63,9 +63,16 @@ def _repo(**overrides: Any) -> MagicMock:
         "delete_write_in": None,
         "fetch_write_ins": [],
         # The scenario grain of the same occupancy fact (kindred#2382, PR 3).
-        # Both seed paths copy into it and a scenario write targets it, so
-        # every one of these has a caller -- an empty default is the shape a
+        # Two of these have callers: `fetch_draft_write_ins` (the scenario seed
+        # reads its source through it) and `create_draft_write_in` (both seed
+        # paths write through it). An empty default for the read is the shape a
         # weekend with no write-ins really has.
+        #
+        # `find_`, `update_` and `delete_draft_write_in` are still DARK, and
+        # deliberately so: `set_availability` takes no scenario and writes the
+        # LIVE table, which is the gap PR 4 closes. They are stubbed anyway so
+        # that a test which starts reaching one fails on its own assertion
+        # rather than on an un-awaitable bare MagicMock.
         "fetch_draft_write_ins": [],
         "find_draft_write_in": None,
         "create_draft_write_in": SimpleNamespace(id="draft_write_in_new"),
@@ -883,6 +890,44 @@ class TestCopyFromMirrorAlsoCopiesWriteIns:
         repo.update_write_in.assert_not_called()
         repo.delete_write_in.assert_not_called()
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [400, 403])
+    async def test_a_failed_seed_create_keeps_its_upstream_status(
+        self, write_service: LodgingWriteService, repo: MagicMock, status: int
+    ) -> None:
+        """A collision on the draft's unique index is a 400, never a 500.
+
+        REACHABLE, not hypothetical. The up-front guard counts PLACEMENTS
+        only, so a weekend whose mirror carries nothing copyable -- early
+        season, before CampMinder has assigned any lodging -- passes that
+        check on every attempt while the write-ins it seeded are already
+        sitting in the scenario. A second `POST /api/lodging/placements/copy`
+        then collides on `idx_lodging_write_in_draft_unique`.
+
+        Nothing on this router catches `ClientResponseError`, so one that
+        escapes `_seed_write_ins` unconverted reaches api/main.py's catch-all
+        handler and the caller is told "Internal server error" for a state the
+        server understands perfectly well -- the same shape
+        `test_copying_into_an_unknown_weekend_is_404_not_500` refuses for the
+        weekend lookup. 403 is parametrised beside it because a refusal must
+        not be reported as a collision either; `pb_error_to_http` maps both
+        auth flavours to 403 for the reason
+        `TestARefusedWriteIsNeverReportedAsSuccess` spells out.
+        """
+        repo.fetch_write_ins = AsyncMock(return_value=[_write_in_row()])
+        repo.create_draft_write_in = AsyncMock(
+            side_effect=ClientResponseError(
+                "duplicate", status=status, data={}, url="", is_abort=False, original_error=None
+            )
+        )
+
+        with pytest.raises(HTTPException) as excinfo:
+            await write_service.copy_from_mirror(
+                PlacementCopyRequest(year=2026, session_cm_id=1000001, scenario="scn_1")
+            )
+
+        assert excinfo.value.status_code == status
+
 
 class TestCopyScenarioToScenarioAlsoCopiesWriteIns:
     """The source SCENARIO's own write-ins, for the reason the mirror seed copies the live ones.
@@ -943,6 +988,29 @@ class TestCopyScenarioToScenarioAlsoCopiesWriteIns:
         )
 
         repo.create_draft_write_in.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_failed_seed_create_keeps_its_upstream_status(
+        self, write_service: LodgingWriteService, repo: MagicMock
+    ) -> None:
+        """The mirror seed's guard, asserted on this path too.
+
+        One helper serves both seeds, so this is the assertion that catches a
+        later change converting only the path it was looking at.
+        """
+        repo.fetch_draft_write_ins = AsyncMock(return_value=[_write_in_row()])
+        repo.create_draft_write_in = AsyncMock(
+            side_effect=ClientResponseError(
+                "duplicate", status=400, data={}, url="", is_abort=False, original_error=None
+            )
+        )
+
+        with pytest.raises(HTTPException) as excinfo:
+            await write_service.copy_scenario_to_scenario(
+                year=2026, session_cm_id=1000001, from_scenario="scn_source", to_scenario="scn_dest"
+            )
+
+        assert excinfo.value.status_code == 400
 
 
 class TestARefusedWriteIsNeverReportedAsSuccess:
@@ -1732,8 +1800,12 @@ class TestAWriteInIsStoredAsAnOccupancyNotAnAvailability:
         # The boolean is what the split REMOVED. A write-in table row IS the
         # occupancy; a column restating it would be the conflation coming back.
         assert "family_available" not in data
-        # No scenario yet -- the draft twin stays dark until PR 3. Writing one
-        # here would put rows in a table nothing reads.
+        # NO SCENARIO ON THIS WRITE, still: `set_availability` takes none and
+        # writes the LIVE table, which is a scope in its own right. Since PR 3
+        # of kindred#2382 that is also a known GAP rather than a resting state
+        # -- a write-in made from inside a scenario lands here and that
+        # scenario's own read replaces it away -- and routing the occupancy
+        # half to the draft twin is PR 4's. See `set_availability`.
         assert "scenario" not in data
 
     @pytest.mark.asyncio


### PR DESCRIPTION
> ## ⛔ MERGE ORDER: this PR must NOT reach `main` without PR 4
>
> **On its own this is a user-visible regression.** Reads now REPLACE, but the write path is still
> live-only (`set_availability` takes no scenario). So a staff member working inside a scenario who
> records a write-in has it land on the **live** board, and the scenario read then replaces it away —
> the write-in is not on the board they made it on. Before this PR the read fell through, so the same
> write was visible.
>
> Prior to PR 4, a scenario can only receive write-ins by copy at seed time. PR 4 closes it in three
> small steps (optional `scenario` on `AvailabilityWriteRequest`; route the OCCUPANCY half to the
> draft when it is non-blank, ROLE half always live; `LodgingBoard` passes its existing `scenario`
> prop through). Land them together, or land PR 4 first.

## What

**PR 3 of 4 for kindred issue #2382.** Stacked on #2424 (`feature/phase-e-writein-read`) — review that first.

PR 1 (#2422) created `lodging_write_ins` and `lodging_write_ins_draft` dark. PR 2 (#2424) moved the 21 rows out of `lodging_availability` and switched every reader onto the **live** table at behavioural parity, deliberately leaving the draft twin unread behind two guard tests. **This PR turns the twin on.**

Three things, exactly:

### 1. Replace-on-read

A request naming a scenario reads `fetch_draft_write_ins` and **does not read the live table at all**. This is kindred#1974's no-fall-through rule for `lodging_assignments_draft`, applied unchanged — not a new overlay semantic invented for this one table. A unit with no draft row holds **no** write-in in that scenario, whatever the live board says.

With no scenario, the live table is read exactly as before: the live board is a scope in its own right rather than the absence of one (owner, 2026-08-15 — "we need to allow write ins to happen in campminder prod, not just scenarios, for staff to properly evaluate the board").

Both `build_roster` and `build_summary` were wired — they hold parallel TaskGroups and fixing only one is the half-fix the guards in this file's tests exist to catch.

**The two PR-2 guards are replaced with the positive assertion of the new behaviour**, not merely deleted:

| PR 2 guard | Now |
|---|---|
| `test_no_scenario_dimension_is_read_yet` | `test_the_mirror_reads_the_live_table_and_never_the_draft` (the no-scenario side is still pinned) + the whole of `TestAScenariosWriteInsReplaceTheLiveOnes` |
| `fetch_draft_write_ins.await_count == 0` on the lander | kept for the **mirror** sweep, where it is now a real assertion, and mirrored by `test_the_lander_reads_each_weekends_draft_write_ins_in_a_scenario` |

### 2. Write-ins are copied in BOTH seed paths

Owner ruling, 2026-08-16. `copy_from_mirror` copies the **live board's** rows; `copy_scenario_to_scenario` copies the **source scenario's own**. Shaped after the `lodging_slot_merges` copy already sitting in `copy_scenario_to_scenario`: read the source tier, create the destination's rows, no emptiness check of its own, not counted into `LodgingCopyResponse.copied` (that number means placements).

The reason is carried into the code, because it is safety rather than convenience: without the copy a fresh scenario shows every written-into cabin as **open**, and kindred#2247's placement gate reads exactly that field — so it would let a family be dropped into a room the live board records as occupied. **The split creates that failure mode; the copy is what closes it.**

`copy_from_mirror`'s docstring said "Availability is NOT copied". That sentence had become half-false, and is rewritten: the staff↔family **ROLE** override is still not copied (it has no scenario dimension and nothing to disagree about), the **OCCUPANCY** half now is.

### 3. Scenario-delete cascade — found, not built

Checked both places the brief named:

- **`pocketbase/lodging/hooks.go`** — nothing. It registers these collections only for the year guards.
- **Python `delete_scenario`** (`api/routers/scenarios.py`) — nothing for lodging. It sweeps `bunk_assignments_draft` by hand for summer and touches no lodging table.

It is a **schema property**: `scenario` is declared `cascadeDelete: true` on `lodging_write_ins_draft` in migration `1500000161`, exactly as `lodging_assignments_draft` (1500000132) and `lodging_slot_merges` (1500000139) declare it. Adding a pre-delete loop would re-create the N+1 that `bunk_assignments_draft`'s own flip to `cascadeDelete` existed to remove.

So there is nothing to build — but PR 3 is where that guarantee becomes load-bearing (an orphan row holds a slot in `idx_lodging_write_in_draft_unique` that no board can see or clear), so it is now **pinned from both ends**:

- `TestLodgingWriteInDraftScenarioIsRequiredAndCascades` (package `main`) — the migration declares it, scoped to the draft's own field so the `unit` relation's `cascadeDelete: true` cannot satisfy it by accident.
- `TestDeletingAScenarioSweepsItsDraftWriteIns` + `TestDeletingAScenarioLeavesTheLiveWriteInsAlone` (package `lodging`) — the effect, against the running engine.

## What is deliberately NOT here

- **No migration.** `1500000161` already declares everything this needs.
- **No `frontend/src` file is touched.** No schema and no wire change, so nothing regenerates. `family_available_override` still spells an occupancy as `false` — the compat shim PR 2 kept on purpose stays.
- #2093's forest open-tint proxy, the premise comments at `writeIn.ts:1-25` / `unitBadges.ts:302` / `lodging_repository.py:18-22`, and removing the compat shim are **PR 4**.
- Widening the single-cover arity to N write-ins per container is kindred#2381, which does **not** dissolve into this.
- `frontend/src/utils/boardLayout.ts` untouched (in-flight PR #2404).

## ⚠️ Known gap PR 4 must close — the WRITE path is still live-only

`set_availability` takes no `scenario` and writes the live occupancy table. That was correct while reads fell through; it is **not** correct now that they replace. Concretely, after this PR:

> a staff member viewing scenario A records a write-in → it lands on the **live** board → scenario A's read replaces with draft rows → the write-in they just made is not on the board they made it on.

Nothing in this PR can fix that on its own, because the fix needs the frontend to send the scenario, and the brief for this PR scopes `frontend/src` out. **PR 4 owns it**, and it is small:

1. `AvailabilityWriteRequest` gains `scenario: str = Field(default="")` — blank means the live board, mirroring `SlotMergeRequest`'s optional scenario.
2. `set_availability` routes its **occupancy** half to `find/create/update/delete_draft_write_in` when the scenario is non-blank. The **role** half always stays on `lodging_availability` (owner ruling: it is not scenario-scoped), so a release written from inside a scenario is still a weekend fact.
3. `LodgingBoard` passes its existing `scenario` prop into `useUnitAvailability`, and `setUnitAvailability` puts it on the body.

Until (3) lands, `find_draft_write_in`, `update_draft_write_in` and `delete_draft_write_in` stay dark — the same one-PR lag `fetch_draft_write_ins` had. `create_draft_write_in` gains its caller here (the two seeds).

## Tests

TDD throughout: every assertion below was written first, run, and watched fail before the implementation existed. Everything that was green on first write was mutation-checked by breaking the implementation and reading the **exit code**, then restored.

**`tests/unit/api/services/test_lodging_roster_service.py`** — new `TestAScenariosWriteInsReplaceTheLiveOnes`:

- a scenario reads the draft table and not the live one (both directions asserted)
- a live write-in does **not** fall through into a scenario — the assertion a merge implementation fails
- a scenario's own write-in closes the unit, names its occupant and carries its note
- two scenarios write the same family into different cabins (the requirement, in one test)
- a scenario's write-in still covers the rooms beneath a building — catches wiring the fetch and leaving the cover walk on the live list
- the ROLE override is still read from the live table inside a scenario
- the lander reads each weekend's draft write-ins, arguments pinned not just the count
- the lander **counts** a scenario's write-in as reserved, pinned against `build_roster`'s own counts — the "the answer is used" half a call-count assertion cannot see

**`tests/unit/api/services/test_lodging_write_service.py`** — new `TestCopyFromMirrorAlsoCopiesWriteIns` and `TestCopyScenarioToScenarioAlsoCopiesWriteIns`: payload shape including `scenario`, every row copied not only the first, the right source per seed path (a mirror seed must not read the draft; a scenario seed must not read the live board), no rows means no creates, and a seed never writes the table it copied from. `test_availability_is_not_copied` is renamed and its stale docstring rewritten to say which half is still not copied and why.

**`tests/unit/api/routers/test_lodging_endpoints.py`** — the seed carries write-ins at the **endpoint**, not only in the service. `_mirror_reads` had to start keying on `expand: "units"`: one `mock_pb.collection.return_value` serves every collection, and `fetch_write_ins`' filter is byte-identical to `fetch_assignments`', so a filter-only match handed a placement row back as a write-in.

**Review pass (independent, post-authoring)** — one behavioural defect fixed in branch: `_seed_write_ins` let a `ClientResponseError` escape unconverted, so a colliding seed create reached api/main.py's catch-all as a **500** rather than the 400 its own docstring promised. Reachable, because the up-front guard counts *placements* only: a weekend whose mirror holds nothing copyable passes it on every attempt while the write-ins the first seed wrote are already there. The create now raises through `pb_error_to_http`, pinned by `test_a_failed_seed_create_keeps_its_upstream_status` on **both** seed paths (400 and 403 parametrised, so a refusal is not reported as a collision). No second emptiness guard was added — that decision stands as written.

The same pass retired the premise comments this PR falsified — `set_availability`'s "the draft twin stays dark until PR 3" (now carrying the write-path gap and the shape of PR 4's fix instead), `_build_units`' "a scenario reads the same live rows it does today", `written_in_unit_ids`' docstring, the `_repo` fixture's "every one of these has a caller", and three "stays dark until PR 3" test comments. `docs/architecture/lodging-occupancy.md` gained the same gap paragraph.

**Go** — the two cascade tests above, plus `TestLodgingWriteInLiveTableHasNoScenarioColumn` (the nullable-`scenario` sentinel this repository already turned down must not grow back onto the live table).

Mutation checks run and confirmed red: roster read reverted (6 red), summary read reverted (2 red), mirror seed copy removed (2 red + 1 endpoint red), scenario seed reading the live board (2 red), `scenario` dropped from the copy payload (3 red — the endpoint test goes red too), fixture `CascadeDelete` removed (1 red), migration `cascadeDelete: false` (1 red), migration `required: false` (1 red), `scenario` moved onto the shared `occupancyFields` (1 red).

Also corrected three stale counts PR 2 left in `lodging_roster_service.py` docstrings — `build_roster` makes thirteen fetches now, not twelve, and the lander makes five session-scoped reads per weekend, not four.

## CI

⚠️ **This PR gets no CI.** Workflows trigger on `pull_request: branches: [main]` and this targets `feature/phase-e-writein-read`. Local gates, run in this worktree:

```
$ bash scripts/pre-push-verify.sh
── Python ──      PASS ruff format   PASS ruff check   PASS mypy   PASS pytest (unit)
── Go ──          PASS go build   PASS golangci-lint   PASS go test
── Frontend ──    PASS prettier   PASS eslint   PASS tsc   PASS vitest
── Migrations ──  PASS migration headers   PASS no options:{} anti-pattern
── PocketBase JS ── PASS pb-js-lint
── Shell ──       PASS shellcheck
ALL CHECKS PASSED

$ uv run pytest tests/ -q -p no:randomly -n auto
6410 passed, 23 skipped in 141.30s

$ cd pocketbase && go test ./...
ok (all packages)

$ uv run mypy api/
Success: no issues found in 89 source files
```

The pre-push hook additionally ran `api-types-freshness` green — no generated type drift, as expected for a change with no schema or wire movement.

Part of kindred issue #2382 (3 of 4). That issue is answered by PR 4, not by this one.


