### PR TITLE
fix(graph): scope prior-year bunk history to the session it belonged to

### DIFF
--- a/bunking/sync/bunk_request_processor/data/cache/temporal_name_cache.py
+++ b/bunking/sync/bunk_request_processor/data/cache/temporal_name_cache.py
@@ -194,8 +194,23 @@ class TemporalNameCache:
 
         Unlike monolith which queries non-existent 'historical_bunking' table,
         we use the modern schema: bunk_assignments with year < current_year.
+
+        The query is deliberately NOT filtered by session type. This dict has
+        two consumers that want opposite things (#2427): `_build_name_index`
+        uses mere PRESENCE here to give a person a "historical" bucket in the
+        name index, and a Family Camp attendee is a perfectly real prior-year
+        person to resolve a name against — filtering at the load would silently
+        drop ~922 people from name resolution. `verify_bunk_together` instead
+        wants cabins only. So each record carries its `session_type` and the
+        bunk-comparison consumer does the filtering.
         """
         logger.info("Loading historical bunking data...")
+
+        # Imported at call time, not module scope: `bunking.graph` imports
+        # `bunking.satisfaction`, which imports this package's `core.models`, so
+        # a top-level import here is a genuine cycle. Importing at call time
+        # keeps ONE definition of the eligible-session-type set.
+        from bunking.graph.social_graph_builder import LAST_YEAR_HISTORY_SESSION_TYPES  # noqa: PLC0415
 
         try:
             # Get all sessions for name lookup
@@ -208,10 +223,16 @@ class TemporalNameCache:
             # This limits memory usage while still providing useful historical context
             # For bunk request processing, 2 years is sufficient for name disambiguation
             min_year = self.year - 2
+            # `sort: "id"` makes the per-(person, year) pick below deterministic.
+            # PocketBase's get_full_list has no inherent order, so without it the
+            # kept row could change between runs with no code change — 442 of the
+            # 3,826 (person, year) keys in this two-year window carry more than
+            # one row, so the pick decides something real.
             assignments = self.pb.collection("bunk_assignments").get_full_list(
                 query_params={
                     "filter": f"year >= {min_year} && year < {self.year}",
                     "expand": "person,bunk,session",
+                    "sort": "id",
                 }
             )
 
@@ -227,15 +248,29 @@ class TemporalNameCache:
                 person_cm_id = getattr(person_data, "cm_id", None)
                 year = getattr(assignment, "year", None)
                 session_cm_id = getattr(session_data, "cm_id", None) if session_data else None
+                session_type = (getattr(session_data, "session_type", "") if session_data else "") or ""
                 bunk_name = getattr(bunk_data, "name", "") if bunk_data else ""
 
                 if person_cm_id and year:
                     if person_cm_id not in self._historical_bunking:
                         self._historical_bunking[person_cm_id] = {}
 
-                    # Only store most recent assignment per year
-                    # (in case of duplicates)
-                    if year not in self._historical_bunking[person_cm_id]:
+                    # One record per (person, year). The old comment here said
+                    # "most recent assignment per year" — that was never true;
+                    # the rows arrive unordered and this kept whichever came
+                    # first. It is now the first row in record-id order, EXCEPT
+                    # that a cabin-bearing session beats a non-bunking one: a
+                    # person who held both a summer cabin and a Family Camp day
+                    # group last year must be remembered by the cabin, or the
+                    # bunk-comparison consumer loses their real history (#2427).
+                    existing = self._historical_bunking[person_cm_id].get(year)
+                    is_eligible = session_type in LAST_YEAR_HISTORY_SESSION_TYPES
+                    replaces_existing = (
+                        existing is not None
+                        and is_eligible
+                        and existing.get("session_type", "") not in LAST_YEAR_HISTORY_SESSION_TYPES
+                    )
+                    if existing is None or replaces_existing:
                         self._historical_bunking[person_cm_id][year] = {
                             "session_cm_id": session_cm_id,
                             "session_name": session_lookup.get(session_cm_id, f"Session {session_cm_id}")
@@ -243,7 +278,13 @@ class TemporalNameCache:
                             else "",
                             "parent_session_id": session_cm_id,  # Simplified - no parent tracking for historical
                             "parent_session_name": session_lookup.get(session_cm_id, "") if session_cm_id else "",
-                            "bunk": bunk_name,
+                            # `bunk_name` is the key `verify_bunk_together`
+                            # reads. It used to be written as "bunk", so that
+                            # consumer read "" for everybody and returned
+                            # (False, "") every time — the whole historical
+                            # verification path was inert (#2427).
+                            "bunk_name": bunk_name,
+                            "session_type": session_type,
                         }
 
             total_historical = sum(len(years) for years in self._historical_bunking.values())
@@ -503,11 +544,18 @@ class TemporalNameCache:
             target_cm_ids: List of target CM IDs to check
             year: Year to check
 
+        Only sessions that actually put children in a cabin count. A shared
+        Family Camp day group is not evidence that two children bunked
+        together — day groups run to a median of 53 people (#2427).
+
         Returns:
             Tuple of (were_together, bunk_name):
             - (True, bunk_name) if all were in same bunk
             - (False, "") if not all together or data missing
         """
+        # Imported at call time — see `_load_historical_bunking` for why.
+        from bunking.graph.social_graph_builder import LAST_YEAR_HISTORY_SESSION_TYPES  # noqa: PLC0415
+
         # Get requester's historical bunking for the year
         requester_data = self._historical_bunking.get(requester_cm_id, {})
         requester_year_data = requester_data.get(year, {})
@@ -519,6 +567,9 @@ class TemporalNameCache:
         requester_session = requester_year_data.get("session_cm_id")
 
         if not requester_bunk:
+            return False, ""
+
+        if requester_year_data.get("session_type", "") not in LAST_YEAR_HISTORY_SESSION_TYPES:
             return False, ""
 
         # Empty target list is vacuously true (all zero targets were in same bunk)
@@ -537,6 +588,10 @@ class TemporalNameCache:
             target_bunk = target_year_data.get("bunk_name", "")
             target_session = target_year_data.get("session_cm_id")
 
+            # No session-type check on the target: the comparison below already
+            # requires the target to be in the SAME session as the requester,
+            # and a session has exactly one type, so the requester-side check
+            # above settles it for everyone in the group.
             # Both bunk name and session must match
             if target_bunk != requester_bunk or target_session != requester_session:
                 return False, ""

--- a/bunking/sync/bunk_request_processor/data/repositories/attendee_repository.py
+++ b/bunking/sync/bunk_request_processor/data/repositories/attendee_repository.py
@@ -529,10 +529,17 @@ class AttendeeRepository:
             # served more than one session, so filtering on bunk + year alone
             # returned children the requester never met (median peer set 29
             # against a session-scoped 8).
+            #
+            # Same `sort: "id"` STABLE_SORT convention as the query above, and
+            # for the same reason: `_try_prior_bunkmate_resolution` returns the
+            # FIRST camper in `cm_ids` whose name matches the target, so two
+            # cabinmates sharing a first name are separated by nothing but the
+            # order this query happened to return.
             bunkmates = self.pb.collection("bunk_assignments").get_full_list(
                 query_params={
                     "filter": f'bunk = "{bunk_id}" && year = {previous_year} && session = "{session_id}"',
                     "expand": "person",
+                    "sort": "id",
                 }
             )
 

--- a/bunking/sync/bunk_request_processor/data/repositories/attendee_repository.py
+++ b/bunking/sync/bunk_request_processor/data/repositories/attendee_repository.py
@@ -466,15 +466,36 @@ class AttendeeRepository:
             Dict with cm_ids, prior_bunk, prior_year, total_in_bunk, returning_count
             Empty dict if no prior year assignment found or on error
         """
+        # Imported at call time, not module scope: `bunking.graph` imports
+        # `bunking.satisfaction`, which imports this package's `core.models`, so
+        # a top-level import here is a genuine cycle. Importing at call time
+        # keeps ONE definition of the eligible-session-type set rather than
+        # adding another copy of it.
+        from bunking.graph.social_graph_builder import LAST_YEAR_HISTORY_SESSION_TYPES  # noqa: PLC0415
+
         try:
             previous_year = year - 1
 
-            # Find requester's bunk assignment from prior year
+            # Find requester's bunk assignment from prior year.
+            #
+            # The session-type predicate is pushed INTO the query so the
+            # database returns only rows from a session that actually puts
+            # children in a cabin. Without it a Family Camp DAY GROUP was
+            # eligible to be returned as a summer `prior_bunk`, and the whole
+            # day group then came back as "bunkmates" (#2426). `sort: "id"`
+            # breaks ties deterministically for the rarer case of two eligible
+            # rows -- PocketBase's get_full_list has no inherent order, so the
+            # winner could otherwise change between runs with no code change.
+            # Same predicate and same STABLE_SORT convention as
+            # `bunking/graph/social_graph_builder.py`, which already carries
+            # this fix for its own query.
+            type_clause = " || ".join(f'session.session_type = "{t}"' for t in LAST_YEAR_HISTORY_SESSION_TYPES)
             try:
                 assignments = self.pb.collection("bunk_assignments").get_full_list(
                     query_params={
-                        "filter": f"person.cm_id = {requester_cm_id} && year = {previous_year}",
-                        "expand": "person,bunk",
+                        "filter": f"person.cm_id = {requester_cm_id} && year = {previous_year} && ({type_clause})",
+                        "expand": "person,bunk,session",
+                        "sort": "id",
                     }
                 )
             except Exception:
@@ -488,19 +509,31 @@ class AttendeeRepository:
             requester_assignment = assignments[0]
             expand = getattr(requester_assignment, "expand", {}) or {}
             bunk_data = expand.get("bunk")
+            session_data = get_session_from_expand(requester_assignment)
 
             if not bunk_data:
                 return {}
 
             bunk_id = getattr(bunk_data, "id", None)
             bunk_name = getattr(bunk_data, "name", None)
+            session_id = getattr(session_data, "id", None) if session_data else None
 
-            if not bunk_id:
+            # Without the session we cannot scope the bunk to a week, and an
+            # unscoped query would return the whole building -- which is the
+            # defect this method is being fixed for. Return nothing instead.
+            if not bunk_id or not session_id:
                 return {}
 
-            # Find all campers in that bunk for prior year
+            # Find all campers in that bunk for prior year, IN THAT SESSION. A
+            # bunk is a building: 42 of the 57 bunks carrying a 2025 assignment
+            # served more than one session, so filtering on bunk + year alone
+            # returned children the requester never met (median peer set 29
+            # against a session-scoped 8).
             bunkmates = self.pb.collection("bunk_assignments").get_full_list(
-                query_params={"filter": f'bunk = "{bunk_id}" && year = {previous_year}', "expand": "person"}
+                query_params={
+                    "filter": f'bunk = "{bunk_id}" && year = {previous_year} && session = "{session_id}"',
+                    "expand": "person",
+                }
             )
 
             if not bunkmates:

--- a/bunking/sync/bunk_request_processor/social/social_graph.py
+++ b/bunking/sync/bunk_request_processor/social/social_graph.py
@@ -254,6 +254,14 @@ class SocialGraph:
 
     async def _add_historical_bunking_relationships(self, graph: nx.Graph, session_cm_id: int) -> None:
         """Add historical bunking relationships from previous years using bunk_assignments table"""
+        # Imported at call time, not module scope: `bunking.graph` imports
+        # `bunking.satisfaction`, which imports this package's `core.models`,
+        # so a top-level import here is a genuine cycle (it fails with
+        # "cannot import name 'BucketCount' from partially initialized module
+        # bunking.satisfaction"). A call-time import keeps ONE definition of
+        # the eligible-session-type set instead of adding a fourth copy of it.
+        from bunking.graph.social_graph_builder import LAST_YEAR_HISTORY_SESSION_TYPES  # noqa: PLC0415
+
         try:
             # Get all people in this session's graph
             if graph.number_of_nodes() == 0:
@@ -266,31 +274,54 @@ class SocialGraph:
             chunk_size = 25
             all_assignments = []
 
+            # Only sessions that actually put children in a cabin can produce a
+            # prior-year bunkmate. Without this predicate a Family Camp DAY
+            # GROUP -- which holds a median of 53 people and is not a cabin at
+            # all -- was scored as summer bunkmate history (#2425). The same
+            # predicate, from the same constant, already guards the equivalent
+            # query in `bunking/graph/social_graph_builder.py`; it was never
+            # swept sideways into this file, which is what produced #2425,
+            # #2426 and #2427 at once.
+            #
+            # `session` is a single-select relation (maxSelect=1), so
+            # dot-notation reaches the related row's `session_type` directly --
+            # the same pattern social_graph_builder uses.
+            type_clause = " || ".join(f'session.session_type = "{t}"' for t in LAST_YEAR_HISTORY_SESSION_TYPES)
+
             for chunk in batched(person_cm_ids, chunk_size, strict=False):
                 person_filter = " || ".join([f"person.cm_id = {pid}" for pid in chunk])
-                filter_str = f"year < {self.year} && ({person_filter})"
+                filter_str = f"year < {self.year} && ({type_clause}) && ({person_filter})"
 
                 assignments = self.pb.collection("bunk_assignments").get_full_list(
-                    query_params={"filter": filter_str, "expand": "person,bunk"}
+                    query_params={"filter": filter_str, "expand": "person,bunk,session"}
                 )
                 all_assignments.extend(assignments)
 
-            # Group assignments by (year, bunk) to find who bunked together
-            year_bunk_members: dict[tuple[int, str], set[int]] = {}
+            # Group assignments by (year, bunk, session) to find who bunked
+            # together. The session belongs in the key: a bunk is a BUILDING,
+            # reused by successive sessions -- 42 of the 57 bunks carrying a
+            # 2025 assignment served more than one session -- so keying on
+            # (year, bunk) alone paired children who occupied the same cabin in
+            # different weeks and never met (#2425).
+            year_bunk_members: dict[tuple[int, str, str], set[int]] = {}
             for assignment in all_assignments:
                 expand = getattr(assignment, "expand", {}) or {}
                 person_data = get_person_from_expand(assignment)
                 bunk_data = expand.get("bunk")
+                session_data = get_session_from_expand(assignment)
 
-                if not person_data or not bunk_data:
+                if not person_data or not bunk_data or not session_data:
                     continue
 
                 person_cm_id = getattr(person_data, "cm_id", None)
                 bunk_id = getattr(bunk_data, "id", None)
+                session_id = getattr(session_data, "id", None)
                 year = getattr(assignment, "year", None)
 
-                if person_cm_id and bunk_id and year:
-                    key = (year, bunk_id)
+                # A row whose session cannot be resolved cannot be scoped to a
+                # week, so it is dropped rather than merged into the building.
+                if person_cm_id and bunk_id and session_id and year:
+                    key = (year, bunk_id, session_id)
                     if key not in year_bunk_members:
                         year_bunk_members[key] = set()
                     year_bunk_members[key].add(person_cm_id)
@@ -299,7 +330,7 @@ class SocialGraph:
             historical_edges = 0
             processed_pairs: set[tuple[int, int]] = set()
 
-            for (year, _bunk_id), members in year_bunk_members.items():
+            for (year, _bunk_id, _session_id), members in year_bunk_members.items():
                 # Only consider members who are in the current session's graph
                 graph_members = [m for m in members if m in graph]
 

--- a/bunking/sync/bunk_request_processor/social/social_graph.py
+++ b/bunking/sync/bunk_request_processor/social/social_graph.py
@@ -330,7 +330,16 @@ class SocialGraph:
             historical_edges = 0
             processed_pairs: set[tuple[int, int]] = set()
 
-            for (year, _bunk_id, _session_id), members in year_bunk_members.items():
+            # Most recent year first. `processed_pairs` below keeps exactly ONE
+            # edge per pair, so for a pair that bunked together in more than one
+            # year the FIRST key visited is the one whose `recency_weight`
+            # survives. Iterating in dict order made that whichever key the
+            # unsorted query happened to insert first -- so a pair's weight
+            # could differ between runs, and the older year could beat the newer
+            # one, contradicting the "more recent = stronger" rule below.
+            for (year, _bunk_id, _session_id), members in sorted(
+                year_bunk_members.items(), key=lambda item: item[0][0], reverse=True
+            ):
                 # Only consider members who are in the current session's graph
                 graph_members = [m for m in members if m in graph]
 

--- a/tests/unit/sync/bunk_request_processor/data/cache/test_temporal_name_cache.py
+++ b/tests/unit/sync/bunk_request_processor/data/cache/test_temporal_name_cache.py
@@ -5,6 +5,7 @@ matching monolith's build_temporal_name_cache() behavior."""
 
 import logging
 from datetime import datetime
+from typing import Any
 from unittest.mock import Mock
 
 
@@ -265,7 +266,8 @@ class TestTemporalNameCache:
                 "session_name": "Session 3",
                 "parent_session_id": 1002,
                 "parent_session_name": "Session 3",
-                "bunk": "B-5",
+                "bunk_name": "B-5",
+                "session_type": "main",
             }
         }
 
