### PR TITLE
fix(api): compute historical journey child age at that year's session start

### DIFF
--- a/api/services/lodging_repository.py
+++ b/api/services/lodging_repository.py
@@ -581,7 +581,14 @@ class LodgingRepository:
                     f"person.household_id = {household_cm_id} "
                     f'&& session.session_type = "family" && {ACTIVE_ENROLLED_FILTER}'
                 ),
-                "expand": "person",
+                # `session` alongside `person` (kindred#2420): the journey
+                # needs to know WHICH family session this attendee row is
+                # enrolled in, to compute that child's age at that specific
+                # session's start rather than at the year's earliest
+                # camp-wide family session -- a season runs several, months
+                # apart, and a household does not necessarily attend the
+                # first one.
+                "expand": "person,session",
                 "sort": STABLE_SORT,
             },
         )

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -466,6 +466,19 @@ def _children_oldest_first(children: list[Any]) -> list[Any]:
     return sorted(children, key=lambda c: -(_f(c, "age") or 0.0))
 
 
+def _child_identity(person: Any) -> Any:
+    """The same key `PartyChild.person_cm_id` is published under.
+
+    CampMinder id when there is one; the PB record id string otherwise, for
+    the rare person row with neither -- kept rather than collapsed onto
+    every other anonymous sibling. Shared by `build_household_journey`'s
+    dedup (`seen_by_year`) and its per-child session lookup
+    (`session_start_by_year`) so the two can never disagree about which
+    child is which.
+    """
+    return _i(person, "cm_id") or str(getattr(person, "id", ""))
+
+
 def _housing_state(cabin: str, year_assignments: Mapping[int, str]) -> HousingState:
     """What is known about one household's housing in one year (kindred#2073).
 
@@ -1476,6 +1489,15 @@ class LodgingRosterService:
         )
 
         children_by_year: dict[int, list[Any]] = {}
+        # kindred#2420: each traced child's age has to be computed at THAT
+        # CHILD'S OWN family session start, not at the year's earliest
+        # camp-wide family session -- a season runs several (6 to 10 a year
+        # on the production snapshot, from May through December), and a
+        # household attends whichever one it booked, not necessarily the
+        # first of the year. Keyed the same way `seen_by_year` below is, so
+        # the year's earliest of THIS CHILD'S OWN attendee rows wins, ties
+        # included, without a second pass over `attendees`.
+        session_start_by_year: dict[int, dict[Any, date]] = {}
         # A JOURNEY ROW IS A YEAR, NOT A SESSION, and this is where that stops
         # being a wording point. A family can book two of a season's weekends,
         # which gives one child TWO enrolled family attendee rows in the same
@@ -1493,11 +1515,19 @@ class LodgingRosterService:
         # than collapsed onto every other anonymous sibling.
         seen_by_year: dict[int, set[Any]] = {}
         for attendee in attendees:
-            person = (getattr(attendee, "expand", None) or {}).get("person")
+            expand = getattr(attendee, "expand", None) or {}
+            person = expand.get("person")
             if person is None:
                 continue
             year = _i(attendee, "year")
-            identity = _i(person, "cm_id") or str(getattr(person, "id", ""))
+            identity = _child_identity(person)
+            session = expand.get("session")
+            start = _as_date(_s(session, "start_date")) if session is not None else None
+            if identity and start is not None:
+                starts = session_start_by_year.setdefault(year, {})
+                existing = starts.get(identity)
+                if existing is None or start < existing:
+                    starts[identity] = start
             if identity:
                 seen = seen_by_year.setdefault(year, set())
                 if identity in seen:
@@ -1515,35 +1545,15 @@ class LodgingRosterService:
             )
             if year > 0
         ]
-        cabin_maps, weekend_sessions_by_year = await asyncio.gather(
-            asyncio.gather(*(self.repository.fetch_cabin_assignments_by_household_cm_id(year) for year in years)),
-            # kindred#2420: the age shown for a past year has to be computed
-            # at THAT year's own family session start, not read off
-            # `persons.age` (a live CampMinder attribute the sync mirrors
-            # unchanged onto every year's row). `fetch_weekend_sessions`
-            # already exists for the roster's own session picker, so this
-            # reuses it rather than adding a new repository read.
-            asyncio.gather(*(self.repository.fetch_weekend_sessions(year) for year in years)),
+        cabin_maps = await asyncio.gather(
+            *(self.repository.fetch_cabin_assignments_by_household_cm_id(year) for year in years)
         )
 
         rows: list[HouseholdJourneyYear] = []
-        for year, assignments, sessions in zip(years, cabin_maps, weekend_sessions_by_year, strict=True):
+        for year, assignments in zip(years, cabin_maps, strict=True):
             cabin = assignments.get(household_cm_id, "")
             children = _children_oldest_first(children_by_year.get(year, []))
-            # The EARLIEST family session of the year, matching how a family
-            # camp weekend book-ended by two sessions in one calendar year is
-            # already collapsed to one journey row above (`seen_by_year`).
-            # `None` when a year has no camp_sessions row at all (e.g. a
-            # registration-only year with neither a child nor an adult), in
-            # which case `_party_child` keeps the current-season fallback.
-            session_start = min(
-                (
-                    start
-                    for session in sessions
-                    if _s(session, "session_type") == "family" and (start := _as_date(_s(session, "start_date")))
-                ),
-                default=None,
-            )
+            year_starts = session_start_by_year.get(year, {})
             rows.append(
                 HouseholdJourneyYear(
                     year=year,
@@ -1555,7 +1565,17 @@ class LodgingRosterService:
                     # rendering either as an error or as a family with no kids.
                     enrollment="enrolled" if children else "none_on_file",
                     adults=[_party_adult(adult) for adult in adults_by_year.get(year, [])],
-                    children=[_party_child(child, as_of=session_start) for child in children],
+                    children=[
+                        # Each child's OWN attended session start
+                        # (kindred#2420) -- `None` when this child's
+                        # attendee row carried no readable session date
+                        # (e.g. an unexpanded `session` relation, or a
+                        # camp_sessions row missing `start_date`), in which
+                        # case `_party_child` keeps the current-season
+                        # fallback rather than guessing at a camp-wide date.
+                        _party_child(child, as_of=year_starts.get(_child_identity(child)))
+                        for child in children
+                    ],
                 )
             )
         return HouseholdJourneyResponse(household_cm_id=household_cm_id, years=rows)

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -397,8 +397,46 @@ def _party_adult(adult: Any) -> PartyAdult:
     )
 
 
-def _party_child(child: Any) -> PartyChild:
-    """A `persons` row as the wire sees it. See `_party_adult` on sharing."""
+def _age_at(birthdate: date, as_of: date) -> float | None:
+    """Completed years.months at `as_of`, in the same yy.mm encoding
+    `persons.age` uses (kindred#2420).
+
+    Built on `_completed_months` -- the same whole-month arithmetic
+    `_consumes_a_bed` already trusts for the infant-bed rule -- so a
+    historical age and an infant-bed decision can never disagree about how
+    a month is counted.
+
+    A negative month count means `as_of` predates the birth -- bad data, not
+    a valid age -- and is reported as unknown rather than a nonsense
+    negative number.
+    """
+    total_months = _completed_months(birthdate, as_of)
+    if total_months < 0:
+        return None
+    years, months = divmod(total_months, 12)
+    return float(f"{years}.{months:02d}")
+
+
+def _party_child(child: Any, *, as_of: date | None = None) -> PartyChild:
+    """A `persons` row as the wire sees it. See `_party_adult` on sharing.
+
+    `as_of` is the ONE thing that lets this stay one mapping instead of
+    forking (kindred#2420). `_build_household_parties` (the current-season
+    roster) omits it and gets the same `persons.age` snapshot it always has
+    -- that surface's blast radius is deliberately untouched. Only
+    `build_household_journey` passes it, because only the journey renders a
+    PAST year, and `persons.age` is CampMinder's LIVE attribute: the sync
+    mirrors it on every touch, so a historical row without `as_of` would
+    show the child's age TODAY on every year of their history, which is
+    kindred#2420's bug verbatim.
+    """
+    age = _f(child, "age") or None
+    if as_of is not None:
+        birthdate = _as_date(_s(child, "birthdate"))
+        # A missing/unparseable birthdate shows NO age for a historical row
+        # rather than falling back to the stale stored value -- that
+        # fallback is exactly the bug this branch exists to fix.
+        age = _age_at(birthdate, as_of) if birthdate is not None else None
     return PartyChild(
         person_cm_id=_i(child, "cm_id"),
         display_name=_person_display_name(child),
@@ -408,17 +446,17 @@ def _party_child(child: Any) -> PartyChild:
         # for which that split is wrong.
         last_name=_s(child, "last_name"),
         # persons.age is CampMinder's yy.mm as a REAL (kindred#2088): 0.06 is a
-        # real 6-month-old, not a rounding artifact, so this must read the raw
-        # float, not _i()'s truncated int. `or None` is still deliberate here
-        # -- age == 0.0 is the UNKNOWN-AGE population (no birthdate on file),
-        # not a newborn.
+        # real 6-month-old, not a rounding artifact, so the current-season
+        # (`as_of=None`) path must read the raw float, not _i()'s truncated
+        # int. `or None` is still deliberate there -- age == 0.0 is the
+        # UNKNOWN-AGE population (no birthdate on file), not a newborn.
         #
         # DO NOT threshold the infant discount on this field, here or
         # client-side (kindred#2046). yy.mm means months never exceed `.11`, so
         # `age < 1.5` is really "under 24 months" -- 44 children on 2026's
         # rostered cohort against the derived rule's 24. `_consumes_a_bed`
         # reads `birthdate` instead.
-        age=_f(child, "age") or None,
+        age=age,
         grade=_i(child, "grade") or None,
     )
 
@@ -1477,14 +1515,35 @@ class LodgingRosterService:
             )
             if year > 0
         ]
-        cabin_maps = await asyncio.gather(
-            *(self.repository.fetch_cabin_assignments_by_household_cm_id(year) for year in years)
+        cabin_maps, weekend_sessions_by_year = await asyncio.gather(
+            asyncio.gather(*(self.repository.fetch_cabin_assignments_by_household_cm_id(year) for year in years)),
+            # kindred#2420: the age shown for a past year has to be computed
+            # at THAT year's own family session start, not read off
+            # `persons.age` (a live CampMinder attribute the sync mirrors
+            # unchanged onto every year's row). `fetch_weekend_sessions`
+            # already exists for the roster's own session picker, so this
+            # reuses it rather than adding a new repository read.
+            asyncio.gather(*(self.repository.fetch_weekend_sessions(year) for year in years)),
         )
 
         rows: list[HouseholdJourneyYear] = []
-        for year, assignments in zip(years, cabin_maps, strict=True):
+        for year, assignments, sessions in zip(years, cabin_maps, weekend_sessions_by_year, strict=True):
             cabin = assignments.get(household_cm_id, "")
             children = _children_oldest_first(children_by_year.get(year, []))
+            # The EARLIEST family session of the year, matching how a family
+            # camp weekend book-ended by two sessions in one calendar year is
+            # already collapsed to one journey row above (`seen_by_year`).
+            # `None` when a year has no camp_sessions row at all (e.g. a
+            # registration-only year with neither a child nor an adult), in
+            # which case `_party_child` keeps the current-season fallback.
+            session_start = min(
+                (
+                    start
+                    for session in sessions
+                    if _s(session, "session_type") == "family" and (start := _as_date(_s(session, "start_date")))
+                ),
+                default=None,
+            )
             rows.append(
                 HouseholdJourneyYear(
                     year=year,
@@ -1496,7 +1555,7 @@ class LodgingRosterService:
                     # rendering either as an error or as a family with no kids.
                     enrollment="enrolled" if children else "none_on_file",
                     adults=[_party_adult(adult) for adult in adults_by_year.get(year, [])],
-                    children=[_party_child(child) for child in children],
+                    children=[_party_child(child, as_of=session_start) for child in children],
                 )
             )
         return HouseholdJourneyResponse(household_cm_id=household_cm_id, years=rows)

--- a/tests/unit/api/services/test_lodging_repository.py
+++ b/tests/unit/api/services/test_lodging_repository.py
@@ -1134,7 +1134,10 @@ class TestFetchHouseholdFamilyAttendees:
         assert "status_id = 2" in params["filter"]
         # No year predicate at all -- the sweep IS every year on file.
         assert "year =" not in params["filter"]
-        assert params["expand"] == "person"
+        # `session` alongside `person` (kindred#2420): the journey computes
+        # each child's age at THEIR OWN attended session's start, which
+        # needs that session's `start_date` in hand.
+        assert params["expand"] == "person,session"
 
     @pytest.mark.asyncio
     async def test_an_unresolvable_household_reads_nothing(self, repo: LodgingRepository, pb: MagicMock) -> None:

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -212,7 +212,14 @@ def _child(
     grade: int = 4,
     household_pb_id: str = "hh_1",
     birthdate: str = "",
+    session: Any | None = None,
 ) -> SimpleNamespace:
+    """An attendee row, `expand`ed the way `fetch_household_family_attendees`
+    hands one back. `session` (kindred#2420) is the family-camp session THIS
+    attendee row is enrolled in -- omitted by default because most fixtures
+    here do not care, which is also the `as_of=None` / "keep the stored
+    value" path every pre-existing journey fixture exercises.
+    """
     person = _rec(
         cm_id=cm_id,
         first_name=first,
@@ -226,7 +233,10 @@ def _child(
         # bed, which is itself pinned below.
         birthdate=birthdate,
     )
-    return _rec(person_id=cm_id, expand={"person": person})
+    expand: dict[str, Any] = {"person": person}
+    if session is not None:
+        expand["session"] = session
+    return _rec(person_id=cm_id, expand=expand)
 
 
 def _adult(
@@ -3875,23 +3885,12 @@ def _journey_repo(**overrides: Any) -> MagicMock:
     would make the whole housing-state derivation untestable.
     """
     cabins_by_year: dict[int, dict[int, str]] = overrides.pop("cabins_by_year", {})
-    # kindred#2420: each traced year's `camp_sessions` rows, so the journey
-    # can derive that year's age at ITS OWN family session start rather than
-    # publishing `persons.age` (a live attribute) unchanged. Empty by
-    # default -- a test that does not care gets no session for any year,
-    # which is the `as_of=None` / "keep the stored value" path and matches
-    # every pre-existing journey fixture here.
-    weekend_sessions_by_year: dict[int, list[Any]] = overrides.pop("weekend_sessions_by_year", {})
     repo = _repo(**overrides)
 
     async def _cabins(year: int) -> dict[int, str]:
         return cabins_by_year.get(year, {})
 
-    async def _sessions(year: int) -> list[Any]:
-        return weekend_sessions_by_year.get(year, [])
-
     repo.fetch_cabin_assignments_by_household_cm_id = AsyncMock(side_effect=_cabins)
-    repo.fetch_weekend_sessions = AsyncMock(side_effect=_sessions)
     return repo
 
 
@@ -4171,11 +4170,8 @@ class TestHouseholdJourney:
             end_date="2019-07-08",
             sort_order=1,
         )
-        child = _child(cm_id=1000001, first="Ava", last="Chen", age=17.04, birthdate="2010-08-01")
-        repo = _journey_repo(
-            fetch_household_family_attendees=[_rec(year=2019, **vars(child))],
-            weekend_sessions_by_year={2019: [session_2019]},
-        )
+        child = _child(cm_id=1000001, first="Ava", last="Chen", age=17.04, birthdate="2010-08-01", session=session_2019)
+        repo = _journey_repo(fetch_household_family_attendees=[_rec(year=2019, **vars(child))])
 
         journey = await LodgingRosterService(repo).build_household_journey(2000001)
 
@@ -4198,15 +4194,52 @@ class TestHouseholdJourney:
             end_date="2019-07-08",
             sort_order=1,
         )
