### PR TITLE
feat(frontend): one box places a family or writes a name in, and the strip loses its write-in

### DIFF
--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -264,7 +264,7 @@ class LodgingUnitSummary(BaseModel):
     # standing `inventory_class` decides. None and False are different answers
     # and must not be flattened into one.
     #
-    # IT DOES NOT ANSWER "IS SOMEBODY IN IT". That is `write_in` below, read
+    # IT DOES NOT ANSWER "IS SOMEBODY IN IT". That is `write_ins` below, read
     # from `lodging_write_ins` / `_draft`. Until PR 4 of kindred#2382 an
     # occupancy also reported itself here as False, because
     # `is_family_available` and the board's forest open-tint were both derived
@@ -272,7 +272,7 @@ class LodgingUnitSummary(BaseModel):
     # False here means a role decision and never an occupant. A reader that
     # wants "can a family go in this space" wants `is_family_available`, which
     # folds both facts in; a reader that wants "is somebody in it" wants
-    # `write_in`.
+    # `write_ins`.
     #
     # Stated explicitly rather than implied. The rejected encoding was a row
     # meaning "the opposite of this unit's current default", which an ordinary
@@ -319,9 +319,19 @@ class LodgingUnitSummary(BaseModel):
     # Its rule is `is_family_available` in api/services/lodging_rules.py, and
     # that is the only place the two are combined.
     is_family_available: bool = False
-    # The write-in that closes this space, resolved through the unit tree --
+    # EVERY write-in that closes this space, resolved through the unit tree --
     # this unit's own row, else the nearest ancestor's, else the nearest
-    # descendant's. None means no write-in covers it.
+    # written-into descendant on each branch beneath it. Empty means no
+    # write-in covers it.
+    #
+    # A LIST since kindred#2381, and that arity is the whole point rather than
+    # future-proofing. A merged container draws in place of its rooms, so the
+    # four write-ins Clouds Rest carries in one 2026 weekend collapsed to
+    # whichever room sorted first and the other three were invisible -- while
+    # each clear silently re-populated the card with the next occupant, so
+    # destroying all four read as four failed clicks. A write-in must survive a
+    # merge and a split the way an assignment does, and an assignment does it
+    # by the drawn card carrying however many leaves it covers.
     #
     # The fields above stay STRICTLY this unit's own row: they are what the
     # write path reads back. Folding an inherited fact into any of them would
@@ -338,7 +348,7 @@ class LodgingUnitSummary(BaseModel):
     # blocks placement without moving the bed counts. That is the behaviour the
     # counts have always had, and changing it is a counts decision rather than
     # a side effect of the split.
-    write_in: WriteInCover | None = None
+    write_ins: list[WriteInCover] = Field(default_factory=list)
     map_x: float | None = None
     map_y: float | None = None
 

--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -326,7 +326,7 @@ class LodgingUnitSummary(BaseModel):
     #
     # A LIST since kindred#2381, and that arity is the whole point rather than
     # future-proofing. A merged container draws in place of its rooms, so the
-    # four write-ins Clouds Rest carries in one 2026 weekend collapsed to
+    # four write-ins one 2026 container carries in a single weekend collapsed to
     # whichever room sorted first and the other three were invisible -- while
     # each clear silently re-populated the card with the next occupant, so
     # destroying all four read as four failed clicks. A write-in must survive a

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -574,8 +574,10 @@ def written_in_unit_ids(write_ins: list[Any]) -> frozenset[str]:
     return frozenset(_s(row, "unit") for row in write_ins)
 
 
-def write_in_covers(units: list[LodgingUnitSummary], write_in_unit_ids: frozenset[str]) -> dict[str, WriteInCover]:
-    """Which units each write-in closes, keyed by unit code.
+def write_in_covers(
+    units: list[LodgingUnitSummary], write_in_unit_ids: frozenset[str]
+) -> dict[str, list[WriteInCover]]:
+    """Which write-ins close each unit's space, keyed by unit code.
 
     THE UNIT A ROW NAMES IS NOT THE ONLY SPACE IT CLOSES. A write-in is a fact
     about a physical space and a building's space contains its rooms', but the