@@ -672,3 +674,123 @@ class TestTemporalNameCache:
         assert any(
             record.levelno == logging.WARNING and "Loaded 0 persons" in record.message for record in caplog.records
         )
+
+
+def _bunk_assignment(
+    person_cm_id: int,
+    year: int,
+    bunk_name: str,
+    session_cm_id: int,
+    session_type: str,
+    record_id: str,
+) -> Mock:
+    """Build a bunk_assignments record whose expand looks like PocketBase's."""
+    assignment = Mock(spec=["expand", "year", "id"])
+    assignment.id = record_id
+    assignment.year = year
+    person = Mock(spec=["cm_id"])
+    person.cm_id = person_cm_id
+    bunk = Mock(spec=["name"])
+    bunk.name = bunk_name
+    session = Mock(spec=["cm_id", "session_type", "name"])
+    session.cm_id = session_cm_id
+    session.session_type = session_type
+    session.name = f"Session {session_cm_id}"
+    assignment.expand = {"person": person, "bunk": bunk, "session": session}
+    return assignment
+
+
+def _load_cache(assignments):
+    """Run _load_historical_bunking against mocked PocketBase collections."""
+    from bunking.sync.bunk_request_processor.data.cache.temporal_name_cache import (
+        TemporalNameCache,
+    )
+
+    captured: dict[str, Any] = {}
+
+    sessions_collection = Mock()
+    sessions_collection.get_full_list = Mock(return_value=[])
+
+    assignments_collection = Mock()
+
+    def _get_full_list(**kwargs):
+        captured.update(kwargs.get("query_params", {}))
+        return list(assignments)
+
+    assignments_collection.get_full_list = Mock(side_effect=_get_full_list)
+
+    pb = Mock()
+    pb.collection = Mock(
+        side_effect=lambda name: sessions_collection if name == "camp_sessions" else assignments_collection
+    )
+
+    cache = TemporalNameCache(pb, year=2026)
+    cache._load_historical_bunking()
+    return cache, captured
+
+
+class TestHistoricalBunkingSessionType:
+    """The temporal cache must not treat Family Camp day groups as cabins (#2427)."""
+
+    def test_record_carries_session_type_and_bunk_name(self):
+        cache, _ = _load_cache([_bunk_assignment(1001, 2025, "Cabin 7", 500, "main", "rec_a")])
+
+        record = cache.get_historical_info(1001, 2025)
+        assert record is not None
+        assert record["session_type"] == "main"
+        # The producer must write the key `verify_bunk_together` reads.
+        assert record["bunk_name"] == "Cabin 7"
+
+    def test_load_is_deterministic_and_keeps_day_group_people_in_the_index(self):
+        """The load stays unfiltered on purpose — the name index needs those people."""
+        cache, captured = _load_cache([_bunk_assignment(1002, 2025, "Day Group 3", 900, "family", "rec_b")])
+
+        assert captured.get("sort") == "id"
+        # A Family Camp attendee is still a real prior-year person for name resolution.
+        assert 2025 in cache._historical_bunking[1002]
+        assert cache._historical_bunking[1002][2025]["session_type"] == "family"
+
+    def test_eligible_row_beats_a_day_group_row_whatever_the_order(self):
+        eligible = _bunk_assignment(1003, 2025, "Cabin 7", 500, "main", "rec_c")
+        day_group = _bunk_assignment(1003, 2025, "Day Group 3", 900, "family", "rec_d")
+
+        for rows in ([day_group, eligible], [eligible, day_group]):
+            cache, _ = _load_cache(rows)
+            record = cache.get_historical_info(1003, 2025)
+            assert record["bunk_name"] == "Cabin 7"
+            assert record["session_type"] == "main"
+
+    def test_verify_bunk_together_reads_what_the_loader_writes(self):
+        """The producer wrote "bunk" and the consumer read "bunk_name" — it was inert."""
+        cache, _ = _load_cache(
+            [
+                _bunk_assignment(1004, 2025, "Cabin 7", 500, "main", "rec_e"),
+                _bunk_assignment(1005, 2025, "Cabin 7", 500, "main", "rec_f"),
+            ]
+        )
+
+        were_together, bunk_name = cache.verify_bunk_together(1004, [1005], 2025)
+
+        assert were_together is True
+        assert bunk_name == "Cabin 7"
+
+    def test_verify_bunk_together_rejects_a_shared_day_group(self):
+        cache, _ = _load_cache(
+            [
+                _bunk_assignment(1006, 2025, "Day Group 3", 900, "family", "rec_g"),
+                _bunk_assignment(1007, 2025, "Day Group 3", 900, "family", "rec_h"),
+            ]
+        )
+
+        assert cache.verify_bunk_together(1006, [1007], 2025) == (False, "")
+
+    def test_verify_bunk_together_rejects_a_target_from_another_session(self):
+        """Same cabin name, different week — not bunkmates."""
+        cache, _ = _load_cache(
+            [
+                _bunk_assignment(1008, 2025, "Cabin 7", 500, "main", "rec_i"),
+                _bunk_assignment(1009, 2025, "Cabin 7", 501, "main", "rec_j"),
+            ]
+        )
+
+        assert cache.verify_bunk_together(1008, [1009], 2025) == (False, "")

