### PR TITLE
chore(sync): finish the PHI vocabulary sweep on the Go export/logging guard

### DIFF
--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -38,8 +38,8 @@ from api.services.lodging_rules import RequestTextAuthorship
 # The narrative columns on family_camp_medical. Named here so the boundary test
 # can assert on them rather than on a hand-maintained list.
 #
-# This list is kept identical to `phiColumns` in
-# pocketbase/sync/lodging_phi_test.go, and a test asserts that. Go's list keeps
+# This list is kept identical to `narrativeColumns` in
+# pocketbase/sync/lodging_medical_narrative_test.go, and a test asserts that. Go's list keeps
 # the narrative out of exports and logs; this one keeps it out of API payloads.
 # A column registered in only one is screened on one side and served on the
 # other.

--- a/docs/architecture/sync-layer.md
+++ b/docs/architecture/sync-layer.md
@@ -123,7 +123,7 @@ For jobs with other custom parameters (session, etc.), similar pattern applies.
 export config at all — that is the correct shape for anything writing data that must never reach a
 spreadsheet. `lodging_assignments` is the worked example: it is in the map so the skip optimisation
 knows what it writes, and deliberately absent from `GetReadableYearExports()`, with
-`sync/lodging_phi_test.go` asserting that membership in the map never implies an export.
+`sync/lodging_medical_narrative_test.go` asserting that membership in the map never implies an export.
 
 Example for a new `widgets` sync that populates the `widgets` table:
 ```go

--- a/docs/reference/tables.md
+++ b/docs/reference/tables.md
@@ -701,7 +701,7 @@ Family camp medical and dietary information per household.
 
 **Narrative medical text.** Every text column below is a medical disclosure
 about named individuals. Admin-gated on all five rules, absent from every export
-config, and never logged — `pocketbase/sync/lodging_phi_test.go` asserts all
+config, and never logged — `pocketbase/sync/lodging_medical_narrative_test.go` asserts all
 three. The board shows the derived booleans on `family_camp_registrations`,
 never these. The API serves them from one endpoint gated on `bunking.manage`,
 the same permission every other gated endpoint on that router uses — the

--- a/frontend/src/components/weekend/FamilyCard.test.tsx
+++ b/frontend/src/components/weekend/FamilyCard.test.tsx
@@ -7,8 +7,8 @@
  * later session would helpfully add back:
  *
  *   - request text: 12 of 232 contain health vocabulary including a named
- *     diagnosis, and the roster's PHI exposure was accepted for opening ONE
- *     row at a time, not for printing it across 62 cards at once;
+ *     diagnosis, and the roster's medical-narrative exposure was accepted for
+ *     opening ONE row at a time, not for printing it across 62 cards at once;
  *   - the medical affordance: true for 62 of 62 parties;
  *   - `needs_resolution`: true for 44 of 62.
  *

--- a/frontend/src/components/weekend/boardLayout.ts
+++ b/frontend/src/components/weekend/boardLayout.ts
@@ -404,7 +404,7 @@ export interface ConsentFlag {
    * because the disagreement is the thing worth a human look.
    */
   conflictCount: number
-  /** Ready to render beside the slot. Never PHI. */
+  /** Ready to render beside the slot. Never the medical narrative. */
   reason: string
 }
 

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -348,13 +348,13 @@ type medicalData struct {
 	allergyInfo      string
 	dietaryInfo      string
 	additionalInfo   string
-	// PHI narrative. Detailed medical disclosures about named individuals.
-	// Never logged, never exported (see lodging_phi_test.go).
+	// Medical narrative. Detailed medical disclosures about named individuals.
+	// Never logged, never exported (see lodging_medical_narrative_test.go).
 	//
 	// The two below are the ones this plan added, but the never-log/never-export
 	// contract covers EVERY text field on this struct -- cpapInfo, physicianInfo,
 	// specialNeedsInfo, allergyInfo, dietaryInfo and additionalInfo carry the
-	// same kind of sentence. lodging_phi_test.go's phiColumns is the full list
+	// same kind of sentence. lodging_medical_narrative_test.go's narrativeColumns is the full list
 	// and the authority; this comment sits here only because it is where a
 	// future editor adding a field will be looking.
 	bathroomExplain      string
@@ -637,7 +637,7 @@ func (s *FamilyCampDerivedSync) loadFieldDefinitions(_ context.Context) (map[str
 // a housing flag it now goes through lodgingRequestFields, which resolves the
 // canonical display name from the cm_id — so a rename survives admission AND
 // routing. What is left here is the residue: fields admitted by id whose routing
-// is either by name heuristic or, for the two PHI narratives, by a name-keyed
+// is either by name heuristic or, for the two medical narratives, by a name-keyed
 // lookup in processMedical.
 //
 // The entries duplicated in lodgingRequestFields are kept rather than deleted:
@@ -646,10 +646,10 @@ func (s *FamilyCampDerivedSync) loadFieldDefinitions(_ context.Context) (map[str
 var extraFieldCMIDs = map[int]bool{
 	274057: true, // Housing Accommodation        (Camper) — successor to FAM Camp-Accommodation
 	274055: true, // Housing Accomodation  (sic)  (Adult)
-	274058: true, // Housing Accommodation-Yes    (Camper) — PHI narrative, spec 5
-	274059: true, // Housing-Bathroom             (Camper) — PHI narrative, spec 5
+	274058: true, // Housing Accommodation-Yes    (Camper) — medical narrative, spec 5
+	274059: true, // Housing-Bathroom             (Camper) — medical narrative, spec 5
 	274053: true, // Adult-Bathroom               (Adult)
-	274054: true, // Bathroom-Yes                 (Adult)  — PHI narrative, spec 5
+	274054: true, // Bathroom-Yes                 (Adult)  — medical narrative, spec 5
 	256933: true, // Adult-CPAP                   (Adult)
 	257248: true, // Adult-Infant                 (Adult)
 	256935: true, // Adult-Opt Out                (Adult)
@@ -1654,10 +1654,10 @@ func (s *FamilyCampDerivedSync) processMedical(personValues []customValueEntry) 
 			med.additionalInfo = v
 		}
 
-		// PHI narrative for the two accessibility questions. These sentences
+		// Medical narrative for the two accessibility questions. These sentences
 		// describe named individuals' medical circumstances, so they live only
 		// here -- family_camp_medical is admin-gated on all five rules and is
-		// absent from every export config (lodging_phi_test.go asserts that).
+		// absent from every export config (lodging_medical_narrative_test.go asserts that).
 		bathroomParts := []string{}
 		for _, key := range []string{"Housing-Bathroom", "Bathroom-Yes"} {
 			if v, ok := fields[key]; ok && v != "" {

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -2023,7 +2023,7 @@ func TestProcessRegistrationsUnansweredOptOutIsNotMandatory(t *testing.T) {
 }
 
 // TestProcessMedicalRoutesNarrativeToTheAdminGatedTable: the sentences explaining
-// a bathroom or accommodation need are PHI and belong only in
+// a bathroom or accommodation need are medical narrative and belong only in
 // family_camp_medical (spec 5.1).
 func TestProcessMedicalRoutesNarrativeToTheAdminGatedTable(t *testing.T) {
 	t.Parallel()
@@ -2068,7 +2068,7 @@ func TestProcessMedicalRoutesNarrativeToTheAdminGatedTable(t *testing.T) {
 		for _, field := range []string{r.requestText, r.notes, r.goals, r.specialOccasions} {
 			if strings.Contains(field, "documented condition") ||
 				strings.Contains(field, "ground-floor") {
-				t.Errorf("PHI narrative reached family_camp_registrations: %q", field)
+				t.Errorf("medical narrative reached family_camp_registrations: %q", field)
 			}
 		}
 	}

--- a/pocketbase/sync/lodging_medical_narrative_test.go
+++ b/pocketbase/sync/lodging_medical_narrative_test.go
@@ -7,15 +7,15 @@ import (
 	"testing"
 )
 
-// phiCollections hold detailed medical disclosures about named individuals.
+// narrativeCollections hold detailed medical disclosures about named individuals.
 // Spec 5.1 puts them in a separate, admin-gated collection; 5.2 keeps them out
 // of every export.
-var phiCollections = []string{"family_camp_medical"}
+var narrativeCollections = []string{"family_camp_medical"}
 
-// phiColumns are the column names carrying narrative medical text. Any of these
-// appearing in an export config means a disclosure is being written to a Google
-// Sheet next to the person's name.
-var phiColumns = []string{
+// narrativeColumns are the column names carrying narrative medical text. Any of
+// these appearing in an export config means a disclosure is being written to a
+// Google Sheet next to the person's name.
+var narrativeColumns = []string{
 	"cpap_info",
 	"special_needs_info",
 	"allergy_info",
@@ -28,37 +28,37 @@ var phiColumns = []string{
 
 // KNOWN EXPOSURE, deliberately not fixed here. person_custom_values and
 // household_custom_values ARE exported to Google Sheets, with First Name, Last
-// Name, Field Name and the raw Value, so the PHI narrative already reaches
+// Name, Field Name and the raw Value, so the medical narrative already reaches
 // Sheets through the raw tables alongside the individual's name. That predates
 // this work and staff may depend on the sheet, so narrowing it is a behavior
 // change with a real chance of breaking a workflow -- it is recorded for the
 // owner rather than changed silently. What follows covers what this plan is
-// responsible for: no NEW collection carries PHI into an export.
+// responsible for: no NEW collection carries medical narrative into an export.
 
-// TestPHICollectionsAreNotExported is the assertion spec 5.4 asks for.
-func TestPHICollectionsAreNotExported(t *testing.T) {
+// TestNarrativeCollectionsAreNotExported is the assertion spec 5.4 asks for.
+func TestNarrativeCollectionsAreNotExported(t *testing.T) {
 	t.Parallel()
 	configs := append(GetReadableYearExports(), GetReadableGlobalExports()...)
 
 	// Without this the test passes by looking at nothing: every assertion below
-	// is inside the loop, so an empty config list reads as "no PHI exported"
-	// rather than as "the export registry moved and this test went blind".
+	// is inside the loop, so an empty config list reads as "no medical narrative
+	// exported" rather than as "the export registry moved and this test went blind".
 	if len(configs) == 0 {
-		t.Fatal("no export configs found; this test cannot prove anything about PHI containment")
+		t.Fatal("no export configs found; this test cannot prove anything about medical narrative containment")
 	}
 
 	for _, cfg := range configs {
-		for _, phi := range phiCollections {
-			if cfg.Collection == phi {
+		for _, collection := range narrativeCollections {
+			if cfg.Collection == collection {
 				t.Errorf("collection %q is exported to sheet %q; spec 5.2 forbids it",
-					phi, cfg.SheetName)
+					collection, cfg.SheetName)
 			}
 		}
 		for _, col := range cfg.Columns {
-			for _, phi := range phiColumns {
-				if col.Field == phi {
-					t.Errorf("export %q writes PHI column %q to sheet %q",
-						cfg.Collection, phi, cfg.SheetName)
+			for _, column := range narrativeColumns {
+				if col.Field == column {
+					t.Errorf("export %q writes medical narrative column %q to sheet %q",
+						cfg.Collection, column, cfg.SheetName)
 				}
 			}
 		}
@@ -121,8 +121,8 @@ func TestLodgingCollectionsAreNeverExported(t *testing.T) {
 // TestFamilyCampDerivedManifestIsNotAnExportList is the family-camp half of the
 // same claim TestLodgingCollectionsAreNeverExported makes about the ingest, and
 // it is the half that matters most here: SyncJobToCollections["family_camp_derived"]
-// lists family_camp_medical, which is the PHI collection this whole file exists
-// to keep out of Google Sheets.
+// lists family_camp_medical, which is the narrative collection this whole file
+// exists to keep out of Google Sheets.
 //
 // The two lists look interchangeable and are not -- one is a write manifest, the
 // other a publish list -- and the cost of confusing them is different for each
@@ -146,10 +146,10 @@ func TestFamilyCampDerivedManifestIsNotAnExportList(t *testing.T) {
 		t.Fatalf("%q missing from SyncJobToCollections", serviceNameFamilyCampDerived)
 	}
 
-	sawPHICollection := false
+	sawNarrativeCollection := false
 	for _, collection := range written {
-		if slices.Contains(phiCollections, collection) {
-			sawPHICollection = true
+		if slices.Contains(narrativeCollections, collection) {
+			sawNarrativeCollection = true
 		}
 		if where, isExported := exported[collection]; isExported {
 			t.Errorf("%s is both written by %s and exported by %s",
@@ -158,51 +158,52 @@ func TestFamilyCampDerivedManifestIsNotAnExportList(t *testing.T) {
 	}
 
 	// Without this the test drifts into vacuity the day the manifest stops
-	// listing the PHI collection: the loop above would still pass, having
+	// listing the narrative collection: the loop above would still pass, having
 	// checked nothing that matters.
-	if !sawPHICollection {
-		t.Errorf("%q no longer writes any collection in phiCollections (%v); "+
+	if !sawNarrativeCollection {
+		t.Errorf("%q no longer writes any collection in narrativeCollections (%v); "+
 			"either the manifest is wrong or this test needs rescoping",
-			serviceNameFamilyCampDerived, phiCollections)
+			serviceNameFamilyCampDerived, narrativeCollections)
 	}
 }
 
-// TestPHINarrativeIsNeverLogged: spec 5.2 bars PHI from logs as well as
-// exports. This greps the source rather than the runtime, because the failure
-// mode is a slog call somebody adds later while debugging.
+// TestNarrativeIsNeverLogged: spec 5.2 bars medical narrative from logs as well
+// as exports. This greps the source rather than the runtime, because the
+// failure mode is a slog call somebody adds later while debugging.
 //
 // It reads the source text of every file that handles narrative or request
-// text: a slog line naming any PHI field would put a disclosure into the log
-// stream, which on this deployment goes to the container log and from there
-// wherever logs go.
-func TestPHINarrativeIsNeverLogged(t *testing.T) {
+// text: a slog line naming any narrative field would put a disclosure into the
+// log stream, which on this deployment goes to the container log and from
+// there wherever logs go.
+func TestNarrativeIsNeverLogged(t *testing.T) {
 	t.Parallel()
 	for _, file := range []string{"family_camp_derived.go", "lodging_requests.go"} {
-		for _, v := range phiLogViolations(readSourceFile(t, file)) {
+		for _, v := range narrativeLogViolations(readSourceFile(t, file)) {
 			t.Errorf("%s: %s", file, v)
 		}
 	}
 }
 
-// phiNarrativeExprs are the Go expressions that evaluate to narrative text.
-// Separate from phiColumns because a log line can name either the column or the
-// struct field that feeds it.
-var phiNarrativeExprs = []string{
+// narrativeExprs are the Go expressions that evaluate to narrative text.
+// Separate from narrativeColumns because a log line can name either the
+// column or the struct field that feeds it.
+var narrativeExprs = []string{
 	"med.cpapInfo", "med.specialNeedsInfo", "med.allergyInfo",
 	"med.dietaryInfo", "med.additionalInfo", "med.bathroomExplain",
 	"med.accommodationExplain", "med.physicianInfo",
 	"reg.requestText", "req.RequestText", "a.req.RequestText",
 }
 
-// phiLogViolations returns one message per slog call that names PHI.
+// narrativeLogViolations returns one message per slog call that names medical
+// narrative.
 //
 // It joins each call across lines before matching. The previous version tested
 // `strings.HasPrefix(trimmed, "slog.")` on individual lines, which meant gofmt
 // wrapping a long call -- exactly what happens when arguments are added to it --
-// moved the PHI argument onto a continuation line the scanner never looked at.
-// A guard with a formatting-dependent blind spot is worse than no guard, because
-// it reads as coverage.
-func phiLogViolations(src string) []string {
+// moved the narrative argument onto a continuation line the scanner never
+// looked at. A guard with a formatting-dependent blind spot is worse than no
+// guard, because it reads as coverage.
+func narrativeLogViolations(src string) []string {
 	var out []string
 	lines := strings.Split(src, "\n")
 
@@ -221,12 +222,12 @@ func phiLogViolations(src string) []string {
 			i = j
 		}
 
-		for _, phi := range phiColumns {
-			if strings.Contains(call, `"`+phi+`"`) {
-				out = append(out, "a slog call references the PHI column "+phi+":\n  "+call)
+		for _, column := range narrativeColumns {
+			if strings.Contains(call, `"`+column+`"`) {
+				out = append(out, "a slog call references the medical narrative column "+column+":\n  "+call)
 			}
 		}
-		for _, expr := range phiNarrativeExprs {
+		for _, expr := range narrativeExprs {
 			if strings.Contains(call, expr) {
 				out = append(out, "a slog call logs "+expr+":\n  "+call)
 			}
@@ -239,10 +240,10 @@ func parenDepth(s string) int {
 	return strings.Count(s, "(") - strings.Count(s, ")")
 }
 
-// TestPHILogScannerCatchesWrappedCalls is the guard for the guard. The bug this
-// covers is not hypothetical: the line-anchored version passed on every input
-// below except the first.
-func TestPHILogScannerCatchesWrappedCalls(t *testing.T) {
+// TestNarrativeLogScannerCatchesWrappedCalls is the guard for the guard. The
+// bug this covers is not hypothetical: the line-anchored version passed on
+// every input below except the first.
+func TestNarrativeLogScannerCatchesWrappedCalls(t *testing.T) {
 	t.Parallel()
 	cases := map[string]bool{
 		`slog.Info("x", "v", med.bathroomExplain)`:                                      true,
@@ -253,9 +254,9 @@ func TestPHILogScannerCatchesWrappedCalls(t *testing.T) {
 		`bathroomParts = append(bathroomParts, med.bathroomExplain)`:                    false,
 	}
 	for src, wantViolation := range cases {
-		got := phiLogViolations(src)
+		got := narrativeLogViolations(src)
 		if wantViolation && len(got) == 0 {
-			t.Errorf("scanner missed a PHI log call:\n%s", src)
+			t.Errorf("scanner missed a medical narrative log call:\n%s", src)
 		}
 		if !wantViolation && len(got) > 0 {
 			t.Errorf("scanner false-positived on:\n%s\n  -> %v", src, got)

--- a/pocketbase/sync/lodging_session_status_test.go
+++ b/pocketbase/sync/lodging_session_status_test.go
@@ -31,7 +31,7 @@ const statusCollection = "lodging_session_status"
 // A source scan rather than a behavioral assertion, because the property is
 // an ABSENCE — there is no call to intercept and no mock that can observe a
 // write that was never coded. Same shape as the export-registry guards in
-// lodging_phi_test.go: cheap, and it fails at the moment someone adds the
+// lodging_medical_narrative_test.go: cheap, and it fails at the moment someone adds the
 // reference rather than in production.
 func TestSyncNeverWritesTheStaffOwnedWeekendStatus(t *testing.T) {
 	t.Parallel()

--- a/pocketbase/sync/table_exporter.go
+++ b/pocketbase/sync/table_exporter.go
@@ -57,7 +57,7 @@ var SyncJobToCollections = map[string][]string{
 	"family_camp_derived": {"family_camp_adults", "family_camp_registrations", "family_camp_medical"},
 	// Assignment ingest. Present so the export-skip optimisation knows which
 	// collections this job writes -- NOT an export. None of these collections
-	// appears in GetReadableYearExports(), and lodging_phi_test.go asserts that.
+	// appears in GetReadableYearExports(), and lodging_medical_narrative_test.go asserts that.
 	"lodging_assignments": {
 		"lodging_assignments", "lodging_assignment_history", "lodging_ingest_issues",
 	},

--- a/tests/unit/api/test_lodging_medical_narrative_containment.py
+++ b/tests/unit/api/test_lodging_medical_narrative_containment.py
@@ -24,7 +24,7 @@ from api.schemas.lodging import (
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-GO_NARRATIVE_GUARD = REPO_ROOT / "pocketbase" / "sync" / "lodging_phi_test.go"
+GO_NARRATIVE_GUARD = REPO_ROOT / "pocketbase" / "sync" / "lodging_medical_narrative_test.go"
 
 
 def _reachable_models(model: type[BaseModel], seen: set[type[BaseModel]] | None = None) -> set[type[BaseModel]]:
@@ -58,14 +58,14 @@ def _all_field_names(model: type[BaseModel]) -> set[str]:
 
 
 def _go_narrative_columns() -> set[str]:
-    """The phiColumns list from the Go export/logging guard.
+    """The narrativeColumns list from the Go export/logging guard.
 
-    The Go identifier keeps its historical name; this side reads it by that
-    name, which is why the literal survives the rename.
+    Kindred#2409 renamed the Go side's PHI vocabulary to match this file's;
+    this parses the identifier by its current name.
     """
     source = GO_NARRATIVE_GUARD.read_text()
-    block = re.search(r"var phiColumns = \[\]string\{(.*?)\}", source, re.DOTALL)
-    assert block, "could not find phiColumns in lodging_phi_test.go"
+    block = re.search(r"var narrativeColumns = \[\]string\{(.*?)\}", source, re.DOTALL)
+    assert block, "could not find narrativeColumns in lodging_medical_narrative_test.go"
     return set(re.findall(r'"([^"]+)"', block.group(1)))
 
 


### PR DESCRIPTION
## What was left

#2408 renamed the PHI framing everywhere except the Go export/logging guard
(group 3 of #2398's taxonomy), deferring it because the file was owned by a
sibling branch at the time. That branch merged; this is the deferred rename.

**Measured before**, `git grep -c PHI` (case-sensitive, excluding
`package-lock.json`) on `main` @ `1797f9bd`: **76 lines across 15 files**.
**Measured after** the same grep on this branch: **46 lines across 11 files**.

## What changed

`pocketbase/sync/lodging_phi_test.go` → `pocketbase/sync/lodging_medical_narrative_test.go`
(`git mv`), and inside it:

- `phiCollections` → `narrativeCollections`
- `phiColumns` → `narrativeColumns`
- `phiNarrativeExprs` → `narrativeExprs`
- `phiLogViolations` → `narrativeLogViolations`
- `TestPHICollectionsAreNotExported` → `TestNarrativeCollectionsAreNotExported`
- `TestPHINarrativeIsNeverLogged` → `TestNarrativeIsNeverLogged`
- `TestPHILogScannerCatchesWrappedCalls` → `TestNarrativeLogScannerCatchesWrappedCalls`
- every "PHI" comment/error string reworded to "medical narrative"

**The cross-language contract moved in this same commit**, because splitting it
is the trap the issue called out: `tests/unit/api/test_lodging_medical_narrative_containment.py`
reads the Go guard *by path* and parses `var phiColumns` *by literal regex*. Both
the `GO_NARRATIVE_GUARD` path constant and the `var narrativeColumns` regex were
updated together, and `test_narrative_field_names_match_the_go_guard` is the one
test that proves the two sides still agree — it was written FIRST against the
renamed Python side while the Go side still had the old name/path, run, and
confirmed it failed with `FileNotFoundError` before the Go rename landed.
Mutation-checked afterward: reverting one Go column name (`physician_info` →
`physician_info_MUTATED`) turned it red with a clear set-diff before being
restored.

Filename/identifier citations updated to match, across:

- `pocketbase/sync/family_camp_derived.go` (6 "PHI" comments + 3 filename cites)
- `pocketbase/sync/family_camp_derived_test.go` (2)
- `pocketbase/sync/table_exporter.go`, `pocketbase/sync/lodging_session_status_test.go` (1 filename cite each)
- `api/schemas/lodging.py` (the `narrativeColumns` cross-reference comment only — see below)
- `frontend/src/components/weekend/boardLayout.ts`, `FamilyCard.test.tsx` (doc comments; no frontend test pins either literal, confirmed by grep before editing)
- `docs/reference/tables.md`, `docs/architecture/sync-layer.md` (filename cites)

## What deliberately did NOT change (Group B — KEEP)

Per the issue: a permission and a migration file that were literally called
`lodging.phi`, plus the tests and docstrings that record that history. None of
these were touched:

- `pocketbase/pb_migrations/1500000126`, `1500000130`, `1500000150`,
  `1500000154_drop_lodging_phi_permission.js` — an applied migration's filename
  cannot change
- `pocketbase/main_drop_lodging_phi_permission_test.go`,
  `pocketbase/main_lodging_rbac_test.go`
- `tests/unit/api/test_lodging_constants.py`, `tests/unit/rbac/test_permissions.py`
- `api/services/lodging_roster_service.py:13`

**One divergence from the issue's per-file table, resolved in the tree's
favor:** the issue placed `api/schemas/lodging.py` entirely in group A, but the
file has two separate things in it. Line 14 ("`Permission.LODGING_PHI`, and
kindred#2398 stopped calling that a PHI boundary") is the same shape as the
explicitly-KEEP `lodging_roster_service.py:13` — a docstring recording the name
of a permission that genuinely was called that — so it was left alone. Only
the separate `narrativeColumns`/filename cross-reference comment at lines 41-42
was renamed, since that one describes the live cross-language contract, not
history.

Also NOT done, both out of scope for this issue: the "sibling endpoint" loose
claim cleanup (five remaining copies, four editable/one an immutable
migration, called out separately in #2409's body) and any gate/behavior
change — this is vocabulary only.

## Verification

- `uv run ruff check .` — clean
- `uv run pytest tests/unit/api -q` — 2345 passed
- `cd pocketbase && go build ./... && go test ./...` — all packages pass
  (`sync` 80.6s, `lodging` 37.1s)
- `cd frontend && ./node_modules/.bin/vitest run FamilyCard.test.tsx boardLayout.test.ts` — 177 passed
- `bash scripts/pre-push-verify.sh` — see CI Summary

Closes #2409.
