### PR TITLE
fix(sync): collapse a household's medical answers by total aggregation, not first-wins

### DIFF
--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -1756,27 +1756,28 @@ func (s *FamilyCampDerivedSync) processMedical(personValues []customValueEntry) 
 			householdPBID: householdID,
 		}
 
-		// CPAP info. The two Camper-partition names are generations of the SAME
-		// question, so they collapse to one answer; Adult-CPAP is a DIFFERENT
-		// PERSON and is therefore additive.
+		// CPAP info, unioned across all three fields and deduplicated.
 		//
-		// That split has to match the flag logic in processRegistrations, which
-		// ORs across all three. A single first-wins loop over all three -- what
-		// this was -- meant a household with a camper "outlet needed" answer and
-		// an adult "bathroom ... needed" answer raised BOTH flags while the
-		// medical record kept only the camper's sentence, leaving
-		// needs_private_bathroom with nothing behind it in the one place staff
-		// can look for the reason.
+		// The union is what has to match the flag logic in processRegistrations,
+		// which ORs across all three: any answer that can raise needs_power or
+		// needs_private_bathroom has to be readable in the one place staff can
+		// look for the reason. Dedup is what keeps the union honest -- the two
+		// Camper-partition names are generations of the SAME question, and
+		// answering both must not print the sentence twice.
+		//
+		// It replaces a first-non-empty-wins loop over the two camper names,
+		// which stopped at whichever had an answer: a "No" on Family Camp-CPAP
+		// hid a disclosure on FAM CAMP-CPAP outright, in 27 households in 2025
+		// and 1 in 2026 on the production snapshot, each of them carrying a
+		// housing flag their cpap_info then denied. Taking one field's answer as
+		// the household's is the same first-wins mistake medicalAnswers exists
+		// to end, one level up.
 		cpapParts := []string{}
-		for _, key := range []string{fieldFamilyCampCPAP, fieldFamCampCPAP} {
-			if p := fields.parts(key); len(p) > 0 {
-				cpapParts = append(cpapParts, p...)
-				break
-			}
-		}
-		for _, v := range fields.parts(fieldAdultCPAP) {
-			if !slices.Contains(cpapParts, v) {
-				cpapParts = append(cpapParts, v)
+		for _, key := range []string{fieldFamilyCampCPAP, fieldFamCampCPAP, fieldAdultCPAP} {
+			for _, v := range fields.parts(key) {
+				if !slices.Contains(cpapParts, v) {
+					cpapParts = append(cpapParts, v)
+				}
 			}
 		}
 		cpapParts = cpapGateParts(cpapParts)

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -1598,7 +1598,10 @@ var medicalColumnLimits = map[string]int{
 // "Family Camp-CPAP" is a true binary gate too and is deliberately absent. The
 // CPAP column is fed by three fields of two different shapes -- the other two
 // are multi-option selects whose text says WHICH accommodation is needed -- and
-// kindred#2255 carves it out for its own pass.
+// kindred#2255 carves it out for its own pass. Absent from this map is NOT
+// absent from the rule: cpapGateParts drops that column's denials by the half
+// of the OR that survives multi-option answers, so no household's row renders a
+// gate contradicting the need beside it.
 var medicalGateFields = map[string]struct{}{
 	"Family Medical-Allergies":     {},
 	"Family Medical-Dietary Needs": {},
@@ -1652,6 +1655,46 @@ func (m medicalAnswers) parts(fieldName string) []string {
 		}
 	}
 	return slices.Clone(values)
+}
+
+// cpapGateParts drops a household's pure CPAP denials whenever anyone in it
+// disclosed a need.
+//
+// The CPAP column is the one gate/explain pair processMedical still stores as a
+// gate STRING, and docs/reference/family-camp-field-provenance.md section 4
+// names Special Needs and CPAP as the two pairs where splitting the halves does
+// real harm. Special Needs is a Yes/No gate and collapses by OR through
+// medicalGateFields; CPAP cannot, because the three CPAP fields are
+// multi-option selects whose affirmative options say WHICH accommodation is
+// needed (kindred#1875, see classifyCPAPAnswer). Two different affirmatives are
+// two different needs and both have to survive, so this is only the half of the
+// OR that applies: a household that needs an outlet needs it whoever else on
+// the form said no.
+//
+// Without it the household aggregation would put a denial and a disclosure in
+// one column -- "No; Yes, outlet needed for CPAP machine" -- which is the
+// rendered contradiction medicalGateFields exists to prevent, arriving through
+// the one column medicalGateFields does not cover. Measured on the production
+// snapshot it is 1 household-year in 2026 and 1-2 a year back to 2022: rare,
+// and on a column staff read to decide whether a family needs a powered cabin.
+//
+// Every stored answer to the three fields is either "No" or starts "Yes"
+// (30,124 values checked), so parseBoolFieldValue -- which anchors on the
+// leading token, the whole reason it is not enough to CLASSIFY these answers --
+// is exactly the right test for which of them is a denial.
+func cpapGateParts(parts []string) []string {
+	disclosed := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if parseBoolFieldValue(part) {
+			disclosed = append(disclosed, part)
+		}
+	}
+	if len(disclosed) == 0 {
+		// Nobody disclosed. "No" is still an answer, and blanking it would be
+		// the silent loss this whole function's neighbors exist to end.
+		return parts
+	}
+	return disclosed
 }
 
 // joinMedicalColumn concatenates one column's parts within its declared cap,
@@ -1736,6 +1779,7 @@ func (s *FamilyCampDerivedSync) processMedical(personValues []customValueEntry) 
 				cpapParts = append(cpapParts, v)
 			}
 		}
+		cpapParts = cpapGateParts(cpapParts)
 		cpapParts = append(cpapParts, fields.parts("Family Medical-CPAP Explain")...)
 		med.cpapInfo = s.joinMedicalColumn(householdID, "cpap_info", cpapParts)
 

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -1560,25 +1560,155 @@ func (s *FamilyCampDerivedSync) applyHouseholdRequests(
 	}
 }
 