--- a/tests/unit/sync/bunk_request_processor/data/repositories/test_prior_year_bunkmates.py
+++ b/tests/unit/sync/bunk_request_processor/data/repositories/test_prior_year_bunkmates.py
@@ -1,0 +1,114 @@
+"""Tests for AttendeeRepository.find_prior_year_bunkmates session scoping (#2426).
+
+Three defects are pinned here:
+
+1. the first query had no ``session_type`` predicate, so a Family Camp day
+   group was eligible to be returned as a summer ``prior_bunk``;
+2. it had no sort, then took ``assignments[0]`` — an arbitrary pick;
+3. the second query filtered on ``bunk`` + ``year`` with no session, and a bunk
+   is a building reused by successive sessions, so the returned "bunkmates"
+   were largely children the requester never met.
+"""
+
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from bunking.graph.social_graph_builder import LAST_YEAR_HISTORY_SESSION_TYPES
+from bunking.sync.bunk_request_processor.data.repositories.attendee_repository import (
+    AttendeeRepository,
+)
+
+
+def _assignment(person_cm_id: int, bunk_id: str, bunk_name: str, session_id: str) -> Mock:
+    """Build a bunk_assignments record whose expand looks like PocketBase's."""
+    assignment = Mock(spec=["expand", "year"])
+    assignment.year = 2025
+    person = Mock(spec=["cm_id"])
+    person.cm_id = person_cm_id
+    bunk = Mock(spec=["id", "name"])
+    bunk.id = bunk_id
+    bunk.name = bunk_name
+    session = Mock(spec=["id"])
+    session.id = session_id
+    assignment.expand = {"person": person, "bunk": bunk, "session": session}
+    return assignment
+
+
+class TestFindPriorYearBunkmatesSessionScope:
+    @pytest.fixture
+    def captured(self) -> list[dict[str, Any]]:
+        return []
+
+    @staticmethod
+    def _repo(
+        captured: list[dict[str, Any]],
+        responder: Callable[[dict[str, Any]], list[Any]],
+    ) -> AttendeeRepository:
+        pb = Mock()
+        collection = Mock()
+
+        def _get_full_list(**kwargs):
+            query_params = kwargs.get("query_params", {})
+            captured.append(query_params)
+            return responder(query_params)
+
+        collection.get_full_list.side_effect = _get_full_list
+        pb.collection = Mock(return_value=collection)
+        repo = AttendeeRepository(pb)
+        repo.bulk_get_sessions_for_persons = Mock(return_value={})  # type: ignore[method-assign]
+        return repo
+
+    def test_first_query_filters_session_type_and_sorts_deterministically(self, captured):
+        repo = self._repo(captured, lambda _query_params: [])
+
+        repo.find_prior_year_bunkmates(requester_cm_id=1001, session_cm_id=123, year=2026)
+
+        assert len(captured) == 1
+        filter_str = captured[0]["filter"]
+        assert "person.cm_id = 1001" in filter_str
+        assert "year = 2025" in filter_str
+        for session_type in LAST_YEAR_HISTORY_SESSION_TYPES:
+            assert f'session.session_type = "{session_type}"' in filter_str
+        assert captured[0].get("sort") == "id"
+        assert "session" in captured[0]["expand"]
+
+    def test_second_query_is_scoped_to_the_requesters_own_session(self, captured):
+        requester_row = _assignment(1001, "bunk_A", "Cabin 7", "sess_1")
+        peer_row = _assignment(2002, "bunk_A", "Cabin 7", "sess_1")
+
+        def responder(query_params):
+            return [requester_row] if "person.cm_id" in query_params["filter"] else [peer_row]
+
+        repo = self._repo(captured, responder)
+        repo.bulk_get_sessions_for_persons = Mock(return_value={2002: 4321})  # type: ignore[method-assign]
+
+        result = repo.find_prior_year_bunkmates(requester_cm_id=1001, session_cm_id=123, year=2026)
+
+        assert len(captured) == 2
+        bunkmate_filter = captured[1]["filter"]
+        assert 'bunk = "bunk_A"' in bunkmate_filter
+        assert "year = 2025" in bunkmate_filter
+        assert 'session = "sess_1"' in bunkmate_filter
+
+        assert result["prior_bunk"] == "Cabin 7"
+        assert result["cm_ids"] == [2002]
+        assert result["total_in_bunk"] == 1
+        assert result["returning_count"] == 1
+
+    def test_prior_year_row_without_a_session_returns_nothing(self, captured):
+        """Unscopable row — returning the whole building would be the old defect."""
+        requester_row = _assignment(1001, "bunk_A", "Cabin 7", "sess_1")
+        requester_row.expand = {
+            "person": requester_row.expand["person"],
+            "bunk": requester_row.expand["bunk"],
+        }
+
+        repo = self._repo(captured, lambda _query_params: [requester_row])
+
+        result = repo.find_prior_year_bunkmates(requester_cm_id=1001, session_cm_id=123, year=2026)
+
+        assert result == {}
+        assert len(captured) == 1, "must not fall back to an unscoped bunkmate query"

