### PR TITLE
fix(sync): admit the adult accommodation explain twin, cm_id 224987

### DIFF
--- a/docs/reference/family-camp-field-provenance.md
+++ b/docs/reference/family-camp-field-provenance.md
@@ -386,6 +386,7 @@ Known pairs — housing plus the medical forms that use the same convention:
 | `Family Camp-Special Needs` (182696) | `Family Camp-Special Needs Yes` (182698) |
 | `Family Camp-CPAP` (171577) | `Family Medical-CPAP Explain` (171578) |
 | `Housing Accommodation` (274057) | `Housing Accommodation-Yes` (274058) |
+| `Housing Accomodation` (274055, Adult, sic) | `Accommodation-Explain` (224987) |
 | `FAM CAMP-bathroom` (274056) | `Housing-Bathroom` (274059) |
 | `Family Camp-Special occasions` (60413) | `Family Camp-describe special occasion` |
 | `Adult-Bathroom` (274053) | `Bathroom-Yes` (274054) |

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -648,6 +648,7 @@ var extraFieldCMIDs = map[int]bool{
 	274055: true, // Housing Accomodation  (sic)  (Adult)
 	274058: true, // Housing Accommodation-Yes    (Camper) — medical narrative, spec 5
 	274059: true, // Housing-Bathroom             (Camper) — medical narrative, spec 5
+	224987: true, // Accommodation-Explain        (Adult)  — medical narrative, spec 5; twin of 274058, kindred#2224
 	274053: true, // Adult-Bathroom               (Adult)
 	274054: true, // Bathroom-Yes                 (Adult)  — medical narrative, spec 5
 	256933: true, // Adult-CPAP                   (Adult)
@@ -1819,8 +1820,19 @@ func (s *FamilyCampDerivedSync) processMedical(personValues []customValueEntry) 
 		}
 		med.bathroomExplain = s.joinMedicalColumn(householdID, "bathroom_explain", bathroomParts)
 