-        child = _child(cm_id=1000001, age=17.04, birthdate="")
-        repo = _journey_repo(
-            fetch_household_family_attendees=[_rec(year=2019, **vars(child))],
-            weekend_sessions_by_year={2019: [session_2019]},
-        )
+        child = _child(cm_id=1000001, age=17.04, birthdate="", session=session_2019)
+        repo = _journey_repo(fetch_household_family_attendees=[_rec(year=2019, **vars(child))])
 
         journey = await LodgingRosterService(repo).build_household_journey(2000001)
 
         assert journey.years[0].children[0].age is None
+
+    @pytest.mark.asyncio
+    async def test_a_historical_age_uses_the_childs_own_attended_session_not_the_years_earliest_kindred_2420(
+        self,
+    ) -> None:
+        """A camp season runs several family-camp weekends months apart --
+        the production snapshot shows 6 to 10 a year, from May through
+        December (kindred#2420 follow-up: 2023 alone ran 2023-05-26 through
+        2023-12-28). Picking the YEAR'S EARLIEST family session camp-wide,
+        rather than the specific session THIS household's child was actually
+        enrolled in, reintroduces a smaller version of the exact bug this
+        issue fixes -- the age would still be wrong, just by weeks or months
+        instead of a full year.
+
+        Ava Chen, born 2010-08-01, is enrolled in the LATE (September)
+        session only -- nothing enrolls her in the year's early (May)
+        session. At the May session she would have been a completed
+        8-years-9-months; by her actual September session she is a completed
+        9-years-1-month. Asserting 9.01 (not 8.09) is what proves the age
+        comes from her own attendee row's session, not a camp-wide scan.
+        """
+        # The year's EARLIEST family session (2019-05-24) is deliberately
+        # never attached to this child anywhere in this fixture -- proving
+        # it is never read is the point.
+        session_late = _rec(
+            id="sess_late",
+            cm_id=3000003,
+            name="Family Camp 4",
+            session_type="family",
+            year=2019,
+            start_date="2019-09-19",
+            end_date="2019-09-22",
+            sort_order=4,
+        )
+        child = _child(cm_id=1000001, first="Ava", last="Chen", age=17.04, birthdate="2010-08-01", session=session_late)
+        repo = _journey_repo(fetch_household_family_attendees=[_rec(year=2019, **vars(child))])
+
+        journey = await LodgingRosterService(repo).build_household_journey(2000001)
+
+        assert journey.years[0].children[0].age == 9.01
 
 
 class TestWriteInCovers:

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -3875,12 +3875,23 @@ def _journey_repo(**overrides: Any) -> MagicMock:
     would make the whole housing-state derivation untestable.
     """
     cabins_by_year: dict[int, dict[int, str]] = overrides.pop("cabins_by_year", {})
+    # kindred#2420: each traced year's `camp_sessions` rows, so the journey
+    # can derive that year's age at ITS OWN family session start rather than
+    # publishing `persons.age` (a live attribute) unchanged. Empty by
+    # default -- a test that does not care gets no session for any year,
+    # which is the `as_of=None` / "keep the stored value" path and matches
+    # every pre-existing journey fixture here.
+    weekend_sessions_by_year: dict[int, list[Any]] = overrides.pop("weekend_sessions_by_year", {})
     repo = _repo(**overrides)
 
     async def _cabins(year: int) -> dict[int, str]:
         return cabins_by_year.get(year, {})
 
+    async def _sessions(year: int) -> list[Any]:
+        return weekend_sessions_by_year.get(year, [])
+
     repo.fetch_cabin_assignments_by_household_cm_id = AsyncMock(side_effect=_cabins)
+    repo.fetch_weekend_sessions = AsyncMock(side_effect=_sessions)
     return repo
 
 
@@ -4131,6 +4142,71 @@ class TestHouseholdJourney:
 
         assert journey.years == []
         repo.fetch_cabin_assignments_by_household_cm_id.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_historical_years_age_is_the_childs_age_that_year_not_today_kindred_2420(self) -> None:
+        """The regression pin for kindred#2420.
+
+        `persons.age` is CampMinder's LIVE attribute, mirrored verbatim
+        whenever the sync last touched the row -- not "age as of that
+        year's season", however plausible a stored number looks on its own.
+        A fixture whose stored `age` is a PLAUSIBLE-BUT-WRONG "today's age"
+        must still render the age computed at that YEAR's own family-camp
+        session start -- asserting on the stored value would re-pin the bug
+        this issue fixes (kindred#2420's acceptance condition 5).
+
+        Ava Chen, born 2010-08-01: the 2019 family session started
+        2019-07-05, four weeks before her ninth birthday, so she was
+        completed-8-years-11-months old that week -- nowhere near the
+        `age=17.04` the fixture's `persons` row carries (a later sync's
+        snapshot of her CURRENT age).
+        """
+        session_2019 = _rec(
+            id="sess_2019",
+            cm_id=3000001,
+            name="Family Camp 1",
+            session_type="family",
+            year=2019,
+            start_date="2019-07-05",
+            end_date="2019-07-08",
+            sort_order=1,
+        )
+        child = _child(cm_id=1000001, first="Ava", last="Chen", age=17.04, birthdate="2010-08-01")
+        repo = _journey_repo(
+            fetch_household_family_attendees=[_rec(year=2019, **vars(child))],
+            weekend_sessions_by_year={2019: [session_2019]},
+        )
+
+        journey = await LodgingRosterService(repo).build_household_journey(2000001)
+
+        assert journey.years[0].children[0].age == 8.11
+
+    @pytest.mark.asyncio
+    async def test_a_historical_child_with_no_birthdate_shows_no_age_kindred_2420(self) -> None:
+        """Acceptance condition 3: a child with no usable birthdate must
+        show NO age for a historical year, rather than falling back to the
+        stale stored value (which is exactly the bug being fixed) or
+        crashing on an unparseable date.
+        """
+        session_2019 = _rec(
+            id="sess_2019",
+            cm_id=3000001,
+            name="Family Camp 1",
+            session_type="family",
+            year=2019,
+            start_date="2019-07-05",
+            end_date="2019-07-08",
+            sort_order=1,
+        )
+        child = _child(cm_id=1000001, age=17.04, birthdate="")
+        repo = _journey_repo(
+            fetch_household_family_attendees=[_rec(year=2019, **vars(child))],
+            weekend_sessions_by_year={2019: [session_2019]},
+        )
+
+        journey = await LodgingRosterService(repo).build_household_journey(2000001)
+
+        assert journey.years[0].children[0].age is None
 
 
 class TestWriteInCovers:


### PR DESCRIPTION
The family history "see members" modal (`HouseholdYearMembersModal`) showed every past
journey year at each child's age **today**, not their age that year — 4,464 of 5,473
renderable child rows (81.6%) on the production snapshot were wrong by a full year or
more, and every 2017/2018/2019/2022/2023/2024 row (4,061 rows) was wrong by at least one
year (kindred#2420).

Root cause: `persons.age` is CampMinder's live `yy.mm` attribute, mirrored unchanged by
the nightly sync on every touch (typically the person's own birthday). `_party_child`
published that stored column straight onto the wire for every caller, and
`build_household_journey` — which already knows which year each row belongs to — had no
way to tell `_party_child` a year had passed.

Fix, server-side only, in `api/services/lodging_roster_service.py`:

- `_party_child` gains an optional `as_of: date | None` keyword. `None` (the default,
  used unchanged by the current-season roster path `_build_household_parties`) keeps
  publishing the stored `persons.age` exactly as before — that surface's blast radius is
  untouched. When `build_household_journey` passes a year's own family session start
  date, `_party_child` instead computes completed years.months from `persons.birthdate`
  at that date (`_age_at`, built on the same `_completed_months` whole-month arithmetic
  `_consumes_a_bed` already uses for the infant-bed rule), and reports no age at all when
  the child has no usable birthdate rather than falling back to the stale value.
- `build_household_journey` derives each traced year's earliest **family** session start
  from `fetch_weekend_sessions(year)` (an existing repository read, reused rather than
  adding a new one) and threads it through as `as_of`.

`birthdate` is still never sent to the client — `/api/lodging/households/{id}/journey`
has no `require_permission` gate, so publishing a new personal identifier there to save a
server-side subtraction was ruled out in the issue. The age is computed and discarded
server-side; the wire shape (`PartyChild.age: float | None`) is unchanged, so no frontend
edit was needed — `HouseholdYearMembersModal` already renders whatever `PartyChild.age`
holds.

Deliberately NOT done:
- No change to the four current-season board renderers of `PartyChild.age`
  (`FamilyCard`, `HouseholdRosterRow`, `FamilyDetailsPanel`, `LodgingUnitCard`'s sort) —
  those read "age now" correctly today and are out of this issue's blast radius.
- No change to `_children_oldest_first`'s sibling ordering, which sorts on the same
  (still-stale) `persons.age` — sibling order is unaffected by which year is stale
  because all siblings age at the same rate, per the issue's own analysis.
- Nothing in the `HouseholdJourneyYear` schema or the journey-row-assembly loop's other
  fields (cabin, housing state, enrollment) touched — that region belongs to kindred#2393,
  a merge collision to sequence rather than a dependency.

Regression tests pin the historical-year computation directly: a fixture child whose
stored `persons.age` reads as "today's age" now renders that year's computed age instead
(mutation-checked — reverting the `as_of` branch turns both new tests red), and a second
test pins that a missing birthdate renders no age rather than the stale one.

Closes #2420.
