### PR TITLE
fix(sync): paginate GetSessions/GetSessionGroups past TotalCount

### DIFF
--- a/pocketbase/campminder/client.go
+++ b/pocketbase/campminder/client.go
@@ -53,6 +53,10 @@ type Client struct {
 
 	// authURL overrides the production auth endpoint. Non-empty only in tests.
 	authURL string
+
+	// apiBaseURL overrides baseURL for regular (non-auth) API requests made via
+	// makeRequest. Non-empty only in tests.
+	apiBaseURL string
 }
 
 // Config holds CampMinder configuration
@@ -315,7 +319,11 @@ func (c *Client) makeRequest(method, endpoint string, params map[string]string) 
 	}
 
 	// Build URL with parameters
-	fullURL := fmt.Sprintf("%s/%s", baseURL, strings.TrimPrefix(endpoint, "/"))
+	base := baseURL
+	if c.apiBaseURL != "" {
+		base = c.apiBaseURL
+	}
+	fullURL := fmt.Sprintf("%s/%s", base, strings.TrimPrefix(endpoint, "/"))
 
 	if len(params) > 0 && method == "GET" {
 		values := url.Values{}
@@ -369,32 +377,49 @@ func (c *Client) makeRequest(method, endpoint string, params map[string]string) 
 	return body, nil
 }
 