+		// Same two-partition shape as bathroomExplain above: "Housing
+		// Accommodation-Yes" is the Camper-partition narrative and
+		// "Accommodation-Explain" (cm_id 224987) is its Adult-partition twin.
+		// Reading the Camper key alone dropped every household narrated only
+		// through the adult gate -- 12 of 42 accommodation-gated households in
+		// 2026 production. kindred#2224.
+		accommodationKeys := []string{"Housing Accommodation-Yes", "Accommodation-Explain"}
+		accommodationParts := make([]string, 0, len(accommodationKeys))
+		for _, key := range accommodationKeys {
+			accommodationParts = append(accommodationParts, fields.parts(key)...)
+		}
 		med.accommodationExplain = s.joinMedicalColumn(
-			householdID, "accommodation_explain", fields.parts("Housing Accommodation-Yes"))
+			householdID, "accommodation_explain", accommodationParts)
 
 		// Only include if has some data
 		if med.cpapInfo != "" || med.physicianInfo != "" ||

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -1422,6 +1422,7 @@ func TestLoadFieldDefinitionsIncludesCMIDAllowlist(t *testing.T) {
 		223999: "FAM Camp-Accommodation", // retired but kept for 2023/2024 backfill
 		274057: "Housing Accommodation",  // Camper successor, name heuristic misses it
 		274055: "Housing Accomodation",   // Adult twin, CampMinder's own typo
+		224987: "Accommodation-Explain",  // Adult explain twin of 274058 (kindred#2224)
 		274133: "Shared-request",         // request-layer free text (spec 4.1)
 		206286: "COVID-19 Bunking Requests",
 		34140:  "CA-Register for Family Camp", // matched by the NAME heuristic
@@ -1443,6 +1444,7 @@ func TestLoadFieldDefinitionsIncludesCMIDAllowlist(t *testing.T) {
 		"FAM Camp-Accommodation",
 		"Housing Accommodation",
 		"Housing Accomodation",
+		"Accommodation-Explain",
 		"Shared-request",
 		"COVID-19 Bunking Requests",
 		"CA-Register for Family Camp",
@@ -1941,6 +1943,37 @@ func TestProcessMedicalCPAPIncludesAdultField(t *testing.T) {
 	}
 	if meds[0].cpapInfo == "" {
 		t.Error("cpapInfo empty; an adult-only CPAP answer was dropped")
+	}
+}
+
+// TestProcessMedicalAccommodationExplainIncludesAdultField is the accommodation
+// twin of TestProcessMedicalCPAPIncludesAdultField, and of the two-key loop
+// bathroomExplain already runs. accommodationExplain read only "Housing
+// Accommodation-Yes" (the Camper key), so a household narrated solely through
+// the adult gate's own explain twin -- "Accommodation-Explain", cm_id 224987,
+// admitted by extraFieldCMIDs -- lost its narrative outright even though the
+// field was in the map. kindred#2224.
+//
+// Measured against production, 2026: of 42 accommodation-gated households, 12
+// had no Camper-side narrative, and all 12 have text in this field -- so
+// admitting it alone takes the un-narrated count from 12 to 0.
+func TestProcessMedicalAccommodationExplainIncludesAdultField(t *testing.T) {
+	t.Parallel()
+	s := NewFamilyCampDerivedSync(nil)
+	ts := time.Date(2025, 4, 21, 0, 0, 0, 0, time.UTC)
+
+	const accommodationText = "requires accessible transfer space"
+
+	meds := s.processMedical([]customValueEntry{
+		{householdPBID: "hh_martinez", fieldName: "Accommodation-Explain",
+			value: accommodationText, lastUpdated: ts},
+	})
+	if len(meds) != 1 {
+		t.Fatalf("medical rows = %d, want 1", len(meds))
+	}
+	if meds[0].accommodationExplain != accommodationText {
+		t.Errorf("accommodationExplain = %q; an adult-only accommodation "+
+			"explain was dropped", meds[0].accommodationExplain)
 	}
 }
 


### PR DESCRIPTION
## Stacked PR — no CI

This branch is stacked on open PR #2450 (`feature/fc-adult-medical-dedup`), because
`processMedical`'s aggregation shape (the `answerSet`/`medicalGateFields` rewrite) is what this
change's anchors sit on top of. **Base is `feature/fc-adult-medical-dedup`, not `main`, so this PR
gets no CI** — this repo's workflow trigger is `pull_request: branches: [main]`. It will pick up CI
automatically once #2450 merges and this is re-based/re-targeted onto `main`.

**Part of #2224. Unblocks #2072.** This is the backend half only — no card, no UI, no migration. It
closes nothing.

## The defect

`processMedical` in `pocketbase/sync/family_camp_derived.go` reads the accommodation-need free text
from the Camper-partition field only, `"Housing Accommodation-Yes"`. Three statements above it,
`bathroomExplain` already loops **both** partitions — `["Housing-Bathroom", "Bathroom-Yes"]` — but
`accommodationExplain` never got its Adult-partition twin.

That twin exists in CampMinder: `Accommodation-Explain`, cm_id **224987**, partition `["Adult"]` —
the accommodation gate's own partition. It was never admitted into the sync's field map at all
(`extraFieldCMIDs` had no entry for it), so the household narratives sitting behind the adult gate
were invisible before routing ever got a chance to drop them.

## Measured (production snapshot, 2026, re-verified against the current tree post-#2450)

| | |
|---|---|
| 224987 non-empty 2026 values | 13 |
| ...belonging to persons who answered the adult gate `Yes` | 13 of 13 |
| 224987 values, all years | 140 (2023: 30, 2024: 58, 2025: 39, 2026: 13) |
| Accommodation-gated households, 2026 | 42 |
| ...narrated by the Camper explain alone | 30 |
| ...un-narrated **before** this change | 12 |
| ...un-narrated **after** admitting 224987 | **0** |

SQL run directly against `pocketbase/pb_data/data-prod.db`, unioning the camper (274057) and adult
(274055) gate-Yes households for 2026 and checking narrative coverage from 274058 (Camper explain)
alone vs. 274058 ∪ 224987 (Adult explain). Confirms the issue's claim under the **new** aggregation
`processMedical` gained in #2450 (union-by-household rather than first-wins) — the two-key loop
composes cleanly with that aggregation because `medicalAnswers.parts()` already unions every
household member's answers per field name; adding a second field name is exactly the same shape as
`bathroomExplain`'s existing loop.

## The change

- `pocketbase/sync/family_camp_derived.go`: added `224987: true` to `extraFieldCMIDs` (admission),
  and changed `accommodationExplain`'s single-key read to loop
  `["Housing Accommodation-Yes", "Accommodation-Explain"]`, mirroring `bathroomExplain`'s existing
  two-key loop exactly.
- `pocketbase/sync/family_camp_derived_test.go`: extended
  `TestLoadFieldDefinitionsIncludesCMIDAllowlist` to assert 224987 is admitted, and added
  `TestProcessMedicalAccommodationExplainIncludesAdultField` (the accommodation-column twin of the
  existing `TestProcessMedicalCPAPIncludesAdultField`) asserting an Adult-only accommodation
  narrative is no longer dropped. Both were run RED before the fix, and each was mutation-checked
  (reverting the corresponding line flips it back to RED).

`pocketbase/sync/lodging_fields.go` was **not** touched — 224987 is a PHI narrative routed by a
name-keyed lookup inside `processMedical`, the same pattern as its siblings 274058/274059, neither
of which appears in `lodgingRequestFields` either. Confirmed by grep before assuming otherwise.

## Deliberately NOT done

- No `needs_fridge` or any other derived boolean — that is #2224's next slice, sequenced after this
  per the issue's most recent ruling.
- No `NEEDS_DIMENSIONS`/`needsFit.ts` entry, no card visual — that belongs to #2072's gutter.
- No migration — `accommodation_explain` already exists as a column (migration 1500000126); this
  only changes what feeds it.

Files touched: `pocketbase/sync/family_camp_derived.go`,
`pocketbase/sync/family_camp_derived_test.go`.