--- a/tests/unit/sync/bunk_request_processor/data/repositories/test_prior_year_bunkmates.py
+++ b/tests/unit/sync/bunk_request_processor/data/repositories/test_prior_year_bunkmates.py
@@ -112,3 +112,25 @@ class TestFindPriorYearBunkmatesSessionScope:
 
         assert result == {}
         assert len(captured) == 1, "must not fall back to an unscoped bunkmate query"
+
+    def test_bunkmate_query_is_sorted_so_the_returned_order_is_stable(self, captured):
+        """`cm_ids` order decides a resolution, so it must not vary between runs.
+
+        `_try_prior_bunkmate_resolution` walks `cm_ids` and returns the FIRST
+        camper whose name matches, so two cabinmates sharing a first name are
+        separated by nothing but the order this query happened to return. The
+        sibling query above already carries `sort: "id"` for exactly this
+        reason; the bunkmate query needs the same STABLE_SORT convention.
+        """
+        requester_row = _assignment(1001, "bunk_A", "Cabin 7", "sess_1")
+        peer_row = _assignment(2002, "bunk_A", "Cabin 7", "sess_1")
+
+        def responder(query_params):
+            return [requester_row] if "person.cm_id" in query_params["filter"] else [peer_row]
+
+        repo = self._repo(captured, responder)
+
+        repo.find_prior_year_bunkmates(requester_cm_id=1001, session_cm_id=123, year=2026)
+
+        assert len(captured) == 2
+        assert captured[1].get("sort") == "id"