-// GetSessions retrieves all sessions for the configured season
+// sessionsPageSize is the page size used by GetSessions and GetSessionGroups.
+// Both methods loop across pages using TotalCount, so this bounds request
+// count rather than capping the result set (see #2437).
+const sessionsPageSize = 100
+
+// GetSessions retrieves all sessions for the configured season, paginating
+// as needed so that a TotalCount beyond one page is never silently dropped
+// (#2437).
 //
 //nolint:dupl // Similar pattern to GetSessionGroups, intentional for different endpoints
 func (c *Client) GetSessions() ([]map[string]any, error) {
-	params := map[string]string{
-		"clientid":   c.clientID,
-		"seasonid":   strconv.Itoa(c.seasonID),
-		"pagenumber": "1",
-		"pagesize":   "100",
+	var all []map[string]any
+
+	for page := 1; ; page++ {
+		params := map[string]string{
+			"clientid":   c.clientID,
+			"seasonid":   strconv.Itoa(c.seasonID),
+			"pagenumber": strconv.Itoa(page),
+			"pagesize":   strconv.Itoa(sessionsPageSize),
+		}
+
+		body, err := c.makeRequest("GET", "sessions", params)
+		if err != nil {
+			return nil, err
+		}
+
+		var response struct {
+			TotalCount int              `json:"TotalCount"`
+			Results    []map[string]any `json:"Results"`
+		}
+
+		if err := json.Unmarshal(body, &response); err != nil {
+			return nil, fmt.Errorf("decode sessions response: %w", err)
+		}
+
+		all = append(all, response.Results...)
+
+		if len(response.Results) == 0 || len(all) >= response.TotalCount {
+			break
+		}
 	}
 
-	body, err := c.makeRequest("GET", "sessions", params)
-	if err != nil {
-		return nil, err
-	}
-
-	var response struct {
-		TotalCount int              `json:"TotalCount"`
-		Results    []map[string]any `json:"Results"`
-	}
-
-	if err := json.Unmarshal(body, &response); err != nil {
-		return nil, fmt.Errorf("decode sessions response: %w", err)
-	}
-
-	return response.Results, nil
+	return all, nil
 }
 
 // GetAttendeesPage retrieves attendees with pagination
@@ -683,32 +708,44 @@ func (c *Client) parseRateLimitSeconds(body string) int {
 	return 60
 }
 
-// GetSessionGroups retrieves session groupings for the configured season
+// GetSessionGroups retrieves session groupings for the configured season,
+// paginating as needed so that a TotalCount beyond one page is never
+// silently dropped (#2437).
 //
 //nolint:dupl // Similar pattern to GetSessions, intentional for different endpoints
 func (c *Client) GetSessionGroups() ([]map[string]any, error) {
-	params := map[string]string{
-		"clientid":   c.clientID,
-		"seasonid":   strconv.Itoa(c.seasonID),
-		"pagenumber": "1",
-		"pagesize":   "100",
+	var all []map[string]any
+
+	for page := 1; ; page++ {
+		params := map[string]string{
+			"clientid":   c.clientID,
+			"seasonid":   strconv.Itoa(c.seasonID),
+			"pagenumber": strconv.Itoa(page),
+			"pagesize":   strconv.Itoa(sessionsPageSize),
+		}
+
+		body, err := c.makeRequest("GET", "sessions/groups", params)
+		if err != nil {
+			return nil, err
+		}
+
+		var response struct {
+			TotalCount int              `json:"TotalCount"`
+			Results    []map[string]any `json:"Results"`
+		}
+
+		if err := json.Unmarshal(body, &response); err != nil {
+			return nil, fmt.Errorf("decode session groups response: %w", err)
+		}
+
+		all = append(all, response.Results...)
+
+		if len(response.Results) == 0 || len(all) >= response.TotalCount {
+			break
+		}
 	}
 
-	body, err := c.makeRequest("GET", "sessions/groups", params)
-	if err != nil {
-		return nil, err
-	}
-
-	var response struct {
-		TotalCount int              `json:"TotalCount"`
-		Results    []map[string]any `json:"Results"`
-	}
-
-	if err := json.Unmarshal(body, &response); err != nil {
-		return nil, fmt.Errorf("decode session groups response: %w", err)
-	}
-
-	return response.Results, nil
+	return all, nil
 }
 
 // GetPersonTagDefinitions retrieves person tag definitions from CampMinder

--- a/pocketbase/campminder/client_test.go
+++ b/pocketbase/campminder/client_test.go
@@ -708,3 +708,166 @@ func TestCloneWithYear_OwnHTTPClient(t *testing.T) {
 			cloned.httpClient.Timeout, original.httpClient.Timeout)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// #2437 — GetSessions/GetSessionGroups must paginate past TotalCount instead
+// of silently discarding it after one page of 100.
+// ---------------------------------------------------------------------------
+
+// TestGetSessions_PaginatesPastFirstPage verifies that when TotalCount
+// exceeds the size of a single page, GetSessions fetches subsequent pages
+// and returns the full accumulated result set rather than silently
+// truncating at the first page (the pre-fix behavior: session 101+ would
+// vanish with no error and no log line).
+func TestGetSessions_PaginatesPastFirstPage(t *testing.T) {
+	t.Setenv("CAMPMINDER_PRIMARY_KEY", "test-subscription-key")
+
+	const totalCount = 101 // one more than the old hardcoded pagesize of 100
+
+	var pagesRequested []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("pagenumber")
+		pagesRequested = append(pagesRequested, page)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		switch page {
+		case "1":
+			results := make([]string, 0, 100)
+			for i := range 100 {
+				results = append(results, fmt.Sprintf(`{"ID":%d}`, i+1))
+			}
+			_, _ = fmt.Fprintf(w, `{"TotalCount":%d,"Results":[%s]}`,
+				totalCount, strings.Join(results, ","))
+		case "2":
+			_, _ = fmt.Fprintf(w, `{"TotalCount":%d,"Results":[{"ID":101}]}`, totalCount)
+		default:
+			t.Errorf("unexpected pagenumber requested: %q", page)
+		}
+	}))
+	defer srv.Close()
+
+	client := &Client{
+		apiKey:          "test-key",
+		subscriptionKey: "test-subscription-key",
+		clientID:        "test-client",
+		seasonID:        2025,
+		httpClient:      &http.Client{Timeout: 5 * time.Second},
+		accessToken:     "pre-seeded-token",
+		tokenExpiry:     time.Now().Add(time.Hour),
+		apiBaseURL:      srv.URL,
+	}
+
+	sessions, err := client.GetSessions()
+	if err != nil {
+		t.Fatalf("GetSessions() failed: %v", err)
+	}
+
+	if len(sessions) != totalCount {
+		t.Errorf("GetSessions() returned %d sessions, want %d (TotalCount) — session 101 was silently dropped",
+			len(sessions), totalCount)
+	}
+
+	if len(pagesRequested) < 2 {
+		t.Errorf("GetSessions() requested %d page(s) (%v), want at least 2 to cover TotalCount=%d",
+			len(pagesRequested), pagesRequested, totalCount)
+	}
+}
+
+// TestGetSessionGroups_PaginatesPastFirstPage is the GetSessionGroups analog
+// of TestGetSessions_PaginatesPastFirstPage — same silent-truncation bug,
+// same fix, same shape.
+func TestGetSessionGroups_PaginatesPastFirstPage(t *testing.T) {
+	t.Setenv("CAMPMINDER_PRIMARY_KEY", "test-subscription-key")
+
+	const totalCount = 101
+
+	var pagesRequested []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("pagenumber")
+		pagesRequested = append(pagesRequested, page)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		switch page {
+		case "1":
+			results := make([]string, 0, 100)
+			for i := range 100 {
+				results = append(results, fmt.Sprintf(`{"ID":%d}`, i+1))
+			}
+			_, _ = fmt.Fprintf(w, `{"TotalCount":%d,"Results":[%s]}`,
+				totalCount, strings.Join(results, ","))
+		case "2":
+			_, _ = fmt.Fprintf(w, `{"TotalCount":%d,"Results":[{"ID":101}]}`, totalCount)
+		default:
+			t.Errorf("unexpected pagenumber requested: %q", page)
+		}
+	}))
+	defer srv.Close()
+
+	client := &Client{
+		apiKey:          "test-key",
+		subscriptionKey: "test-subscription-key",
+		clientID:        "test-client",
+		seasonID:        2025,
+		httpClient:      &http.Client{Timeout: 5 * time.Second},
+		accessToken:     "pre-seeded-token",
+		tokenExpiry:     time.Now().Add(time.Hour),
+		apiBaseURL:      srv.URL,
+	}
+
+	groups, err := client.GetSessionGroups()
+	if err != nil {
+		t.Fatalf("GetSessionGroups() failed: %v", err)
+	}
+
+	if len(groups) != totalCount {
+		t.Errorf("GetSessionGroups() returned %d groups, want %d (TotalCount) — group 101 was silently dropped",
+			len(groups), totalCount)
+	}
+
+	if len(pagesRequested) < 2 {
+		t.Errorf("GetSessionGroups() requested %d page(s) (%v), want at least 2 to cover TotalCount=%d",
+			len(pagesRequested), pagesRequested, totalCount)
+	}
+}
+
+// TestGetSessions_SinglePageUnderLimit verifies that when TotalCount fits in
+// one page, GetSessions makes exactly one request (no unnecessary second
+// page fetch).
+func TestGetSessions_SinglePageUnderLimit(t *testing.T) {
+	t.Setenv("CAMPMINDER_PRIMARY_KEY", "test-subscription-key")
+
+	requestCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"TotalCount":3,"Results":[{"ID":1},{"ID":2},{"ID":3}]}`)
+	}))
+	defer srv.Close()
+
+	client := &Client{
+		apiKey:          "test-key",
+		subscriptionKey: "test-subscription-key",
+		clientID:        "test-client",
+		seasonID:        2025,
+		httpClient:      &http.Client{Timeout: 5 * time.Second},
+		accessToken:     "pre-seeded-token",
+		tokenExpiry:     time.Now().Add(time.Hour),
+		apiBaseURL:      srv.URL,
+	}
+
+	sessions, err := client.GetSessions()
+	if err != nil {
+		t.Fatalf("GetSessions() failed: %v", err)
+	}
+	if len(sessions) != 3 {
+		t.Errorf("GetSessions() returned %d sessions, want 3", len(sessions))
+	}
+	if requestCount != 1 {
+		t.Errorf("GetSessions() made %d requests, want 1 (all results fit in one page)", requestCount)
+	}
+}


### PR DESCRIPTION
`GetSessions` and `GetSessionGroups` in `pocketbase/campminder/client.go` requested a single page
of 100 records, decoded `TotalCount` from the CampMinder response, and then discarded it. At 101
sessions (or session groups), the 101st record would silently disappear — no error, no log line.
The bug was latent, not yet firing: production's measured peak was 58 sessions in 2024, but the
2020-2024 trend added roughly five sessions a year.

## Fix

Both methods now loop over `pagenumber`, accumulating `Results` across pages, until
`len(accumulated) >= TotalCount` or a page comes back empty. This removes the class of bug rather
than just raising the ceiling (e.g. bumping `pagesize` to 500 would still leave a silent cliff at
501). The page size itself is unchanged (100 per page); only the "single page and done" assumption
was removed.

To make this testable, added an `apiBaseURL` field to `Client`, following the same pattern the
existing `authURL` field already uses to redirect auth calls to a test server — `apiBaseURL` does
the same for `makeRequest`'s regular API calls. It is empty in production and non-empty only in
tests.

## Tests

- `TestGetSessions_PaginatesPastFirstPage` / `TestGetSessionGroups_PaginatesPastFirstPage`: a mock
  server returns `TotalCount: 101` split across two pages; asserts all 101 records come back and
  at least two pages were requested.
- `TestGetSessions_SinglePageUnderLimit`: asserts no extra request is made when everything fits in
  page 1.

All three were run against the pre-fix single-page code first and failed (verified RED), then
against the fix (verified GREEN). Mutation-checked by re-breaking each method's loop-continuation
condition post-fix and confirming the corresponding test goes RED again.

## Verification note

`bash scripts/pre-push-verify.sh`'s combined `go test -race ./... -v` step hit Go's hardcoded
600s default test timeout on the unrelated `sync` package, purely from this worktree's host
running 9 concurrent overnight agents (each running their own heavy test suite). Isolated re-runs
prove it is a contention artifact, not a regression: `go test -race ./sync/... -timeout 25m`
passed clean in 656.751s (vs. the documented 297s baseline under normal load — consistent with
CPU starvation, not breakage), `go build ./...`, the full `go test ./...` (no `-race`), and
`golangci-lint run` (both scoped to `campminder` and repo-wide) all passed clean. The diff here
touches zero files under `sync/`.

## Deliberately NOT done

- Did not add a loud error path for the "response came back short of TotalCount" case beyond the
  loop's own retry — the loop just keeps requesting pages until it has everything or the server
  stops returning results, which is the strictly better fix the issue itself preferred over an
  error-and-bail.
- Did not touch the other single-page "get all" methods in this file (`GetDivisions`,
  `GetStaffProgramAreas`, `GetStaffOrgCategories`, `GetStaffPositions`) — they already use
  `pagesize: 500` against typical counts well under 100, and were out of scope for this issue.

Closes #2437.
