### PR TITLE
feat(api,frontend): render housing in today's language on the journey card and the family card

### DIFF
--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -577,12 +577,37 @@ class RosterParty(BaseModel):
     # 1,433 rows from 2017-2021. So "" is NOT "nobody assigned them", and no
     # consumer should render a placeholder or a dash for it.
     #
-    # FREE TEXT out of `cabin_assignment`, deliberately NOT resolved against
-    # `lodging_units` -- see `fetch_cabin_assignments_by_household_cm_id` for
-    # why (the registry holds only the current year, and 3 of the 88 distinct
-    # strings across 2022-2025 resolve to no alias at all). It may therefore
-    # name something no card on the board is called. Never match it against a
-    # `unit_code`.
+    # RESOLVED TO THE REGISTRY NAME (kindred#2332), not the raw string staff
+    # typed last season. Owner ruling 2026-08-18: *"the last year housing
+    # should use the same language via the alias year over year concept so it
+    # appears in current language."* This field used to carry the prior year's
+    # `cabin_assignment` free text straight through, so the family card
+    # contradicted the board card beside it -- 37 of 88 distinct raw strings
+    # resolve to a different registry name, covering 716 of 1,861 rows (38.5%).
+    #
+    # `HousingNameResolver.display_name` does the work, at the PRIOR year's
+    # alias window: the window says which raw string was in use when, and is an
+    # input to FINDING the unit, never to naming it. A string that resolves to
+    # nothing renders unchanged, which is what the three strings naming a unit
+    # FAMILY rather than a unit do (kindred#2392).
+    #
+    # THE RAW STRING IS NOT DUPLICATED HERE. It is provenance, and it lives on
+    # `HouseholdJourneyYear.cabin_name_raw` -- the same household-year fact, on
+    # the surface whose job is the record, one click away through this card.
+    #
+    # Still never match it against a `unit_code`: it is a NAME, and a name is
+    # not an identity. The board's own placement travels in `unit_code` /
+    # `unit_codes`.
+    #
+    # ⚠️ NOT PER-WEEKEND, and no consumer may render it as such (kindred#2336).
+    # `cabin_assignment` has grain (household, year) because its source is one
+    # CampMinder household custom field per household-year -- so a household
+    # attending two weekends of a season shows the SAME cabin for both, and its
+    # later weekend overwrites nothing because there was never a second value.
+    # Staff confirmed 2026-08-15 that this is acceptable and asked for no
+    # snapshot or lookback. 41 of 1,703 cabin-holding household-years are
+    # multi-weekend; treating the fan-out as per-weekend placement manufactured
+    # 12 of 17 false multi-household occupancies in one analysis.
     #
     # Only ever populated on the ROSTER, and only for household-grain parties:
     # `build_summary` keeps nothing but counts, and an adult-weekend guest is
@@ -705,11 +730,25 @@ class HouseholdJourneyYear(BaseModel):
 
     year: int = 0
     housing: HousingState = "unknown"
-    # The staff-written free text out of `family_camp_registrations`, NOT
-    # resolved to a `lodging_units` row: `lodging_units` holds only the
-    # current year, so a 2023 string can name a cabin that no longer exists
-    # under that name. See `fetch_cabin_assignments_by_household_cm_id`.
+    # The unit's name TODAY (kindred#2332), whichever year the row is.
+    #
+    # Owner ruling 2026-08-18: a prior year's housing renders in the current
+    # language, because staff recognise the cabin they use now -- a 2022 row
+    # displaying a name nobody has used since 2023 is a lookup task, not
+    # information. Renames are routine: fourteen of the 118 units were renamed
+    # one at a time in the admin GUI on 2026-08-15, inside two minutes.
+    #
+    # `HousingNameResolver.display_name` resolves it at THIS ROW'S OWN YEAR --
+    # the alias window says which raw string was in use when, which is what
+    # finds the unit; the unit's present-day `lodging_units.name` is what names
+    # it. Falls back to the raw string unchanged when nothing resolves.
     cabin_name: str = ""
+    # What staff actually typed that season, verbatim -- provenance, not a
+    # name. Equal to `cabin_name` whenever nothing resolved, and "" whenever
+    # `cabin_name` is. The client shows it only where the two DISAGREE, which
+    # is 716 of 1,861 rows on the production snapshot: rendering it beside an
+    # identical name would be noise on the other 1,145.
+    cabin_name_raw: str = ""
     enrollment: EnrollmentState = "none_on_file"
     # Every `family_camp_adults` row for the year, blanks and placeholders
     # included -- the same contract `RosterParty.adults` publishes, so the

--- a/api/services/lodging_repository.py
+++ b/api/services/lodging_repository.py
@@ -74,6 +74,7 @@ from api.constants.collections import (
     LODGING_INGEST_ISSUES,
     LODGING_SESSION_STATUS,
     LODGING_SLOT_MERGES,
+    LODGING_UNIT_ALIASES,
     LODGING_UNITS,
     LODGING_WRITE_INS,
     LODGING_WRITE_INS_DRAFT,
@@ -310,6 +311,58 @@ class LodgingRepository:
                 "sort": "area.sort_order,name",
             },
         )
+
+    async def fetch_all_units(self) -> list[Any]:
+        """EVERY lodging unit, every season -- the registry, for NAMING things.
+
+        kindred#2332. Deliberately unfiltered, and that is what separates it
+        from `fetch_units`. Naming a unit is a question about the PRESENT, so
+        the registry's latest season has to be discovered from the table
+        rather than assumed to be the year being read: `lodging_units` holds
+        2026 only (118 of 118), so resolving a 2023 cabin string against 2023's
+        units finds nothing at all. That is the trap that made display
+        resolution look impossible (kindred#2392).
+
+        Older seasons are read too, not merely tolerated. An alias stores
+        whichever season's record ids existed when it was written and is never
+        re-pointed, so translating a stored member id needs `code` for units of
+        EVERY year -- `code` is the cross-year identity thread, exactly as
+        `AliasResolver` uses it.
+
+        No `expand`: `HousingNameResolver` wants `code`, `name`, `year` and
+        `parent_unit`, and the area relation is `fetch_units`' business.
+
+        Deliberately NOT cached, for `fetch_units`' reason made sharper by this
+        issue -- `lodging_units.name` is written straight to PocketBase from
+        the admin panel, and staff rename in bursts (fourteen of the 118 units
+        on 2026-08-15, inside two minutes). A TTL here would show the old name
+        on four surfaces at once.
+        """
+        return await self._page(LODGING_UNITS, query_params={"sort": STABLE_SORT})
+
+    async def fetch_unit_aliases(self) -> list[Any]:
+        """Every `lodging_unit_aliases` row -- the historical spellings.
+
+        NO YEAR FILTER, because the table has no `year` column and never
+        should: a row's `valid_from_year` / `valid_to_year` window records what
+        a building was CALLED from a given year, which is a rename history and
+        not a per-year copy. The window is applied per raw string at the year
+        THAT STRING came from (`HousingNameResolver.display_name`), never at
+        the registry's loaded year -- pinning it to the current season
+        discards the four rows carrying `valid_to_year = 2024` and strands 49
+        of the 1,861 cabin-bearing rows at their raw spelling.
+
+        `member_units` is left as raw relation ids rather than expanded: the
+        resolver maps id -> code -> the registry year's row off
+        `fetch_all_units`, which it holds anyway, so an expand would pay for
+        rows already in hand.
+
+        Deliberately NOT cached: `mapUnresolvedAlias` in `lodgingCrud.ts`
+        writes this table straight from the admin panel, never through this
+        API -- the same argument `count_open_unresolved_aliases` makes for the
+        queue that feeds it.
+        """
+        return await self._page(LODGING_UNIT_ALIASES, query_params={"sort": STABLE_SORT})
 
     async def fetch_availability(self, year: int, session_cm_id: int) -> list[Any]:
         """Staff RELEASES for one session -- the staff<->family role override.
@@ -878,14 +931,33 @@ class LodgingRepository:
         """Where each household slept in `year`, keyed by household CampMinder id.
 
         The staff-written string out of `family_camp_registrations.cabin_assignment`