--- a/tests/unit/sync/bunk_request_processor/social/test_social_graph.py
+++ b/tests/unit/sync/bunk_request_processor/social/test_social_graph.py
@@ -14,6 +14,7 @@ from unittest.mock import Mock
 import networkx as nx
 import pytest
 
+from bunking.graph.social_graph_builder import LAST_YEAR_HISTORY_SESSION_TYPES
 from bunking.sync.bunk_request_processor.core.models import Person
 from bunking.sync.bunk_request_processor.resolution.interfaces import ResolutionResult
 from bunking.sync.bunk_request_processor.social.social_graph import (
@@ -1004,12 +1005,23 @@ class TestAddInformationalRelationshipsExpandedPerson:
         ]
 
         # Historical bunk assignments for previous year
+        # Both rows carry a session: prior-year bunkmate grouping is keyed on
+        # (year, bunk, session), because a bunk is a building reused by
+        # successive sessions (#2425).
         hist_assignment1 = Mock()
-        hist_assignment1.expand = {"person": Mock(cm_id=501), "bunk": Mock(id="bunk_A")}
+        hist_assignment1.expand = {
+            "person": Mock(cm_id=501),
+            "bunk": Mock(id="bunk_A"),
+            "session": Mock(id="sess_1"),
+        }
         hist_assignment1.year = 2024
 
         hist_assignment2 = Mock()
