### PR TITLE
fix(metrics): fold Family Camp into cancellation still-attending lookup

### DIFF
--- a/api/services/cancellation_service.py
+++ b/api/services/cancellation_service.py
@@ -25,6 +25,7 @@ from api.services.breakdown_calculator import calculate_percentage, compute_regi
 from api.services.extractors import extract_gender, extract_grade
 from api.utils.session_metrics import (
     DEFAULT_SUMMER_SESSION_TYPES,
+    FAMILY_SESSION_TYPE,
     SUMMER_TEEN_TYPES,
     build_ag_parent_map,
     get_session_from_expand,
@@ -35,11 +36,6 @@ from bunking.logging_config import get_logger
 
 # Back-compat alias as an explicit module export (shared default lives in session_metrics).
 SUMMER_SESSION_TYPES = DEFAULT_SUMMER_SESSION_TYPES
-
-# Family Camp session type -- not part of DISPLAY_SESSION_TYPES / DEFAULT_SUMMER_SESSION_TYPES
-# (adult-focused, separate program), but a household that cancels a summer session while
-# keeping a Family Camp weekend is still attending camp. See enrollment_session_ids below.
-FAMILY_SESSION_TYPE = "family"
 
 if TYPE_CHECKING:
     from .metrics_repository import MetricsRepository

--- a/api/services/cancellation_service.py
+++ b/api/services/cancellation_service.py
@@ -36,6 +36,11 @@ from bunking.logging_config import get_logger
 # Back-compat alias as an explicit module export (shared default lives in session_metrics).
 SUMMER_SESSION_TYPES = DEFAULT_SUMMER_SESSION_TYPES
 
+# Family Camp session type -- not part of DISPLAY_SESSION_TYPES / DEFAULT_SUMMER_SESSION_TYPES
+# (adult-focused, separate program), but a household that cancels a summer session while
+# keeping a Family Camp weekend is still attending camp. See enrollment_session_ids below.
+FAMILY_SESSION_TYPE = "family"
+
 if TYPE_CHECKING:
     from .metrics_repository import MetricsRepository
 
@@ -82,7 +87,14 @@ class CancellationService:
         # not a true departure. Fold teen session ids into the enrollment lookup
         # only -- the display scope below stays summer-only / the requested filter.
         teen_sessions = await self.repository.fetch_sessions(year, list(SUMMER_TEEN_TYPES))
-        enrollment_session_ids = set(all_sessions.keys()) | set(teen_sessions.keys())
+
+        # Family Camp also counts as "still attending camp": a household that
+        # cancels a summer session but keeps a Family Camp weekend reads as
+        # has_other_sessions, not a true departure. Fold family session ids
+        # into the enrollment lookup only -- same rule as teens above, the
+        # display scope below stays summer-only / the requested filter.
+        family_sessions = await self.repository.fetch_sessions(year, [FAMILY_SESSION_TYPE])
+        enrollment_session_ids = set(all_sessions.keys()) | set(teen_sessions.keys()) | set(family_sessions.keys())
 
         # Fetch filtered sessions for display
         effective_types = session_types or list(SUMMER_SESSION_TYPES)

--- a/api/services/waitlist_service.py
+++ b/api/services/waitlist_service.py
@@ -24,6 +24,7 @@ from api.services.breakdown_calculator import calculate_percentage, compute_regi
 from api.services.extractors import extract_gender, extract_grade
 from api.utils.session_metrics import (
     DEFAULT_SUMMER_SESSION_TYPES,
+    FAMILY_SESSION_TYPE,
     SUMMER_TEEN_TYPES,
     build_ag_parent_map,
     get_session_from_expand,
@@ -74,7 +75,14 @@ class WaitlistService:
         # not no_enrollment. Fold teen session ids into the enrollment lookup only
         # -- the display scope below stays summer-only / the requested filter.
         teen_sessions = await self.repository.fetch_sessions(year, list(SUMMER_TEEN_TYPES))
-        enrollment_session_ids = set(all_sessions.keys()) | set(teen_sessions.keys())
+
+        # Family Camp also counts as "enrolled at camp": a household waitlisted
+        # for a summer session but already enrolled in a Family Camp weekend
+        # reads as has_enrollment, not no_enrollment. Fold family session ids
+        # into the enrollment lookup only -- same rule as teens above, the
+        # display scope below stays summer-only / the requested filter.
+        family_sessions = await self.repository.fetch_sessions(year, [FAMILY_SESSION_TYPE])
+        enrollment_session_ids = set(all_sessions.keys()) | set(teen_sessions.keys()) | set(family_sessions.keys())
 
         # Fetch filtered sessions for waitlist display
         effective_types = session_types or list(SUMMER_SESSION_TYPES)

--- a/api/utils/session_metrics.py
+++ b/api/utils/session_metrics.py
@@ -80,6 +80,13 @@ SUMMER_PROGRAM_SESSION_TYPES = ("main", "embedded", "ag", "quest")
 # exclude off-season noise (fall Family-Camp CIT, Aug->May Teen Interns, Feb L.A. Trip).
 SUMMER_TEEN_TYPES = ("scit", "tli")
 
+# Family Camp session type — not part of DISPLAY_SESSION_TYPES / DEFAULT_SUMMER_SESSION_TYPES
+# (adult-focused, separate program), but a household that cancels/waitlists for a summer
+# session while already enrolled in a Family Camp weekend is still attending camp. Folded
+# into the cross-session "still attending" enrollment lookup in cancellation_service.py and
+# waitlist_service.py only — never into the display scope.
+FAMILY_SESSION_TYPE = "family"
+
 # Display labels for the merged teen rows (one row per teen session_type),
 # shared by the forecast and availability services.
 TEEN_DISPLAY_NAMES: dict[str, str] = {"scit": "SCIT", "tli": "TLI"}

--- a/tests/unit/api/test_cancellation_service.py
+++ b/tests/unit/api/test_cancellation_service.py
@@ -541,3 +541,65 @@ class TestTeenCrossSessionEnrollment:
 
         assert result.has_other_sessions == 1
         assert result.no_other_sessions == 0
+
+
+class TestFamilyCampCrossSessionEnrollment:
+    """A cancelled summer camper whose household still attends a Family Camp
+    weekend must count as 'has other sessions', not a true departure. The
+    cross-session enrollment lookup has to span Family Camp too, mirroring the
+    existing SCIT/TLI teen-program handling above.
+    """
+
+    @pytest.mark.asyncio
+    async def test_summer_camper_kept_in_family_camp_counts_as_has_other(
+        self, cancellation_service, mock_repository, sample_persons
+    ):
+        session1 = create_mock_session(1001, "Session 1", 2026, "main", "2026-06-15", "2026-07-05")
+        family_weekend = create_mock_session(3001, "Fall Family Camp", 2026, "family", "2026-09-11", "2026-09-13")
+        summer_sessions = {1001: session1}
+        family_sessions = {3001: family_weekend}
+
+        # Noah (104) cancelled his summer session but the household is still
+        # enrolled in a Family Camp weekend.
+        cancelled = [
+            create_mock_attendee(
+                104,
+                session_cm_id=session1.cm_id,
+                session=session1,
+                status="cancelled",
+                effective_date="2026-01-10",
+            ),
+        ]
+        enrolled = [
+            create_mock_attendee(
+                104,
+                session_cm_id=family_weekend.cm_id,
+                session=family_weekend,
+                status="enrolled",
+                effective_date="2025-11-10",
+            ),
+        ]
+
+        def fetch_sessions_side_effect(year, session_types=None):
+            requested = set(session_types or [])
+            if requested == {"family"}:
+                return family_sessions
+            return summer_sessions
+
+        mock_repository.fetch_sessions = AsyncMock(side_effect=fetch_sessions_side_effect)
+        mock_repository.fetch_persons.return_value = sample_persons
+        mock_repository.fetch_attendees = AsyncMock(
+            side_effect=lambda year, status_filter=None: (
+                cancelled if status_filter == ["cancelled", "withdrawn", "dismissed"] else enrolled
+            )
+        )
+        mock_repository.fetch_status_history = AsyncMock(return_value=[])
+
+        result = await cancellation_service.calculate_cancellations(year=2026)
+
+        # has_other_sessions / no_other_sessions is the "still-attending" lookup
+        # this fix corrects. true_departure_count is a separate metric (driven by
+        # detect_session_swaps' same-day cancel+enroll heuristic) that this fix
+        # deliberately does not touch -- out of scope per the issue.
+        assert result.has_other_sessions == 1
+        assert result.no_other_sessions == 0

--- a/tests/unit/api/test_waitlist_service.py
+++ b/tests/unit/api/test_waitlist_service.py
@@ -1535,3 +1535,70 @@ class TestWaitlistDuration:
         assert result.avg_days_to_acceptance == pytest.approx(104.5, abs=1)
         # median of [89, 120] = 104.5
         assert result.median_days_to_acceptance == pytest.approx(104.5, abs=1)
+
+
+# ============================================================================
+# Family Camp cross-session enrollment (mirrors cancellation_service.py's fix)
+# ============================================================================
+
+
+class TestFamilyCampCrossSessionEnrollment:
+    """A camper waitlisted for a summer session whose household is already
+    enrolled in a Family Camp weekend must show has_enrollment, not
+    no_enrollment -- same "still at camp" reasoning as the teen-program fold-in
+    above, and the same bug independently present in cancellation_service.py
+    (fixed there; this mirrors that fix for the waitlist service).
+    """
+
+    @pytest.mark.asyncio
+    async def test_summer_waitlist_sees_family_camp_enrollment(
+        self,
+        waitlist_service: WaitlistService,
+        mock_repository: Mock,
+        sample_persons: dict[int, Mock],
+    ) -> None:
+        session1 = create_mock_session(1001, "Session 1", 2026, "main")
+        family_weekend = create_mock_session(3001, "Fall Family Camp", 2026, "family", start_date="2026-09-11")
+        summer_sessions = {1001: session1}
+        family_sessions = {3001: family_weekend}
+
+        def fetch_sessions_side_effect(year, session_types=None):
+            requested = set(session_types or [])
+            if requested == {"family"}:
+                return family_sessions
+            return summer_sessions
+
+        # Noah (104) is waitlisted for a summer session; his household is
+        # already enrolled in a Family Camp weekend.
+        waitlisted_attendees = [
+            create_mock_attendee(
+                104,
+                session_cm_id=session1.cm_id,
+                session=session1,
+                status="waitlisted",
+                status_id=8,
+            ),
+        ]
+        enrolled_attendees = [
+            create_mock_attendee(
+                104,
+                session_cm_id=family_weekend.cm_id,
+                session=family_weekend,
+                status="enrolled",
+                status_id=2,
+            ),
+        ]
+
+        mock_repository.fetch_attendees = AsyncMock(
+            side_effect=lambda year, status_filter=None: (
+                waitlisted_attendees if status_filter == "waitlisted" else enrolled_attendees
+            )
+        )
+        mock_repository.fetch_sessions = AsyncMock(side_effect=fetch_sessions_side_effect)
+        mock_repository.fetch_persons.return_value = sample_persons
+        mock_repository.fetch_status_history = AsyncMock(return_value=[])
+
+        result = await waitlist_service.calculate_waitlist(year=2026)
+
+        assert result.waitlisted_has_enrollment == 1
+        assert result.waitlisted_no_enrollment == 0


### PR DESCRIPTION
`cancellation_service.py` already folds teen (SCIT/TLI) sessions into its cross-session
enrollment lookup, so a camper who cancels one summer session but keeps another summer
or teen session reads as `has_other_sessions`, not a true departure. Family Camp was
missing from that lookup entirely: 64 distinct persons in the 2026 production snapshot
hold both a summer cancellation and an enrolled Family Camp weekend row (grain: distinct
`person_id`, `attendee_status_history` joined to enrolled `attendees`), and every one of
them was eligible to be classified as having left camp entirely on the strength of the
summer cancellation alone.

## What changed

Fetch Family Camp sessions the same way teen sessions are already fetched, and fold
their ids into `enrollment_session_ids` only — the display scope (`filtered_sessions`)
is untouched, so this does not add Family Camp to summer metrics; it only stops the
service asserting a departure that did not happen.

## Deliberately NOT done

- `true_departure_count` / `session_swap_count` are a separate metric driven by
  `detect_session_swaps`' same-day cancel+enroll heuristic and never read
  `enrollment_session_ids` at all — out of scope for this fix.
- The broader "Family Camp is invisible to the metrics stack" question (adding Family
  Camp to summer display/breakdowns) is a separate product decision and is not part of
  this change, per the issue.

## Testing

Added `TestFamilyCampCrossSessionEnrollment`, mirroring the existing
`TestTeenCrossSessionEnrollment` pattern: a cancelled summer camper whose household
keeps a Family Camp weekend enrollment now counts as `has_other_sessions`, not
`no_other_sessions`. Written first, verified failing (`has_other_sessions == 0` when it
should be `1`), then implemented. Mutation-checked by reverting the
`enrollment_session_ids` union back to teen-only, confirming the new test goes red, and
restoring.

Closes #2435.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