-        -- FREE TEXT, not a relation. It is deliberately NOT resolved to a
-        `lodging_units` row here: `lodging_units` holds only the current year,
-        so a 2023 string can name a cabin that no longer exists under that
-        name, and 3 of the 88 distinct strings across 2022-2025 resolve to no
-        alias at all. What staff wrote is the fact they are recalling; the
-        alias resolution (`lodging_unit_aliases` → `member_units`, honouring
-        `valid_from_year` / `valid_to_year`) is a separate job with a separate
-        failure mode.
+        -- FREE TEXT, not a relation, and RAW: this read returns exactly what
+        staff typed that season and resolves nothing.
+
+        RESOLUTION HAPPENS AT DISPLAY, ONE LAYER UP (kindred#2332). Owner
+        ruling 2026-08-18: every surface renders the unit's CURRENT registry
+        name, so `HousingNameResolver` -- fed by `fetch_all_units` and
+        `fetch_unit_aliases` -- translates this string in the service, at the
+        year the string came from. Keeping the raw value here is what lets the
+        journey publish the name and its provenance from one read, and what
+        keeps `_housing_state` deciding placed/not-placed on PRESENCE rather
+        than on whether a name happened to resolve.
+
+        ⚠ ONE STRING PER HOUSEHOLD-YEAR, WITH NO SESSION DIMENSION, and no
+        caller may present it as per-weekend (kindred#2336). The source is a
+        single CampMinder household custom field (`Family Camp Cabin`, one
+        value per household-year), so a household attending two weekends of a
+        season has one cabin for both -- there is no second weekend's answer
+        being lost, and widening the grain would replicate one string N times
+        and bake the fan-out into the schema. Staff confirmed 2026-08-15 that
+        the overwrite is acceptable and declined a snapshot or lookback. 41 of
+        1,703 cabin-holding household-years are multi-weekend; cutting this
+        column by weekend as though it were a placement manufactured 12 of 17
+        false multi-household occupancies in one analysis. The honest
+        per-weekend rule already ships in Go
+        (`LodgingAssignmentsSync.AttributeSession`), which pins the year's
+        single string to a weekend only when the household attended exactly
+        one and queues an ingest issue otherwise.
 
         ⚠️ KEYED BY cm_id, AND THAT IS THE ENTIRE POINT. `registration.household`
         is a PocketBase relation into a YEAR-SCOPED `households` table, so a

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -1293,20 +1293,27 @@ class LodgingRosterService:
     async def build_summary(self, year: int, scenario: str = "") -> WeekendSummaryResponse:
         """Every weekend in the year with its counts, in one pass.
 
-        `build_roster` makes THIRTEEN fetches (12 concurrent + `fetch_session`
-        alone before them), of which SEVEN are year-scoped -- the unit
+        `build_roster` makes SIXTEEN reads (fourteen concurrent tasks issuing
+        fifteen reads -- `_housing_names` is one task making two -- plus
+        `fetch_session` alone before them), of which TEN are constant across
+        every weekend of the year. EIGHT of the ten are year-scoped: the unit
         registry, households, the prior-household set, family-camp adults,
-        registrations, the unresolved-alias count and last year's cabins
-        (kindred#2075) are identical for every weekend in the year. Calling it
-        once per weekend to fill the lander would repeat all seven N times,
-        which is why a weekend with zero parties still costs about three
-        seconds.
+        registrations, the unresolved-alias count, last year's cabins
+        (kindred#2075) and the raw per-field request answers (kindred#2330).
+        The other two are kindred#2332's registry-naming pair, which carry no
+        year at all and are therefore constant for the same reason. Calling
+        `build_roster` once per weekend to fill the lander would repeat all
+        ten N times, which is why a weekend with zero parties still costs
+        about three seconds.
 
-        The lander fetches only SIX of those seven. Last year's cabins feed
-        `RosterParty.last_year_cabin`, and no `WeekendSummaryEntry` carries a
-        party -- `_build_parties` runs here purely to be counted, so the
-        seventh read would buy a field nothing renders. `_build_parties` takes
-        it as a defaulted keyword for exactly that reason.
+        The lander fetches only SIX of those ten, and declines four. No
+        `WeekendSummaryEntry` carries a party -- `_build_parties` runs here
+        purely to be counted -- so last year's cabins
+        (`RosterParty.last_year_cabin`), kindred#2330's request answers, and
+        kindred#2332's two registry reads that would name the cabin all buy
+        fields nothing renders. `_build_parties` takes the first two as
+        defaulted keywords for exactly that reason, and the naming pair is
+        simply absent from the TaskGroup below.
 
         kindred#1963 measures this from eleven and eight, so that issue is
         partly pre-paid: kindred#1889 deleted `has_medical_narrative`, the only

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -53,6 +53,9 @@ from api.schemas.lodging import (
 )
 from api.services.lodging_rules import (
     REQUEST_TEXT_SOURCES,
+    HousingNameResolver,
+    RegistryUnit,
+    UnitAlias,
     amenity_coverage,
     container_bathroom,
     effective_bathroom,
@@ -1175,6 +1178,14 @@ class LodgingRosterService:
             # deliberately absent from `build_summary`'s parallel TaskGroup,
             # which keeps nothing but counts.
             last_year_cabins_task = tg.create_task(self.repository.fetch_cabin_assignments_by_household_cm_id(year - 1))
+            # kindred#2332's registry index, for turning the raw string above
+            # into the name the unit carries TODAY. Two reads, neither
+            # year-filtered and neither cached -- see `_housing_names`.
+            # Deliberately absent from `build_summary`'s TaskGroup for exactly
+            # the reason last year's cabins are: no `WeekendSummaryEntry`
+            # carries a party, so both would be paid on every weekend of the
+            # year to name a field nothing renders.
+            housing_names_task = tg.create_task(self._housing_names())
             adults_task = tg.create_task(self.repository.fetch_family_camp_adults(year))
             registrations_task = tg.create_task(self.repository.fetch_family_camp_registrations(year))
             # kindred#2330. The RAW per-field, per-child request answers --
@@ -1242,13 +1253,24 @@ class LodgingRosterService:
         # there would be work no response can read -- once per weekend, across
         # every weekend of the year, on every lander request.
         _resolve_write_in_covers(unit_summaries, written_in_unit_ids(write_ins))
+        housing_names = housing_names_task.result()
         parties = self._build_parties(
             session_type=session_type,
             session_start=_as_date(_s(session, "start_date")),
             attendees=attendees_task.result(),
             households=households,
             prior_cm_ids=prior_task.result(),
-            last_year_cabins=last_year_cabins_task.result(),
+            # RESOLVED HERE, not in the party builder, and at `year - 1`
+            # (kindred#2332). The string came out of the PRIOR season, so the
+            # prior season is the year its alias window is tested at; testing
+            # it at the roster's own year would strand every row whose alias
+            # carries `valid_to_year = 2024` on its raw spelling. The NAME is
+            # still the present one -- the window finds the unit, it does not
+            # name it.
+            last_year_cabins={
+                household_cm_id: housing_names.display_name(raw, year - 1)
+                for household_cm_id, raw in last_year_cabins_task.result().items()
+            },
             adults_by_household=adults_task.result(),
             registrations=registrations_task.result(),
             request_values=request_values_task.result(),
@@ -1447,6 +1469,50 @@ class LodgingRosterService:
             **{field: _s(record, field) for field in sorted(MEDICAL_NARRATIVE_FIELD_NAMES)},
         )
 
+    async def _housing_names(self) -> HousingNameResolver:
+        """The registry, indexed for naming -- kindred#2332's one helper.
+
+        TWO READS, NEITHER YEAR-FILTERED, and both deliberately uncached (see
+        their docstrings). `lodging_units` is year-scoped and holds 2026 only,
+        so the season that NAMES a unit has to be discovered from the table;
+        `lodging_unit_aliases` has no year column at all, because a row's
+        window is a rename history rather than a per-year copy.
+
+        The flattening happens here and the rule happens in `lodging_rules`,
+        which is what keeps the resolution total over plain values and
+        unit-testable without a database.
+        """
+        units, aliases = await asyncio.gather(
+            self.repository.fetch_all_units(),
+            self.repository.fetch_unit_aliases(),
+        )
+        return HousingNameResolver.build(
+            [
+                RegistryUnit(
+                    unit_id=_s(unit, "id"),
+                    code=_s(unit, "code"),
+                    name=_s(unit, "name"),
+                    year=_i(unit, "year"),
+                    # The RAW relation value, which is a PocketBase record id
+                    # and not a code -- joining `parent_unit` against `code`
+                    # returns nothing, silently. `_build_units` publishes the
+                    # code form for the board; the collapse rule needs the id
+                    # form, because that is what it is stored as.
+                    parent_id=_s(unit, "parent_unit"),
+                )
+                for unit in units
+            ],
+            [
+                UnitAlias(
+                    alias_string=_s(alias, "alias_string"),
+                    member_unit_ids=tuple(str(member) for member in (getattr(alias, "member_units", None) or [])),
+                    valid_from_year=_i(alias, "valid_from_year"),
+                    valid_to_year=_i(alias, "valid_to_year"),
+                )
+                for alias in aliases
+            ],
+        )
+
     async def build_household_journey(self, household_cm_id: int) -> HouseholdJourneyResponse:
         """A household's family-camp record, year by year (kindred#2073).
 
@@ -1545,8 +1611,12 @@ class LodgingRosterService:
             )
             if year > 0
         ]