-        hist_assignment2.expand = {"person": Mock(cm_id=502), "bunk": Mock(id="bunk_A")}
+        hist_assignment2.expand = {
+            "person": Mock(cm_id=502),
+            "bunk": Mock(id="bunk_A"),
+            "session": Mock(id="sess_1"),
+        }
         hist_assignment2.year = 2024
 
         def mock_get_full_list(**kwargs):
@@ -1426,3 +1438,108 @@ class TestGenderAwareScoring:
         # AG session — no gender adjustment, both candidates have equal score (0.0)
         # Original order preserved when scores are tied
         assert len(ranked) == 2
+
+
+class TestHistoricalBunkingSessionScope:
+    """Prior-year BUNKMATE edges must come from a real summer cabin (#2425).
+
+    Two defects are pinned here:
+    1. the query had no ``session_type`` predicate, so Family Camp day groups
+       were scored as summer bunkmate history;
+    2. the grouping key was ``(year, bunk)`` with no session in it, so children
+       who occupied the same cabin in different weeks were paired.
+    """
+
+    @staticmethod
+    def _assignment(person_cm_id: int, bunk_id: str, year: int, session_id: str) -> Mock:
+        assignment = Mock(spec=["expand", "year"])
+        assignment.year = year
+        person = Mock(spec=["cm_id"])
+        person.cm_id = person_cm_id
+        bunk = Mock(spec=["id"])
+        bunk.id = bunk_id
+        session = Mock(spec=["id"])
+        session.id = session_id
+        assignment.expand = {"person": person, "bunk": bunk, "session": session}
+        return assignment
+
+    @staticmethod
+    def _graph(*person_cm_ids: int) -> nx.Graph:
+        graph = nx.Graph()
+        for cm_id in person_cm_ids:
+            graph.add_node(cm_id)
+        return graph
+
+    @pytest.mark.asyncio
+    async def test_query_carries_session_type_predicate(self):
+        """The prior-year query must exclude non-bunking session types in SQL."""
+        mock_pb = Mock()
+        sg = SocialGraph(pb=mock_pb, year=2026, session_cm_ids=[1234])
+
+        captured: list[dict[str, Any]] = []
+
+        def _get_full_list(**kwargs):
+            captured.append(kwargs.get("query_params", {}))
+            return []
+
+        mock_pb.collection.return_value.get_full_list.side_effect = _get_full_list
+
+        await sg._add_historical_bunking_relationships(self._graph(601), 1234)
+
+        assert captured, "expected a bunk_assignments query"
+        filter_str = captured[0]["filter"]
+        for session_type in LAST_YEAR_HISTORY_SESSION_TYPES:
+            assert f'session.session_type = "{session_type}"' in filter_str
+        assert "session" in captured[0]["expand"]
+
+    @pytest.mark.asyncio
+    async def test_same_bunk_different_session_is_not_a_bunkmate_edge(self):
+        """A cabin reused by a later session must not pair the two occupants."""
+        mock_pb = Mock()
+        sg = SocialGraph(pb=mock_pb, year=2026, session_cm_ids=[1234])
+
+        mock_pb.collection.return_value.get_full_list.return_value = [
+            self._assignment(701, "bunk_A", 2025, "sess_1"),
+            self._assignment(702, "bunk_A", 2025, "sess_2"),
+        ]
+
+        graph = self._graph(701, 702)
+        await sg._add_historical_bunking_relationships(graph, 1234)
+
+        assert not graph.has_edge(701, 702)
+
+    @pytest.mark.asyncio
+    async def test_same_bunk_same_session_is_a_bunkmate_edge(self):
+        """Real cabinmates — same bunk, same session, same year — still pair."""
+        mock_pb = Mock()
+        sg = SocialGraph(pb=mock_pb, year=2026, session_cm_ids=[1234])
+
+        mock_pb.collection.return_value.get_full_list.return_value = [
+            self._assignment(801, "bunk_A", 2025, "sess_1"),
+            self._assignment(802, "bunk_A", 2025, "sess_1"),
+        ]
+
+        graph = self._graph(801, 802)
+        await sg._add_historical_bunking_relationships(graph, 1234)
+
+        assert graph.has_edge(801, 802)
+        assert RelationshipType.BUNKMATE in graph[801][802]["relationship_types"]
+
+    @pytest.mark.asyncio
+    async def test_assignment_without_session_is_skipped(self):
+        """A row whose session cannot be resolved cannot be scoped, so it is dropped."""
+        mock_pb = Mock()
+        sg = SocialGraph(pb=mock_pb, year=2026, session_cm_ids=[1234])
+
+        rows = [
+            self._assignment(901, "bunk_A", 2025, "sess_1"),
+            self._assignment(902, "bunk_A", 2025, "sess_1"),
+        ]
+        for row in rows:
+            row.expand = {"person": row.expand["person"], "bunk": row.expand["bunk"]}
+
+        graph = self._graph(901, 902)
+        mock_pb.collection.return_value.get_full_list.return_value = rows
+        await sg._add_historical_bunking_relationships(graph, 1234)
+
+        assert not graph.has_edge(901, 902)