@@ -586,10 +588,27 @@ def write_in_covers(units: list[LodgingUnitSummary], write_in_unit_ids: frozense
     family could be dropped into a space somebody is already sleeping in.
 
     Order, highest first: the unit's OWN row, else the nearest ANCESTOR's, else
-    the nearest DESCENDANT's. Own beats inherited because it is the more
-    specific statement about the same space; an ancestor beats a descendant
-    because a building closed whole says something about every room in it,
-    where one room says only that the building is no longer free to let whole.
+    EVERY written-into descendant beneath it. Own beats inherited because it is
+    the more specific statement about the same space; an ancestor beats a
+    descendant because a building closed whole says something about every room
+    in it, where one room says only that the building is no longer free to let
+    whole.
+
+    THE DESCENDANT STEP RETURNS ALL OF THEM (kindred#2381), and that is the
+    arity fix. A merged container draws in place of its rooms, so returning the
+    first match dropped every other occupant off the board -- four of them on
+    the one 2026 container that carries four -- and made each clear look like a
+    failed click as the card re-resolved to the next room. The first two steps
+    stay single-answer: an own row is one row, and an ancestor chain has exactly
+    one nearest member.
+
+    Per-branch NEAREST, not every descendant. A written-into bed inside a
+    written-into wing is already inside that wing's space, so the wing's row
+    speaks for it and returning both would print one space twice. The walk
+    therefore stops descending a branch the moment it finds a row on it.
+
+    Ordered by `code` at every level, so two identical payloads never disagree
+    about the sequence a card draws its occupants in.
 
     RESOLVED FROM OWN ROWS ONLY, never transitively through a cover computed
     for somebody else -- which is what keeps a caretaker in room A off room B.
@@ -622,8 +641,11 @@ def write_in_covers(units: list[LodgingUnitSummary], write_in_unit_ids: frozense
     for unit in units:
         if unit.parent_code:
             children.setdefault(unit.parent_code, []).append(unit)
-    # Sorted so two identical payloads never disagree about WHICH row a card
-    # names when a building has several written-into rooms beneath it.
+    # Sorted so two identical payloads never disagree about the ORDER a card
+    # draws its occupants in when a building has several written-into rooms
+    # beneath it. It used to settle WHICH single row was named, because only
+    # one survived; kindred#2381 returns them all and this now fixes their
+    # sequence instead.
     for bucket in children.values():
         bucket.sort(key=lambda child: child.code)
 
@@ -640,7 +662,15 @@ def write_in_covers(units: list[LodgingUnitSummary], write_in_unit_ids: frozense
             cursor = by_code.get(cursor.parent_code) if cursor.parent_code else None
         return None
 
-    def _nearest_descendant(unit: LodgingUnitSummary) -> LodgingUnitSummary | None:
+    def _written_in_descendants(unit: LodgingUnitSummary) -> list[LodgingUnitSummary]:
+        """Every written-into descendant, nearest-first on each branch.
+
+        Breadth-first over `code`-sorted buckets, so the result is ordered and
+        two identical payloads agree. A branch is not descended past a match:
+        the matched unit's space contains whatever is below it, and its row
+        already speaks for that space.
+        """
+        found: list[LodgingUnitSummary] = []
         seen = {unit.code}
         queue = list(children.get(unit.code, []))
         while queue:
@@ -649,11 +679,12 @@ def write_in_covers(units: list[LodgingUnitSummary], write_in_unit_ids: frozense
                 continue
             seen.add(node.code)
             if _is_written_in(node):
-                return node
+                found.append(node)
+                continue
             queue.extend(children.get(node.code, []))
-        return None
+        return found
 
-    covers: dict[str, WriteInCover] = {}
+    covers: dict[str, list[WriteInCover]] = {}
     for unit in units:
         # Blank codes are excluded from BOTH sides, not just the lookup above.
         # `_build_units` reads this map back by code, so one blank-coded row
@@ -662,16 +693,23 @@ def write_in_covers(units: list[LodgingUnitSummary], write_in_unit_ids: frozense
         # a space on the strength of a row it does not hold.
         if not unit.code:
             continue
-        source = unit if _is_written_in(unit) else (_nearest_ancestor(unit) or _nearest_descendant(unit))
-        if source is None:
+        if _is_written_in(unit):
+            sources = [unit]
+        else:
+            ancestor = _nearest_ancestor(unit)
+            sources = [ancestor] if ancestor is not None else _written_in_descendants(unit)
+        if not sources:
             continue
-        covers[unit.code] = WriteInCover(
-            unit_id=source.unit_id,
-            unit_code=source.code,
-            unit_name=source.name,
-            occupant_name=source.occupant_name,
-            note=source.reason,
-        )
+        covers[unit.code] = [
+            WriteInCover(
+                unit_id=source.unit_id,
+                unit_code=source.code,
+                unit_name=source.name,
+                occupant_name=source.occupant_name,
+                note=source.reason,
+            )
+            for source in sources
+        ]
     return covers
 
 
@@ -684,7 +722,7 @@ def _resolve_write_in_covers(units: list[LodgingUnitSummary], write_in_unit_ids:
     """
     covers = write_in_covers(units, write_in_unit_ids)
     for unit in units:
-        unit.write_in = covers.get(unit.code)
+        unit.write_ins = covers.get(unit.code, [])
 
 
 def drawn_units(units: list[LodgingUnitSummary]) -> list[LodgingUnitSummary]:
@@ -1566,7 +1604,7 @@ class LodgingRosterService:
             # compat shim out. `family_available_override` is now the ROLE row
             # and nothing else -- a staff cabin opened to families for the
             # weekend, or a bare `false` closing one -- while "is somebody in
-            # this space" is answered by `write_in` alone. Until PR 4 this field
+            # this space" is answered by `write_ins` alone. Until PR 4 this field
             # reported `False` for an occupancy too, because
             # `is_family_available` and the board's open-tint were both derived
             # from it; both read the occupancy source directly now.

--- a/frontend/src/components/weekend/LodgingBoard.availability.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.availability.test.tsx
@@ -145,7 +145,12 @@ describe('LodgingBoard — the availability gate', () => {
     // it in.
     renderBoard({ scenario: '' })
 
-    expect(screen.getByRole('button', { name: 'Write in Cedar 1' })).toBeInTheDocument()
+    // The BOX, since 2026-08-18 — the strip's "Write in" button is gone and
+    // creating a write-in is typing into the card's own control. Named for the
+    // write-in alone here, because with no scenario there is nothing to place.
+    expect(
+      screen.getByRole('combobox', { name: /write in an occupant for cedar 1/i })
+    ).toBeInTheDocument()
   })
 
   it('offers no control without bunking.manage', () => {
@@ -191,10 +196,10 @@ describe('LodgingBoard — the control becomes a write', () => {
     const user = userEvent.setup()
     renderBoard()
 
-    await user.click(screen.getByRole('button', { name: 'Write in Cedar 2' }))
-    await user.type(screen.getByRole('textbox', { name: /^occupant$/i }), 'Emma Johnson')
-    await user.type(screen.getByRole('textbox', { name: /note/i }), 'Back Monday')
-    await user.click(screen.getByRole('button', { name: /^write in$/i }))
+    await user.type(
+      screen.getByRole('combobox', { name: /place a family in cedar 2/i }),
+      'Emma Johnson{Enter}'
+    )
 
     expect(setAvailability).toHaveBeenCalledTimes(1)
     expect(setAvailability).toHaveBeenCalledWith({
@@ -202,7 +207,11 @@ describe('LodgingBoard — the control becomes a write', () => {
       unitName: 'Cedar 2',
       familyAvailable: false,
       occupantName: 'Emma Johnson',
-      reason: 'Back Monday',
+      // EMPTY, and that is the shape change. The strip collected an optional
+      // note beside the occupant; the box collects a name only, and a note is
+      // added afterwards by the pencil on the write-in's own card. One control
+      // asking one question, rather than two boxes on every tile.
+      reason: '',
     })
   })
 
@@ -212,8 +221,11 @@ describe('LodgingBoard — the control becomes a write', () => {
     pendingUnitId = 'u1'
     renderBoard()
 
-    expect(screen.getByRole('button', { name: 'Write in Cedar 1' })).toBeDisabled()
-    expect(screen.getByRole('button', { name: 'Write in Cedar 2' })).toBeEnabled()
+    // The BOX carries the per-card gate now that the strip button is gone —
+    // and it matters more on a combobox, which invites a staff member to keep
+    // typing a second write-in against an unsettled first.
+    expect(screen.getByRole('combobox', { name: /place a family in cedar 1/i })).toBeDisabled()
+    expect(screen.getByRole('combobox', { name: /place a family in cedar 2/i })).toBeEnabled()
     await Promise.resolve()
   })
 })

--- a/frontend/src/components/weekend/LodgingBoard.availability.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.availability.test.tsx
@@ -218,12 +218,13 @@ describe('LodgingBoard — the control becomes a write', () => {
   })
 })
 
-describe('LodgingBoard — clearing a write-in this card inherited', () => {
+describe('LodgingBoard — removing a write-in this card inherited', () => {
   /*
    * The row names one unit; it closes a SPACE. Split a written-into building
    * and its ROOMS inherit the write-in, while the building — no longer drawn —
-   * has nowhere to offer the clear from. The room offers it, and both the write
-   * and the in-flight disable have to follow the row rather than the card.
+   * has nowhere to offer a removal from. The room's card carries it, as the X
+   * on the `WriteInCard` it draws, and both the write and the in-flight
+   * disable have to follow the ROW rather than the card.
    */
   const COVER = {
     unit_id: 'u-house',
@@ -232,13 +233,13 @@ describe('LodgingBoard — clearing a write-in this card inherited', () => {
     occupant_name: 'Liam Garcia',
     note: '',
   }
-  const room = unit({ unit_id: 'u-room', code: 'house-a', name: 'House A', write_in: COVER })
+  const room = unit({ unit_id: 'u-room', code: 'house-a', name: 'House A', write_ins: [COVER] })
 
   it('sends the unit that HOLDS the row, not the card it was clicked on', async () => {
     const user = userEvent.setup()
     renderBoard({ units: [room] })
 
-    await user.click(screen.getByRole('button', { name: 'Clear Write-in House A' }))
+    await user.click(screen.getByRole('button', { name: 'Remove write-in Liam Garcia' }))
 
     expect(setAvailability).toHaveBeenCalledWith({
       unitId: 'u-house',
@@ -249,14 +250,16 @@ describe('LodgingBoard — clearing a write-in this card inherited', () => {
     })
   })
 
-  it('disables the card while the row it points at is being written', async () => {
+  it('disables the card while the row it points at is being written', () => {
     // `pendingUnitId` names the unit the WRITE targets, which for an inherited
-    // clear is never this card's own id — so keying the disable on the card
-    // alone leaves the button live for the whole write and invites a second
-    // click on a row that is already going away.
+    // removal is never this card's own id — so keying the disable on the card
+    // alone leaves the X live for the whole write and invites a second click
+    // on a row that is already going away. Matched with `some` since
+    // kindred#2381: a merged card covers several rows and the pending write
+    // belongs to whichever one was clicked.
     pendingUnitId = 'u-house'
     renderBoard({ units: [room] })
 
-    expect(screen.getByRole('button', { name: 'Clear Write-in House A' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Remove write-in Liam Garcia' })).toBeDisabled()
   })
 })

--- a/frontend/src/components/weekend/LodgingBoard.drag.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.drag.test.tsx
@@ -353,14 +353,15 @@ describe('LodgingBoard — placing a family from the space itself (kindred#2080)
     return screen.getByRole('combobox', { name: new RegExp(`place a family in ${name}`, 'i') })
   }
 
-  it('mounts the control on an empty space while placement is live', () => {
+  it('mounts the control on every placeable space, occupied or not', () => {
     boardWithUnplaced()
     expect(pickerFor('Cedar 2')).toBeInTheDocument()
-    // Cedar 1 already holds a family, so it offers nothing — the same rule
-    // that hides Hold on an occupied card.
-    expect(
-      screen.queryByRole('combobox', { name: /place a family in cedar 1/i })
-    ).not.toBeInTheDocument()
+    // Cedar 1 already holds a family and STILL offers the box. It did not
+    // before 2026-08-18, on the rule that hid the strip's write-in on an
+    // occupied card — a rule this change deletes, because the box is now the
+    // only way to write somebody in and a partly-filled merged building was
+    // left with no path at all.
+    expect(screen.getByRole('combobox', { name: /place a family in cedar 1/i })).toBeInTheDocument()
   })
 
   it('offers nothing without a scenario', () => {

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -64,7 +64,7 @@ import { LodgingUnitCard } from './LodgingUnitCard'
 import { partyKey } from './partyKey'
 import { resolvePartyUnit } from './rosterAttention'
 import type { UnitAvailabilityWrite } from './UnitAvailabilityControl'
-import { writeInSource } from './writeIn'
+import { writeInEntries } from './writeIn'
 
 export interface LodgingBoardProps {
   parties: RosterPartyRow[]
@@ -519,18 +519,25 @@ export function LodgingBoard({
                             hue={area.hue}
                             canPlace={canPlace}
                             canSetAvailability={canSetAvailability}
-                            // THIS card's unit, or the one holding the
-                            // write-in it inherited. `pendingUnitId` names the
-                            // unit the WRITE targets, and for an inherited
-                            // clear that is never this card's own id — so
+                            // THIS card's unit, or ANY of the ones holding a
+                            // write-in it covers. `pendingUnitId` names the
+                            // unit the WRITE targets, and a write-in removal
+                            // targets the row's own unit, which for an
+                            // inherited row is never this card's id — so
                             // keying the disable on the card alone leaves the
-                            // button live for the whole write. Same shape as
-                            // `savingMerge` below, and for the same reason:
-                            // the unit written is not always the unit drawn.
+                            // corner X live for the whole write. `some`, not
+                            // one id, since kindred#2381: a merged container
+                            // covers every write-in beneath it and the pending
+                            // write belongs to whichever one was clicked. Same
+                            // shape as `savingMerge` below, and for the same
+                            // reason: the unit written is not always the unit
+                            // drawn.
                             savingAvailability={
                               pendingUnitId === slot.unit.unit_id ||
                               (pendingUnitId !== '' &&
-                                pendingUnitId === writeInSource(slot.unit)?.unitId)
+                                writeInEntries(slot.unit).some(
+                                  (entry) => entry.source.unitId === pendingUnitId
+                                ))
                             }
                             onSetAvailability={writeAvailability}
                             canMerge={canMergeUnits}

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -322,10 +322,17 @@ export function LodgingBoard({
    * kindred#2080 — the unit card's picker, resolved through the DROP path.
    *
    * `resolvePickerPlacement` IS `resolveDrop`, so this branch inherits every
-   * refusal the drag has (a held space, a non-combined container, a party
-   * carrying neither CampMinder id, a party already alone in the room) rather
-   * than restating any of them, and produces the same `PlacementIntent` for
-   * the same `move`. One placement path with two affordances, not two paths.
+   * refusal the drag has (a non-combined container, a party carrying neither
+   * CampMinder id, a party already alone in the room) rather than restating
+   * any of them, and produces the same `PlacementIntent` for the same `move`.
+   * One placement path with two affordances, not two paths.
+   *
+   * That inheritance cuts both ways, which is what kindred#2432 proved: this
+   * list said "a held space" first until the written-into refusal was struck
+   * in `resolveDrop`, and this branch gave it up in the same change with
+   * nothing here to edit. A copy of the list is not a second gate — but a
+   * STALE copy of it is the next reader's evidence for restoring one, so keep
+   * the two in step.
    *
    * `canPlace` is re-checked here for the same reason `handleDragEnd`
    * re-checks it: the card's own gate is the affordance half, and a write

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -478,7 +478,7 @@ describe('LodgingUnitCard — a held unit refuses the drop outright (#2087)', ()
     return el as HTMLElement
   }
 
-  const held = unit({ write_in: cover(), is_family_available: false })
+  const held = unit({ write_ins: [cover()], is_family_available: false })
 
   it('keeps the droppable disabled on a held unit even while placement is live', () => {
     overDroppableId = unitDroppableId('cedar-1')
@@ -1402,7 +1402,7 @@ describe('LodgingUnitCard — the open-space title marker (#2093)', () => {
     const { container } = render(
       <LodgingUnitCard
         slot={slot({
-          unit: unit({ write_in: cover(), occupant_name: 'Emma Johnson' }),
+          unit: unit({ write_ins: [cover()], occupant_name: 'Emma Johnson' }),
         })}
         hue={hue}
         canPlace
@@ -1430,7 +1430,7 @@ describe('LodgingUnitCard — the open-space title marker (#2093)', () => {
     // write schema.
     const { container } = render(
       <LodgingUnitCard
-        slot={slot({ unit: unit({ write_in: cover({ occupant_name: '' }) }) })}
+        slot={slot({ unit: unit({ write_ins: [cover({ occupant_name: '' })] }) })}
         hue={hue}
         canPlace
         onOpenParty={vi.fn()}
@@ -1475,7 +1475,7 @@ describe('the write-in occupant card (kindred#2078)', () => {
       <LodgingUnitCard
         slot={slot({
           unit: unit({
-            write_in: cover(),
+            write_ins: [cover()],
             occupant_name: 'Emma Johnson',
             is_family_available: false,
           }),
@@ -1498,7 +1498,7 @@ describe('the write-in occupant card (kindred#2078)', () => {
       <LodgingUnitCard
         slot={slot({
           unit: unit({
-            write_in: cover({ occupant_name: 'Liam Garcia' }),
+            write_ins: [cover({ occupant_name: 'Liam Garcia' })],
             occupant_name: 'Liam Garcia',
             is_family_available: false,
           }),
@@ -1529,7 +1529,7 @@ describe('the write-in occupant card (kindred#2078)', () => {
       <LodgingUnitCard
         slot={slot({
           unit: unit({
-            write_in: cover(),
+            write_ins: [cover()],
             occupant_name: 'Emma Johnson',
             is_family_available: false,
           }),
@@ -2227,7 +2227,7 @@ describe('LodgingUnitCard — placing a family from the space itself (kindred#20
      * REFUSAL and is spoken for by the invalid merge target.
      */
     const { container } = renderCard({
-      slot: slot({ unit: unit({ write_in: cover() }) }),
+      slot: slot({ unit: unit({ write_ins: [cover()] }) }),
     })
     expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
     expect(container.querySelector('.opacity-40')).toBeNull()
@@ -2309,7 +2309,7 @@ describe('LodgingUnitCard — no sr-only text of any kind (kindred#2348)', () =>
 describe('LodgingUnitCard — the write-in chip, dropped in favour of the well (kindred#2252)', () => {
   const HUE = 'hsl(160 45% 42%)'
   const WRITTEN_IN = unit({
-    write_in: cover(),
+    write_ins: [cover()],
     occupant_name: 'Emma Johnson',
     is_family_available: false,
   })
@@ -2352,7 +2352,7 @@ describe('LodgingUnitCard — the write-in chip, dropped in favour of the well (
         slot={slot({
           unit: unit({
             inventory_class: 'staff_default',
-            write_in: cover(),
+            write_ins: [cover()],
             occupant_name: 'Emma Johnson',
             is_family_available: false,
           }),
@@ -2364,18 +2364,89 @@ describe('LodgingUnitCard — the write-in chip, dropped in favour of the well (
     expect(screen.getByText('Staff')).toBeInTheDocument()
   })
 
-  it('labels the availability control "Clear Write-in" rather than a bare "Clear"', () => {
-    // The chip is gone, so the button is now the ONLY thing on this card
-    // saying what a click removes. "Clear" alone stopped saying that.
+  it('removes a write-in from the card that draws it, not from the availability strip', () => {
+    // kindred#2381. The strip's single "Clear Write-in" could name only one
+    // row, so a merged card covering four destroyed them one silent click at
+    // a time. The X lives on the `WriteInCard`, and the write it sends names
+    // that card's own row.
+    const onSetAvailability = vi.fn()
     render(
       <LodgingUnitCard
         slot={slot({ unit: WRITTEN_IN })}
         hue={HUE}
         canSetAvailability
-        onSetAvailability={vi.fn()}
+        onSetAvailability={onSetAvailability}
         onOpenParty={vi.fn()}
       />
     )
-    expect(screen.getByRole('button', { name: 'Clear Write-in Cedar 1' })).toBeInTheDocument()
+
+    expect(screen.queryByRole('button', { name: /clear/i })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Remove write-in Emma Johnson' }))
+
+    expect(onSetAvailability).toHaveBeenCalledWith({
+      unitId: 'u1',
+      unitName: 'Cedar 1',
+      familyAvailable: null,
+      occupantName: '',
+      reason: '',
+    })
+  })
+
+  it('draws one card per write-in, each removing its own row', () => {
+    // THE REPORTED CASE. A merged building stands in for its rooms, so every
+    // write-in beneath it lands in this one well. Before kindred#2381 the card
+    // showed whichever room sorted first and hid the rest.
+    const onSetAvailability = vi.fn()
+    render(
+      <LodgingUnitCard
+        slot={slot({
+          unit: unit({
+            unit_id: 'u-house',
+            code: 'house',
+            name: 'House',
+            is_container: true,
+            is_combined: true,
+            is_family_available: false,
+            write_ins: [
+              cover({
+                unit_id: 'u-back',
+                unit_code: 'house-back',
+                unit_name: 'House Back',
+                occupant_name: 'Emma Johnson',
+              }),
+              cover({
+                unit_id: 'u-loft',
+                unit_code: 'house-loft',
+                unit_name: 'House Loft',
+                occupant_name: 'Liam Garcia',
+              }),
+            ],
+          }),
+        })}
+        hue={HUE}
+        canSetAvailability
+        onSetAvailability={onSetAvailability}
+        onOpenParty={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
+    expect(screen.getByText('Liam Garcia')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove write-in Liam Garcia' }))
+
+    expect(onSetAvailability).toHaveBeenCalledWith({
+      unitId: 'u-loft',
+      unitName: 'House Loft',
+      familyAvailable: null,
+      occupantName: '',
+      reason: '',
+    })
+  })
+
+  it('offers no removal to a reader without bunking.manage', () => {
+    render(<LodgingUnitCard slot={slot({ unit: WRITTEN_IN })} hue={HUE} onOpenParty={vi.fn()} />)
+
+    expect(screen.queryByRole('button', { name: /remove write-in/i })).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -2233,9 +2233,16 @@ describe('LodgingUnitCard — placing a family from the space itself (kindred#20
     expect(container.querySelector('.opacity-40')).toBeNull()
   })
 
-  it('is absent on an occupied space, mirroring Hold', () => {
+  it('is PRESENT on an occupied space — it is the only write-in path there is', () => {
+    // Inverted by the owner ruling of 2026-08-18. It used to be absent here,
+    // "mirroring Hold", and that was coherent while the box only placed
+    // families: a second family reaches a shareable space by drag. It stopped
+    // being coherent when the box became the only way to write somebody in —
+    // a partly-filled merged building then offered no input at all, since the
+    // strip's write-in was refused by #2090's gate and its rooms lose their
+    // cards to the merge.
     renderCard({ slot: slot({ parties: [party()] }) })
-    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+    expect(screen.getByRole('combobox')).toBeInTheDocument()
   })
 
   it('is absent without a scenario or without the permission to place', () => {
@@ -2430,12 +2437,14 @@ describe('LodgingUnitCard — the write-in chip, dropped in favour of the well (
 
     expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
     expect(screen.getByText('Liam Garcia')).toBeInTheDocument()
-    // AND WHICH ROOM EACH IS IN. Four occupants in one merged well sleep in
-    // four different rooms; a name with no space beside it tells a staff
-    // member nothing they can act on. (The 2026 container this issue is about
-    // holds four — a loft, a side room, a back room and a laundry.)
-    expect(screen.getByText('Written in at House Back')).toBeInTheDocument()
-    expect(screen.getByText('Written in at House Loft')).toBeInTheDocument()
+    // WITHOUT a per-card "Written in at <room>" line, struck 2026-08-18. The
+    // room dimension is real — four occupants in one merged well sleep in four
+    // rooms — but a line that says it for write-ins and stays silent about the
+    // FAMILIES in the same well is worse than one that says it for neither.
+    // One shorthand covering every occupant is kindred#2458.
+    expect(screen.queryByText(/written in at/i)).not.toBeInTheDocument()
+    // The X still names its OWN row, which is what made the line dispensable:
+    // removal never depended on the reader knowing which room it was.
 
     fireEvent.click(screen.getByRole('button', { name: 'Remove write-in Liam Garcia' }))
 

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -2447,4 +2447,41 @@ describe('LodgingUnitCard — the write-in chip, dropped in favour of the well (
 
     expect(screen.queryByRole('button', { name: /remove write-in/i })).not.toBeInTheDocument()
   })
+
+  it('edits a write-in from the card that draws it, upserting the same row (kindred#2430)', () => {
+    // No delete-and-recreate: the edit write names the SAME row the removal
+    // above does (`unitId`/`unitName` from the row's own source), with
+    // `familyAvailable: false` — the write-in "hold" value, not `null` — so
+    // `set_availability`'s upsert updates the row in place.
+    const onSetAvailability = vi.fn()
+    render(
+      <LodgingUnitCard
+        slot={slot({ unit: WRITTEN_IN })}
+        hue={HUE}
+        canSetAvailability
+        onSetAvailability={onSetAvailability}
+        onOpenParty={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit write-in Emma Johnson' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Occupant' }), {
+      target: { value: 'Emma Johnson-Reyes' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(onSetAvailability).toHaveBeenCalledWith({
+      unitId: 'u1',
+      unitName: 'Cedar 1',
+      familyAvailable: false,
+      occupantName: 'Emma Johnson-Reyes',
+      reason: '',
+    })
+  })
+
+  it('offers no edit to a reader without bunking.manage', () => {
+    render(<LodgingUnitCard slot={slot({ unit: WRITTEN_IN })} hue={HUE} onOpenParty={vi.fn()} />)
+
+    expect(screen.queryByRole('button', { name: /edit write-in/i })).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -1390,7 +1390,7 @@ describe('LodgingUnitCard — the open-space title marker (#2093)', () => {
      *
      * kindred#2078 RE-EXPRESSED this conjunct. It used to read the proxy
      * `unit.family_available_override === false` inline under the name `held`;
-     * it now goes through `writeInOccupant`, so the tint is keyed on the fact
+     * it now goes through `writeInEntries`, so the tint is keyed on the fact
      * ("somebody is in this room") rather than on a spelling. This test is
      * what pins that the re-expression did not drop the gate.
      *
@@ -2340,13 +2340,11 @@ describe('LodgingUnitCard — the write-in chip, dropped in favour of the well (
 
   it('does not suppress the "Staff" badge — a closed staff cabin is exempt from the gate, not just no write-in', () => {
     // This is the case `writeInBadgeApplies`'s `inventory_class !==
-    // 'staff_default'` half exists for: a staff cabin closed for the weekend
-    // synthesises a `writeInOccupant` cover the same way a family room's
-    // write-in does (`writeIn.ts`'s `coveringWriteIn` fallback reads
-    // `family_available_override === false` for either role), so reading
-    // `writeInOccupant(unit) !== null` alone here would swallow the "Staff"
-    // chip along with the "Write-in" one. Pins both halves of the gate at
-    // once — the class check AND the scoping to this card only.
+    // 'staff_default'` half exists for: a staff cabin written into for the
+    // weekend carries a cover the same way a family room's write-in does, so
+    // reading `hasWriteIn(unit)` alone here would swallow the "Staff" chip
+    // along with the "Write-in" one. Pins both halves of the gate at once —
+    // the class check AND the scoping to this card only.
     render(
       <LodgingUnitCard
         slot={slot({

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -480,7 +480,15 @@ describe('LodgingUnitCard — a held unit refuses the drop outright (#2087)', ()
 
   const held = unit({ write_ins: [cover()], is_family_available: false })
 
-  it('keeps the droppable disabled on a held unit even while placement is live', () => {
+  it('lights a WRITTEN-INTO unit as a drop target — a write-in does not close the space', () => {
+    /*
+     * Inverted by kindred#2432's ruling. The droppable was disabled on a
+     * written-into unit, the affordance half of #2090's refusal, so a family
+     * dragged toward a cabin holding one paper registration never even
+     * highlighted. `resolveDrop` no longer refuses that drop, so the
+     * affordance must not either — a target that refuses silently is worse
+     * than one that never lit.
+     */
     overDroppableId = unitDroppableId('cedar-1')
     const { container } = render(
       <LodgingUnitCard
@@ -490,7 +498,7 @@ describe('LodgingUnitCard — a held unit refuses the drop outright (#2087)', ()
         onOpenParty={vi.fn()}
       />
     )
-    expect(card(container)).not.toHaveClass('border-primary')
+    expect(card(container)).toHaveClass('border-primary')
   })
 
   it('keeps an ordinary unheld unit droppable enabled (regression guard)', () => {
@@ -2219,17 +2227,21 @@ describe('LodgingUnitCard — placing a family from the space itself (kindred#20
     expect(onPlaceParty.mock.calls[0]?.[1]).toEqual(unplaced)
   })
 
-  it('is ABSENT on a held space, not dimmed', () => {
+  it('is PRESENT on a written-into space, so a second occupant can be added either way round', () => {
     /*
-     * A hold refuses placement outright (#2087/#2090), and Hold's own control
-     * vanishes rather than dimming in the same situation. Absent adds no
-     * fifth meaning to the board's ruled signal vocabulary — `opacity-40` is
-     * REFUSAL and is spoken for by the invalid merge target.
+     * Also inverted by kindred#2432. The box used to vanish here, mirroring
+     * the strip's write-in, on #2090's rule that a write-in and a placement
+     * were mutually exclusive. They are not: the reported case is one paper
+     * registration — which has no CampMinder record, so a write-in is the only
+     * way to record it — sharing a cabin with one placed family.
+     *
+     * Still not DIMMED, which is the half that survives: `opacity-40` means
+     * REFUSAL on this board and is spoken for by the invalid merge target.
      */
     const { container } = renderCard({
       slot: slot({ unit: unit({ write_ins: [cover()] }) }),
     })
-    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+    expect(screen.getByRole('combobox')).toBeInTheDocument()
     expect(container.querySelector('.opacity-40')).toBeNull()
   })
 

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -2430,6 +2430,12 @@ describe('LodgingUnitCard — the write-in chip, dropped in favour of the well (
 
     expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
     expect(screen.getByText('Liam Garcia')).toBeInTheDocument()
+    // AND WHICH ROOM EACH IS IN. Four occupants in one merged well sleep in
+    // four different rooms; a name with no space beside it tells a staff
+    // member nothing they can act on. (The 2026 container this issue is about
+    // holds four — a loft, a side room, a back room and a laundry.)
+    expect(screen.getByText('Written in at House Back')).toBeInTheDocument()
+    expect(screen.getByText('Written in at House Loft')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Remove write-in Liam Garcia' }))
 
@@ -2440,6 +2446,22 @@ describe('LodgingUnitCard — the write-in chip, dropped in favour of the well (
       occupantName: '',
       reason: '',
     })
+  })
+
+  it('says nothing extra when the row is the drawing card\u2019s own', () => {
+    // The overwhelmingly common case. `WRITTEN_IN`'s cover names `cedar-1`,
+    // which is the card's own code, so the source line stays off.
+    render(
+      <LodgingUnitCard
+        slot={slot({ unit: WRITTEN_IN })}
+        hue={HUE}
+        canSetAvailability
+        onSetAvailability={vi.fn()}
+        onOpenParty={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByText(/^Written in at/)).not.toBeInTheDocument()
   })
 
   it('offers no removal to a reader without bunking.manage', () => {

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -103,8 +103,9 @@ const RING_CLASSES: Record<'dropTarget' | 'consentFlagged' | 'plain', string> = 
  * consent, red to over-capacity), so a fifth meaning cannot have a fifth
  * colour without collapsing the ones that exist. It cannot have an OPACITY
  * either: the 2026-08-09 signal-vocabulary ruling assigns one channel per
- * question, and `opacity-40` is REFUSAL ("you may not") — the invalid merge
- * target below and #2087's held space. This mark says "it will work; nothing
+ * question, and `opacity-40` is REFUSAL ("you may not") — spoken for by the
+ * invalid merge target below, and by that alone since kindred#2432 struck the
+ * written-into space's refusal. This mark says "it will work; nothing
  * here meets the need", which is a different KIND of statement rather than a
  * weaker refusal, so it stays at full contrast: legible, droppable, flagged.
  *
@@ -416,12 +417,13 @@ export function LodgingUnitCard({
   // above — and which one dnd-kit resolves `over` to would be a tie decided
   // by hook registration order, not by which gesture is actually in flight.
   //
-  // Disabled on a WRITTEN-INTO unit (#2078/#2087): a write-in blocks placement
-  // outright, per the owner ruling on #2090. This is the AFFORDANCE half — it
-  // keeps dnd-kit from ever reporting `isOver` here, so the card cannot even
-  // highlight as a target — while `resolveDrop` (`dragPlacement.ts`) is the
-  // half that actually enforces it, because #2080 adds a placement path that
-  // reaches `resolveDrop` without ever touching this hook.
+  // NOT disabled on a WRITTEN-INTO unit any more — kindred#2432, owner ruling
+  // 2026-08-18: *"we should be able to add families to any write in space, or
+  // add a write in to a family space — regardless of which came first."* This
+  // read `|| held` until then, the AFFORDANCE half of #2090's refusal, whose
+  // enforcing half lived in `resolveDrop`. Both went in the same change, and
+  // they have to: leaving this one would keep the card from ever reporting
+  // `isOver`, so a drop the resolver now accepts could never be aimed at it.
   //
   // Read through `writeInEntries` rather than as an inline
   // `family_available_override === false`, which is what this was until
@@ -438,10 +440,15 @@ export function LodgingUnitCard({
   // 2026 building that carries four — and each entry pairs the occupant with
   // the row that holds it, so the card's own X can name that row and no other.
   const writeIns = writeInEntries(unit)
-  const held = writeIns.length > 0
+  // Renamed from `held` with kindred#2432, and the rename is the point: this
+  // says WHO IS IN IT and no longer says the space is shut. Every surviving
+  // reader below is one that genuinely wants "somebody is already in this
+  // room" — the em-dash occupancy figure and the open-space to-do tint — and
+  // none of them is a refusal.
+  const writtenInto = writeIns.length > 0
   const { setNodeRef: setUnitDropRef, isOver: isUnitOver } = useDroppable({
     id: unitDroppableId(unit.code),
-    disabled: !canPlace || mergeDragActive || held,
+    disabled: !canPlace || mergeDragActive,
   })
 
   const setCardRef = (node: HTMLDivElement | null) => {
@@ -511,31 +518,46 @@ export function LodgingUnitCard({
   // suppressed the instant this card becomes an active drop target, same as
   // the old wash was.
   //
-  // `!held` is the second gate, and it is not cosmetic: EMPTY and
-  // OPEN are different predicates and this is where they part. A write-in
-  // blocks placement outright (`held` above; `dragPlacement.ts` refuses the
-  // drop), so a written-into cabin has no family in it and can take none.
-  // That was harmless while the empty treatment was a neutral grey wash, but
-  // the forest tint says "the remaining work is here" — and the marker is the
-  // to-do list. Painting such a cabin forest sends staff at the one room they
-  // may not fill. The dashed EDGE still applies to it, being structural
-  // rather than an invitation.
+  // `!writtenInto` is the second gate, and it SURVIVES kindred#2432 on a
+  // reason that changed underneath it — which is exactly the kind of gate that
+  // gets deleted by accident, so read this before touching it.
+  //
+  // It used to mean *this cabin may not be filled*: a write-in refused
+  // placement outright, so painting it forest sent staff at the one room they
+  // could not use. That reason is gone — a written-into cabin now takes a
+  // family like any other. What remains is the predicate this gate was always
+  // really about: EMPTY and OPEN are different questions, and a room somebody
+  // is already sleeping in is not empty. The tint says "the remaining work is
+  // HERE", and a cabin with an occupant in its well is not where the remaining
+  // work is, even though a second party may now join them.
+  //
+  // The dashed EDGE still applies to it, being structural rather than an
+  // invitation, and that split is unchanged.
   //
   // Keyed on the OCCUPANT SIGNAL, never on the occupant's NAME being filled
-  // in: a write-in nobody named still closes the room, and gating on the name
-  // would hand exactly that room back to the to-do marker.
-  const openMarkerActive = dashed && !held && ringState !== 'dropTarget'
+  // in: a write-in nobody named still puts somebody in the room, and gating on
+  // the name would hand exactly that room back to the to-do marker.
+  const openMarkerActive = dashed && !writtenInto && ringState !== 'dropTarget'
 
   /*
    * The corner figure, and the sentence behind it (kindred#2078).
    *
    * A write-in with nobody else in the room reports the em dash rather than a
    * count: it occupies wholesale and has no party size, so any digit here
-   * would assert something nobody recorded. A card that somehow carries BOTH a
-   * write-in and a placement keeps the placement count — that is a real number
-   * about real people, and the card should not go quiet about them.
+   * would assert something nobody recorded. A card carrying BOTH a write-in and
+   * a placement keeps the placement count — that is a real number about real
+   * people, and the card should not go quiet about them.
+   *
+   * ⚠️ THAT SECOND CASE IS ROUTINE SINCE kindred#2432 and was a legacy-row
+   * curiosity before it, and the number it prints UNDERSTATES a shared space:
+   * `lodging_write_ins` carries `occupant_name` and `note` and no count, so the
+   * write-in's own party contributes nothing here and the free-bed figure reads
+   * high. Filed as kindred#2439 (optional write-in headcount) and ruled an
+   * optional investigation rather than a blocker — an understated count on a
+   * space staff can share beats a space they could not share at all. Do not
+   * "fix" it by guessing a headcount here.
    */
-  const wholesaleWriteIn = held && occupants === 0
+  const wholesaleWriteIn = writtenInto && occupants === 0
   const occupancyFigure = wholesaleWriteIn ? '—' : String(occupants)
 
   /*
@@ -617,21 +639,34 @@ export function LodgingUnitCard({
   /*
    * Whether this card offers to place a family from itself (kindred#2080).
    *
-   * ABSENT, NOT DIMMED, in every negative case — mirroring how Hold itself
-   * vanishes on an occupied card rather than greying out. That is a signal
-   * decision, not a style one: under the board's ruled vocabulary
-   * (2026-08-09) `opacity-40` MEANS refusal and is spoken for by the invalid
-   * merge target and by a held space. An absent control adds no fifth
-   * meaning to any channel.
+   * ABSENT, NOT DIMMED, in every negative case. That is a signal decision, not
+   * a style one: under the board's ruled vocabulary (2026-08-09) `opacity-40`
+   * MEANS refusal and is spoken for by the invalid merge target. An absent
+   * control adds no fifth meaning to any channel.
    *
-   * The four gates, and why each is a gate rather than a fit judgement:
+   * THREE gates since kindred#2432, and why each is a gate rather than a fit
+   * judgement:
    *
-   *   - `held` — a hold blocks placement outright (#2087/#2090), and
-   *     `resolveDrop` refuses the write. Offering the control would name an
-   *     action that writes nothing.
    *   - `isSplitContainer` — `resolveDrop` rejects one as a target, and it
    *     gets no card anyway; belt-and-braces, exactly as `sharing` above.
    *   - no writer / no `canPlace` — no scenario, or no `bunking.manage`.
+   *
+   * ⚠️ A FOURTH GATE, `!held`, was struck by kindred#2432 and must not come
+   * back. It said "a hold blocks placement outright (#2087/#2090), so offering
+   * the control would name an action that writes nothing" — true only while
+   * `resolveDrop` refused a written-into space, which it no longer does.
+   * `resolvePickerPlacement` is a thin adapter over `resolveDrop`, so a gate
+   * here that RESTATES a refusal the resolver makes is the drift that design
+   * exists to prevent, and a gate that CONTRADICTS one is worse still.
+   *
+   * `parties.length === 0` is neither, and the distinction is the one to hold
+   * on to before reading the rule above as licence to delete it: the resolver
+   * ACCEPTS a second family onto an occupied card, and so does the drag. This
+   * gate does not refuse that placement — it declines to OFFER it from a
+   * surface whose question is "which family goes in this empty space", leaving
+   * the deliberate path (drag) intact. A gate that removes an affordance
+   * without removing an outcome is a scoping choice; only a gate that changes
+   * what the board will accept would be the drift.
    *
    * NOT gated on the list being empty. "Everyone has a cabin" is a real
    * answer to the question the control asks, and the picker says it; hiding
@@ -669,7 +704,23 @@ export function LodgingUnitCard({
    * CampMinder mirror loses its write-in path entirely.
    */
   const canOfferWriteIn = canSetAvailability && onSetAvailability !== undefined
-  const canPickFamily = (canOfferPlacement || canOfferWriteIn) && !held && !isSplitContainer
+  /**
+   * ⚠️ TWO GATES WERE STRUCK HERE AND NEITHER MAY COME BACK.
+   *
+   *   `parties.length === 0` — struck 2026-08-18. Coherent while this box only
+   *   placed families; incoherent once it became the only way to write somebody
+   *   in, because a partly-filled merged building then had no input at all.
+   *
+   *   `!writtenInto` — struck with kindred#2432. It refused the box on a card
+   *   that already holds a write-in, which is the mirror of the same mistake:
+   *   the reported case is one paper registration sharing a cabin with one
+   *   placed family, and this gate blocked the second half of it.
+   *
+   * Together they are the "mix and match" rule: a family and a write-in may
+   * share a space in either order, on a leaf or on a container, and each is
+   * removed independently.
+   */
+  const canPickFamily = (canOfferPlacement || canOfferWriteIn) && !isSplitContainer
 
   const cardStateClassName = [
     RING_CLASSES[ringState],
@@ -692,8 +743,8 @@ export function LodgingUnitCard({
   // Deliberately reuses `openMarkerActive` rather than bare `dashed`: the
   // owner ruling frames the tint as ONE resting-state signal, and a title
   // that stayed bold forest while the background wash had already stood down
-  // — for an active drop target, or for a held room — would be the two halves
-  // of the same mark silently drifting apart.
+  // — for an active drop target, or for a room somebody is written into —
+  // would be the two halves of the same mark silently drifting apart.
   const openTitleClassName = openMarkerActive
     ? 'text-primary font-bold'
     : 'text-foreground font-semibold'
@@ -1013,9 +1064,22 @@ export function LodgingUnitCard({
       <div className="flex min-h-[100px] flex-1 flex-col gap-2">
         {/* A write-in, drawn where the board draws occupancy (kindred#2078).
             FIRST and unconditionally, never in an either/or with the parties
-            below: a card carrying both is not a state any writer produces
-            (#2090 rules the two mutually exclusive), but if a legacy row ever
-            does, hiding one of them would drop somebody from the board. */}
+            below. That was defensive when it was written — #2090 ruled the two
+            mutually exclusive, so a card carrying both was only reachable
+            through a legacy row — and kindred#2432 makes it the ROUTINE state:
+            a paper registration recorded as a write-in, sharing the cabin with
+            a placed CampMinder family.
+
+            ⚠️ THIS IS #2091'S VISUAL PRECEDENT, deliberately and by default.
+            "Mark a space that holds two families the way the master housing
+            sheet does" is unbuilt, so whatever a shared well looks like here is
+            what it will look like there. The chosen form is the most
+            conservative one available: ONE well, the occupants stacked in the
+            order they already stack, NO divider, NO new chip, NO new colour —
+            the existing `WriteInCard` and `FamilyCard` frames unchanged. A
+            shared space is not a new KIND of card; it is a card with two
+            occupants in it. If #2091 later wants a shared-space treatment it
+            should EXTEND this rather than contradict it. */}
         {writeIns.map((entry) => (
           <WriteInCard
             key={entry.source.unitId}
@@ -1065,7 +1129,13 @@ export function LodgingUnitCard({
             isSaving={savingAvailability}
           />
         ))}
-        {parties.length === 0 && !held ? (
+        {/* The invitation, and it stands down for a write-in even though the
+            card now accepts a drop: the well is not EMPTY — a `WriteInCard` is
+            sitting in it — and "Drop families here" under a named occupant
+            describes the wrong space. The card is still a live drop target;
+            the placeholder is about what the well contains, not about what the
+            card will accept. */}
+        {parties.length === 0 && !writtenInto ? (
           /* Summer's wording in family vocabulary — `BunkCard` says "Drop
              campers here". An empty slot's job is to be a target, and "Empty"
              described the state without offering the action.

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -38,7 +38,7 @@ import {
 } from './unitBadges'
 import { UnitAvailabilityControl } from './UnitAvailabilityControl'
 import type { UnitAvailabilityWrite } from './UnitAvailabilityControl'
-import { writeInOccupant, writeInSource } from './writeIn'
+import { writeInEntries } from './writeIn'
 import { WriteInCard } from './WriteInCard'
 
 /**
@@ -423,7 +423,7 @@ export function LodgingUnitCard({
   // half that actually enforces it, because #2080 adds a placement path that
   // reaches `resolveDrop` without ever touching this hook.
   //
-  // Read through `writeInOccupant` rather than as an inline
+  // Read through `writeInEntries` rather than as an inline
   // `family_available_override === false`, which is what this was until
   // kindred#2078. Three consumers on this card shared that expression under
   // the name `held`, and one of them — #2093's open-tint gate below — was
@@ -432,12 +432,13 @@ export function LodgingUnitCard({
   // occupancy into its own scenario-scoped table, and that field now answers
   // the staff↔family role alone. Had the three consumers kept the inline
   // spelling, the split would have had to find all three.
-  const writeIn = writeInOccupant(unit)
-  // WHOSE row it is. Undefined whenever it is this card's own, so the common
-  // case says nothing extra — see `WriteInCard`'s own prop doc.
-  const writeInAt = writeInSource(unit)
-  const writeInAtName = writeInAt !== null && !writeInAt.isOwn ? writeInAt.unitName : undefined
-  const held = writeIn !== null
+  //
+  // A LIST since kindred#2381. A merged container draws in place of its rooms,
+  // so every write-in beneath it lands on this card — four of them on the one
+  // 2026 building that carries four — and each entry pairs the occupant with
+  // the row that holds it, so the card's own X can name that row and no other.
+  const writeIns = writeInEntries(unit)
+  const held = writeIns.length > 0
   const { setNodeRef: setUnitDropRef, isOver: isUnitOver } = useDroppable({
     id: unitDroppableId(unit.code),
     disabled: !canPlace || mergeDragActive || held,
@@ -510,7 +511,7 @@ export function LodgingUnitCard({
   // suppressed the instant this card becomes an active drop target, same as
   // the old wash was.
   //
-  // `writeIn === null` is the second gate, and it is not cosmetic: EMPTY and
+  // `!held` is the second gate, and it is not cosmetic: EMPTY and
   // OPEN are different predicates and this is where they part. A write-in
   // blocks placement outright (`held` above; `dragPlacement.ts` refuses the
   // drop), so a written-into cabin has no family in it and can take none.
@@ -523,7 +524,7 @@ export function LodgingUnitCard({
   // Keyed on the OCCUPANT SIGNAL, never on the occupant's NAME being filled
   // in: a write-in nobody named still closes the room, and gating on the name
   // would hand exactly that room back to the to-do marker.
-  const openMarkerActive = dashed && writeIn === null && ringState !== 'dropTarget'
+  const openMarkerActive = dashed && !held && ringState !== 'dropTarget'
 
   /*
    * The corner figure, and the sentence behind it (kindred#2078).
@@ -534,7 +535,7 @@ export function LodgingUnitCard({
    * write-in and a placement keeps the placement count — that is a real number
    * about real people, and the card should not go quiet about them.
    */
-  const wholesaleWriteIn = writeIn !== null && occupants === 0
+  const wholesaleWriteIn = held && occupants === 0
   const occupancyFigure = wholesaleWriteIn ? '—' : String(occupants)
 
   /*
@@ -963,8 +964,36 @@ export function LodgingUnitCard({
             below: a card carrying both is not a state any writer produces
             (#2090 rules the two mutually exclusive), but if a legacy row ever
             does, hiding one of them would drop somebody from the board. */}
-        {writeIn !== null && <WriteInCard occupant={writeIn} atUnitName={writeInAtName} />}
-        {parties.length === 0 && writeIn === null ? (
+        {writeIns.map((entry) => (
+          <WriteInCard
+            key={entry.source.unitId}
+            occupant={entry.occupant}
+            // BOUND TO THIS ROW, which is the whole point of the per-card X:
+            // the strip's single "Clear Write-in" named whichever row the
+            // server resolved first, so on a merged building a click removed
+            // one, the card re-populated with the next occupant, and the
+            // action read as a no-op while it destroyed them one by one.
+            //
+            // `familyAvailable: null` DELETES, and the occupant and reason are
+            // empty because a removal asserts nothing — the same write the
+            // strip's clear sent, now pointed at a row the reader can see.
+            {...(canSetAvailability && onSetAvailability !== undefined
+              ? {
+                  onRemove: () => {
+                    onSetAvailability({
+                      unitId: entry.source.unitId,
+                      unitName: entry.source.unitName,
+                      familyAvailable: null,
+                      occupantName: '',
+                      reason: '',
+                    })
+                  },
+                }
+              : {})}
+            isRemoving={savingAvailability}
+          />
+        ))}
+        {parties.length === 0 && !held ? (
           /* Summer's wording in family vocabulary — `BunkCard` says "Drop
              campers here". An empty slot's job is to be a target, and "Empty"
              described the state without offering the action.

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -988,9 +988,23 @@ export function LodgingUnitCard({
                       reason: '',
                     })
                   },
+                  // BOUND TO THIS ROW for the same reason `onRemove` is — kindred#2430.
+                  // `familyAvailable: false` is the write-in "hold" value, never
+                  // `null`: `set_availability` upserts a write-in
+                  // (`_upsert_row(what='write-in', ...)`), so this write updates
+                  // the existing row rather than creating a second one.
+                  onEdit: (write: { occupantName: string; reason: string }) => {
+                    onSetAvailability({
+                      unitId: entry.source.unitId,
+                      unitName: entry.source.unitName,
+                      familyAvailable: false,
+                      occupantName: write.occupantName,
+                      reason: write.reason,
+                    })
+                  },
                 }
               : {})}
-            isRemoving={savingAvailability}
+            isSaving={savingAvailability}
           />
         ))}
         {parties.length === 0 && !held ? (

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -629,10 +629,6 @@ export function LodgingUnitCard({
    *   - `held` — a hold blocks placement outright (#2087/#2090), and
    *     `resolveDrop` refuses the write. Offering the control would name an
    *     action that writes nothing.
-   *   - occupied — Hold's own rule, and the same reasoning: the card that
-   *     already holds a family is not the card staff are looking to fill.
-   *     A SECOND family still reaches a shareable space by drag, which
-   *     remains the path for a share that has to be looked at deliberately.
    *   - `isSplitContainer` — `resolveDrop` rejects one as a target, and it
    *     gets no card anyway; belt-and-braces, exactly as `sharing` above.
    *   - no writer / no `canPlace` — no scenario, or no `bunking.manage`.
@@ -640,9 +636,40 @@ export function LodgingUnitCard({
    * NOT gated on the list being empty. "Everyone has a cabin" is a real
    * answer to the question the control asks, and the picker says it; hiding
    * the control instead would leave staff wondering where it went.
+   *
+   * ★ NO LONGER GATED ON `parties.length === 0` (owner ruling, 2026-08-18).
+   *
+   * It was, and the reason was sound while this box only placed families: the
+   * card already holding one is not the card staff are looking to fill, and a
+   * second family reaches a shareable space by drag. That reasoning does not
+   * survive the box becoming the ONLY way to write somebody in. The owner hit
+   * it on a merged building:
+   *
+   *   > "if i populate 3/4 of clouds rest, i cannot add a write in directly
+   *   >  to it"
+   *
+   * — because the strip's "Write in" action refused an occupied card (#2090)
+   * and this box was hidden by the same condition, so a partly-filled merged
+   * container offered NO input at all. A container is the case that bites,
+   * since its rooms lose their own cards to the merge and there is nowhere
+   * else to go.
+   *
+   * Family rows on an occupied card are not a new claim: this control has
+   * always annotated rather than refused, and every refusal on the path is
+   * still `resolvePickerPlacement` → `resolveDrop`'s, inherited whole.
    */
-  const canPickFamily =
-    canPlace && onPlaceParty !== undefined && !held && !isSplitContainer && parties.length === 0
+  const canOfferPlacement = canPlace && onPlaceParty !== undefined
+  /**
+   * THE DIVERGENCE FROM `canPlace`, preserved from the strip's write-in.
+   *
+   * Who is sleeping in a cabin is a fact about the WEEKEND, not about a plan,
+   * so staff must be able to record one without first creating a scenario.
+   * The strip's "Write in" was gated on `canSetAvailability`, never on
+   * `canPlace`, and the box that replaced it has to keep that — otherwise the
+   * CampMinder mirror loses its write-in path entirely.
+   */
+  const canOfferWriteIn = canSetAvailability && onSetAvailability !== undefined
+  const canPickFamily = (canOfferPlacement || canOfferWriteIn) && !held && !isSplitContainer
 
   const cardStateClassName = [
     RING_CLASSES[ringState],
@@ -839,7 +866,6 @@ export function LodgingUnitCard({
         <UnitAvailabilityControl
           unit={unit}
           canManage={canSetAvailability && onSetAvailability !== undefined}
-          occupied={parties.length > 0}
           isSaving={savingAvailability}
           onSubmit={(write) => {
             onSetAvailability?.(write)
@@ -857,13 +883,39 @@ export function LodgingUnitCard({
         {canPickFamily && (
           <PlaceFamilyPicker
             unit={unit}
-            parties={unplacedParties}
+            // EMPTY where placement is refused, which is how the control knows
+            // it is a write-in box rather than both. Passing the queue anyway
+            // would offer rows that `resolvePickerPlacement` refuses.
+            parties={canOfferPlacement ? unplacedParties : []}
+            isSaving={savingAvailability}
             // The registry, only so a combined house is judged by its
             // whole-house capacity rather than by its container row's delta.
             units={units}
             onSelect={(party) => {
-              onPlaceParty(unit, party)
+              onPlaceParty?.(unit, party)
             }}
+            {...(canOfferWriteIn
+              ? {
+                  // The write the strip's "Write in" action used to send,
+                  // from the box that replaced it. `familyAvailable: false`
+                  // IS the write-in (kindred#2382 moved the row out of
+                  // `lodging_availability`, and the write shape stayed).
+                  //
+                  // `reason: ''` — the note is optional and this path does not
+                  // collect one. A write-in that wants a note gets it from the
+                  // pencil on its own card, which is where every other edit to
+                  // a write-in now lives.
+                  onWriteIn: (occupantName: string) => {
+                    onSetAvailability({
+                      unitId: unit.unit_id,
+                      unitName: unit.name,
+                      familyAvailable: false,
+                      occupantName,
+                      reason: '',
+                    })
+                  },
+                }
+              : {})}
           />
         )}
         {/* Merging is promotion to the parent: dragging this handle onto a
@@ -974,7 +1026,6 @@ export function LodgingUnitCard({
             // sleeping in four DIFFERENT rooms, and a split building's rooms
             // each draw a card for the one row the building holds, so without
             // this a name in the well names no space at all.
-            atUnitName={entry.source.isOwn ? undefined : entry.source.unitName}
             // BOUND TO THIS ROW, which is the whole point of the per-card X:
             // the strip's single "Clear Write-in" named whichever row the
             // server resolved first, so on a merged building a click removed

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -968,6 +968,13 @@ export function LodgingUnitCard({
           <WriteInCard
             key={entry.source.unitId}
             occupant={entry.occupant}
+            // WHOSE row it is, and undefined whenever it is this card's own —
+            // so the common case says nothing extra. Restored during review of
+            // kindred#2381: a merged container's well can hold four occupants
+            // sleeping in four DIFFERENT rooms, and a split building's rooms
+            // each draw a card for the one row the building holds, so without
+            // this a name in the well names no space at all.
+            atUnitName={entry.source.isOwn ? undefined : entry.source.unitName}
             // BOUND TO THIS ROW, which is the whole point of the per-card X:
             // the strip's single "Clear Write-in" named whichever row the
             // server resolved first, so on a merged building a click removed

--- a/frontend/src/components/weekend/MapUnitPopover.test.tsx
+++ b/frontend/src/components/weekend/MapUnitPopover.test.tsx
@@ -185,7 +185,7 @@ describe('MapUnitPopover — one room', () => {
         units={[
           mapUnit(
             row({
-              write_in: cover(),
+              write_ins: [cover()],
               occupant_name: 'Emma Johnson',
               is_family_available: false,
             })
@@ -526,7 +526,7 @@ describe('MapUnitPopover — a cluster of rooms', () => {
           unit_id: 'u2',
           code: 'cedar-2',
           name: 'Cedar 2',
-          write_in: cover({ unit_id: 'u2', unit_code: 'cedar-2', unit_name: 'Cedar 2' }),
+          write_ins: [cover({ unit_id: 'u2', unit_code: 'cedar-2', unit_name: 'Cedar 2' })],
           is_family_available: false,
           is_active: false,
         })
@@ -954,7 +954,7 @@ describe('MapUnitPopover — the whole-building marker, extended from the board 
         units={[
           mapUnit(
             row({
-              write_in: cover(),
+              write_ins: [cover()],
               occupant_name: 'Emma Johnson',
               is_family_available: false,
             }),

--- a/frontend/src/components/weekend/PlaceFamilyPicker.test.tsx
+++ b/frontend/src/components/weekend/PlaceFamilyPicker.test.tsx
@@ -428,3 +428,97 @@ describe('PlaceFamilyPicker — nothing left to place', () => {
     expect(screen.getByText('Everyone has a cabin.')).toBeInTheDocument()
   })
 })
+
+/**
+ * ONE BOX, TWO OUTCOMES (owner ruling, 2026-08-18).
+ *
+ * The board used to carry a separate "Write in" button on every card's
+ * availability strip, so a cabin offered two typeable rectangles for the same
+ * question — *who is sleeping here* — and staff had to decide which control to
+ * reach for before they knew whether the answer was a registered family. The
+ * ruling collapses them: type into the one box, and if nothing matches, what
+ * you typed becomes the write-in.
+ *
+ *   > "simply letting staff type into the 'place a family' text box. if they
+ *   >  type something, and it has no matches and they hit enter, that becomes
+ *   >  the write in. one fewer chip on the board on every tile, big win."
+ *
+ * The offer is a real ROW rather than an invisible Enter binding: a bare
+ * keystroke with no on-screen affordance is undiscoverable, and the board is
+ * close to pointer-only, so the same path has to be clickable.
+ */
+describe('writing in a name from the same box', () => {
+  it('offers to write in what was typed once no family matches', async () => {
+    const onWriteIn = vi.fn()
+    renderPicker({ onWriteIn })
+
+    await userEvent.type(searchBox(), 'Grandparents of Chen')
+
+    expect(screen.getByRole('option', { name: /write in/i })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: /Grandparents of Chen/ })).toBeInTheDocument()
+  })
+
+  it('writes in on Enter, and hands back exactly what was typed', async () => {
+    const onWriteIn = vi.fn()
+    const { onSelect } = renderPicker({ onWriteIn })
+
+    await userEvent.type(searchBox(), '  Grandparents of Chen  {Enter}')
+
+    expect(onWriteIn).toHaveBeenCalledWith('Grandparents of Chen')
+    // The two outcomes are exclusive: a write-in is not also a placement.
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('writes in on a click, for a board that is close to pointer-only', async () => {
+    const onWriteIn = vi.fn()
+    renderPicker({ onWriteIn })
+
+    await userEvent.type(searchBox(), 'Paper registration')
+    await userEvent.click(screen.getByRole('option', { name: /write in/i }))
+
+    expect(onWriteIn).toHaveBeenCalledWith('Paper registration')
+  })
+
+  it('clears the box afterwards, so the card does not sit holding a used query', async () => {
+    const onWriteIn = vi.fn()
+    renderPicker({ onWriteIn })
+
+    await userEvent.type(searchBox(), 'Paper registration{Enter}')
+
+    expect(searchBox()).toHaveValue('')
+  })
+
+  it('never offers a write-in while a family still matches', async () => {
+    const onWriteIn = vi.fn()
+    renderPicker({ onWriteIn })
+
+    await userEvent.type(searchBox(), 'Johnson')
+
+    expect(screen.queryByRole('option', { name: /write in/i })).not.toBeInTheDocument()
+    // Enter still places the family the arrows selected, unchanged.
+    await userEvent.keyboard('{ArrowDown}{Enter}')
+    expect(onWriteIn).not.toHaveBeenCalled()
+  })
+
+  it('offers nothing for whitespace alone', async () => {
+    const onWriteIn = vi.fn()
+    renderPicker({ onWriteIn })
+
+    await userEvent.type(searchBox(), '   ')
+
+    expect(screen.queryByRole('option', { name: /write in/i })).not.toBeInTheDocument()
+    await userEvent.keyboard('{Enter}')
+    expect(onWriteIn).not.toHaveBeenCalled()
+  })
+
+  it('stays a pure family picker where the caller offers no write-in path', async () => {
+    // Read-only staff, or a card whose write-in path is refused: the control
+    // must not grow an affordance the caller cannot honour.
+    renderPicker()
+
+    await userEvent.type(searchBox(), 'Nobody At All')
+
+    expect(screen.queryByRole('option', { name: /write in/i })).not.toBeInTheDocument()
+    expect(screen.getByText(/No parties match/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/weekend/PlaceFamilyPicker.tsx
+++ b/frontend/src/components/weekend/PlaceFamilyPicker.tsx
@@ -64,6 +64,29 @@ export interface PlaceFamilyPickerProps {
    */
   units?: LodgingUnitRow[]
   onSelect: (party: RosterPartyRow) => void
+  /**
+   * Record a name that is not a registered family — the write-in
+   * (owner ruling, 2026-08-18).
+   *
+   * The card used to carry a SECOND typeable box for this, on the availability
+   * strip, so every tile asked "who is sleeping here" twice and staff had to
+   * choose a control before they knew which kind of answer they had. One box
+   * answers both: a family if one matches, a written-in name if none does.
+   *
+   * Optional, and the offer is absent when it is: a caller with no write path
+   * (read-only staff) must not be shown an affordance it cannot honour.
+   */
+  onWriteIn?: (occupantName: string) => void
+  /**
+   * True while a write THIS card started is in flight.
+   *
+   * Inherited from the strip button this box replaced: 81 cards share one
+   * mutation, so the gate has to be per-card or one cabin's write freezes the
+   * board. It matters more here than it did on a button — a combobox invites
+   * a staff member to keep typing, and a second write-in submitted against an
+   * unsettled first is a duplicate nobody asked for.
+   */
+  isSaving?: boolean
 }
 
 /**
@@ -77,7 +100,14 @@ const NOTE_TONE: Record<'partial' | 'unmet', string> = {
   partial: 'text-muted-foreground',
 }
 
-export function PlaceFamilyPicker({ unit, parties, units = [], onSelect }: PlaceFamilyPickerProps) {
+export function PlaceFamilyPicker({
+  unit,
+  parties,
+  units = [],
+  onSelect,
+  onWriteIn,
+  isSaving = false,
+}: PlaceFamilyPickerProps) {
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
   /** -1 is "no row active", which is the state Enter must do nothing in. */
@@ -150,8 +180,50 @@ export function PlaceFamilyPicker({ unit, parties, units = [], onSelect }: Place
     [parties, unit, units, needle]
   )
 
+  /**
+   * THE WRITE-IN OFFER, and the three conditions are each load-bearing.
+   *
+   * `onWriteIn` — the caller can actually write one.
+   * `trimmed !== ''` — whitespace asserts nothing, and an occupant name is
+   *                    required; an empty write-in would name nobody.
+   * `candidates.length === 0` — a family still matching means the staff member
+   *                    is most likely still typing toward it, and stealing
+   *                    Enter from a visible row would place the wrong thing.
+   *                    The ruling says it in those words: "if they type
+   *                    something, and it has no matches and they hit enter".
+   *
+   * Consequence worth stating: a name that happens to match a family's search
+   * text can never become a write-in from this box. That is the right trade —
+   * the far more common mistake is writing in somebody who IS registered — and
+   * an extra distinguishing word reaches the offer.
+   */
+  const offersWriteIn = onWriteIn !== undefined && trimmed !== '' && candidates.length === 0
+
+  /**
+   * Whether this card can place a family at all.
+   *
+   * FALSE on the CampMinder mirror, where there is no scenario: recording who
+   * is sleeping in a cabin is a fact about the weekend, not about a plan, so
+   * the write-in half stays live where the placement half cannot be. The
+   * caller passes an empty queue in that case rather than a second flag.
+   */
+  const placementLive = parties.length > 0 || onWriteIn === undefined
+  const placeLabel =
+    onWriteIn === undefined
+      ? `Place a family in ${unit.name}`
+      : `Place a family in ${unit.name}, or write in a name`
+
   const choose = (party: RosterPartyRow) => {
     onSelect(party)
+    setQuery('')
+    close()
+  }
+
+  const writeIn = () => {
+    if (!offersWriteIn || onWriteIn === undefined) return
+    // The TRIMMED text, which is what the offer row shows. Staff type into a
+    // search box and a trailing space is a typing artefact, not a name.
+    onWriteIn(trimmed)
     setQuery('')
     close()
   }
@@ -188,8 +260,12 @@ export function PlaceFamilyPicker({ unit, parties, units = [], onSelect }: Place
       return
     }
     if (event.key === 'Enter') {
-      // Never a submit: this control can be mounted inside Hold's own form.
+      // Never a submit: this control can be mounted inside a release form.
       event.preventDefault()
+      if (offersWriteIn) {
+        writeIn()
+        return
+      }
       const chosen = candidates[activeIndex]
       if (chosen !== undefined) choose(chosen.party)
     }
@@ -226,9 +302,20 @@ export function PlaceFamilyPicker({ unit, parties, units = [], onSelect }: Place
         role="combobox"
         // Named for the cabin, exactly as Hold's own button is: ~82 controls
         // all called "Place a family" is unusable with a screen reader.
-        aria-label={`Place a family in ${unit.name}`}
-        placeholder="Place a family…"
+        // NAMED FOR WHAT THIS CARD CAN ACTUALLY DO, which is not always both.
+        // On the CampMinder mirror there is no scenario, so nothing can be
+        // placed and the box is a write-in box only — calling it "Place a
+        // family" there would name an action the staff member cannot take.
+        aria-label={placementLive ? placeLabel : `Write in an occupant for ${unit.name}`}
+        placeholder={
+          placementLive
+            ? onWriteIn === undefined
+              ? 'Place a family…'
+              : 'Place a family, or write in…'
+            : 'Write in a name…'
+        }
         value={query}
+        disabled={isSaving}
         aria-expanded={open}
         aria-autocomplete="list"
         // Unconditional, though the listbox only exists while open: the
@@ -264,16 +351,50 @@ export function PlaceFamilyPicker({ unit, parties, units = [], onSelect }: Place
           aria-label={`Families to place in ${unit.name}`}
           className="border-border bg-background max-h-48 overflow-y-auto rounded-md border"
         >
-          {parties.length === 0 ? (
-            /* The ONLY way this list is empty, because nothing is ever
-               hidden. `FloatingUnplacedBadge` already says this over the same
-               parties — one state, one sentence. */
+          {offersWriteIn ? (
+            /* The one row an empty result offers, rather than a dead end.
+               `role="option"` and `aria-selected` because it IS the listbox's
+               only option here — Enter acts on it without an arrow press, so
+               saying it is selected is the truth rather than a decoration. */
+            <button
+              type="button"
+              role="option"
+              aria-selected={true}
+              tabIndex={-1}
+              data-testid="write-in-offer"
+              onMouseDown={(event) => {
+                event.preventDefault()
+              }}
+              onClick={writeIn}
+              className="bg-muted flex w-full flex-col gap-0.5 px-2 py-1.5 text-left text-sm"
+            >
+              <span className="truncate">{`Write in "${trimmed}"`}</span>
+              {/* Both halves of what just happened: no family matched, and
+                  this records a name instead. The muted key is the list's own
+                  advisory ink, not a warning — writing somebody in is an
+                  ordinary act, not a fallback from a failure. */}
+              <span className="text-muted-foreground text-xs">
+                No family matches — records who is in this space
+              </span>
+            </button>
+          ) : parties.length === 0 ? (
+            /* Nothing left to place. `FloatingUnplacedBadge` already says this
+               over the same parties — one state, one sentence.
+
+               BELOW the write-in offer, deliberately: on the CampMinder mirror
+               there is no scenario and therefore no placement queue at all, so
+               this branch is the one an unfiltered box lands on. Above the
+               offer it would tell a staff member "everyone has a cabin" while
+               swallowing the name they had just typed. */
             <p className="text-muted-foreground px-2 py-3 text-center text-sm italic">
               Everyone has a cabin.
             </p>
           ) : candidates.length === 0 ? (
             /* A typo, not a fit verdict. `FloatingQueueBadge`'s own wording,
-               in the same "parties" vocabulary an adult weekend needs. */
+               in the same "parties" vocabulary an adult weekend needs. Only
+               reachable where the caller offers no write-in path; otherwise
+               the offer row above says the same thing and gives it somewhere
+               to go. */
             <p className="text-muted-foreground px-2 py-3 text-center text-sm">
               {`No parties match "${trimmed}"`}
             </p>

--- a/frontend/src/components/weekend/PlaceFamilyPicker.tsx
+++ b/frontend/src/components/weekend/PlaceFamilyPicker.tsx
@@ -369,12 +369,14 @@ export function PlaceFamilyPicker({
               className="bg-muted flex w-full flex-col gap-0.5 px-2 py-1.5 text-left text-sm"
             >
               <span className="truncate">{`Write in "${trimmed}"`}</span>
-              {/* Both halves of what just happened: no family matched, and
-                  this records a name instead. The muted key is the list's own
+              {/* THE ACTION, not a description of it (owner, 2026-08-18).
+                  This read "records who is in this space", which explained
+                  what a write-in is to a staff member who already knew and
+                  left the keystroke unsaid. The muted key is the list's own
                   advisory ink, not a warning — writing somebody in is an
                   ordinary act, not a fallback from a failure. */}
               <span className="text-muted-foreground text-xs">
-                No family matches — records who is in this space
+                No family matches — press Enter to save this write-in
               </span>
             </button>
           ) : parties.length === 0 ? (

--- a/frontend/src/components/weekend/UnitAvailabilityControl.test.tsx
+++ b/frontend/src/components/weekend/UnitAvailabilityControl.test.tsx
@@ -88,7 +88,6 @@ function renderControl(props: Partial<React.ComponentProps<typeof UnitAvailabili
     <UnitAvailabilityControl
       unit={unit()}
       canManage
-      occupied={false}
       isSaving={false}
       onSubmit={onSubmit}
       {...props}
@@ -98,6 +97,26 @@ function renderControl(props: Partial<React.ComponentProps<typeof UnitAvailabili
 }
 
 describe('UnitAvailabilityControl', () => {
+  /*
+   * ★ THE WRITE-IN PROMPT IS GONE FROM THIS CONTROL (owner ruling, 2026-08-18).
+   *
+   * Nine tests were deleted here, not weakened — they specified a form this
+   * strip no longer mounts. Where each guarantee now lives:
+   *
+   *   an occupant name is REQUIRED      -> PlaceFamilyPicker.test.tsx, "offers
+   *                                        nothing for whitespace alone"
+   *   the note is OPTIONAL              -> WriteInCard.test.tsx's edit form
+   *   name and note never substitute    -> WriteInCard.test.tsx's edit form
+   *   a MERGED building can be written  -> LodgingUnitCard.test.tsx, the
+   *     into                               picker's own gate
+   *   an abandoned form is cleared      -> PlaceFamilyPicker clears its query
+   *
+   * The reason the strip lost it: the card already carried a family box, so
+   * every tile offered two typeable rectangles for one question — who is
+   * sleeping here — and #2090's gate on this one meant a partly-filled merged
+   * building could be written into by neither.
+   */
+
   it('offers nothing without bunking.manage', () => {
     // The same gate as the endpoint. A control that 403s on click is worse
     // than no control: it teaches staff the board is broken.
@@ -107,77 +126,23 @@ describe('UnitAvailabilityControl', () => {
   })
 
   it('offers nothing to write into an OCCUPIED unit — a write-in and a placement are mutually exclusive (#2090)', () => {
-    // A space that already has a family assigned may not also be marked
-    // held. `occupied` is a fact from the slot's own parties, kept separate
-    // from `canManage`'s permission gate — folding it in there would
-    // resurrect the scenario dimension 1500000135 deleted.
-    renderControl({ occupied: true })
+    // Nothing, and no longer BECAUSE it is occupied. The strip stopped
+    // offering a write-in at all on 2026-08-18 — creating one is the card's
+    // own family box — so occupancy is not a dimension this control has any
+    // more, and it takes no `occupied` prop to carry it.
+    renderControl()
 
-    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /write in/i })).not.toBeInTheDocument()
   })
 
-  it('still offers to write into an unoccupied unit (regression guard)', () => {
-    renderControl({ occupied: false })
+  it('offers no write-in on an ordinary family cabin either', () => {
+    // The regression guard, inverted by the same ruling: this used to assert
+    // the button WAS offered here. A second typeable box beside the card's
+    // family picker, both asking who is sleeping in the cabin, is exactly what
+    // the ruling removed.
+    renderControl()
 
-    expect(screen.getByRole('button', { name: /write in/i })).toBeInTheDocument()
-  })
-
-  it('writes an occupant into a family cabin, with no note at all', async () => {
-    // The note is OPTIONAL. This is the common path and the one that must not
-    // grow a second required field by accident.
-    const user = userEvent.setup()
-    const { onSubmit } = renderControl()
-
-    await user.click(screen.getByRole('button', { name: /write in/i }))
-    await user.type(screen.getByRole('textbox', { name: /^occupant$/i }), 'Emma Johnson')
-    await user.click(screen.getByRole('button', { name: /^write in$/i }))
-
-    expect(onSubmit).toHaveBeenCalledWith({
-      unitId: 'u1',
-      unitName: 'Cedar 1',
-      familyAvailable: false,
-      occupantName: 'Emma Johnson',
-      reason: '',
-    })
-  })
-
-  it('carries the optional note beside the occupant when staff give one', async () => {
-    const user = userEvent.setup()
-    const { onSubmit } = renderControl()
-
-    await user.click(screen.getByRole('button', { name: /write in/i }))
-    await user.type(screen.getByRole('textbox', { name: /^occupant$/i }), 'Liam Garcia')
-    await user.type(screen.getByRole('textbox', { name: /note/i }), 'Back Monday')
-    await user.click(screen.getByRole('button', { name: /^write in$/i }))
-
-    expect(onSubmit).toHaveBeenCalledWith({
-      unitId: 'u1',
-      unitName: 'Cedar 1',
-      familyAvailable: false,
-      occupantName: 'Liam Garcia',
-      reason: 'Back Monday',
-    })
-  })
-
-  it('accepts a note that is not a person, because there is no second control for one', async () => {
-    // The accepted cost, ruled on rather than prevented: a staff member who
-    // types "burst pipe" into the occupant field gets a card showing an
-    // occupant called "burst pipe". Splitting the two cases was explicitly
-    // rejected as not worth a second concept.
-    const user = userEvent.setup()
-    const { onSubmit } = renderControl()
-
-    await user.click(screen.getByRole('button', { name: /write in/i }))
-    await user.type(screen.getByRole('textbox', { name: /^occupant$/i }), 'burst pipe')
-    await user.click(screen.getByRole('button', { name: /^write in$/i }))
-
-    expect(onSubmit).toHaveBeenCalledWith({
-      unitId: 'u1',
-      unitName: 'Cedar 1',
-      familyAvailable: false,
-      occupantName: 'burst pipe',
-      reason: '',
-    })
+    expect(screen.queryByRole('button', { name: /write in/i })).not.toBeInTheDocument()
   })
 
   it('releases a staff cabin to families for this weekend', async () => {
@@ -208,64 +173,6 @@ describe('UnitAvailabilityControl', () => {
     expect(screen.queryByRole('textbox', { name: /^occupant$/i })).not.toBeInTheDocument()
   })
 
-  it('will not write a nameless occupant into a cabin, and says so', async () => {
-    // A write-in with no name is a closed room nobody can account for: staff
-    // can see it is unavailable and have no way to learn who is in it.
-    //
-    // The visible refusal is asserted, not just the absent call. An earlier
-    // version disabled the submit button AND guarded in the handler; deleting
-    // the guard broke no test, because a click on a disabled button never
-    // reaches a handler at all. Two guards masking each other means neither is
-    // pinned — so the button stays live and the refusal is a thing you can see.
-    const user = userEvent.setup()
-    const { onSubmit } = renderControl()
-
-    await user.click(screen.getByRole('button', { name: /write in/i }))
-    await user.click(screen.getByRole('button', { name: /^write in$/i }))
-
-    expect(onSubmit).not.toHaveBeenCalled()
-    expect(screen.getByText(/say who is in it/i)).toBeInTheDocument()
-  })
-
-  it('does not let the optional note stand in for the occupant', async () => {
-    // The whole point of two fields: a note is not a name, and a write-in
-    // with only a note is exactly the state 1500000148 unwound.
-    const user = userEvent.setup()
-    const { onSubmit } = renderControl()
-
-    await user.click(screen.getByRole('button', { name: /write in/i }))
-    await user.type(screen.getByRole('textbox', { name: /note/i }), 'Back Monday')
-    await user.click(screen.getByRole('button', { name: /^write in$/i }))
-
-    expect(onSubmit).not.toHaveBeenCalled()
-    expect(screen.getByText(/say who is in it/i)).toBeInTheDocument()
-  })
-
-  it('refuses an empty occupant submitted from the keyboard too', async () => {
-    // Enter in the text field is a second way into the same handler, and the
-    // one a staff member typing quickly will actually use.
-    const user = userEvent.setup()
-    const { onSubmit } = renderControl()
-
-    await user.click(screen.getByRole('button', { name: /write in/i }))
-    await user.type(screen.getByRole('textbox', { name: /^occupant$/i }), '{Enter}')
-
-    expect(onSubmit).not.toHaveBeenCalled()
-    expect(screen.getByText(/say who is in it/i)).toBeInTheDocument()
-  })
-
-  it('treats blank space as no occupant at all', async () => {
-    const user = userEvent.setup()
-    const { onSubmit } = renderControl()
-
-    await user.click(screen.getByRole('button', { name: /write in/i }))
-    await user.type(screen.getByRole('textbox', { name: /^occupant$/i }), '   ')
-    await user.click(screen.getByRole('button', { name: /^write in$/i }))
-
-    expect(onSubmit).not.toHaveBeenCalled()
-    expect(screen.getByText(/say who is in it/i)).toBeInTheDocument()
-  })
-
   it('still refuses a release with no reason', async () => {
     // The release branch keeps its own required field and its own wording.
     // Reshaping the flag must not quietly retire the guardrail on the branch
@@ -281,14 +188,18 @@ describe('UnitAvailabilityControl', () => {
   })
 
   it('takes the refusal back as soon as staff start typing', async () => {
+    // Generic form behaviour, pinned on the one prompt that still exists. It
+    // used to be pinned on the write-in's occupant field; that prompt went
+    // with the `hold` action on 2026-08-18.
     const user = userEvent.setup()
-    renderControl()
+    renderControl({ unit: STAFF_CABIN })
 
-    await user.click(screen.getByRole('button', { name: /write in/i }))
-    await user.click(screen.getByRole('button', { name: /^write in$/i }))
-    await user.type(screen.getByRole('textbox', { name: /^occupant$/i }), 'E')
+    await user.click(screen.getByRole('button', { name: /release/i }))
+    await user.click(screen.getByRole('button', { name: /^release$/i }))
+    expect(screen.getByText(/say why/i)).toBeInTheDocument()
 
-    expect(screen.queryByText(/say who is in it/i)).not.toBeInTheDocument()
+    await user.type(screen.getByRole('textbox', { name: 'Reason' }), 'B')
+    expect(screen.queryByText(/say why/i)).not.toBeInTheDocument()
   })
 
   it('offers NOTHING on a written-into cabin — the removal is the X on its card', () => {
@@ -363,59 +274,14 @@ describe('UnitAvailabilityControl', () => {
     expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 
-  it('offers to write into a MERGED building', async () => {
-    // The staff-facing half of the container fix. A merged building IS the
-    // card the board draws in place of its rooms, so it is the only surface a
-    // write-in for that building can be recorded on -- merging is exactly what
-    // takes its rooms' own cards away.
-    const user = userEvent.setup()
-    const { onSubmit } = renderControl({
-      unit: unit({
-        unit_id: 'u3',
-        code: 'clouds-rest',
-        name: 'Clouds Rest',
-        is_container: true,
-        is_combined: true,
-      }),
-    })
+  it('offers nothing on a MERGED building — but no longer closes its write-in path', () => {
+    // #2090's gate used to leave a partly-filled merged building with NO
+    // write-in path at all: refused here, and its rooms have no cards of their
+    // own to carry one. The card's family box now takes it, whether or not a
+    // family is already placed. See `LodgingUnitCard`'s `canPickFamily`.
+    renderControl({ unit: unit({ is_container: true, is_combined: true }) })
 
-    await user.click(screen.getByRole('button', { name: 'Write in Clouds Rest' }))
-    await user.type(screen.getByRole('textbox', { name: /^occupant$/i }), 'Liam Garcia')
-    await user.click(screen.getByRole('button', { name: /^write in$/i }))
-
-    expect(onSubmit).toHaveBeenCalledWith({
-      unitId: 'u3',
-      unitName: 'Clouds Rest',
-      familyAvailable: false,
-      occupantName: 'Liam Garcia',
-      reason: '',
-    })
-  })
-
-  it('still offers nothing on a MERGED building that holds a family (#2090)', () => {
-    renderControl({
-      unit: unit({ is_container: true, is_combined: true }),
-      occupied: true,
-    })
-
-    expect(screen.queryByRole('button')).not.toBeInTheDocument()
-  })
-
-  it('abandons BOTH fields when the form is cancelled', async () => {
-    // Reopening with the last abandoned entry still in the box is how one
-    // cabin's occupant ends up written into another. Two fields, two ways to
-    // get that wrong.
-    const user = userEvent.setup()
-    renderControl()
-
-    await user.click(screen.getByRole('button', { name: /write in/i }))
-    await user.type(screen.getByRole('textbox', { name: /^occupant$/i }), 'Emma Johnson')
-    await user.type(screen.getByRole('textbox', { name: /note/i }), 'Back Monday')
-    await user.click(screen.getByRole('button', { name: /cancel/i }))
-    await user.click(screen.getByRole('button', { name: /write in/i }))
-
-    expect(screen.getByRole('textbox', { name: /^occupant$/i })).toHaveValue('')
-    expect(screen.getByRole('textbox', { name: /note/i })).toHaveValue('')
+    expect(screen.queryByRole('button', { name: /write in/i })).not.toBeInTheDocument()
   })
 })
 

--- a/frontend/src/components/weekend/UnitAvailabilityControl.test.tsx
+++ b/frontend/src/components/weekend/UnitAvailabilityControl.test.tsx
@@ -76,7 +76,7 @@ function cover(overrides: Partial<WriteInCoverRow> = {}): WriteInCoverRow {
 }
 
 const WRITTEN_IN_CABIN = unit({
-  write_in: cover(),
+  write_ins: [cover()],
   occupant_name: 'Emma Johnson',
   reason: '',
   is_family_available: false,
@@ -291,28 +291,17 @@ describe('UnitAvailabilityControl', () => {
     expect(screen.queryByText(/say who is in it/i)).not.toBeInTheDocument()
   })
 
-  it('clears a write-in in one click, writing null rather than a value that agrees, and names what it clears (#2252)', async () => {
-    // `null` DELETES the row. Writing "available" onto a family cabin instead
-    // would pin it against a later change to its role -- the reversal-encoding
-    // failure spec §5.4 rejected, arriving through the UI.
-    //
-    // The exact button name is the assertion: kindred#2252 dropped the
-    // redundant "Write-in" chip from `LodgingUnitCard`'s badge row, which
-    // made this the only thing on the card saying what a click removes. A
-    // bare "Clear" would pass the loose `/clear/i` query this used to use.
-    const user = userEvent.setup()
-    const { onSubmit } = renderControl({ unit: WRITTEN_IN_CABIN })
+  it('offers NOTHING on a written-into cabin — the removal is the X on its card', () => {
+    // kindred#2381, superseding #2252's "Clear Write-in" label here. That
+    // button named whichever row the server resolved first, which was sound
+    // only while a card could carry one write-in. A merged container covers
+    // every write-in beneath it, so one button had four rows to choose from:
+    // each click destroyed the row it named, the card re-populated with the
+    // next occupant, and the action read as a no-op. Each `WriteInCard` owns
+    // its own removal now.
+    renderControl({ unit: WRITTEN_IN_CABIN })
 
-    await user.click(screen.getByRole('button', { name: 'Clear Write-in Cedar 1' }))
-
-    expect(onSubmit).toHaveBeenCalledWith({
-      unitId: 'u1',
-      unitName: 'Cedar 1',
-      familyAvailable: null,
-      occupantName: '',
-      reason: '',
-    })
-    expect(screen.queryByRole('textbox', { name: /^occupant$/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 
   it('leaves a write-in\u2019s note to the occupant card and prints no italic line of its own', () => {
@@ -323,7 +312,7 @@ describe('UnitAvailabilityControl', () => {
     // on one card, which is the double-print 1500000148 was written to avoid.
     renderControl({
       unit: unit({
-        write_in: cover({ note: 'Back Monday' }),
+        write_ins: [cover({ note: 'Back Monday' })],
         occupant_name: 'Emma Johnson',
         reason: 'Back Monday',
         is_family_available: false,
@@ -357,9 +346,12 @@ describe('UnitAvailabilityControl', () => {
 
   it('does not offer a second write while this unit is being written', async () => {
     const user = userEvent.setup()
-    const { onSubmit } = renderControl({ unit: WRITTEN_IN_CABIN, isSaving: true })
+    const { onSubmit } = renderControl({
+      unit: unit({ family_available_override: true }),
+      isSaving: true,
+    })
 
-    await user.click(screen.getByRole('button', { name: 'Clear Write-in Cedar 1' }))
+    await user.click(screen.getByRole('button', { name: 'Clear Cedar 1' }))
 
     expect(onSubmit).not.toHaveBeenCalled()
   })
@@ -431,38 +423,28 @@ describe('a write-in this unit inherited from elsewhere in the tree', () => {
   /*
    * The row names one unit; it closes a SPACE. Split a written-into building
    * and its rooms inherit the write-in — and the building, having no card any
-   * more, has nowhere to offer the clear from. So the inheriting card offers
-   * it, and the write has to name the unit that HOLDS the row: sending this
-   * card's own id would delete nothing.
+   * more, has nowhere to offer a removal from. The inheriting CARD carries it,
+   * as the X on the `WriteInCard` it draws in its well (kindred#2381); this
+   * strip resolves ROLE rows only and stays out of it.
    */
   const ROOM_UNDER_A_WRITTEN_IN_HOUSE = unit({
     unit_id: 'u-room',
     code: 'house-a',
     name: 'House A',
-    write_in: {
-      unit_id: 'u-house',
-      unit_code: 'house',
-      unit_name: 'House',
-      occupant_name: 'Liam Garcia',
-      note: '',
-    },
+    write_ins: [
+      {
+        unit_id: 'u-house',
+        unit_code: 'house',
+        unit_name: 'House',
+        occupant_name: 'Liam Garcia',
+        note: '',
+      },
+    ],
   })
 
-  it('offers to clear it, labelled "Clear Write-in" and naming the unit that actually holds the row (#2252)', async () => {
-    // The button reads on the INHERITING card ("House A"), and the label is
-    // still "Clear Write-in" there — the relabel is keyed on what the action
-    // clears, not on whose own row it happens to be.
-    const user = userEvent.setup()
-    const { onSubmit } = renderControl({ unit: ROOM_UNDER_A_WRITTEN_IN_HOUSE })
+  it('offers no strip action at all, rather than one that names a row out of several', () => {
+    renderControl({ unit: ROOM_UNDER_A_WRITTEN_IN_HOUSE })
 
-    await user.click(screen.getByRole('button', { name: 'Clear Write-in House A' }))
-
-    expect(onSubmit).toHaveBeenCalledWith({
-      unitId: 'u-house',
-      unitName: 'House',
-      familyAvailable: null,
-      occupantName: '',
-      reason: '',
-    })
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/weekend/UnitAvailabilityControl.tsx
+++ b/frontend/src/components/weekend/UnitAvailabilityControl.tsx
@@ -41,6 +41,17 @@
  * and have no way to learn who is in it. Clearing asks for neither: it restores
  * the unit's standing role rather than asserting anything.
  *
+ * ## What this control no longer does
+ *
+ * REMOVE A WRITE-IN. Until kindred#2381 it offered a "Clear Write-in" naming
+ * whichever row the server resolved first, which held only while a card could
+ * carry one. A merged container covers every write-in beneath it, so one
+ * button had four rows to choose from and picked silently: each click removed
+ * the row it named, the card re-populated with the next occupant, and the
+ * action read as a no-op while it worked through them. Removal is the X on
+ * each `WriteInCard` now, and `availabilityAction` returns null for a
+ * written-into space rather than a clear this control could offer.
+ *
  * ## Why no italic line under the badge row any more
  *
  * It used to print `unit.reason` there for every override. Since kindred#2078 a
@@ -61,12 +72,14 @@ export interface UnitAvailabilityWrite {
    *
    * A write-in covers a space and the board draws whichever level the unit
    * tree resolves to, so a room can inherit its building's write-in and a
-   * merged building one of its rooms'. There is one `lodging_write_ins` row
-   * either way (kindred#2382 moved occupancy off `lodging_availability`, which
-   * now answers only the staff↔family role), and clearing it has to target the
-   * unit that HOLDS it — the card's own id would delete nothing, and the unit
-   * holding the row has no card to offer the clear from. `availabilityAction`
-   * resolves which; this only carries it.
+   * merged building one of its rooms'. Removing one has to target the unit
+   * that HOLDS the row — the card's own id would delete nothing, and the unit
+   * holding the row has no card of its own.
+   *
+   * TWO CALLERS SINCE kindred#2381, and only one of them is this control.
+   * `availabilityAction` resolves a ROLE row and always names the card's own
+   * unit; each `WriteInCard`'s corner X sends this same write bound to the row
+   * that card draws. The field carries the target either way.
    */
   unitId: string
   /** That unit's name, for the confirmation toast. */

--- a/frontend/src/components/weekend/UnitAvailabilityControl.tsx
+++ b/frontend/src/components/weekend/UnitAvailabilityControl.tsx
@@ -109,15 +109,6 @@ export interface UnitAvailabilityControlProps {
    * the board it was made on — see `useUnitAvailability`.
    */
   canManage: boolean
-  /**
-   * Whether the slot this unit sits in already holds a party this scenario —
-   * a fact read off the CARD, never off availability itself. Owner ruling on
-   * #2090: a write-in and a placement are mutually exclusive states, so an
-   * occupied unit offers no write-in action. Kept separate from `canManage`:
-   * folding occupancy into the permission gate would resurrect the scenario
-   * dimension 1500000135 deleted.
-   */
-  occupied: boolean
   /** True while THIS unit's write is in flight. */
   isSaving: boolean
   onSubmit: (write: UnitAvailabilityWrite) => void
@@ -126,19 +117,16 @@ export interface UnitAvailabilityControlProps {
 export function UnitAvailabilityControl({
   unit,
   canManage,
-  occupied,
   isSaving,
   onSubmit,
 }: UnitAvailabilityControlProps) {
-  // The REQUIRED field of whichever prompt is showing — an occupant for a
-  // write-in, a reason for a release. One piece of state, because exactly one
-  // of the two is ever mounted and a second would be dead on every render.
+  // The REQUIRED field of the one prompt that still exists: a release's
+  // reason. It was shared with the write-in's occupant field until the
+  // 2026-08-18 ruling moved write-in creation onto the card's family box.
   const [required, setRequired] = useState('')
-  // The optional note, mounted only by the write-in prompt.
-  const [note, setNote] = useState('')
   const [isOpen, setIsOpen] = useState(false)
   const [wantsRequired, setWantsRequired] = useState(false)
-  const action = availabilityAction(unit, occupied)
+  const action = availabilityAction(unit)
 
   const close = () => {
     setIsOpen(false)
@@ -146,7 +134,6 @@ export function UnitAvailabilityControl({
     // Cleared on the way out, not on the way in: an entry left over from an
     // abandoned edit is how one cabin's occupant ends up written into another.
     setRequired('')
-    setNote('')
   }
 
   // Shown to everyone, including a reader without `bunking.manage`. Knowing a
@@ -165,11 +152,12 @@ export function UnitAvailabilityControl({
   if (action === null || !canManage) return explanation
 
   if (isOpen && action.prompt !== 'none') {
-    const askingOccupant = action.prompt === 'occupant'
-    const requiredLabel = askingOccupant ? 'Occupant' : 'Reason'
-    const refusal = askingOccupant
-      ? 'Say who is in it, so next week’s staff know who to ask.'
-      : 'Say why, so next week’s staff can act on it.'
+    // ONE prompt reaches here now — a release's reason. The write-in's
+    // "Occupant" + optional "Note" pair went with the action that asked for
+    // it: a write-in is created by typing into the card's own family box, and
+    // its note is edited by the pencil on its own `WriteInCard`.
+    const requiredLabel = 'Reason'
+    const refusal = 'Say why, so next week’s staff can act on it.'
 
     return (
       <>
@@ -194,12 +182,10 @@ export function UnitAvailabilityControl({
               unitId: action.unitId,
               unitName: action.unitName,
               familyAvailable: action.familyAvailable,
-              // The note NEVER stands in for the occupant, and the occupant
-              // never doubles as the note: two fields, two facts. Collapsing
-              // them is the state 1500000148 spent two guarded statements
-              // unwinding.
-              occupantName: askingOccupant ? trimmed : '',
-              reason: askingOccupant ? note.trim() : trimmed,
+              // A release names no occupant, so this is always empty — the
+              // one prompt left asks for a reason and nothing else.
+              occupantName: '',
+              reason: trimmed,
             })
             close()
           }}
@@ -207,12 +193,12 @@ export function UnitAvailabilityControl({
           <input
             type="text"
             aria-label={requiredLabel}
-            placeholder={askingOccupant ? 'Emma Johnson, burst pipe…' : 'Burst pipe, caretaker…'}
+            placeholder="Burst pipe, caretaker…"
             value={required}
             maxLength={500}
-            // deliberate: this input only mounts when the staff member just clicked
-            // "Write in"/"Release" (a modal-open equivalent), and the whole point of the
-            // click is to type into it next.
+            // deliberate: this input only mounts when the staff member just
+            // clicked "Release" (a modal-open equivalent), and the whole point
+            // of the click is to type into it next.
             autoFocus
             aria-invalid={wantsRequired && required.trim() === ''}
             onChange={(event) => {
@@ -221,23 +207,6 @@ export function UnitAvailabilityControl({
             }}
             className="border-border bg-background text-foreground placeholder:text-muted-foreground/60 focus:border-primary/50 focus:ring-primary/10 w-full rounded-md border px-1.5 py-1 text-sm focus:ring-2 focus:outline-none aria-[invalid=true]:border-amber-500"
           />
-          {/* OPTIONAL, and only beside a write-in. It carries the "say why, so
-              next week's staff can act on it" affordance a bare name loses —
-              prospectively: 1500000148 cleared the note of every row it moved,
-              so this column is empty on all of them and that is correct. */}
-          {askingOccupant && (
-            <input
-              type="text"
-              aria-label="Note (optional)"
-              placeholder="Note (optional) — back Monday…"
-              value={note}
-              maxLength={500}
-              onChange={(event) => {
-                setNote(event.target.value)
-              }}
-              className="border-border bg-background text-foreground placeholder:text-muted-foreground/60 focus:border-primary/50 focus:ring-primary/10 w-full rounded-md border px-1.5 py-1 text-sm focus:ring-2 focus:outline-none"
-            />
-          )}
           {wantsRequired && required.trim() === '' && (
             <span className="text-xs font-medium text-amber-700 dark:text-amber-400">
               {refusal}

--- a/frontend/src/components/weekend/WriteInCard.test.tsx
+++ b/frontend/src/components/weekend/WriteInCard.test.tsx
@@ -90,52 +90,6 @@ describe('WriteInCard', () => {
   })
 })
 
-describe('a write-in the card INHERITED from elsewhere in the tree', () => {
-  /*
-   * The row names one unit; it closes a SPACE. Split a written-into building
-   * and its rooms carry the occupant; merge over a written-into room and the
-   * building does.
-   *
-   * RESTORED during review of kindred#2381, which deleted this line along with
-   * the strip's single "Clear Write-in". Only one of the two reasons it carried
-   * died with that button — "go and find the Clear on a card the merge took
-   * away". The other is identity, and the plural well sharpens it: four
-   * occupants in one merged well sleep in four different rooms, and every room
-   * of a SPLIT building draws a card for the one row the building holds, so
-   * each card's X empties all the others.
-   */
-  it('says which unit the write-in is recorded at', () => {
-    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} atUnitName="House" />)
-
-    expect(screen.getByText('Written in at House')).toBeInTheDocument()
-  })
-
-  it('says nothing extra when the row is the card\u2019s own', () => {
-    // The overwhelmingly common case, and the one that must stay quiet: a line
-    // on every written-into card restating the card's own name is chrome.
-    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} />)
-
-    expect(screen.queryByText(/^Written in at/)).not.toBeInTheDocument()
-  })
-
-  it('keeps saying it beside the corner controls, not instead of them', () => {
-    // The line and the per-row X answer different questions — WHERE the row
-    // is, and REMOVE this row — so neither replaces the other.
-    render(
-      <WriteInCard
-        occupant={{ name: 'Liam Garcia', note: '' }}
-        atUnitName="House Loft"
-        onRemove={() => undefined}
-        onEdit={() => undefined}
-      />
-    )
-
-    expect(screen.getByText('Written in at House Loft')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Remove write-in Liam Garcia' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Edit write-in Liam Garcia' })).toBeInTheDocument()
-  })
-})
-
 describe('the corner control that removes THIS write-in', () => {
   /*
    * Owner ruling, 2026-08-18 (kindred#2381 part 4): a small X in each card's
@@ -349,12 +303,22 @@ describe('the corner control that edits THIS write-in (kindred#2430)', () => {
 
 describe('the "Written in at …" footer', () => {
   /*
-   * DELETED — kindred#2381. It existed to tell a reader that the row lives on
-   * a different unit than the card drawing it, which mattered only because a
-   * merged card showed ONE write-in and hid the rest: staff would go looking
-   * for the Clear on a card the merge had taken away. Every write-in is drawn
-   * now, and each carries its own removal, so the note says nothing the screen
-   * does not.
+   * DELETED TWICE, and the second time is the one that sticks.
+   *
+   * kindred#2381 struck it: it existed to say the row lives on a different
+   * unit than the card drawing it, which mattered only because a merged card
+   * showed ONE write-in and hid the rest, sending staff to look for the Clear
+   * on a card the merge had taken away. Every write-in is drawn now, each with
+   * its own removal.
+   *
+   * Review then RESTORED it on an identity argument — four occupants in one
+   * merged well sleep in four rooms. The owner struck it again on 2026-08-18,
+   * and the argument against is that the identity claim is true of FAMILIES in
+   * that well too, and this line said nothing about them. A merged card that
+   * explains its write-ins' rooms while staying silent about its families' is
+   * worse than one that explains neither. The room dimension belongs to one
+   * shorthand covering every occupant — kindred#2458 — and this footer was a
+   * half-built version of it.
    */
   it('is not printed, on an inherited row or any other', () => {
     render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} onRemove={() => undefined} />)

--- a/frontend/src/components/weekend/WriteInCard.test.tsx
+++ b/frontend/src/components/weekend/WriteInCard.test.tsx
@@ -62,6 +62,20 @@ describe('WriteInCard', () => {
     expect(container.querySelector('[draggable="true"]')).toBeNull()
   })
 
+  it('wraps a long occupant name instead of truncating it (kindred#2431)', () => {
+    // Owner ruling, 2026-08-18: WRAP, following the #2253 precedent — a
+    // truncated name is not a shorter name, it is a different one, and two
+    // write-ins sharing a prefix would render identically.
+    render(<WriteInCard occupant={{ name: 'Alexandra Vandenberg-Okonkwo', note: '' }} />)
+
+    const nameSpan = screen.getByText('Alexandra Vandenberg-Okonkwo')
+    expect(nameSpan.className).not.toMatch(/\btruncate\b/)
+    // `min-w-0` STAYS: it is what lets the flex child shrink below its
+    // content width, which is what makes it wrap rather than overflow the
+    // card (same reasoning `HouseholdJourneyCard` records for its own span).
+    expect(nameSpan.className).toMatch(/\bmin-w-0\b/)
+  })
+
   it("wears FamilyCard's frame verbatim, so the two cannot drift apart", () => {
     // A SOURCE assertion, not a rendered one, and deliberately so. `CARD_FRAME`
     // is module-private to `FamilyCard.tsx` and that file is owned by another
@@ -122,16 +136,148 @@ describe('the corner control that removes THIS write-in', () => {
     expect(onRemove).toHaveBeenCalledTimes(1)
   })
 
-  it('is disabled while the removal is in flight', () => {
+  it('is disabled while a write to this row is in flight', () => {
+    // RENAMED from `isRemoving` (kindred#2430): the flag now gates the edit
+    // pencil too, since both controls write the same row.
     render(
       <WriteInCard
         occupant={{ name: 'Liam Garcia', note: '' }}
         onRemove={() => undefined}
-        isRemoving
+        onEdit={() => undefined}
+        isSaving
       />
     )
 
     expect(screen.getByRole('button', { name: 'Remove write-in Liam Garcia' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Edit write-in Liam Garcia' })).toBeDisabled()
+  })
+})
+
+describe('the corner control that edits THIS write-in (kindred#2430)', () => {
+  /*
+   * Owner ruling, 2026-08-18 (supersedes an earlier same-day HOLD): a small
+   * pencil, ALWAYS VISIBLE, beside #2381's X — not shown only on hover
+   * (staff could not find the edit path in the first place, so a hidden
+   * control does not fix that) and not click-the-card (`WriteInCard.tsx:18`
+   * documents the card as deliberately not a button; a discrete control
+   * preserves that rather than reversing it).
+   *
+   * No API change: `set_availability` already upserts a write-in's row
+   * (`_upsert_row(what='write-in', ...)` in
+   * `api/services/lodging_write_service.py`), so a second write to the same
+   * row updates it in place. This control only has to collect the edit and
+   * send the same shape `UnitAvailabilityControl`'s occupant prompt does.
+   */
+  it('is absent when the reader cannot edit', () => {
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} />)
+
+    expect(screen.queryByRole('button', { name: /edit write-in/i })).not.toBeInTheDocument()
+  })
+
+  it('renders beside the X with no hover-only class — ALWAYS visible', () => {
+    render(
+      <WriteInCard
+        occupant={{ name: 'Liam Garcia', note: '' }}
+        onRemove={() => undefined}
+        onEdit={() => undefined}
+      />
+    )
+
+    const pencil = screen.getByRole('button', { name: 'Edit write-in Liam Garcia' })
+    // A hover-reveal control would still be IN the DOM (CSS hides it), so
+    // presence alone cannot tell the two apart — the className has to be
+    // checked for the classes that would make it hover-only.
+    expect(pencil.className).not.toMatch(/opacity-0/)
+    expect(pencil.className).not.toMatch(/group-hover/)
+    expect(screen.getByRole('button', { name: 'Remove write-in Liam Garcia' })).toBeInTheDocument()
+  })
+
+  it('still offers an edit for a write-in nobody named', () => {
+    render(<WriteInCard occupant={{ name: '', note: '' }} onEdit={() => undefined} />)
+
+    expect(
+      screen.getByRole('button', { name: 'Edit write-in Occupant not named' })
+    ).toBeInTheDocument()
+  })
+
+  it('opens an inline form pre-filled with the occupant and note already on the row', () => {
+    render(
+      <WriteInCard
+        occupant={{ name: 'Liam Garcia', note: 'Kitchen lead, Fri–Sun' }}
+        onEdit={() => undefined}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit write-in Liam Garcia' }))
+
+    expect(screen.getByRole('textbox', { name: 'Occupant' })).toHaveValue('Liam Garcia')
+    expect(screen.getByRole('textbox', { name: 'Note (optional)' })).toHaveValue(
+      'Kitchen lead, Fri–Sun'
+    )
+  })
+
+  it('calls back once with the trimmed occupant and note, and closes the form', () => {
+    const onEdit = vi.fn()
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} onEdit={onEdit} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit write-in Liam Garcia' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Occupant' }), {
+      target: { value: '  Liam Garcia-Reyes  ' },
+    })
+    fireEvent.change(screen.getByRole('textbox', { name: 'Note (optional)' }), {
+      target: { value: 'Back Monday' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(onEdit).toHaveBeenCalledTimes(1)
+    expect(onEdit).toHaveBeenCalledWith({
+      occupantName: 'Liam Garcia-Reyes',
+      reason: 'Back Monday',
+    })
+    expect(screen.queryByRole('textbox', { name: 'Occupant' })).not.toBeInTheDocument()
+  })
+
+  it('refuses an empty occupant name, the same guard the write-in prompt uses', () => {
+    const onEdit = vi.fn()
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} onEdit={onEdit} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit write-in Liam Garcia' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Occupant' }), { target: { value: '  ' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(onEdit).not.toHaveBeenCalled()
+    expect(screen.getByRole('textbox', { name: 'Occupant' })).toBeInTheDocument()
+  })
+
+  it('lets Cancel close the form without writing anything', () => {
+    const onEdit = vi.fn()
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} onEdit={onEdit} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit write-in Liam Garcia' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Occupant' }), {
+      target: { value: 'Somebody Else' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(onEdit).not.toHaveBeenCalled()
+    expect(screen.queryByRole('textbox', { name: 'Occupant' })).not.toBeInTheDocument()
+    // The original label is still what the card prints — nothing was
+    // written, so nothing changed.
+    expect(screen.getByText('Liam Garcia')).toBeInTheDocument()
+  })
+
+  it('re-opens pre-filled from the CURRENT row, not a stale draft left over from a cancelled edit', () => {
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} onEdit={() => undefined} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit write-in Liam Garcia' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Occupant' }), {
+      target: { value: 'Abandoned Draft' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit write-in Liam Garcia' }))
+
+    expect(screen.getByRole('textbox', { name: 'Occupant' })).toHaveValue('Liam Garcia')
   })
 })
 

--- a/frontend/src/components/weekend/WriteInCard.test.tsx
+++ b/frontend/src/components/weekend/WriteInCard.test.tsx
@@ -6,8 +6,8 @@
 import { readFileSync } from 'fs'
 import { resolve } from 'path'
 
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
 
 import { WriteInCard, WRITE_IN_FRAME } from './WriteInCard'
 
@@ -51,10 +51,11 @@ describe('WriteInCard', () => {
     expect(container.querySelector('[data-family-card]')).toBeNull()
   })
 
-  it('is not draggable and is not a button', () => {
+  it('is not draggable, and the CARD itself is never a button', () => {
     // `FamilyCard` is a `<button>` that opens the family panel and a dnd-kit
     // draggable. There is no panel behind a write-in and nowhere to drag it —
-    // a control that looks interactive and is not is worse than plain text.
+    // a card that looks interactive and is not is worse than plain text. The
+    // corner control below is a real button; the card body stays inert.
     const { container } = render(<WriteInCard occupant={{ name: 'Emma Johnson', note: '' }} />)
 
     expect(screen.queryByRole('button')).not.toBeInTheDocument()
@@ -75,24 +76,76 @@ describe('WriteInCard', () => {
   })
 })
 
-describe('a write-in the card INHERITED from elsewhere in the tree', () => {
+describe('the corner control that removes THIS write-in', () => {
   /*
-   * The row names one unit; it closes a SPACE. Split a written-into building
-   * and its rooms carry the occupant; merge over a written-into room and the
-   * building does. Printing the name alone on the inheriting card would say
-   * this room's own row names them — and staff would go looking on a card that
-   * no longer exists for the Clear that is right in front of them.
+   * Owner ruling, 2026-08-18 (kindred#2381 part 4): a small X in each card's
+   * top-right, one per write-in — not a row of full "Clear Write-in" buttons,
+   * which was refused, and not one control for a well that may hold four.
+   *
+   * It is what makes the plural card safe. The single control it replaces
+   * named whichever row the server resolved first, so on a merged building
+   * carrying four write-ins a click removed one, the card re-populated with
+   * the next occupant, and the action read as a no-op — four clicks destroyed
+   * four rows with nothing ever disclosing that more than one existed.
    */
-  it('says which unit the write-in is recorded at', () => {
-    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} atUnitName="House" />)
+  it('is absent when the reader cannot remove anything', () => {
+    // No `bunking.manage`, and therefore no handler. A control that does
+    // nothing is worse than no control.
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} />)
 
-    expect(screen.getByText('Written in at House')).toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 
-  it('says nothing extra when the row is the card’s own', () => {
-    // The overwhelmingly common case, and the one that must stay quiet: a line
-    // on every written-into card restating the card's own name is chrome.
-    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} />)
+  it('names the occupant it would remove, so four of them are four questions', () => {
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} onRemove={() => undefined} />)
+
+    expect(screen.getByRole('button', { name: 'Remove write-in Liam Garcia' })).toBeInTheDocument()
+  })
+
+  it('still offers a removal for a write-in nobody named', () => {
+    render(<WriteInCard occupant={{ name: '', note: '' }} onRemove={() => undefined} />)
+
+    expect(
+      screen.getByRole('button', { name: 'Remove write-in Occupant not named' })
+    ).toBeInTheDocument()
+  })
+
+  it('calls back exactly once, with no argument to get wrong', () => {
+    // The CARD knows which row it draws; the caller binds the target. Passing
+    // an id up from here would be a second place that has to agree about
+    // which of the four rows this card is.
+    const onRemove = vi.fn()
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} onRemove={onRemove} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove write-in Liam Garcia' }))
+
+    expect(onRemove).toHaveBeenCalledTimes(1)
+  })
+
+  it('is disabled while the removal is in flight', () => {
+    render(
+      <WriteInCard
+        occupant={{ name: 'Liam Garcia', note: '' }}
+        onRemove={() => undefined}
+        isRemoving
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Remove write-in Liam Garcia' })).toBeDisabled()
+  })
+})
+
+describe('the "Written in at …" footer', () => {
+  /*
+   * DELETED — kindred#2381. It existed to tell a reader that the row lives on
+   * a different unit than the card drawing it, which mattered only because a
+   * merged card showed ONE write-in and hid the rest: staff would go looking
+   * for the Clear on a card the merge had taken away. Every write-in is drawn
+   * now, and each carries its own removal, so the note says nothing the screen
+   * does not.
+   */
+  it('is not printed, on an inherited row or any other', () => {
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} onRemove={() => undefined} />)
 
     expect(screen.queryByText(/written in at/i)).not.toBeInTheDocument()
   })

--- a/frontend/src/components/weekend/WriteInCard.test.tsx
+++ b/frontend/src/components/weekend/WriteInCard.test.tsx
@@ -90,6 +90,52 @@ describe('WriteInCard', () => {
   })
 })
 
+describe('a write-in the card INHERITED from elsewhere in the tree', () => {
+  /*
+   * The row names one unit; it closes a SPACE. Split a written-into building
+   * and its rooms carry the occupant; merge over a written-into room and the
+   * building does.
+   *
+   * RESTORED during review of kindred#2381, which deleted this line along with
+   * the strip's single "Clear Write-in". Only one of the two reasons it carried
+   * died with that button — "go and find the Clear on a card the merge took
+   * away". The other is identity, and the plural well sharpens it: four
+   * occupants in one merged well sleep in four different rooms, and every room
+   * of a SPLIT building draws a card for the one row the building holds, so
+   * each card's X empties all the others.
+   */
+  it('says which unit the write-in is recorded at', () => {
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} atUnitName="House" />)
+
+    expect(screen.getByText('Written in at House')).toBeInTheDocument()
+  })
+
+  it('says nothing extra when the row is the card\u2019s own', () => {
+    // The overwhelmingly common case, and the one that must stay quiet: a line
+    // on every written-into card restating the card's own name is chrome.
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} />)
+
+    expect(screen.queryByText(/^Written in at/)).not.toBeInTheDocument()
+  })
+
+  it('keeps saying it beside the corner controls, not instead of them', () => {
+    // The line and the per-row X answer different questions — WHERE the row
+    // is, and REMOVE this row — so neither replaces the other.
+    render(
+      <WriteInCard
+        occupant={{ name: 'Liam Garcia', note: '' }}
+        atUnitName="House Loft"
+        onRemove={() => undefined}
+        onEdit={() => undefined}
+      />
+    )
+
+    expect(screen.getByText('Written in at House Loft')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Remove write-in Liam Garcia' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Edit write-in Liam Garcia' })).toBeInTheDocument()
+  })
+})
+
 describe('the corner control that removes THIS write-in', () => {
   /*
    * Owner ruling, 2026-08-18 (kindred#2381 part 4): a small X in each card's
@@ -198,6 +244,26 @@ describe('the corner control that edits THIS write-in (kindred#2430)', () => {
     expect(
       screen.getByRole('button', { name: 'Edit write-in Occupant not named' })
     ).toBeInTheDocument()
+  })
+
+  it('labels both boxes with the prompt\u2019s own placeholders', () => {
+    // The note is EMPTY on every row predating kindred#2078 (1500000148
+    // cleared each one it copied), so without a placeholder the second box is
+    // a blank unlabelled input under the name. Same strings
+    // `UnitAvailabilityControl`'s occupant prompt uses, so one control does
+    // not teach a different vocabulary from the other.
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} onEdit={() => undefined} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit write-in Liam Garcia' }))
+
+    expect(screen.getByRole('textbox', { name: 'Occupant' })).toHaveAttribute(
+      'placeholder',
+      'Emma Johnson, burst pipe…'
+    )
+    expect(screen.getByRole('textbox', { name: 'Note (optional)' })).toHaveAttribute(
+      'placeholder',
+      'Note (optional) — back Monday…'
+    )
   })
 
   it('opens an inline form pre-filled with the occupant and note already on the row', () => {

--- a/frontend/src/components/weekend/WriteInCard.tsx
+++ b/frontend/src/components/weekend/WriteInCard.tsx
@@ -62,6 +62,32 @@
  * display-name convention to fall back on — the same argument #2253 made
  * for a housing name, stronger here because there is no shorter form at all.
  *
+ * ## WHOSE row it is, printed when it is not this card's own
+ *
+ * Restored during review of kindred#2381 after being deleted with it. The
+ * line had TWO reasons in the code that carried it and only one of them —
+ * "go and find the Clear on the card the merge took away" — died with the
+ * per-card X. The other is identity, and the plural well makes it sharper
+ * rather than redundant:
+ *
+ *   - MERGE. The one 2026 container carrying four write-ins holds them on
+ *     four different rooms — a loft, a side room, a back room and a laundry.
+ *     Four names in one well with no room beside them does not tell a staff
+ *     member where anybody is sleeping.
+ *   - SPLIT. Split a written-into building and every room draws a card for
+ *     the SAME row. Without this line each room asserts its own row names
+ *     that person, and each card's X — all of them pointed at the one
+ *     building row — empties all the others too, with nothing on screen
+ *     saying why.
+ *   - Two rows whose occupants are named alike, or both unnamed (`UNNAMED`
+ *     below is a state a legacy row can be in), otherwise render as two
+ *     identical cards. That is the same objection kindred#2431 above makes
+ *     to truncating a name, one card over.
+ *
+ * Undefined on the card whose own row it is, which is the overwhelmingly
+ * common case — a line restating the card's own name on every written-into
+ * card is chrome staff learn to read past.
+ *
  * ## The edit control, kindred#2430
  *
  * Owner ruling, 2026-08-18 (supersedes an earlier same-day HOLD): a small
@@ -109,11 +135,31 @@ export interface WriteInCardProps {
    * second permission flag here.
    */
   onEdit?: (write: { occupantName: string; reason: string }) => void
-  /** True while a write to THIS row — a removal or an edit — is in flight. */
+  /**
+   * The unit the row is recorded at, when that is NOT the card drawing this.
+   *
+   * See "WHOSE row it is" above. Undefined on the card whose own row it is.
+   */
+  atUnitName?: string | undefined
+  /**
+   * True while a write this card's controls are waiting on is in flight.
+   *
+   * Card-level rather than row-level at the only caller: `LodgingBoard` knows
+   * one `pendingUnitId` and `LodgingUnitCard` passes the same answer to every
+   * `WriteInCard` in its well, so a write to one row disables the corner
+   * controls on all of them. Deliberately the conservative direction — the
+   * alternative leaves an X live beside a row that is already going away.
+   */
   isSaving?: boolean
 }
 
-export function WriteInCard({ occupant, onRemove, onEdit, isSaving = false }: WriteInCardProps) {
+export function WriteInCard({
+  occupant,
+  onRemove,
+  onEdit,
+  atUnitName,
+  isSaving = false,
+}: WriteInCardProps) {
   const named = occupant.name !== ''
   const label = named ? occupant.name : UNNAMED
 
@@ -161,6 +207,12 @@ export function WriteInCard({ occupant, onRemove, onEdit, isSaving = false }: Wr
           <input
             type="text"
             aria-label="Occupant"
+            // THE SAME PLACEHOLDERS `UnitAvailabilityControl`'s occupant
+            // prompt uses. Not decoration on the second box: 1500000148
+            // cleared the note of every row it moved, so an edit opened on
+            // any pre-existing write-in shows an empty, otherwise unlabelled
+            // input under the name.
+            placeholder="Emma Johnson, burst pipe…"
             value={draftName}
             maxLength={500}
             autoFocus
@@ -174,6 +226,7 @@ export function WriteInCard({ occupant, onRemove, onEdit, isSaving = false }: Wr
           <input
             type="text"
             aria-label="Note (optional)"
+            placeholder="Note (optional) — back Monday…"
             value={draftNote}
             maxLength={500}
             onChange={(event) => {
@@ -268,13 +321,16 @@ export function WriteInCard({ occupant, onRemove, onEdit, isSaving = false }: Wr
         // migration onward. That emptiness is correct, not a bug.
         <span className="text-muted-foreground text-xs leading-tight">{occupant.note}</span>
       )}
-      {/* NO "Written in at …" FOOTER. It told a reader the row lives on a unit
-          other than the card drawing it, which was worth saying only while a
-          merged card showed ONE write-in and hid the rest — the note existed to
-          send staff to the Clear on a card the merge had taken away. Every
-          write-in is drawn now and each carries its own removal, so the line
-          would restate what the reader can see. Deleted with its prop
-          (kindred#2381), so nothing can pass one in by habit. */}
+      {atUnitName !== undefined && atUnitName !== '' && (
+        // WHERE the row lives, not a second occupant fact — which is why it
+        // sits under the note in the same muted key rather than beside the
+        // name. Four occupants in one merged well are four rooms, and the X
+        // on each of a split building's room cards points at the one row they
+        // all draw; neither is legible without this line.
+        <span className="text-muted-foreground text-xs leading-tight italic">
+          {`Written in at ${atUnitName}`}
+        </span>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/weekend/WriteInCard.tsx
+++ b/frontend/src/components/weekend/WriteInCard.tsx
@@ -136,12 +136,6 @@ export interface WriteInCardProps {
    */
   onEdit?: (write: { occupantName: string; reason: string }) => void
   /**
-   * The unit the row is recorded at, when that is NOT the card drawing this.
-   *
-   * See "WHOSE row it is" above. Undefined on the card whose own row it is.
-   */
-  atUnitName?: string | undefined
-  /**
    * True while a write this card's controls are waiting on is in flight.
    *
    * Card-level rather than row-level at the only caller: `LodgingBoard` knows
@@ -153,13 +147,7 @@ export interface WriteInCardProps {
   isSaving?: boolean
 }
 
-export function WriteInCard({
-  occupant,
-  onRemove,
-  onEdit,
-  atUnitName,
-  isSaving = false,
-}: WriteInCardProps) {
+export function WriteInCard({ occupant, onRemove, onEdit, isSaving = false }: WriteInCardProps) {
   const named = occupant.name !== ''
   const label = named ? occupant.name : UNNAMED
 
@@ -321,16 +309,14 @@ export function WriteInCard({
         // migration onward. That emptiness is correct, not a bug.
         <span className="text-muted-foreground text-xs leading-tight">{occupant.note}</span>
       )}
-      {atUnitName !== undefined && atUnitName !== '' && (
-        // WHERE the row lives, not a second occupant fact — which is why it
-        // sits under the note in the same muted key rather than beside the
-        // name. Four occupants in one merged well are four rooms, and the X
-        // on each of a split building's room cards points at the one row they
-        // all draw; neither is legible without this line.
-        <span className="text-muted-foreground text-xs leading-tight italic">
-          {`Written in at ${atUnitName}`}
-        </span>
-      )}
+      {/* NO "Written in at …" LINE — struck by the owner, 2026-08-18.
+          It said WHERE the row lives, for a merged well holding several
+          occupants from several rooms. The room dimension is real and still
+          worth showing; what was wrong was showing it once per write-in card
+          and nowhere else, so a merged building explained its write-ins' rooms
+          while saying nothing about its FAMILIES' rooms. That belongs to one
+          shorthand covering every occupant of a merged card — filed as
+          kindred#2458 — and this line was the half-built version of it. */}
     </div>
   )
 }

--- a/frontend/src/components/weekend/WriteInCard.tsx
+++ b/frontend/src/components/weekend/WriteInCard.tsx
@@ -1,5 +1,5 @@
 /**
- * A write-in, drawn in the unit's occupant well — kindred#2078.
+ * A write-in, drawn in the unit's occupant well — kindred#2078, kindred#2381.
  *
  * Owner ruling, 2026-08-09: a hold IS a write-in. What the row records is a
  * person sleeping in the room, almost always non-rostered weekend staff, and
@@ -8,6 +8,17 @@
  * and closed* when in truth it was *full*. This is the same fact, printed
  * where the board prints occupancy.
  *
+ * ## ONE CARD PER WRITE-IN, and the well may hold several
+ *
+ * A merged container draws in place of its rooms, so every write-in beneath it
+ * lands here (kindred#2381). Each card is one row, and its corner control
+ * removes that row and no other — which is what makes the plural well safe.
+ * The single "Clear Write-in" button it replaces named whichever row the
+ * server resolved first, so on the one 2026 building carrying four write-ins a
+ * click removed one, the card silently re-populated with the next occupant,
+ * and four clicks destroyed four rows while the board never disclosed that
+ * more than one existed.
+ *
  * ## Deliberately NOT a `FamilyCard`
  *
  * It wears `FamilyCard`'s frame, and none of its behaviour:
@@ -15,9 +26,13 @@
  *   - no `data-family-card`. Board code queries that selector to find PLACED
  *     parties; a write-in is an occupant, not a placement, and marking it would
  *     count a family in a room no family is in.
- *   - no `useDraggable`, and not a `<button>`. There is no family panel behind
- *     a write-in and nowhere to drag it to, and a control that looks
- *     interactive and is not is worse than plain text.
+ *   - no `useDraggable`, and THE CARD ITSELF is not a `<button>`. There is no
+ *     family panel behind a write-in and nowhere to drag it to, and a card that
+ *     looks interactive and is not is worse than plain text. That reasoning
+ *     survives kindred#2381 intact and is why the removal is a discrete corner
+ *     control rather than "click the card": the card body stays inert, and the
+ *     things that are interactive are visibly buttons. #2430's edit control
+ *     joins this one in the same corner, for the same reason.
  *   - no party-size figure and no chip row. A write-in is a name; nothing else
  *     is known, and a `0` beside it would assert something.
  *
@@ -35,41 +50,67 @@ import type { WriteInOccupant } from './writeIn'
 export const WRITE_IN_FRAME =
   'group border-border flex w-full flex-col gap-1 rounded-xl border-2 p-2.5 text-left'
 
+/** What a card prints when the row named nobody. Also the removal's handle. */
+const UNNAMED = 'Occupant not named'
+
 export interface WriteInCardProps {
   occupant: WriteInOccupant
   /**
-   * The unit the row is recorded at, when that is NOT the card drawing this.
+   * Remove THIS write-in — omitted for a reader who cannot, which is what
+   * hides the control rather than a second permission flag here.
    *
-   * A write-in names one unit and closes a space: split a written-into
-   * building and its rooms carry the occupant, merge over a written-into room
-   * and the building does. Undefined on the card whose own row it is, which is
-   * the overwhelmingly common case — a line restating the card's own name on
-   * every written-into card is chrome staff learn to read past.
+   * NO ARGUMENT. The card knows which of the well's rows it draws and the
+   * caller binds the target, so there is exactly one place that has to agree
+   * about which row a corner X belongs to. Passing an id up would make two.
    */
-  atUnitName?: string | undefined
+  onRemove?: () => void
+  /** True while THIS card's removal is in flight. */
+  isRemoving?: boolean
 }
 
-export function WriteInCard({ occupant, atUnitName }: WriteInCardProps) {
+export function WriteInCard({ occupant, onRemove, isRemoving = false }: WriteInCardProps) {
   const named = occupant.name !== ''
+  const label = named ? occupant.name : UNNAMED
 
   return (
     <div data-write-in-card className={`${WRITE_IN_FRAME} bg-background`}>
-      <span
-        // `FamilyCard`'s own name line, minus the flex row it shares with a
-        // party-size badge this card does not have.
-        className={
-          named
-            ? 'text-foreground min-w-0 truncate text-sm leading-tight font-semibold'
-            : 'text-muted-foreground min-w-0 truncate text-sm leading-tight italic'
-        }
-      >
-        {/* STATED, not left blank. A row can reach here unnamed — the write
-            schema is permissive where the control is not, and a pre-1500000148
-            row with an empty note backfilled to nothing — and an empty card in
-            a closed room reads as an open room the board mysteriously refuses
-            drops on. */}
-        {named ? occupant.name : 'Occupant not named'}
-      </span>
+      {/* The name line and the corner controls, in `FamilyCard`'s own flex row
+          — which this card used to drop because it had no party-size badge to
+          share it with. It has a control to share it with now. */}
+      <div className="flex items-start gap-1">
+        <span
+          className={
+            named
+              ? 'text-foreground min-w-0 flex-1 truncate text-sm leading-tight font-semibold'
+              : 'text-muted-foreground min-w-0 flex-1 truncate text-sm leading-tight italic'
+          }
+        >
+          {/* STATED, not left blank. A row can reach here unnamed — the write
+              schema is permissive where the control is not, and a pre-1500000148
+              row with an empty note backfilled to nothing — and an empty card in
+              a closed room reads as an open room the board mysteriously refuses
+              drops on. */}
+          {label}
+        </span>
+        {onRemove !== undefined && (
+          <button
+            type="button"
+            disabled={isRemoving}
+            // NAMED FOR THE OCCUPANT, not a bare "Remove". A merged building's
+            // well can hold four of these, and four controls called the same
+            // thing are one question asked four times. (`aria-label` here is a
+            // test query handle — see frontend/CLAUDE.md on how minimal this
+            // repo's accessibility is meant to be.)
+            aria-label={`Remove write-in ${label}`}
+            onClick={onRemove}
+            className="text-muted-foreground hover:text-foreground hover:border-foreground/30 border-border flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full border text-[11px] leading-none disabled:opacity-40"
+          >
+            {/* MULTIPLICATION SIGN, not the letter x — the glyph the rest of
+                the board's dismissals use. */}
+            ×
+          </button>
+        )}
+      </div>
       {occupant.note !== '' && (
         // INSIDE the card, where the old italic line sat above it: the note
         // describes the occupant, not the room. Empty on every historical row
@@ -78,16 +119,13 @@ export function WriteInCard({ occupant, atUnitName }: WriteInCardProps) {
         // migration onward. That emptiness is correct, not a bug.
         <span className="text-muted-foreground text-xs leading-tight">{occupant.note}</span>
       )}
-      {atUnitName !== undefined && atUnitName !== '' && (
-        // WHERE the row lives, not a second occupant fact — which is why it
-        // sits under the note in the same muted key rather than beside the
-        // name. Without it the card asserts this room's own row names them,
-        // and the staff member goes looking for the Clear on a card the merge
-        // or split has taken away, when it is on this one.
-        <span className="text-muted-foreground text-xs leading-tight italic">
-          {`Written in at ${atUnitName}`}
-        </span>
-      )}
+      {/* NO "Written in at …" FOOTER. It told a reader the row lives on a unit
+          other than the card drawing it, which was worth saying only while a
+          merged card showed ONE write-in and hid the rest — the note existed to
+          send staff to the Clear on a card the merge had taken away. Every
+          write-in is drawn now and each carries its own removal, so the line
+          would restate what the reader can see. Deleted with its prop
+          (kindred#2381), so nothing can pass one in by habit. */}
     </div>
   )
 }

--- a/frontend/src/components/weekend/WriteInCard.tsx
+++ b/frontend/src/components/weekend/WriteInCard.tsx
@@ -43,7 +43,42 @@
  * else's file. `WriteInCard.test.tsx` reads the literal out of `FamilyCard.tsx`
  * and asserts the two are identical, which makes the copy loud instead of a
  * silent drift waiting to happen.
+ *
+ * ## The name wraps, kindred#2431
+ *
+ * Owner ruling, 2026-08-18, following the #2253 precedent
+ * (`HouseholdJourneyCard.tsx`'s housing span): a truncated name is not a
+ * shorter name, it is a different one — two write-ins that share a prefix
+ * would render identically. `min-w-0` stays on the span even though
+ * `truncate` is gone: it is what lets the flex child shrink below its
+ * content width, which is what makes it wrap rather than push the card
+ * wider than its well.
+ *
+ * A DELIBERATE divergence from summer, per the root CLAUDE.md §4 rule:
+ * summer's direct analog still truncates (`camper/CampJourneyTimeline.tsx`,
+ * the `record.bunkName` span), because a cabin callsign is a short,
+ * fixed-format string with nothing meaningful to lose to an ellipsis. A
+ * write-in's occupant name is staff-typed free text with no alias or
+ * display-name convention to fall back on — the same argument #2253 made
+ * for a housing name, stronger here because there is no shorter form at all.
+ *
+ * ## The edit control, kindred#2430
+ *
+ * Owner ruling, 2026-08-18 (supersedes an earlier same-day HOLD): a small
+ * pencil, ALWAYS VISIBLE, beside the X — not hover-only (the reported
+ * problem was that staff could not FIND an edit path, so a control that
+ * only appears on hover does not fix it) and not click-the-card (which
+ * would reverse the "deliberately NOT a `FamilyCard`" decision above). It
+ * opens an inline form, pre-filled from this row, and writes back through
+ * the same `onSetAvailability` channel `onRemove` already uses — no API
+ * change: `set_availability` upserts a write-in
+ * (`_upsert_row(what='write-in', ...)` in
+ * `api/services/lodging_write_service.py`), so a second write to the same
+ * row updates it rather than duplicating it.
  */
+import { Pencil } from 'lucide-react'
+import { useState } from 'react'
+
 import type { WriteInOccupant } from './writeIn'
 
 /** `FamilyCard`'s `CARD_FRAME`, verbatim. Pinned by this module's test. */
@@ -64,13 +99,113 @@ export interface WriteInCardProps {
    * about which row a corner X belongs to. Passing an id up would make two.
    */
   onRemove?: () => void
-  /** True while THIS card's removal is in flight. */
-  isRemoving?: boolean
+  /**
+   * Save an edit to THIS write-in's occupant name and note — kindred#2430.
+   *
+   * NO ID, for the same reason `onRemove` takes none: the card knows which
+   * row it draws and the caller binds the target, so there is exactly one
+   * place that has to agree about which of the well's rows this is. Omitted
+   * for a reader who cannot edit, which hides the pencil rather than a
+   * second permission flag here.
+   */
+  onEdit?: (write: { occupantName: string; reason: string }) => void
+  /** True while a write to THIS row — a removal or an edit — is in flight. */
+  isSaving?: boolean
 }
 
-export function WriteInCard({ occupant, onRemove, isRemoving = false }: WriteInCardProps) {
+export function WriteInCard({ occupant, onRemove, onEdit, isSaving = false }: WriteInCardProps) {
   const named = occupant.name !== ''
   const label = named ? occupant.name : UNNAMED
+
+  // Local to this card, never lifted: the well can hold several of these and
+  // each edits independently. Re-seeded from `occupant` every time the form
+  // OPENS (not on every render) so a cancelled edit's draft never survives to
+  // the next open — see `openEdit`.
+  const [isEditing, setIsEditing] = useState(false)
+  const [draftName, setDraftName] = useState(occupant.name)
+  const [draftNote, setDraftNote] = useState(occupant.note)
+  const [wantsName, setWantsName] = useState(false)
+
+  const openEdit = () => {
+    setDraftName(occupant.name)
+    setDraftNote(occupant.note)
+    setWantsName(false)
+    setIsEditing(true)
+  }
+  const closeEdit = () => {
+    setIsEditing(false)
+    setWantsName(false)
+  }
+
+  if (isEditing) {
+    return (
+      <div data-write-in-card className={`${WRITE_IN_FRAME} bg-background`}>
+        <form
+          className="flex w-full flex-col gap-1"
+          onSubmit={(event) => {
+            event.preventDefault()
+            const trimmedName = draftName.trim()
+            // THE SAME GUARD `UnitAvailabilityControl`'s occupant prompt
+            // uses: a write-in that names nobody is a valid state a legacy
+            // row can already be in, but an edit that CLEARS a name is a
+            // staff member erasing who is in the room, which is worth a
+            // refusal rather than a silent write.
+            if (trimmedName === '') {
+              setWantsName(true)
+              return
+            }
+            onEdit?.({ occupantName: trimmedName, reason: draftNote.trim() })
+            closeEdit()
+          }}
+        >
+          <input
+            type="text"
+            aria-label="Occupant"
+            value={draftName}
+            maxLength={500}
+            autoFocus
+            aria-invalid={wantsName && draftName.trim() === ''}
+            onChange={(event) => {
+              setDraftName(event.target.value)
+              setWantsName(false)
+            }}
+            className="border-border bg-background text-foreground placeholder:text-muted-foreground/60 focus:border-primary/50 focus:ring-primary/10 w-full rounded-md border px-1.5 py-1 text-sm focus:ring-2 focus:outline-none aria-[invalid=true]:border-amber-500"
+          />
+          <input
+            type="text"
+            aria-label="Note (optional)"
+            value={draftNote}
+            maxLength={500}
+            onChange={(event) => {
+              setDraftNote(event.target.value)
+            }}
+            className="border-border bg-background text-foreground placeholder:text-muted-foreground/60 focus:border-primary/50 focus:ring-primary/10 w-full rounded-md border px-1.5 py-1 text-sm focus:ring-2 focus:outline-none"
+          />
+          {wantsName && draftName.trim() === '' && (
+            <span className="text-xs font-medium text-amber-700 dark:text-amber-400">
+              Say who is in it, so next week’s staff know who to ask.
+            </span>
+          )}
+          <div className="flex items-center gap-1.5">
+            <button
+              type="submit"
+              disabled={isSaving}
+              className="bg-primary text-primary-foreground rounded-md px-2 py-0.5 text-xs font-medium disabled:opacity-40"
+            >
+              Save
+            </button>
+            <button
+              type="button"
+              onClick={closeEdit}
+              className="text-muted-foreground hover:text-foreground rounded-md px-1.5 py-0.5 text-xs"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </div>
+    )
+  }
 
   return (
     <div data-write-in-card className={`${WRITE_IN_FRAME} bg-background`}>
@@ -81,8 +216,8 @@ export function WriteInCard({ occupant, onRemove, isRemoving = false }: WriteInC
         <span
           className={
             named
-              ? 'text-foreground min-w-0 flex-1 truncate text-sm leading-tight font-semibold'
-              : 'text-muted-foreground min-w-0 flex-1 truncate text-sm leading-tight italic'
+              ? 'text-foreground min-w-0 flex-1 text-sm leading-tight font-semibold'
+              : 'text-muted-foreground min-w-0 flex-1 text-sm leading-tight italic'
           }
         >
           {/* STATED, not left blank. A row can reach here unnamed — the write
@@ -92,10 +227,24 @@ export function WriteInCard({ occupant, onRemove, isRemoving = false }: WriteInC
               drops on. */}
           {label}
         </span>
+        {onEdit !== undefined && (
+          <button
+            type="button"
+            disabled={isSaving}
+            // NAMED FOR THE OCCUPANT, same reason as the X below: four edit
+            // controls called "Edit" on one merged card are one question
+            // asked four times.
+            aria-label={`Edit write-in ${label}`}
+            onClick={openEdit}
+            className="text-muted-foreground hover:text-foreground hover:border-foreground/30 border-border flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full border text-[11px] leading-none disabled:opacity-40"
+          >
+            <Pencil className="h-2.5 w-2.5" />
+          </button>
+        )}
         {onRemove !== undefined && (
           <button
             type="button"
-            disabled={isRemoving}
+            disabled={isSaving}
             // NAMED FOR THE OCCUPANT, not a bare "Remove". A merged building's
             // well can hold four of these, and four controls called the same
             // thing are one question asked four times. (`aria-label` here is a

--- a/frontend/src/components/weekend/dragPlacement.test.ts
+++ b/frontend/src/components/weekend/dragPlacement.test.ts
@@ -330,29 +330,40 @@ describe('resolveDrop', () => {
     ).toEqual({ kind: 'unplace', party: merged })
   })
 
-  it('refuses a drop onto a held unit (#2087) — a hold blocks placement outright', () => {
-    // Owner ruling on #2090: a hold is global and blocks placement, not merely
-    // dimmed. This is the load-bearing check, since `resolveDrop` is the only
-    // path #2080's picker reaches — a `disabled`-only fix would not cover it.
-    const held = unit({ write_ins: [cover()], is_family_available: false })
+  it('accepts a drop onto a WRITTEN-INTO unit — a write-in names an occupant, it does not close the space (#2432)', () => {
+    // THE REVERSAL of #2090, and this is the site that enforced it: `if
+    // (hasWriteIn(unit)) return null`, whose own comment called it "the
+    // load-bearing one". Owner ruling 2026-08-18 — *"we should be able to add
+    // families to any write in space, or add a write in to a family space —
+    // regardless of which came first"* — so this direction (family onto a
+    // written-into space) must go through.
+    //
+    // The case staff reported is one paper registration (recordable ONLY as a
+    // write-in, since it has no CampMinder record) sharing a cabin with one
+    // CampMinder family. Refusing here is what made the one case the control
+    // exists for the one case it would not do.
+    const writtenInto = unit({ write_ins: [cover()], is_family_available: false })
     const p = party()
     expect(
       resolveDrop({
         activeId: partyKey(p),
         overId: unitDroppableId('cedar-1'),
         parties: [p],
-        units: [held],
+        units: [writtenInto],
       })
-    ).toBeNull()
+    ).toMatchObject({ kind: 'place', unitId: 'u1', unitCode: 'cedar-1' })
   })
 
-  it('refuses a drop into a ROOM of a building somebody is written into', () => {
-    // The split case. Staff wrote into the whole house while it was merged,
-    // then split it: the row still names the house, which now has no card, and
-    // without the server's resolved cover this drop went through — a family
-    // into a space somebody is already sleeping in, with nothing on screen to
-    // warn them. The refusal reads the COVER, so both directions of the tree
-    // arrive here as the same fact.
+  it('accepts a drop into a ROOM of a building somebody is written into (#2432)', () => {
+    // The split case, reversed with the rest. Staff wrote into the whole house
+    // while it was merged, then split it: the row still names the house, which
+    // now has no card, and the drop lands in one of its rooms.
+    //
+    // This ONE tree walk is what the reversal keeps: the family and the
+    // write-in must land in the same well so the card names both occupants,
+    // and the server's resolved cover is what puts them there whichever level
+    // the board happens to be drawing. What is gone is the refusal that used
+    // to sit on top of it.
     const room = unit({
       code: 'house-a',
       write_ins: [
@@ -373,13 +384,13 @@ describe('resolveDrop', () => {
         parties: [p],
         units: [room],
       })
-    ).toBeNull()
+    ).toMatchObject({ kind: 'place', unitCode: 'house-a' })
   })
 
-  it('refuses a whole-house drop when one of its ROOMS is written into', () => {
-    // The mirror case, and the one that predates the split fix: merge a
-    // building over a written-into room and the room stops being drawn, so the
-    // building's card said nothing about the caretaker in it and took the drop.
+  it('accepts a whole-house drop when one of its ROOMS is written into (#2432)', () => {
+    // The mirror case: merge a building over a written-into room and the room
+    // stops being drawn, so the building's card is where both the write-in and
+    // the placement now read.
     const house = unit({
       code: 'house',
       is_container: true,
@@ -402,7 +413,7 @@ describe('resolveDrop', () => {
         parties: [p],
         units: [house],
       })
-    ).toBeNull()
+    ).toMatchObject({ kind: 'place', unitCode: 'house' })
   })
 
   it('still accepts a drop onto an ordinary unheld unit (regression guard)', () => {
@@ -755,16 +766,17 @@ describe('resolvePickerPlacement', () => {
     })
   })
 
-  it('inherits the held-space refusal rather than adding a second one', () => {
-    // #2087/#2199 put the refusal in `resolveDrop` precisely because #2080
-    // reaches placement without touching a `useDroppable`. A picker-layer
-    // check of its own would be the second copy that comment exists to
-    // prevent.
+  it('inherits the written-into space’s ACCEPTANCE rather than keeping a refusal of its own (#2432)', () => {
+    // The adapter has no rules, which is the whole design — so reversing #2090
+    // in `resolveDrop` reverses it here for free. Pinned in both directions on
+    // purpose: a picker-layer copy of the old refusal would survive the
+    // reversal silently and leave #2080's placement path saying no while drag
+    // said yes.
     const p = party()
-    const held = unit({ write_ins: [cover()], is_family_available: false })
+    const writtenInto = unit({ write_ins: [cover()], is_family_available: false })
     expect(
-      resolvePickerPlacement({ party: p, unitCode: 'cedar-1', parties: [p], units: [held] })
-    ).toBeNull()
+      resolvePickerPlacement({ party: p, unitCode: 'cedar-1', parties: [p], units: [writtenInto] })
+    ).toMatchObject({ kind: 'place', unitCode: 'cedar-1' })
   })
 
   it('refuses a party carrying neither CampMinder id', () => {

--- a/frontend/src/components/weekend/dragPlacement.test.ts
+++ b/frontend/src/components/weekend/dragPlacement.test.ts
@@ -354,6 +354,35 @@ describe('resolveDrop', () => {
     ).toMatchObject({ kind: 'place', unitId: 'u1', unitCode: 'cedar-1' })
   })
 
+  it('accepts a PLACED party moved onto a written-into room — the reported case', () => {
+    /*
+     * The direction the first #2432 pass did not cover in a test: not a fresh
+     * placement from the queue, but a family ALREADY in another cabin dragged
+     * across onto a room that holds a write-in.
+     *
+     * Reported against the worktree: an unplaced family could be added to a
+     * written-into room from the card's box, while the same family already
+     * placed in another cabin could not be dragged there.
+     */
+    const writtenInto = unit({
+      unit_id: 'u2',
+      code: 'cedar-2',
+      name: 'Cedar 2',
+      write_ins: [cover({ unit_id: 'u2', unit_code: 'cedar-2', unit_name: 'Cedar 2' })],
+      is_family_available: false,
+    })
+    const p = party({ unit_code: 'cedar-1', unit_name: 'Cedar 1', unit_codes: ['cedar-1'] })
+
+    expect(
+      resolveDrop({
+        activeId: partyKey(p),
+        overId: unitDroppableId('cedar-2'),
+        parties: [p],
+        units: [CEDAR_1, writtenInto],
+      })
+    ).toMatchObject({ kind: 'place', unitId: 'u2', unitCode: 'cedar-2' })
+  })
+
   it('accepts a drop into a ROOM of a building somebody is written into (#2432)', () => {
     // The split case, reversed with the rest. Staff wrote into the whole house
     // while it was merged, then split it: the row still names the house, which

--- a/frontend/src/components/weekend/dragPlacement.test.ts
+++ b/frontend/src/components/weekend/dragPlacement.test.ts
@@ -334,7 +334,7 @@ describe('resolveDrop', () => {
     // Owner ruling on #2090: a hold is global and blocks placement, not merely
     // dimmed. This is the load-bearing check, since `resolveDrop` is the only
     // path #2080's picker reaches — a `disabled`-only fix would not cover it.
-    const held = unit({ write_in: cover(), is_family_available: false })
+    const held = unit({ write_ins: [cover()], is_family_available: false })
     const p = party()
     expect(
       resolveDrop({
@@ -355,13 +355,15 @@ describe('resolveDrop', () => {
     // arrive here as the same fact.
     const room = unit({
       code: 'house-a',
-      write_in: {
-        unit_id: 'id-house',
-        unit_code: 'house',
-        unit_name: 'House',
-        occupant_name: 'Liam Garcia',
-        note: '',
-      },
+      write_ins: [
+        {
+          unit_id: 'id-house',
+          unit_code: 'house',
+          unit_name: 'House',
+          occupant_name: 'Liam Garcia',
+          note: '',
+        },
+      ],
     })
     const p = party()
     expect(
@@ -382,13 +384,15 @@ describe('resolveDrop', () => {
       code: 'house',
       is_container: true,
       is_combined: true,
-      write_in: {
-        unit_id: 'id-house-a',
-        unit_code: 'house-a',
-        unit_name: 'House A',
-        occupant_name: 'Ava Martinez',
-        note: '',
-      },
+      write_ins: [
+        {
+          unit_id: 'id-house-a',
+          unit_code: 'house-a',
+          unit_name: 'House A',
+          occupant_name: 'Ava Martinez',
+          note: '',
+        },
+      ],
     })
     const p = party()
     expect(
@@ -757,7 +761,7 @@ describe('resolvePickerPlacement', () => {
     // check of its own would be the second copy that comment exists to
     // prevent.
     const p = party()
-    const held = unit({ write_in: cover(), is_family_available: false })
+    const held = unit({ write_ins: [cover()], is_family_available: false })
     expect(
       resolvePickerPlacement({ party: p, unitCode: 'cedar-1', parties: [p], units: [held] })
     ).toBeNull()

--- a/frontend/src/components/weekend/dragPlacement.ts
+++ b/frontend/src/components/weekend/dragPlacement.ts
@@ -23,13 +23,18 @@
  * nine tasks and removed in kindred#1903; `docs/architecture/lodging-occupancy.md`
  * says why, and the reasoning is not obvious. Do not add one here.
  *
+ * **It never refuses a WRITTEN-INTO space.** It did until kindred#2432, on
+ * #2090's ruling that a write-in and a placement were mutually exclusive. They
+ * are not: a write-in names an occupant the system has no record of — a paper
+ * registration, most often — and such a party can legitimately share a cabin
+ * with a placed family. See the gate's own headstone inside `resolveDrop`.
+ *
  * What it does refuse is a write that cannot succeed: a unit the payload does
  * not carry, a container row, and a party carrying neither CampMinder id.
  */
 import type { LodgingUnitRow, RosterPartyRow, WeekendRoster } from '../../types/lodging'
 import { occupiedCodes } from './boardLayout'
 import { partyKey } from './partyKey'
-import { hasWriteIn } from './writeIn'
 
 /**
  * The queue droppable. One id, imported by the badge that registers it and
@@ -216,21 +221,33 @@ export function resolveDrop({
 
   const unit = units.find((candidate) => candidate.code === target.unitCode)
   if (unit === undefined) return null
-  // Owner ruling on #2090: a hold is a GLOBAL fact about the building (who is
-  // in it, chiefly non-rostered staff), not a scenario-scoped reservation of
-  // empty space, and held/occupied are mutually exclusive states. Dragging
-  // onto a held unit is refused outright, not dimmed — see #2087. This is
-  // the load-bearing check: #2080 adds a placement path that never touches a
-  // `useDroppable`, so a refusal only on that hook's `disabled` flag would be
-  // silently bypassed by it. `LodgingUnitCard` also disables its droppable
-  // for the drag affordance, but this is what actually enforces it.
-  // Read through `hasWriteIn`, never the raw column: a row names one unit but
-  // closes a SPACE, and the board draws whichever level the tree resolves to.
-  // Split a written-into building and this drop lands in one of its rooms;
-  // merge over a written-into room and it lands on the building.
-  // The column answers only for the unit it sits on, so both of those went
-  // through — a family into a space somebody is already sleeping in.
-  if (hasWriteIn(unit)) return null
+  // ⚠️ NO WRITE-IN REFUSAL HERE, and its absence is a ruling rather than an
+  // omission — do not restore one.
+  //
+  // `if (hasWriteIn(unit)) return null` stood on this line until kindred#2432,
+  // under #2090 ("held and occupied are mutually exclusive"), and its own
+  // comment called it *the load-bearing one*: #2080 adds a placement path that
+  // never touches a `useDroppable`, so a refusal living only on that hook's
+  // `disabled` flag would be silently bypassed. That reasoning about WHERE a
+  // refusal has to live was correct and is why this was the last gate standing;
+  // what was struck is the refusal itself.
+  //
+  // Owner ruling 2026-08-18: *"we should be able to add families to any write
+  // in space, or add a write in to a family space — regardless of which came
+  // first."* A write-in NAMES AN OCCUPANT; it does not CLOSE THE SPACE. The
+  // reported case is one paper registration — which has no CampMinder record,
+  // so a write-in is the only way to record it at all — sharing a cabin with
+  // one placed CampMinder family, and this line is what refused it.
+  //
+  // The tree walk the refusal used to ride on is still doing its job upstream:
+  // `hasWriteIn` read the SERVER-RESOLVED cover rather than the raw column
+  // precisely because a row names one unit but covers a whole space, and that
+  // is what still lands the write-in and the family in the SAME card's well
+  // whichever level the board draws (`LodgingUnitCard`'s `writeInEntries`).
+  //
+  // The known cost is filed, not hidden: a write-in carries no headcount, so a
+  // shared space's free-bed figure overstates once both are in it (kindred#2439,
+  // ruled an optional investigation and explicitly not a blocker).
   // A COMBINED container IS a card now — Task 6 draws its own row in place of
   // its rooms (unitLevel.ts, `drawnUnits`) — so it must accept a drop exactly
   // like any other drawn unit. A NON-combined container still carries only
@@ -267,9 +284,11 @@ export interface ResolvePickerPlacementArgs {
  *
  * A thin adapter and nothing more, and that is the whole design: the second
  * placement path must not be a second set of rules. Everything that makes a
- * drop a no-op or a refusal — a held space (#2087), a non-combined container,
- * a party carrying neither CampMinder id, a party already alone in this room —
- * is inherited here for free because the answer is literally `resolveDrop`'s.
+ * drop a no-op or a refusal — a non-combined container, a party carrying
+ * neither CampMinder id, a party already alone in this room — is inherited
+ * here for free because the answer is literally `resolveDrop`'s. That cuts
+ * both ways, which kindred#2432 is the proof of: striking the written-into
+ * refusal in `resolveDrop` struck it here too, with nothing to edit.
  * A picker-layer copy of any of them is the drift this exists to prevent.
  *
  * The party is re-resolved out of `parties` by its own key rather than trusted

--- a/frontend/src/components/weekend/dragPlacement.ts
+++ b/frontend/src/components/weekend/dragPlacement.ts
@@ -29,7 +29,7 @@
 import type { LodgingUnitRow, RosterPartyRow, WeekendRoster } from '../../types/lodging'
 import { occupiedCodes } from './boardLayout'
 import { partyKey } from './partyKey'
-import { writeInOccupant } from './writeIn'
+import { hasWriteIn } from './writeIn'
 
 /**
  * The queue droppable. One id, imported by the badge that registers it and
@@ -224,13 +224,13 @@ export function resolveDrop({
   // `useDroppable`, so a refusal only on that hook's `disabled` flag would be
   // silently bypassed by it. `LodgingUnitCard` also disables its droppable
   // for the drag affordance, but this is what actually enforces it.
-  // Read through `writeInOccupant`, never the raw column: the row names one
-  // unit but closes a SPACE, and the board draws whichever level the tree
-  // resolves to. Split a written-into building and this drop lands in one of
-  // its rooms; merge over a written-into room and it lands on the building.
+  // Read through `hasWriteIn`, never the raw column: a row names one unit but
+  // closes a SPACE, and the board draws whichever level the tree resolves to.
+  // Split a written-into building and this drop lands in one of its rooms;
+  // merge over a written-into room and it lands on the building.
   // The column answers only for the unit it sits on, so both of those went
   // through — a family into a space somebody is already sleeping in.
-  if (writeInOccupant(unit) !== null) return null
+  if (hasWriteIn(unit)) return null
   // A COMBINED container IS a card now — Task 6 draws its own row in place of
   // its rooms (unitLevel.ts, `drawnUnits`) — so it must accept a drop exactly
   // like any other drawn unit. A NON-combined container still carries only

--- a/frontend/src/components/weekend/needsFit.test.ts
+++ b/frontend/src/components/weekend/needsFit.test.ts
@@ -6,7 +6,9 @@
  * unconfirmed (measured against the production snapshot of 2026-08-06, cabins
  * were 118/118 confirmed) but because staff routinely place families against
  * the machine's opinion and are right to. Deliberately a DIFFERENT mechanism
- * from #2087's hard block on a held space, which is a refusal.
+ * from the invalid merge target's hard block, which is a refusal. #2087's
+ * block on a written-into space used to be the other example here; kindred#2432
+ * struck it, so the merge target is now the only thing on the refusal channel.
  *
  * Fictional data throughout.
  */

--- a/frontend/src/components/weekend/needsFit.ts
+++ b/frontend/src/components/weekend/needsFit.ts
@@ -13,7 +13,8 @@
  * two apart:
  *
  *   dim  (`opacity-40` + `pointer-events-none`) = REFUSAL. Owned by the
- *        invalid merge target and by a held space (#2087). Not this.
+ *        invalid merge target, and by that alone since kindred#2432 struck
+ *        the written-into space's refusal (#2087/#2090). Not this.
  *   hatch (`background-image`, at FULL strength)= ADVISORY MISFIT. This.
  *   forest tint                                  = open and available, at rest
  *        only (#2093).

--- a/frontend/src/components/weekend/unitBadges.test.ts
+++ b/frontend/src/components/weekend/unitBadges.test.ts
@@ -238,18 +238,13 @@ describe('availabilityAction', () => {
   // must not say two things about one cabin: a card badged "Held" offering to
   // "Hold" it is the drift this prevents.
 
-  it('offers to write somebody into an ordinary family cabin', () => {
-    expect(availabilityAction(unit())).toEqual({
-      kind: 'hold',
-      label: 'Write in',
-      familyAvailable: false,
-      prompt: 'occupant',
-      // The write NAMES a unit, and for every action but an inherited clear
-      // that unit is the card's own. Asserted rather than left off, so the
-      // pair cannot quietly go missing from the payload the board sends.
-      unitId: 'u1',
-      unitName: 'Cedar 1',
-    })
+  it('offers NOTHING on an ordinary family cabin — the write-in left this strip', () => {
+    // This used to return a `hold`/"Write in" action, and it is the assertion
+    // that changed most in the 2026-08-18 ruling. Creating a write-in is now
+    // the card's own family box: type a name, and if no registered family
+    // matches, that text becomes the write-in. Two typeable boxes asking who
+    // is sleeping in one cabin was the thing the ruling removed.
+    expect(availabilityAction(unit())).toBeNull()
   })
 
   it('offers to release permanent staff housing', () => {
@@ -334,9 +329,9 @@ describe('availabilityAction', () => {
     // The trap. `unit.family_available_override !== null` is the test; a
     // truthiness test (`if (unit.family_available_override)`) treats an
     // ordinary cabin's null and a held cabin's false alike, and whichever way
-    // that branch falls, one of "Hold" or "Clear" becomes unreachable on most
-    // of the board.
-    expect(availabilityAction(unit({ family_available_override: null }))?.kind).toBe('hold')
+    // that branch falls, `clear` becomes either unreachable or offered on every
+    // ordinary cabin. Null must fall through to nothing; false must clear.
+    expect(availabilityAction(unit({ family_available_override: null }))).toBeNull()
     expect(
       availabilityAction(unit({ family_available_override: false, is_family_available: false }))
         ?.kind
@@ -348,12 +343,20 @@ describe('availabilityAction', () => {
     ).toBeNull()
   })
 
-  it('offers nothing to hold an OCCUPIED family cabin — held and occupied are mutually exclusive (#2090)', () => {
-    expect(availabilityAction(unit(), true)).toBeNull()
+  it('offers nothing on a plain family cabin — creating a write-in left this strip entirely', () => {
+    // The 2026-08-18 ruling: a write-in is created by typing into the card's
+    // own family box, so this strip has no write-in action to offer and no
+    // occupancy gate to apply. It used to return a `hold` here, and to refuse
+    // one on an occupied card (#2090) — both are gone together.
+    expect(availabilityAction(unit())).toBeNull()
   })
 
-  it('still offers to hold an unoccupied family cabin (regression guard)', () => {
-    expect(availabilityAction(unit(), false)?.kind).toBe('hold')
+  it('takes no occupancy argument at all any more', () => {
+    // The signature IS the guarantee: with the write-in branch gone, every
+    // action left is about the unit's ROLE row, which a placed family has
+    // never had any bearing on. A second parameter would be the #2090 gate
+    // growing back.
+    expect(availabilityAction).toHaveLength(1)
   })
 
   it('offers nothing on a SPLIT container', () => {
@@ -364,15 +367,15 @@ describe('availabilityAction', () => {
     expect(availabilityAction(unit({ is_container: true }))).toBeNull()
   })
 
-  it('offers a write-in on a MERGED building', () => {
-    // The gate used to refuse EVERY container, on the premise that a container
-    // gets no card and no family can be placed into one. Merge-by-drag (#2012)
-    // made both halves false for a COMBINED container: it is the one card the
-    // board draws in place of its rooms, and `dragPlacement` accepts it as a
-    // drop target. Refusing it here left the four `default_combined` buildings
-    // in the 2026 registry with no write-in path at all — their rooms have no
-    // cards to carry one either.
-    expect(availabilityAction(unit({ is_container: true, is_combined: true }))?.kind).toBe('hold')
+  it('offers nothing on a MERGED building, like every other card', () => {
+    // This once asserted a `hold`, and the reasoning behind it still matters:
+    // a COMBINED container is the one card the board draws in place of its
+    // rooms, so refusing it a write-in left the four `default_combined`
+    // buildings in the 2026 registry with no path at all — their rooms have no
+    // cards to carry one either. The 2026-08-18 ruling keeps that guarantee
+    // and moves it: the path is the card's own family box, which is reachable
+    // on a combined container whether or not it already holds a family.
+    expect(availabilityAction(unit({ is_container: true, is_combined: true }))).toBeNull()
   })
 
   it('offers nothing on a MERGED building that has been written into', () => {
@@ -384,11 +387,13 @@ describe('availabilityAction', () => {
     ).toBeNull()
   })
 
-  it('offers nothing on a MERGED building that already holds a family (#2090)', () => {
-    // The occupancy rule is untouched: a write-in and a placement stay mutually
-    // exclusive. A combined container simply now REACHES that rule instead of
-    // being refused a step earlier for being a container.
-    expect(availabilityAction(unit({ is_container: true, is_combined: true }), true)).toBeNull()
+  it('offers nothing on a MERGED building either — but the write-in path is no longer closed', () => {
+    // This strip stays silent on a combined container, as on every other card.
+    // What CHANGED is what that silence costs: it used to mean a partly-filled
+    // merged building had no write-in path at all, because its rooms lose their
+    // own cards to the merge and #2090's gate refused the building. The box on
+    // the card now takes it. See `LodgingUnitCard`'s `canPickFamily`.
+    expect(availabilityAction(unit({ is_container: true, is_combined: true }))).toBeNull()
   })
 })
 
@@ -528,16 +533,19 @@ describe('a write-in inherited from elsewhere in the tree', () => {
     expect(availabilityAction(unit({ code: 'house-a', write_ins: [coverFromBuilding] }))).toBeNull()
   })
 
-  it('offers nothing on an occupied card either, rather than a stale write-in path', () => {
-    expect(
-      availabilityAction(unit({ code: 'house-a', write_ins: [coverFromBuilding] }), true)
-    ).toBeNull()
+  it('offers nothing on a card covered by a relative’s write-in, occupied or not', () => {
+    expect(availabilityAction(unit({ code: 'house-a', write_ins: [coverFromBuilding] }))).toBeNull()
   })
 
-  it('names the card’s OWN unit when the write-in starts here', () => {
-    const action = availabilityAction(unit())
+  it('names the card’s OWN unit on the actions it does still return', () => {
+    // A released staff cabin is the reachable one: its `clear` names its own
+    // row. The unit pair is asserted rather than left off, so it cannot go
+    // quietly missing from the payload the board sends.
+    const action = availabilityAction(
+      unit({ inventory_class: 'staff_default', family_available_override: true })
+    )
 
-    expect(action?.kind).toBe('hold')
+    expect(action?.kind).toBe('clear')
     expect(action?.unitId).toBe('u1')
     expect(action?.unitName).toBe('Cedar 1')
   })

--- a/frontend/src/components/weekend/unitBadges.test.ts
+++ b/frontend/src/components/weekend/unitBadges.test.ts
@@ -98,14 +98,14 @@ describe('reservationBadge', () => {
     // drawn unit. Badging it "Building" while `availabilityAction` offers to
     // CLEAR the write-in is the exact drift this module exists to prevent.
     expect(
-      reservationBadge(unit({ is_container: true, is_combined: true, write_in: cover() }))?.label
+      reservationBadge(unit({ is_container: true, is_combined: true, write_ins: [cover()] }))?.label
     ).toBe('Write-in')
   })
 
   it('keeps saying Building on a SPLIT container carrying an override', () => {
     // A split container gets no card at all, so there is nothing to badge and
     // no action to agree with. Unchanged, deliberately.
-    expect(reservationBadge(unit({ is_container: true, write_in: cover() }))?.label).toBe(
+    expect(reservationBadge(unit({ is_container: true, write_ins: [cover()] }))?.label).toBe(
       'Building'
     )
   })
@@ -121,7 +121,7 @@ describe('reservationBadge', () => {
     // why this is "Write-in" and not "Staff".
     const badge = reservationBadge(
       unit({
-        write_in: cover({ occupant_name: 'Emma Johnson' }),
+        write_ins: [cover({ occupant_name: 'Emma Johnson' })],
         occupant_name: 'Emma Johnson',
         is_family_available: false,
       })
@@ -186,9 +186,9 @@ describe('reservationBadge', () => {
     ).toBeNull()
     // A write-in on the same cabin still badges, which is the half that must
     // not be lost with it.
-    expect(reservationBadge(unit({ write_in: cover(), is_family_available: false }))?.label).toBe(
-      'Write-in'
-    )
+    expect(
+      reservationBadge(unit({ write_ins: [cover()], is_family_available: false }))?.label
+    ).toBe('Write-in')
   })
 
   it('does not badge a staff cabin as Released merely for lacking an override', () => {
@@ -218,13 +218,13 @@ describe('reservationBadge', () => {
   it('ignores the reason text entirely, because the rule never branches on it', () => {
     const held = reservationBadge(
       unit({
-        write_in: cover({ note: 'Burst pipe' }),
+        write_ins: [cover({ note: 'Burst pipe' })],
         reason: 'Burst pipe',
         is_family_available: false,
       })
     )
     const alsoHeld = reservationBadge(
-      unit({ write_in: cover(), reason: '', is_family_available: false })
+      unit({ write_ins: [cover()], reason: '', is_family_available: false })
     )
 
     expect(held?.label).toBe('Write-in')
@@ -267,26 +267,30 @@ describe('availabilityAction', () => {
     })
   })
 
-  it('offers to clear a held family cabin, labelled for what it actually removes (#2252)', () => {
-    // `null` DELETES the row. There is no value meaning "normal": writing one
-    // would pin the unit against a later change to its role.
-    //
-    // The label is 'Clear Write-in', not the bare 'Clear' this used to read.
-    // kindred#2252: the badge chip that used to sit beside this button on
-    // `LodgingUnitCard` is gone there (the well's `WriteInCard` already names
-    // the occupant), so the button is now the only thing on that card saying
-    // what a click does — and "Clear" alone does not say what it clears.
+  it('offers NOTHING on a written-into family cabin — the removal is on its card', () => {
+    // kindred#2381, superseding #2252's 'Clear Write-in' label. That label was
+    // right while the strip was the only thing on the card naming what a click
+    // removes; it stopped being true once a card could cover four write-ins
+    // and each got its own X. The strip is back to ROLE rows only.
     expect(
       availabilityAction(
         unit({
-          write_in: cover({ note: 'Burst pipe' }),
+          write_ins: [cover({ note: 'Burst pipe' })],
           reason: 'Burst pipe',
           is_family_available: false,
         })
       )
+    ).toBeNull()
+  })
+
+  it('offers to clear a role row with `null`, which DELETES it', () => {
+    // There is no value meaning "normal": writing one would pin the unit
+    // against a later change to its role.
+    expect(
+      availabilityAction(unit({ family_available_override: true, is_family_available: true }))
     ).toEqual({
       kind: 'clear',
-      label: 'Clear Write-in',
+      label: 'Clear',
       familyAvailable: null,
       prompt: 'none',
       unitId: 'u1',
@@ -294,12 +298,10 @@ describe('availabilityAction', () => {
     })
   })
 
-  it('offers to clear a released staff cabin, and does NOT borrow the write-in wording (#2252)', () => {
-    // This branch clears a RELEASE, not a write-in — `writeInSource` never
-    // matches a staff cabin's own release row, so it never reaches the
-    // relabelled branch. Asserted by name, not just by kind: a copy/paste that
-    // pointed this branch at the write-in label too would say "Clear
-    // Write-in" on a card that was never written into.
+  it('offers to clear a released staff cabin, naming its own row', () => {
+    // This branch clears a RELEASE, not a write-in, and it fires ahead of the
+    // write-in gate so a staff cabin that a relative's write-in also covers
+    // keeps the clear its badge names.
     expect(
       availabilityAction(
         unit({
@@ -340,13 +342,10 @@ describe('availabilityAction', () => {
         ?.kind
     ).toBe('clear')
     // And a write-in, which is a different row in a different table, offers
-    // the relabelled clear rather than this one.
+    // NOTHING here: its removal is the X on its own card (kindred#2381).
     expect(
-      availabilityAction(unit({ write_in: cover(), is_family_available: false }))
-    ).toMatchObject({
-      kind: 'clear',
-      label: 'Clear Write-in',
-    })
+      availabilityAction(unit({ write_ins: [cover()], is_family_available: false }))
+    ).toBeNull()
   })
 
   it('offers nothing to hold an OCCUPIED family cabin — held and occupied are mutually exclusive (#2090)', () => {
@@ -376,10 +375,13 @@ describe('availabilityAction', () => {
     expect(availabilityAction(unit({ is_container: true, is_combined: true }))?.kind).toBe('hold')
   })
 
-  it('offers to clear a MERGED building that has been written into', () => {
+  it('offers nothing on a MERGED building that has been written into', () => {
+    // It may cover four rows at once and the strip carries ONE action, so no
+    // button here could name which of the four a click would destroy. Each
+    // write-in is removed by the X on its own card (kindred#2381).
     expect(
-      availabilityAction(unit({ is_container: true, is_combined: true, write_in: cover() }))?.kind
-    ).toBe('clear')
+      availabilityAction(unit({ is_container: true, is_combined: true, write_ins: [cover()] }))
+    ).toBeNull()
   })
 
   it('offers nothing on a MERGED building that already holds a family (#2090)', () => {
@@ -497,9 +499,10 @@ describe('a write-in inherited from elsewhere in the tree', () => {
    * The board draws whichever level the tree resolves to, so the card carrying
    * a write-in is often not the unit the row names: split a written-into
    * building and its rooms carry it; merge over a written-into room and the
-   * building does. Both must BADGE the fact and both must be able to CLEAR it
-   * — a card that inherits a write-in and cannot undo it is a dead end, since
-   * the unit holding the row has no card at all.
+   * building does. Both must BADGE the fact, and neither offers a strip action
+   * for it: since kindred#2381 a card may cover several write-ins at once, and
+   * each is removed by the X on its own `WriteInCard` — the only control that
+   * can name one row out of four.
    */
   const coverFromBuilding = {
     unit_id: 'id-house',
@@ -510,28 +513,25 @@ describe('a write-in inherited from elsewhere in the tree', () => {
   }
 
   it('badges a room whose BUILDING was written into', () => {
-    expect(reservationBadge(unit({ code: 'house-a', write_in: coverFromBuilding }))?.label).toBe(
+    expect(reservationBadge(unit({ code: 'house-a', write_ins: [coverFromBuilding] }))?.label).toBe(
       'Write-in'
     )
   })
 
-  it('offers to clear it, naming the unit that actually holds the row', () => {
-    const action = availabilityAction(unit({ code: 'house-a', write_in: coverFromBuilding }))
-
-    expect(action?.kind).toBe('clear')
-    // The WRITE TARGET, not the card. Sending this card's own id would delete
-    // nothing: the row belongs to the building, and the room has none.
-    expect(action?.unitId).toBe('id-house')
-    expect(action?.unitName).toBe('House')
+  it('offers no strip action, because the removal lives on the card', () => {
+    // kindred#2381. The strip carries ONE action, so on a merged building over
+    // four write-ins it could name only one of the four rows — and it did:
+    // clearing re-resolved the card to the next occupant, so the click read as
+    // a no-op and four of them destroyed four rows without ever disclosing
+    // that more than one existed. Removal is now the X on each `WriteInCard`,
+    // which can only delete the row it sits on.
+    expect(availabilityAction(unit({ code: 'house-a', write_ins: [coverFromBuilding] }))).toBeNull()
   })
 
-  it('clears an inherited write-in even on an occupied card', () => {
-    // Same reasoning the own-row branch already carries: a clear only ever
-    // REDUCES the conflict, so occupancy is never the state that needs it
-    // blocked.
+  it('offers nothing on an occupied card either, rather than a stale write-in path', () => {
     expect(
-      availabilityAction(unit({ code: 'house-a', write_in: coverFromBuilding }), true)?.kind
-    ).toBe('clear')
+      availabilityAction(unit({ code: 'house-a', write_ins: [coverFromBuilding] }), true)
+    ).toBeNull()
   })
 
   it('names the card’s OWN unit when the write-in starts here', () => {
@@ -553,14 +553,14 @@ describe('a write-in inherited from elsewhere in the tree', () => {
 
     expect(
       reservationBadge(
-        unit({ code: 'house', is_container: true, is_combined: true, write_in: fromRoom })
+        unit({ code: 'house', is_container: true, is_combined: true, write_ins: [fromRoom] })
       )?.label
     ).toBe('Write-in')
     expect(
       availabilityAction(
-        unit({ code: 'house', is_container: true, is_combined: true, write_in: fromRoom })
-      )?.unitId
-    ).toBe('id-house-a')
+        unit({ code: 'house', is_container: true, is_combined: true, write_ins: [fromRoom] })
+      )
+    ).toBeNull()
   })
 })
 
@@ -570,9 +570,10 @@ describe('the badge and the clear must name the SAME row', () => {
    * drift — a card badged "Write-in" that offers to "Write in" says two things
    * about one cabin. Once a write-in can be INHERITED, that invariant grows
    * teeth: a card can carry its own availability row AND a relative's
-   * write-in at the same time, and one control has two rows to choose from.
-   * It must clear the one the badge is naming, or the toast reports success
-   * for a row the staff member was not looking at.
+   * write-in at the same time. The strip resolves the ROLE rows only — a
+   * write-in is removed from its own card since kindred#2381 — so a card the
+   * badge calls "Write-in" must offer no strip action at all rather than one
+   * that quietly unmakes something the reader was not looking at.
    */
   const coverFromBuilding = {
     unit_id: 'id-house',
@@ -592,11 +593,14 @@ describe('the badge and the clear must name the SAME row', () => {
       code: 'house-a',
       name: 'House A',
       family_available_override: true,
-      write_in: coverFromBuilding,
+      write_ins: [coverFromBuilding],
     })
 
     expect(reservationBadge(stale)?.label).toBe('Write-in')
-    expect(availabilityAction(stale)?.unitId).toBe('id-house')
+    // No strip action at all: the badge names the write-in, and a write-in is
+    // removed from its own card. The stale role row becomes clearable again
+    // once nothing is written into the space.
+    expect(availabilityAction(stale)).toBeNull()
   })
 
   it('still clears its OWN row on a released staff cabin, which is what its badge names', () => {
@@ -610,7 +614,7 @@ describe('the badge and the clear must name the SAME row', () => {
       name: 'House A',
       inventory_class: 'staff_default',
       family_available_override: true,
-      write_in: coverFromBuilding,
+      write_ins: [coverFromBuilding],
     })
 
     expect(reservationBadge(released)?.label).toBe('Released')

--- a/frontend/src/components/weekend/unitBadges.ts
+++ b/frontend/src/components/weekend/unitBadges.ts
@@ -29,7 +29,7 @@
  * | branch | fact | field | stored in | scope |
  * |---|---|---|---|---|
  * | "Released" | staff<->family ROLE | `family_available_override` | `lodging_availability` | the WEEKEND |
- * | "Write-in" | OCCUPANCY | `write_in` (via `writeInOccupant`) | `lodging_write_ins`/`_draft` | the SCENARIO |
+ * | "Write-in" | OCCUPANCY | `write_ins` (via `hasWriteIn`) | `lodging_write_ins`/`_draft` | the SCENARIO |
  *
  * So a `family_available_override === false` is a role decision that names
  * NOBODY, and does not badge here. It used to badge "Write-in", because the
@@ -38,7 +38,7 @@
  * wrong about.
  */
 import type { LodgingUnitRow } from '../../types/lodging'
-import { writeInOccupant, writeInSource } from './writeIn'
+import { hasWriteIn } from './writeIn'
 
 export interface UnitBadge {
   label: string
@@ -66,7 +66,7 @@ export interface UnitBadge {
  * `reservationBadge` directly, unaffected by this function existing.
  */
 export function writeInBadgeApplies(unit: LodgingUnitRow): boolean {
-  return unit.inventory_class !== 'staff_default' && writeInOccupant(unit) !== null
+  return unit.inventory_class !== 'staff_default' && hasWriteIn(unit)
 }
 
 export function reservationBadge(unit: LodgingUnitRow): UnitBadge | null {
@@ -115,7 +115,7 @@ export function reservationBadge(unit: LodgingUnitRow): UnitBadge | null {
   // It still does not read `occupant_name`: "written in for a caretaker" and
   // "written in for a burst pipe" are the same fact about availability, which
   // is the same reason the reason text never reached this badge.
-  // Read through `writeInBadgeApplies` (`writeInOccupant`, never the raw
+  // Read through `writeInBadgeApplies` (`hasWriteIn`, never the raw
   // `family_available_override`). The board draws whichever level the tree
   // resolves to, so the card carrying a write-in is often not the unit whose
   // row it is: split a written-into building and its ROOMS carry it; merge
@@ -260,17 +260,19 @@ export interface AvailabilityAction {
   /** What the control collects before it may write — see `AvailabilityPrompt`. */
   prompt: AvailabilityPrompt
   /**
-   * The unit the write NAMES, which is not always the card it is offered on.
+   * The unit the write NAMES — always the card's own, since kindred#2381.
    *
-   * A write-in covers a space, and the board draws whichever level the tree
-   * resolves to — so a room can inherit its building's write-in, and a merged
-   * building one of its rooms'. There is exactly one `lodging_write_ins` row
-   * either way (kindred#2382 split occupancy off `lodging_availability`, which
-   * now answers only the staff↔family role), and clearing it has to target the
-   * unit that HOLDS it:
-   * sending the card's own id would delete nothing, and the unit holding the
-   * row has no card to offer the clear from. Every other action names the
-   * card's own unit.
+   * It was not always, and the exception was the write-in clear: a write-in
+   * covers a space and the board draws whichever level the tree resolves to,
+   * so a room can inherit its building's row and a merged building one of its
+   * rooms', and the clear had to target the unit that HOLDS the row. That
+   * action is gone — a card may now cover several write-ins and each is
+   * removed by the X on its own `WriteInCard` — so every action this returns
+   * is about the card's own availability row again.
+   *
+   * KEPT rather than collapsed into the caller reading `unit.unit_id`: the
+   * write model carries a target either way, and one field that is always the
+   * card's own is cheaper to read than a rule spread across two modules.
    */
   unitId: string
   /** That unit's name, for the confirmation toast. */
@@ -322,10 +324,10 @@ export type AvailabilityPrompt = 'occupant' | 'reason' | 'none'
  * that is now a statement about the staff↔family ROLE alone: "we're moving
  * staff to X for weekend Y" is true in every plan, which is why 1500000135's
  * reasoning survived kindred#2382 intact for this half. The OCCUPANCY that
- * used to share the field is scenario-scoped and lives in `write_in` — so the
- * `clear` this offers for a write-in unmakes a fact that belongs to the board
- * you are looking at, while the `clear` it offers for a release unmakes one
- * that belongs to the weekend.
+ * used to share the field is scenario-scoped and lives in `write_ins` — and
+ * since kindred#2381 this resolves the ROLE rows only. A written-into space
+ * returns null here and is removed from its own card, because one action
+ * cannot name one row out of the several a merged card may cover.
  */
 export function availabilityAction(
   unit: LodgingUnitRow,
@@ -349,55 +351,55 @@ export function availabilityAction(
   // (closed this weekend) are different answers, and collapsing them makes
   // either "Write in" or "Clear" unreachable across most of the board.
   const own = { unitId: unit.unit_id, unitName: unit.name }
-  // `label` defaults to the bare 'Clear' the RELEASE and the "agrees with the
-  // role" branches keep — neither of those undoes a write-in, so borrowing
-  // its wording would name a fact that is not there. The write-in branch below
-  // passes 'Clear Write-in' explicitly (kindred#2252): the chip that used to
-  // sit beside this button on `LodgingUnitCard` said "Write-in" out loud, and
-  // #2252 dropped it from that card as redundant with the well's `WriteInCard`
-  // — so the button is now the only thing left on that card naming what a
-  // click removes, and a bare 'Clear' stopped saying that.
-  const clear = (
-    target: { unitId: string; unitName: string },
-    label = 'Clear'
-  ): AvailabilityAction => ({
+  // 'Clear' for both surviving branches — the RELEASE and the "agrees with the
+  // role" one — because neither undoes a write-in and borrowing #2252's 'Clear
+  // Write-in' wording would name a fact that is not there. That label went with
+  // the write-in branch (kindred#2381); what it distinguished this button from
+  // no longer sits beside it.
+  const clear = (target: { unitId: string; unitName: string }): AvailabilityAction => ({
     kind: 'clear',
-    label,
+    label: 'Clear',
     familyAvailable: null,
     prompt: 'none',
     ...target,
   })
   /*
-   * THE THREE CLEAR BRANCHES ARE ORDERED TO MIRROR `reservationBadge` ABOVE,
-   * and that ordering is the rule rather than an accident of writing.
+   * THE BRANCHES ARE ORDERED TO MIRROR `reservationBadge` ABOVE, and that
+   * ordering is the rule rather than an accident of writing.
    *
-   * Once a write-in can be INHERITED, a card can carry its own availability
-   * row AND a relative's write-in at once — two rows, one control. This module
-   * already promises the badge and the action cannot drift ("a card badged
-   * 'Write-in' that offers to 'Write in' says two things about one cabin"), so
-   * the clear names whichever row the badge names. Anything else reports
-   * success for a row the staff member was not looking at, and leaves the fact
-   * they meant to remove sitting on the card.
+   * A card can carry its own availability row AND a relative's write-in at
+   * once — two rows, one control. This module already promises the badge and
+   * the action cannot drift ("a card badged 'Write-in' that offers to 'Write
+   * in' says two things about one cabin"), so a card the badge calls
+   * "Write-in" offers no strip action at all rather than one that quietly
+   * unmakes the other row. Anything else reports success for a row the staff
+   * member was not looking at.
    */
   // A released staff cabin badges "Released" off its OWN row, so that is the
   // row its clear names — even when a relative's write-in also covers it.
   if (unit.inventory_class === 'staff_default' && unit.family_available_override === true) {
     return clear(own)
   }
-  // The write-in COVERING this space, which badges "Write-in". Its own row
-  // when it has one — the server resolves own first — else its building's or
-  // one of its rooms'.
+  // A SPACE SOMEBODY IS WRITTEN INTO OFFERS NOTHING HERE — kindred#2381.
   //
-  // Offered before the `occupied` gate below for the reason that gate's own
-  // comment gives: a clear only ever REDUCES the conflict, so occupancy is
-  // never the state that needs it blocked. Without this branch an inheriting
-  // card is a dead end: it badges a write-in it cannot undo, and the unit
-  // holding the row has no card at all — which is exactly what a merge or a
-  // split does to it.
-  const source = writeInSource(unit)
-  if (source !== null) {
-    return clear({ unitId: source.unitId, unitName: source.unitName }, 'Clear Write-in')
-  }
+  // This used to return a 'Clear Write-in' naming whichever row the server
+  // resolved first, which was sound only while a card could carry exactly one.
+  // A merged container covers every write-in beneath it — four of them on the
+  // one 2026 building that has four — and one button cannot name four rows:
+  // each click destroyed the row it named, the card re-populated with the next
+  // occupant, and the action read as a no-op while it worked through them.
+  //
+  // Removal moved onto the cards, one X per `WriteInCard`, which can only ever
+  // delete the row it sits on. The dead end that branch existed to prevent —
+  // an inheriting card badging a write-in it cannot undo, while the unit
+  // holding the row has no card at all — is closed by the X rather than by
+  // this action, so returning null here strands nothing.
+  //
+  // ABOVE the `occupied` gate, exactly where the clear was: a written-into
+  // card must not fall through to the 'Write in' branch at the bottom and
+  // offer to write a SECOND occupant into a space that already resolves an own
+  // row ahead of its descendants — which would hide the ones already there.
+  if (hasWriteIn(unit)) return null
   // Any other ROLE override of its own — this branch has never been about
   // occupancy and is less so since kindred#2382. Two states reach it, both
   // storable and neither written by any surface: a `true` on a family-pool row

--- a/frontend/src/components/weekend/unitBadges.ts
+++ b/frontend/src/components/weekend/unitBadges.ts
@@ -252,7 +252,7 @@ export function sharingConflictBadge(
 
 /** Which of the three reachable availability outcomes this unit can move to. */
 export interface AvailabilityAction {
-  kind: 'hold' | 'release' | 'clear'
+  kind: 'release' | 'clear'
   /** The button's label, drawn from the same vocabulary as the badge above. */
   label: string
   /** What the write sends. `null` DELETES the row. */
@@ -287,18 +287,21 @@ export interface AvailabilityAction {
  * whether the action has anything to ask. What it asks FOR now differs by
  * action, and a boolean cannot say which:
  *
- *   'occupant' — a write-in. A REQUIRED occupant name plus an OPTIONAL note.
- *                ONE control and one action: hold IS the write-in (owner
- *                ruling, 2026-08-09), so there is no second "mark unavailable"
- *                path and no burst-pipe / staff-write-in split.
  *   'reason'   — a release. A required reason and nothing else: opening a
  *                staff cabin to families names no occupant, so prompting for
  *                one would ask for a fact that does not exist.
  *   'none'     — a clear. It restores the unit's standing role rather than
  *                asserting anything about this weekend, so there is nothing
  *                to say.
+ *
+ * There WAS a third, `'occupant'` — a write-in's required name plus an
+ * optional note. It went with the `hold` action on 2026-08-18: a write-in is
+ * created by typing into the card's own family box, so this strip no longer
+ * asks for an occupant, and the note is edited by the pencil on the write-in's
+ * own card. Removed rather than kept unused, because a prompt nothing returns
+ * is a form branch nothing can reach.
  */
-export type AvailabilityPrompt = 'occupant' | 'reason' | 'none'
+export type AvailabilityPrompt = 'reason' | 'none'
 
 /**
  * The one action a unit's card offers, or null if it offers none.
@@ -313,12 +316,12 @@ export type AvailabilityPrompt = 'occupant' | 'reason' | 'none'
  * Lives beside `reservationBadge` so the two cannot drift. A card badged
  * "Write-in" that offers to "Write in" says two things about one cabin.
  *
- * `occupied` names a fact from the SLOT (whether any party is placed on this
- * card this scenario), never folded into `canManage`'s permission gate.
- * Owner ruling on #2090: written-in and occupied are mutually exclusive
- * states, so a space that already holds a family may not also be written into
- * — but this must not become a THIRD dimension threaded onto availability
- * itself.
+ * ★ TAKES NO `occupied` ARGUMENT since the 2026-08-18 ruling, and the absence
+ * is the point. It used to, purely to enforce #2090's "written-in and occupied
+ * are mutually exclusive" gate on the one branch that offered a write-in. That
+ * branch is gone (see the bottom of the function), so occupancy no longer
+ * decides anything here: every action this returns is about the unit's ROLE
+ * row, which a placed family has never had any bearing on.
  *
  * `family_available_override` IS still weekend-level and scenario-less, and
  * that is now a statement about the staff↔family ROLE alone: "we're moving
@@ -329,10 +332,7 @@ export type AvailabilityPrompt = 'occupant' | 'reason' | 'none'
  * returns null here and is removed from its own card, because one action
  * cannot name one row out of the several a merged card may cover.
  */
-export function availabilityAction(
-  unit: LodgingUnitRow,
-  occupied = false
-): AvailabilityAction | null {
+export function availabilityAction(unit: LodgingUnitRow): AvailabilityAction | null {
   // A SPLIT container is a whole-building aggregate, never a bookable room:
   // `drawnUnits` descends past it and `resolveDrop` rejects it as a target, so
   // an availability row written against one is a row no surface could show or
@@ -421,10 +421,31 @@ export function availabilityAction(
   if (unit.inventory_class === 'staff_default') {
     return { kind: 'release', label: 'Release', familyAvailable: true, prompt: 'reason', ...own }
   }
-  // An already-occupied space offers no write-in: the fix for #2090. Only
-  // reachable here, past both branches above, so an already-held unit keeps
-  // its `clear` action regardless of occupancy — clearing only ever REDUCES
-  // the conflict, so it is never the state that needs blocking.
-  if (occupied) return null
-  return { kind: 'hold', label: 'Write in', familyAvailable: false, prompt: 'occupant', ...own }
+  // ★ THE STRIP NO LONGER OFFERS "Write in" AT ALL (owner ruling, 2026-08-18).
+  //
+  // It used to end here with a `hold` action, gated on `!occupied` — the fix
+  // for #2090. Both the action and its gate are gone, and the gate is the
+  // reason the action had to go rather than the other way round.
+  //
+  // Creating a write-in moved into the card's own family box: type a name, and
+  // if no registered family matches, that text becomes the write-in
+  // (`PlaceFamilyPicker`'s `onWriteIn`). The ruling's own framing:
+  //
+  //   > "one fewer chip on the board on every tile, big win ... it removes two
+  //   >  rectangular boxes coexisting and typeable when the write in is also
+  //   >  happening"
+  //
+  // — two controls asking "who is sleeping here", side by side, and a staff
+  // member forced to pick one before knowing which kind of answer they had.
+  //
+  // What the move FIXED, and what a re-introduction would break: #2090's gate
+  // made a partly-filled space refuse a write-in, and on a merged container
+  // that left no path at all, since the rooms lose their own cards to the
+  // merge. `LodgingUnitCard`'s `canPickFamily` carries the reasoning in full.
+  //
+  // Returning null here is therefore the whole of the write-in's absence from
+  // this strip: removal is the X on each `WriteInCard`, editing is the pencil
+  // beside it, and creation is the box. None of the three is an availability
+  // action any more.
+  return null
 }

--- a/frontend/src/components/weekend/writeIn.test.ts
+++ b/frontend/src/components/weekend/writeIn.test.ts
@@ -1,18 +1,22 @@
 /**
- * A write-in is a named occupant of a space — kindred#2078, kindred#2382.
+ * A write-in is a named occupant of a space — kindred#2078, kindred#2382, kindred#2381.
  *
- * The single definition of "is somebody written into this room", and the one
- * the board reads. It exists because #2093's forest open-tint was written
- * against the PROXY `unit.family_available_override === false` under the name
- * `held`, and a rename alone would have left the tint keyed on a spelling
- * rather than on the fact.
+ * The single definition of "who is written into this space", and the one the
+ * board reads. It exists because #2093's forest open-tint was written against
+ * the PROXY `unit.family_available_override === false` under the name `held`,
+ * and a rename alone would have left the tint keyed on a spelling rather than
+ * on the fact.
  *
- * THAT PROXY IS GONE, which is what these tests now pin. kindred#2382 moved
+ * THAT PROXY IS GONE, which is what these tests pin. kindred#2382 moved
  * occupancy into its own table and stopped the wire spelling one as
  * `family_available_override === false`; that field answers the staff↔family
  * ROLE and nothing else. Every fixture below that means "somebody is in it"
- * therefore carries a `write_in`, and a bare `false` means "closed by role",
- * which names nobody.
+ * therefore carries a `write_ins` entry, and a bare `false` means "closed by
+ * role", which names nobody.
+ *
+ * PLURAL since kindred#2381. A merged container draws in place of its rooms,
+ * so a card can cover several written-into rooms at once and every one of them
+ * has to reach the screen.
  *
  * Fictional data throughout. Production write-in notes are real family and
  * staff names; nothing here is dumped from any database.
@@ -20,7 +24,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { LodgingUnitRow, WriteInCoverRow } from '../../types/lodging'
-import { writeInOccupant, writeInSource } from './writeIn'
+import { hasWriteIn, writeInEntries } from './writeIn'
 
 function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
   return {
@@ -63,54 +67,51 @@ function cover(overrides: Partial<WriteInCoverRow> = {}): WriteInCoverRow {
   }
 }
 
-describe('writeInOccupant', () => {
+describe('writeInEntries', () => {
   it('names the occupant of a room somebody has been written into', () => {
     expect(
-      writeInOccupant(
+      writeInEntries(
         unit({
-          write_in: cover({ occupant_name: 'Emma Johnson', note: 'Kitchen lead, Fri–Sun' }),
+          write_ins: [cover({ occupant_name: 'Emma Johnson', note: 'Kitchen lead, Fri–Sun' })],
           occupant_name: 'Emma Johnson',
           reason: 'Kitchen lead, Fri–Sun',
           is_family_available: false,
         })
-      )
-    ).toEqual({ name: 'Emma Johnson', note: 'Kitchen lead, Fri–Sun' })
+      ).map((entry) => entry.occupant)
+    ).toEqual([{ name: 'Emma Johnson', note: 'Kitchen lead, Fri–Sun' }])
   })
 
-  it('is null for a room the ROLE closed, which names nobody', () => {
+  it('is empty for a room the ROLE closed, which names nobody', () => {
     // kindred#2382. `family_available_override === false` used to BE the
     // write-in — the occupancy and the staff↔family role shared one boolean.
     // With the two apart, a bare `false` is a role decision ("closed this
     // weekend") with no occupant behind it, and reading it as a write-in would
     // have the card report somebody who exists in no row anywhere.
-    expect(
-      writeInOccupant(unit({ family_available_override: false, is_family_available: false }))
-    ).toBeNull()
-    expect(
-      writeInSource(unit({ family_available_override: false, is_family_available: false }))
-    ).toBeNull()
+    const roleClosed = unit({ family_available_override: false, is_family_available: false })
+    expect(writeInEntries(roleClosed)).toEqual([])
+    expect(hasWriteIn(roleClosed)).toBe(false)
   })
 
-  it('is null for a room nobody has written into', () => {
+  it('is empty for a room nobody has written into', () => {
     // `null` on the override means "no row for this weekend, ask the unit's
     // role" — not "closed". Collapsing the two is the failure `reservationBadge`
     // documents at length, arriving one module over.
-    expect(writeInOccupant(unit())).toBeNull()
-    expect(writeInOccupant(unit({ family_available_override: null }))).toBeNull()
+    expect(writeInEntries(unit())).toEqual([])
+    expect(writeInEntries(unit({ family_available_override: null }))).toEqual([])
   })
 
-  it('is null for a staff cabin RELEASED to families', () => {
+  it('is empty for a staff cabin RELEASED to families', () => {
     // A release opens a room; it names no occupant. `true` and `false` are
     // opposite answers and only one of them is a write-in.
     expect(
-      writeInOccupant(
+      writeInEntries(
         unit({
           inventory_class: 'staff_default',
           family_available_override: true,
           reason: 'Overflow',
         })
       )
-    ).toBeNull()
+    ).toEqual([])
   })
 
   it('still reports a write-in whose occupant nobody named', () => {
@@ -118,18 +119,16 @@ describe('writeInOccupant', () => {
     // which is permissive where the control is not. The room is still closed,
     // so reporting "no write-in" here would hand it back to the open-tint and
     // send staff at the one room they may not fill.
-    expect(writeInOccupant(unit({ write_in: cover(), is_family_available: false }))).toEqual({
-      name: '',
-      note: '',
-    })
+    const entries = writeInEntries(unit({ write_ins: [cover()], is_family_available: false }))
+    expect(entries.map((entry) => entry.occupant)).toEqual([{ name: '', note: '' }])
   })
 
   it('treats a whitespace-only occupant as unnamed rather than as a name', () => {
     expect(
-      writeInOccupant(
-        unit({ write_in: cover({ occupant_name: '   ' }), is_family_available: false })
-      )
-    ).toEqual({ name: '', note: '' })
+      writeInEntries(
+        unit({ write_ins: [cover({ occupant_name: '   ' })], is_family_available: false })
+      ).map((entry) => entry.occupant)
+    ).toEqual([{ name: '', note: '' }])
   })
 
   it('does not fall back to the note when the occupant is unnamed', () => {
@@ -137,14 +136,23 @@ describe('writeInOccupant', () => {
     // the column behind it, precisely so one string cannot render twice on one
     // card. A fallback here would restore that double-print by another route.
     expect(
-      writeInOccupant(
+      writeInEntries(
         unit({
-          write_in: cover({ note: 'Back Monday' }),
+          write_ins: [cover({ note: 'Back Monday' })],
           reason: 'Back Monday',
           is_family_available: false,
         })
-      )
-    ).toEqual({ name: '', note: 'Back Monday' })
+      ).map((entry) => entry.occupant)
+    ).toEqual([{ name: '', note: 'Back Monday' }])
+  })
+
+  it('treats a payload with no write_ins key at all as uncovered', () => {
+    // The field is OPTIONAL on the wire, so an older or partial payload omits
+    // it entirely. `undefined` is "no cover", never a crash on `.length`.
+    const bare = unit()
+    delete (bare as { write_ins?: unknown }).write_ins
+    expect(writeInEntries(bare)).toEqual([])
+    expect(hasWriteIn(bare)).toBe(false)
   })
 })
 
@@ -158,63 +166,126 @@ describe('a write-in resolved through the unit tree', () => {
    */
   const inherited = unit({
     code: 'house-a',
-    write_in: {
-      unit_id: 'id-house',
-      unit_code: 'house',
-      unit_name: 'House',
-      occupant_name: 'Liam Garcia',
-      note: 'Back Monday',
-    },
+    write_ins: [
+      {
+        unit_id: 'id-house',
+        unit_code: 'house',
+        unit_name: 'House',
+        occupant_name: 'Liam Garcia',
+        note: 'Back Monday',
+      },
+    ],
   })
 
   it('names the occupant of a room its BUILDING was written into', () => {
-    expect(writeInOccupant(inherited)).toEqual({ name: 'Liam Garcia', note: 'Back Monday' })
+    expect(writeInEntries(inherited).map((entry) => entry.occupant)).toEqual([
+      { name: 'Liam Garcia', note: 'Back Monday' },
+    ])
   })
 
   it('reports the row it came from, and that it is not this unit’s own', () => {
-    expect(writeInSource(inherited)).toEqual({
-      unitId: 'id-house',
-      unitCode: 'house',
-      unitName: 'House',
-      isOwn: false,
-    })
+    expect(writeInEntries(inherited).map((entry) => entry.source)).toEqual([
+      { unitId: 'id-house', unitCode: 'house', unitName: 'House', isOwn: false },
+    ])
   })
 
   it('marks a unit’s OWN row as its own, so the card does not attribute it elsewhere', () => {
     const own = unit({
       code: 'cedar-1',
-      write_in: {
-        unit_id: 'u1',
-        unit_code: 'cedar-1',
-        unit_name: 'Cedar 1',
-        occupant_name: 'Emma Johnson',
-        note: '',
-      },
+      write_ins: [
+        {
+          unit_id: 'u1',
+          unit_code: 'cedar-1',
+          unit_name: 'Cedar 1',
+          occupant_name: 'Emma Johnson',
+          note: '',
+        },
+      ],
     })
 
-    expect(writeInSource(own)?.isOwn).toBe(true)
+    expect(writeInEntries(own)[0]?.source.isOwn).toBe(true)
   })
 
   it('reads the cover and never the old proxy, so a role row cannot fake one', () => {
     // THE COMPAT SHIM, retired by kindred#2382 PR 4. This used to synthesise a
     // cover from `family_available_override === false` plus the unit's own
     // `occupant_name`, because the wire had no other way to say "somebody is in
-    // it". It has one now — `write_in` is resolved server-side on every unit —
+    // it". It has one now — `write_ins` is resolved server-side on every unit —
     // and the old spelling means something else entirely, so reading it would
     // report an occupant a role-closed cabin does not have.
     expect(
-      writeInOccupant(
+      writeInEntries(
         unit({
           family_available_override: false,
           occupant_name: 'Emma Johnson',
           is_family_available: false,
         })
       )
-    ).toBeNull()
+    ).toEqual([])
   })
 
   it('says nothing when neither a cover nor an own row closes the space', () => {
-    expect(writeInOccupant(unit())).toBeNull()
-    expect(writeInSource(unit())).toBeNull()
+    expect(writeInEntries(unit())).toEqual([])
+    expect(hasWriteIn(unit())).toBe(false)
+  })
+})
+
+describe('a merged container over several written-into rooms', () => {
+  /*
+   * THE REPORTED CASE — kindred#2381. A container that draws combined stands in
+   * for its rooms, so all four of its written-into leaves resolve onto its one
+   * card. Returning one of them hid three occupants and made each clear look
+   * like a failed click as the card re-populated with the next name.
+   */
+  const merged = unit({
+    unit_id: 'id-house',
+    code: 'house',
+    name: 'House',
+    is_container: true,
+    is_combined: true,
+    write_ins: [
+      cover({
+        unit_id: 'id-back',
+        unit_code: 'house-back',
+        unit_name: 'House Back',
+        occupant_name: 'Emma Johnson',
+      }),
+      cover({
+        unit_id: 'id-loft',
+        unit_code: 'house-loft',
+        unit_name: 'House Loft',
+        occupant_name: 'Liam Garcia',
+      }),
+      cover({
+        unit_id: 'id-side',
+        unit_code: 'house-side',
+        unit_name: 'House Side',
+        occupant_name: 'Olivia Martinez',
+      }),
+    ],
+  })
+
+  it('names every occupant the card covers, in the order the server sent them', () => {
+    expect(writeInEntries(merged).map((entry) => entry.occupant.name)).toEqual([
+      'Emma Johnson',
+      'Liam Garcia',
+      'Olivia Martinez',
+    ])
+  })
+
+  it('pairs each occupant with the row that holds it, so a removal targets that row', () => {
+    // The pairing is the point of one entry rather than two parallel arrays:
+    // an X drawn on the third card must delete the THIRD row, and index
+    // alignment maintained by hand is exactly the invariant that rots.
+    expect(writeInEntries(merged).map((entry) => entry.source.unitId)).toEqual([
+      'id-back',
+      'id-loft',
+      'id-side',
+    ])
+    expect(writeInEntries(merged).every((entry) => !entry.source.isOwn)).toBe(true)
+  })
+
+  it('reports the space as covered', () => {
+    expect(hasWriteIn(merged)).toBe(true)
   })
 })

--- a/frontend/src/components/weekend/writeIn.ts
+++ b/frontend/src/components/weekend/writeIn.ts
@@ -33,7 +33,7 @@
  * so by testing `unit.family_available_override === false` — a PROXY for "is
  * somebody in it". Reading the fact through one named function is what let the
  * proxy be retired here, once, instead of in every consumer: that field now
- * answers the ROLE alone, and `write_in` answers this one.
+ * answers the ROLE alone, and `write_ins` answers this one.
  *
  * ## What is deliberately NOT here
  *
@@ -42,9 +42,9 @@
  * string rendered as both the occupant's NAME and the card's italic reason line
  * printed twice on one card. A fallback would restore that by another route.
  *
- * No fallback from `write_in` to `family_available_override === false` either,
+ * No fallback from `write_ins` to `family_available_override === false` either,
  * and that one was deliberately removed rather than never written — see
- * `coveringWriteIn`.
+ * `coveringWriteIns`.
  */
 import type { LodgingUnitRow, WriteInCoverRow } from '../../types/lodging'
 
@@ -69,22 +69,31 @@ export interface WriteInOccupant {
 }
 
 /**
- * The occupant written into this space for this weekend, or `null` if none.
+ * WHO is in this space and WHOSE row says so, kept together — one entry per
+ * write-in covering the unit.
  *
- * "This space", not "this unit": a building's write-in closes its rooms and a
- * room's closes its building as a whole-house let, and the board draws whichever
- * level the unit tree resolves to. The server does that walk (`write_in_covers`)
- * and this reads its answer.
+ * A PAIR rather than two functions returning two arrays, which is what this
+ * was until kindred#2381 (`writeInOccupant` / `writeInSource`). Splitting them
+ * was right while there was exactly one cover: "who is in this space" is what
+ * the card prints and "whose row is this" is what a CLEAR has to name, and
+ * sending the card's own id for an inherited write-in would delete nothing at
+ * all. With N covers on one card the two answers have to stay lined up — the X
+ * drawn on the third card must delete the THIRD row — and index alignment held
+ * by hand across two arrays is the invariant that rots first.
  */
-export function writeInOccupant(unit: LodgingUnitRow): WriteInOccupant | null {
-  const cover = coveringWriteIn(unit)
-  if (cover === null) return null
-  return { name: (cover.occupant_name ?? '').trim(), note: (cover.note ?? '').trim() }
+export interface WriteInEntry {
+  occupant: WriteInOccupant
+  source: WriteInSource
 }
 
-/** Where a unit's write-in is recorded, or `null` if none covers it. */
+/**
+ * Where a unit's write-in is recorded.
+ *
+ * A room can inherit its building's row and a merged building one of its
+ * rooms', so this is not always the unit the card draws.
+ */
 export interface WriteInSource {
-  /** The unit the `lodging_write_ins` row belongs to — a clear's target. */
+  /** The unit the `lodging_write_ins` row belongs to — a removal's target. */
   unitId: string
   unitCode: string
   unitName: string
@@ -93,29 +102,57 @@ export interface WriteInSource {
 }
 
 /**
- * WHICH unit holds the write-in covering this one.
+ * Every write-in closing this space for this weekend, in the server's order.
  *
- * A SECOND function rather than more fields on `WriteInOccupant`, because the
- * two answer different questions and only one of them is display. "Who is in
- * this space" is what the card prints; "whose row is this" is what a CLEAR has
- * to name, and sending the card's own id for an inherited write-in would
- * delete nothing at all — the room has no row. Keeping them apart is also what
- * left every existing reader of the occupant untouched.
+ * "This space", not "this unit": a building's write-in closes its rooms and a
+ * room's closes its building as a whole-house let, and the board draws
+ * whichever level the unit tree resolves to. The server does that walk
+ * (`write_in_covers`) and this reads its answer.
+ *
+ * PLURAL since kindred#2381, and the arity is the fix rather than a
+ * generalisation. A merged container stands in for its rooms, so the four
+ * write-ins one 2026 building carries in a single weekend all land on one
+ * card — and returning the first hid three occupants while making each clear
+ * read as a failed click, because the card immediately re-populated with the
+ * next name. An assignment survives a merge and a split by having the drawn
+ * card carry however many leaves it covers; this is a write-in doing the same.
+ *
+ * ORDERED BY THE SERVER (`code` at every level), never re-sorted here: two
+ * places deciding the sequence is two places that can disagree about it.
  */
-export function writeInSource(unit: LodgingUnitRow): WriteInSource | null {
-  const cover = coveringWriteIn(unit)
-  if (cover === null) return null
-  const unitCode = cover.unit_code ?? ''
-  return {
-    unitId: cover.unit_id ?? '',
-    unitCode,
-    unitName: cover.unit_name ?? '',
-    isOwn: unitCode === unit.code,
-  }
+export function writeInEntries(unit: LodgingUnitRow): WriteInEntry[] {
+  return coveringWriteIns(unit).map((cover) => {
+    const unitCode = cover.unit_code ?? ''
+    return {
+      occupant: {
+        name: (cover.occupant_name ?? '').trim(),
+        note: (cover.note ?? '').trim(),
+      },
+      source: {
+        unitId: cover.unit_id ?? '',
+        unitCode,
+        unitName: cover.unit_name ?? '',
+        isOwn: unitCode === unit.code,
+      },
+    }
+  })
 }
 
 /**
- * The server-resolved cover, and NOTHING else.
+ * Whether ANY write-in closes this space.
+ *
+ * The gate every consumer that only needs the yes/no reads — the drop refusal
+ * (`dragPlacement`), its affordance half on the card, and the "Write-in" chip.
+ * Spelled once so a merged card covering four occupants and a room covering
+ * one are the same answer to those three, which `!== null` on a single cover
+ * silently stopped being.
+ */
+export function hasWriteIn(unit: LodgingUnitRow): boolean {
+  return coveringWriteIns(unit).length > 0
+}
+
+/**
+ * The server-resolved covers, and NOTHING else.
  *
  * ## Why the old fallback is gone rather than merely unused
  *
@@ -133,9 +170,11 @@ export function writeInSource(unit: LodgingUnitRow): WriteInSource | null {
  * fabricated occupant is not the conservative answer — it is a different wrong
  * one, and it would also block placement into a cabin that is merely closed.
  *
- * There is no gap left to guard. `write_in` is built for every unit the API
- * returns, and a unit with neither a cover nor a role row is simply open.
+ * There is no gap left to guard. `write_ins` is built for every unit the API
+ * returns, and a unit with neither a cover nor a role row is simply open. The
+ * `?? []` is for the FIELD being absent from an older payload, not for a unit
+ * the walk declined to answer for.
  */
-function coveringWriteIn(unit: LodgingUnitRow): WriteInCoverRow | null {
-  return unit.write_in ?? null
+function coveringWriteIns(unit: LodgingUnitRow): WriteInCoverRow[] {
+  return unit.write_ins ?? []
 }

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -2226,7 +2226,10 @@ export type LodgingUnitSummary = {
    * Is Family Available
    */
   is_family_available?: boolean
-  write_in?: WriteInCover | null
+  /**
+   * Write Ins
+   */
+  write_ins?: Array<WriteInCover>
   /**
    * Map X
    */

--- a/frontend/src/types/lodging.test.ts
+++ b/frontend/src/types/lodging.test.ts
@@ -258,7 +258,7 @@ const _exhaustiveLodgingUnit: Required<LodgingUnitRow> = {
   // nearest descendant's. Distinct from the three fields above, which stay
   // strictly this unit's own row: a room can be closed by a write-in it does
   // not hold, which is what a merge or a split does to one.
-  write_in: null,
+  write_ins: [],
   map_x: 0.5,
   map_y: 0.5,
 }

--- a/frontend/src/types/lodging.ts
+++ b/frontend/src/types/lodging.ts
@@ -56,7 +56,7 @@ export type RosterCountSummary = RosterCounts
 export type LodgingUnitRow = LodgingUnitSummary
 /**
  * The write-in covering a unit's space, resolved through the tree by the
- * server. Read it through `writeInOccupant`/`writeInSource`, never inline: the
+ * server. Read it through `writeInEntries`/`hasWriteIn`, never inline: the
  * point of naming the fact once is that the board's five consumers cannot
  * drift onto different spellings of it.
  */

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -4642,14 +4642,14 @@ class TestTheWireStopsSpellingAnOccupancyAsFamilyAvailableFalse:
     still reported `family_available_override = False`, because
     `is_family_available` -- and through it every count on the stats bar, and
     the board's own forest open-tint -- was derived from that one field. Every
-    consumer has since been re-pointed at the occupancy source (`write_in`, and
-    `writeInOccupant` on the client), so the field can go back to answering the
+    consumer has since been re-pointed at the occupancy source (`write_ins`, and
+    `writeInEntries` on the client), so the field can go back to answering the
     ONE question it is named for.
 
     | on the wire | what it means now |
     |---|---|
     | `family_available_override` | the staff<->family ROLE row, and nothing else |
-    | `write_in` | somebody is in this space -- the occupancy, resolved |
+    | `write_ins` | who is in this space -- the occupancy, resolved |
     | `is_family_available` | the DERIVED answer, which still folds both in |
 
     `is_family_available` is what does not move, and that is the point of the

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -1064,14 +1064,14 @@ class TestUnitsAndCounts:
         by_code = {u.code: u for u in roster.units}
         # The room holds no row of its own -- and is closed all the same.
         assert by_code["house-a"].family_available_override is None
-        assert by_code["house-a"].write_in is not None
-        assert by_code["house-a"].write_in.unit_id == "u1"
-        assert by_code["house-a"].write_in.occupant_name == "Liam Garcia"
-        assert by_code["house-a"].write_in.note == "Back Monday"
+        assert by_code["house-a"].write_ins != []
+        assert by_code["house-a"].write_ins[0].unit_id == "u1"
+        assert by_code["house-a"].write_ins[0].occupant_name == "Liam Garcia"
+        assert by_code["house-a"].write_ins[0].note == "Back Monday"
         # And the building still reads as its own, so the card that holds the
         # row does not start attributing it elsewhere.
-        assert by_code["house"].write_in is not None
-        assert by_code["house"].write_in.unit_code == "house"
+        assert by_code["house"].write_ins != []
+        assert by_code["house"].write_ins[0].unit_code == "house"
 
     @pytest.mark.asyncio
     async def test_a_write_in_on_a_room_reaches_the_building_over_it(self) -> None:
@@ -1089,9 +1089,9 @@ class TestUnitsAndCounts:
         roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
 
         by_code = {u.code: u for u in roster.units}
-        assert by_code["house"].write_in is not None
-        assert by_code["house"].write_in.unit_id == "u2"
-        assert by_code["house"].write_in.occupant_name == "Ava Martinez"
+        assert by_code["house"].write_ins != []
+        assert by_code["house"].write_ins[0].unit_id == "u2"
+        assert by_code["house"].write_ins[0].occupant_name == "Ava Martinez"
 
     @pytest.mark.asyncio
     async def test_an_ordinary_open_cabin_carries_no_cover_at_all(self) -> None:
@@ -1104,7 +1104,7 @@ class TestUnitsAndCounts:
         )
         roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
 
-        assert roster.units[0].write_in is None
+        assert roster.units[0].write_ins == []
 
     @pytest.mark.asyncio
     async def test_a_true_override_beats_a_false_default(self) -> None:
@@ -4184,9 +4184,9 @@ class TestWriteInCovers:
 
         covers = write_in_covers([house, room], self._written("house"))
 
-        assert covers["house-a"].unit_code == "house"
-        assert covers["house-a"].occupant_name == "Liam Garcia"
-        assert covers["house-a"].note == "Back Monday"
+        assert covers["house-a"][0].unit_code == "house"
+        assert covers["house-a"][0].occupant_name == "Liam Garcia"
+        assert covers["house-a"][0].note == "Back Monday"
 
     def test_a_building_surfaces_the_write_in_of_a_room_beneath_it(self) -> None:
         # The MERGE case, and the mirror of the one above: the row names a room
@@ -4197,8 +4197,8 @@ class TestWriteInCovers:
 
         covers = write_in_covers([house, written_room, other_room], self._written("house-a"))
 
-        assert covers["house"].unit_code == "house-a"
-        assert covers["house"].occupant_name == "Liam Garcia"
+        assert covers["house"][0].unit_code == "house-a"
+        assert covers["house"][0].occupant_name == "Liam Garcia"
 
     def test_a_sibling_room_is_not_covered(self) -> None:
         # The one direction that must NOT propagate. A caretaker in room A says
@@ -4213,7 +4213,7 @@ class TestWriteInCovers:
         covers = write_in_covers([house, written_room, other_room], self._written("house-a"))
 
         assert "house-b" not in covers
-        assert covers["house"].unit_code == "house-a"
+        assert covers["house"][0].unit_code == "house-a"
 
     def test_a_units_own_write_in_beats_an_inherited_one(self) -> None:
         house = self._unit("house", is_container=True, occupant_name="Liam Garcia")
@@ -4221,8 +4221,8 @@ class TestWriteInCovers:
 
         covers = write_in_covers([house, room], self._written("house", "house-a"))
 
-        assert covers["house-a"].unit_code == "house-a"
-        assert covers["house-a"].occupant_name == "Ava Martinez"
+        assert covers["house-a"][0].unit_code == "house-a"
+        assert covers["house-a"][0].occupant_name == "Ava Martinez"
 
     def test_the_nearest_ancestor_wins(self) -> None:
         block = self._unit("block", is_container=True, occupant_name="Ava Martinez")
@@ -4236,7 +4236,7 @@ class TestWriteInCovers:
 
         covers = write_in_covers([block, house, room], self._written("block", "house"))
 
-        assert covers["house-a"].unit_code == "house"
+        assert covers["house-a"][0].unit_code == "house"
 
     def test_a_release_is_not_a_write_in(self) -> None:
         # A ROLE release is a staff cabin OPENED to families for the weekend. It
@@ -4295,17 +4295,64 @@ class TestWriteInCovers:
 
         assert write_in_covers([written, other], self._written("")) == {}
 
-    def test_several_written_rooms_pick_one_deterministically(self) -> None:
-        # A building over two written-into rooms is closed either way; the
-        # point is that two identical payloads never disagree about WHICH row
-        # the card names, which a set-ordered walk would not guarantee.
+    def test_several_written_rooms_are_all_returned_in_code_order(self) -> None:
+        # A building over two written-into rooms carries BOTH, in `code` order
+        # so two identical payloads never disagree about the sequence a card
+        # draws them in. This used to return exactly one and drop the rest --
+        # kindred#2381, the merge half of the parity bug.
         house = self._unit("house", is_container=True, is_combined=True)
         room_b = self._unit("house-b", parent_code="house", occupant_name="Ava Martinez")
         room_a = self._unit("house-a", parent_code="house", occupant_name="Liam Garcia")
         written = self._written("house-a", "house-b")
 
-        assert write_in_covers([house, room_b, room_a], written)["house"].unit_code == "house-a"
-        assert write_in_covers([house, room_a, room_b], written)["house"].unit_code == "house-a"
+        for units in ([house, room_b, room_a], [house, room_a, room_b]):
+            assert [cover.unit_code for cover in write_in_covers(units, written)["house"]] == [
+                "house-a",
+                "house-b",
+            ]
+
+    def test_a_merged_building_surfaces_every_written_room_beneath_it(self) -> None:
+        """The reported case: four written-into rooms under one merged card.
+
+        A merged container draws in place of its rooms, so before kindred#2381
+        the four occupants collapsed to whichever room sorted first and the
+        other three were invisible -- and each clear silently re-populated the
+        card with the next one, which read as a failed click.
+        """
+        house = self._unit("house", is_container=True, is_combined=True)
+        rooms = [
+            self._unit("house-back", parent_code="house", occupant_name="Emma Johnson"),
+            self._unit("house-laundry", parent_code="house", occupant_name="Liam Garcia"),
+            self._unit("house-loft", parent_code="house", occupant_name="Olivia Martinez"),
+            self._unit("house-side", parent_code="house", occupant_name="Noah Chen"),
+        ]
+
+        covers = write_in_covers([house, *rooms], self._written(*(room.code for room in rooms)))
+
+        assert [cover.occupant_name for cover in covers["house"]] == [
+            "Emma Johnson",
+            "Liam Garcia",
+            "Olivia Martinez",
+            "Noah Chen",
+        ]
+        # Each room still answers for itself alone -- the collect-all runs
+        # DOWNWARD from the drawn card and never sideways.
+        for room in rooms:
+            assert [cover.unit_code for cover in covers[room.code]] == [room.code]
+
+    def test_the_descendant_walk_stops_at_the_nearest_written_room_on_each_branch(self) -> None:
+        # A written-into room inside a written-into wing is already inside that
+        # wing's space -- the wing's row speaks for it, and returning both to
+        # the building would print the same space twice. "Collect all" is
+        # per-branch nearest, not every descendant.
+        house = self._unit("house", is_container=True, is_combined=True)
+        wing = self._unit("house-a", parent_code="house", is_container=True, occupant_name="Emma Johnson")
+        bed = self._unit("house-a-1", parent_code="house-a", occupant_name="Liam Garcia")
+        other_wing = self._unit("house-b", parent_code="house", occupant_name="Olivia Martinez")
+
+        covers = write_in_covers([house, wing, bed, other_wing], self._written("house-a", "house-a-1", "house-b"))
+
+        assert [cover.unit_code for cover in covers["house"]] == ["house-a", "house-b"]
 
 
 class TestWriteInsResolveFromTheirOwnTable:
@@ -4356,9 +4403,9 @@ class TestWriteInsResolveFromTheirOwnTable:
         # answering both. See TestTheWireStopsSpellingAnOccupancyAsFamilyAvailableFalse.
         assert unit.family_available_override is None
         assert unit.is_family_available is False
-        assert unit.write_in is not None
-        assert unit.write_in.unit_id == "u1"
-        assert unit.write_in.occupant_name == "Liam Garcia"
+        assert unit.write_ins != []
+        assert unit.write_ins[0].unit_id == "u1"
+        assert unit.write_ins[0].occupant_name == "Liam Garcia"
 
     @pytest.mark.asyncio
     async def test_a_stale_availability_occupancy_row_no_longer_writes_anybody_in(self) -> None:
@@ -4385,7 +4432,7 @@ class TestWriteInsResolveFromTheirOwnTable:
         roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
 
         assert roster.units[0].is_family_available is False
-        assert roster.units[0].write_in is None
+        assert roster.units[0].write_ins == []
 
     @pytest.mark.asyncio
     async def test_a_role_release_still_comes_from_availability(self) -> None:
@@ -4412,7 +4459,7 @@ class TestWriteInsResolveFromTheirOwnTable:
         # A release names no occupant and closes nothing, so it must never
         # resolve to a cover -- inheriting one would silently open every room
         # beneath a released building.
-        assert unit.write_in is None
+        assert unit.write_ins == []
 
     @pytest.mark.asyncio
     async def test_a_write_in_outranks_a_release_on_the_same_unit(self) -> None:
@@ -4439,7 +4486,7 @@ class TestWriteInsResolveFromTheirOwnTable:
         assert unit.family_available_override is True
         assert unit.is_family_available is False
         assert unit.occupant_name == "Ava Martinez"
-        assert unit.write_in is not None
+        assert unit.write_ins != []
 
     @pytest.mark.asyncio
     async def test_the_roster_reads_the_write_in_table_for_this_weekend(self) -> None:
@@ -4539,7 +4586,7 @@ class TestWriteInsResolveFromTheirOwnTable:
 
         repo.fetch_write_ins.assert_awaited_once_with(2026, 1000001)
         assert repo.fetch_draft_write_ins.await_count == 0
-        assert roster.units[0].write_in is not None
+        assert roster.units[0].write_ins != []
 
     @pytest.mark.asyncio
     async def test_a_written_into_cabin_is_still_counted_as_reserved(self) -> None:
@@ -4582,10 +4629,10 @@ class TestWriteInsResolveFromTheirOwnTable:
 
         by_code = {u.code: u for u in roster.units}
         assert by_code["house-a"].family_available_override is None
-        assert by_code["house-a"].write_in is not None
-        assert by_code["house-a"].write_in.unit_id == "u1"
-        assert by_code["house-a"].write_in.occupant_name == "Liam Garcia"
-        assert by_code["house-a"].write_in.note == "Back Monday"
+        assert by_code["house-a"].write_ins != []
+        assert by_code["house-a"].write_ins[0].unit_id == "u1"
+        assert by_code["house-a"].write_ins[0].occupant_name == "Liam Garcia"
+        assert by_code["house-a"].write_ins[0].note == "Back Monday"
 
 
 class TestTheWireStopsSpellingAnOccupancyAsFamilyAvailableFalse:
@@ -4635,7 +4682,7 @@ class TestTheWireStopsSpellingAnOccupancyAsFamilyAvailableFalse:
         # THE HALF THAT MUST NOT MOVE. The derived answer still folds the
         # occupancy in, so nothing staff read changes.
         assert unit.is_family_available is False
-        assert unit.write_in is not None
+        assert unit.write_ins != []
         assert unit.occupant_name == "Liam Garcia"
 
     @pytest.mark.asyncio
@@ -4668,7 +4715,7 @@ class TestTheWireStopsSpellingAnOccupancyAsFamilyAvailableFalse:
         # safe direction: reading the release instead would open a cabin with
         # somebody sleeping in it.
         assert unit.is_family_available is False
-        assert unit.write_in is not None
+        assert unit.write_ins != []
 
     @pytest.mark.asyncio
     async def test_the_counts_do_not_move_when_the_shim_comes_out(self) -> None:
@@ -4716,7 +4763,7 @@ class TestTheWireStopsSpellingAnOccupancyAsFamilyAvailableFalse:
         unit = roster.units[0]
         assert unit.family_available_override is False
         assert unit.is_family_available is False
-        assert unit.write_in is None
+        assert unit.write_ins == []
 
 
 class TestAScenariosWriteInsReplaceTheLiveOnes:
@@ -4774,7 +4821,7 @@ class TestAScenariosWriteInsReplaceTheLiveOnes:
         roster = await LodgingRosterService(repo).build_roster(2026, 1000001, scenario="scn_1")
 
         unit = roster.units[0]
-        assert unit.write_in is None
+        assert unit.write_ins == []
         assert unit.family_available_override is None
         assert unit.is_family_available is True
         assert unit.occupant_name == ""
@@ -4803,8 +4850,8 @@ class TestAScenariosWriteInsReplaceTheLiveOnes:
         assert unit.is_family_available is False
         assert unit.occupant_name == "Olivia Chen"
         assert unit.reason == "Paper registration"
-        assert unit.write_in is not None
-        assert unit.write_in.unit_id == "u1"
+        assert unit.write_ins != []
+        assert unit.write_ins[0].unit_id == "u1"
 
     @pytest.mark.asyncio
     async def test_two_scenarios_can_write_the_same_family_into_different_cabins(self) -> None:
@@ -4863,9 +4910,9 @@ class TestAScenariosWriteInsReplaceTheLiveOnes:
         roster = await LodgingRosterService(repo).build_roster(2026, 1000001, scenario="scn_1")
 
         by_code = {u.code: u for u in roster.units}
-        assert by_code["house-a"].write_in is not None
-        assert by_code["house-a"].write_in.unit_id == "u1"
-        assert by_code["house-a"].write_in.occupant_name == "Olivia Chen"
+        assert by_code["house-a"].write_ins != []
+        assert by_code["house-a"].write_ins[0].unit_id == "u1"
+        assert by_code["house-a"].write_ins[0].occupant_name == "Olivia Chen"
 
     @pytest.mark.asyncio
     async def test_the_role_override_is_still_read_from_the_live_table_in_a_scenario(self) -> None:


### PR DESCRIPTION
feat(frontend): one box places a family or writes a name in, and the strip loses its write-in

Every tile carried two typeable rectangles asking the same question -- who is
sleeping in this cabin. The card's family picker was one; the availability
strip's "Write in" button opened the other, an occupant field plus an optional
note. Staff had to choose a control before they knew which kind of answer they
had.

Now there is one box. Type into it: if a registered family matches, place them;
if none does, the list offers `Write in "<what you typed>"`, on Enter or on a
click, and that text becomes the write-in.

## What this fixes beyond the tidy-up

#2090 gated the strip's write-in on the space being empty, and the picker was
hidden on an occupied card by a parallel rule. On a MERGED building that left no
write-in path at all -- refused on the building, and its rooms lose their own
cards to the merge:

    "if i populate 3/4 of clouds rest, i cannot add a write in directly to it"

Both gates are gone. The box is offered on every placeable card, occupied or
not, and family rows keep inheriting every refusal from
`resolvePickerPlacement` -> `resolveDrop` exactly as before.

## Kept deliberately

- **The note.** It carries real information -- one of the three notes in
  production is a third occupant's name, not a remark -- so the field stays,
  edited by the pencil on the write-in's own card. What went is the SECOND
  place to type one, mid-creation, beside a box that was already open.
- **The divergence from `canPlace`.** Recording who is in a cabin is a fact
  about the weekend, not about a plan, so the box stays live on the CampMinder
  mirror where nothing can be placed -- named "Write in an occupant for X"
  there, since offering to place a family would name an impossible action.
- **The per-card pending gate**, moved onto the box. 81 cards share one
  mutation, and a combobox invites a second write-in against an unsettled first.

## Also struck: the "Written in at <room>" line

It said which room a merged card's write-in belongs to. The room dimension is
real, but the line said it for write-ins and stayed silent about the FAMILIES in
the same well -- a half-built version of one shorthand covering every occupant,
which is filed as #2458.

## Not done

No API change and no migration: `set_availability` already routes a write-in
through `_upsert_row`, and the `note` column and its three rows are untouched.
The write-in still carries no headcount, so a shared space's free-bed figure
understates -- that is #2439, unchanged by this.

## Mix and match, either order, leaf or container

A second commit completes the reversal. Adding a write-in to a cabin holding a
family worked; the mirror did not — a cabin whose only occupant was a write-in
refused a family and offered no box. Three gates enforced the old rule and all
three are gone: `resolveDrop`'s write-in refusal (the load-bearing one, since
the picker path never touches a `useDroppable`), the card's `useDroppable`
`disabled: … || held` (the affordance half — without it the target never even
highlighted), and `canPickFamily`'s `!held`.

A write-in NAMES AN OCCUPANT; it does not CLOSE THE SPACE.

Closes #2381.
Closes #2430.
Closes #2431.
Closes #2432.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


---

Supersedes the earlier shape of this PR, which kept the strip's "Write in"
button beside the card's family box and added a `Written in at …` line. Both
were struck by the owner on review, 2026-08-18.

