### PR TITLE
fix(metrics): scope and dedupe the historical-trends cancellation rate

### DIFF
--- a/api/services/historical_service.py
+++ b/api/services/historical_service.py
@@ -69,28 +69,39 @@ class HistoricalService:
         if session_cm_id is not None:
             session_name = await self._get_session_name_for_filtering(session_cm_id, years, session_types)
 
-        # Fetch attendees, persons, sessions, and cancellation counts for all years in parallel
+        # Fetch attendees, persons, sessions, and cancellation transitions for all years in parallel
         attendee_futures = [self.repo.fetch_attendees(y) for y in years]
         person_futures = [self.repo.fetch_persons(y) for y in years]
         session_futures = [self.repo.fetch_sessions(y, session_types=session_types) for y in years]
-        cancel_futures = [self._fetch_cancellation_count(y) for y in years]
+        cancel_futures = [self._fetch_cancellation_transitions(y) for y in years]
 
         all_attendees = await asyncio.gather(*attendee_futures)
         all_persons = await asyncio.gather(*person_futures)
         all_sessions = await asyncio.gather(*session_futures)
-        all_cancel_counts = await asyncio.gather(*cancel_futures)
+        all_cancel_transitions = await asyncio.gather(*cancel_futures)
 
         # Compute metrics for each year
         year_metrics_list: list[YearMetrics] = []
 