+// medicalColumnLimits are the declared max lengths of the family_camp_medical
+// text columns, which are NOT uniform: allergy_info, dietary_info,
+// special_needs_info and additional_info are 10,000, cpap_info and
+// physician_info 5,000 (migration 1500000035), and bathroom_explain and
+// accommodation_explain 4,000 (migration 1500000126).
+//
+// They matter for the first time now that a column concatenates every
+// answerer's disclosure instead of one: record.Set() past a PocketBase field's
+// max fails the whole row's save, which would lose a household rather than a
+// sentence. Worst case in the production snapshot is 2,128 of 10,000, so this
+// is a guard, not a working limit -- joinAnswers drops whole answers and the
+// caller logs the count.
+var medicalColumnLimits = map[string]int{
+	"allergy_info":          10000,
+	"dietary_info":          10000,
+	"special_needs_info":    10000,
+	"additional_info":       10000,
+	"cpap_info":             5000,
+	"physician_info":        5000,
+	"bathroom_explain":      4000,
+	"accommodation_explain": 4000,
+}
+
+// medicalGateFields are the family-camp medical questions processMedical reads
+// whose entire answer vocabulary is "Yes" / "No" -- 2 distinct values each, 3
+// characters at the longest, across 30,124 stored answers.
+//
+// They are named because a gate cannot be concatenated the way a narrative can.
+// CampMinder asks each of these questions in two parts, a gate and a free-text
+// explanation, and processMedical stores the pair in one column. Joining two
+// people's gate answers verbatim renders "No; Yes; <A>; <B>" -- two
+// contradictory gates in front of the text -- which is why an earlier uniform
+// dedup-and-join over every field was reverted. A household's gate is the OR of
+// its answers instead: see medicalAnswers.parts.
+//
+// "Family Camp-CPAP" is a true binary gate too and is deliberately absent. The
+// CPAP column is fed by three fields of two different shapes -- the other two
+// are multi-option selects whose text says WHICH accommodation is needed -- and
+// kindred#2255 carves it out for its own pass.
+var medicalGateFields = map[string]struct{}{
+	"Family Medical-Allergies":     {},
+	"Family Medical-Dietary Needs": {},
+	"Family Camp-Special Needs":    {},
+	"Family Camp-Physician":        {},
+}
+
+// gateAnswerYes is the affirmative token those gates store.
+const gateAnswerYes = "Yes"
+
+// medicalAnswers holds one household's family-camp medical answers: every
+// distinct answer given to each field, in canonical order, across everyone who
+// answered it.
+//
+// It replaces a first-non-empty-wins map. That map discarded every answer after
+// the first because `personValues` carries one entry per person per field and
+// CampMinder asks these questions on a per-CAMPER form, so a household with two
+// enrolled children answers each question twice. 105 of 464 family-camp
+// households in 2026 (22.6%) lost a real second disclosure to it, and because
+// the gate and its explanation were chosen independently, 836 of 8,864 stored
+// rows read "No; <description of the condition it denies>" -- one person's
+// denial glued to another person's disclosure.
+type medicalAnswers map[string][]string
+
+// parts returns the answers to one field, ready to be concatenated into a
+// column.
+//
+// A binary gate collapses to a single token by OR: if anyone in the household
+// said Yes, the household's answer is Yes. That is the same total aggregation
+// processRegistrations already applies to the housing flags, and it is what
+// makes the narrative join safe. Anything else keeps every distinct answer,
+// because a second person's sentence is a second disclosure.
+//
+// A gate whose answers are all negative falls through to the join rather than
+// picking one, so a vocabulary that ever widens past Yes/No is not silently
+// narrowed to whichever value sorted first.
+func (m medicalAnswers) parts(fieldName string) []string {
+	values := m[fieldName]
+	if len(values) == 0 {
+		return nil
+	}
+	if _, isGate := medicalGateFields[fieldName]; !isGate {
+		// Cloned because callers append the next field's parts onto this
+		// slice: handing back the map's own backing array would let one
+		// column's join overwrite another's answers.
+		return slices.Clone(values)
+	}
+	for _, v := range values {
+		if strings.EqualFold(v, gateAnswerYes) {
+			return []string{v}
+		}
+	}
+	return slices.Clone(values)
+}
+
+// joinMedicalColumn concatenates one column's parts within its declared cap,
+// dropping whole answers rather than cutting one in half and counting what it
+// dropped.
+//
+// The log carries counts only. Every column on this struct is a medical
+// disclosure about a named individual and none of them may be logged; see the
+// contract on medicalData.
+func (s *FamilyCampDerivedSync) joinMedicalColumn(householdPBID, column string, parts []string) string {
+	limit, ok := medicalColumnLimits[column]
+	if !ok {
+		// Fail SAFE, not quiet. joinAnswers with a zero limit would return an
+		// empty string, so a column added here and forgotten in the limits map
+		// would silently blank itself -- the exact class of loss this function
+		// exists to end. Keep every answer and shout instead.
+		slog.Error("Family camp medical column has no declared length limit",
+			"column", column, "hint", "add it to medicalColumnLimits")
+		return strings.Join(parts, answerJoinSeparator)
+	}
+
+	joined, dropped, truncated := joinAnswers(parts, limit)
+	if dropped > 0 || truncated {
+		slog.Warn("Family camp medical column exceeded its cap",
+			"household", householdPBID, "column", column,
+			"dropped_answers", dropped, "truncated", truncated)
+	}
+	return joined
+}
+
 // processMedical extracts medical data from person custom values
 func (s *FamilyCampDerivedSync) processMedical(personValues []customValueEntry) []*medicalData {
-	// Map: household -> field_name -> value (for concatenation)
-	fieldsByHousehold := make(map[string]map[string]string)
+	// Map: household -> field_name -> the distinct answers given to it
+	setsByHousehold := make(map[string]map[string]*answerSet)
 
 	for _, v := range personValues {
-		if fieldsByHousehold[v.householdPBID] == nil {
-			fieldsByHousehold[v.householdPBID] = make(map[string]string)
+		if setsByHousehold[v.householdPBID] == nil {
+			setsByHousehold[v.householdPBID] = make(map[string]*answerSet)
 		}
-
-		// First non-empty wins
-		if _, exists := fieldsByHousehold[v.householdPBID][v.fieldName]; !exists {
-			fieldsByHousehold[v.householdPBID][v.fieldName] = v.value
+		set := setsByHousehold[v.householdPBID][v.fieldName]
+		if set == nil {
+			set = &answerSet{}
+			setsByHousehold[v.householdPBID][v.fieldName] = set
 		}
+		set.add(v.value)
 	}
 
 	// Process each household
 	var result []*medicalData
-	for householdID, fields := range fieldsByHousehold {
+	for householdID, sets := range setsByHousehold {
+		fields := make(medicalAnswers, len(sets))
+		for name, set := range sets {
+			if values := set.values(); len(values) > 0 {
+				fields[name] = values
+			}
+		}
+
 		med := &medicalData{
 			householdPBID: householdID,
 		}
@@ -1596,79 +1726,56 @@ func (s *FamilyCampDerivedSync) processMedical(personValues []customValueEntry) 
 		// can look for the reason.
 		cpapParts := []string{}
 		for _, key := range []string{fieldFamilyCampCPAP, fieldFamCampCPAP} {
-			if v, ok := fields[key]; ok && v != "" {
-				cpapParts = append(cpapParts, v)
+			if p := fields.parts(key); len(p) > 0 {
+				cpapParts = append(cpapParts, p...)
 				break
 			}
 		}
-		if v, ok := fields[fieldAdultCPAP]; ok && v != "" && !slices.Contains(cpapParts, v) {
-			cpapParts = append(cpapParts, v)
+		for _, v := range fields.parts(fieldAdultCPAP) {
+			if !slices.Contains(cpapParts, v) {
+				cpapParts = append(cpapParts, v)
+			}
 		}
-		if v, ok := fields["Family Medical-CPAP Explain"]; ok && v != "" {
-			cpapParts = append(cpapParts, v)
-		}
-		med.cpapInfo = strings.Join(cpapParts, "; ")
+		cpapParts = append(cpapParts, fields.parts("Family Medical-CPAP Explain")...)
+		med.cpapInfo = s.joinMedicalColumn(householdID, "cpap_info", cpapParts)
 
 		// Physician info
-		physicianParts := []string{}
-		if v, ok := fields["Family Camp-Physician"]; ok && v != "" {
-			physicianParts = append(physicianParts, v)
-		}
-		if v, ok := fields["Family Camp-Physician If Yes"]; ok && v != "" {
-			physicianParts = append(physicianParts, v)
-		}
-		med.physicianInfo = strings.Join(physicianParts, "; ")
+		physicianParts := fields.parts("Family Camp-Physician")
+		physicianParts = append(physicianParts, fields.parts("Family Camp-Physician If Yes")...)
+		med.physicianInfo = s.joinMedicalColumn(householdID, "physician_info", physicianParts)
 
 		// Special needs info
-		specialParts := []string{}
-		if v, ok := fields["Family Camp-Special Needs"]; ok && v != "" {
-			specialParts = append(specialParts, v)
-		}
-		if v, ok := fields["Family Camp-Special Needs Yes"]; ok && v != "" {
-			specialParts = append(specialParts, v)
-		}
-		med.specialNeedsInfo = strings.Join(specialParts, "; ")
+		specialParts := fields.parts("Family Camp-Special Needs")
+		specialParts = append(specialParts, fields.parts("Family Camp-Special Needs Yes")...)
+		med.specialNeedsInfo = s.joinMedicalColumn(householdID, "special_needs_info", specialParts)
 
 		// Allergy info
-		allergyParts := []string{}
-		if v, ok := fields["Family Medical-Allergies"]; ok && v != "" {
-			allergyParts = append(allergyParts, v)
-		}
-		if v, ok := fields["Family Medical-Allergy Info"]; ok && v != "" {
-			allergyParts = append(allergyParts, v)
-		}
-		med.allergyInfo = strings.Join(allergyParts, "; ")
+		allergyParts := fields.parts("Family Medical-Allergies")
+		allergyParts = append(allergyParts, fields.parts("Family Medical-Allergy Info")...)
+		med.allergyInfo = s.joinMedicalColumn(householdID, "allergy_info", allergyParts)
 
 		// Dietary info
-		dietaryParts := []string{}
-		if v, ok := fields["Family Medical-Dietary Needs"]; ok && v != "" {
-			dietaryParts = append(dietaryParts, v)
-		}
-		if v, ok := fields["Family Medical-Dietary Explain"]; ok && v != "" {
-			dietaryParts = append(dietaryParts, v)
-		}
-		med.dietaryInfo = strings.Join(dietaryParts, "; ")
+		dietaryParts := fields.parts("Family Medical-Dietary Needs")
+		dietaryParts = append(dietaryParts, fields.parts("Family Medical-Dietary Explain")...)
+		med.dietaryInfo = s.joinMedicalColumn(householdID, "dietary_info", dietaryParts)
 
 		// Additional info
-		if v, ok := fields["Family Medical-Additional"]; ok && v != "" {
-			med.additionalInfo = v
-		}
+		med.additionalInfo = s.joinMedicalColumn(
+			householdID, "additional_info", fields.parts("Family Medical-Additional"))
 
 		// PHI narrative for the two accessibility questions. These sentences
 		// describe named individuals' medical circumstances, so they live only
 		// here -- family_camp_medical is admin-gated on all five rules and is
 		// absent from every export config (lodging_phi_test.go asserts that).
-		bathroomParts := []string{}
-		for _, key := range []string{"Housing-Bathroom", "Bathroom-Yes"} {
-			if v, ok := fields[key]; ok && v != "" {
-				bathroomParts = append(bathroomParts, v)
-			}
+		bathroomKeys := []string{"Housing-Bathroom", "Bathroom-Yes"}
+		bathroomParts := make([]string, 0, len(bathroomKeys))
+		for _, key := range bathroomKeys {
+			bathroomParts = append(bathroomParts, fields.parts(key)...)
 		}
-		med.bathroomExplain = strings.Join(bathroomParts, "; ")
+		med.bathroomExplain = s.joinMedicalColumn(householdID, "bathroom_explain", bathroomParts)
 
-		if v, ok := fields["Housing Accommodation-Yes"]; ok && v != "" {
-			med.accommodationExplain = v
-		}
+		med.accommodationExplain = s.joinMedicalColumn(
+			householdID, "accommodation_explain", fields.parts("Housing Accommodation-Yes"))
 
 		// Only include if has some data
 		if med.cpapInfo != "" || med.physicianInfo != "" ||

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
+	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -3339,24 +3342,157 @@ func TestJoinMedicalColumnKeepsEverythingForAnUndeclaredColumn(t *testing.T) {
 	}
 }
 
-// TestMedicalColumnLimitsMatchTheSchema pins the map against the migrations
-// that declare the columns (1500000035 and 1500000126). A limit larger than the
-// real one does not cap anything -- record.Set() past a PocketBase field's max
-// fails the whole row's save, losing a household rather than a sentence.
+// medicalColumnMaxPattern finds one text field's declared cap in a PocketBase
+// migration: `name: "<column>"` and the `max:` that belongs to the SAME field
+// literal. `[^}]*?` is what binds the two -- it cannot cross the closing brace
+// of the field it started in, so a field that declares no max reads as absent
+// rather than silently borrowing the next field's.
+var medicalColumnMaxPattern = regexp.MustCompile(`name:\s*["']([a-z_]+)["'][^}]*?max:\s*(\d+)`)
+
+// TestMedicalColumnLimitsMatchTheSchema pins medicalColumnLimits against the
+// migrations that declare the columns, by READING them.
+//
+// It used to restate the same literals a second time, which pins nothing: a
+// migration that narrowed a column would leave the map too large and the test
+// still green. A limit larger than the real one caps nothing -- record.Set()
+// past a PocketBase field's max fails the whole row's save, losing a household
+// rather than a sentence -- so the map has to be checked against the schema and
+// not against itself.
+//
+// Every migration is scanned, in file-number order, so the LAST declaration
+// wins: a later migration that changes a cap is what this has to catch. Files
+// that never mention family_camp_medical are skipped, because
+// 1500000044_camper_dietary.js declares an allergy_info of its own on a
+// different collection.
 func TestMedicalColumnLimitsMatchTheSchema(t *testing.T) {
 	t.Parallel()
-	want := map[string]int{
-		"allergy_info": 10000, "dietary_info": 10000,
-		"special_needs_info": 10000, "additional_info": 10000,
-		"cpap_info": 5000, "physician_info": 5000,
-		"bathroom_explain": 4000, "accommodation_explain": 4000,
+
+	paths, err := filepath.Glob("../pb_migrations/*.js")
+	if err != nil {
+		t.Fatalf("globbing migrations: %v", err)
 	}
-	if len(medicalColumnLimits) != len(want) {
-		t.Fatalf("medicalColumnLimits has %d columns, want %d", len(medicalColumnLimits), len(want))
+	if len(paths) == 0 {
+		t.Fatal("no migrations found -- this test would pass vacuously")
 	}
-	for column, limit := range want {
-		if got := medicalColumnLimits[column]; got != limit {
-			t.Errorf("medicalColumnLimits[%q] = %d, want %d", column, got, limit)
+	slices.Sort(paths)
+
+	declared := make(map[string]int, len(medicalColumnLimits))
+	for _, path := range paths {
+		source, err := os.ReadFile(path) //nolint:gosec // fixed repo-relative glob
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
 		}
+		if !strings.Contains(string(source), "family_camp_medical") {
+			continue
+		}
+		for _, m := range medicalColumnMaxPattern.FindAllStringSubmatch(string(source), -1) {
+			if _, wanted := medicalColumnLimits[m[1]]; !wanted {
+				continue
+			}
+			declaredMax, err := strconv.Atoi(m[2])
+			if err != nil {
+				t.Fatalf("%s declares a non-numeric max for %s: %v", path, m[1], err)
+			}
+			declared[m[1]] = declaredMax
+		}
+	}
+
+	for column, limit := range medicalColumnLimits {
+		got, ok := declared[column]
+		if !ok {
+			t.Errorf("medicalColumnLimits declares %q, which no migration creates on "+
+				"family_camp_medical -- record.Set() would be rejected", column)
+			continue
+		}
+		if got != limit {
+			t.Errorf("medicalColumnLimits[%q] = %d, but the migrations declare max %d",
+				column, limit, got)
+		}
+	}
+	for column := range declared {
+		if _, ok := medicalColumnLimits[column]; !ok {
+			t.Errorf("family_camp_medical.%s has a declared max but no entry in "+
+				"medicalColumnLimits -- joinMedicalColumn would not cap it", column)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The CPAP column is the one gate/explain pair processMedical still stores as a
+// gate STRING. docs/reference/family-camp-field-provenance.md section 4 names
+// Special Needs and CPAP as the two pairs where a split across children does
+// real harm; Special Needs is now ORed, and CPAP is carved out of kindred#2255
+// for its own pass. Aggregating it the way every other field is aggregated is
+// what would put a denial and a disclosure in one column.
+// ---------------------------------------------------------------------------
+
+// TestProcessMedicalDropsADeniedCPAPGateBesideADisclosedOne: one child's form
+// says No and another's says Yes. Keeping both renders
+// "No; Yes; <explanation>" -- the contradiction medicalGateFields exists to
+// prevent, reaching the row through the one column medicalGateFields does not
+// cover.
+func TestProcessMedicalDropsADeniedCPAPGateBesideADisclosedOne(t *testing.T) {
+	t.Parallel()
+	s := NewFamilyCampDerivedSync(nil)
+	ts := time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC)
+
+	meds := s.processMedical([]customValueEntry{
+		{householdPBID: "hh_johnson", fieldName: "Family Camp-CPAP", value: "No", lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Family Camp-CPAP", value: "Yes", lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Adult-CPAP", value: "No", lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-CPAP Explain",
+			value: "needs an outlet overnight", lastUpdated: ts},
+	})
+	if len(meds) != 1 {
+		t.Fatalf("medical rows = %d, want 1", len(meds))
+	}
+	if got, want := meds[0].cpapInfo, "Yes; needs an outlet overnight"; got != want {
+		t.Errorf("cpapInfo = %q, want %q -- a denial in front of the need it denies", got, want)
+	}
+}
+
+// TestProcessMedicalKeepsTwoDifferentCPAPNeeds: the CPAP fields are NOT a
+// two-value gate (kindred#1875) -- every affirmative option names WHICH
+// accommodation is needed, so two different affirmatives are two different
+// needs and neither may be collapsed away. Only the pure denial goes.
+func TestProcessMedicalKeepsTwoDifferentCPAPNeeds(t *testing.T) {
+	t.Parallel()
+	s := NewFamilyCampDerivedSync(nil)
+	ts := time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC)
+
+	const (
+		outlet   = "Yes, outlet needed for CPAP machine"
+		bathroom = "Yes, bathroom or other housing accommodation needed"
+	)
+	meds := s.processMedical([]customValueEntry{
+		{householdPBID: "hh_johnson", fieldName: "FAM CAMP-CPAP", value: "No", lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "FAM CAMP-CPAP", value: outlet, lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "FAM CAMP-CPAP", value: bathroom, lastUpdated: ts},
+	})
+	if len(meds) != 1 {
+		t.Fatalf("medical rows = %d, want 1", len(meds))
+	}
+	if got, want := meds[0].cpapInfo, bathroom+"; "+outlet; got != want {
+		t.Errorf("cpapInfo = %q, want %q", got, want)
+	}
+}
+
+// TestProcessMedicalKeepsAnUnanimousCPAPDenial: dropping negatives is only the
+// half of the OR that applies. A household where nobody said Yes still has an
+// answer, and blanking it would be the silent loss this whole change ends.
+func TestProcessMedicalKeepsAnUnanimousCPAPDenial(t *testing.T) {
+	t.Parallel()
+	s := NewFamilyCampDerivedSync(nil)
+	ts := time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC)
+
+	meds := s.processMedical([]customValueEntry{
+		{householdPBID: "hh_johnson", fieldName: "Family Camp-CPAP", value: "No", lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Family Camp-CPAP", value: "No", lastUpdated: ts},
+	})
+	if len(meds) != 1 {
+		t.Fatalf("medical rows = %d, want 1", len(meds))
+	}
+	if got, want := meds[0].cpapInfo, "No"; got != want {
+		t.Errorf("cpapInfo = %q, want %q", got, want)
 	}
 }

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -3359,9 +3359,15 @@ var medicalColumnMaxPattern = regexp.MustCompile(`name:\s*["']([a-z_]+)["'][^}]*
 // rather than a sentence -- so the map has to be checked against the schema and
 // not against itself.
 //
-// Every migration is scanned, in file-number order, so the LAST declaration
-// wins: a later migration that changes a cap is what this has to catch. Files
-// that never mention family_camp_medical are skipped, because
+// EVERY declaration found must agree with the map, rather than the last one
+// winning. A regex over JavaScript cannot tell which collection or which
+// direction of migrate() a field literal sits in, so last-wins would let a
+// same-named field on another collection, or a down() block, quietly stand in
+// for a narrowed medical limit. Requiring agreement turns that into a loud
+// failure naming the file, which is the safe direction for a guard: a migration
+// that legitimately changes a cap has to update this map anyway.
+//
+// Files that never mention family_camp_medical are skipped, because
 // 1500000044_camper_dietary.js declares an allergy_info of its own on a
 // different collection.
 func TestMedicalColumnLimitsMatchTheSchema(t *testing.T) {
@@ -3376,7 +3382,11 @@ func TestMedicalColumnLimitsMatchTheSchema(t *testing.T) {
 	}
 	slices.Sort(paths)
 
-	declared := make(map[string]int, len(medicalColumnLimits))
+	type declaration struct {
+		path string
+		max  int
+	}
+	declared := make(map[string][]declaration, len(medicalColumnLimits))
 	for _, path := range paths {
 		source, err := os.ReadFile(path) //nolint:gosec // fixed repo-relative glob
 		if err != nil {
@@ -3393,20 +3403,22 @@ func TestMedicalColumnLimitsMatchTheSchema(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%s declares a non-numeric max for %s: %v", path, m[1], err)
 			}
-			declared[m[1]] = declaredMax
+			declared[m[1]] = append(declared[m[1]], declaration{path: path, max: declaredMax})
 		}
 	}
 
 	for column, limit := range medicalColumnLimits {
-		got, ok := declared[column]
-		if !ok {
+		sites := declared[column]
+		if len(sites) == 0 {
 			t.Errorf("medicalColumnLimits declares %q, which no migration creates on "+
 				"family_camp_medical -- record.Set() would be rejected", column)
 			continue
 		}
-		if got != limit {
-			t.Errorf("medicalColumnLimits[%q] = %d, but the migrations declare max %d",
-				column, limit, got)
+		for _, site := range sites {
+			if site.max != limit {
+				t.Errorf("medicalColumnLimits[%q] = %d, but %s declares max %d",
+					column, limit, filepath.Base(site.path), site.max)
+			}
 		}
 	}
 	for column := range declared {
@@ -3474,6 +3486,33 @@ func TestProcessMedicalKeepsTwoDifferentCPAPNeeds(t *testing.T) {
 	}
 	if got, want := meds[0].cpapInfo, bathroom+"; "+outlet; got != want {
 		t.Errorf("cpapInfo = %q, want %q", got, want)
+	}
+}
+
+// TestProcessMedicalUnionsBothCamperCPAPFields: the two Camper-partition CPAP
+// names are the same question asked twice, and a household can carry an answer
+// under each. processMedical used to stop at the first name that had one, so a
+// "No" on Family Camp-CPAP hid a disclosure on FAM CAMP-CPAP entirely -- while
+// processRegistrations ORs BOTH fields into needs_power and
+// needs_private_bathroom, so the household got a housing flag with a cpap_info
+// that denies it. 27 households in 2025 and 1 in 2026 on the production
+// snapshot.
+func TestProcessMedicalUnionsBothCamperCPAPFields(t *testing.T) {
+	t.Parallel()
+	s := NewFamilyCampDerivedSync(nil)
+	ts := time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC)
+
+	const outlet = "Yes, outlet needed for CPAP machine"
+	meds := s.processMedical([]customValueEntry{
+		{householdPBID: "hh_johnson", fieldName: "Family Camp-CPAP", value: "No", lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "FAM CAMP-CPAP", value: outlet, lastUpdated: ts},
+	})
+	if len(meds) != 1 {
+		t.Fatalf("medical rows = %d, want 1", len(meds))
+	}
+	if got, want := meds[0].cpapInfo, outlet; got != want {
+		t.Errorf("cpapInfo = %q, want %q -- the flag says the household needs power "+
+			"and the narrative would deny it", got, want)
 	}
 }
 

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -301,7 +301,13 @@ func TestMedicalInfoBlobConcatenation(t *testing.T) {
 	}
 }
 
-// TestMedicalDeduplicationByHousehold tests that medical info is deduplicated per household
+// TestMedicalDeduplicationByHousehold tests that medical info is deduplicated per household.
+//
+// NOTE: it drives aggregateMedicalByHousehold, a test-local reimplementation,
+// and asserts only non-emptiness -- so it is blind to how production collapses a
+// household's answers and cannot fail when processMedical changes. The real
+// coverage of that is TestProcessMedicalKeepsEveryAnswerersNarrative and the
+// kindred#2255 tests beside it.
 func TestMedicalDeduplicationByHousehold(t *testing.T) {
 	t.Parallel()
 	personValues := []testPersonCustomValue{
@@ -3146,6 +3152,211 @@ func TestAdultsCollectionHasAttributeConflictsColumn(t *testing.T) {
 	} {
 		if !strings.Contains(string(source), want) {
 			t.Errorf("migration is missing %q -- a plain fields.add({...}) is silently ignored in PB v0.23", want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// kindred#2255 -- processMedical must collapse a household's answers by TOTAL
+// aggregation, never by picking a winner.
+//
+// The tests below are deliberately written against the PRODUCTION
+// processMedical. The two tests that look like they already cover this
+// (TestMedicalDeduplicationByHousehold, which drives a test-local
+// reimplementation and asserts only non-emptiness, and
+// TestProcessMedicalCollapsesCamperCPAPGenerations, which exercises one person)
+// are blind to the defect by construction.
+// ---------------------------------------------------------------------------
+
+// medicalNarrativeA/B are placeholder disclosures. Never put a real medical
+// sentence, or a real name, in a fixture.
+const (
+	medicalNarrativeA = "carries an epinephrine auto-injector"
+	medicalNarrativeB = "reacts to shellfish"
+)
+
+// TestProcessMedicalKeepsEveryAnswerersNarrative is the regression test the
+// issue says no fixture covered: two people in one household answer the SAME
+// narrative field and both answers must survive. Before the fix the flatten
+// kept whichever record id sorted first and discarded the rest, which is why
+// staff saw part of a household's medical picture and not all of it.
+func TestProcessMedicalKeepsEveryAnswerersNarrative(t *testing.T) {
+	t.Parallel()
+	s := NewFamilyCampDerivedSync(nil)
+	ts := time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC)
+
+	meds := s.processMedical([]customValueEntry{
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-Allergy Info",
+			value: medicalNarrativeA, lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-Allergy Info",
+			value: medicalNarrativeB, lastUpdated: ts},
+	})
+	if len(meds) != 1 {
+		t.Fatalf("medical rows = %d, want 1", len(meds))
+	}
+	for _, want := range []string{medicalNarrativeA, medicalNarrativeB} {
+		if !strings.Contains(meds[0].allergyInfo, want) {
+			t.Errorf("allergyInfo dropped an answerer's disclosure: %q missing from %q",
+				want, meds[0].allergyInfo)
+		}
+	}
+}
+
+// TestProcessMedicalOrsTheGateAcrossAnswerers pins the half of the fix that
+// makes the join safe. A gate is a two-value Yes/No question; joining two
+// people's gate answers verbatim would render "No; Yes; <narrative>", which is
+// why an earlier uniform dedup-and-join was reverted. The household's gate is
+// the OR of its answers, so the one person who said Yes is not overruled by the
+// one who said No.
+//
+// The "No" is listed FIRST so the test fails against first-non-empty-wins
+// rather than passing by luck of load order.
+func TestProcessMedicalOrsTheGateAcrossAnswerers(t *testing.T) {
+	t.Parallel()
+	s := NewFamilyCampDerivedSync(nil)
+	ts := time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC)
+
+	meds := s.processMedical([]customValueEntry{
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-Allergies",
+			value: "No", lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-Allergies",
+			value: "Yes", lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-Allergy Info",
+			value: medicalNarrativeA, lastUpdated: ts},
+	})
+	if len(meds) != 1 {
+		t.Fatalf("medical rows = %d, want 1", len(meds))
+	}
+	if got, want := meds[0].allergyInfo, "Yes; "+medicalNarrativeA; got != want {
+		t.Errorf("allergyInfo = %q, want %q -- a denial in front of the condition "+
+			"it denies is the rendered contradiction this fixes", got, want)
+	}
+}
+
+// TestProcessMedicalIsOrderIndependent is the probe the issue prescribes
+// instead of a flakiness test: the winner used to be a function of load order,
+// so feeding the same answers in the opposite order must produce byte-identical
+// output. It must not pin which answerer wins, because after the fix none does.
+func TestProcessMedicalIsOrderIndependent(t *testing.T) {
+	t.Parallel()
+	s := NewFamilyCampDerivedSync(nil)
+	ts := time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC)
+
+	forward := []customValueEntry{
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-Allergies", value: "No", lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-Allergy Info", value: medicalNarrativeA, lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-Dietary Needs", value: "Yes", lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-Dietary Explain", value: "no dairy", lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Family Camp-Special Needs", value: "Yes", lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Family Camp-Special Needs Yes",
+			value: "needs a quiet unit", lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-Allergies", value: "Yes", lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-Allergy Info", value: medicalNarrativeB, lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-Dietary Needs", value: "No", lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Family Camp-Special Needs", value: "No", lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-Additional", value: "second note", lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-Additional", value: "first note", lastUpdated: ts},
+	}
+	reversed := make([]customValueEntry, len(forward))
+	for i, v := range forward {
+		reversed[len(forward)-1-i] = v
+	}
+
+	a := s.processMedical(forward)
+	b := s.processMedical(reversed)
+	if len(a) != 1 || len(b) != 1 {
+		t.Fatalf("medical rows = %d and %d, want 1 each", len(a), len(b))
+	}
+	if *a[0] != *b[0] {
+		t.Errorf("processMedical output depends on load order:\n forward  = %+v\n reversed = %+v", *a[0], *b[0])
+	}
+}
+
+// TestProcessMedicalCollapsesOneAnswerFannedOntoSiblings covers the case that
+// is far more common than genuine disagreement: CampMinder asks the family-camp
+// questions on a per-CAMPER form, so one parent's single answer arrives once
+// per enrolled child. Three identical copies are one answer, not three.
+func TestProcessMedicalCollapsesOneAnswerFannedOntoSiblings(t *testing.T) {
+	t.Parallel()
+	s := NewFamilyCampDerivedSync(nil)
+	ts := time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC)
+
+	meds := s.processMedical([]customValueEntry{
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-Allergy Info", value: medicalNarrativeA, lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-Allergy Info", value: medicalNarrativeA, lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-Allergy Info", value: medicalNarrativeA, lastUpdated: ts},
+	})
+	if len(meds) != 1 {
+		t.Fatalf("medical rows = %d, want 1", len(meds))
+	}
+	if got, want := meds[0].allergyInfo, medicalNarrativeA; got != want {
+		t.Errorf("allergyInfo = %q, want %q", got, want)
+	}
+}
+
+// TestProcessMedicalCapsAJoinedColumn: joining several answers is what makes a
+// column able to overflow for the first time. family_camp_medical's columns are
+// NOT uniformly 10,000 -- bathroom_explain and accommodation_explain are 4,000
+// -- and record.Set() past a PocketBase field's max fails the row's save, which
+// would lose the whole household rather than one sentence.
+func TestProcessMedicalCapsAJoinedColumn(t *testing.T) {
+	t.Parallel()
+	s := NewFamilyCampDerivedSync(nil)
+	ts := time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC)
+
+	limit := medicalColumnLimits["bathroom_explain"]
+	if limit == 0 {
+		t.Fatal("bathroom_explain has no declared column limit")
+	}
+	long := strings.Repeat("a", limit-10)
+	meds := s.processMedical([]customValueEntry{
+		{householdPBID: "hh_johnson", fieldName: "Housing-Bathroom", value: long, lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Bathroom-Yes", value: strings.Repeat("b", 100), lastUpdated: ts},
+	})
+	if len(meds) != 1 {
+		t.Fatalf("medical rows = %d, want 1", len(meds))
+	}
+	if n := len([]rune(meds[0].bathroomExplain)); n > limit {
+		t.Errorf("bathroomExplain = %d runes, over the %d column cap", n, limit)
+	}
+	if !strings.Contains(meds[0].bathroomExplain, long) {
+		t.Error("bathroomExplain cut an answer in half instead of dropping a whole one")
+	}
+}
+
+// TestJoinMedicalColumnKeepsEverythingForAnUndeclaredColumn: joinAnswers with a
+// zero limit returns "", so a column added to processMedical and forgotten in
+// medicalColumnLimits would blank itself on every sync -- silently, and for
+// every household. The fallback keeps the answers.
+func TestJoinMedicalColumnKeepsEverythingForAnUndeclaredColumn(t *testing.T) {
+	t.Parallel()
+	s := NewFamilyCampDerivedSync(nil)
+
+	got := s.joinMedicalColumn("hh_johnson", "a_column_nobody_declared",
+		[]string{medicalNarrativeA, medicalNarrativeB})
+	if want := medicalNarrativeA + "; " + medicalNarrativeB; got != want {
+		t.Errorf("joinMedicalColumn = %q, want %q", got, want)
+	}
+}
+
+// TestMedicalColumnLimitsMatchTheSchema pins the map against the migrations
+// that declare the columns (1500000035 and 1500000126). A limit larger than the
+// real one does not cap anything -- record.Set() past a PocketBase field's max
+// fails the whole row's save, losing a household rather than a sentence.
+func TestMedicalColumnLimitsMatchTheSchema(t *testing.T) {
+	t.Parallel()
+	want := map[string]int{
+		"allergy_info": 10000, "dietary_info": 10000,
+		"special_needs_info": 10000, "additional_info": 10000,
+		"cpap_info": 5000, "physician_info": 5000,
+		"bathroom_explain": 4000, "accommodation_explain": 4000,
+	}
+	if len(medicalColumnLimits) != len(want) {
+		t.Fatalf("medicalColumnLimits has %d columns, want %d", len(medicalColumnLimits), len(want))
+	}
+	for column, limit := range want {
+		if got := medicalColumnLimits[column]; got != limit {
+			t.Errorf("medicalColumnLimits[%q] = %d, want %d", column, got, limit)
 		}
 	}
 }


### PR DESCRIPTION
`processMedical` folded every person's family-camp medical answer into one household row by keeping
the first value it saw per field. `personValues` carries one entry per person per field, and
CampMinder asks the family-camp questions on a per-CAMPER form, so a household with two enrolled
children answers each question twice — and every answer after the first was discarded before any of
the per-column logic ran. That is why staff saw part of a household's medical picture and not all of
it.

Measured on the production snapshot: **105 of 464 family-camp households in 2026 (22.6%) lost at
least one real second disclosure** — narrative fields only, nullish values excluded; 121 of 464 if
you count all sixteen medical source fields — and the all-year range is 20–28% back to 2017. And because the
gate ("Yes"/"No") and its explanation are separate fields, they were selected independently, so
**836 of 8,864 stored rows read `"No; <a description of the condition it denies>"`** — 243 of the
330 allergy cases are genuine cross-attribution, one person's denial glued to another person's disclosure.

## What changed

The flatten is replaced by **total aggregation on both sides**, which is what binds a gate to its
explanation: after this change neither half has a "winner" that could come from a different person.

- The per-field map now accumulates into `answerSet` — the reviewed dedup-and-join shipped for
  `family_camp_registration_text.go` — so the common case (one parent's answer fanned onto every
  child's form) still collapses to one, while two genuine disclosures both survive, joined in a
  canonical order that does not depend on record-id load order.
- **A binary gate collapses by OR, not by join.** Joining two people's gate answers verbatim renders
  `"No; Yes; <A>; <B>"`, which is why an earlier uniform dedup-and-join across every field was
  reverted. `medicalGateFields` names the four gates `processMedical` reads and
  `medicalAnswers.parts` returns `Yes` if anyone in the household said `Yes` — the same aggregation
  `processRegistrations` already applies to the housing flags. A gate whose answers are all negative
  falls through to the join, so a vocabulary that ever widens past Yes/No is not silently narrowed.
- Each column is now capped at its **real** declared max, which is not uniform: 10,000 for
  `allergy_info` / `dietary_info` / `special_needs_info` / `additional_info`, 5,000 for `cpap_info`
  and `physician_info`, 4,000 for `bathroom_explain` and `accommodation_explain`. Joining is what
  makes overflow possible for the first time, and `record.Set()` past a PocketBase field's max fails
  the whole row's save — losing a household rather than a sentence. `joinAnswers` drops whole
  answers rather than cutting one in half and the count is logged; the values never are.
  An undeclared column falls back to keeping everything and logging an error, because a zero limit
  would otherwise blank the column silently.

- **The CPAP column is unioned across all three of its fields, then filtered.** It used to stop at
  the first of the two camper-partition names that had an answer, so a `"No"` on `Family Camp-CPAP`
  hid a real disclosure on `FAM CAMP-CPAP` outright — 27 households in 2025 and 1 in 2026, each
  carrying a `needs_power` / `needs_private_bathroom` flag that `processRegistrations` ORs from all
  three fields and a `cpap_info` that then denied it. Union-and-dedup is the same total aggregation
  `medicalAnswers` applies one level up, and dedup is what keeps the two generations of one question
  from printing twice.
- **The CPAP column keeps the gate rule by a different mechanism.** Its three fields cannot be ORed
  to one token: they are multi-option selects whose affirmative options say WHICH accommodation is
  needed (#1875), so two different affirmatives are two different needs. `cpapGateParts` therefore
  applies only the half of the OR that survives that — a pure denial is dropped whenever anyone in
  the household disclosed, both affirmatives survive, and a unanimous "No" is still kept. Without it
  the household aggregation renders `"No; Yes, outlet needed for CPAP machine"` on the one pair
  `docs/reference/family-camp-field-provenance.md` §4 names, alongside Special Needs, as doing real
  harm when the halves split: 1 household-year in 2026 and 1–2 a year back to 2022. No
  classification changes — `needs_power` and `needs_private_bathroom` come from `classifyCPAPAnswer`
  over the raw values and are untouched.

## Tests

Nine new tests against the production `processMedical` — both answerers' narratives survive, the
gate ORs so `"No; <narrative>"` becomes `"Yes; <narrative>"`, output is byte-identical when the
input slice is reversed (the order-independence probe, which does not pin which answerer wins), one
answer fanned onto three siblings collapses to one, a joined column stays inside its cap, and the
four CPAP cases: a denial beside a disclosure, two different needs, a unanimous denial, and an
answer under each of the two camper-partition field names. Two
more cover the undeclared-column fallback and pin the limits map against the migrations.

`TestMedicalColumnLimitsMatchTheSchema` READS the migrations. It first restated the same literals a
second time, which pins nothing — a migration narrowing a column would leave the map too large, the
exact direction that fails a whole row's save, and the test would still be green. It now scans every
migration mentioning `family_camp_medical` in file-number order, takes the last declared `max` per
column and compares both ways. Mutation-checked by setting `bathroom_explain` to 9999: red, then
green on restore.

`TestMedicalDeduplicationByHousehold` gained a note saying what it does not cover: it drives a
test-local reimplementation and asserts only non-emptiness, so it is blind to this defect by
construction and could not have caught it.

## What this deliberately does NOT do

**It is the sync half only, and the issue stays open.** The owner ruled that the gates come out of
the narrative columns into their own nullable boolean columns, and that a YES renders a chip on the
family details panel while a NO and a null render nothing. That needs a migration,
`HouseholdMedicalResponse`, `MEDICAL_NARRATIVE_FIELD_NAMES`, regenerated `pocketbase-types.ts` and
the existing `AccessibilityFlagList` chips gaining a click — none of which is in this PR. The gate
token therefore still rides in the narrative column, exactly as before; it is simply no longer
capable of contradicting the text beside it, on any of the columns — the gates through
`medicalGateFields`, CPAP through `cpapGateParts`.

Nothing here forecloses that work: the gate values are now aggregated in one named place, which is
where the boolean will be read from.

Also untouched: `processAdults` (its merge policy was ruled unchanged, and the answers it discards
have been recorded in `attribute_conflicts` since #2421), `classifyCPAPAnswer` itself and its two
"multi-option" comments, and the CPAP gate's own boolean column — #2255 still carves that out for
its own pass.

Part of #2257.
Refs #2255.
Refs #2275.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Medical information now retains distinct answers from all household members.
  * Affirmative medical needs are combined accurately, including CPAP-related responses.
  * Duplicate answers are removed, and results no longer depend on response order.
  * Narrative responses are combined within field limits without splitting individual answers.
  * Missing field limits fail safely while recording an error; over-limit content reports discarded answers.

* **Tests**
  * Added coverage for multi-person medical responses, deduplication, ordering, field limits, and CPAP scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