--- a/tests/unit/sync/bunk_request_processor/social/test_social_graph.py
+++ b/tests/unit/sync/bunk_request_processor/social/test_social_graph.py
@@ -1543,3 +1543,28 @@ class TestHistoricalBunkingSessionScope:
         await sg._add_historical_bunking_relationships(graph, 1234)
 
         assert not graph.has_edge(901, 902)
+
+    @pytest.mark.asyncio
+    async def test_a_pair_that_bunked_in_two_years_is_weighted_by_the_recent_one(self):
+        """`processed_pairs` keeps ONE edge per pair, so which year wins must not be luck.
+
+        The weight is documented as "more recent = stronger", but the pair is
+        deduped against whichever grouping key the unsorted query happened to
+        insert first. Feed the older year first: the surviving edge must still
+        carry the RECENT year's recency weight.
+        """
+        mock_pb = Mock()
+        sg = SocialGraph(pb=mock_pb, year=2026, session_cm_ids=[1234])
+
+        mock_pb.collection.return_value.get_full_list.return_value = [
+            self._assignment(1101, "bunk_OLD", 2023, "sess_old"),
+            self._assignment(1102, "bunk_OLD", 2023, "sess_old"),
+            self._assignment(1101, "bunk_NEW", 2025, "sess_new"),
+            self._assignment(1102, "bunk_NEW", 2025, "sess_new"),
+        ]
+
+        graph = self._graph(1101, 1102)
+        await sg._add_historical_bunking_relationships(graph, 1234)
+
+        expected = RELATIONSHIP_WEIGHTS[RelationshipType.BUNKMATE] * (1.0 / (1 + 1 * 0.2))
+        assert graph[1101][1102]["weight"] == pytest.approx(expected)