-        for year, attendees, persons, sessions, cancel_count in zip(
-            years, all_attendees, all_persons, all_sessions, all_cancel_counts, strict=True
+        for year, attendees, persons, sessions, cancel_transitions in zip(
+            years, all_attendees, all_persons, all_sessions, all_cancel_transitions, strict=True
         ):
             # Filter attendees by session type and/or session name
             filtered = self._filter_attendees(attendees, sessions, session_types, session_cm_id, session_name, duration)
 
             # Deduplicate by person_id
             person_ids = {pid for a in filtered if (pid := getattr(a, "person_id", None)) is not None}
+
+            # Cancellations use the SAME scope (session_types/session_cm_id/duration) and the
+            # same distinct-person grain as the enrolled denominator above -- see #2434, where
+            # an unscoped, row-counted numerator inflated the rendered rate ~2.4x.
+            filtered_cancellations = self._filter_attendees(
+                cancel_transitions, sessions, session_types, session_cm_id, session_name, duration
+            )
+            cancelled_person_ids = {
+                pid for t in filtered_cancellations if (pid := getattr(t, "person_id", None)) is not None
+            }
+            cancel_count = len(cancelled_person_ids)
 
             year_metric = self._compute_year_metrics(year, person_ids, persons, cancel_count)
             year_metrics_list.append(year_metric)
@@ -149,16 +160,20 @@ class HistoricalService:
 
         return None
 
-    async def _fetch_cancellation_count(self, year: int) -> int:
-        """Fetch total cancellation count for a year."""
-        if hasattr(self.repo, "fetch_cancellation_count"):
-            result: int = await self.repo.fetch_cancellation_count(year)
-            return result
+    async def _fetch_cancellation_transitions(self, year: int) -> list[Any]:
+        """Fetch raw cancellation status-transition rows for a year.
+
+        Returns the unfiltered rows so the caller can scope them by
+        session_type/session_cm_id/duration identically to the enrolled
+        denominator (see calculate_historical_trends), and dedupe by
+        person_id for the correct grain. No repository defines a
+        pre-aggregated ``fetch_cancellation_count`` -- see #2434.
+        """
         try:
-            transitions = await self.repo.fetch_status_transitions(year, ["cancelled", "withdrawn", "dismissed"])
-            return len(transitions)
+            result: list[Any] = await self.repo.fetch_status_transitions(year, ["cancelled", "withdrawn", "dismissed"])
+            return result
         except Exception:
-            return 0
+            return []
 
     def _compute_year_metrics(
         self, year: int, person_ids: set[int], persons: dict[int, Any], total_cancelled: int = 0

--- a/tests/unit/api/services/test_historical_service.py
+++ b/tests/unit/api/services/test_historical_service.py
@@ -45,6 +45,29 @@ def make_mock_attendee(
     return attendee
 
 
+def make_mock_transition(
+    person_id: int,
+    session_cm_id: int,
+    session_type: str = "main",
+    new_status: str = "cancelled",
+) -> MagicMock:
+    """Create a mock attendee_status_history transition with session expand.
+
+    Shaped identically to make_mock_attendee's expand so the same
+    session-scoping helper (filter_attendees_by_session) can filter both.
+    """
+    transition = MagicMock()
+    transition.person_id = person_id
+    transition.new_status = new_status
+
+    session = MagicMock()
+    session.cm_id = session_cm_id
+    session.session_type = session_type
+
+    transition.expand = {"session": session}
+    return transition
+
+
 def make_mock_session(
     cm_id: int,
     name: str,
@@ -66,7 +89,7 @@ def _make_repo_with_defaults() -> MagicMock:
     repo.fetch_attendees = AsyncMock(return_value=[])
     repo.fetch_persons = AsyncMock(return_value={})
     repo.fetch_sessions = AsyncMock(return_value={})
-    repo.fetch_cancellation_count = AsyncMock(return_value=0)
+    repo.fetch_status_transitions = AsyncMock(return_value=[])
     return repo
 
 
@@ -241,18 +264,19 @@ class TestHistoricalServiceFromAttendees:
         assert result.years[0].total_enrolled == 1
 
     @pytest.mark.asyncio
-    async def test_cancellation_metrics_unchanged(self, mock_repository: MagicMock) -> None:
-        """Cancellation logic should still work (already uses status_transitions)."""
+    async def test_cancellation_rate_from_status_transitions(self, mock_repository: MagicMock) -> None:
+        """Cancellation count is derived from fetch_status_transitions, distinct persons."""
         from api.services.historical_service import HistoricalService
 
         attendees = [make_mock_attendee(1001, 5001)]
         persons = {1001: make_mock_person(1001, "M")}
         sessions = {5001: make_mock_session(5001, "Session 1")}
+        transitions = [make_mock_transition(2001 + i, 5001) for i in range(5)]
 
         mock_repository.fetch_attendees = AsyncMock(return_value=attendees)
         mock_repository.fetch_persons = AsyncMock(return_value=persons)
         mock_repository.fetch_sessions = AsyncMock(return_value=sessions)
-        mock_repository.fetch_cancellation_count = AsyncMock(return_value=5)
+        mock_repository.fetch_status_transitions = AsyncMock(return_value=transitions)
 
         service = HistoricalService(mock_repository)
         result = await service.calculate_historical_trends(years=[2025])
@@ -261,6 +285,93 @@ class TestHistoricalServiceFromAttendees:
         assert year_metric.total_cancelled == 5
         # cancellation_rate = 5 / (1 + 5) = 83.33%
         assert abs(year_metric.cancellation_rate - 83.33) < 0.01
+
+    @pytest.mark.asyncio
+    async def test_cancellation_count_dedupes_by_person_not_rows(self, mock_repository: MagicMock) -> None:
+        """A person with two cancellation transition rows in a year counts once.
+
+        Regression test for #2434 grain mismatch: the fallback used to return
+        len(transitions) (rows), inflating the count above the distinct-person
+        denominator it was divided against.
+        """
+        from api.services.historical_service import HistoricalService
+
+        attendees = [make_mock_attendee(1001, 5001)]
+        persons = {1001: make_mock_person(1001, "M")}
+        sessions = {5001: make_mock_session(5001, "Session 1")}
+        # Person 3001 cancelled out of two different sessions the same year —
+        # two rows, one person.
+        transitions = [
+            make_mock_transition(3001, 5001),
+            make_mock_transition(3001, 5002),
+        ]
+
+        mock_repository.fetch_attendees = AsyncMock(return_value=attendees)
+        mock_repository.fetch_persons = AsyncMock(return_value=persons)
+        mock_repository.fetch_sessions = AsyncMock(return_value=sessions)
+        mock_repository.fetch_status_transitions = AsyncMock(return_value=transitions)
+
+        service = HistoricalService(mock_repository)
+        result = await service.calculate_historical_trends(years=[2025])
+
+        assert result.years[0].total_cancelled == 1
+
+    @pytest.mark.asyncio
+    async def test_cancellation_count_scoped_to_session_types(self, mock_repository: MagicMock) -> None:
+        """Cancellations outside the requested session_types are excluded.
+
+        Regression test for #2434 scope mismatch: the fallback counted every
+        cancellation regardless of session_types, against a denominator that
+        was already type-scoped.
+        """
+        from api.services.historical_service import HistoricalService
+
+        attendees = [make_mock_attendee(1001, 5001, "Session 1", "main")]
+        persons = {1001: make_mock_person(1001, "M")}
+        sessions = {5001: make_mock_session(5001, "Session 1", "main")}
+        transitions = [
+            make_mock_transition(3001, 5001, session_type="main"),
+            make_mock_transition(3002, 5002, session_type="family"),  # out of scope
+        ]
+
+        mock_repository.fetch_attendees = AsyncMock(return_value=attendees)
+        mock_repository.fetch_persons = AsyncMock(return_value=persons)
+        mock_repository.fetch_sessions = AsyncMock(return_value=sessions)
+        mock_repository.fetch_status_transitions = AsyncMock(return_value=transitions)
+
+        service = HistoricalService(mock_repository)
+        result = await service.calculate_historical_trends(years=[2025], session_types=["main"])
+
+        assert result.years[0].total_cancelled == 1
+
+    @pytest.mark.asyncio
+    async def test_phantom_fetch_cancellation_count_is_ignored(self, mock_repository: MagicMock) -> None:
+        """A repo that also happens to define fetch_cancellation_count is not consulted.
+
+        Regression test for #2434: the service used to hasattr()-probe for a
+        method no repository implementation defines, so the branch was dead in
+        production and only ever exercised by a test double. That probe/branch
+        must be gone — fetch_status_transitions is the only path now.
+        """
+        from api.services.historical_service import HistoricalService
+
+        attendees = [make_mock_attendee(1001, 5001)]
+        persons = {1001: make_mock_person(1001, "M")}
+        sessions = {5001: make_mock_session(5001, "Session 1")}
+        transitions = [make_mock_transition(3001, 5001)]
+
+        mock_repository.fetch_attendees = AsyncMock(return_value=attendees)
+        mock_repository.fetch_persons = AsyncMock(return_value=persons)
+        mock_repository.fetch_sessions = AsyncMock(return_value=sessions)
+        mock_repository.fetch_status_transitions = AsyncMock(return_value=transitions)
+        # If the service still probed for this, it would use 999 instead of
+        # the real status-transitions count of 1.
+        mock_repository.fetch_cancellation_count = AsyncMock(return_value=999)
+
+        service = HistoricalService(mock_repository)
+        result = await service.calculate_historical_trends(years=[2025])
+
+        assert result.years[0].total_cancelled == 1
 
 
 # ============================================================================

--- a/tests/unit/api/test_velocity_service.py
+++ b/tests/unit/api/test_velocity_service.py
@@ -1655,11 +1655,21 @@ class TestHistoricalCancellationMetrics:
         mock_repo.fetch_persons.side_effect = mock_fetch_persons
         mock_repo.fetch_sessions = AsyncMock(return_value=sessions_both)
 
-        # Mock cancellation count
-        async def mock_fetch_cancellation_count(year, **kwargs):
-            return 5 if year == 2025 else 8
+        # Mock cancellation transitions (service derives the count itself,
+        # scoped and deduplicated by person_id — see #2434)
+        def make_transition(pid: int) -> Mock:
+            t = Mock()
+            t.person_id = pid
+            t.expand = {"session": mock_session}
+            return t
 
-        mock_repo.fetch_cancellation_count = mock_fetch_cancellation_count
+        transitions_2025 = [make_transition(2001 + i) for i in range(5)]
+        transitions_2026 = [make_transition(3001 + i) for i in range(8)]
+
+        async def mock_fetch_status_transitions(year, statuses, **kwargs):
+            return transitions_2025 if year == 2025 else transitions_2026
+
+        mock_repo.fetch_status_transitions = mock_fetch_status_transitions
 
         svc = HistoricalService(mock_repo)
         result = await svc.calculate_historical_trends(years=[2025, 2026])


### PR DESCRIPTION
The cancellation rate on the historical-trends view rendered ~2.4x the true figure (measured on
prod: 18.95% rendered vs 7.99% correct, 2026, display session types), from two structural defects
in `HistoricalService._fetch_cancellation_count`:

1. A dead `hasattr(self.repo, "fetch_cancellation_count")` guard. No repository implementation
   (PocketBase-backed `MetricsRepository` or the direct-SQLite `MetricsSQLRepository`) defines that
   method, so the guard was always `False` in production and the fallback branch was the only path
   ever run — while every existing test installed the phantom method directly on its mock, so the
   real fallback had zero coverage.
2. That fallback counted ALL status-transition rows for the year with no `session_types` scoping
   (the enrolled denominator IS type-scoped), and counted rows instead of distinct persons (a person
   cancelling out of two sessions in one year was counted twice).

## Fix

Fetch the raw cancellation transitions per year, then run them through the exact same
`_filter_attendees` scoping (`session_types`/`session_cm_id`/`duration`) used for the
enrolled-person denominator, and dedupe by `person_id` before counting — giving the numerator the
same scope and grain as the denominator it's divided against. The dead `hasattr` branch is deleted
rather than given a real implementation, since no repository needs a pre-aggregated count method
once the scoped/deduped path exists.

## Tests

Three new regression tests in `tests/unit/api/services/test_historical_service.py` pin the exact
defects: session-type scoping, person-grain dedup, and that a repo defining the phantom
`fetch_cancellation_count` is now ignored entirely. Each was verified failing before the fix and
mutation-checked (breaking the corresponding production line turns it red again). The two test
files that previously installed the phantom method on a mock (`test_historical_service.py`,
`test_velocity_service.py`) now mock `fetch_status_transitions` instead, exercising the real
production path for the first time.

## Not done

The five-year trend line still renders 0% for years with no `attendee_status_history` coverage
(prod currently holds rows for one year only), rather than distinguishing "no data" from "zero
cancellations". Doing that correctly needs an API response contract change
(`api/schemas/metrics.py`) and a frontend rendering change
(`frontend/src/components/metrics/TrendLineChart.tsx`), both out of scope for this file-disjoint
fix — filed as #2443.

Closes #2434.