-        cabin_maps = await asyncio.gather(
-            *(self.repository.fetch_cabin_assignments_by_household_cm_id(year) for year in years)
+        # The cabin sweep and the registry read go together: the sweep is
+        # `@cached_by_year` and usually free, the registry read never is, and
+        # neither depends on the other.
+        cabin_maps, housing_names = await asyncio.gather(
+            asyncio.gather(*(self.repository.fetch_cabin_assignments_by_household_cm_id(year) for year in years)),
+            self._housing_names(),
         )
 
         rows: list[HouseholdJourneyYear] = []
@@ -1557,8 +1627,17 @@ class LodgingRosterService:
             rows.append(
                 HouseholdJourneyYear(
                     year=year,
+                    # PRESENCE, not resolvability: a string nobody can map is
+                    # still a household that was placed. Deriving the state
+                    # from `cabin_name` instead would report the three
+                    # unmappable strings (kindred#2392) as unplaced families.
                     housing=_housing_state(cabin, assignments),
-                    cabin_name=cabin,
+                    # kindred#2332. THIS ROW'S OWN YEAR is the alias window --
+                    # the window says which raw string was in use then, which
+                    # is what finds the unit. The name is always the present
+                    # one.
+                    cabin_name=housing_names.display_name(cabin, year),
+                    cabin_name_raw=cabin,
                     # An empty child list is NOT a childless family: 2020 was
                     # cancelled outright and 2021 has no family attendee rows
                     # at all. Naming the state here is what stops the client

--- a/api/services/lodging_rules.py
+++ b/api/services/lodging_rules.py
@@ -376,3 +376,217 @@ def request_text_authorship(label: str) -> RequestTextAuthorship:
     once a staff member has read it as a parent's ask.
     """
     return _REQUEST_TEXT_AUTHORSHIP.get(label, "staff")
+
+
+# ------------------------------------------------------------ housing names
+#
+# kindred#2332. ONE housing-name display convention, for every surface that
+# shows where a household slept.
+#
+# Owner ruling 2026-08-18: *"the last year housing should use the same
+# language via the alias year over year concept so it appears in current
+# language."* Whatever staff call a unit in the admin GUI is what appears
+# everywhere -- the board card, the family history modal, and
+# `RosterParty.last_year_cabin` on the family card.
+#
+# THE ALIAS YEAR WINDOW SAYS WHICH RAW STRING WAS IN USE WHEN. It is an input
+# to FINDING the unit and never to NAMING it: once the unit is identified, its
+# present-day `lodging_units.name` is what renders. A 2022 row displaying a
+# name nobody has used since 2023 is a lookup task, not information -- and
+# renames are routine here, fourteen of the 118 units having been renamed one
+# at a time in the admin GUI inside two minutes on 2026-08-15.
+#
+# Deliberately a MIRROR of `AliasResolver` (`pocketbase/sync/lodging_alias_resolver.go`)
+# rather than a second opinion: same lookup key (outer whitespace and case
+# only, inner spacing significant), same all-or-nothing member translation
+# through `code`, same refusal on two rows whose windows both contain the
+# year. What is NOT shared is the target year -- the Go resolver places rows in
+# their own season, this one always names them in the registry's latest one.
+
+
+class RegistryUnit(NamedTuple):
+    """One `lodging_units` row, flattened to the columns naming needs.
+
+    `parent_id` is the raw `parent_unit` RELATION VALUE, which is a PocketBase
+    record id and not a code -- joining it against `code` returns nothing, with
+    no error (18 of the 118 units are grandchildren, so the silence is not even
+    total).
+    """
+
+    unit_id: str
+    code: str
+    name: str
+    year: int
+    parent_id: str
+
+
+class UnitAlias(NamedTuple):
+    """One `lodging_unit_aliases` row, flattened.
+
+    `valid_from_year` / `valid_to_year` are PocketBase number columns, declared
+    `NUMERIC DEFAULT 0 NOT NULL`. An unset bound stores as 0, never NULL --
+    181 of the 187 seeded rows are unbounded on both sides -- so 0 means "no
+    bound" and must never be compared as a real year.
+    """
+
+    alias_string: str
+    member_unit_ids: tuple[str, ...]
+    valid_from_year: int
+    valid_to_year: int
+
+    def covers(self, year: int) -> bool:
+        if self.valid_from_year > 0 and year < self.valid_from_year:
+            return False
+        return not (self.valid_to_year > 0 and year > self.valid_to_year)
+
+
+def housing_lookup_key(raw: str) -> str:
+    """Normalise OUTER whitespace and case only -- `aliasLookupKey`'s rule.
+
+    Inner spacing stays significant: the seed stores strings verbatim and one
+    of them genuinely carries a double space before its separator. Collapsing
+    inner runs would merge it with a single-space variant that means the same
+    room today but need not tomorrow.
+    """
+    return raw.strip().casefold()
+
+
+# What two or more member names are joined with when they share no parent. No
+# production row reaches this branch -- all seven in-use multi-member aliases
+# resolve to siblings under one container -- and the separator changes no
+# measured figure. It exists so the rule stays total.
+_MEMBER_JOIN = " + "
+
+
+class HousingNameResolver:
+    """Raw staff-written cabin string -> the name that unit carries TODAY.
+
+    Built from the whole `lodging_units` table and the whole alias table, and
+    read once per string. Both are small (118 units, 187 aliases) and there are
+    only 88 distinct raw values across 2022-2026 to resolve.
+    """
+
+    __slots__ = ("_alias_by_key", "_code_by_unit_id", "_current_by_code", "_direct_by_key", "registry_year")
+
+    def __init__(
+        self,
+        *,
+        registry_year: int,
+        current_by_code: dict[str, RegistryUnit],
+        code_by_unit_id: dict[str, str],
+        direct_by_key: dict[str, str | None],
+        alias_by_key: dict[str, list[UnitAlias]],
+    ) -> None:
+        self.registry_year = registry_year
+        self._current_by_code = current_by_code
+        self._code_by_unit_id = code_by_unit_id
+        self._direct_by_key = direct_by_key
+        self._alias_by_key = alias_by_key
+
+    @classmethod
+    def build(cls, units: Sequence[RegistryUnit], aliases: Sequence[UnitAlias]) -> HousingNameResolver:
+        """Index the registry once.
+
+        THE REGISTRY YEAR IS THE LATEST SEASON THE TABLE HOLDS, not the year
+        being rostered and not the year the row came from. `lodging_units` is
+        year-scoped and holds 2026 only today (118 of 118), so resolving a 2023
+        string against 2023's units would find nothing at all -- that is the
+        trap that makes this look impossible (kindred#2392). Naming a unit is a
+        question about the present, so the present season answers it.
+        """
+        registry_year = max((unit.year for unit in units), default=0)
+        # Codes are the cross-year identity thread, so this index spans EVERY
+        # season: an alias stores whichever season's record ids existed when it
+        # was written and is never re-pointed.
+        code_by_unit_id = {unit.unit_id: unit.code for unit in units}
+        current_by_code = {unit.code: unit for unit in units if unit.year == registry_year}
+
+        # A string that already names a unit today needs no alias, and the
+        # answer cannot be wrong. `None` marks a key two different units both
+        # answer to -- refuse rather than pick, the same call `Resolve` makes
+        # on two overlapping alias rows.
+        direct_by_key: dict[str, str | None] = {}
+        for unit in current_by_code.values():
+            for candidate in (unit.name, unit.code):
+                key = housing_lookup_key(candidate)
+                if not key:
+                    continue
+                if key in direct_by_key and direct_by_key[key] != unit.code:
+                    direct_by_key[key] = None
+                else:
+                    direct_by_key[key] = unit.code
+
+        alias_by_key: dict[str, list[UnitAlias]] = {}
+        for alias in aliases:
+            key = housing_lookup_key(alias.alias_string)
+            if key:
+                alias_by_key.setdefault(key, []).append(alias)
+
+        return cls(
+            registry_year=registry_year,
+            current_by_code=current_by_code,
+            code_by_unit_id=code_by_unit_id,
+            direct_by_key=direct_by_key,
+            alias_by_key=alias_by_key,
+        )
+
+    def display_name(self, raw: str, year: int) -> str:
+        """The unit's CURRENT name, or `raw` unchanged when nothing resolves.
+
+        `year` is the year the RAW STRING came from, and its only job is
+        picking which alias row was in use then.
+
+        THE COLLAPSE RULE, stated so it stops being re-derived: when a string
+        resolves to 2+ units that share one non-empty `parent_unit`, the parent
+        unit's name renders and never the joined member names. When it resolves
+        to one unit, that unit's name renders. When nothing resolves, the raw
+        string renders unchanged.
+
+        The collapse is what does the work, not the resolution: joining member
+        names is up to 35 characters, one MORE than the worst raw string, on a
+        `whitespace-nowrap` span. Every one of the seven in-use multi-member
+        aliases resolves to exactly two siblings under one container.
+        """
+        key = housing_lookup_key(raw)
+        if not key:
+            return raw
+
+        direct = self._direct_by_key.get(key, "")
+        if direct:
+            return self._current_by_code[direct].name
+
+        matches = [alias for alias in self._alias_by_key.get(key, ()) if alias.covers(year)]
+        if len(matches) != 1:
+            # 0 is a work-queue item, not an error -- three of the 88 distinct
+            # strings name a unit FAMILY rather than a unit and need staff
+            # knowledge (kindred#2392). 2+ is the overlapping-window pair the
+            # unique index on (alias_string, valid_from_year) permits; picking
+            # one arbitrarily would name a cabin nobody chose.
+            return raw
+
+        members: list[RegistryUnit] = []
+        for unit_id in matches[0].member_unit_ids:
+            # ALL OR NOTHING, on both doors, exactly as `Resolve` does it. A
+            # stored id whose unit row is gone, and a code with no row in the
+            # registry year, are the same failure: a member that cannot be
+            # carried into the present. Keeping the ones that survive would
+            # silently shrink a family's rooms.
+            code = self._code_by_unit_id.get(unit_id, "")
+            unit = self._current_by_code.get(code) if code else None
+            if unit is None:
+                return raw
+            members.append(unit)
+
+        if not members:
+            return raw
+        if len(members) == 1:
+            return members[0].name
+
+        parent_ids = {unit.parent_id for unit in members}
+        if len(parent_ids) == 1:
+            parent_id = next(iter(parent_ids))
+            parent_code = self._code_by_unit_id.get(parent_id, "") if parent_id else ""
+            parent = self._current_by_code.get(parent_code) if parent_code else None
+            if parent is not None:
+                return parent.name
+        return _MEMBER_JOIN.join(unit.name for unit in members)

--- a/api/services/lodging_rules.py
+++ b/api/services/lodging_rules.py
@@ -503,8 +503,13 @@ class HousingNameResolver:
 
         # A string that already names a unit today needs no alias, and the
         # answer cannot be wrong. `None` marks a key two different units both
-        # answer to -- refuse rather than pick, the same call `Resolve` makes
-        # on two overlapping alias rows.
+        # answer to -- never pick one of them, the same call `Resolve` makes
+        # on two overlapping alias rows. It is a DEFERRAL rather than a
+        # refusal: `display_name` treats a `None` exactly as it treats a key
+        # that is absent, so an alias row covering the year still gets its
+        # say, and only when that fails too does the raw string render. An
+        # alias is a deliberate staff mapping and a name collision is an
+        # accident, so the mapping is the better answer of the two.
         direct_by_key: dict[str, str | None] = {}
         for unit in current_by_code.values():
             for candidate in (unit.name, unit.code):

--- a/frontend/src/components/ui/Tooltip.test.tsx
+++ b/frontend/src/components/ui/Tooltip.test.tsx
@@ -184,6 +184,43 @@ describe('Tooltip — touch', () => {
   })
 })
 
+describe('Tooltip — a purely informational trigger (pinOnClick={false})', () => {
+  /**
+   * kindred#2332's provenance affordance on the family history modal. The
+   * bubble only restates what staff typed that season; there is nothing to
+   * act on and nothing to keep open while you work beside it. Pinning made
+   * it stick after a click and read as a stuck popover, so this trigger opts
+   * out of the tap-pins default while staying a focusable button — hover and
+   * Tab must both still reach it.
+   */
+  it('does not stay open after a click once the pointer leaves', () => {
+    renderChip({ pinOnClick: false })
+    fireEvent.pointerEnter(trigger())
+    fireEvent.click(trigger())
+    fireEvent.pointerOut(trigger(), { relatedTarget: document.body })
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+  })
+
+  it('still opens on hover and on keyboard focus', () => {
+    renderChip({ pinOnClick: false })
+    fireEvent.pointerEnter(trigger())
+    expect(screen.getByRole('tooltip')).toBeInTheDocument()
+    fireEvent.pointerOut(trigger(), { relatedTarget: document.body })
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+
+    fireEvent.focus(trigger())
+    expect(screen.getByRole('tooltip')).toBeInTheDocument()
+  })
+
+  it('leaves the tap-pins default alone for every other trigger', () => {
+    renderChip()
+    fireEvent.pointerEnter(trigger())
+    fireEvent.click(trigger())
+    fireEvent.pointerOut(trigger(), { relatedTarget: document.body })
+    expect(screen.getByRole('tooltip')).toBeInTheDocument()
+  })
+})
+
 describe('Tooltip — a trigger that already has its own action', () => {
   it('runs the action on click instead of pinning', () => {
     const onActivate = vi.fn()

--- a/frontend/src/components/ui/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip.tsx
@@ -100,6 +100,20 @@ export interface TooltipProps {
    * focus the tap produced.
    */
   onActivate?: () => void
+  /**
+   * Opt a purely informational trigger out of decision 3's tap-pins default.
+   *
+   * That default exists so a bubble a staff member opened stays readable while
+   * they work beside it. Worth having where the sentence is something to act
+   * on; it reads as a stuck popover where the sentence merely restates a value
+   * already on screen. `HouseholdJourneyCard`'s provenance name is the second
+   * kind — it says what staff typed that season and there is nothing to do
+   * about it — so a click there should leave no residue (kindred#2332).
+   *
+   * This is NOT a way to make a tooltip mouse-only: the trigger stays a
+   * focusable button and Tab still opens the bubble.
+   */
+  pinOnClick?: boolean
 }
 
 /**
@@ -127,6 +141,7 @@ export function Tooltip({
   'aria-pressed': ariaPressed,
   'data-testid': testId,
   onActivate,
+  pinOnClick = true,
 }: TooltipProps) {
   const triggerRef = useRef<HTMLButtonElement>(null)
   const bubbleRef = useRef<HTMLDivElement>(null)
@@ -260,6 +275,7 @@ export function Tooltip({
             onActivate()
             return
           }
+          if (!pinOnClick) return
           setPinned((wasPinned) => !wasPinned)
         }}
         onKeyDown={(event) => {

--- a/frontend/src/components/weekend/FamilyCard.tsx
+++ b/frontend/src/components/weekend/FamilyCard.tsx
@@ -303,7 +303,14 @@ function FamilyCardIdentity({ party }: { party: RosterPartyRow }) {
   // surfaces that replaced the salutation with this same list (kindred#2084).
   const attendingAdults = computeAttendingAdults(party)
   const { names: adultNames, sharedSurname: sharedAdultSurname } = dedupeAdultNames(attendingAdults)
-  // Last year's cabin, right-anchored on the grey line below (kindred#2075).
+  // Last year's cabin, right-anchored on the grey line below (kindred#2075),
+  // resolved to the current registry name by kindred#2332.
+  //
+  // ⚠ A YEAR'S HOUSING, NOT A WEEKEND'S (kindred#2336). `cabin_assignment` has
+  // grain (household, year) because its CampMinder source is one household
+  // custom field per season, so a household attending two weekends carries one
+  // cabin for both. Staff accepted that 2026-08-15. Never read this as "where
+  // they slept on THIS weekend last year".
   //
   // Trimmed here rather than trusted: '' is the common case (202 of 2026's 459
   // registered households) and a whitespace-only string must read as the same
@@ -406,10 +413,16 @@ function FamilyCardIdentity({ party }: { party: RosterPartyRow }) {
                   {sharedAdultSurname.length > 0 && ` ${sharedAdultSurname}`}
                 </span>
               )}
-              {/* The staff-written string out of last year's registration,
-                  verbatim — never resolved against the unit registry, so it
-                  can legitimately name something no card on the board is
-                  called (see the schema field). `ml-auto` right-anchors it
+              {/* Last year's housing, named in TODAY's language (kindred#2332)
+                  — the server resolves the staff-written string through the
+                  alias layer and sends the unit's present-day registry name,
+                  so this line and the board card behind it finally agree.
+                  Nothing here strips or shortens it: `lodging_units.name`
+                  averages 10.5 characters and tops out at 24, against a raw
+                  string that reached 34. The raw string itself is provenance
+                  and is NOT duplicated onto this card — it rides on the
+                  journey's `cabin_name_raw`, one click away in the details
+                  panel this card opens. `ml-auto` right-anchors it
                   whether or not adults sit beside it: a household with no
                   attending adult has no grey line for the cabin to join, and
                   the cabin is real data that is not dropped to preserve a

--- a/frontend/src/components/weekend/HouseholdJourneyCard.test.tsx
+++ b/frontend/src/components/weekend/HouseholdJourneyCard.test.tsx
@@ -461,9 +461,30 @@ describe('the raw staff-written string, as provenance', () => {
     const trigger = within(rowFor(2022)).getByTestId('household-journey-housing-provenance')
     expect(trigger.textContent).toContain('Meadow House 1')
 
-    fireEvent.click(trigger)
+    fireEvent.pointerEnter(trigger)
 
     expect(screen.getByRole('tooltip').textContent).toContain('Old Meadow 1')
+  })
+
+  it('leaves nothing pinned open after a click', () => {
+    // The affordance is informational: it restates the season's raw string and
+    // offers nothing to act on. Pinning it left a bubble covering the rows
+    // below after a click that meant nothing, which read as a stuck popover.
+    show([
+      _row({
+        year: 2022,
+        housing: 'placed',
+        cabin_name: 'Meadow House 1',
+        cabin_name_raw: 'Old Meadow 1',
+      }),
+    ])
+
+    const trigger = within(rowFor(2022)).getByTestId('household-journey-housing-provenance')
+    fireEvent.pointerEnter(trigger)
+    fireEvent.click(trigger)
+    fireEvent.pointerOut(trigger, { relatedTarget: document.body })
+
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
   })
 
   it('says nothing extra when the raw string IS the registry name', () => {

--- a/frontend/src/components/weekend/HouseholdJourneyCard.test.tsx
+++ b/frontend/src/components/weekend/HouseholdJourneyCard.test.tsx
@@ -435,3 +435,64 @@ describe('a party with no household', () => {
     expect(useHouseholdJourney).toHaveBeenCalledWith(null)
   })
 })
+
+/**
+ * kindred#2332. A prior year's housing renders in TODAY's language.
+ *
+ * Owner ruling 2026-08-18: *"the last year housing should use the same
+ * language via the alias year over year concept so it appears in current
+ * language."* The server does the resolving — `cabin_name` is already the
+ * unit's present-day registry name and `cabin_name_raw` is what staff typed
+ * that season. What this surface owes is the provenance, and only where the
+ * two disagree: 716 of 1,861 rows on the production snapshot, and 1,145 where
+ * showing it would be noise.
+ */
+describe('the raw staff-written string, as provenance', () => {
+  it('offers what staff wrote when it disagrees with the registry name', () => {
+    show([
+      _row({
+        year: 2022,
+        housing: 'placed',
+        cabin_name: 'Meadow House 1',
+        cabin_name_raw: 'Old Meadow 1',
+      }),
+    ])
+
+    const trigger = within(rowFor(2022)).getByTestId('household-journey-housing-provenance')
+    expect(trigger.textContent).toContain('Meadow House 1')
+
+    fireEvent.click(trigger)
+
+    expect(screen.getByRole('tooltip').textContent).toContain('Old Meadow 1')
+  })
+
+  it('says nothing extra when the raw string IS the registry name', () => {
+    show([
+      _row({
+        year: 2025,
+        housing: 'placed',
+        cabin_name: 'Cedar Lodge 2',
+        cabin_name_raw: 'Cedar Lodge 2',
+      }),
+    ])
+
+    expect(within(rowFor(2025)).queryByTestId('household-journey-housing-provenance')).toBeNull()
+    expect(rowFor(2025).textContent).toContain('Cedar Lodge 2')
+  })
+
+  it('says nothing extra on a year with no cabin at all', () => {
+    show([_row({ year: 2019, housing: 'unknown', cabin_name: '', cabin_name_raw: '' })])
+
+    expect(within(rowFor(2019)).queryByTestId('household-journey-housing-provenance')).toBeNull()
+    expect(rowFor(2019).textContent).toContain('Housing unknown')
+  })
+
+  it('says nothing extra when the server sent no raw string', () => {
+    // An older payload, or a client reading a field a regen dropped. The name
+    // still renders; only the provenance affordance goes away.
+    show([_row({ year: 2023, housing: 'placed', cabin_name: 'Meadow House 1' })])
+
+    expect(within(rowFor(2023)).queryByTestId('household-journey-housing-provenance')).toBeNull()
+    expect(rowFor(2023).textContent).toContain('Meadow House 1')
+  })
+})

--- a/frontend/src/components/weekend/HouseholdJourneyCard.tsx
+++ b/frontend/src/components/weekend/HouseholdJourneyCard.tsx
@@ -117,6 +117,21 @@ function JourneyRows({
           const isCurrentYear = year === currentYear
           const isPlaced = row.housing === 'placed'
           const count = memberCount(row)
+          const housing = housingLabel(row, currentYear)
+          // kindred#2332. The server resolves `cabin_name` to the unit's
+          // PRESENT-DAY registry name, so a 2022 row reads in the language
+          // staff use now — which is the whole point, since fourteen of the
+          // 118 units were renamed in one two-minute burst on 2026-08-15.
+          // `cabin_name_raw` is what was typed that season: real provenance,
+          // and not the name.
+          //
+          // OFFERED ONLY WHERE THE TWO DISAGREE — 716 of 1,861 rows on the
+          // snapshot. On the other 1,145 the trigger would decorate a name
+          // with a tooltip repeating it back, which is how an affordance stops
+          // being read. Absent or blank means an older payload, and the name
+          // still renders.
+          const rawHousing = (row.cabin_name_raw ?? '').trim()
+          const showsProvenance = isPlaced && rawHousing.length > 0 && rawHousing !== housing
 
           return (
             <div
@@ -169,7 +184,22 @@ function JourneyRows({
                 }`}
               >
                 {isPlaced && <Home className="h-3.5 w-3.5 flex-shrink-0 opacity-60" />}
-                {housingLabel(row, currentYear)}
+                {/* A real Tooltip and not a `title` (kindred#2177), and the
+                    same trigger shape `LodgingUnitCard` gives its occupancy
+                    figure. `min-w-0 text-left` is what keeps the kindred#2253
+                    wrap: a button centres its text and will not shrink below
+                    its content width without it. */}
+                {showsProvenance ? (
+                  <Tooltip
+                    content={`Recorded as "${rawHousing}" that season`}
+                    data-testid="household-journey-housing-provenance"
+                    className="decoration-muted-foreground/60 min-w-0 text-left underline decoration-dotted underline-offset-2"
+                  >
+                    {housing}
+                  </Tooltip>
+                ) : (
+                  housing
+                )}
               </span>
 
               {/* NOT "a childless family" and NOT an error — 2020's season was

--- a/frontend/src/components/weekend/HouseholdJourneyCard.tsx
+++ b/frontend/src/components/weekend/HouseholdJourneyCard.tsx
@@ -193,6 +193,11 @@ function JourneyRows({
                   <Tooltip
                     content={`Recorded as "${rawHousing}" that season`}
                     data-testid="household-journey-housing-provenance"
+                    // Hover and focus only. The sentence restates what staff
+                    // typed that season and there is nothing to act on, so
+                    // the tap-pins default left a bubble stuck open over the
+                    // rows below it after a click that meant nothing.
+                    pinOnClick={false}
                     className="decoration-muted-foreground/60 min-w-0 text-left underline decoration-dotted underline-offset-2"
                   >
                     {housing}

--- a/frontend/src/hooks/useWeekendRoster.ts
+++ b/frontend/src/hooks/useWeekendRoster.ts
@@ -106,9 +106,15 @@ export function useWeekendRoster(year: number, sessionCmId: number | null, scena
  * exactly as the roster hooks above do and as summer's own board hooks do.
  * Nothing in this repo writes a past year's `cabin_assignment` or
  * `family_camp_adults` — both are sync-written — so there is no writer to
- * invalidate against and no freshness being given up. The lodging registry
- * edits that DO feed the roster do not reach this payload: it carries staff
- * free text out of `family_camp_registrations`, never a `lodging_units` row.
+ * invalidate against on the history itself.
+ *
+ * ⚠ kindred#2332 CHANGED THE SECOND HALF OF THAT ARGUMENT. `cabin_name` is now
+ * the unit's present-day `lodging_units.name`, resolved server-side, so an
+ * admin-panel rename DOES move this payload — and admin renames are written
+ * straight to PocketBase, not through this API. `invalidateLodgingRegistryQueries`
+ * is what covers it; a rename that leaves this key alone shows the old name in
+ * the history modal while the board behind it shows the new one, which is the
+ * exact disagreement this issue existed to remove.
  *
  * NOT year-scoped, unlike every other hook here. See `queryKeys.householdJourney`.
  */

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -2007,6 +2007,10 @@ export type HouseholdJourneyYear = {
    */
   cabin_name?: string
   /**
+   * Cabin Name Raw
+   */
+  cabin_name_raw?: string
+  /**
    * Enrollment
    */
   enrollment?: 'enrolled' | 'none_on_file'

--- a/frontend/src/types/lodging.test.ts
+++ b/frontend/src/types/lodging.test.ts
@@ -68,7 +68,14 @@ void _exhaustivePartyChild
 const _exhaustiveHouseholdJourneyRow: Required<HouseholdJourneyRow> = {
   year: 2025,
   housing: 'placed',
-  cabin_name: 'Cedar Lodge - Room 2',
+  // kindred#2332: the unit's name TODAY, whichever year the row is — the
+  // server resolves the staff-written string through the alias layer and
+  // renders the present-day registry name.
+  cabin_name: 'Meadow House 1',
+  // What staff typed that season. Provenance, not a name, and the two
+  // DISAGREE here on purpose: that disagreement is 716 of 1,861 rows on the
+  // snapshot, and it is the only case the card shows this field in.
+  cabin_name_raw: 'Old Meadow 1',
   enrollment: 'enrolled',
   adults: [],
   children: [],
@@ -97,11 +104,13 @@ const _exhaustiveRosterParty: Required<RosterPartyRow> = {
   effective_bathroom: 'unknown',
   arrival_eta: '',
   is_returning: false,
-  // kindred#2075: the DIRECTLY prior year's staff-written cabin string, free
-  // text out of `family_camp_registrations.cabin_assignment`. '' is the
-  // common case and means UNKNOWN, not "unassigned" — a regen that dropped
-  // this field would degrade every returning family's card to silence with
-  // nothing else to notice.
+  // kindred#2075, resolved by kindred#2332: the DIRECTLY prior year's housing,
+  // rendered as the unit's PRESENT-DAY registry name rather than the raw
+  // string staff typed that season. '' is the common case and means UNKNOWN,
+  // not "unassigned" — a regen that dropped this field would degrade every
+  // returning family's card to silence with nothing else to notice. The raw
+  // string is provenance and lives on `HouseholdJourneyRow.cabin_name_raw`,
+  // one click away through this card.
   last_year_cabin: '',
   share: {
     preference: 'unknown',

--- a/frontend/src/utils/queryKeys.test.ts
+++ b/frontend/src/utils/queryKeys.test.ts
@@ -178,6 +178,26 @@ describe('invalidateLodgingRegistryQueries', () => {
     expect(client.keys).toContainEqual([...queryKeys.lodgingIngestIssuesPrefix()])
   })
 
+  it('invalidates the household journey, which kindred#2332 made registry-fed', () => {
+    // It was NOT registry-fed before: the journey carried the staff-written
+    // `cabin_assignment` free text, so a unit rename could not move it and
+    // `useHouseholdJourney` inherits the 30 minute app default with no writer
+    // to invalidate against. kindred#2332 resolves `cabin_name` to the unit's
+    // present-day `lodging_units.name`, so an admin rename now DOES move this
+    // payload — and staff rename in bursts (fourteen units in two minutes on
+    // 2026-08-15). Without this the history modal shows the old name for half
+    // an hour while the board behind it shows the new one, which is the exact
+    // disagreement the issue existed to remove.
+    const client = recordingClient()
+    invalidateLodgingRegistryQueries(client)
+
+    const journey = client.keys.find((k) => k[0] === 'household-journey')
+    expect(journey).toHaveLength(1)
+    // By PREFIX: the real key is ['household-journey', householdCmId] and the
+    // admin panel knows no household at all.
+    expect(queryKeys.householdJourney(2000001).slice(0, 1)).toEqual(journey)
+  })
+
   it('invalidates the weekend keys by PREFIX, not by exact key', () => {
     // The admin panel knows neither the year nor the weekend, and the real
     // keys are [key, year] / [key, year, sessionCmId]. An exact-key

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -512,6 +512,9 @@ export const queryKeys = {
    * entry per season and re-pay a multi-year sweep for nothing.
    */
   householdJourney: (householdCmId: number) => ['household-journey', householdCmId] as const,
+  // The invalidation prefix, added by kindred#2332. `invalidateLodgingRegistryQueries`
+  // knows no household at all, and the real key carries one.
+  householdJourneyPrefix: () => ['household-journey'] as const,
   /** The medical narrative. Only ever fetched behind a `bunking.manage` check. */
   householdMedical: (year: number, householdCmId: number) =>
     ['household-medical', year, householdCmId] as const,
@@ -628,6 +631,15 @@ export function invalidateLodgingRegistryQueries(queryClient: {
   void queryClient.invalidateQueries({ queryKey: queryKeys.weekendRosterPrefix() })
   void queryClient.invalidateQueries({ queryKey: queryKeys.weekendSummaryPrefix() })
   void queryClient.invalidateQueries({ queryKey: queryKeys.weekendSessionsPrefix() })
+  // kindred#2332 put the household journey on this list. It used to carry the
+  // staff-written `cabin_assignment` free text, which no registry edit could
+  // move; it now carries the unit's PRESENT-DAY `lodging_units.name`, so a
+  // rename in the admin panel changes it. `useHouseholdJourney` inherits the
+  // 30 minute app default and has no other writer to invalidate against, so
+  // without this line the history modal would keep showing the old name while
+  // the board behind it shows the new one — the disagreement the issue exists
+  // to remove, re-created by the fix for it.
+  void queryClient.invalidateQueries({ queryKey: queryKeys.householdJourneyPrefix() })
 }
 
 /**

--- a/tests/unit/api/services/test_lodging_repository.py
+++ b/tests/unit/api/services/test_lodging_repository.py
@@ -1934,3 +1934,65 @@ class TestFetchRequestTextValues:
         pb.collection.return_value.get_full_list.side_effect = None
         pb.collection.return_value.get_full_list.return_value = []
         assert await repo.fetch_request_text_values(2026) == first
+
+
+class TestRegistryNameReads:
+    """kindred#2332's two reads: the whole unit registry and the whole alias
+    table, which together let a prior year's housing render in TODAY's
+    language.
+
+    NEITHER IS YEAR-FILTERED, and that is the point of both. `lodging_units` is
+    year-scoped and holds 2026 only, so the registry's LATEST season has to be
+    discovered from the table rather than assumed to be the year being read --
+    filtering to a 2023 row's own year finds nothing at all (kindred#2392).
+    `lodging_unit_aliases` has no `year` column: a row's window
+    (`valid_from_year` / `valid_to_year`) says which raw string was in use
+    when, which is a rename history and not a per-year copy.
+    """
+
+    @pytest.mark.asyncio
+    async def test_all_units_are_read_without_a_year_filter(self, repo: LodgingRepository, pb: MagicMock) -> None:
+        await repo.fetch_all_units()
+
+        pb.collection.assert_called_with("lodging_units")
+        assert "year" not in _last_query(pb).get("filter", "")
+
+    @pytest.mark.asyncio
+    async def test_all_units_does_not_pay_for_the_area_expand(self, repo: LodgingRepository, pb: MagicMock) -> None:
+        """Naming needs `code`, `name`, `year` and `parent_unit` and nothing
+        else -- the area is `fetch_units`' business, for the board's grouping.
+        """
+        await repo.fetch_all_units()
+
+        assert "expand" not in _last_query(pb)
+
+    @pytest.mark.asyncio
+    async def test_all_units_is_never_cached(self, repo: LodgingRepository, pb: MagicMock) -> None:
+        """Same reason `fetch_units` is not: `lodging_units.name` is written
+        straight to PocketBase from the admin panel, and this issue's own
+        evidence is that staff rename units in bursts -- fourteen of the 118 in
+        under two minutes on 2026-08-15. A TTL here shows the old name on every
+        surface at once.
+        """
+        await repo.fetch_all_units()
+        await repo.fetch_all_units()
+
+        assert pb.collection.return_value.get_full_list.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_aliases_are_read_whole_and_unfiltered(self, repo: LodgingRepository, pb: MagicMock) -> None:
+        await repo.fetch_unit_aliases()
+
+        pb.collection.assert_called_with("lodging_unit_aliases")
+        assert not _last_query(pb).get("filter", "")
+
+    @pytest.mark.asyncio
+    async def test_aliases_are_never_cached(self, repo: LodgingRepository, pb: MagicMock) -> None:
+        """`mapUnresolvedAlias` in `lodgingCrud.ts` writes this table straight
+        from the admin panel, never through this API -- the same argument
+        `count_open_unresolved_aliases` makes for the queue it feeds.
+        """
+        await repo.fetch_unit_aliases()
+        await repo.fetch_unit_aliases()
+
+        assert pb.collection.return_value.get_full_list.call_count == 2

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -53,6 +53,10 @@ def _unit(
     sleeps: int = 0,
     is_container: bool = False,
     inventory_class: str = "family_pool",
+    # The registry season. `lodging_units` is year-scoped (1500000141) and
+    # holds 2026 only on the snapshot; kindred#2332's naming resolver reads
+    # the column to find the LATEST season, so it has to be on the fixture.
+    year: int = 2026,
     is_active: bool = True,
     is_confirmed: bool = True,
     bathroom: str = "none",
@@ -72,6 +76,7 @@ def _unit(
         id=pb_id,
         code=code,
         name=name,
+        year=year,
         sleeps=sleeps,
         is_container=is_container,
         inventory_class=inventory_class,
@@ -157,6 +162,13 @@ def _repo(**overrides: Any) -> MagicMock:
         "fetch_household_by_cm_id": None,
         "fetch_medical_for_household": None,
         "count_open_unresolved_aliases": 0,
+        # kindred#2332's two registry reads, neither year-filtered. EMPTY is
+        # the honest default and the one that keeps every other test in this
+        # file meaningful: an empty registry resolves nothing, so a raw cabin
+        # string travels through unchanged, which is exactly what a fresh
+        # deployment does.
+        "fetch_all_units": [],
+        "fetch_unit_aliases": [],
         # DELIBERATELY still here, though the repository method is gone: the
         # tests that pin the roster no longer asking for this count need an
         # attribute to run `assert_not_called()` against. A bare MagicMock
@@ -5367,3 +5379,193 @@ class TestStaffAuthoredBlocksAreScreenReduced:
             ("BunkingNotes Notes", "staff"),
             ("Internal Bunk Notes", "staff"),
         ]
+
+
+def _alias_row(alias_string: str, *member_ids: str, valid_from: int = 0, valid_to: int = 0) -> SimpleNamespace:
+    """One `lodging_unit_aliases` row as PocketBase hands it over.
+
+    `member_units` is a relation column, so it arrives as a LIST OF RECORD IDS
+    -- never codes. 0 on either bound means "no bound": PocketBase number
+    columns are `NUMERIC DEFAULT 0 NOT NULL` and an unset year stores as 0.
+    """
+    return _rec(
+        alias_string=alias_string,
+        member_units=list(member_ids),
+        valid_from_year=valid_from,
+        valid_to_year=valid_to,
+    )
+
+
+class TestHousingRendersInTodaysLanguage:
+    """kindred#2332 / kindred#2336. ONE housing-name display convention.
+
+    Owner ruling 2026-08-18: *"the last year housing should use the same
+    language via the alias year over year concept so it appears in current
+    language."* Whatever staff call a unit in the admin GUI is what appears on
+    every surface. The alias's year window says which raw string was in use
+    WHEN -- an input to finding the unit, never to naming it.
+
+    Measured on the production snapshot: 37 of 88 distinct raw strings resolve
+    to a different registry name, covering 716 of 1,861 rows (38.5%).
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_journey_renames_a_prior_year_into_the_current_registry(self) -> None:
+        repo = _journey_repo(
+            fetch_household_family_attendees=[_rec(year=2022, **vars(_child()))],
+            cabins_by_year={2022: {2000001: "Old Meadow 1"}},
+            fetch_all_units=[_unit("u1", "meadow-1", "Meadow House 1")],
+            fetch_unit_aliases=[_alias_row("Old Meadow 1", "u1")],
+        )
+
+        journey = await LodgingRosterService(repo).build_household_journey(2000001)
+
+        assert journey.years[0].cabin_name == "Meadow House 1"
+
+    @pytest.mark.asyncio
+    async def test_the_journey_keeps_the_raw_string_as_provenance(self) -> None:
+        """*What staff wrote in 2022* is a real fact and stays on the wire --
+        it is just not the NAME. The journey is the surface that shows it,
+        because the journey is the surface whose whole job is the record.
+        """
+        repo = _journey_repo(
+            fetch_household_family_attendees=[_rec(year=2022, **vars(_child()))],
+            cabins_by_year={2022: {2000001: "Old Meadow 1"}},
+            fetch_all_units=[_unit("u1", "meadow-1", "Meadow House 1")],
+            fetch_unit_aliases=[_alias_row("Old Meadow 1", "u1")],
+        )
+
+        journey = await LodgingRosterService(repo).build_household_journey(2000001)
+
+        assert journey.years[0].cabin_name_raw == "Old Meadow 1"
+
+    @pytest.mark.asyncio
+    async def test_an_unresolvable_string_renders_and_travels_unchanged(self) -> None:
+        """Three of the 88 distinct strings name a unit FAMILY and not a unit
+        (kindred#2392). What staff wrote beats a blank.
+        """
+        repo = _journey_repo(
+            fetch_household_family_attendees=[_rec(year=2022, **vars(_child()))],
+            cabins_by_year={2022: {2000001: "Ridge 2"}},
+            fetch_all_units=[_unit("u1", "meadow-1", "Meadow House 1")],
+        )
+
+        journey = await LodgingRosterService(repo).build_household_journey(2000001)
+
+        assert journey.years[0].cabin_name == "Ridge 2"
+        assert journey.years[0].cabin_name_raw == "Ridge 2"
+
+    @pytest.mark.asyncio
+    async def test_a_year_with_no_cabin_carries_neither_a_name_nor_a_raw_string(self) -> None:
+        repo = _journey_repo(
+            fetch_household_family_attendees=[_rec(year=2019, **vars(_child()))],
+            fetch_all_units=[_unit("u1", "meadow-1", "Meadow House 1")],
+        )
+
+        journey = await LodgingRosterService(repo).build_household_journey(2000001)
+
+        assert journey.years[0].cabin_name == ""
+        assert journey.years[0].cabin_name_raw == ""
+
+    @pytest.mark.asyncio
+    async def test_the_journey_resolves_each_year_at_its_own_window(self) -> None:
+        """An alias carrying `valid_to_year = 2024` is CORRECT for the years it
+        covers. Evaluating every window at the registry's loaded year discards
+        it -- 1,792 of 1,861 rows instead of 1,841 on the snapshot -- and the
+        row that ought to rename silently keeps its raw spelling.
+        """
+        repo = _journey_repo(
+            fetch_household_family_attendees=[
+                _rec(year=2023, **vars(_child())),
+                _rec(year=2026, **vars(_child())),
+            ],
+            cabins_by_year={2023: {2000001: "Old Meadow 1"}, 2026: {2000001: "Old Meadow 1"}},
+            fetch_all_units=[_unit("u1", "meadow-1", "Meadow House 1")],
+            fetch_unit_aliases=[_alias_row("Old Meadow 1", "u1", valid_to=2024)],
+        )
+
+        journey = await LodgingRosterService(repo).build_household_journey(2000001)
+
+        by_year = {row.year: row.cabin_name for row in journey.years}
+        assert by_year == {2026: "Old Meadow 1", 2023: "Meadow House 1"}
+
+    @pytest.mark.asyncio
+    async def test_the_family_card_renames_last_years_cabin_too(self) -> None:
+        """`RosterParty.last_year_cabin` was NOT alias-resolved at all before
+        this -- it came straight out of
+        `fetch_cabin_assignments_by_household_cm_id(year - 1)`. If only the
+        journey adopts the registry name, the board contradicts itself on the
+        family card.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_households={"hh_1": _household(title="The Garcia Family")},
+            fetch_attendees_for_session=[_child(cm_id=1000002, first="Liam", last="Garcia")],
+            fetch_prior_household_cm_ids={2000001},
+            fetch_cabin_assignments_by_household_cm_id={2000001: "Old Meadow 1"},
+            fetch_all_units=[_unit("u1", "meadow-1", "Meadow House 1")],
+            fetch_unit_aliases=[_alias_row("Old Meadow 1", "u1")],
+        )
+
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.parties[0].last_year_cabin == "Meadow House 1"
+
+    @pytest.mark.asyncio
+    async def test_last_years_cabin_is_windowed_at_last_year_not_this_one(self) -> None:
+        """The string came out of the PRIOR season, so the prior season is the
+        year its alias window is tested at. Testing it at the roster's own year
+        strands the row on its raw spelling.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_households={"hh_1": _household(title="The Garcia Family")},
+            fetch_attendees_for_session=[_child(cm_id=1000002, first="Liam", last="Garcia")],
+            fetch_prior_household_cm_ids={2000001},
+            fetch_cabin_assignments_by_household_cm_id={2000001: "Old Meadow 1"},
+            fetch_all_units=[_unit("u1", "meadow-1", "Meadow House 1")],
+            fetch_unit_aliases=[_alias_row("Old Meadow 1", "u1", valid_to=2025)],
+        )
+
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.parties[0].last_year_cabin == "Meadow House 1"
+
+    @pytest.mark.asyncio
+    async def test_a_multi_room_alias_collapses_to_its_container(self) -> None:
+        """THE COLLAPSE RULE. Joining member names reaches 35 characters, one
+        MORE than the worst raw string, on a `whitespace-nowrap` span -- so
+        naive resolution makes truncation WORSE. All seven in-use multi-member
+        aliases resolve to two siblings under one container.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_households={"hh_1": _household(title="The Garcia Family")},
+            fetch_attendees_for_session=[_child(cm_id=1000002, first="Liam", last="Garcia")],
+            fetch_prior_household_cm_ids={2000001},
+            fetch_cabin_assignments_by_household_cm_id={2000001: "Cedar 1and2"},
+            fetch_all_units=[
+                _unit("p1", "cedar", "Cedar Lodge", is_container=True),
+                _unit("u1", "cedar-1", "Cedar Lodge Room 1", parent_unit="p1"),
+                _unit("u2", "cedar-2", "Cedar Lodge Room 2", parent_unit="p1"),
+            ],
+            fetch_unit_aliases=[_alias_row("Cedar 1and2", "u1", "u2")],
+        )
+
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.parties[0].last_year_cabin == "Cedar Lodge"
+
+    @pytest.mark.asyncio
+    async def test_the_lander_pays_for_neither_registry_read(self) -> None:
+        """`build_summary` keeps nothing but counts and no `WeekendSummaryEntry`
+        carries a party, so it already skips last year's cabins. Resolving
+        names there would put back the per-weekend cost kindred#1963 bought
+        out -- two more year-agnostic reads on every weekend of the year.
+        """
+        repo = _repo(fetch_weekend_sessions=[FAMILY_SESSION])
+
+        await LodgingRosterService(repo).build_summary(2026)
+
+        repo.fetch_all_units.assert_not_called()
+        repo.fetch_unit_aliases.assert_not_called()

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -2767,15 +2767,20 @@ class TestMedicalFlagsAndNarrative:
 class TestBuildSummary:
     """The lander's batched read.
 
-    It exists for one reason: `build_roster` makes twelve fetches of which
-    seven are year-scoped, so filling a lander weekend-by-weekend repeats that
-    year-wide work once per weekend. The point of these tests is that the
-    batch does it ONCE and still agrees with the roster.
+    It exists for one reason: `build_roster` makes sixteen reads of which TEN
+    are constant across every weekend of the year -- eight year-scoped, plus
+    kindred#2332's two year-agnostic registry-naming reads -- so filling a
+    lander weekend-by-weekend repeats that year-wide work once per weekend.
+    The point of these tests is that the batch does it ONCE and still agrees
+    with the roster.
 
-    Both counts were one lower until kindred#2075 added last year's cabins,
-    and one higher again before that until kindred#1889 removed the whole-year
-    medical read from both paths. The lander batches SIX of the seven -- see
-    `test_the_lander_never_reads_last_years_cabins` for the one it declines.
+    The constant count has only ever grown: kindred#2075 added last year's
+    cabins, kindred#2330 the raw request answers, kindred#2332 the naming
+    pair; kindred#1889 removed the whole-year medical read from both paths.
+    The lander batches SIX of the ten and declines four -- see
+    `test_the_lander_never_reads_last_years_cabins`,
+    `test_the_lander_summary_does_not_pay_for_the_raw_request_read` and
+    `test_the_lander_pays_for_neither_registry_read`.
     """
 
     @pytest.mark.asyncio

--- a/tests/unit/api/services/test_lodging_rules.py
+++ b/tests/unit/api/services/test_lodging_rules.py
@@ -470,3 +470,29 @@ class TestHousingNameResolver:
 
         assert resolver.registry_year == 0
         assert resolver.display_name("Cedar Lodge - Room 2", 2025) == "Cedar Lodge - Room 2"
+
+    def test_two_units_answering_to_one_name_defer_to_the_alias_table(self) -> None:
+        """A direct name collision is an ACCIDENT; an alias row is a staff
+        mapping. `build` refuses to pick between the two colliding units, and
+        `display_name` then treats that refusal exactly as it treats a key no
+        unit answers to -- so the alias still gets its say, and the raw string
+        renders only when it fails too.
+        """
+        collide = [_unit("u1", "cedar-1", "Cedar Lodge 1"), _unit("u2", "c2", "cedar lodge 1")]
+        resolver = HousingNameResolver.build(
+            [*collide, _unit("u3", "pine-1", "Pine Cabin 1")],
+            [_alias("Cedar Lodge 1", "u3")],
+        )
+
+        assert resolver.display_name("Cedar Lodge 1", 2023) == "Pine Cabin 1"
+
+    def test_a_name_two_units_answer_to_renders_unchanged_with_no_alias(self) -> None:
+        """The other half of the same rule: with nothing to defer TO, naming
+        either colliding unit would name a cabin nobody chose.
+        """
+        resolver = HousingNameResolver.build(
+            [_unit("u1", "cedar-1", "Cedar Lodge 1"), _unit("u2", "c2", "cedar lodge 1")],
+            [],
+        )
+
+        assert resolver.display_name("Cedar Lodge 1", 2023) == "Cedar Lodge 1"

--- a/tests/unit/api/services/test_lodging_rules.py
+++ b/tests/unit/api/services/test_lodging_rules.py
@@ -19,6 +19,9 @@ from api.services.lodging_rules import (
     BUNKING_CSV_REQUEST_TEXT_FIELDS,
     FAMILY_CAMP_REQUEST_TEXT_CM_IDS,
     REQUEST_TEXT_SOURCES,
+    HousingNameResolver,
+    RegistryUnit,
+    UnitAlias,
     amenity_coverage,
     container_bathroom,
     effective_bathroom,
@@ -305,3 +308,165 @@ class TestRequestTextSourceRegistry:
         """`family` is the WRONG default for an unknown field: it would render
         a staff note in the amber treatment reserved for a family's own ask."""
         assert request_text_authorship("Some Field We Have Never Seen") == "staff"
+
+
+def _unit(unit_id: str, code: str, name: str, *, year: int = 2026, parent_id: str = "") -> RegistryUnit:
+    return RegistryUnit(unit_id=unit_id, code=code, name=name, year=year, parent_id=parent_id)
+
+
+def _alias(alias_string: str, *member_ids: str, valid_from: int = 0, valid_to: int = 0) -> UnitAlias:
+    return UnitAlias(
+        alias_string=alias_string,
+        member_unit_ids=tuple(member_ids),
+        valid_from_year=valid_from,
+        valid_to_year=valid_to,
+    )
+
+
+class TestHousingNameResolver:
+    """kindred#2332: a prior year's housing renders in TODAY's language.
+
+    Owner ruling 2026-08-18: *"the last year housing should use the same
+    language via the alias year over year concept so it appears in current
+    language."* The alias's year window says which raw string was in use WHEN;
+    it is an input to FINDING the unit, never to NAMING it. Once the unit is
+    identified, its present-day `lodging_units.name` renders.
+    """
+
+    def test_a_blank_string_stays_blank(self) -> None:
+        assert HousingNameResolver.build([], []).display_name("", 2025) == ""
+
+    def test_a_string_that_already_names_a_unit_resolves_without_an_alias(self) -> None:
+        resolver = HousingNameResolver.build([_unit("u1", "cedar-1", "Cedar Lodge 1")], [])
+
+        assert resolver.display_name("cedar lodge 1", 2023) == "Cedar Lodge 1"
+
+    def test_the_unit_code_resolves_too(self) -> None:
+        resolver = HousingNameResolver.build([_unit("u1", "cedar-1", "Cedar Lodge 1")], [])
+
+        assert resolver.display_name("cedar-1", 2023) == "Cedar Lodge 1"
+
+    def test_a_renamed_unit_renders_its_current_name_not_the_historical_string(self) -> None:
+        """THE RULING, in one test. `Old Meadow 1` is what staff typed in
+        2022; the unit is called `Meadow House 1` today, so that is what a
+        2022 row shows.
+        """
+        resolver = HousingNameResolver.build(
+            [_unit("u1", "meadow-1", "Meadow House 1")],
+            [_alias("Old Meadow 1", "u1")],
+        )
+
+        assert resolver.display_name("Old Meadow 1", 2022) == "Meadow House 1"
+
+    def test_an_alias_is_windowed_at_the_rows_own_year_not_the_registry_year(self) -> None:
+        """`valid_to_year = 2024` is correct for the years it covers. Windowing
+        every alias at the registry's loaded year would discard it -- 1,792 of
+        1,861 rows instead of 1,841 on the production snapshot.
+        """
+        resolver = HousingNameResolver.build(
+            [_unit("u1", "meadow-1", "Meadow House 1")],
+            [_alias("Old Meadow 1", "u1", valid_to=2024)],
+        )
+
+        assert resolver.display_name("Old Meadow 1", 2023) == "Meadow House 1"
+        assert resolver.display_name("Old Meadow 1", 2026) == "Old Meadow 1"
+
+    def test_two_members_under_one_parent_collapse_to_the_parents_name(self) -> None:
+        """THE COLLAPSE RULE. Joining member names gives up to 35 characters --
+        longer than the 34-character worst raw string, on a `whitespace-nowrap`
+        span. Every multi-member alias in use shares one container parent.
+        """
+        resolver = HousingNameResolver.build(
+            [
+                _unit("p1", "cedar", "Cedar Lodge"),
+                _unit("u1", "cedar-1", "Cedar Lodge Room 1", parent_id="p1"),
+                _unit("u2", "cedar-2", "Cedar Lodge Room 2", parent_id="p1"),
+            ],
+            [_alias("Cedar 1and2", "u1", "u2")],
+        )
+
+        assert resolver.display_name("Cedar 1and2", 2023) == "Cedar Lodge"
+
+    def test_members_with_no_shared_parent_join_rather_than_inventing_one(self) -> None:
+        """No production row reaches this branch -- all seven in-use
+        multi-member aliases share one parent -- but the rule stays total.
+        """
+        resolver = HousingNameResolver.build(
+            [_unit("u1", "cedar-1", "Cedar Lodge 1"), _unit("u2", "pine-1", "Pine Cabin 1")],
+            [_alias("Cedar 1 and Pine 1", "u1", "u2")],
+        )
+
+        assert resolver.display_name("Cedar 1 and Pine 1", 2023) == "Cedar Lodge 1 + Pine Cabin 1"
+
+    def test_two_alias_rows_covering_one_year_refuse_rather_than_guess(self) -> None:
+        """The unique index is on (alias_string, valid_from_year), not on
+        alias_string alone, so the admin UI can create an overlapping pair.
+        `AliasResolver.Resolve` calls that `Ambiguous` and places nobody.
+        """
+        resolver = HousingNameResolver.build(
+            [_unit("u1", "cedar-1", "Cedar Lodge 1"), _unit("u2", "pine-1", "Pine Cabin 1")],
+            [_alias("Overlap", "u1", valid_from=2020), _alias("Overlap", "u2", valid_from=2021)],
+        )
+
+        assert resolver.display_name("Overlap", 2023) == "Overlap"
+
+    def test_a_member_missing_from_the_registry_year_is_all_or_nothing(self) -> None:
+        """Go's `Resolve` refuses on the same door: returning the members that
+        DO exist would silently shrink a family's rooms.
+        """
+        resolver = HousingNameResolver.build(
+            [
+                _unit("p1", "cedar", "Cedar Lodge"),
+                _unit("u1", "cedar-1", "Cedar Lodge Room 1", parent_id="p1"),
+            ],
+            [_alias("Cedar 1and2", "u1", "u9")],
+        )
+
+        assert resolver.display_name("Cedar 1and2", 2023) == "Cedar 1and2"
+
+    def test_an_unresolvable_string_renders_unchanged(self) -> None:
+        """Three of the 88 distinct strings name a unit FAMILY and not a unit
+        (kindred#2392). What staff wrote is better than nothing.
+        """
+        resolver = HousingNameResolver.build([_unit("u1", "cedar-1", "Cedar Lodge 1")], [])
+
+        assert resolver.display_name("Ridge 2", 2022) == "Ridge 2"
+
+    def test_the_registry_year_is_the_latest_season_the_table_holds(self) -> None:
+        """`lodging_units` is a year-scoped table that today holds 2026 only.
+        A stale season's row must not become the display name.
+        """
+        resolver = HousingNameResolver.build(
+            # Current season FIRST, so an index that merely takes the last row
+            # per code -- rather than filtering to the registry year -- ends up
+            # holding the stale one and this test still catches it.
+            [
+                _unit("new", "cedar-1", "Cedar Lodge 1", year=2026),
+                _unit("old", "cedar-1", "Old Cedar 1", year=2025),
+            ],
+            [_alias("Old Cedar 1", "old")],
+        )
+
+        assert resolver.registry_year == 2026
+        assert resolver.display_name("Old Cedar 1", 2022) == "Cedar Lodge 1"
+
+    def test_inner_spacing_stays_significant_and_outer_does_not(self) -> None:
+        """`aliasLookupKey` in Go lowercases and trims and does no more: one
+        seeded string genuinely carries a double space before its separator.
+        """
+        resolver = HousingNameResolver.build(
+            [_unit("u1", "cedar-1", "Cedar Lodge 1")],
+            [_alias("Cedar  Lodge - 1", "u1")],
+        )
+
+        assert resolver.display_name("  cedar  lodge - 1  ", 2023) == "Cedar Lodge 1"
+        assert resolver.display_name("Cedar Lodge - 1", 2023) == "Cedar Lodge - 1"
+
+    def test_an_empty_registry_leaves_every_string_alone(self) -> None:
+        """A fresh deployment seeds no units. Rendering nothing, or rendering
+        a blank, would be worse than rendering what staff wrote.
+        """
+        resolver = HousingNameResolver.build([], [])
+
+        assert resolver.registry_year == 0
+        assert resolver.display_name("Cedar Lodge - Room 2", 2025) == "Cedar Lodge - Room 2"


### PR DESCRIPTION
## The defect

A household's housing history rendered the string a staff member typed that season, verbatim, while the board card beside it rendered the curated registry name. **37 of 88 distinct `cabin_assignment` strings resolve to a different registry name, covering 716 of 1,861 rows (38.5%)** — and **21 of 67 live 2026 households** showed one name on the board and another in the history modal at once.

`RosterParty.last_year_cabin` was worse than "stale": it was **never alias-resolved at all**. It came straight out of `fetch_cabin_assignments_by_household_cm_id(year - 1)`, and the roster service's only alias work was `count_open_unresolved_aliases`, which counts a badge and resolves nothing.

Owner ruling 2026-08-18: *"the last year housing should use the same language via the alias year over year concept so it appears in current language."* The alias's year window says **which raw string was in use when**. It is an input to *finding* the unit, never to *naming* it. Once the unit is identified, its present-day `lodging_units.name` renders. The evidence that this matters is in the data: fourteen of the 118 units were renamed one at a time in the admin GUI on 2026-08-15, inside two minutes.

## The change

**`api/services/lodging_rules.py` — `HousingNameResolver`, a pure rule.** Deliberately a mirror of Go's `AliasResolver`, not a second opinion: same lookup key (outer whitespace and case only, inner spacing significant), same all-or-nothing member translation through `code`, same refusal when two alias rows both cover the year. What differs is the target — the Go resolver places rows in their own season, this one always *names* them in the registry's latest one.

**The rules, stated so they stop being re-derived:**

| input | rendered |
|---|---|
| a string that already names a unit today (name or code) | that unit's `name` |
| an alias covering the row's own year, one member | that member's current `name` |
| an alias covering the row's own year, 2+ members sharing one non-empty `parent_unit` | **the parent unit's `name`** |
| 2+ members sharing no parent | member names joined — no production row reaches this |
| nothing, or two overlapping alias rows | the raw string, unchanged |

**The collapse is what does the work, not the resolution.** Joining member names reaches 35 characters — one *more* than the 34-character worst raw string — on a `whitespace-nowrap` span, so naive resolution makes truncation worse. Every one of the seven in-use multi-member aliases is two siblings under one container. `lodging_units.name` averages 10.5 characters and tops out at 24, against raw strings that reach 34; the long tail lives entirely in the raw text.

**Windowed at the ROW's own year, and this is the trap.** Four aliases carry `valid_to_year = 2024` and are correct for the years they cover. Pinning every window to the registry's loaded year discards them and strands 49 rows at their raw spelling (1,792 of 1,861 instead of 1,841). Windowing is done because it is correct — **not** because it is what lifts resolution: 1,841 of 1,861 resolve with windows applied and 1,841 with them ignored, since only 6 of 187 aliases carry a window at all and each is used only inside it.

**Two new repository reads, neither year-filtered and neither cached.** `fetch_all_units()` reads every season because the season that *names* a unit has to be discovered from a table that holds 2026 only, and because an alias stores whichever season's record ids existed when it was written — `code` is the cross-year identity thread. `fetch_unit_aliases()` reads a table that has no `year` column by design. Both are admin-panel-written, so a TTL would show the old name on four surfaces at once. They are absent from `build_summary`'s TaskGroup, for the same reason last year's cabins already were: no `WeekendSummaryEntry` carries a party, so both would be paid on every weekend of the year to name a field nothing renders. A guard test pins that.

**Wire.** `HouseholdJourneyYear.cabin_name` and `RosterParty.last_year_cabin` now carry the resolved name. `cabin_name_raw` is new and carries the verbatim staff string as provenance. That answers the issue's one open decision — the value is the current registry name in both fields, and the raw string is published **once**, on the journey, rather than duplicated onto the roster party: the family card's right-anchored cabin opens the details panel, and the journey is inside it.

**Journey card.** Where the two disagree the name becomes a `ui/Tooltip` trigger reading `Recorded as "…" that season`. A real Tooltip and not a `title`, per #2177, and the same trigger shape `LodgingUnitCard` gives its occupancy figure. Offered *only* where they disagree: on the other 1,145 rows it would decorate a name with a tooltip repeating it back.

**`invalidateLodgingRegistryQueries` gained the household-journey prefix**, and this is the part the change would have been wrong without. The journey used to carry free text no registry edit could move, so `useHouseholdJourney` inherits the 30-minute app default with no writer to invalidate against. It is now registry-fed. Without the new line an admin rename would leave the history modal showing the old name for half an hour while the board behind it showed the new one — the exact disagreement this work exists to remove, re-created by the fix for it.

## #2336, folded in

Reduced by its own owner ruling to documentation plus read-path, and two of its three anchors are comments this change had to rewrite anyway. `cabin_assignment` has grain `(household, year)` because its source is one CampMinder household custom field per household-year, so a household attending two weekends carries one cabin for both — staff confirmed 2026-08-15 that the overwrite is acceptable and declined a snapshot or lookback. That is now stated at the read (`fetch_cabin_assignments_by_household_cm_id`), at both schema fields, and on `FamilyCard`, so the next reader does not re-open it as data loss. 41 of 1,703 cabin-holding household-years are multi-weekend, and treating that fan-out as per-weekend placement manufactured 12 of 17 false multi-household occupancies in one analysis.

## Deliberately NOT done

- **No headline truncation number.** The 595 → N figure has oscillated three times against unmoved data, because each pass used a different resolver. The rules table above is the durable statement; the collapse rule is stable under both resolution orders and every join separator.
- **No ingest-time normalisation.** It cannot work for history: `lodging_units` holds 2026 only, so `AliasResolver`'s `(code, year)` lookup finds nothing for a 2023 row. See #2392.
- **No new alias rows.** Three strings genuinely name a unit *family* rather than a unit and need staff knowledge; four of the originally-claimed seven already exist with `valid_to_year = 2024` and would collide on the `(alias_string, valid_from_year)` unique index.
- **No schema change and no migration.** #2336's widening option was retired by its own investigation — the upstream field never held a second weekend's answer, so a `(household, year, session)` key would replicate one string N times and bake the fan-out in.
- **No `last_year_cabin_raw`.** A second raw field on the roster party would be a wire field nothing renders.
- **No board-card change.** `LodgingUnitCard`'s `truncate text-lg` heading already renders `lodging_units.name` and is untouched.
- **No `MapUnitPopover`-style common-prefix stripping.** The registry names are short; the prefix problem was in the raw strings, and resolving removes it at the source.
- **The weekend line stays for #2393**, which should call this helper rather than re-derive it.

## Verification

`ruff`, `mypy`, `pytest` (6,329 unit), `prettier`, `eslint`, `tsc`, `vitest` — `scripts/pre-push-verify.sh --all` green. `scripts/dev/verify-no-hardcoded-lodging.sh` green. Every new test was run RED first and mutation-checked: dropping the parent collapse, windowing at the registry year instead of the row's, picking the first of an ambiguous alias pair, indexing units without the registry-year filter, resolving `last_year_cabin` at the roster's own year, dropping the raw provenance, making the lander pay for the registry reads, showing the provenance trigger unconditionally, rendering the raw instead of the resolved name, and removing the journey invalidation each turned one test red and were each restored.

⚠️ **UI-visible on two surfaces. Held for the owner's eyes.**

Closes #2332.
Closes #2336.
