### PR TITLE
fix(sync): admit the adult weekends' WW- prefix into financial aid applications

### DIFF
--- a/pocketbase/sync/financial_aid_applications.go
+++ b/pocketbase/sync/financial_aid_applications.go
@@ -22,6 +22,14 @@ const (
 	faFieldSummerQuestAmtRequested       = "Summer/Quest: Amt Requested"
 	faFieldFamilyCampAmtRequested        = "Family Camp: Amt Requested"
 	faFieldBnaiMitzvahAmtRequested       = "B'nai Mitzvah: Amt Requested"
+	// WW- fields are the adult weekends' equivalent of the CA- interest
+	// indicators above -- same four-question shape (interest / amount
+	// awarded / donation amount / donation other), routed to the same four
+	// program-neutral columns. See kindred#2436.
+	faFieldWWFinancialAssistanceInterest = "WW-FA"
+	faFieldWWFinancialAssistanceAmount   = "WW-FA Amount"
+	faFieldWWDonationAmount              = "WW-Donation Amount"
+	faFieldWWDonationOther               = "WW-Donation Amount Other"
 	// Boolean string parsing constants (shared with other sync files)
 	boolYes = "yes"
 )
@@ -306,6 +314,18 @@ func isFAFieldName(name string) bool {
 		return false
 	}
 
+	// WW- prefix: the adult weekends' equivalent of the CA- interest
+	// indicators, same fixed allowlist shape (kindred#2436).
+	if len(name) >= 3 && name[:3] == "WW-" {
+		if name == faFieldWWFinancialAssistanceInterest ||
+			name == faFieldWWFinancialAssistanceAmount ||
+			name == faFieldWWDonationAmount ||
+			name == faFieldWWDonationOther {
+			return true
+		}
+		return false
+	}
+
 	// Special amount requested fields without FA- prefix
 	if name == faFieldSummerQuestAmtRequested ||
 		name == faFieldFamilyCampAmtRequested ||
@@ -471,6 +491,27 @@ func (s *FinancialAidApplicationsSync) mapFieldToApplication(app *faApplicationD
 			app.donationPreference = value
 		}
 	case faFieldCADonationOther:
+		if app.donationOther == "" {
+			app.donationOther = value
+		}
+
+	// Interest indicators (WW- prefix, adult weekends -- kindred#2436). Same
+	// four program-neutral columns as the CA- arms above: a WW- answer only
+	// ever lands on the row for the adult who filled out that form, so this
+	// is admission into an existing column, not a grain change.
+	case faFieldWWFinancialAssistanceInterest:
+		if !app.interestExpressed {
+			app.interestExpressed = hasInterestExpressed(value)
+		}
+	case faFieldWWFinancialAssistanceAmount:
+		if app.amountAwarded == 0 {
+			app.amountAwarded = parseNumberValue(value)
+		}
+	case faFieldWWDonationAmount:
+		if app.donationPreference == "" {
+			app.donationPreference = value
+		}
+	case faFieldWWDonationOther:
 		if app.donationOther == "" {
 			app.donationOther = value
 		}

--- a/pocketbase/sync/financial_aid_applications_test.go
+++ b/pocketbase/sync/financial_aid_applications_test.go
@@ -47,6 +47,79 @@ func TestFinancialAidApplicationsLoadFieldDefinitionsTrimsNames(t *testing.T) {
 	}
 }
 
+// TestFinancialAidApplicationsAdmitsWWFields is the regression test for
+// kindred#2436. The adult weekends' four WW- financial-aid fields
+// (WW-FA, WW-FA Amount, WW-Donation Amount, WW-Donation Amount Other) were
+// dropped on the floor: isFAFieldName only ever admitted "FA-" and a fixed CA-
+// allowlist, so loadFieldDefinitions never put a WW- field_definition ID into
+// the map, and loadPersonCustomValues' `if !ok { continue }` silently threw
+// every WW- answer away before mapFieldToApplication ever saw it. Measured
+// against the production snapshot: 63 WW-FA Amount answers in 2025, 24 in
+// 2026.
+//
+// These four fields are structurally identical (interest / awarded amount /
+// donation amount / donation-other) to the CA- fields that already share the
+// same four columns -- interest_expressed, amount_awarded,
+// donation_preference, donation_other -- none of which carry a "_summer" or
+// any other program suffix. Routing WW- into them is admission, not a grain
+// change: the column's meaning ("did this person express interest in
+// financial assistance, for whatever program they applied to") does not
+// change, and a WW- answer only ever lands on the row for the adult who filled
+// out that form.
+func TestFinancialAidApplicationsAdmitsWWFields(t *testing.T) {
+	t.Parallel()
+	app := newFieldDefsTestApp(t, map[int]string{
+		1: "WW-FA",
+		2: "WW-FA Amount",
+		3: "WW-Donation Amount",
+		4: "WW-Donation Amount Other",
+	})
+
+	s := NewFinancialAidApplicationsSync(app)
+	got, err := s.loadFieldDefinitions(context.Background())
+	if err != nil {
+		t.Fatalf("loadFieldDefinitions: %v", err)
+	}
+
+	want := map[string]bool{
+		"WW-FA":                    true,
+		"WW-FA Amount":             true,
+		"WW-Donation Amount":       true,
+		"WW-Donation Amount Other": true,
+	}
+	for _, name := range got {
+		if !want[name] {
+			continue // other tests' fixtures may share this app; only check ours are present
+		}
+		delete(want, name)
+	}
+	for missing := range want {
+		t.Errorf("loadFieldDefinitions did not admit WW- field %q -- kindred#2436 not fixed", missing)
+	}
+
+	fa := &faApplicationData{}
+	s.mapFieldToApplication(fa, "WW-FA", "Yes")
+	if !fa.interestExpressed {
+		t.Errorf("mapFieldToApplication(%q) did not set interestExpressed", "WW-FA")
+	}
+	s.mapFieldToApplication(fa, "WW-FA Amount", "$1,200")
+	if fa.amountAwarded != 1200 {
+		t.Errorf("mapFieldToApplication(%q) amountAwarded = %v, want 1200", "WW-FA Amount", fa.amountAwarded)
+	}
+
+	fa2 := &faApplicationData{}
+	s.mapFieldToApplication(fa2, "WW-Donation Amount", "$50")
+	if fa2.donationPreference != "$50" {
+		t.Errorf("mapFieldToApplication(%q) donationPreference = %q, want %q",
+			"WW-Donation Amount", fa2.donationPreference, "$50")
+	}
+	s.mapFieldToApplication(fa2, "WW-Donation Amount Other", "In honor of Liam Garcia")
+	if fa2.donationOther != "In honor of Liam Garcia" {
+		t.Errorf("mapFieldToApplication(%q) donationOther = %q, want %q",
+			"WW-Donation Amount Other", fa2.donationOther, "In honor of Liam Garcia")
+	}
+}
+
 // TestFinancialAidApplicationsSync_Name verifies the service name is correct
 func TestFinancialAidApplicationsSync_Name(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
`isFAFieldName` in `financial_aid_applications.go` admitted `FA-` fields by prefix and a fixed
`CA-` allowlist, but nothing else. The adult weekends' four `WW-` fields
(`WW-FA`, `WW-FA Amount`, `WW-Donation Amount`, `WW-Donation Amount Other`) matched neither rule,
so `loadFieldDefinitions` never mapped their `field_definition` IDs, and
`loadPersonCustomValues`'s `if !ok { continue }` threw every `WW-` answer away before
`mapFieldToApplication` ever saw it.

Measured against the production snapshot (`custom_field_defs` joined to `person_custom_values`,
non-empty values): **`WW-FA Amount` carries 63 answers in 2025 and 24 in 2026** — the exact
numbers in #2436. The other three `WW-` fields carry comparable volume per year (300-470 for
`WW-FA`/`WW-Donation Amount`, single digits for `WW-Donation Amount Other`), all dropped the same
way.