--- a/tests/unit/sync/bunk_request_processor/test_historical_bunking_verification.py
+++ b/tests/unit/sync/bunk_request_processor/test_historical_bunking_verification.py
@@ -40,10 +40,10 @@ class TestVerifyBunkTogether:
         """
         # Setup: Pre-populate historical bunking cache
         temporal_cache._historical_bunking = {
-            1001: {2024: {"bunk_name": "B-3", "session_cm_id": 123}},  # requester
-            1002: {2024: {"bunk_name": "B-3", "session_cm_id": 123}},  # target 1
-            1003: {2024: {"bunk_name": "B-3", "session_cm_id": 123}},  # target 2
-            1004: {2024: {"bunk_name": "B-3", "session_cm_id": 123}},  # target 3
+            1001: {2024: {"bunk_name": "B-3", "session_cm_id": 123, "session_type": "main"}},  # requester
+            1002: {2024: {"bunk_name": "B-3", "session_cm_id": 123, "session_type": "main"}},  # target 1
+            1003: {2024: {"bunk_name": "B-3", "session_cm_id": 123, "session_type": "main"}},  # target 2
+            1004: {2024: {"bunk_name": "B-3", "session_cm_id": 123, "session_type": "main"}},  # target 3
         }
 
         were_together, bunk_name = temporal_cache.verify_bunk_together(
@@ -56,9 +56,9 @@ class TestVerifyBunkTogether:
     def test_verify_bunk_together_different_bunks(self, temporal_cache):
         """When one target was in a different bunk, return (False, "")."""
         temporal_cache._historical_bunking = {
-            1001: {2024: {"bunk_name": "B-3", "session_cm_id": 123}},
-            1002: {2024: {"bunk_name": "B-3", "session_cm_id": 123}},
-            1003: {2024: {"bunk_name": "B-4", "session_cm_id": 123}},  # Different bunk!
+            1001: {2024: {"bunk_name": "B-3", "session_cm_id": 123, "session_type": "main"}},
+            1002: {2024: {"bunk_name": "B-3", "session_cm_id": 123, "session_type": "main"}},
+            1003: {2024: {"bunk_name": "B-4", "session_cm_id": 123, "session_type": "main"}},  # Different bunk!
         }
 
         were_together, bunk_name = temporal_cache.verify_bunk_together(
@@ -71,8 +71,8 @@ class TestVerifyBunkTogether:
     def test_verify_bunk_together_different_sessions(self, temporal_cache):
         """When targets were in same bunk name but different session, return False."""
         temporal_cache._historical_bunking = {
-            1001: {2024: {"bunk_name": "B-3", "session_cm_id": 123}},
-            1002: {2024: {"bunk_name": "B-3", "session_cm_id": 456}},  # Different session!
+            1001: {2024: {"bunk_name": "B-3", "session_cm_id": 123, "session_type": "main"}},
+            1002: {2024: {"bunk_name": "B-3", "session_cm_id": 456, "session_type": "main"}},  # Different session!
         }
 
         were_together, bunk_name = temporal_cache.verify_bunk_together(
@@ -86,7 +86,7 @@ class TestVerifyBunkTogether:
         """When requester has no historical data for the year, return (False, "")."""
         temporal_cache._historical_bunking = {
             # No entry for requester 1001
-            1002: {2024: {"bunk_name": "B-3", "session_cm_id": 123}},
+            1002: {2024: {"bunk_name": "B-3", "session_cm_id": 123, "session_type": "main"}},
         }
 
         were_together, bunk_name = temporal_cache.verify_bunk_together(
@@ -99,8 +99,8 @@ class TestVerifyBunkTogether:
     def test_verify_bunk_together_target_no_history(self, temporal_cache):
         """When any target has no historical data for the year, return False."""
         temporal_cache._historical_bunking = {
-            1001: {2024: {"bunk_name": "B-3", "session_cm_id": 123}},
-            1002: {2024: {"bunk_name": "B-3", "session_cm_id": 123}},
+            1001: {2024: {"bunk_name": "B-3", "session_cm_id": 123, "session_type": "main"}},
+            1002: {2024: {"bunk_name": "B-3", "session_cm_id": 123, "session_type": "main"}},
             # No entry for target 1003
         }
 
@@ -114,7 +114,7 @@ class TestVerifyBunkTogether:
     def test_verify_bunk_together_empty_targets(self, temporal_cache):
         """When target list is empty, return (True, bunk_name) - vacuously true."""
         temporal_cache._historical_bunking = {
-            1001: {2024: {"bunk_name": "B-3", "session_cm_id": 123}},
+            1001: {2024: {"bunk_name": "B-3", "session_cm_id": 123, "session_type": "main"}},
         }
 
         were_together, bunk_name = temporal_cache.verify_bunk_together(


### PR DESCRIPTION
Three places read prior-year `bunk_assignments` to decide who a camper bunked with
last year. None of them filtered on session type, so Family Camp **day groups** —
which hold a median of 53 people and are not cabins — were scored as summer bunkmate
history. Two of them also keyed on a bunk **without its session**, and a bunk is a
building: 42 of the 57 bunks carrying a 2025 assignment served more than one session,
so children who occupied the same cabin in different weeks were treated as bunkmates.

The identical fix has been in `bunking/graph/social_graph_builder.py` since #2350 /
#2259 / #2358, with a 30-line comment describing exactly this failure. It was never
swept sideways — which is why the same defect existed at three more sites. All three
now use that file's `LAST_YEAR_HISTORY_SESSION_TYPES`; no fourth copy of the set was
added.

## What was wrong, measured on the prod snapshot

| site | defect | size |
|---|---|---:|
| `social/social_graph.py` | no type predicate; grouping key `(year, bunk)` | **2,942 of 4,935** BUNKMATE edges false (59.6%) — 954 from day groups, 1,988 from the missing session |
| `data/repositories/attendee_repository.py` | no type predicate, no sort, `assignments[0]`; second query on `bunk` + `year` only | **147 of 782** requesters handed a day group as `prior_bunk`; **651 of 728** peer lookups inflated (median 29 vs a session-scoped 8) |
| `data/cache/temporal_name_cache.py` | no type on the record; producer/consumer key mismatch | **33%** of the rows the two-year window loads are day groups |

A false BUNKMATE edge is not merely noise: these edges feed `social_distance`,
`shared_connections` and `in_ego_network`, which score name-resolution confidence for
bunk-request disambiguation. The failure mode is the resolver becoming *more* confident
about the wrong person.

## What changed

- **`social_graph.py`** — the prior-year query carries the session-type predicate, and
  the grouping key is now `(year, bunk, session)`. A row whose session cannot be
  resolved is dropped rather than merged into the building.
- **`attendee_repository.py`** — `find_prior_year_bunkmates` filters the first query by
  session type and sorts by record id (PocketBase's `get_full_list` has no inherent
  order, so the pick could otherwise change between runs with no code change), then
  scopes the bunkmate query to the requester's own session.
- **`temporal_name_cache.py`** — each record now carries its `session_type`, the load is
  sorted for a deterministic per-year pick, and a cabin-bearing row beats a day-group
  row for the same person and year. The false `# Only store most recent assignment per
  year` comment is corrected: the rows arrive unordered and nothing sorted them.
- **`temporal_name_cache.py`, behaviour revival** — the loader wrote the bunk under
  `"bunk"` while `verify_bunk_together` read `"bunk_name"`, so that consumer returned
  `(False, "")` for *everyone* and historical group verification was inert. The producer
  now writes the key the consumer reads. This is safe only because the type check lands
  in the same change: fixing the key alone would have started producing false "verified
  bunked together" results from shared day groups.

## Deliberately NOT done

- **The temporal cache load is still unfiltered, on purpose.** Presence in
  `_historical_bunking` is what gives a person a `"historical"` bucket in the name index,
  and a Family Camp attendee is a perfectly real prior-year person to resolve a name
  against. Filtering at the load would have silently dropped ~922 people from name
  resolution. The type is stored on the record and the bunk-comparison consumer filters;
  the two concerns stay apart.
- **`LAST_YEAR_HISTORY_SESSION_TYPES` was not moved to a shared leaf module.** A
  module-level import of it from inside `bunk_request_processor` is a genuine circular
  import (`bunking.graph` → `bunking.satisfaction` → `bunk_request_processor.core.models`
  → the package's own `__init__`); it fails with `cannot import name 'BucketCount' from
  partially initialized module`. Moving the constant would mean editing
  `bunking/graph/social_graph_builder.py`, which is outside this PR's file scope, so the
  three new call sites import it at call time with a `# noqa: PLC0415` and a comment.
  Consolidating it into a leaf module is worth a follow-up.
- The unused third near-copy, `VALID_SESSION_TYPES` in `core/constants.py`, is untouched.
- The three consumers (`context_builder.py`, `phase2_resolution_service.py`,
  `historical_verification_service.py`) are untouched — the returned shapes are unchanged.
- No target-side session-type check in `verify_bunk_together`: the comparison already
  requires the target to be in the *same session* as the requester, and a session has one
  type, so it would be dead code.

## Tests

Ten new tests, written and run failing first. The pre-existing fixtures that hand-built
`_historical_bunking` with keys the producer never wrote — the thing that let the inert
consumer look healthy for three passes — were corrected to the real record shape.

Closes #2425.
Closes #2426.
Closes #2427.