## The grain decision this issue called out

The `WW-` fields are structurally identical (interest indicator / amount awarded / donation
amount / donation-other) to the four `CA-` fields already routed by this file
(`CA-FinancialAssistanceInterest`, `CA-FinancialAssistanceAmount`, `CA-Donation amount`,
`CA-Donation other`), and land on the same four destination columns:
`interest_expressed`, `amount_awarded`, `donation_preference`, `donation_other`.

Checked directly against the table schema (`financial_aid_applications`): none of those four
columns carry a `_summer` suffix or any other program qualifier — unlike this same table's
`summer_amount_requested` / `fc_amount_requested` / `tbm_amount_requested`, which *are*
program-scoped and which this change does not touch. Admitting `WW-` values into the
program-neutral columns does not change what any existing row means: the grain here is one row
per (person, year), and a `WW-` answer only ever lands on the row for the adult who filled out
that weekend's form. This is admission into a column that already accepts a second, differently
prefixed writer (`CA-`) — not a grain change, and not a new column.

This satisfies the issue's own decision rule ("if the destination column is already
program-neutral... BUILD IT"), so this PR builds it. No PocketBase migration, no new column.

## `household_demographics.go` — investigated, not changed

The issue named `household_demographics.go` as a second file to check. Checked the production
`custom_field_defs` table for every `WW-`-prefixed field: there are exactly four, and all four are
the financial-aid/donation fields fixed above — none is a demographics-shaped question (no
`WW-Family Description`, `WW-Jewish Affiliation`, etc.). `IsHHField`/`MapHHFieldToColumn` in that
file have nothing to admit for this issue, so it is untouched here. (Grain safety for that file's
own `_summer` columns was already established by #2260, unrelated to this issue.)

## Testing

`TestFinancialAidApplicationsAdmitsWWFields` is the regression test: it pins that
`loadFieldDefinitions` admits all four `WW-` field names and that `mapFieldToApplication` routes
each to its column, using the same `newFieldDefsTestApp` fixture pattern as the existing
`kindred#1873` regression test in this file. Written first, confirmed red (all four
`loadFieldDefinitions` assertions and all four `mapFieldToApplication` assertions failing), then
made green by extending `isFAFieldName` and `mapFieldToApplication` with the `WW-` allowlist
mirroring the `CA-` arm. Mutation-checked afterward by changing the `WW-` prefix branch to a
non-matching prefix and re-running: the test failed as expected (all four fields unadmitted),
confirming it is not vacuously green — then restored and re-confirmed green.

`go build ./...`, `golangci-lint run`, and `go test ./sync/...` (scoped) all pass clean. The
unscoped `pre-push-verify.sh` run's `go test ./...` hit the go test framework's own 10-minute
per-package timeout inside the `sync` package under this run's 9-way-parallel-agent CPU
contention — the timeout fired inside unrelated pre-existing tests (`TestAliasResolverFlagsOverlappingWindows`,
lodging assignment sync tests), not this change's tests, both of which had already passed cleanly
moments earlier in the same run.

## Deliberately NOT done

- No change to `household_demographics.go` (see above — nothing there to admit).
- No PocketBase migration and no new columns — the whole point of the grain check above.
- Did not touch the pre-existing first-non-empty-wins collision behavior between `CA-` and other
  fields sharing these columns (one person+year in the whole production snapshot has both a `CA-`
  and a `WW-` value); that ordering is this file's existing design for every field, not something
  introduced or changed by this fix.

Closes #2436.
