### PR TITLE
feat(frontend): let a write-in and a family share one space, in either order

### DIFF
--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -344,10 +344,14 @@ class LodgingUnitSummary(BaseModel):
     # open every room beneath a released building.
     #
     # ⚠️ `is_family_available` deliberately does NOT read this field: it folds
-    # in the unit's OWN occupancy row only, so an inherited write-in badges and
-    # blocks placement without moving the bed counts. That is the behaviour the
-    # counts have always had, and changing it is a counts decision rather than
-    # a side effect of the split.
+    # in the unit's OWN occupancy row only, so an inherited write-in badges
+    # without moving the bed counts. That is the behaviour the counts have
+    # always had, and changing it is a counts decision rather than a side
+    # effect of the split.
+    #
+    # It said "badges and BLOCKS PLACEMENT" until kindred#2432, which struck
+    # every client-side refusal of a placement onto a written-into space. An
+    # inherited write-in now badges and discloses; it blocks nothing.
     write_ins: list[WriteInCover] = Field(default_factory=list)
     map_x: float | None = None
     map_y: float | None = None

--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -264,7 +264,7 @@ class LodgingUnitSummary(BaseModel):
     # standing `inventory_class` decides. None and False are different answers
     # and must not be flattened into one.
     #
-    # IT DOES NOT ANSWER "IS SOMEBODY IN IT". That is `write_in` below, read
+    # IT DOES NOT ANSWER "IS SOMEBODY IN IT". That is `write_ins` below, read
     # from `lodging_write_ins` / `_draft`. Until PR 4 of kindred#2382 an
     # occupancy also reported itself here as False, because
     # `is_family_available` and the board's forest open-tint were both derived
@@ -272,7 +272,7 @@ class LodgingUnitSummary(BaseModel):
     # False here means a role decision and never an occupant. A reader that
     # wants "can a family go in this space" wants `is_family_available`, which
     # folds both facts in; a reader that wants "is somebody in it" wants
-    # `write_in`.
+    # `write_ins`.
     #
     # Stated explicitly rather than implied. The rejected encoding was a row
     # meaning "the opposite of this unit's current default", which an ordinary
@@ -319,9 +319,19 @@ class LodgingUnitSummary(BaseModel):
     # Its rule is `is_family_available` in api/services/lodging_rules.py, and
     # that is the only place the two are combined.
     is_family_available: bool = False
-    # The write-in that closes this space, resolved through the unit tree --
+    # EVERY write-in that closes this space, resolved through the unit tree --
     # this unit's own row, else the nearest ancestor's, else the nearest
-    # descendant's. None means no write-in covers it.
+    # written-into descendant on each branch beneath it. Empty means no
+    # write-in covers it.
+    #
+    # A LIST since kindred#2381, and that arity is the whole point rather than
+    # future-proofing. A merged container draws in place of its rooms, so the
+    # four write-ins Clouds Rest carries in one 2026 weekend collapsed to
+    # whichever room sorted first and the other three were invisible -- while
+    # each clear silently re-populated the card with the next occupant, so
+    # destroying all four read as four failed clicks. A write-in must survive a
+    # merge and a split the way an assignment does, and an assignment does it
+    # by the drawn card carrying however many leaves it covers.
     #
     # The fields above stay STRICTLY this unit's own row: they are what the
     # write path reads back. Folding an inherited fact into any of them would
@@ -338,7 +348,7 @@ class LodgingUnitSummary(BaseModel):
     # blocks placement without moving the bed counts. That is the behaviour the
     # counts have always had, and changing it is a counts decision rather than
     # a side effect of the split.
-    write_in: WriteInCover | None = None
+    write_ins: list[WriteInCover] = Field(default_factory=list)
     map_x: float | None = None
     map_y: float | None = None
 

--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -326,7 +326,7 @@ class LodgingUnitSummary(BaseModel):
     #
     # A LIST since kindred#2381, and that arity is the whole point rather than
     # future-proofing. A merged container draws in place of its rooms, so the
-    # four write-ins Clouds Rest carries in one 2026 weekend collapsed to
+    # four write-ins one 2026 container carries in a single weekend collapsed to
     # whichever room sorted first and the other three were invisible -- while
     # each clear silently re-populated the card with the next occupant, so
     # destroying all four read as four failed clicks. A write-in must survive a

--- a/api/services/lodging_repository.py
+++ b/api/services/lodging_repository.py
@@ -502,9 +502,11 @@ class LodgingRepository:
         `fetch_write_ins` whenever the request names a scenario, and the live
         table is then not read at all. `copy_from_mirror` and
         `copy_scenario_to_scenario` both seed it, so a fresh scenario starts
-        with the write-ins its source had rather than blank -- without that,
-        kindred#2247's placement gate would let a family be dropped into a room
-        the live board records as occupied.
+        with the write-ins its source had rather than blank -- without that, a
+        room the live board records as occupied shows up empty on the scenario
+        and its occupant is not on the board at all. (The older reason here was
+        kindred#2247's placement gate refusing such a drop; kindred#2432 struck
+        the gate, and disclosure is what the seed protects.)
 
         `scenario_id` is client-supplied and escaped, for the reason
         `fetch_draft_assignments` spells out. The weekend is named by

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -1138,8 +1138,10 @@ class LodgingRosterService:
             # A fresh scenario is seeded by an explicit COPY in both seed paths
             # (`copy_from_mirror` and `copy_scenario_to_scenario`, owner ruling
             # 2026-08-16), which is what stops it starting blank -- without it
-            # kindred#2247's placement gate would let a family be dropped into
-            # a room the live board records as occupied. Rendering the live
+            # a room the live board records as occupied renders empty on the
+            # scenario, occupant and all. (Was "kindred#2247's placement gate
+            # would let a family be dropped into" one; kindred#2432 struck that
+            # gate -- the disclosure is the part that matters.) Rendering the live
             # rows through this read's gaps would be the overlay instead, and
             # would make two scenarios unable to disagree.
             write_ins_task = tg.create_task(

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -574,8 +574,10 @@ def written_in_unit_ids(write_ins: list[Any]) -> frozenset[str]:
     return frozenset(_s(row, "unit") for row in write_ins)
 
 
-def write_in_covers(units: list[LodgingUnitSummary], write_in_unit_ids: frozenset[str]) -> dict[str, WriteInCover]:
-    """Which units each write-in closes, keyed by unit code.
+def write_in_covers(
+    units: list[LodgingUnitSummary], write_in_unit_ids: frozenset[str]
+) -> dict[str, list[WriteInCover]]:
+    """Which write-ins close each unit's space, keyed by unit code.
 
     THE UNIT A ROW NAMES IS NOT THE ONLY SPACE IT CLOSES. A write-in is a fact
     about a physical space and a building's space contains its rooms', but the
@@ -586,10 +588,27 @@ def write_in_covers(units: list[LodgingUnitSummary], write_in_unit_ids: frozense
     family could be dropped into a space somebody is already sleeping in.
 
     Order, highest first: the unit's OWN row, else the nearest ANCESTOR's, else
-    the nearest DESCENDANT's. Own beats inherited because it is the more
-    specific statement about the same space; an ancestor beats a descendant
-    because a building closed whole says something about every room in it,
-    where one room says only that the building is no longer free to let whole.
+    EVERY written-into descendant beneath it. Own beats inherited because it is
+    the more specific statement about the same space; an ancestor beats a
+    descendant because a building closed whole says something about every room
+    in it, where one room says only that the building is no longer free to let
+    whole.
+
+    THE DESCENDANT STEP RETURNS ALL OF THEM (kindred#2381), and that is the
+    arity fix. A merged container draws in place of its rooms, so returning the
+    first match dropped every other occupant off the board -- four of them on
+    the one 2026 container that carries four -- and made each clear look like a
+    failed click as the card re-resolved to the next room. The first two steps
+    stay single-answer: an own row is one row, and an ancestor chain has exactly
+    one nearest member.
+
+    Per-branch NEAREST, not every descendant. A written-into bed inside a
+    written-into wing is already inside that wing's space, so the wing's row
+    speaks for it and returning both would print one space twice. The walk
+    therefore stops descending a branch the moment it finds a row on it.
+
+    Ordered by `code` at every level, so two identical payloads never disagree
+    about the sequence a card draws its occupants in.
 
     RESOLVED FROM OWN ROWS ONLY, never transitively through a cover computed
     for somebody else -- which is what keeps a caretaker in room A off room B.
@@ -622,8 +641,11 @@ def write_in_covers(units: list[LodgingUnitSummary], write_in_unit_ids: frozense
     for unit in units:
         if unit.parent_code:
             children.setdefault(unit.parent_code, []).append(unit)
-    # Sorted so two identical payloads never disagree about WHICH row a card
-    # names when a building has several written-into rooms beneath it.
+    # Sorted so two identical payloads never disagree about the ORDER a card
+    # draws its occupants in when a building has several written-into rooms
+    # beneath it. It used to settle WHICH single row was named, because only
+    # one survived; kindred#2381 returns them all and this now fixes their
+    # sequence instead.
     for bucket in children.values():
         bucket.sort(key=lambda child: child.code)
 
@@ -640,7 +662,15 @@ def write_in_covers(units: list[LodgingUnitSummary], write_in_unit_ids: frozense
             cursor = by_code.get(cursor.parent_code) if cursor.parent_code else None
         return None
 
-    def _nearest_descendant(unit: LodgingUnitSummary) -> LodgingUnitSummary | None:
+    def _written_in_descendants(unit: LodgingUnitSummary) -> list[LodgingUnitSummary]:
+        """Every written-into descendant, nearest-first on each branch.
+
+        Breadth-first over `code`-sorted buckets, so the result is ordered and
+        two identical payloads agree. A branch is not descended past a match:
+        the matched unit's space contains whatever is below it, and its row
+        already speaks for that space.
+        """
+        found: list[LodgingUnitSummary] = []
         seen = {unit.code}
         queue = list(children.get(unit.code, []))
         while queue:
@@ -649,11 +679,12 @@ def write_in_covers(units: list[LodgingUnitSummary], write_in_unit_ids: frozense
                 continue
             seen.add(node.code)
             if _is_written_in(node):
-                return node
+                found.append(node)
+                continue
             queue.extend(children.get(node.code, []))
-        return None
+        return found
 
-    covers: dict[str, WriteInCover] = {}
+    covers: dict[str, list[WriteInCover]] = {}
     for unit in units:
         # Blank codes are excluded from BOTH sides, not just the lookup above.
         # `_build_units` reads this map back by code, so one blank-coded row
@@ -662,16 +693,23 @@ def write_in_covers(units: list[LodgingUnitSummary], write_in_unit_ids: frozense
         # a space on the strength of a row it does not hold.
         if not unit.code:
             continue
-        source = unit if _is_written_in(unit) else (_nearest_ancestor(unit) or _nearest_descendant(unit))
-        if source is None:
+        if _is_written_in(unit):
+            sources = [unit]
+        else:
+            ancestor = _nearest_ancestor(unit)
+            sources = [ancestor] if ancestor is not None else _written_in_descendants(unit)
+        if not sources:
             continue
-        covers[unit.code] = WriteInCover(
-            unit_id=source.unit_id,
-            unit_code=source.code,
-            unit_name=source.name,
-            occupant_name=source.occupant_name,
-            note=source.reason,
-        )
+        covers[unit.code] = [
+            WriteInCover(
+                unit_id=source.unit_id,
+                unit_code=source.code,
+                unit_name=source.name,
+                occupant_name=source.occupant_name,
+                note=source.reason,
+            )
+            for source in sources
+        ]
     return covers
 
 
@@ -684,7 +722,7 @@ def _resolve_write_in_covers(units: list[LodgingUnitSummary], write_in_unit_ids:
     """
     covers = write_in_covers(units, write_in_unit_ids)
     for unit in units:
-        unit.write_in = covers.get(unit.code)
+        unit.write_ins = covers.get(unit.code, [])
 
 
 def drawn_units(units: list[LodgingUnitSummary]) -> list[LodgingUnitSummary]:
@@ -1566,7 +1604,7 @@ class LodgingRosterService:
             # compat shim out. `family_available_override` is now the ROLE row
             # and nothing else -- a staff cabin opened to families for the
             # weekend, or a bare `false` closing one -- while "is somebody in
-            # this space" is answered by `write_in` alone. Until PR 4 this field
+            # this space" is answered by `write_ins` alone. Until PR 4 this field
             # reported `False` for an occupancy too, because
             # `is_family_available` and the board's open-tint were both derived
             # from it; both read the occupancy source directly now.

--- a/api/services/lodging_write_service.py
+++ b/api/services/lodging_write_service.py
@@ -322,11 +322,18 @@ class LodgingWriteService:
         of the boolean 1500000161 split apart (owner ruling, kindred#2382,
         2026-08-16). Once a scenario's write-ins REPLACE the live ones rather
         than falling through, a scenario seeded without them starts with every
-        written-into cabin looking OPEN -- and kindred#2247's placement gate
-        reads exactly that, so it would let a family be dropped into a room the
-        live board records as occupied. That failure mode is one this split
-        CREATES rather than inherits, and this copy is what closes it. See
-        `_seed_write_ins`.
+        written-into cabin looking OPEN, with the occupant gone from the
+        scenario entirely. That failure mode is one this split CREATES rather
+        than inherits, and this copy is what closes it. See `_seed_write_ins`.
+
+        ⚠️ THE REASON IS DISCLOSURE, NOT A GATE, since kindred#2432. This said
+        the seed existed because "kindred#2247's placement gate would let a
+        family be dropped into a room the live board records as occupied" --
+        and that gate is struck: a family may now be placed into a written-into
+        space on purpose. What the seed protects is the staff member's ability
+        to SEE the occupant before deciding to share the room, which is the
+        half that always mattered. Do not read the gate's removal as licence to
+        drop this copy.
 
         A mirror row is SKIPPED, not failed on, when it names no party grain
         (it would key on nothing, dedupe against nothing, and be exactly the
@@ -579,8 +586,10 @@ class LodgingWriteService:
         # and unlike the role override there IS something for two scenarios to
         # disagree about, which is the whole of kindred#2382. Dropping this
         # would make "copy from Option A" produce a board showing fewer
-        # occupied rooms than Option A does, and kindred#2247's placement gate
-        # would then offer those rooms.
+        # occupied rooms than Option A does -- those occupants would simply not
+        # be on the copy. (This used to add "and kindred#2247's placement gate
+        # would then offer those rooms"; kindred#2432 struck that gate, and the
+        # disclosure argument is what the seed always really rested on.)
         write_ins = await self._seed_write_ins(
             rows=await self.repository.fetch_draft_write_ins(year, session_cm_id, from_scenario),
             session_pb_id=session_pb_id,
@@ -617,10 +626,16 @@ class LodgingWriteService:
         it is a safety argument rather than a convenience one. A scenario's
         write-ins REPLACE the live ones on read (kindred#2382, matching
         kindred#1974's no-fall-through rule for placements), so a scenario
-        seeded without them shows every written-into cabin as OPEN --
-        kindred#2247's placement gate reads exactly that field, so it would
-        offer a room the live board records as occupied. The split creates that
+        seeded without them shows every written-into cabin as OPEN, with its
+        occupant absent from the scenario altogether. The split creates that
         failure mode; this copy is what closes it.
+
+        ⚠️ The safety argument is DISCLOSURE since kindred#2432, not refusal.
+        It used to run "kindred#2247's placement gate reads exactly that field,
+        so it would offer a room the live board records as occupied"; that gate
+        is gone and a family may now be placed alongside a write-in on purpose.
+        Staff still have to be able to SEE the occupant to make that call, so
+        this copy is load-bearing exactly as before.
 
         NO EMPTINESS CHECK AND NO RACE RECOVERY OF ITS OWN, following the
         `lodging_slot_merges` copy in `copy_scenario_to_scenario` rather than

--- a/docs/architecture/lodging-occupancy.md
+++ b/docs/architecture/lodging-occupancy.md
@@ -183,31 +183,94 @@ rule: it blocks legitimate work and teaches staff to ignore warnings.
   remains the DERIVED answer and still folds both facts in: occupancy closes a
   unit whatever the role says, so no reported number moved.
 
-  ### What a hold represents (owner ruling, 2026-08-09; kindred#2090, kindred#2087)
+  ⚠️ **kindred#2432 did not touch that derivation, deliberately.** The board
+  now places a family into a written-into space, but `is_family_available`
+  still resolves `false` for one, so the stats bar's *spaces* figure stays
+  CONSERVATIVE about a space that can in fact take a family. That is the safe
+  direction to be wrong in and it keeps one narrow pre-existing edge from
+  widening: a `staff_default` cabin RELEASED to families and then written into
+  resolves `false` and drops off the board entirely via `isPlanningInventory`
+  (`boardLayout.ts`) — reachable only with a release and a write-in on the same
+  staff unit and no party placed on it, since any placement keeps the card
+  drawn. Loosening the derivation is an API-side decision that has to be taken
+  with the stats-bar arithmetic beside it, not as a side effect.
 
-  A hold records **who is in a building** — chiefly non-rostered staff, a
-  caretaker, a burst pipe — not a reservation of empty space. It is a fact
-  about the BUILDING for one weekend; a placement is a fact about a PLAN.
-  They used to live on different axes for that reason, but the two questions
-  "is anyone in this building" and "has a family been placed here" answer the
-  same underlying fact from two directions, and the ruling settles them as
-  **mutually exclusive states**: a unit cannot be both held and occupied.
+  ### What a write-in represents (owner ruling, 2026-08-18; kindred#2432)
 
-  Concretely: a write-in covering a unit **blocks placement outright**
-  (`resolveDrop` in `dragPlacement.ts`, plus the matching `useDroppable`
-  `disabled` flag in `LodgingUnitCard.tsx`, refuse a drop onto a written-into
-  unit rather than merely dimming it), and a unit already holding a placed
-  party offers no "Write in" action (`availabilityAction` in `unitBadges.ts`
-  takes the slot's own occupancy and returns `null` for the `hold` branch). The
-  `clear` action — removing an existing write-in — is never blocked by
-  occupancy, since clearing only ever reduces the conflict.
+  A write-in records **who is in a building** — non-rostered staff, a
+  caretaker, a paper registration — not a reservation of empty space. It is a
+  fact about the BUILDING for one weekend; a placement is a fact about a PLAN.
 
-  Both gates read the fact through `writeInOccupant` (`writeIn.ts`), never
-  through `family_available_override`. They were written against that column
-  when it still doubled as the occupancy store; naming the fact once is what
-  let kindred#2382 re-point it in one place, and it is also what makes them
-  respect the unit tree — a write-in names one unit but closes a SPACE, so a
-  building's write-in blocks a drop into its rooms and vice versa.
+  **A write-in NAMES AN OCCUPANT. It does not CLOSE THE SPACE.** A write-in
+  and a placement may share one unit, in either order:
+
+  > *"we should be able to add families to any write in space, or add a write
+  > in to a family space — regardless of which came first."*
+
+  ⚠️ **This REVERSES the 2026-08-09 ruling on kindred#2090/kindred#2087**,
+  which held the two "mutually exclusive states: a unit cannot be both held and
+  occupied", and the reversal is stated here rather than the old rule being
+  quietly deleted, because the old rule is the one the next reader will
+  otherwise re-derive from the shape of the surrounding code. #2090 was ruled
+  while a hold and a write-in were the same act (kindred#2078, *"hold IS the
+  write-in"*), and under that collapse "occupied and held" really was
+  contradictory. The collapse has one real exception, and it is the case staff
+  actually reported: a paper registration has no CampMinder record, so it
+  cannot be placed on the board at all and a write-in is the ONLY way to record
+  it — and such a party can legitimately share a cabin with a placed family.
+  Refusing made the one case the control exists for the one case it would not
+  do. (The production snapshot bears the shape out: of 16 written-into units in
+  the 2026 weekend, two name a paper registration explicitly, and 8 already
+  carried a draft placement alongside the write-in.)
+
+  Concretely, kindred#2432 struck **four** refusals, and they had to go
+  together — the first two are the enforcing and affordance halves of one gate,
+  and leaving either would have left the reversal half-done while looking
+  finished:
+
+  - `resolveDrop` in `dragPlacement.ts` — the load-bearing one, since
+    kindred#2080's picker reaches placement without touching a droppable.
+  - the `useDroppable` `disabled` flag in `LodgingUnitCard.tsx` — without this
+    dnd-kit never reports `isOver`, so a drop the resolver now accepts could
+    not be aimed at the card.
+  - `availabilityAction`'s occupancy gate in `unitBadges.ts` — the mirror
+    direction, a write-in onto a placed family. The `occupied` argument is
+    **deleted** rather than defaulted, here and on `UnitAvailabilityControl`'s
+    props, so a caller holding an occupancy fact has nowhere to spell it and
+    `tsc` enforces the reversal.
+  - `canPickFamily`'s `!held` in `LodgingUnitCard.tsx` — otherwise #2080's
+    picker stays absent for a placement drag performs happily.
+
+  `resolvePickerPlacement` needed no edit at all, which is the payoff of it
+  being a thin adapter over `resolveDrop`.
+
+  **What did NOT change.** `availabilityAction` still returns `null` for a
+  written-into card, and that gate is about **write-in arity**, not occupancy
+  (kindred#2381: one button cannot name which of four rows a click would
+  destroy). `canPickFamily` still requires `parties.length === 0` — a second
+  family reaches a shareable space by drag, which stays the deliberate path,
+  and kindred#2091 (marking a space that holds two families) is unbuilt. The
+  `clear` action is still never blocked by occupancy. The open-space forest
+  tint and the "Drop families here" placeholder still stand down on a
+  written-into cabin, on the surviving half of their reason: a room somebody is
+  sleeping in is not EMPTY, even though it is now placeable.
+
+  Every gate reads the fact through `writeInEntries`/`hasWriteIn`
+  (`writeIn.ts`), never through `family_available_override`. They were written
+  against that column when it still doubled as the occupancy store; naming the
+  fact once is what let kindred#2382 re-point it in one place, and the same
+  tree walk is what now lands the write-in and the family in the SAME card's
+  well whichever level the board draws — a write-in names one unit but covers a
+  SPACE.
+
+  **The known cost is filed, not hidden.** A write-in carries no headcount
+  (`lodging_write_ins` holds `occupant_name` and `note` and no count), so a
+  shared space's occupancy figure and its free-bed arithmetic both understate:
+  a 10-bed cabin holding a party of 6 plus a written-in party of 3 reads 4 free
+  when 1 is. That is kindred#2439, ruled an optional investigation and
+  explicitly not a blocker — an understated count on a space staff can share
+  beats a space they could not share at all. Do not guess a headcount to
+  paper over it.
 - The unique indexes on `lodging_assignments` are
   `(session, year, household_cm_id)` and the person-grain equivalent, each
   partial on `> 0` so the two grains do not collide. (Migration `1500000132`

--- a/frontend/src/components/weekend/LodgingBoard.availability.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.availability.test.tsx
@@ -218,12 +218,13 @@ describe('LodgingBoard — the control becomes a write', () => {
   })
 })
 
-describe('LodgingBoard — clearing a write-in this card inherited', () => {
+describe('LodgingBoard — removing a write-in this card inherited', () => {
   /*
    * The row names one unit; it closes a SPACE. Split a written-into building
    * and its ROOMS inherit the write-in, while the building — no longer drawn —
-   * has nowhere to offer the clear from. The room offers it, and both the write
-   * and the in-flight disable have to follow the row rather than the card.
+   * has nowhere to offer a removal from. The room's card carries it, as the X
+   * on the `WriteInCard` it draws, and both the write and the in-flight
+   * disable have to follow the ROW rather than the card.
    */
   const COVER = {
     unit_id: 'u-house',
@@ -232,13 +233,13 @@ describe('LodgingBoard — clearing a write-in this card inherited', () => {
     occupant_name: 'Liam Garcia',
     note: '',
   }
-  const room = unit({ unit_id: 'u-room', code: 'house-a', name: 'House A', write_in: COVER })
+  const room = unit({ unit_id: 'u-room', code: 'house-a', name: 'House A', write_ins: [COVER] })
 
   it('sends the unit that HOLDS the row, not the card it was clicked on', async () => {
     const user = userEvent.setup()
     renderBoard({ units: [room] })
 
-    await user.click(screen.getByRole('button', { name: 'Clear Write-in House A' }))
+    await user.click(screen.getByRole('button', { name: 'Remove write-in Liam Garcia' }))
 
     expect(setAvailability).toHaveBeenCalledWith({
       unitId: 'u-house',
@@ -249,14 +250,16 @@ describe('LodgingBoard — clearing a write-in this card inherited', () => {
     })
   })
 
-  it('disables the card while the row it points at is being written', async () => {
+  it('disables the card while the row it points at is being written', () => {
     // `pendingUnitId` names the unit the WRITE targets, which for an inherited
-    // clear is never this card's own id — so keying the disable on the card
-    // alone leaves the button live for the whole write and invites a second
-    // click on a row that is already going away.
+    // removal is never this card's own id — so keying the disable on the card
+    // alone leaves the X live for the whole write and invites a second click
+    // on a row that is already going away. Matched with `some` since
+    // kindred#2381: a merged card covers several rows and the pending write
+    // belongs to whichever one was clicked.
     pendingUnitId = 'u-house'
     renderBoard({ units: [room] })
 
-    expect(screen.getByRole('button', { name: 'Clear Write-in House A' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Remove write-in Liam Garcia' })).toBeDisabled()
   })
 })

--- a/frontend/src/components/weekend/LodgingBoard.drag.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.drag.test.tsx
@@ -356,8 +356,10 @@ describe('LodgingBoard — placing a family from the space itself (kindred#2080)
   it('mounts the control on an empty space while placement is live', () => {
     boardWithUnplaced()
     expect(pickerFor('Cedar 2')).toBeInTheDocument()
-    // Cedar 1 already holds a family, so it offers nothing — the same rule
-    // that hides Hold on an occupied card.
+    // Cedar 1 already holds a family, so it offers nothing. NOT the write-in
+    // rule and no longer a mirror of Hold: kindred#2432 struck Hold's own
+    // occupancy gate, and a second family still reaches a shareable space by
+    // drag, which stays the deliberate path for a share.
     expect(
       screen.queryByRole('combobox', { name: /place a family in cedar 1/i })
     ).not.toBeInTheDocument()

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -64,7 +64,7 @@ import { LodgingUnitCard } from './LodgingUnitCard'
 import { partyKey } from './partyKey'
 import { resolvePartyUnit } from './rosterAttention'
 import type { UnitAvailabilityWrite } from './UnitAvailabilityControl'
-import { writeInSource } from './writeIn'
+import { writeInEntries } from './writeIn'
 
 export interface LodgingBoardProps {
   parties: RosterPartyRow[]
@@ -519,18 +519,25 @@ export function LodgingBoard({
                             hue={area.hue}
                             canPlace={canPlace}
                             canSetAvailability={canSetAvailability}
-                            // THIS card's unit, or the one holding the
-                            // write-in it inherited. `pendingUnitId` names the
-                            // unit the WRITE targets, and for an inherited
-                            // clear that is never this card's own id — so
+                            // THIS card's unit, or ANY of the ones holding a
+                            // write-in it covers. `pendingUnitId` names the
+                            // unit the WRITE targets, and a write-in removal
+                            // targets the row's own unit, which for an
+                            // inherited row is never this card's id — so
                             // keying the disable on the card alone leaves the
-                            // button live for the whole write. Same shape as
-                            // `savingMerge` below, and for the same reason:
-                            // the unit written is not always the unit drawn.
+                            // corner X live for the whole write. `some`, not
+                            // one id, since kindred#2381: a merged container
+                            // covers every write-in beneath it and the pending
+                            // write belongs to whichever one was clicked. Same
+                            // shape as `savingMerge` below, and for the same
+                            // reason: the unit written is not always the unit
+                            // drawn.
                             savingAvailability={
                               pendingUnitId === slot.unit.unit_id ||
                               (pendingUnitId !== '' &&
-                                pendingUnitId === writeInSource(slot.unit)?.unitId)
+                                writeInEntries(slot.unit).some(
+                                  (entry) => entry.source.unitId === pendingUnitId
+                                ))
                             }
                             onSetAvailability={writeAvailability}
                             canMerge={canMergeUnits}

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -322,10 +322,17 @@ export function LodgingBoard({
    * kindred#2080 — the unit card's picker, resolved through the DROP path.
    *
    * `resolvePickerPlacement` IS `resolveDrop`, so this branch inherits every
-   * refusal the drag has (a held space, a non-combined container, a party
-   * carrying neither CampMinder id, a party already alone in the room) rather
-   * than restating any of them, and produces the same `PlacementIntent` for
-   * the same `move`. One placement path with two affordances, not two paths.
+   * refusal the drag has (a non-combined container, a party carrying neither
+   * CampMinder id, a party already alone in the room) rather than restating
+   * any of them, and produces the same `PlacementIntent` for the same `move`.
+   * One placement path with two affordances, not two paths.
+   *
+   * That inheritance cuts both ways, which is what kindred#2432 proved: this
+   * list said "a held space" first until the written-into refusal was struck
+   * in `resolveDrop`, and this branch gave it up in the same change with
+   * nothing here to edit. A copy of the list is not a second gate — but a
+   * STALE copy of it is the next reader's evidence for restoring one, so keep
+   * the two in step.
    *
    * `canPlace` is re-checked here for the same reason `handleDragEnd`
    * re-checks it: the card's own gate is the affordance half, and a write

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -478,7 +478,7 @@ describe('LodgingUnitCard — a held unit refuses the drop outright (#2087)', ()
     return el as HTMLElement
   }
 
-  const held = unit({ write_in: cover(), is_family_available: false })
+  const held = unit({ write_ins: [cover()], is_family_available: false })
 
   it('keeps the droppable disabled on a held unit even while placement is live', () => {
     overDroppableId = unitDroppableId('cedar-1')
@@ -1402,7 +1402,7 @@ describe('LodgingUnitCard — the open-space title marker (#2093)', () => {
     const { container } = render(
       <LodgingUnitCard
         slot={slot({
-          unit: unit({ write_in: cover(), occupant_name: 'Emma Johnson' }),
+          unit: unit({ write_ins: [cover()], occupant_name: 'Emma Johnson' }),
         })}
         hue={hue}
         canPlace
@@ -1430,7 +1430,7 @@ describe('LodgingUnitCard — the open-space title marker (#2093)', () => {
     // write schema.
     const { container } = render(
       <LodgingUnitCard
-        slot={slot({ unit: unit({ write_in: cover({ occupant_name: '' }) }) })}
+        slot={slot({ unit: unit({ write_ins: [cover({ occupant_name: '' })] }) })}
         hue={hue}
         canPlace
         onOpenParty={vi.fn()}
@@ -1475,7 +1475,7 @@ describe('the write-in occupant card (kindred#2078)', () => {
       <LodgingUnitCard
         slot={slot({
           unit: unit({
-            write_in: cover(),
+            write_ins: [cover()],
             occupant_name: 'Emma Johnson',
             is_family_available: false,
           }),
@@ -1498,7 +1498,7 @@ describe('the write-in occupant card (kindred#2078)', () => {
       <LodgingUnitCard
         slot={slot({
           unit: unit({
-            write_in: cover({ occupant_name: 'Liam Garcia' }),
+            write_ins: [cover({ occupant_name: 'Liam Garcia' })],
             occupant_name: 'Liam Garcia',
             is_family_available: false,
           }),
@@ -1529,7 +1529,7 @@ describe('the write-in occupant card (kindred#2078)', () => {
       <LodgingUnitCard
         slot={slot({
           unit: unit({
-            write_in: cover(),
+            write_ins: [cover()],
             occupant_name: 'Emma Johnson',
             is_family_available: false,
           }),
@@ -2227,7 +2227,7 @@ describe('LodgingUnitCard — placing a family from the space itself (kindred#20
      * REFUSAL and is spoken for by the invalid merge target.
      */
     const { container } = renderCard({
-      slot: slot({ unit: unit({ write_in: cover() }) }),
+      slot: slot({ unit: unit({ write_ins: [cover()] }) }),
     })
     expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
     expect(container.querySelector('.opacity-40')).toBeNull()
@@ -2309,7 +2309,7 @@ describe('LodgingUnitCard — no sr-only text of any kind (kindred#2348)', () =>
 describe('LodgingUnitCard — the write-in chip, dropped in favour of the well (kindred#2252)', () => {
   const HUE = 'hsl(160 45% 42%)'
   const WRITTEN_IN = unit({
-    write_in: cover(),
+    write_ins: [cover()],
     occupant_name: 'Emma Johnson',
     is_family_available: false,
   })
@@ -2352,7 +2352,7 @@ describe('LodgingUnitCard — the write-in chip, dropped in favour of the well (
         slot={slot({
           unit: unit({
             inventory_class: 'staff_default',
-            write_in: cover(),
+            write_ins: [cover()],
             occupant_name: 'Emma Johnson',
             is_family_available: false,
           }),
@@ -2364,18 +2364,89 @@ describe('LodgingUnitCard — the write-in chip, dropped in favour of the well (
     expect(screen.getByText('Staff')).toBeInTheDocument()
   })
 
-  it('labels the availability control "Clear Write-in" rather than a bare "Clear"', () => {
-    // The chip is gone, so the button is now the ONLY thing on this card
-    // saying what a click removes. "Clear" alone stopped saying that.
+  it('removes a write-in from the card that draws it, not from the availability strip', () => {
+    // kindred#2381. The strip's single "Clear Write-in" could name only one
+    // row, so a merged card covering four destroyed them one silent click at
+    // a time. The X lives on the `WriteInCard`, and the write it sends names
+    // that card's own row.
+    const onSetAvailability = vi.fn()
     render(
       <LodgingUnitCard
         slot={slot({ unit: WRITTEN_IN })}
         hue={HUE}
         canSetAvailability
-        onSetAvailability={vi.fn()}
+        onSetAvailability={onSetAvailability}
         onOpenParty={vi.fn()}
       />
     )
-    expect(screen.getByRole('button', { name: 'Clear Write-in Cedar 1' })).toBeInTheDocument()
+
+    expect(screen.queryByRole('button', { name: /clear/i })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Remove write-in Emma Johnson' }))
+
+    expect(onSetAvailability).toHaveBeenCalledWith({
+      unitId: 'u1',
+      unitName: 'Cedar 1',
+      familyAvailable: null,
+      occupantName: '',
+      reason: '',
+    })
+  })
+
+  it('draws one card per write-in, each removing its own row', () => {
+    // THE REPORTED CASE. A merged building stands in for its rooms, so every
+    // write-in beneath it lands in this one well. Before kindred#2381 the card
+    // showed whichever room sorted first and hid the rest.
+    const onSetAvailability = vi.fn()
+    render(
+      <LodgingUnitCard
+        slot={slot({
+          unit: unit({
+            unit_id: 'u-house',
+            code: 'house',
+            name: 'House',
+            is_container: true,
+            is_combined: true,
+            is_family_available: false,
+            write_ins: [
+              cover({
+                unit_id: 'u-back',
+                unit_code: 'house-back',
+                unit_name: 'House Back',
+                occupant_name: 'Emma Johnson',
+              }),
+              cover({
+                unit_id: 'u-loft',
+                unit_code: 'house-loft',
+                unit_name: 'House Loft',
+                occupant_name: 'Liam Garcia',
+              }),
+            ],
+          }),
+        })}
+        hue={HUE}
+        canSetAvailability
+        onSetAvailability={onSetAvailability}
+        onOpenParty={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
+    expect(screen.getByText('Liam Garcia')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove write-in Liam Garcia' }))
+
+    expect(onSetAvailability).toHaveBeenCalledWith({
+      unitId: 'u-loft',
+      unitName: 'House Loft',
+      familyAvailable: null,
+      occupantName: '',
+      reason: '',
+    })
+  })
+
+  it('offers no removal to a reader without bunking.manage', () => {
+    render(<LodgingUnitCard slot={slot({ unit: WRITTEN_IN })} hue={HUE} onOpenParty={vi.fn()} />)
+
+    expect(screen.queryByRole('button', { name: /remove write-in/i })).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -466,39 +466,124 @@ describe('LodgingUnitCard', () => {
   })
 })
 
-describe('LodgingUnitCard — a held unit refuses the drop outright (#2087)', () => {
-  // The `disabled` half of the fix. `resolveDrop` (dragPlacement.test.ts) is
-  // the load-bearing check — #2080's picker never touches a droppable at
-  // all — but `useDroppable`'s own `disabled` flag is what keeps dnd-kit
-  // from ever reporting `isOver` for a held card in the first place, which
-  // is what this asserts.
+describe('LodgingUnitCard — a written-into unit still takes a family (#2432)', () => {
+  // The AFFORDANCE half of the reversal. `resolveDrop` (dragPlacement.test.ts)
+  // is the load-bearing check — #2080's picker never touches a droppable at
+  // all — but `useDroppable`'s own `disabled` flag is what decides whether
+  // dnd-kit ever reports `isOver` here, so a reversal that moved only the
+  // resolver would leave the card refusing to light up for a drop it accepts.
   function card(container: HTMLElement): HTMLElement {
     const el = container.querySelector('[data-unit-card]')
     if (!el) throw new Error('no card rendered')
     return el as HTMLElement
   }
 
-  const held = unit({ write_ins: [cover()], is_family_available: false })
+  const writtenInto = unit({ write_ins: [cover()], is_family_available: false })
 
-  it('keeps the droppable disabled on a held unit even while placement is live', () => {
+  it('keeps the droppable ENABLED on a written-into unit while placement is live', () => {
     overDroppableId = unitDroppableId('cedar-1')
     const { container } = render(
       <LodgingUnitCard
-        slot={slot({ unit: held })}
+        slot={slot({ unit: writtenInto })}
         hue="hsl(160 45% 42%)"
         canPlace
         onOpenParty={vi.fn()}
       />
     )
-    expect(card(container)).not.toHaveClass('border-primary')
+    expect(card(container)).toHaveClass('border-primary')
   })
 
-  it('keeps an ordinary unheld unit droppable enabled (regression guard)', () => {
+  it('keeps an ordinary unwritten unit droppable enabled (regression guard)', () => {
     overDroppableId = unitDroppableId('cedar-1')
     const { container } = render(
       <LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" canPlace onOpenParty={vi.fn()} />
     )
     expect(card(container)).toHaveClass('border-primary')
+  })
+
+  it('still refuses every card while a MERGE drag is in flight', () => {
+    // The one `disabled` reason that survives, and it is not about occupancy:
+    // a card mid-merge-drag sits over two overlapping droppables and which one
+    // dnd-kit resolves `over` to would be decided by hook registration order.
+    overDroppableId = unitDroppableId('cedar-1')
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot()}
+        hue="hsl(160 45% 42%)"
+        canPlace
+        mergeSourceUnit={unit({ code: 'cedar-2', unit_id: 'u2', parent_code: 'house' })}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(card(container)).not.toHaveClass('border-primary')
+  })
+})
+
+describe('LodgingUnitCard — the shared occupant well (#2432)', () => {
+  // The first card the board ever draws with a `WriteInCard` and a
+  // `FamilyCard` in it at once, which makes it #2091's visual precedent by
+  // default (#2091 — marking a space that holds two families — is unbuilt).
+  // ONE well, stacked in the order the well already uses, no divider and no
+  // new mark: a shared space is not a new KIND of card, it is a card with two
+  // occupants in it.
+  const HUE = 'hsl(160 45% 42%)'
+
+  function renderShared(props: Record<string, unknown> = {}) {
+    return render(
+      <LodgingUnitCard
+        slot={slot({
+          unit: unit({ write_ins: [cover({ occupant_name: 'Ava Martinez' })] }),
+          parties: [party()],
+        })}
+        hue={HUE}
+        canPlace
+        canSetAvailability
+        onSetAvailability={vi.fn()}
+        onOpenParty={vi.fn()}
+        {...props}
+      />
+    )
+  }
+
+  it('draws the write-in and the placed family together, neither hiding the other', () => {
+    renderShared()
+    // The write-in's occupant, from `WriteInCard`.
+    expect(screen.getByText('Ava Martinez')).toBeInTheDocument()
+    // The placed family, from `FamilyCard`, which titles itself with the
+    // party's first adult rather than the household surname.
+    expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
+  })
+
+  it('offers to write somebody into a space that already holds a family', () => {
+    // The OTHER direction of the symmetric ruling, and the one the reporter
+    // asked for: a paper registration has no CampMinder record, so a write-in
+    // is the only way to record it — and the control used to vanish the moment
+    // a CampMinder family was placed in the space.
+    renderShared({ slot: slot({ parties: [party()] }) })
+    expect(screen.getByRole('button', { name: 'Write in Cedar 1' })).toBeInTheDocument()
+  })
+
+  it('offers to write into a MERGED building that already holds a family', () => {
+    renderShared({
+      slot: slot({
+        unit: unit({ code: 'house', name: 'House', is_container: true, is_combined: true }),
+        parties: [party({ unit_code: 'house', unit_name: 'House', unit_codes: ['house'] })],
+      }),
+    })
+    expect(screen.getByRole('button', { name: 'Write in House' })).toBeInTheDocument()
+  })
+
+  it('keeps the placement’s real bed count rather than the wholesale em dash', () => {
+    // A write-in alone occupies WHOLESALE and reports `—`, because it carries
+    // no party size. Once a family is placed alongside it the card has a real
+    // number about real people and must not go quiet about them.
+    //
+    // ⚠️ That number UNDERSTATES a shared space, because the write-in's own
+    // head is not in it — filed as kindred#2439 and explicitly not a blocker:
+    // an understated count on a space staff can now share beats a space they
+    // could not share at all.
+    renderShared()
+    expect(screen.getByTestId('unit-occupancy')).toHaveTextContent('3/5')
   })
 })
 
@@ -2219,21 +2304,26 @@ describe('LodgingUnitCard — placing a family from the space itself (kindred#20
     expect(onPlaceParty.mock.calls[0]?.[1]).toEqual(unplaced)
   })
 
-  it('is ABSENT on a held space, not dimmed', () => {
+  it('is OFFERED on a written-into space, which is now a placeable one (#2432)', () => {
     /*
-     * A hold refuses placement outright (#2087/#2090), and Hold's own control
-     * vanishes rather than dimming in the same situation. Absent adds no
-     * fifth meaning to the board's ruled signal vocabulary — `opacity-40` is
-     * REFUSAL and is spoken for by the invalid merge target.
+     * #2080's picker is the second placement path and deliberately has no
+     * rules of its own — `resolvePickerPlacement` is a thin adapter over
+     * `resolveDrop`. So a picker still hidden here would name a refusal the
+     * resolver no longer makes: the control would be absent for a placement
+     * that drag performs happily.
      */
     const { container } = renderCard({
       slot: slot({ unit: unit({ write_ins: [cover()] }) }),
     })
-    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: /place a family in cedar 1/i })).toBeInTheDocument()
     expect(container.querySelector('.opacity-40')).toBeNull()
   })
 
-  it('is absent on an occupied space, mirroring Hold', () => {
+  it('is absent on a space that already holds a family', () => {
+    // NOT the write-in rule, and no longer a mirror of it. A SECOND family
+    // reaches a shareable space by drag, which stays the path for a share that
+    // has to be looked at deliberately — and #2091 (marking a space that holds
+    // two families) is unbuilt, so nothing here should invent that case.
     renderCard({ slot: slot({ parties: [party()] }) })
     expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
   })

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -2447,4 +2447,41 @@ describe('LodgingUnitCard — the write-in chip, dropped in favour of the well (
 
     expect(screen.queryByRole('button', { name: /remove write-in/i })).not.toBeInTheDocument()
   })
+
+  it('edits a write-in from the card that draws it, upserting the same row (kindred#2430)', () => {
+    // No delete-and-recreate: the edit write names the SAME row the removal
+    // above does (`unitId`/`unitName` from the row's own source), with
+    // `familyAvailable: false` — the write-in "hold" value, not `null` — so
+    // `set_availability`'s upsert updates the row in place.
+    const onSetAvailability = vi.fn()
+    render(
+      <LodgingUnitCard
+        slot={slot({ unit: WRITTEN_IN })}
+        hue={HUE}
+        canSetAvailability
+        onSetAvailability={onSetAvailability}
+        onOpenParty={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit write-in Emma Johnson' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Occupant' }), {
+      target: { value: 'Emma Johnson-Reyes' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(onSetAvailability).toHaveBeenCalledWith({
+      unitId: 'u1',
+      unitName: 'Cedar 1',
+      familyAvailable: false,
+      occupantName: 'Emma Johnson-Reyes',
+      reason: '',
+    })
+  })
+
+  it('offers no edit to a reader without bunking.manage', () => {
+    render(<LodgingUnitCard slot={slot({ unit: WRITTEN_IN })} hue={HUE} onOpenParty={vi.fn()} />)
+
+    expect(screen.queryByRole('button', { name: /edit write-in/i })).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -2079,7 +2079,8 @@ describe('LodgingUnitCard — the needs-misfit hatch (#1912)', () => {
    * The board's signal vocabulary, ruled 2026-08-09 and binding here:
    *
    *   dim (`opacity-40` + `pointer-events-none`) = REFUSAL — an invalid merge
-   *     target, or a held space (#2087). "You may not."
+   *     target, and since kindred#2432 nothing else. "You may not." A
+   *     written-into space (#2087) was the second owner until that reversal.
    *   hatch (`background-image`, FULL strength) = ADVISORY MISFIT — "it will
    *     work; nothing here meets the need". This block.
    *   forest tint = open and available, at rest (#2093).

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -1390,7 +1390,7 @@ describe('LodgingUnitCard — the open-space title marker (#2093)', () => {
      *
      * kindred#2078 RE-EXPRESSED this conjunct. It used to read the proxy
      * `unit.family_available_override === false` inline under the name `held`;
-     * it now goes through `writeInOccupant`, so the tint is keyed on the fact
+     * it now goes through `writeInEntries`, so the tint is keyed on the fact
      * ("somebody is in this room") rather than on a spelling. This test is
      * what pins that the re-expression did not drop the gate.
      *
@@ -2340,13 +2340,11 @@ describe('LodgingUnitCard — the write-in chip, dropped in favour of the well (
 
   it('does not suppress the "Staff" badge — a closed staff cabin is exempt from the gate, not just no write-in', () => {
     // This is the case `writeInBadgeApplies`'s `inventory_class !==
-    // 'staff_default'` half exists for: a staff cabin closed for the weekend
-    // synthesises a `writeInOccupant` cover the same way a family room's
-    // write-in does (`writeIn.ts`'s `coveringWriteIn` fallback reads
-    // `family_available_override === false` for either role), so reading
-    // `writeInOccupant(unit) !== null` alone here would swallow the "Staff"
-    // chip along with the "Write-in" one. Pins both halves of the gate at
-    // once — the class check AND the scoping to this card only.
+    // 'staff_default'` half exists for: a staff cabin written into for the
+    // weekend carries a cover the same way a family room's write-in does, so
+    // reading `hasWriteIn(unit)` alone here would swallow the "Staff" chip
+    // along with the "Write-in" one. Pins both halves of the gate at once —
+    // the class check AND the scoping to this card only.
     render(
       <LodgingUnitCard
         slot={slot({

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -2430,6 +2430,12 @@ describe('LodgingUnitCard — the write-in chip, dropped in favour of the well (
 
     expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
     expect(screen.getByText('Liam Garcia')).toBeInTheDocument()
+    // AND WHICH ROOM EACH IS IN. Four occupants in one merged well sleep in
+    // four different rooms; a name with no space beside it tells a staff
+    // member nothing they can act on. (The 2026 container this issue is about
+    // holds four — a loft, a side room, a back room and a laundry.)
+    expect(screen.getByText('Written in at House Back')).toBeInTheDocument()
+    expect(screen.getByText('Written in at House Loft')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Remove write-in Liam Garcia' }))
 
@@ -2440,6 +2446,22 @@ describe('LodgingUnitCard — the write-in chip, dropped in favour of the well (
       occupantName: '',
       reason: '',
     })
+  })
+
+  it('says nothing extra when the row is the drawing card\u2019s own', () => {
+    // The overwhelmingly common case. `WRITTEN_IN`'s cover names `cedar-1`,
+    // which is the card's own code, so the source line stays off.
+    render(
+      <LodgingUnitCard
+        slot={slot({ unit: WRITTEN_IN })}
+        hue={HUE}
+        canSetAvailability
+        onSetAvailability={vi.fn()}
+        onOpenParty={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByText(/^Written in at/)).not.toBeInTheDocument()
   })
 
   it('offers no removal to a reader without bunking.manage', () => {

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -38,7 +38,7 @@ import {
 } from './unitBadges'
 import { UnitAvailabilityControl } from './UnitAvailabilityControl'
 import type { UnitAvailabilityWrite } from './UnitAvailabilityControl'
-import { writeInOccupant, writeInSource } from './writeIn'
+import { writeInEntries } from './writeIn'
 import { WriteInCard } from './WriteInCard'
 
 /**
@@ -423,7 +423,7 @@ export function LodgingUnitCard({
   // half that actually enforces it, because #2080 adds a placement path that
   // reaches `resolveDrop` without ever touching this hook.
   //
-  // Read through `writeInOccupant` rather than as an inline
+  // Read through `writeInEntries` rather than as an inline
   // `family_available_override === false`, which is what this was until
   // kindred#2078. Three consumers on this card shared that expression under
   // the name `held`, and one of them — #2093's open-tint gate below — was
@@ -432,12 +432,13 @@ export function LodgingUnitCard({
   // occupancy into its own scenario-scoped table, and that field now answers
   // the staff↔family role alone. Had the three consumers kept the inline
   // spelling, the split would have had to find all three.
-  const writeIn = writeInOccupant(unit)
-  // WHOSE row it is. Undefined whenever it is this card's own, so the common
-  // case says nothing extra — see `WriteInCard`'s own prop doc.
-  const writeInAt = writeInSource(unit)
-  const writeInAtName = writeInAt !== null && !writeInAt.isOwn ? writeInAt.unitName : undefined
-  const held = writeIn !== null
+  //
+  // A LIST since kindred#2381. A merged container draws in place of its rooms,
+  // so every write-in beneath it lands on this card — four of them on the one
+  // 2026 building that carries four — and each entry pairs the occupant with
+  // the row that holds it, so the card's own X can name that row and no other.
+  const writeIns = writeInEntries(unit)
+  const held = writeIns.length > 0
   const { setNodeRef: setUnitDropRef, isOver: isUnitOver } = useDroppable({
     id: unitDroppableId(unit.code),
     disabled: !canPlace || mergeDragActive || held,
@@ -510,7 +511,7 @@ export function LodgingUnitCard({
   // suppressed the instant this card becomes an active drop target, same as
   // the old wash was.
   //
-  // `writeIn === null` is the second gate, and it is not cosmetic: EMPTY and
+  // `!held` is the second gate, and it is not cosmetic: EMPTY and
   // OPEN are different predicates and this is where they part. A write-in
   // blocks placement outright (`held` above; `dragPlacement.ts` refuses the
   // drop), so a written-into cabin has no family in it and can take none.
@@ -523,7 +524,7 @@ export function LodgingUnitCard({
   // Keyed on the OCCUPANT SIGNAL, never on the occupant's NAME being filled
   // in: a write-in nobody named still closes the room, and gating on the name
   // would hand exactly that room back to the to-do marker.
-  const openMarkerActive = dashed && writeIn === null && ringState !== 'dropTarget'
+  const openMarkerActive = dashed && !held && ringState !== 'dropTarget'
 
   /*
    * The corner figure, and the sentence behind it (kindred#2078).
@@ -534,7 +535,7 @@ export function LodgingUnitCard({
    * write-in and a placement keeps the placement count — that is a real number
    * about real people, and the card should not go quiet about them.
    */
-  const wholesaleWriteIn = writeIn !== null && occupants === 0
+  const wholesaleWriteIn = held && occupants === 0
   const occupancyFigure = wholesaleWriteIn ? '—' : String(occupants)
 
   /*
@@ -963,8 +964,36 @@ export function LodgingUnitCard({
             below: a card carrying both is not a state any writer produces
             (#2090 rules the two mutually exclusive), but if a legacy row ever
             does, hiding one of them would drop somebody from the board. */}
-        {writeIn !== null && <WriteInCard occupant={writeIn} atUnitName={writeInAtName} />}
-        {parties.length === 0 && writeIn === null ? (
+        {writeIns.map((entry) => (
+          <WriteInCard
+            key={entry.source.unitId}
+            occupant={entry.occupant}
+            // BOUND TO THIS ROW, which is the whole point of the per-card X:
+            // the strip's single "Clear Write-in" named whichever row the
+            // server resolved first, so on a merged building a click removed
+            // one, the card re-populated with the next occupant, and the
+            // action read as a no-op while it destroyed them one by one.
+            //
+            // `familyAvailable: null` DELETES, and the occupant and reason are
+            // empty because a removal asserts nothing — the same write the
+            // strip's clear sent, now pointed at a row the reader can see.
+            {...(canSetAvailability && onSetAvailability !== undefined
+              ? {
+                  onRemove: () => {
+                    onSetAvailability({
+                      unitId: entry.source.unitId,
+                      unitName: entry.source.unitName,
+                      familyAvailable: null,
+                      occupantName: '',
+                      reason: '',
+                    })
+                  },
+                }
+              : {})}
+            isRemoving={savingAvailability}
+          />
+        ))}
+        {parties.length === 0 && !held ? (
           /* Summer's wording in family vocabulary — `BunkCard` says "Drop
              campers here". An empty slot's job is to be a target, and "Empty"
              described the state without offering the action.

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -988,9 +988,23 @@ export function LodgingUnitCard({
                       reason: '',
                     })
                   },
+                  // BOUND TO THIS ROW for the same reason `onRemove` is — kindred#2430.
+                  // `familyAvailable: false` is the write-in "hold" value, never
+                  // `null`: `set_availability` upserts a write-in
+                  // (`_upsert_row(what='write-in', ...)`), so this write updates
+                  // the existing row rather than creating a second one.
+                  onEdit: (write: { occupantName: string; reason: string }) => {
+                    onSetAvailability({
+                      unitId: entry.source.unitId,
+                      unitName: entry.source.unitName,
+                      familyAvailable: false,
+                      occupantName: write.occupantName,
+                      reason: write.reason,
+                    })
+                  },
                 }
               : {})}
-            isRemoving={savingAvailability}
+            isSaving={savingAvailability}
           />
         ))}
         {parties.length === 0 && !held ? (

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -103,8 +103,9 @@ const RING_CLASSES: Record<'dropTarget' | 'consentFlagged' | 'plain', string> = 
  * consent, red to over-capacity), so a fifth meaning cannot have a fifth
  * colour without collapsing the ones that exist. It cannot have an OPACITY
  * either: the 2026-08-09 signal-vocabulary ruling assigns one channel per
- * question, and `opacity-40` is REFUSAL ("you may not") — the invalid merge
- * target below and #2087's held space. This mark says "it will work; nothing
+ * question, and `opacity-40` is REFUSAL ("you may not") — spoken for by the
+ * invalid merge target below, and by that alone since kindred#2432 struck the
+ * written-into space's refusal. This mark says "it will work; nothing
  * here meets the need", which is a different KIND of statement rather than a
  * weaker refusal, so it stays at full contrast: legible, droppable, flagged.
  *
@@ -416,12 +417,13 @@ export function LodgingUnitCard({
   // above — and which one dnd-kit resolves `over` to would be a tie decided
   // by hook registration order, not by which gesture is actually in flight.
   //
-  // Disabled on a WRITTEN-INTO unit (#2078/#2087): a write-in blocks placement
-  // outright, per the owner ruling on #2090. This is the AFFORDANCE half — it
-  // keeps dnd-kit from ever reporting `isOver` here, so the card cannot even
-  // highlight as a target — while `resolveDrop` (`dragPlacement.ts`) is the
-  // half that actually enforces it, because #2080 adds a placement path that
-  // reaches `resolveDrop` without ever touching this hook.
+  // NOT disabled on a WRITTEN-INTO unit any more — kindred#2432, owner ruling
+  // 2026-08-18: *"we should be able to add families to any write in space, or
+  // add a write in to a family space — regardless of which came first."* This
+  // read `|| held` until then, the AFFORDANCE half of #2090's refusal, whose
+  // enforcing half lived in `resolveDrop`. Both went in the same change, and
+  // they have to: leaving this one would keep the card from ever reporting
+  // `isOver`, so a drop the resolver now accepts could never be aimed at it.
   //
   // Read through `writeInEntries` rather than as an inline
   // `family_available_override === false`, which is what this was until
@@ -438,10 +440,15 @@ export function LodgingUnitCard({
   // 2026 building that carries four — and each entry pairs the occupant with
   // the row that holds it, so the card's own X can name that row and no other.
   const writeIns = writeInEntries(unit)
-  const held = writeIns.length > 0
+  // Renamed from `held` with kindred#2432, and the rename is the point: this
+  // says WHO IS IN IT and no longer says the space is shut. Every surviving
+  // reader below is one that genuinely wants "somebody is already in this
+  // room" — the em-dash occupancy figure and the open-space to-do tint — and
+  // none of them is a refusal.
+  const writtenInto = writeIns.length > 0
   const { setNodeRef: setUnitDropRef, isOver: isUnitOver } = useDroppable({
     id: unitDroppableId(unit.code),
-    disabled: !canPlace || mergeDragActive || held,
+    disabled: !canPlace || mergeDragActive,
   })
 
   const setCardRef = (node: HTMLDivElement | null) => {
@@ -511,31 +518,46 @@ export function LodgingUnitCard({
   // suppressed the instant this card becomes an active drop target, same as
   // the old wash was.
   //
-  // `!held` is the second gate, and it is not cosmetic: EMPTY and
-  // OPEN are different predicates and this is where they part. A write-in
-  // blocks placement outright (`held` above; `dragPlacement.ts` refuses the
-  // drop), so a written-into cabin has no family in it and can take none.
-  // That was harmless while the empty treatment was a neutral grey wash, but
-  // the forest tint says "the remaining work is here" — and the marker is the
-  // to-do list. Painting such a cabin forest sends staff at the one room they
-  // may not fill. The dashed EDGE still applies to it, being structural
-  // rather than an invitation.
+  // `!writtenInto` is the second gate, and it SURVIVES kindred#2432 on a
+  // reason that changed underneath it — which is exactly the kind of gate that
+  // gets deleted by accident, so read this before touching it.
+  //
+  // It used to mean *this cabin may not be filled*: a write-in refused
+  // placement outright, so painting it forest sent staff at the one room they
+  // could not use. That reason is gone — a written-into cabin now takes a
+  // family like any other. What remains is the predicate this gate was always
+  // really about: EMPTY and OPEN are different questions, and a room somebody
+  // is already sleeping in is not empty. The tint says "the remaining work is
+  // HERE", and a cabin with an occupant in its well is not where the remaining
+  // work is, even though a second party may now join them.
+  //
+  // The dashed EDGE still applies to it, being structural rather than an
+  // invitation, and that split is unchanged.
   //
   // Keyed on the OCCUPANT SIGNAL, never on the occupant's NAME being filled
-  // in: a write-in nobody named still closes the room, and gating on the name
-  // would hand exactly that room back to the to-do marker.
-  const openMarkerActive = dashed && !held && ringState !== 'dropTarget'
+  // in: a write-in nobody named still puts somebody in the room, and gating on
+  // the name would hand exactly that room back to the to-do marker.
+  const openMarkerActive = dashed && !writtenInto && ringState !== 'dropTarget'
 
   /*
    * The corner figure, and the sentence behind it (kindred#2078).
    *
    * A write-in with nobody else in the room reports the em dash rather than a
    * count: it occupies wholesale and has no party size, so any digit here
-   * would assert something nobody recorded. A card that somehow carries BOTH a
-   * write-in and a placement keeps the placement count — that is a real number
-   * about real people, and the card should not go quiet about them.
+   * would assert something nobody recorded. A card carrying BOTH a write-in and
+   * a placement keeps the placement count — that is a real number about real
+   * people, and the card should not go quiet about them.
+   *
+   * ⚠️ THAT SECOND CASE IS ROUTINE SINCE kindred#2432 and was a legacy-row
+   * curiosity before it, and the number it prints UNDERSTATES a shared space:
+   * `lodging_write_ins` carries `occupant_name` and `note` and no count, so the
+   * write-in's own party contributes nothing here and the free-bed figure reads
+   * high. Filed as kindred#2439 (optional write-in headcount) and ruled an
+   * optional investigation rather than a blocker — an understated count on a
+   * space staff can share beats a space they could not share at all. Do not
+   * "fix" it by guessing a headcount here.
    */
-  const wholesaleWriteIn = held && occupants === 0
+  const wholesaleWriteIn = writtenInto && occupants === 0
   const occupancyFigure = wholesaleWriteIn ? '—' : String(occupants)
 
   /*
@@ -617,32 +639,37 @@ export function LodgingUnitCard({
   /*
    * Whether this card offers to place a family from itself (kindred#2080).
    *
-   * ABSENT, NOT DIMMED, in every negative case — mirroring how Hold itself
-   * vanishes on an occupied card rather than greying out. That is a signal
-   * decision, not a style one: under the board's ruled vocabulary
-   * (2026-08-09) `opacity-40` MEANS refusal and is spoken for by the invalid
-   * merge target and by a held space. An absent control adds no fifth
-   * meaning to any channel.
+   * ABSENT, NOT DIMMED, in every negative case. That is a signal decision, not
+   * a style one: under the board's ruled vocabulary (2026-08-09) `opacity-40`
+   * MEANS refusal and is spoken for by the invalid merge target. An absent
+   * control adds no fifth meaning to any channel.
    *
-   * The four gates, and why each is a gate rather than a fit judgement:
+   * THREE gates since kindred#2432, and why each is a gate rather than a fit
+   * judgement:
    *
-   *   - `held` — a hold blocks placement outright (#2087/#2090), and
-   *     `resolveDrop` refuses the write. Offering the control would name an
-   *     action that writes nothing.
-   *   - occupied — Hold's own rule, and the same reasoning: the card that
-   *     already holds a family is not the card staff are looking to fill.
-   *     A SECOND family still reaches a shareable space by drag, which
-   *     remains the path for a share that has to be looked at deliberately.
+   *   - `parties.length === 0` — the card that already holds a family is not
+   *     the card staff are looking to fill. A SECOND family still reaches a
+   *     shareable space by drag, which remains the path for a share that has to
+   *     be looked at deliberately, and #2091 (marking a space that holds two
+   *     families) is unbuilt, so nothing here should invent that treatment.
    *   - `isSplitContainer` — `resolveDrop` rejects one as a target, and it
    *     gets no card anyway; belt-and-braces, exactly as `sharing` above.
    *   - no writer / no `canPlace` — no scenario, or no `bunking.manage`.
+   *
+   * ⚠️ A FOURTH GATE, `!held`, was struck by kindred#2432 and must not come
+   * back. It said "a hold blocks placement outright (#2087/#2090), so offering
+   * the control would name an action that writes nothing" — true only while
+   * `resolveDrop` refused a written-into space, which it no longer does. This
+   * picker has NO rules of its own by design (`resolvePickerPlacement` is a
+   * thin adapter), so a gate here that the resolver does not share is the exact
+   * drift that design exists to prevent.
    *
    * NOT gated on the list being empty. "Everyone has a cabin" is a real
    * answer to the question the control asks, and the picker says it; hiding
    * the control instead would leave staff wondering where it went.
    */
   const canPickFamily =
-    canPlace && onPlaceParty !== undefined && !held && !isSplitContainer && parties.length === 0
+    canPlace && onPlaceParty !== undefined && !isSplitContainer && parties.length === 0
 
   const cardStateClassName = [
     RING_CLASSES[ringState],
@@ -665,8 +692,8 @@ export function LodgingUnitCard({
   // Deliberately reuses `openMarkerActive` rather than bare `dashed`: the
   // owner ruling frames the tint as ONE resting-state signal, and a title
   // that stayed bold forest while the background wash had already stood down
-  // — for an active drop target, or for a held room — would be the two halves
-  // of the same mark silently drifting apart.
+  // — for an active drop target, or for a room somebody is written into —
+  // would be the two halves of the same mark silently drifting apart.
   const openTitleClassName = openMarkerActive
     ? 'text-primary font-bold'
     : 'text-foreground font-semibold'
@@ -839,7 +866,6 @@ export function LodgingUnitCard({
         <UnitAvailabilityControl
           unit={unit}
           canManage={canSetAvailability && onSetAvailability !== undefined}
-          occupied={parties.length > 0}
           isSaving={savingAvailability}
           onSubmit={(write) => {
             onSetAvailability?.(write)
@@ -961,9 +987,22 @@ export function LodgingUnitCard({
       <div className="flex min-h-[100px] flex-1 flex-col gap-2">
         {/* A write-in, drawn where the board draws occupancy (kindred#2078).
             FIRST and unconditionally, never in an either/or with the parties
-            below: a card carrying both is not a state any writer produces
-            (#2090 rules the two mutually exclusive), but if a legacy row ever
-            does, hiding one of them would drop somebody from the board. */}
+            below. That was defensive when it was written — #2090 ruled the two
+            mutually exclusive, so a card carrying both was only reachable
+            through a legacy row — and kindred#2432 makes it the ROUTINE state:
+            a paper registration recorded as a write-in, sharing the cabin with
+            a placed CampMinder family.
+
+            ⚠️ THIS IS #2091'S VISUAL PRECEDENT, deliberately and by default.
+            "Mark a space that holds two families the way the master housing
+            sheet does" is unbuilt, so whatever a shared well looks like here is
+            what it will look like there. The chosen form is the most
+            conservative one available: ONE well, the occupants stacked in the
+            order they already stack, NO divider, NO new chip, NO new colour —
+            the existing `WriteInCard` and `FamilyCard` frames unchanged. A
+            shared space is not a new KIND of card; it is a card with two
+            occupants in it. If #2091 later wants a shared-space treatment it
+            should EXTEND this rather than contradict it. */}
         {writeIns.map((entry) => (
           <WriteInCard
             key={entry.source.unitId}
@@ -1014,7 +1053,13 @@ export function LodgingUnitCard({
             isSaving={savingAvailability}
           />
         ))}
-        {parties.length === 0 && !held ? (
+        {/* The invitation, and it stands down for a write-in even though the
+            card now accepts a drop: the well is not EMPTY — a `WriteInCard` is
+            sitting in it — and "Drop families here" under a named occupant
+            describes the wrong space. The card is still a live drop target;
+            the placeholder is about what the well contains, not about what the
+            card will accept. */}
+        {parties.length === 0 && !writtenInto ? (
           /* Summer's wording in family vocabulary — `BunkCard` says "Drop
              campers here". An empty slot's job is to be a target, and "Empty"
              described the state without offering the action.

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -968,6 +968,13 @@ export function LodgingUnitCard({
           <WriteInCard
             key={entry.source.unitId}
             occupant={entry.occupant}
+            // WHOSE row it is, and undefined whenever it is this card's own —
+            // so the common case says nothing extra. Restored during review of
+            // kindred#2381: a merged container's well can hold four occupants
+            // sleeping in four DIFFERENT rooms, and a split building's rooms
+            // each draw a card for the one row the building holds, so without
+            // this a name in the well names no space at all.
+            atUnitName={entry.source.isOwn ? undefined : entry.source.unitName}
             // BOUND TO THIS ROW, which is the whole point of the per-card X:
             // the strip's single "Clear Write-in" named whichever row the
             // server resolved first, so on a merged building a click removed

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -659,10 +659,19 @@ export function LodgingUnitCard({
    * ⚠️ A FOURTH GATE, `!held`, was struck by kindred#2432 and must not come
    * back. It said "a hold blocks placement outright (#2087/#2090), so offering
    * the control would name an action that writes nothing" — true only while
-   * `resolveDrop` refused a written-into space, which it no longer does. This
-   * picker has NO rules of its own by design (`resolvePickerPlacement` is a
-   * thin adapter), so a gate here that the resolver does not share is the exact
-   * drift that design exists to prevent.
+   * `resolveDrop` refused a written-into space, which it no longer does.
+   * `resolvePickerPlacement` is a thin adapter over `resolveDrop`, so a gate
+   * here that RESTATES a refusal the resolver makes is the drift that design
+   * exists to prevent, and a gate that CONTRADICTS one is worse still.
+   *
+   * `parties.length === 0` is neither, and the distinction is the one to hold
+   * on to before reading the rule above as licence to delete it: the resolver
+   * ACCEPTS a second family onto an occupied card, and so does the drag. This
+   * gate does not refuse that placement — it declines to OFFER it from a
+   * surface whose question is "which family goes in this empty space", leaving
+   * the deliberate path (drag) intact. A gate that removes an affordance
+   * without removing an outcome is a scoping choice; only a gate that changes
+   * what the board will accept would be the drift.
    *
    * NOT gated on the list being empty. "Everyone has a cabin" is a real
    * answer to the question the control asks, and the picker says it; hiding

--- a/frontend/src/components/weekend/MapUnitPopover.test.tsx
+++ b/frontend/src/components/weekend/MapUnitPopover.test.tsx
@@ -185,7 +185,7 @@ describe('MapUnitPopover — one room', () => {
         units={[
           mapUnit(
             row({
-              write_in: cover(),
+              write_ins: [cover()],
               occupant_name: 'Emma Johnson',
               is_family_available: false,
             })
@@ -526,7 +526,7 @@ describe('MapUnitPopover — a cluster of rooms', () => {
           unit_id: 'u2',
           code: 'cedar-2',
           name: 'Cedar 2',
-          write_in: cover({ unit_id: 'u2', unit_code: 'cedar-2', unit_name: 'Cedar 2' }),
+          write_ins: [cover({ unit_id: 'u2', unit_code: 'cedar-2', unit_name: 'Cedar 2' })],
           is_family_available: false,
           is_active: false,
         })
@@ -954,7 +954,7 @@ describe('MapUnitPopover — the whole-building marker, extended from the board 
         units={[
           mapUnit(
             row({
-              write_in: cover(),
+              write_ins: [cover()],
               occupant_name: 'Emma Johnson',
               is_family_available: false,
             }),

--- a/frontend/src/components/weekend/UnitAvailabilityControl.test.tsx
+++ b/frontend/src/components/weekend/UnitAvailabilityControl.test.tsx
@@ -88,7 +88,6 @@ function renderControl(props: Partial<React.ComponentProps<typeof UnitAvailabili
     <UnitAvailabilityControl
       unit={unit()}
       canManage
-      occupied={false}
       isSaving={false}
       onSubmit={onSubmit}
       {...props}
@@ -106,18 +105,19 @@ describe('UnitAvailabilityControl', () => {
     expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 
-  it('offers nothing to write into an OCCUPIED unit — a write-in and a placement are mutually exclusive (#2090)', () => {
-    // A space that already has a family assigned may not also be marked
-    // held. `occupied` is a fact from the slot's own parties, kept separate
-    // from `canManage`'s permission gate — folding it in there would
-    // resurrect the scenario dimension 1500000135 deleted.
-    renderControl({ occupied: true })
-
-    expect(screen.queryByRole('button')).not.toBeInTheDocument()
-  })
-
-  it('still offers to write into an unoccupied unit (regression guard)', () => {
-    renderControl({ occupied: false })
+  it('takes no occupancy fact at all, so it cannot refuse on one (#2432)', () => {
+    /*
+     * This carried an `occupied` prop until kindred#2432, forwarded straight
+     * into `availabilityAction`, and returned nothing when it was true —
+     * #2090's rule that a write-in and a placement were mutually exclusive.
+     *
+     * Owner ruling 2026-08-18 reversed it in both directions, so the prop is
+     * GONE rather than ignored: a caller with an occupancy fact to hand cannot
+     * spell it here. The occupied-card behaviour is pinned where the fact
+     * actually lives — `LodgingUnitCard.test.tsx`, "the shared occupant well
+     * (#2432)" — because this component no longer has an input for it.
+     */
+    renderControl()
 
     expect(screen.getByRole('button', { name: /write in/i })).toBeInTheDocument()
   })
@@ -392,13 +392,13 @@ describe('UnitAvailabilityControl', () => {
     })
   })
 
-  it('still offers nothing on a MERGED building that holds a family (#2090)', () => {
-    renderControl({
-      unit: unit({ is_container: true, is_combined: true }),
-      occupied: true,
-    })
+  it('offers a write-in on a MERGED building (#2432)', () => {
+    // Occupancy no longer reaches this control, so a combined building offers
+    // the action whether or not a family is placed in it. The card-level pin
+    // for the occupied half is in `LodgingUnitCard.test.tsx`.
+    renderControl({ unit: unit({ is_container: true, is_combined: true }) })
 
-    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /write in/i })).toBeInTheDocument()
   })
 
   it('abandons BOTH fields when the form is cancelled', async () => {

--- a/frontend/src/components/weekend/UnitAvailabilityControl.test.tsx
+++ b/frontend/src/components/weekend/UnitAvailabilityControl.test.tsx
@@ -76,7 +76,7 @@ function cover(overrides: Partial<WriteInCoverRow> = {}): WriteInCoverRow {
 }
 
 const WRITTEN_IN_CABIN = unit({
-  write_in: cover(),
+  write_ins: [cover()],
   occupant_name: 'Emma Johnson',
   reason: '',
   is_family_available: false,
@@ -291,28 +291,17 @@ describe('UnitAvailabilityControl', () => {
     expect(screen.queryByText(/say who is in it/i)).not.toBeInTheDocument()
   })
 
-  it('clears a write-in in one click, writing null rather than a value that agrees, and names what it clears (#2252)', async () => {
-    // `null` DELETES the row. Writing "available" onto a family cabin instead
-    // would pin it against a later change to its role -- the reversal-encoding
-    // failure spec §5.4 rejected, arriving through the UI.
-    //
-    // The exact button name is the assertion: kindred#2252 dropped the
-    // redundant "Write-in" chip from `LodgingUnitCard`'s badge row, which
-    // made this the only thing on the card saying what a click removes. A
-    // bare "Clear" would pass the loose `/clear/i` query this used to use.
-    const user = userEvent.setup()
-    const { onSubmit } = renderControl({ unit: WRITTEN_IN_CABIN })
+  it('offers NOTHING on a written-into cabin — the removal is the X on its card', () => {
+    // kindred#2381, superseding #2252's "Clear Write-in" label here. That
+    // button named whichever row the server resolved first, which was sound
+    // only while a card could carry one write-in. A merged container covers
+    // every write-in beneath it, so one button had four rows to choose from:
+    // each click destroyed the row it named, the card re-populated with the
+    // next occupant, and the action read as a no-op. Each `WriteInCard` owns
+    // its own removal now.
+    renderControl({ unit: WRITTEN_IN_CABIN })
 
-    await user.click(screen.getByRole('button', { name: 'Clear Write-in Cedar 1' }))
-
-    expect(onSubmit).toHaveBeenCalledWith({
-      unitId: 'u1',
-      unitName: 'Cedar 1',
-      familyAvailable: null,
-      occupantName: '',
-      reason: '',
-    })
-    expect(screen.queryByRole('textbox', { name: /^occupant$/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 
   it('leaves a write-in\u2019s note to the occupant card and prints no italic line of its own', () => {
@@ -323,7 +312,7 @@ describe('UnitAvailabilityControl', () => {
     // on one card, which is the double-print 1500000148 was written to avoid.
     renderControl({
       unit: unit({
-        write_in: cover({ note: 'Back Monday' }),
+        write_ins: [cover({ note: 'Back Monday' })],
         occupant_name: 'Emma Johnson',
         reason: 'Back Monday',
         is_family_available: false,
@@ -357,9 +346,12 @@ describe('UnitAvailabilityControl', () => {
 
   it('does not offer a second write while this unit is being written', async () => {
     const user = userEvent.setup()
-    const { onSubmit } = renderControl({ unit: WRITTEN_IN_CABIN, isSaving: true })
+    const { onSubmit } = renderControl({
+      unit: unit({ family_available_override: true }),
+      isSaving: true,
+    })
 
-    await user.click(screen.getByRole('button', { name: 'Clear Write-in Cedar 1' }))
+    await user.click(screen.getByRole('button', { name: 'Clear Cedar 1' }))
 
     expect(onSubmit).not.toHaveBeenCalled()
   })
@@ -431,38 +423,28 @@ describe('a write-in this unit inherited from elsewhere in the tree', () => {
   /*
    * The row names one unit; it closes a SPACE. Split a written-into building
    * and its rooms inherit the write-in — and the building, having no card any
-   * more, has nowhere to offer the clear from. So the inheriting card offers
-   * it, and the write has to name the unit that HOLDS the row: sending this
-   * card's own id would delete nothing.
+   * more, has nowhere to offer a removal from. The inheriting CARD carries it,
+   * as the X on the `WriteInCard` it draws in its well (kindred#2381); this
+   * strip resolves ROLE rows only and stays out of it.
    */
   const ROOM_UNDER_A_WRITTEN_IN_HOUSE = unit({
     unit_id: 'u-room',
     code: 'house-a',
     name: 'House A',
-    write_in: {
-      unit_id: 'u-house',
-      unit_code: 'house',
-      unit_name: 'House',
-      occupant_name: 'Liam Garcia',
-      note: '',
-    },
+    write_ins: [
+      {
+        unit_id: 'u-house',
+        unit_code: 'house',
+        unit_name: 'House',
+        occupant_name: 'Liam Garcia',
+        note: '',
+      },
+    ],
   })
 
-  it('offers to clear it, labelled "Clear Write-in" and naming the unit that actually holds the row (#2252)', async () => {
-    // The button reads on the INHERITING card ("House A"), and the label is
-    // still "Clear Write-in" there — the relabel is keyed on what the action
-    // clears, not on whose own row it happens to be.
-    const user = userEvent.setup()
-    const { onSubmit } = renderControl({ unit: ROOM_UNDER_A_WRITTEN_IN_HOUSE })
+  it('offers no strip action at all, rather than one that names a row out of several', () => {
+    renderControl({ unit: ROOM_UNDER_A_WRITTEN_IN_HOUSE })
 
-    await user.click(screen.getByRole('button', { name: 'Clear Write-in House A' }))
-
-    expect(onSubmit).toHaveBeenCalledWith({
-      unitId: 'u-house',
-      unitName: 'House',
-      familyAvailable: null,
-      occupantName: '',
-      reason: '',
-    })
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/weekend/UnitAvailabilityControl.tsx
+++ b/frontend/src/components/weekend/UnitAvailabilityControl.tsx
@@ -41,6 +41,17 @@
  * and have no way to learn who is in it. Clearing asks for neither: it restores
  * the unit's standing role rather than asserting anything.
  *
+ * ## What this control no longer does
+ *
+ * REMOVE A WRITE-IN. Until kindred#2381 it offered a "Clear Write-in" naming
+ * whichever row the server resolved first, which held only while a card could
+ * carry one. A merged container covers every write-in beneath it, so one
+ * button had four rows to choose from and picked silently: each click removed
+ * the row it named, the card re-populated with the next occupant, and the
+ * action read as a no-op while it worked through them. Removal is the X on
+ * each `WriteInCard` now, and `availabilityAction` returns null for a
+ * written-into space rather than a clear this control could offer.
+ *
  * ## Why no italic line under the badge row any more
  *
  * It used to print `unit.reason` there for every override. Since kindred#2078 a
@@ -61,12 +72,14 @@ export interface UnitAvailabilityWrite {
    *
    * A write-in covers a space and the board draws whichever level the unit
    * tree resolves to, so a room can inherit its building's write-in and a
-   * merged building one of its rooms'. There is one `lodging_write_ins` row
-   * either way (kindred#2382 moved occupancy off `lodging_availability`, which
-   * now answers only the staff↔family role), and clearing it has to target the
-   * unit that HOLDS it — the card's own id would delete nothing, and the unit
-   * holding the row has no card to offer the clear from. `availabilityAction`
-   * resolves which; this only carries it.
+   * merged building one of its rooms'. Removing one has to target the unit
+   * that HOLDS the row — the card's own id would delete nothing, and the unit
+   * holding the row has no card of its own.
+   *
+   * TWO CALLERS SINCE kindred#2381, and only one of them is this control.
+   * `availabilityAction` resolves a ROLE row and always names the card's own
+   * unit; each `WriteInCard`'s corner X sends this same write bound to the row
+   * that card draws. The field carries the target either way.
    */
   unitId: string
   /** That unit's name, for the confirmation toast. */

--- a/frontend/src/components/weekend/UnitAvailabilityControl.tsx
+++ b/frontend/src/components/weekend/UnitAvailabilityControl.tsx
@@ -41,6 +41,21 @@
  * and have no way to learn who is in it. Clearing asks for neither: it restores
  * the unit's standing role rather than asserting anything.
  *
+ * ## What this control no longer REFUSES
+ *
+ * A SPACE THAT ALREADY HOLDS A FAMILY — kindred#2432, owner ruling 2026-08-18:
+ * *"we should be able to add families to any write in space, or add a write in
+ * to a family space — regardless of which came first."* This carried an
+ * `occupied` prop until then, forwarded straight into `availabilityAction`
+ * under #2090's rule that a write-in and a placement were mutually exclusive
+ * states. The prop is GONE rather than ignored: the one case staff asked for is
+ * a paper registration — recordable ONLY as a write-in, since it has no
+ * CampMinder record — sharing a cabin with one placed CampMinder family, and a
+ * control that vanished on an occupied card refused exactly that.
+ *
+ * A write-in NAMES AN OCCUPANT. It does not CLOSE THE SPACE, which is why
+ * `dragPlacement` gives up the mirror-image refusal in the same change.
+ *
  * ## What this control no longer does
  *
  * REMOVE A WRITE-IN. Until kindred#2381 it offered a "Clear Write-in" naming
@@ -109,15 +124,6 @@ export interface UnitAvailabilityControlProps {
    * the board it was made on — see `useUnitAvailability`.
    */
   canManage: boolean
-  /**
-   * Whether the slot this unit sits in already holds a party this scenario —
-   * a fact read off the CARD, never off availability itself. Owner ruling on
-   * #2090: a write-in and a placement are mutually exclusive states, so an
-   * occupied unit offers no write-in action. Kept separate from `canManage`:
-   * folding occupancy into the permission gate would resurrect the scenario
-   * dimension 1500000135 deleted.
-   */
-  occupied: boolean
   /** True while THIS unit's write is in flight. */
   isSaving: boolean
   onSubmit: (write: UnitAvailabilityWrite) => void
@@ -126,7 +132,6 @@ export interface UnitAvailabilityControlProps {
 export function UnitAvailabilityControl({
   unit,
   canManage,
-  occupied,
   isSaving,
   onSubmit,
 }: UnitAvailabilityControlProps) {
@@ -138,7 +143,7 @@ export function UnitAvailabilityControl({
   const [note, setNote] = useState('')
   const [isOpen, setIsOpen] = useState(false)
   const [wantsRequired, setWantsRequired] = useState(false)
-  const action = availabilityAction(unit, occupied)
+  const action = availabilityAction(unit)
 
   const close = () => {
     setIsOpen(false)

--- a/frontend/src/components/weekend/WriteInCard.test.tsx
+++ b/frontend/src/components/weekend/WriteInCard.test.tsx
@@ -62,6 +62,20 @@ describe('WriteInCard', () => {
     expect(container.querySelector('[draggable="true"]')).toBeNull()
   })
 
+  it('wraps a long occupant name instead of truncating it (kindred#2431)', () => {
+    // Owner ruling, 2026-08-18: WRAP, following the #2253 precedent — a
+    // truncated name is not a shorter name, it is a different one, and two
+    // write-ins sharing a prefix would render identically.
+    render(<WriteInCard occupant={{ name: 'Alexandra Vandenberg-Okonkwo', note: '' }} />)
+
+    const nameSpan = screen.getByText('Alexandra Vandenberg-Okonkwo')
+    expect(nameSpan.className).not.toMatch(/\btruncate\b/)
+    // `min-w-0` STAYS: it is what lets the flex child shrink below its
+    // content width, which is what makes it wrap rather than overflow the
+    // card (same reasoning `HouseholdJourneyCard` records for its own span).
+    expect(nameSpan.className).toMatch(/\bmin-w-0\b/)
+  })
+
   it("wears FamilyCard's frame verbatim, so the two cannot drift apart", () => {
     // A SOURCE assertion, not a rendered one, and deliberately so. `CARD_FRAME`
     // is module-private to `FamilyCard.tsx` and that file is owned by another
@@ -122,16 +136,148 @@ describe('the corner control that removes THIS write-in', () => {
     expect(onRemove).toHaveBeenCalledTimes(1)
   })
 
-  it('is disabled while the removal is in flight', () => {
+  it('is disabled while a write to this row is in flight', () => {
+    // RENAMED from `isRemoving` (kindred#2430): the flag now gates the edit
+    // pencil too, since both controls write the same row.
     render(
       <WriteInCard
         occupant={{ name: 'Liam Garcia', note: '' }}
         onRemove={() => undefined}
-        isRemoving
+        onEdit={() => undefined}
+        isSaving
       />
     )
 
     expect(screen.getByRole('button', { name: 'Remove write-in Liam Garcia' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Edit write-in Liam Garcia' })).toBeDisabled()
+  })
+})
+
+describe('the corner control that edits THIS write-in (kindred#2430)', () => {
+  /*
+   * Owner ruling, 2026-08-18 (supersedes an earlier same-day HOLD): a small
+   * pencil, ALWAYS VISIBLE, beside #2381's X — not shown only on hover
+   * (staff could not find the edit path in the first place, so a hidden
+   * control does not fix that) and not click-the-card (`WriteInCard.tsx:18`
+   * documents the card as deliberately not a button; a discrete control
+   * preserves that rather than reversing it).
+   *
+   * No API change: `set_availability` already upserts a write-in's row
+   * (`_upsert_row(what='write-in', ...)` in
+   * `api/services/lodging_write_service.py`), so a second write to the same
+   * row updates it in place. This control only has to collect the edit and
+   * send the same shape `UnitAvailabilityControl`'s occupant prompt does.
+   */
+  it('is absent when the reader cannot edit', () => {
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} />)
+
+    expect(screen.queryByRole('button', { name: /edit write-in/i })).not.toBeInTheDocument()
+  })
+
+  it('renders beside the X with no hover-only class — ALWAYS visible', () => {
+    render(
+      <WriteInCard
+        occupant={{ name: 'Liam Garcia', note: '' }}
+        onRemove={() => undefined}
+        onEdit={() => undefined}
+      />
+    )
+
+    const pencil = screen.getByRole('button', { name: 'Edit write-in Liam Garcia' })
+    // A hover-reveal control would still be IN the DOM (CSS hides it), so
+    // presence alone cannot tell the two apart — the className has to be
+    // checked for the classes that would make it hover-only.
+    expect(pencil.className).not.toMatch(/opacity-0/)
+    expect(pencil.className).not.toMatch(/group-hover/)
+    expect(screen.getByRole('button', { name: 'Remove write-in Liam Garcia' })).toBeInTheDocument()
+  })
+
+  it('still offers an edit for a write-in nobody named', () => {
+    render(<WriteInCard occupant={{ name: '', note: '' }} onEdit={() => undefined} />)
+
+    expect(
+      screen.getByRole('button', { name: 'Edit write-in Occupant not named' })
+    ).toBeInTheDocument()
+  })
+
+  it('opens an inline form pre-filled with the occupant and note already on the row', () => {
+    render(
+      <WriteInCard
+        occupant={{ name: 'Liam Garcia', note: 'Kitchen lead, Fri–Sun' }}
+        onEdit={() => undefined}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit write-in Liam Garcia' }))
+
+    expect(screen.getByRole('textbox', { name: 'Occupant' })).toHaveValue('Liam Garcia')
+    expect(screen.getByRole('textbox', { name: 'Note (optional)' })).toHaveValue(
+      'Kitchen lead, Fri–Sun'
+    )
+  })
+
+  it('calls back once with the trimmed occupant and note, and closes the form', () => {
+    const onEdit = vi.fn()
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} onEdit={onEdit} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit write-in Liam Garcia' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Occupant' }), {
+      target: { value: '  Liam Garcia-Reyes  ' },
+    })
+    fireEvent.change(screen.getByRole('textbox', { name: 'Note (optional)' }), {
+      target: { value: 'Back Monday' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(onEdit).toHaveBeenCalledTimes(1)
+    expect(onEdit).toHaveBeenCalledWith({
+      occupantName: 'Liam Garcia-Reyes',
+      reason: 'Back Monday',
+    })
+    expect(screen.queryByRole('textbox', { name: 'Occupant' })).not.toBeInTheDocument()
+  })
+
+  it('refuses an empty occupant name, the same guard the write-in prompt uses', () => {
+    const onEdit = vi.fn()
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} onEdit={onEdit} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit write-in Liam Garcia' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Occupant' }), { target: { value: '  ' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(onEdit).not.toHaveBeenCalled()
+    expect(screen.getByRole('textbox', { name: 'Occupant' })).toBeInTheDocument()
+  })
+
+  it('lets Cancel close the form without writing anything', () => {
+    const onEdit = vi.fn()
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} onEdit={onEdit} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit write-in Liam Garcia' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Occupant' }), {
+      target: { value: 'Somebody Else' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(onEdit).not.toHaveBeenCalled()
+    expect(screen.queryByRole('textbox', { name: 'Occupant' })).not.toBeInTheDocument()
+    // The original label is still what the card prints — nothing was
+    // written, so nothing changed.
+    expect(screen.getByText('Liam Garcia')).toBeInTheDocument()
+  })
+
+  it('re-opens pre-filled from the CURRENT row, not a stale draft left over from a cancelled edit', () => {
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} onEdit={() => undefined} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit write-in Liam Garcia' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Occupant' }), {
+      target: { value: 'Abandoned Draft' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit write-in Liam Garcia' }))
+
+    expect(screen.getByRole('textbox', { name: 'Occupant' })).toHaveValue('Liam Garcia')
   })
 })
 

--- a/frontend/src/components/weekend/WriteInCard.test.tsx
+++ b/frontend/src/components/weekend/WriteInCard.test.tsx
@@ -6,8 +6,8 @@
 import { readFileSync } from 'fs'
 import { resolve } from 'path'
 
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
 
 import { WriteInCard, WRITE_IN_FRAME } from './WriteInCard'
 
@@ -51,10 +51,11 @@ describe('WriteInCard', () => {
     expect(container.querySelector('[data-family-card]')).toBeNull()
   })
 
-  it('is not draggable and is not a button', () => {
+  it('is not draggable, and the CARD itself is never a button', () => {
     // `FamilyCard` is a `<button>` that opens the family panel and a dnd-kit
     // draggable. There is no panel behind a write-in and nowhere to drag it —
-    // a control that looks interactive and is not is worse than plain text.
+    // a card that looks interactive and is not is worse than plain text. The
+    // corner control below is a real button; the card body stays inert.
     const { container } = render(<WriteInCard occupant={{ name: 'Emma Johnson', note: '' }} />)
 
     expect(screen.queryByRole('button')).not.toBeInTheDocument()
@@ -75,24 +76,76 @@ describe('WriteInCard', () => {
   })
 })
 
-describe('a write-in the card INHERITED from elsewhere in the tree', () => {
+describe('the corner control that removes THIS write-in', () => {
   /*
-   * The row names one unit; it closes a SPACE. Split a written-into building
-   * and its rooms carry the occupant; merge over a written-into room and the
-   * building does. Printing the name alone on the inheriting card would say
-   * this room's own row names them — and staff would go looking on a card that
-   * no longer exists for the Clear that is right in front of them.
+   * Owner ruling, 2026-08-18 (kindred#2381 part 4): a small X in each card's
+   * top-right, one per write-in — not a row of full "Clear Write-in" buttons,
+   * which was refused, and not one control for a well that may hold four.
+   *
+   * It is what makes the plural card safe. The single control it replaces
+   * named whichever row the server resolved first, so on a merged building
+   * carrying four write-ins a click removed one, the card re-populated with
+   * the next occupant, and the action read as a no-op — four clicks destroyed
+   * four rows with nothing ever disclosing that more than one existed.
    */
-  it('says which unit the write-in is recorded at', () => {
-    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} atUnitName="House" />)
+  it('is absent when the reader cannot remove anything', () => {
+    // No `bunking.manage`, and therefore no handler. A control that does
+    // nothing is worse than no control.
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} />)
 
-    expect(screen.getByText('Written in at House')).toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 
-  it('says nothing extra when the row is the card’s own', () => {
-    // The overwhelmingly common case, and the one that must stay quiet: a line
-    // on every written-into card restating the card's own name is chrome.
-    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} />)
+  it('names the occupant it would remove, so four of them are four questions', () => {
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} onRemove={() => undefined} />)
+
+    expect(screen.getByRole('button', { name: 'Remove write-in Liam Garcia' })).toBeInTheDocument()
+  })
+
+  it('still offers a removal for a write-in nobody named', () => {
+    render(<WriteInCard occupant={{ name: '', note: '' }} onRemove={() => undefined} />)
+
+    expect(
+      screen.getByRole('button', { name: 'Remove write-in Occupant not named' })
+    ).toBeInTheDocument()
+  })
+
+  it('calls back exactly once, with no argument to get wrong', () => {
+    // The CARD knows which row it draws; the caller binds the target. Passing
+    // an id up from here would be a second place that has to agree about
+    // which of the four rows this card is.
+    const onRemove = vi.fn()
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} onRemove={onRemove} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove write-in Liam Garcia' }))
+
+    expect(onRemove).toHaveBeenCalledTimes(1)
+  })
+
+  it('is disabled while the removal is in flight', () => {
+    render(
+      <WriteInCard
+        occupant={{ name: 'Liam Garcia', note: '' }}
+        onRemove={() => undefined}
+        isRemoving
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Remove write-in Liam Garcia' })).toBeDisabled()
+  })
+})
+
+describe('the "Written in at …" footer', () => {
+  /*
+   * DELETED — kindred#2381. It existed to tell a reader that the row lives on
+   * a different unit than the card drawing it, which mattered only because a
+   * merged card showed ONE write-in and hid the rest: staff would go looking
+   * for the Clear on a card the merge had taken away. Every write-in is drawn
+   * now, and each carries its own removal, so the note says nothing the screen
+   * does not.
+   */
+  it('is not printed, on an inherited row or any other', () => {
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} onRemove={() => undefined} />)
 
     expect(screen.queryByText(/written in at/i)).not.toBeInTheDocument()
   })

--- a/frontend/src/components/weekend/WriteInCard.test.tsx
+++ b/frontend/src/components/weekend/WriteInCard.test.tsx
@@ -90,6 +90,52 @@ describe('WriteInCard', () => {
   })
 })
 
+describe('a write-in the card INHERITED from elsewhere in the tree', () => {
+  /*
+   * The row names one unit; it closes a SPACE. Split a written-into building
+   * and its rooms carry the occupant; merge over a written-into room and the
+   * building does.
+   *
+   * RESTORED during review of kindred#2381, which deleted this line along with
+   * the strip's single "Clear Write-in". Only one of the two reasons it carried
+   * died with that button — "go and find the Clear on a card the merge took
+   * away". The other is identity, and the plural well sharpens it: four
+   * occupants in one merged well sleep in four different rooms, and every room
+   * of a SPLIT building draws a card for the one row the building holds, so
+   * each card's X empties all the others.
+   */
+  it('says which unit the write-in is recorded at', () => {
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} atUnitName="House" />)
+
+    expect(screen.getByText('Written in at House')).toBeInTheDocument()
+  })
+
+  it('says nothing extra when the row is the card\u2019s own', () => {
+    // The overwhelmingly common case, and the one that must stay quiet: a line
+    // on every written-into card restating the card's own name is chrome.
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} />)
+
+    expect(screen.queryByText(/^Written in at/)).not.toBeInTheDocument()
+  })
+
+  it('keeps saying it beside the corner controls, not instead of them', () => {
+    // The line and the per-row X answer different questions — WHERE the row
+    // is, and REMOVE this row — so neither replaces the other.
+    render(
+      <WriteInCard
+        occupant={{ name: 'Liam Garcia', note: '' }}
+        atUnitName="House Loft"
+        onRemove={() => undefined}
+        onEdit={() => undefined}
+      />
+    )
+
+    expect(screen.getByText('Written in at House Loft')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Remove write-in Liam Garcia' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Edit write-in Liam Garcia' })).toBeInTheDocument()
+  })
+})
+
 describe('the corner control that removes THIS write-in', () => {
   /*
    * Owner ruling, 2026-08-18 (kindred#2381 part 4): a small X in each card's
@@ -198,6 +244,26 @@ describe('the corner control that edits THIS write-in (kindred#2430)', () => {
     expect(
       screen.getByRole('button', { name: 'Edit write-in Occupant not named' })
     ).toBeInTheDocument()
+  })
+
+  it('labels both boxes with the prompt\u2019s own placeholders', () => {
+    // The note is EMPTY on every row predating kindred#2078 (1500000148
+    // cleared each one it copied), so without a placeholder the second box is
+    // a blank unlabelled input under the name. Same strings
+    // `UnitAvailabilityControl`'s occupant prompt uses, so one control does
+    // not teach a different vocabulary from the other.
+    render(<WriteInCard occupant={{ name: 'Liam Garcia', note: '' }} onEdit={() => undefined} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit write-in Liam Garcia' }))
+
+    expect(screen.getByRole('textbox', { name: 'Occupant' })).toHaveAttribute(
+      'placeholder',
+      'Emma Johnson, burst pipe…'
+    )
+    expect(screen.getByRole('textbox', { name: 'Note (optional)' })).toHaveAttribute(
+      'placeholder',
+      'Note (optional) — back Monday…'
+    )
   })
 
   it('opens an inline form pre-filled with the occupant and note already on the row', () => {

--- a/frontend/src/components/weekend/WriteInCard.tsx
+++ b/frontend/src/components/weekend/WriteInCard.tsx
@@ -62,6 +62,32 @@
  * display-name convention to fall back on — the same argument #2253 made
  * for a housing name, stronger here because there is no shorter form at all.
  *
+ * ## WHOSE row it is, printed when it is not this card's own
+ *
+ * Restored during review of kindred#2381 after being deleted with it. The
+ * line had TWO reasons in the code that carried it and only one of them —
+ * "go and find the Clear on the card the merge took away" — died with the
+ * per-card X. The other is identity, and the plural well makes it sharper
+ * rather than redundant:
+ *
+ *   - MERGE. The one 2026 container carrying four write-ins holds them on
+ *     four different rooms — a loft, a side room, a back room and a laundry.
+ *     Four names in one well with no room beside them does not tell a staff
+ *     member where anybody is sleeping.
+ *   - SPLIT. Split a written-into building and every room draws a card for
+ *     the SAME row. Without this line each room asserts its own row names
+ *     that person, and each card's X — all of them pointed at the one
+ *     building row — empties all the others too, with nothing on screen
+ *     saying why.
+ *   - Two rows whose occupants are named alike, or both unnamed (`UNNAMED`
+ *     below is a state a legacy row can be in), otherwise render as two
+ *     identical cards. That is the same objection kindred#2431 above makes
+ *     to truncating a name, one card over.
+ *
+ * Undefined on the card whose own row it is, which is the overwhelmingly
+ * common case — a line restating the card's own name on every written-into
+ * card is chrome staff learn to read past.
+ *
  * ## The edit control, kindred#2430
  *
  * Owner ruling, 2026-08-18 (supersedes an earlier same-day HOLD): a small
@@ -109,11 +135,31 @@ export interface WriteInCardProps {
    * second permission flag here.
    */
   onEdit?: (write: { occupantName: string; reason: string }) => void
-  /** True while a write to THIS row — a removal or an edit — is in flight. */
+  /**
+   * The unit the row is recorded at, when that is NOT the card drawing this.
+   *
+   * See "WHOSE row it is" above. Undefined on the card whose own row it is.
+   */
+  atUnitName?: string | undefined
+  /**
+   * True while a write this card's controls are waiting on is in flight.
+   *
+   * Card-level rather than row-level at the only caller: `LodgingBoard` knows
+   * one `pendingUnitId` and `LodgingUnitCard` passes the same answer to every
+   * `WriteInCard` in its well, so a write to one row disables the corner
+   * controls on all of them. Deliberately the conservative direction — the
+   * alternative leaves an X live beside a row that is already going away.
+   */
   isSaving?: boolean
 }
 
-export function WriteInCard({ occupant, onRemove, onEdit, isSaving = false }: WriteInCardProps) {
+export function WriteInCard({
+  occupant,
+  onRemove,
+  onEdit,
+  atUnitName,
+  isSaving = false,
+}: WriteInCardProps) {
   const named = occupant.name !== ''
   const label = named ? occupant.name : UNNAMED
 
@@ -161,6 +207,12 @@ export function WriteInCard({ occupant, onRemove, onEdit, isSaving = false }: Wr
           <input
             type="text"
             aria-label="Occupant"
+            // THE SAME PLACEHOLDERS `UnitAvailabilityControl`'s occupant
+            // prompt uses. Not decoration on the second box: 1500000148
+            // cleared the note of every row it moved, so an edit opened on
+            // any pre-existing write-in shows an empty, otherwise unlabelled
+            // input under the name.
+            placeholder="Emma Johnson, burst pipe…"
             value={draftName}
             maxLength={500}
             autoFocus
@@ -174,6 +226,7 @@ export function WriteInCard({ occupant, onRemove, onEdit, isSaving = false }: Wr
           <input
             type="text"
             aria-label="Note (optional)"
+            placeholder="Note (optional) — back Monday…"
             value={draftNote}
             maxLength={500}
             onChange={(event) => {
@@ -268,13 +321,16 @@ export function WriteInCard({ occupant, onRemove, onEdit, isSaving = false }: Wr
         // migration onward. That emptiness is correct, not a bug.
         <span className="text-muted-foreground text-xs leading-tight">{occupant.note}</span>
       )}
-      {/* NO "Written in at …" FOOTER. It told a reader the row lives on a unit
-          other than the card drawing it, which was worth saying only while a
-          merged card showed ONE write-in and hid the rest — the note existed to
-          send staff to the Clear on a card the merge had taken away. Every
-          write-in is drawn now and each carries its own removal, so the line
-          would restate what the reader can see. Deleted with its prop
-          (kindred#2381), so nothing can pass one in by habit. */}
+      {atUnitName !== undefined && atUnitName !== '' && (
+        // WHERE the row lives, not a second occupant fact — which is why it
+        // sits under the note in the same muted key rather than beside the
+        // name. Four occupants in one merged well are four rooms, and the X
+        // on each of a split building's room cards points at the one row they
+        // all draw; neither is legible without this line.
+        <span className="text-muted-foreground text-xs leading-tight italic">
+          {`Written in at ${atUnitName}`}
+        </span>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/weekend/WriteInCard.tsx
+++ b/frontend/src/components/weekend/WriteInCard.tsx
@@ -1,5 +1,5 @@
 /**
- * A write-in, drawn in the unit's occupant well — kindred#2078.
+ * A write-in, drawn in the unit's occupant well — kindred#2078, kindred#2381.
  *
  * Owner ruling, 2026-08-09: a hold IS a write-in. What the row records is a
  * person sleeping in the room, almost always non-rostered weekend staff, and
@@ -8,6 +8,17 @@
  * and closed* when in truth it was *full*. This is the same fact, printed
  * where the board prints occupancy.
  *
+ * ## ONE CARD PER WRITE-IN, and the well may hold several
+ *
+ * A merged container draws in place of its rooms, so every write-in beneath it
+ * lands here (kindred#2381). Each card is one row, and its corner control
+ * removes that row and no other — which is what makes the plural well safe.
+ * The single "Clear Write-in" button it replaces named whichever row the
+ * server resolved first, so on the one 2026 building carrying four write-ins a
+ * click removed one, the card silently re-populated with the next occupant,
+ * and four clicks destroyed four rows while the board never disclosed that
+ * more than one existed.
+ *
  * ## Deliberately NOT a `FamilyCard`
  *
  * It wears `FamilyCard`'s frame, and none of its behaviour:
@@ -15,9 +26,13 @@
  *   - no `data-family-card`. Board code queries that selector to find PLACED
  *     parties; a write-in is an occupant, not a placement, and marking it would
  *     count a family in a room no family is in.
- *   - no `useDraggable`, and not a `<button>`. There is no family panel behind
- *     a write-in and nowhere to drag it to, and a control that looks
- *     interactive and is not is worse than plain text.
+ *   - no `useDraggable`, and THE CARD ITSELF is not a `<button>`. There is no
+ *     family panel behind a write-in and nowhere to drag it to, and a card that
+ *     looks interactive and is not is worse than plain text. That reasoning
+ *     survives kindred#2381 intact and is why the removal is a discrete corner
+ *     control rather than "click the card": the card body stays inert, and the
+ *     things that are interactive are visibly buttons. #2430's edit control
+ *     joins this one in the same corner, for the same reason.
  *   - no party-size figure and no chip row. A write-in is a name; nothing else
  *     is known, and a `0` beside it would assert something.
  *
@@ -35,41 +50,67 @@ import type { WriteInOccupant } from './writeIn'
 export const WRITE_IN_FRAME =
   'group border-border flex w-full flex-col gap-1 rounded-xl border-2 p-2.5 text-left'
 
+/** What a card prints when the row named nobody. Also the removal's handle. */
+const UNNAMED = 'Occupant not named'
+
 export interface WriteInCardProps {
   occupant: WriteInOccupant
   /**
-   * The unit the row is recorded at, when that is NOT the card drawing this.
+   * Remove THIS write-in — omitted for a reader who cannot, which is what
+   * hides the control rather than a second permission flag here.
    *
-   * A write-in names one unit and closes a space: split a written-into
-   * building and its rooms carry the occupant, merge over a written-into room
-   * and the building does. Undefined on the card whose own row it is, which is
-   * the overwhelmingly common case — a line restating the card's own name on
-   * every written-into card is chrome staff learn to read past.
+   * NO ARGUMENT. The card knows which of the well's rows it draws and the
+   * caller binds the target, so there is exactly one place that has to agree
+   * about which row a corner X belongs to. Passing an id up would make two.
    */
-  atUnitName?: string | undefined
+  onRemove?: () => void
+  /** True while THIS card's removal is in flight. */
+  isRemoving?: boolean
 }
 
-export function WriteInCard({ occupant, atUnitName }: WriteInCardProps) {
+export function WriteInCard({ occupant, onRemove, isRemoving = false }: WriteInCardProps) {
   const named = occupant.name !== ''
+  const label = named ? occupant.name : UNNAMED
 
   return (
     <div data-write-in-card className={`${WRITE_IN_FRAME} bg-background`}>
-      <span
-        // `FamilyCard`'s own name line, minus the flex row it shares with a
-        // party-size badge this card does not have.
-        className={
-          named
-            ? 'text-foreground min-w-0 truncate text-sm leading-tight font-semibold'
-            : 'text-muted-foreground min-w-0 truncate text-sm leading-tight italic'
-        }
-      >
-        {/* STATED, not left blank. A row can reach here unnamed — the write
-            schema is permissive where the control is not, and a pre-1500000148
-            row with an empty note backfilled to nothing — and an empty card in
-            a closed room reads as an open room the board mysteriously refuses
-            drops on. */}
-        {named ? occupant.name : 'Occupant not named'}
-      </span>
+      {/* The name line and the corner controls, in `FamilyCard`'s own flex row
+          — which this card used to drop because it had no party-size badge to
+          share it with. It has a control to share it with now. */}
+      <div className="flex items-start gap-1">
+        <span
+          className={
+            named
+              ? 'text-foreground min-w-0 flex-1 truncate text-sm leading-tight font-semibold'
+              : 'text-muted-foreground min-w-0 flex-1 truncate text-sm leading-tight italic'
+          }
+        >
+          {/* STATED, not left blank. A row can reach here unnamed — the write
+              schema is permissive where the control is not, and a pre-1500000148
+              row with an empty note backfilled to nothing — and an empty card in
+              a closed room reads as an open room the board mysteriously refuses
+              drops on. */}
+          {label}
+        </span>
+        {onRemove !== undefined && (
+          <button
+            type="button"
+            disabled={isRemoving}
+            // NAMED FOR THE OCCUPANT, not a bare "Remove". A merged building's
+            // well can hold four of these, and four controls called the same
+            // thing are one question asked four times. (`aria-label` here is a
+            // test query handle — see frontend/CLAUDE.md on how minimal this
+            // repo's accessibility is meant to be.)
+            aria-label={`Remove write-in ${label}`}
+            onClick={onRemove}
+            className="text-muted-foreground hover:text-foreground hover:border-foreground/30 border-border flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full border text-[11px] leading-none disabled:opacity-40"
+          >
+            {/* MULTIPLICATION SIGN, not the letter x — the glyph the rest of
+                the board's dismissals use. */}
+            ×
+          </button>
+        )}
+      </div>
       {occupant.note !== '' && (
         // INSIDE the card, where the old italic line sat above it: the note
         // describes the occupant, not the room. Empty on every historical row
@@ -78,16 +119,13 @@ export function WriteInCard({ occupant, atUnitName }: WriteInCardProps) {
         // migration onward. That emptiness is correct, not a bug.
         <span className="text-muted-foreground text-xs leading-tight">{occupant.note}</span>
       )}
-      {atUnitName !== undefined && atUnitName !== '' && (
-        // WHERE the row lives, not a second occupant fact — which is why it
-        // sits under the note in the same muted key rather than beside the
-        // name. Without it the card asserts this room's own row names them,
-        // and the staff member goes looking for the Clear on a card the merge
-        // or split has taken away, when it is on this one.
-        <span className="text-muted-foreground text-xs leading-tight italic">
-          {`Written in at ${atUnitName}`}
-        </span>
-      )}
+      {/* NO "Written in at …" FOOTER. It told a reader the row lives on a unit
+          other than the card drawing it, which was worth saying only while a
+          merged card showed ONE write-in and hid the rest — the note existed to
+          send staff to the Clear on a card the merge had taken away. Every
+          write-in is drawn now and each carries its own removal, so the line
+          would restate what the reader can see. Deleted with its prop
+          (kindred#2381), so nothing can pass one in by habit. */}
     </div>
   )
 }

--- a/frontend/src/components/weekend/WriteInCard.tsx
+++ b/frontend/src/components/weekend/WriteInCard.tsx
@@ -43,7 +43,42 @@
  * else's file. `WriteInCard.test.tsx` reads the literal out of `FamilyCard.tsx`
  * and asserts the two are identical, which makes the copy loud instead of a
  * silent drift waiting to happen.
+ *
+ * ## The name wraps, kindred#2431
+ *
+ * Owner ruling, 2026-08-18, following the #2253 precedent
+ * (`HouseholdJourneyCard.tsx`'s housing span): a truncated name is not a
+ * shorter name, it is a different one — two write-ins that share a prefix
+ * would render identically. `min-w-0` stays on the span even though
+ * `truncate` is gone: it is what lets the flex child shrink below its
+ * content width, which is what makes it wrap rather than push the card
+ * wider than its well.
+ *
+ * A DELIBERATE divergence from summer, per the root CLAUDE.md §4 rule:
+ * summer's direct analog still truncates (`camper/CampJourneyTimeline.tsx`,
+ * the `record.bunkName` span), because a cabin callsign is a short,
+ * fixed-format string with nothing meaningful to lose to an ellipsis. A
+ * write-in's occupant name is staff-typed free text with no alias or
+ * display-name convention to fall back on — the same argument #2253 made
+ * for a housing name, stronger here because there is no shorter form at all.
+ *
+ * ## The edit control, kindred#2430
+ *
+ * Owner ruling, 2026-08-18 (supersedes an earlier same-day HOLD): a small
+ * pencil, ALWAYS VISIBLE, beside the X — not hover-only (the reported
+ * problem was that staff could not FIND an edit path, so a control that
+ * only appears on hover does not fix it) and not click-the-card (which
+ * would reverse the "deliberately NOT a `FamilyCard`" decision above). It
+ * opens an inline form, pre-filled from this row, and writes back through
+ * the same `onSetAvailability` channel `onRemove` already uses — no API
+ * change: `set_availability` upserts a write-in
+ * (`_upsert_row(what='write-in', ...)` in
+ * `api/services/lodging_write_service.py`), so a second write to the same
+ * row updates it rather than duplicating it.
  */
+import { Pencil } from 'lucide-react'
+import { useState } from 'react'
+
 import type { WriteInOccupant } from './writeIn'
 
 /** `FamilyCard`'s `CARD_FRAME`, verbatim. Pinned by this module's test. */
@@ -64,13 +99,113 @@ export interface WriteInCardProps {
    * about which row a corner X belongs to. Passing an id up would make two.
    */
   onRemove?: () => void
-  /** True while THIS card's removal is in flight. */
-  isRemoving?: boolean
+  /**
+   * Save an edit to THIS write-in's occupant name and note — kindred#2430.
+   *
+   * NO ID, for the same reason `onRemove` takes none: the card knows which
+   * row it draws and the caller binds the target, so there is exactly one
+   * place that has to agree about which of the well's rows this is. Omitted
+   * for a reader who cannot edit, which hides the pencil rather than a
+   * second permission flag here.
+   */
+  onEdit?: (write: { occupantName: string; reason: string }) => void
+  /** True while a write to THIS row — a removal or an edit — is in flight. */
+  isSaving?: boolean
 }
 
-export function WriteInCard({ occupant, onRemove, isRemoving = false }: WriteInCardProps) {
+export function WriteInCard({ occupant, onRemove, onEdit, isSaving = false }: WriteInCardProps) {
   const named = occupant.name !== ''
   const label = named ? occupant.name : UNNAMED
+
+  // Local to this card, never lifted: the well can hold several of these and
+  // each edits independently. Re-seeded from `occupant` every time the form
+  // OPENS (not on every render) so a cancelled edit's draft never survives to
+  // the next open — see `openEdit`.
+  const [isEditing, setIsEditing] = useState(false)
+  const [draftName, setDraftName] = useState(occupant.name)
+  const [draftNote, setDraftNote] = useState(occupant.note)
+  const [wantsName, setWantsName] = useState(false)
+
+  const openEdit = () => {
+    setDraftName(occupant.name)
+    setDraftNote(occupant.note)
+    setWantsName(false)
+    setIsEditing(true)
+  }
+  const closeEdit = () => {
+    setIsEditing(false)
+    setWantsName(false)
+  }
+
+  if (isEditing) {
+    return (
+      <div data-write-in-card className={`${WRITE_IN_FRAME} bg-background`}>
+        <form
+          className="flex w-full flex-col gap-1"
+          onSubmit={(event) => {
+            event.preventDefault()
+            const trimmedName = draftName.trim()
+            // THE SAME GUARD `UnitAvailabilityControl`'s occupant prompt
+            // uses: a write-in that names nobody is a valid state a legacy
+            // row can already be in, but an edit that CLEARS a name is a
+            // staff member erasing who is in the room, which is worth a
+            // refusal rather than a silent write.
+            if (trimmedName === '') {
+              setWantsName(true)
+              return
+            }
+            onEdit?.({ occupantName: trimmedName, reason: draftNote.trim() })
+            closeEdit()
+          }}
+        >
+          <input
+            type="text"
+            aria-label="Occupant"
+            value={draftName}
+            maxLength={500}
+            autoFocus
+            aria-invalid={wantsName && draftName.trim() === ''}
+            onChange={(event) => {
+              setDraftName(event.target.value)
+              setWantsName(false)
+            }}
+            className="border-border bg-background text-foreground placeholder:text-muted-foreground/60 focus:border-primary/50 focus:ring-primary/10 w-full rounded-md border px-1.5 py-1 text-sm focus:ring-2 focus:outline-none aria-[invalid=true]:border-amber-500"
+          />
+          <input
+            type="text"
+            aria-label="Note (optional)"
+            value={draftNote}
+            maxLength={500}
+            onChange={(event) => {
+              setDraftNote(event.target.value)
+            }}
+            className="border-border bg-background text-foreground placeholder:text-muted-foreground/60 focus:border-primary/50 focus:ring-primary/10 w-full rounded-md border px-1.5 py-1 text-sm focus:ring-2 focus:outline-none"
+          />
+          {wantsName && draftName.trim() === '' && (
+            <span className="text-xs font-medium text-amber-700 dark:text-amber-400">
+              Say who is in it, so next week’s staff know who to ask.
+            </span>
+          )}
+          <div className="flex items-center gap-1.5">
+            <button
+              type="submit"
+              disabled={isSaving}
+              className="bg-primary text-primary-foreground rounded-md px-2 py-0.5 text-xs font-medium disabled:opacity-40"
+            >
+              Save
+            </button>
+            <button
+              type="button"
+              onClick={closeEdit}
+              className="text-muted-foreground hover:text-foreground rounded-md px-1.5 py-0.5 text-xs"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </div>
+    )
+  }
 
   return (
     <div data-write-in-card className={`${WRITE_IN_FRAME} bg-background`}>
@@ -81,8 +216,8 @@ export function WriteInCard({ occupant, onRemove, isRemoving = false }: WriteInC
         <span
           className={
             named
-              ? 'text-foreground min-w-0 flex-1 truncate text-sm leading-tight font-semibold'
-              : 'text-muted-foreground min-w-0 flex-1 truncate text-sm leading-tight italic'
+              ? 'text-foreground min-w-0 flex-1 text-sm leading-tight font-semibold'
+              : 'text-muted-foreground min-w-0 flex-1 text-sm leading-tight italic'
           }
         >
           {/* STATED, not left blank. A row can reach here unnamed — the write
@@ -92,10 +227,24 @@ export function WriteInCard({ occupant, onRemove, isRemoving = false }: WriteInC
               drops on. */}
           {label}
         </span>
+        {onEdit !== undefined && (
+          <button
+            type="button"
+            disabled={isSaving}
+            // NAMED FOR THE OCCUPANT, same reason as the X below: four edit
+            // controls called "Edit" on one merged card are one question
+            // asked four times.
+            aria-label={`Edit write-in ${label}`}
+            onClick={openEdit}
+            className="text-muted-foreground hover:text-foreground hover:border-foreground/30 border-border flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full border text-[11px] leading-none disabled:opacity-40"
+          >
+            <Pencil className="h-2.5 w-2.5" />
+          </button>
+        )}
         {onRemove !== undefined && (
           <button
             type="button"
-            disabled={isRemoving}
+            disabled={isSaving}
             // NAMED FOR THE OCCUPANT, not a bare "Remove". A merged building's
             // well can hold four of these, and four controls called the same
             // thing are one question asked four times. (`aria-label` here is a

--- a/frontend/src/components/weekend/dragPlacement.test.ts
+++ b/frontend/src/components/weekend/dragPlacement.test.ts
@@ -330,29 +330,40 @@ describe('resolveDrop', () => {
     ).toEqual({ kind: 'unplace', party: merged })
   })
 
-  it('refuses a drop onto a held unit (#2087) — a hold blocks placement outright', () => {
-    // Owner ruling on #2090: a hold is global and blocks placement, not merely
-    // dimmed. This is the load-bearing check, since `resolveDrop` is the only
-    // path #2080's picker reaches — a `disabled`-only fix would not cover it.
-    const held = unit({ write_ins: [cover()], is_family_available: false })
+  it('accepts a drop onto a WRITTEN-INTO unit — a write-in names an occupant, it does not close the space (#2432)', () => {
+    // THE REVERSAL of #2090, and this is the site that enforced it: `if
+    // (hasWriteIn(unit)) return null`, whose own comment called it "the
+    // load-bearing one". Owner ruling 2026-08-18 — *"we should be able to add
+    // families to any write in space, or add a write in to a family space —
+    // regardless of which came first"* — so this direction (family onto a
+    // written-into space) must go through.
+    //
+    // The case staff reported is one paper registration (recordable ONLY as a
+    // write-in, since it has no CampMinder record) sharing a cabin with one
+    // CampMinder family. Refusing here is what made the one case the control
+    // exists for the one case it would not do.
+    const writtenInto = unit({ write_ins: [cover()], is_family_available: false })
     const p = party()
     expect(
       resolveDrop({
         activeId: partyKey(p),
         overId: unitDroppableId('cedar-1'),
         parties: [p],
-        units: [held],
+        units: [writtenInto],
       })
-    ).toBeNull()
+    ).toMatchObject({ kind: 'place', unitId: 'u1', unitCode: 'cedar-1' })
   })
 
-  it('refuses a drop into a ROOM of a building somebody is written into', () => {
-    // The split case. Staff wrote into the whole house while it was merged,
-    // then split it: the row still names the house, which now has no card, and
-    // without the server's resolved cover this drop went through — a family
-    // into a space somebody is already sleeping in, with nothing on screen to
-    // warn them. The refusal reads the COVER, so both directions of the tree
-    // arrive here as the same fact.
+  it('accepts a drop into a ROOM of a building somebody is written into (#2432)', () => {
+    // The split case, reversed with the rest. Staff wrote into the whole house
+    // while it was merged, then split it: the row still names the house, which
+    // now has no card, and the drop lands in one of its rooms.
+    //
+    // This ONE tree walk is what the reversal keeps: the family and the
+    // write-in must land in the same well so the card names both occupants,
+    // and the server's resolved cover is what puts them there whichever level
+    // the board happens to be drawing. What is gone is the refusal that used
+    // to sit on top of it.
     const room = unit({
       code: 'house-a',
       write_ins: [
@@ -373,13 +384,13 @@ describe('resolveDrop', () => {
         parties: [p],
         units: [room],
       })
-    ).toBeNull()
+    ).toMatchObject({ kind: 'place', unitCode: 'house-a' })
   })
 
-  it('refuses a whole-house drop when one of its ROOMS is written into', () => {
-    // The mirror case, and the one that predates the split fix: merge a
-    // building over a written-into room and the room stops being drawn, so the
-    // building's card said nothing about the caretaker in it and took the drop.
+  it('accepts a whole-house drop when one of its ROOMS is written into (#2432)', () => {
+    // The mirror case: merge a building over a written-into room and the room
+    // stops being drawn, so the building's card is where both the write-in and
+    // the placement now read.
     const house = unit({
       code: 'house',
       is_container: true,
@@ -402,7 +413,7 @@ describe('resolveDrop', () => {
         parties: [p],
         units: [house],
       })
-    ).toBeNull()
+    ).toMatchObject({ kind: 'place', unitCode: 'house' })
   })
 
   it('still accepts a drop onto an ordinary unheld unit (regression guard)', () => {
@@ -755,16 +766,17 @@ describe('resolvePickerPlacement', () => {
     })
   })
 
-  it('inherits the held-space refusal rather than adding a second one', () => {
-    // #2087/#2199 put the refusal in `resolveDrop` precisely because #2080
-    // reaches placement without touching a `useDroppable`. A picker-layer
-    // check of its own would be the second copy that comment exists to
-    // prevent.
+  it('inherits the written-into space’s ACCEPTANCE rather than keeping a refusal of its own (#2432)', () => {
+    // The adapter has no rules, which is the whole design — so reversing #2090
+    // in `resolveDrop` reverses it here for free. Pinned in both directions on
+    // purpose: a picker-layer copy of the old refusal would survive the
+    // reversal silently and leave #2080's placement path saying no while drag
+    // said yes.
     const p = party()
-    const held = unit({ write_ins: [cover()], is_family_available: false })
+    const writtenInto = unit({ write_ins: [cover()], is_family_available: false })
     expect(
-      resolvePickerPlacement({ party: p, unitCode: 'cedar-1', parties: [p], units: [held] })
-    ).toBeNull()
+      resolvePickerPlacement({ party: p, unitCode: 'cedar-1', parties: [p], units: [writtenInto] })
+    ).toMatchObject({ kind: 'place', unitCode: 'cedar-1' })
   })
 
   it('refuses a party carrying neither CampMinder id', () => {

--- a/frontend/src/components/weekend/dragPlacement.test.ts
+++ b/frontend/src/components/weekend/dragPlacement.test.ts
@@ -334,7 +334,7 @@ describe('resolveDrop', () => {
     // Owner ruling on #2090: a hold is global and blocks placement, not merely
     // dimmed. This is the load-bearing check, since `resolveDrop` is the only
     // path #2080's picker reaches — a `disabled`-only fix would not cover it.
-    const held = unit({ write_in: cover(), is_family_available: false })
+    const held = unit({ write_ins: [cover()], is_family_available: false })
     const p = party()
     expect(
       resolveDrop({
@@ -355,13 +355,15 @@ describe('resolveDrop', () => {
     // arrive here as the same fact.
     const room = unit({
       code: 'house-a',
-      write_in: {
-        unit_id: 'id-house',
-        unit_code: 'house',
-        unit_name: 'House',
-        occupant_name: 'Liam Garcia',
-        note: '',
-      },
+      write_ins: [
+        {
+          unit_id: 'id-house',
+          unit_code: 'house',
+          unit_name: 'House',
+          occupant_name: 'Liam Garcia',
+          note: '',
+        },
+      ],
     })
     const p = party()
     expect(
@@ -382,13 +384,15 @@ describe('resolveDrop', () => {
       code: 'house',
       is_container: true,
       is_combined: true,
-      write_in: {
-        unit_id: 'id-house-a',
-        unit_code: 'house-a',
-        unit_name: 'House A',
-        occupant_name: 'Ava Martinez',
-        note: '',
-      },
+      write_ins: [
+        {
+          unit_id: 'id-house-a',
+          unit_code: 'house-a',
+          unit_name: 'House A',
+          occupant_name: 'Ava Martinez',
+          note: '',
+        },
+      ],
     })
     const p = party()
     expect(
@@ -757,7 +761,7 @@ describe('resolvePickerPlacement', () => {
     // check of its own would be the second copy that comment exists to
     // prevent.
     const p = party()
-    const held = unit({ write_in: cover(), is_family_available: false })
+    const held = unit({ write_ins: [cover()], is_family_available: false })
     expect(
       resolvePickerPlacement({ party: p, unitCode: 'cedar-1', parties: [p], units: [held] })
     ).toBeNull()

--- a/frontend/src/components/weekend/dragPlacement.ts
+++ b/frontend/src/components/weekend/dragPlacement.ts
@@ -23,13 +23,18 @@
  * nine tasks and removed in kindred#1903; `docs/architecture/lodging-occupancy.md`
  * says why, and the reasoning is not obvious. Do not add one here.
  *
+ * **It never refuses a WRITTEN-INTO space.** It did until kindred#2432, on
+ * #2090's ruling that a write-in and a placement were mutually exclusive. They
+ * are not: a write-in names an occupant the system has no record of — a paper
+ * registration, most often — and such a party can legitimately share a cabin
+ * with a placed family. See the gate's own headstone inside `resolveDrop`.
+ *
  * What it does refuse is a write that cannot succeed: a unit the payload does
  * not carry, a container row, and a party carrying neither CampMinder id.
  */
 import type { LodgingUnitRow, RosterPartyRow, WeekendRoster } from '../../types/lodging'
 import { occupiedCodes } from './boardLayout'
 import { partyKey } from './partyKey'
-import { hasWriteIn } from './writeIn'
 
 /**
  * The queue droppable. One id, imported by the badge that registers it and
@@ -216,21 +221,33 @@ export function resolveDrop({
 
   const unit = units.find((candidate) => candidate.code === target.unitCode)
   if (unit === undefined) return null
-  // Owner ruling on #2090: a hold is a GLOBAL fact about the building (who is
-  // in it, chiefly non-rostered staff), not a scenario-scoped reservation of
-  // empty space, and held/occupied are mutually exclusive states. Dragging
-  // onto a held unit is refused outright, not dimmed — see #2087. This is
-  // the load-bearing check: #2080 adds a placement path that never touches a
-  // `useDroppable`, so a refusal only on that hook's `disabled` flag would be
-  // silently bypassed by it. `LodgingUnitCard` also disables its droppable
-  // for the drag affordance, but this is what actually enforces it.
-  // Read through `hasWriteIn`, never the raw column: a row names one unit but
-  // closes a SPACE, and the board draws whichever level the tree resolves to.
-  // Split a written-into building and this drop lands in one of its rooms;
-  // merge over a written-into room and it lands on the building.
-  // The column answers only for the unit it sits on, so both of those went
-  // through — a family into a space somebody is already sleeping in.
-  if (hasWriteIn(unit)) return null
+  // ⚠️ NO WRITE-IN REFUSAL HERE, and its absence is a ruling rather than an
+  // omission — do not restore one.
+  //
+  // `if (hasWriteIn(unit)) return null` stood on this line until kindred#2432,
+  // under #2090 ("held and occupied are mutually exclusive"), and its own
+  // comment called it *the load-bearing one*: #2080 adds a placement path that
+  // never touches a `useDroppable`, so a refusal living only on that hook's
+  // `disabled` flag would be silently bypassed. That reasoning about WHERE a
+  // refusal has to live was correct and is why this was the last gate standing;
+  // what was struck is the refusal itself.
+  //
+  // Owner ruling 2026-08-18: *"we should be able to add families to any write
+  // in space, or add a write in to a family space — regardless of which came
+  // first."* A write-in NAMES AN OCCUPANT; it does not CLOSE THE SPACE. The
+  // reported case is one paper registration — which has no CampMinder record,
+  // so a write-in is the only way to record it at all — sharing a cabin with
+  // one placed CampMinder family, and this line is what refused it.
+  //
+  // The tree walk the refusal used to ride on is still doing its job upstream:
+  // `hasWriteIn` read the SERVER-RESOLVED cover rather than the raw column
+  // precisely because a row names one unit but covers a whole space, and that
+  // is what still lands the write-in and the family in the SAME card's well
+  // whichever level the board draws (`LodgingUnitCard`'s `writeInEntries`).
+  //
+  // The known cost is filed, not hidden: a write-in carries no headcount, so a
+  // shared space's free-bed figure overstates once both are in it (kindred#2439,
+  // ruled an optional investigation and explicitly not a blocker).
   // A COMBINED container IS a card now — Task 6 draws its own row in place of
   // its rooms (unitLevel.ts, `drawnUnits`) — so it must accept a drop exactly
   // like any other drawn unit. A NON-combined container still carries only
@@ -267,9 +284,11 @@ export interface ResolvePickerPlacementArgs {
  *
  * A thin adapter and nothing more, and that is the whole design: the second
  * placement path must not be a second set of rules. Everything that makes a
- * drop a no-op or a refusal — a held space (#2087), a non-combined container,
- * a party carrying neither CampMinder id, a party already alone in this room —
- * is inherited here for free because the answer is literally `resolveDrop`'s.
+ * drop a no-op or a refusal — a non-combined container, a party carrying
+ * neither CampMinder id, a party already alone in this room — is inherited
+ * here for free because the answer is literally `resolveDrop`'s. That cuts
+ * both ways, which kindred#2432 is the proof of: striking the written-into
+ * refusal in `resolveDrop` struck it here too, with nothing to edit.
  * A picker-layer copy of any of them is the drift this exists to prevent.
  *
  * The party is re-resolved out of `parties` by its own key rather than trusted

--- a/frontend/src/components/weekend/dragPlacement.ts
+++ b/frontend/src/components/weekend/dragPlacement.ts
@@ -29,7 +29,7 @@
 import type { LodgingUnitRow, RosterPartyRow, WeekendRoster } from '../../types/lodging'
 import { occupiedCodes } from './boardLayout'
 import { partyKey } from './partyKey'
-import { writeInOccupant } from './writeIn'
+import { hasWriteIn } from './writeIn'
 
 /**
  * The queue droppable. One id, imported by the badge that registers it and
@@ -224,13 +224,13 @@ export function resolveDrop({
   // `useDroppable`, so a refusal only on that hook's `disabled` flag would be
   // silently bypassed by it. `LodgingUnitCard` also disables its droppable
   // for the drag affordance, but this is what actually enforces it.
-  // Read through `writeInOccupant`, never the raw column: the row names one
-  // unit but closes a SPACE, and the board draws whichever level the tree
-  // resolves to. Split a written-into building and this drop lands in one of
-  // its rooms; merge over a written-into room and it lands on the building.
+  // Read through `hasWriteIn`, never the raw column: a row names one unit but
+  // closes a SPACE, and the board draws whichever level the tree resolves to.
+  // Split a written-into building and this drop lands in one of its rooms;
+  // merge over a written-into room and it lands on the building.
   // The column answers only for the unit it sits on, so both of those went
   // through — a family into a space somebody is already sleeping in.
-  if (writeInOccupant(unit) !== null) return null
+  if (hasWriteIn(unit)) return null
   // A COMBINED container IS a card now — Task 6 draws its own row in place of
   // its rooms (unitLevel.ts, `drawnUnits`) — so it must accept a drop exactly
   // like any other drawn unit. A NON-combined container still carries only

--- a/frontend/src/components/weekend/needsFit.test.ts
+++ b/frontend/src/components/weekend/needsFit.test.ts
@@ -6,7 +6,9 @@
  * unconfirmed (measured against the production snapshot of 2026-08-06, cabins
  * were 118/118 confirmed) but because staff routinely place families against
  * the machine's opinion and are right to. Deliberately a DIFFERENT mechanism
- * from #2087's hard block on a held space, which is a refusal.
+ * from the invalid merge target's hard block, which is a refusal. #2087's
+ * block on a written-into space used to be the other example here; kindred#2432
+ * struck it, so the merge target is now the only thing on the refusal channel.
  *
  * Fictional data throughout.
  */

--- a/frontend/src/components/weekend/needsFit.ts
+++ b/frontend/src/components/weekend/needsFit.ts
@@ -13,7 +13,8 @@
  * two apart:
  *
  *   dim  (`opacity-40` + `pointer-events-none`) = REFUSAL. Owned by the
- *        invalid merge target and by a held space (#2087). Not this.
+ *        invalid merge target, and by that alone since kindred#2432 struck
+ *        the written-into space's refusal (#2087/#2090). Not this.
  *   hatch (`background-image`, at FULL strength)= ADVISORY MISFIT. This.
  *   forest tint                                  = open and available, at rest
  *        only (#2093).

--- a/frontend/src/components/weekend/unitBadges.test.ts
+++ b/frontend/src/components/weekend/unitBadges.test.ts
@@ -98,14 +98,14 @@ describe('reservationBadge', () => {
     // drawn unit. Badging it "Building" while `availabilityAction` offers to
     // CLEAR the write-in is the exact drift this module exists to prevent.
     expect(
-      reservationBadge(unit({ is_container: true, is_combined: true, write_in: cover() }))?.label
+      reservationBadge(unit({ is_container: true, is_combined: true, write_ins: [cover()] }))?.label
     ).toBe('Write-in')
   })
 
   it('keeps saying Building on a SPLIT container carrying an override', () => {
     // A split container gets no card at all, so there is nothing to badge and
     // no action to agree with. Unchanged, deliberately.
-    expect(reservationBadge(unit({ is_container: true, write_in: cover() }))?.label).toBe(
+    expect(reservationBadge(unit({ is_container: true, write_ins: [cover()] }))?.label).toBe(
       'Building'
     )
   })
@@ -121,7 +121,7 @@ describe('reservationBadge', () => {
     // why this is "Write-in" and not "Staff".
     const badge = reservationBadge(
       unit({
-        write_in: cover({ occupant_name: 'Emma Johnson' }),
+        write_ins: [cover({ occupant_name: 'Emma Johnson' })],
         occupant_name: 'Emma Johnson',
         is_family_available: false,
       })
@@ -186,9 +186,9 @@ describe('reservationBadge', () => {
     ).toBeNull()
     // A write-in on the same cabin still badges, which is the half that must
     // not be lost with it.
-    expect(reservationBadge(unit({ write_in: cover(), is_family_available: false }))?.label).toBe(
-      'Write-in'
-    )
+    expect(
+      reservationBadge(unit({ write_ins: [cover()], is_family_available: false }))?.label
+    ).toBe('Write-in')
   })
 
   it('does not badge a staff cabin as Released merely for lacking an override', () => {
@@ -218,13 +218,13 @@ describe('reservationBadge', () => {
   it('ignores the reason text entirely, because the rule never branches on it', () => {
     const held = reservationBadge(
       unit({
-        write_in: cover({ note: 'Burst pipe' }),
+        write_ins: [cover({ note: 'Burst pipe' })],
         reason: 'Burst pipe',
         is_family_available: false,
       })
     )
     const alsoHeld = reservationBadge(
-      unit({ write_in: cover(), reason: '', is_family_available: false })
+      unit({ write_ins: [cover()], reason: '', is_family_available: false })
     )
 
     expect(held?.label).toBe('Write-in')
@@ -267,26 +267,30 @@ describe('availabilityAction', () => {
     })
   })
 
-  it('offers to clear a held family cabin, labelled for what it actually removes (#2252)', () => {
-    // `null` DELETES the row. There is no value meaning "normal": writing one
-    // would pin the unit against a later change to its role.
-    //
-    // The label is 'Clear Write-in', not the bare 'Clear' this used to read.
-    // kindred#2252: the badge chip that used to sit beside this button on
-    // `LodgingUnitCard` is gone there (the well's `WriteInCard` already names
-    // the occupant), so the button is now the only thing on that card saying
-    // what a click does — and "Clear" alone does not say what it clears.
+  it('offers NOTHING on a written-into family cabin — the removal is on its card', () => {
+    // kindred#2381, superseding #2252's 'Clear Write-in' label. That label was
+    // right while the strip was the only thing on the card naming what a click
+    // removes; it stopped being true once a card could cover four write-ins
+    // and each got its own X. The strip is back to ROLE rows only.
     expect(
       availabilityAction(
         unit({
-          write_in: cover({ note: 'Burst pipe' }),
+          write_ins: [cover({ note: 'Burst pipe' })],
           reason: 'Burst pipe',
           is_family_available: false,
         })
       )
+    ).toBeNull()
+  })
+
+  it('offers to clear a role row with `null`, which DELETES it', () => {
+    // There is no value meaning "normal": writing one would pin the unit
+    // against a later change to its role.
+    expect(
+      availabilityAction(unit({ family_available_override: true, is_family_available: true }))
     ).toEqual({
       kind: 'clear',
-      label: 'Clear Write-in',
+      label: 'Clear',
       familyAvailable: null,
       prompt: 'none',
       unitId: 'u1',
@@ -294,12 +298,10 @@ describe('availabilityAction', () => {
     })
   })
 
-  it('offers to clear a released staff cabin, and does NOT borrow the write-in wording (#2252)', () => {
-    // This branch clears a RELEASE, not a write-in — `writeInSource` never
-    // matches a staff cabin's own release row, so it never reaches the
-    // relabelled branch. Asserted by name, not just by kind: a copy/paste that
-    // pointed this branch at the write-in label too would say "Clear
-    // Write-in" on a card that was never written into.
+  it('offers to clear a released staff cabin, naming its own row', () => {
+    // This branch clears a RELEASE, not a write-in, and it fires ahead of the
+    // write-in gate so a staff cabin that a relative's write-in also covers
+    // keeps the clear its badge names.
     expect(
       availabilityAction(
         unit({
@@ -340,13 +342,10 @@ describe('availabilityAction', () => {
         ?.kind
     ).toBe('clear')
     // And a write-in, which is a different row in a different table, offers
-    // the relabelled clear rather than this one.
+    // NOTHING here: its removal is the X on its own card (kindred#2381).
     expect(
-      availabilityAction(unit({ write_in: cover(), is_family_available: false }))
-    ).toMatchObject({
-      kind: 'clear',
-      label: 'Clear Write-in',
-    })
+      availabilityAction(unit({ write_ins: [cover()], is_family_available: false }))
+    ).toBeNull()
   })
 
   it('offers nothing to hold an OCCUPIED family cabin — held and occupied are mutually exclusive (#2090)', () => {
@@ -376,10 +375,13 @@ describe('availabilityAction', () => {
     expect(availabilityAction(unit({ is_container: true, is_combined: true }))?.kind).toBe('hold')
   })
 
-  it('offers to clear a MERGED building that has been written into', () => {
+  it('offers nothing on a MERGED building that has been written into', () => {
+    // It may cover four rows at once and the strip carries ONE action, so no
+    // button here could name which of the four a click would destroy. Each
+    // write-in is removed by the X on its own card (kindred#2381).
     expect(
-      availabilityAction(unit({ is_container: true, is_combined: true, write_in: cover() }))?.kind
-    ).toBe('clear')
+      availabilityAction(unit({ is_container: true, is_combined: true, write_ins: [cover()] }))
+    ).toBeNull()
   })
 
   it('offers nothing on a MERGED building that already holds a family (#2090)', () => {
@@ -497,9 +499,10 @@ describe('a write-in inherited from elsewhere in the tree', () => {
    * The board draws whichever level the tree resolves to, so the card carrying
    * a write-in is often not the unit the row names: split a written-into
    * building and its rooms carry it; merge over a written-into room and the
-   * building does. Both must BADGE the fact and both must be able to CLEAR it
-   * — a card that inherits a write-in and cannot undo it is a dead end, since
-   * the unit holding the row has no card at all.
+   * building does. Both must BADGE the fact, and neither offers a strip action
+   * for it: since kindred#2381 a card may cover several write-ins at once, and
+   * each is removed by the X on its own `WriteInCard` — the only control that
+   * can name one row out of four.
    */
   const coverFromBuilding = {
     unit_id: 'id-house',
@@ -510,28 +513,25 @@ describe('a write-in inherited from elsewhere in the tree', () => {
   }
 
   it('badges a room whose BUILDING was written into', () => {
-    expect(reservationBadge(unit({ code: 'house-a', write_in: coverFromBuilding }))?.label).toBe(
+    expect(reservationBadge(unit({ code: 'house-a', write_ins: [coverFromBuilding] }))?.label).toBe(
       'Write-in'
     )
   })
 
-  it('offers to clear it, naming the unit that actually holds the row', () => {
-    const action = availabilityAction(unit({ code: 'house-a', write_in: coverFromBuilding }))
-
-    expect(action?.kind).toBe('clear')
-    // The WRITE TARGET, not the card. Sending this card's own id would delete
-    // nothing: the row belongs to the building, and the room has none.
-    expect(action?.unitId).toBe('id-house')
-    expect(action?.unitName).toBe('House')
+  it('offers no strip action, because the removal lives on the card', () => {
+    // kindred#2381. The strip carries ONE action, so on a merged building over
+    // four write-ins it could name only one of the four rows — and it did:
+    // clearing re-resolved the card to the next occupant, so the click read as
+    // a no-op and four of them destroyed four rows without ever disclosing
+    // that more than one existed. Removal is now the X on each `WriteInCard`,
+    // which can only delete the row it sits on.
+    expect(availabilityAction(unit({ code: 'house-a', write_ins: [coverFromBuilding] }))).toBeNull()
   })
 
-  it('clears an inherited write-in even on an occupied card', () => {
-    // Same reasoning the own-row branch already carries: a clear only ever
-    // REDUCES the conflict, so occupancy is never the state that needs it
-    // blocked.
+  it('offers nothing on an occupied card either, rather than a stale write-in path', () => {
     expect(
-      availabilityAction(unit({ code: 'house-a', write_in: coverFromBuilding }), true)?.kind
-    ).toBe('clear')
+      availabilityAction(unit({ code: 'house-a', write_ins: [coverFromBuilding] }), true)
+    ).toBeNull()
   })
 
   it('names the card’s OWN unit when the write-in starts here', () => {
@@ -553,14 +553,14 @@ describe('a write-in inherited from elsewhere in the tree', () => {
 
     expect(
       reservationBadge(
-        unit({ code: 'house', is_container: true, is_combined: true, write_in: fromRoom })
+        unit({ code: 'house', is_container: true, is_combined: true, write_ins: [fromRoom] })
       )?.label
     ).toBe('Write-in')
     expect(
       availabilityAction(
-        unit({ code: 'house', is_container: true, is_combined: true, write_in: fromRoom })
-      )?.unitId
-    ).toBe('id-house-a')
+        unit({ code: 'house', is_container: true, is_combined: true, write_ins: [fromRoom] })
+      )
+    ).toBeNull()
   })
 })
 
@@ -570,9 +570,10 @@ describe('the badge and the clear must name the SAME row', () => {
    * drift — a card badged "Write-in" that offers to "Write in" says two things
    * about one cabin. Once a write-in can be INHERITED, that invariant grows
    * teeth: a card can carry its own availability row AND a relative's
-   * write-in at the same time, and one control has two rows to choose from.
-   * It must clear the one the badge is naming, or the toast reports success
-   * for a row the staff member was not looking at.
+   * write-in at the same time. The strip resolves the ROLE rows only — a
+   * write-in is removed from its own card since kindred#2381 — so a card the
+   * badge calls "Write-in" must offer no strip action at all rather than one
+   * that quietly unmakes something the reader was not looking at.
    */
   const coverFromBuilding = {
     unit_id: 'id-house',
@@ -592,11 +593,14 @@ describe('the badge and the clear must name the SAME row', () => {
       code: 'house-a',
       name: 'House A',
       family_available_override: true,
-      write_in: coverFromBuilding,
+      write_ins: [coverFromBuilding],
     })
 
     expect(reservationBadge(stale)?.label).toBe('Write-in')
-    expect(availabilityAction(stale)?.unitId).toBe('id-house')
+    // No strip action at all: the badge names the write-in, and a write-in is
+    // removed from its own card. The stale role row becomes clearable again
+    // once nothing is written into the space.
+    expect(availabilityAction(stale)).toBeNull()
   })
 
   it('still clears its OWN row on a released staff cabin, which is what its badge names', () => {
@@ -610,7 +614,7 @@ describe('the badge and the clear must name the SAME row', () => {
       name: 'House A',
       inventory_class: 'staff_default',
       family_available_override: true,
-      write_in: coverFromBuilding,
+      write_ins: [coverFromBuilding],
     })
 
     expect(reservationBadge(released)?.label).toBe('Released')

--- a/frontend/src/components/weekend/unitBadges.test.ts
+++ b/frontend/src/components/weekend/unitBadges.test.ts
@@ -348,12 +348,27 @@ describe('availabilityAction', () => {
     ).toBeNull()
   })
 
-  it('offers nothing to hold an OCCUPIED family cabin — held and occupied are mutually exclusive (#2090)', () => {
-    expect(availabilityAction(unit(), true)).toBeNull()
-  })
-
-  it('still offers to hold an unoccupied family cabin (regression guard)', () => {
-    expect(availabilityAction(unit(), false)?.kind).toBe('hold')
+  it('takes ONE argument, because occupancy is no longer part of the answer (#2432)', () => {
+    /*
+     * This took a second `occupied` argument until kindred#2432 and returned
+     * null when it was true — #2090's rule that "written-in and occupied are
+     * mutually exclusive states".
+     *
+     * Owner ruling 2026-08-18 reversed that in both directions: a write-in
+     * NAMES AN OCCUPANT and does not CLOSE THE SPACE. The argument is gone
+     * rather than defaulted, so a caller holding an occupancy fact has nowhere
+     * to put it — which is what stops the gate growing back by inches. The
+     * behaviour is pinned where the occupancy fact lives, on the card
+     * (`LodgingUnitCard.test.tsx`, "the shared occupant well (#2432)").
+     *
+     * THE ARITY ITSELF IS PINNED BY `tsc`, not here, and deliberately so: a
+     * `Function.length` assertion would not have caught the old signature
+     * either, because a parameter with a default (`occupied = false`) does not
+     * count toward it — 1 before this change and 1 after. A second argument is
+     * a compile error, which pre-push runs; a runtime check would be a test
+     * that cannot fail.
+     */
+    expect(availabilityAction(unit())?.kind).toBe('hold')
   })
 
   it('offers nothing on a SPLIT container', () => {
@@ -382,13 +397,6 @@ describe('availabilityAction', () => {
     expect(
       availabilityAction(unit({ is_container: true, is_combined: true, write_ins: [cover()] }))
     ).toBeNull()
-  })
-
-  it('offers nothing on a MERGED building that already holds a family (#2090)', () => {
-    // The occupancy rule is untouched: a write-in and a placement stay mutually
-    // exclusive. A combined container simply now REACHES that rule instead of
-    // being refused a step earlier for being a container.
-    expect(availabilityAction(unit({ is_container: true, is_combined: true }), true)).toBeNull()
   })
 })
 
@@ -525,13 +533,15 @@ describe('a write-in inherited from elsewhere in the tree', () => {
     // a no-op and four of them destroyed four rows without ever disclosing
     // that more than one existed. Removal is now the X on each `WriteInCard`,
     // which can only delete the row it sits on.
+    //
+    // THIS IS THE ARITY GATE, not the occupancy one kindred#2432 struck, and
+    // the two are worth keeping apart because they refuse the same card for
+    // unrelated reasons. This one is about not knowing WHICH row a click would
+    // destroy; the struck one was about who else is in the room. There is no
+    // longer a separate occupied-card case beside this test, because occupancy
+    // is not an input to `availabilityAction` at all — the assertion would have
+    // been character-for-character this one.
     expect(availabilityAction(unit({ code: 'house-a', write_ins: [coverFromBuilding] }))).toBeNull()
-  })
-
-  it('offers nothing on an occupied card either, rather than a stale write-in path', () => {
-    expect(
-      availabilityAction(unit({ code: 'house-a', write_ins: [coverFromBuilding] }), true)
-    ).toBeNull()
   })
 
   it('names the card’s OWN unit when the write-in starts here', () => {

--- a/frontend/src/components/weekend/unitBadges.ts
+++ b/frontend/src/components/weekend/unitBadges.ts
@@ -29,7 +29,7 @@
  * | branch | fact | field | stored in | scope |
  * |---|---|---|---|---|
  * | "Released" | staff<->family ROLE | `family_available_override` | `lodging_availability` | the WEEKEND |
- * | "Write-in" | OCCUPANCY | `write_in` (via `writeInOccupant`) | `lodging_write_ins`/`_draft` | the SCENARIO |
+ * | "Write-in" | OCCUPANCY | `write_ins` (via `hasWriteIn`) | `lodging_write_ins`/`_draft` | the SCENARIO |
  *
  * So a `family_available_override === false` is a role decision that names
  * NOBODY, and does not badge here. It used to badge "Write-in", because the
@@ -38,7 +38,7 @@
  * wrong about.
  */
 import type { LodgingUnitRow } from '../../types/lodging'
-import { writeInOccupant, writeInSource } from './writeIn'
+import { hasWriteIn } from './writeIn'
 
 export interface UnitBadge {
   label: string
@@ -66,7 +66,7 @@ export interface UnitBadge {
  * `reservationBadge` directly, unaffected by this function existing.
  */
 export function writeInBadgeApplies(unit: LodgingUnitRow): boolean {
-  return unit.inventory_class !== 'staff_default' && writeInOccupant(unit) !== null
+  return unit.inventory_class !== 'staff_default' && hasWriteIn(unit)
 }
 
 export function reservationBadge(unit: LodgingUnitRow): UnitBadge | null {
@@ -115,7 +115,7 @@ export function reservationBadge(unit: LodgingUnitRow): UnitBadge | null {
   // It still does not read `occupant_name`: "written in for a caretaker" and
   // "written in for a burst pipe" are the same fact about availability, which
   // is the same reason the reason text never reached this badge.
-  // Read through `writeInBadgeApplies` (`writeInOccupant`, never the raw
+  // Read through `writeInBadgeApplies` (`hasWriteIn`, never the raw
   // `family_available_override`). The board draws whichever level the tree
   // resolves to, so the card carrying a write-in is often not the unit whose
   // row it is: split a written-into building and its ROOMS carry it; merge
@@ -260,17 +260,19 @@ export interface AvailabilityAction {
   /** What the control collects before it may write — see `AvailabilityPrompt`. */
   prompt: AvailabilityPrompt
   /**
-   * The unit the write NAMES, which is not always the card it is offered on.
+   * The unit the write NAMES — always the card's own, since kindred#2381.
    *
-   * A write-in covers a space, and the board draws whichever level the tree
-   * resolves to — so a room can inherit its building's write-in, and a merged
-   * building one of its rooms'. There is exactly one `lodging_write_ins` row
-   * either way (kindred#2382 split occupancy off `lodging_availability`, which
-   * now answers only the staff↔family role), and clearing it has to target the
-   * unit that HOLDS it:
-   * sending the card's own id would delete nothing, and the unit holding the
-   * row has no card to offer the clear from. Every other action names the
-   * card's own unit.
+   * It was not always, and the exception was the write-in clear: a write-in
+   * covers a space and the board draws whichever level the tree resolves to,
+   * so a room can inherit its building's row and a merged building one of its
+   * rooms', and the clear had to target the unit that HOLDS the row. That
+   * action is gone — a card may now cover several write-ins and each is
+   * removed by the X on its own `WriteInCard` — so every action this returns
+   * is about the card's own availability row again.
+   *
+   * KEPT rather than collapsed into the caller reading `unit.unit_id`: the
+   * write model carries a target either way, and one field that is always the
+   * card's own is cheaper to read than a rule spread across two modules.
    */
   unitId: string
   /** That unit's name, for the confirmation toast. */
@@ -322,10 +324,10 @@ export type AvailabilityPrompt = 'occupant' | 'reason' | 'none'
  * that is now a statement about the staff↔family ROLE alone: "we're moving
  * staff to X for weekend Y" is true in every plan, which is why 1500000135's
  * reasoning survived kindred#2382 intact for this half. The OCCUPANCY that
- * used to share the field is scenario-scoped and lives in `write_in` — so the
- * `clear` this offers for a write-in unmakes a fact that belongs to the board
- * you are looking at, while the `clear` it offers for a release unmakes one
- * that belongs to the weekend.
+ * used to share the field is scenario-scoped and lives in `write_ins` — and
+ * since kindred#2381 this resolves the ROLE rows only. A written-into space
+ * returns null here and is removed from its own card, because one action
+ * cannot name one row out of the several a merged card may cover.
  */
 export function availabilityAction(
   unit: LodgingUnitRow,
@@ -349,55 +351,55 @@ export function availabilityAction(
   // (closed this weekend) are different answers, and collapsing them makes
   // either "Write in" or "Clear" unreachable across most of the board.
   const own = { unitId: unit.unit_id, unitName: unit.name }
-  // `label` defaults to the bare 'Clear' the RELEASE and the "agrees with the
-  // role" branches keep — neither of those undoes a write-in, so borrowing
-  // its wording would name a fact that is not there. The write-in branch below
-  // passes 'Clear Write-in' explicitly (kindred#2252): the chip that used to
-  // sit beside this button on `LodgingUnitCard` said "Write-in" out loud, and
-  // #2252 dropped it from that card as redundant with the well's `WriteInCard`
-  // — so the button is now the only thing left on that card naming what a
-  // click removes, and a bare 'Clear' stopped saying that.
-  const clear = (
-    target: { unitId: string; unitName: string },
-    label = 'Clear'
-  ): AvailabilityAction => ({
+  // 'Clear' for both surviving branches — the RELEASE and the "agrees with the
+  // role" one — because neither undoes a write-in and borrowing #2252's 'Clear
+  // Write-in' wording would name a fact that is not there. That label went with
+  // the write-in branch (kindred#2381); what it distinguished this button from
+  // no longer sits beside it.
+  const clear = (target: { unitId: string; unitName: string }): AvailabilityAction => ({
     kind: 'clear',
-    label,
+    label: 'Clear',
     familyAvailable: null,
     prompt: 'none',
     ...target,
   })
   /*
-   * THE THREE CLEAR BRANCHES ARE ORDERED TO MIRROR `reservationBadge` ABOVE,
-   * and that ordering is the rule rather than an accident of writing.
+   * THE BRANCHES ARE ORDERED TO MIRROR `reservationBadge` ABOVE, and that
+   * ordering is the rule rather than an accident of writing.
    *
-   * Once a write-in can be INHERITED, a card can carry its own availability
-   * row AND a relative's write-in at once — two rows, one control. This module
-   * already promises the badge and the action cannot drift ("a card badged
-   * 'Write-in' that offers to 'Write in' says two things about one cabin"), so
-   * the clear names whichever row the badge names. Anything else reports
-   * success for a row the staff member was not looking at, and leaves the fact
-   * they meant to remove sitting on the card.
+   * A card can carry its own availability row AND a relative's write-in at
+   * once — two rows, one control. This module already promises the badge and
+   * the action cannot drift ("a card badged 'Write-in' that offers to 'Write
+   * in' says two things about one cabin"), so a card the badge calls
+   * "Write-in" offers no strip action at all rather than one that quietly
+   * unmakes the other row. Anything else reports success for a row the staff
+   * member was not looking at.
    */
   // A released staff cabin badges "Released" off its OWN row, so that is the
   // row its clear names — even when a relative's write-in also covers it.
   if (unit.inventory_class === 'staff_default' && unit.family_available_override === true) {
     return clear(own)
   }
-  // The write-in COVERING this space, which badges "Write-in". Its own row
-  // when it has one — the server resolves own first — else its building's or
-  // one of its rooms'.
+  // A SPACE SOMEBODY IS WRITTEN INTO OFFERS NOTHING HERE — kindred#2381.
   //
-  // Offered before the `occupied` gate below for the reason that gate's own
-  // comment gives: a clear only ever REDUCES the conflict, so occupancy is
-  // never the state that needs it blocked. Without this branch an inheriting
-  // card is a dead end: it badges a write-in it cannot undo, and the unit
-  // holding the row has no card at all — which is exactly what a merge or a
-  // split does to it.
-  const source = writeInSource(unit)
-  if (source !== null) {
-    return clear({ unitId: source.unitId, unitName: source.unitName }, 'Clear Write-in')
-  }
+  // This used to return a 'Clear Write-in' naming whichever row the server
+  // resolved first, which was sound only while a card could carry exactly one.
+  // A merged container covers every write-in beneath it — four of them on the
+  // one 2026 building that has four — and one button cannot name four rows:
+  // each click destroyed the row it named, the card re-populated with the next
+  // occupant, and the action read as a no-op while it worked through them.
+  //
+  // Removal moved onto the cards, one X per `WriteInCard`, which can only ever
+  // delete the row it sits on. The dead end that branch existed to prevent —
+  // an inheriting card badging a write-in it cannot undo, while the unit
+  // holding the row has no card at all — is closed by the X rather than by
+  // this action, so returning null here strands nothing.
+  //
+  // ABOVE the `occupied` gate, exactly where the clear was: a written-into
+  // card must not fall through to the 'Write in' branch at the bottom and
+  // offer to write a SECOND occupant into a space that already resolves an own
+  // row ahead of its descendants — which would hide the ones already there.
+  if (hasWriteIn(unit)) return null
   // Any other ROLE override of its own — this branch has never been about
   // occupancy and is less so since kindred#2382. Two states reach it, both
   // storable and neither written by any surface: a `true` on a family-pool row

--- a/frontend/src/components/weekend/unitBadges.ts
+++ b/frontend/src/components/weekend/unitBadges.ts
@@ -313,12 +313,31 @@ export type AvailabilityPrompt = 'occupant' | 'reason' | 'none'
  * Lives beside `reservationBadge` so the two cannot drift. A card badged
  * "Write-in" that offers to "Write in" says two things about one cabin.
  *
- * `occupied` names a fact from the SLOT (whether any party is placed on this
- * card this scenario), never folded into `canManage`'s permission gate.
- * Owner ruling on #2090: written-in and occupied are mutually exclusive
- * states, so a space that already holds a family may not also be written into
- * — but this must not become a THIRD dimension threaded onto availability
- * itself.
+ * OCCUPANCY IS NOT AN INPUT HERE, and its absence is the ruling rather than an
+ * oversight. This took an `occupied` argument from the slot until kindred#2432,
+ * under the #2090 rule that "written-in and occupied are mutually exclusive
+ * states, so a space that already holds a family may not also be written into".
+ *
+ * ⚠️ THE RULE THAT REPLACED IT — owner ruling 2026-08-18, and the next reader
+ * must not restore the gate from the shape of the code:
+ *
+ * > *"we should be able to add families to any write in space, or add a write
+ * > in to a family space — regardless of which came first."*
+ *
+ * NAMING AN OCCUPANT AND CLOSING A SPACE ARE NOW SEPARATE FACTS. #2090 was
+ * ruled when hold and write-in were the same act (#2078, *"hold IS the
+ * write-in"*), and under that collapse "occupied and held" really was
+ * contradictory. The collapse has one real exception: a paper registration has
+ * no CampMinder record, so it cannot be placed on the board at all and a
+ * write-in is the ONLY way to record it — and such a party can legitimately
+ * share a cabin with a placed family. Refusing here made the one case the
+ * control exists for the one case it would not do.
+ *
+ * So the argument is GONE rather than defaulted or ignored: a caller that still
+ * has an occupancy fact to hand cannot spell it, which is how the reversal
+ * stays reversed. Symmetry is the point — `dragPlacement.resolveDrop` gives up
+ * the mirror-image refusal (a family onto a written-into space) in the same
+ * change, and neither direction may re-grow one alone.
  *
  * `family_available_override` IS still weekend-level and scenario-less, and
  * that is now a statement about the staff↔family ROLE alone: "we're moving
@@ -329,10 +348,7 @@ export type AvailabilityPrompt = 'occupant' | 'reason' | 'none'
  * returns null here and is removed from its own card, because one action
  * cannot name one row out of the several a merged card may cover.
  */
-export function availabilityAction(
-  unit: LodgingUnitRow,
-  occupied = false
-): AvailabilityAction | null {
+export function availabilityAction(unit: LodgingUnitRow): AvailabilityAction | null {
   // A SPLIT container is a whole-building aggregate, never a bookable room:
   // `drawnUnits` descends past it and `resolveDrop` rejects it as a target, so
   // an availability row written against one is a row no surface could show or
@@ -395,10 +411,13 @@ export function availabilityAction(
   // holding the row has no card at all — is closed by the X rather than by
   // this action, so returning null here strands nothing.
   //
-  // ABOVE the `occupied` gate, exactly where the clear was: a written-into
-  // card must not fall through to the 'Write in' branch at the bottom and
-  // offer to write a SECOND occupant into a space that already resolves an own
-  // row ahead of its descendants — which would hide the ones already there.
+  // THIS gate survives kindred#2432 and the one below it does not, which is
+  // the distinction worth holding on to: this one is about WRITE-IN ARITY, not
+  // about occupancy. A written-into card must not fall through to the 'Write
+  // in' branch at the bottom and offer to write a SECOND occupant into a space
+  // that already resolves an own row ahead of its descendants — which would
+  // hide the ones already there. A card that holds a FAMILY has no such
+  // problem, and since #2432 it keeps the action.
   if (hasWriteIn(unit)) return null
   // Any other ROLE override of its own — this branch has never been about
   // occupancy and is less so since kindred#2382. Two states reach it, both
@@ -421,10 +440,15 @@ export function availabilityAction(
   if (unit.inventory_class === 'staff_default') {
     return { kind: 'release', label: 'Release', familyAvailable: true, prompt: 'reason', ...own }
   }
-  // An already-occupied space offers no write-in: the fix for #2090. Only
-  // reachable here, past both branches above, so an already-held unit keeps
-  // its `clear` action regardless of occupancy — clearing only ever REDUCES
-  // the conflict, so it is never the state that needs blocking.
-  if (occupied) return null
+  // THE WRITE-IN, offered whether or not a family is already placed here —
+  // kindred#2432 struck the `if (occupied) return null` that used to sit on
+  // this line under #2090. See the docstring above for the ruling that
+  // replaced it; the short form is that this action NAMES AN OCCUPANT and no
+  // longer CLOSES THE SPACE, so there is nothing for occupancy to contradict.
+  //
+  // `familyAvailable: false` is unchanged and is not a contradiction of that:
+  // it is the value `set_availability` routes on to upsert a `lodging_write_ins`
+  // row (`_upsert_row(what='write-in', ...)`), not a claim that the space is
+  // shut. The two facts share one wire field and separate at the table.
   return { kind: 'hold', label: 'Write in', familyAvailable: false, prompt: 'occupant', ...own }
 }

--- a/frontend/src/components/weekend/unitBadges.ts
+++ b/frontend/src/components/weekend/unitBadges.ts
@@ -108,9 +108,14 @@ export function reservationBadge(unit: LodgingUnitRow): UnitBadge | null {
   // opposite expectation: a room kept empty, when in truth it is full.
   //
   // ONLY THE WORD CHANGES. The slate tone stays, because the underlying fact
-  // (this cabin is not available to a family this weekend) is the one the
-  // board already had a colour for, and inventing a second colour for a
-  // renamed concept is how a palette stops meaning anything.
+  // is the one the board already had a colour for, and inventing a second
+  // colour for a renamed concept is how a palette stops meaning anything.
+  //
+  // That fact is SOMEBODY IS IN IT, not "this cabin is not available to a
+  // family this weekend", which is what this comment said until kindred#2432
+  // and is no longer true: a written-into cabin now takes a family in either
+  // order. The chip reports an occupant the system has no record of; it does
+  // not report a closed space, and must not grow back into one.
   //
   // It still does not read `occupant_name`: "written in for a caretaker" and
   // "written in for a burst pipe" are the same fact about availability, which

--- a/frontend/src/components/weekend/writeIn.test.ts
+++ b/frontend/src/components/weekend/writeIn.test.ts
@@ -1,18 +1,22 @@
 /**
- * A write-in is a named occupant of a space — kindred#2078, kindred#2382.
+ * A write-in is a named occupant of a space — kindred#2078, kindred#2382, kindred#2381.
  *
- * The single definition of "is somebody written into this room", and the one
- * the board reads. It exists because #2093's forest open-tint was written
- * against the PROXY `unit.family_available_override === false` under the name
- * `held`, and a rename alone would have left the tint keyed on a spelling
- * rather than on the fact.
+ * The single definition of "who is written into this space", and the one the
+ * board reads. It exists because #2093's forest open-tint was written against
+ * the PROXY `unit.family_available_override === false` under the name `held`,
+ * and a rename alone would have left the tint keyed on a spelling rather than
+ * on the fact.
  *
- * THAT PROXY IS GONE, which is what these tests now pin. kindred#2382 moved
+ * THAT PROXY IS GONE, which is what these tests pin. kindred#2382 moved
  * occupancy into its own table and stopped the wire spelling one as
  * `family_available_override === false`; that field answers the staff↔family
  * ROLE and nothing else. Every fixture below that means "somebody is in it"
- * therefore carries a `write_in`, and a bare `false` means "closed by role",
- * which names nobody.
+ * therefore carries a `write_ins` entry, and a bare `false` means "closed by
+ * role", which names nobody.
+ *
+ * PLURAL since kindred#2381. A merged container draws in place of its rooms,
+ * so a card can cover several written-into rooms at once and every one of them
+ * has to reach the screen.
  *
  * Fictional data throughout. Production write-in notes are real family and
  * staff names; nothing here is dumped from any database.
@@ -20,7 +24,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { LodgingUnitRow, WriteInCoverRow } from '../../types/lodging'
-import { writeInOccupant, writeInSource } from './writeIn'
+import { hasWriteIn, writeInEntries } from './writeIn'
 
 function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
   return {
@@ -63,54 +67,51 @@ function cover(overrides: Partial<WriteInCoverRow> = {}): WriteInCoverRow {
   }
 }
 
-describe('writeInOccupant', () => {
+describe('writeInEntries', () => {
   it('names the occupant of a room somebody has been written into', () => {
     expect(
-      writeInOccupant(
+      writeInEntries(
         unit({
-          write_in: cover({ occupant_name: 'Emma Johnson', note: 'Kitchen lead, Fri–Sun' }),
+          write_ins: [cover({ occupant_name: 'Emma Johnson', note: 'Kitchen lead, Fri–Sun' })],
           occupant_name: 'Emma Johnson',
           reason: 'Kitchen lead, Fri–Sun',
           is_family_available: false,
         })
-      )
-    ).toEqual({ name: 'Emma Johnson', note: 'Kitchen lead, Fri–Sun' })
+      ).map((entry) => entry.occupant)
+    ).toEqual([{ name: 'Emma Johnson', note: 'Kitchen lead, Fri–Sun' }])
   })
 
-  it('is null for a room the ROLE closed, which names nobody', () => {
+  it('is empty for a room the ROLE closed, which names nobody', () => {
     // kindred#2382. `family_available_override === false` used to BE the
     // write-in — the occupancy and the staff↔family role shared one boolean.
     // With the two apart, a bare `false` is a role decision ("closed this
     // weekend") with no occupant behind it, and reading it as a write-in would
     // have the card report somebody who exists in no row anywhere.
-    expect(
-      writeInOccupant(unit({ family_available_override: false, is_family_available: false }))
-    ).toBeNull()
-    expect(
-      writeInSource(unit({ family_available_override: false, is_family_available: false }))
-    ).toBeNull()
+    const roleClosed = unit({ family_available_override: false, is_family_available: false })
+    expect(writeInEntries(roleClosed)).toEqual([])
+    expect(hasWriteIn(roleClosed)).toBe(false)
   })
 
-  it('is null for a room nobody has written into', () => {
+  it('is empty for a room nobody has written into', () => {
     // `null` on the override means "no row for this weekend, ask the unit's
     // role" — not "closed". Collapsing the two is the failure `reservationBadge`
     // documents at length, arriving one module over.
-    expect(writeInOccupant(unit())).toBeNull()
-    expect(writeInOccupant(unit({ family_available_override: null }))).toBeNull()
+    expect(writeInEntries(unit())).toEqual([])
+    expect(writeInEntries(unit({ family_available_override: null }))).toEqual([])
   })
 
-  it('is null for a staff cabin RELEASED to families', () => {
+  it('is empty for a staff cabin RELEASED to families', () => {
     // A release opens a room; it names no occupant. `true` and `false` are
     // opposite answers and only one of them is a write-in.
     expect(
-      writeInOccupant(
+      writeInEntries(
         unit({
           inventory_class: 'staff_default',
           family_available_override: true,
           reason: 'Overflow',
         })
       )
-    ).toBeNull()
+    ).toEqual([])
   })
 
   it('still reports a write-in whose occupant nobody named', () => {
@@ -118,18 +119,16 @@ describe('writeInOccupant', () => {
     // which is permissive where the control is not. The room is still closed,
     // so reporting "no write-in" here would hand it back to the open-tint and
     // send staff at the one room they may not fill.
-    expect(writeInOccupant(unit({ write_in: cover(), is_family_available: false }))).toEqual({
-      name: '',
-      note: '',
-    })
+    const entries = writeInEntries(unit({ write_ins: [cover()], is_family_available: false }))
+    expect(entries.map((entry) => entry.occupant)).toEqual([{ name: '', note: '' }])
   })
 
   it('treats a whitespace-only occupant as unnamed rather than as a name', () => {
     expect(
-      writeInOccupant(
-        unit({ write_in: cover({ occupant_name: '   ' }), is_family_available: false })
-      )
-    ).toEqual({ name: '', note: '' })
+      writeInEntries(
+        unit({ write_ins: [cover({ occupant_name: '   ' })], is_family_available: false })
+      ).map((entry) => entry.occupant)
+    ).toEqual([{ name: '', note: '' }])
   })
 
   it('does not fall back to the note when the occupant is unnamed', () => {
@@ -137,14 +136,23 @@ describe('writeInOccupant', () => {
     // the column behind it, precisely so one string cannot render twice on one
     // card. A fallback here would restore that double-print by another route.
     expect(
-      writeInOccupant(
+      writeInEntries(
         unit({
-          write_in: cover({ note: 'Back Monday' }),
+          write_ins: [cover({ note: 'Back Monday' })],
           reason: 'Back Monday',
           is_family_available: false,
         })
-      )
-    ).toEqual({ name: '', note: 'Back Monday' })
+      ).map((entry) => entry.occupant)
+    ).toEqual([{ name: '', note: 'Back Monday' }])
+  })
+
+  it('treats a payload with no write_ins key at all as uncovered', () => {
+    // The field is OPTIONAL on the wire, so an older or partial payload omits
+    // it entirely. `undefined` is "no cover", never a crash on `.length`.
+    const bare = unit()
+    delete (bare as { write_ins?: unknown }).write_ins
+    expect(writeInEntries(bare)).toEqual([])
+    expect(hasWriteIn(bare)).toBe(false)
   })
 })
 
@@ -158,63 +166,126 @@ describe('a write-in resolved through the unit tree', () => {
    */
   const inherited = unit({
     code: 'house-a',
-    write_in: {
-      unit_id: 'id-house',
-      unit_code: 'house',
-      unit_name: 'House',
-      occupant_name: 'Liam Garcia',
-      note: 'Back Monday',
-    },
+    write_ins: [
+      {
+        unit_id: 'id-house',
+        unit_code: 'house',
+        unit_name: 'House',
+        occupant_name: 'Liam Garcia',
+        note: 'Back Monday',
+      },
+    ],
   })
 
   it('names the occupant of a room its BUILDING was written into', () => {
-    expect(writeInOccupant(inherited)).toEqual({ name: 'Liam Garcia', note: 'Back Monday' })
+    expect(writeInEntries(inherited).map((entry) => entry.occupant)).toEqual([
+      { name: 'Liam Garcia', note: 'Back Monday' },
+    ])
   })
 
   it('reports the row it came from, and that it is not this unit’s own', () => {
-    expect(writeInSource(inherited)).toEqual({
-      unitId: 'id-house',
-      unitCode: 'house',
-      unitName: 'House',
-      isOwn: false,
-    })
+    expect(writeInEntries(inherited).map((entry) => entry.source)).toEqual([
+      { unitId: 'id-house', unitCode: 'house', unitName: 'House', isOwn: false },
+    ])
   })
 
   it('marks a unit’s OWN row as its own, so the card does not attribute it elsewhere', () => {
     const own = unit({
       code: 'cedar-1',
-      write_in: {
-        unit_id: 'u1',
-        unit_code: 'cedar-1',
-        unit_name: 'Cedar 1',
-        occupant_name: 'Emma Johnson',
-        note: '',
-      },
+      write_ins: [
+        {
+          unit_id: 'u1',
+          unit_code: 'cedar-1',
+          unit_name: 'Cedar 1',
+          occupant_name: 'Emma Johnson',
+          note: '',
+        },
+      ],
     })
 
-    expect(writeInSource(own)?.isOwn).toBe(true)
+    expect(writeInEntries(own)[0]?.source.isOwn).toBe(true)
   })
 
   it('reads the cover and never the old proxy, so a role row cannot fake one', () => {
     // THE COMPAT SHIM, retired by kindred#2382 PR 4. This used to synthesise a
     // cover from `family_available_override === false` plus the unit's own
     // `occupant_name`, because the wire had no other way to say "somebody is in
-    // it". It has one now — `write_in` is resolved server-side on every unit —
+    // it". It has one now — `write_ins` is resolved server-side on every unit —
     // and the old spelling means something else entirely, so reading it would
     // report an occupant a role-closed cabin does not have.
     expect(
-      writeInOccupant(
+      writeInEntries(
         unit({
           family_available_override: false,
           occupant_name: 'Emma Johnson',
           is_family_available: false,
         })
       )
-    ).toBeNull()
+    ).toEqual([])
   })
 
   it('says nothing when neither a cover nor an own row closes the space', () => {
-    expect(writeInOccupant(unit())).toBeNull()
-    expect(writeInSource(unit())).toBeNull()
+    expect(writeInEntries(unit())).toEqual([])
+    expect(hasWriteIn(unit())).toBe(false)
+  })
+})
+
+describe('a merged container over several written-into rooms', () => {
+  /*
+   * THE REPORTED CASE — kindred#2381. A container that draws combined stands in
+   * for its rooms, so all four of its written-into leaves resolve onto its one
+   * card. Returning one of them hid three occupants and made each clear look
+   * like a failed click as the card re-populated with the next name.
+   */
+  const merged = unit({
+    unit_id: 'id-house',
+    code: 'house',
+    name: 'House',
+    is_container: true,
+    is_combined: true,
+    write_ins: [
+      cover({
+        unit_id: 'id-back',
+        unit_code: 'house-back',
+        unit_name: 'House Back',
+        occupant_name: 'Emma Johnson',
+      }),
+      cover({
+        unit_id: 'id-loft',
+        unit_code: 'house-loft',
+        unit_name: 'House Loft',
+        occupant_name: 'Liam Garcia',
+      }),
+      cover({
+        unit_id: 'id-side',
+        unit_code: 'house-side',
+        unit_name: 'House Side',
+        occupant_name: 'Olivia Martinez',
+      }),
+    ],
+  })
+
+  it('names every occupant the card covers, in the order the server sent them', () => {
+    expect(writeInEntries(merged).map((entry) => entry.occupant.name)).toEqual([
+      'Emma Johnson',
+      'Liam Garcia',
+      'Olivia Martinez',
+    ])
+  })
+
+  it('pairs each occupant with the row that holds it, so a removal targets that row', () => {
+    // The pairing is the point of one entry rather than two parallel arrays:
+    // an X drawn on the third card must delete the THIRD row, and index
+    // alignment maintained by hand is exactly the invariant that rots.
+    expect(writeInEntries(merged).map((entry) => entry.source.unitId)).toEqual([
+      'id-back',
+      'id-loft',
+      'id-side',
+    ])
+    expect(writeInEntries(merged).every((entry) => !entry.source.isOwn)).toBe(true)
+  })
+
+  it('reports the space as covered', () => {
+    expect(hasWriteIn(merged)).toBe(true)
   })
 })

--- a/frontend/src/components/weekend/writeIn.ts
+++ b/frontend/src/components/weekend/writeIn.ts
@@ -33,7 +33,7 @@
  * so by testing `unit.family_available_override === false` — a PROXY for "is
  * somebody in it". Reading the fact through one named function is what let the
  * proxy be retired here, once, instead of in every consumer: that field now
- * answers the ROLE alone, and `write_in` answers this one.
+ * answers the ROLE alone, and `write_ins` answers this one.
  *
  * ## What is deliberately NOT here
  *
@@ -42,9 +42,9 @@
  * string rendered as both the occupant's NAME and the card's italic reason line
  * printed twice on one card. A fallback would restore that by another route.
  *
- * No fallback from `write_in` to `family_available_override === false` either,
+ * No fallback from `write_ins` to `family_available_override === false` either,
  * and that one was deliberately removed rather than never written — see
- * `coveringWriteIn`.
+ * `coveringWriteIns`.
  */
 import type { LodgingUnitRow, WriteInCoverRow } from '../../types/lodging'
 
@@ -69,22 +69,31 @@ export interface WriteInOccupant {
 }
 
 /**
- * The occupant written into this space for this weekend, or `null` if none.
+ * WHO is in this space and WHOSE row says so, kept together — one entry per
+ * write-in covering the unit.
  *
- * "This space", not "this unit": a building's write-in closes its rooms and a
- * room's closes its building as a whole-house let, and the board draws whichever
- * level the unit tree resolves to. The server does that walk (`write_in_covers`)
- * and this reads its answer.
+ * A PAIR rather than two functions returning two arrays, which is what this
+ * was until kindred#2381 (`writeInOccupant` / `writeInSource`). Splitting them
+ * was right while there was exactly one cover: "who is in this space" is what
+ * the card prints and "whose row is this" is what a CLEAR has to name, and
+ * sending the card's own id for an inherited write-in would delete nothing at
+ * all. With N covers on one card the two answers have to stay lined up — the X
+ * drawn on the third card must delete the THIRD row — and index alignment held
+ * by hand across two arrays is the invariant that rots first.
  */
-export function writeInOccupant(unit: LodgingUnitRow): WriteInOccupant | null {
-  const cover = coveringWriteIn(unit)
-  if (cover === null) return null
-  return { name: (cover.occupant_name ?? '').trim(), note: (cover.note ?? '').trim() }
+export interface WriteInEntry {
+  occupant: WriteInOccupant
+  source: WriteInSource
 }
 
-/** Where a unit's write-in is recorded, or `null` if none covers it. */
+/**
+ * Where a unit's write-in is recorded.
+ *
+ * A room can inherit its building's row and a merged building one of its
+ * rooms', so this is not always the unit the card draws.
+ */
 export interface WriteInSource {
-  /** The unit the `lodging_write_ins` row belongs to — a clear's target. */
+  /** The unit the `lodging_write_ins` row belongs to — a removal's target. */
   unitId: string
   unitCode: string
   unitName: string
@@ -93,29 +102,57 @@ export interface WriteInSource {
 }
 
 /**
- * WHICH unit holds the write-in covering this one.
+ * Every write-in closing this space for this weekend, in the server's order.
  *
- * A SECOND function rather than more fields on `WriteInOccupant`, because the
- * two answer different questions and only one of them is display. "Who is in
- * this space" is what the card prints; "whose row is this" is what a CLEAR has
- * to name, and sending the card's own id for an inherited write-in would
- * delete nothing at all — the room has no row. Keeping them apart is also what
- * left every existing reader of the occupant untouched.
+ * "This space", not "this unit": a building's write-in closes its rooms and a
+ * room's closes its building as a whole-house let, and the board draws
+ * whichever level the unit tree resolves to. The server does that walk
+ * (`write_in_covers`) and this reads its answer.
+ *
+ * PLURAL since kindred#2381, and the arity is the fix rather than a
+ * generalisation. A merged container stands in for its rooms, so the four
+ * write-ins one 2026 building carries in a single weekend all land on one
+ * card — and returning the first hid three occupants while making each clear
+ * read as a failed click, because the card immediately re-populated with the
+ * next name. An assignment survives a merge and a split by having the drawn
+ * card carry however many leaves it covers; this is a write-in doing the same.
+ *
+ * ORDERED BY THE SERVER (`code` at every level), never re-sorted here: two
+ * places deciding the sequence is two places that can disagree about it.
  */
-export function writeInSource(unit: LodgingUnitRow): WriteInSource | null {
-  const cover = coveringWriteIn(unit)
-  if (cover === null) return null
-  const unitCode = cover.unit_code ?? ''
-  return {
-    unitId: cover.unit_id ?? '',
-    unitCode,
-    unitName: cover.unit_name ?? '',
-    isOwn: unitCode === unit.code,
-  }
+export function writeInEntries(unit: LodgingUnitRow): WriteInEntry[] {
+  return coveringWriteIns(unit).map((cover) => {
+    const unitCode = cover.unit_code ?? ''
+    return {
+      occupant: {
+        name: (cover.occupant_name ?? '').trim(),
+        note: (cover.note ?? '').trim(),
+      },
+      source: {
+        unitId: cover.unit_id ?? '',
+        unitCode,
+        unitName: cover.unit_name ?? '',
+        isOwn: unitCode === unit.code,
+      },
+    }
+  })
 }
 
 /**
- * The server-resolved cover, and NOTHING else.
+ * Whether ANY write-in closes this space.
+ *
+ * The gate every consumer that only needs the yes/no reads — the drop refusal
+ * (`dragPlacement`), its affordance half on the card, and the "Write-in" chip.
+ * Spelled once so a merged card covering four occupants and a room covering
+ * one are the same answer to those three, which `!== null` on a single cover
+ * silently stopped being.
+ */
+export function hasWriteIn(unit: LodgingUnitRow): boolean {
+  return coveringWriteIns(unit).length > 0
+}
+
+/**
+ * The server-resolved covers, and NOTHING else.
  *
  * ## Why the old fallback is gone rather than merely unused
  *
@@ -133,9 +170,11 @@ export function writeInSource(unit: LodgingUnitRow): WriteInSource | null {
  * fabricated occupant is not the conservative answer — it is a different wrong
  * one, and it would also block placement into a cabin that is merely closed.
  *
- * There is no gap left to guard. `write_in` is built for every unit the API
- * returns, and a unit with neither a cover nor a role row is simply open.
+ * There is no gap left to guard. `write_ins` is built for every unit the API
+ * returns, and a unit with neither a cover nor a role row is simply open. The
+ * `?? []` is for the FIELD being absent from an older payload, not for a unit
+ * the walk declined to answer for.
  */
-function coveringWriteIn(unit: LodgingUnitRow): WriteInCoverRow | null {
-  return unit.write_in ?? null
+function coveringWriteIns(unit: LodgingUnitRow): WriteInCoverRow[] {
+  return unit.write_ins ?? []
 }

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -2226,7 +2226,10 @@ export type LodgingUnitSummary = {
    * Is Family Available
    */
   is_family_available?: boolean
-  write_in?: WriteInCover | null
+  /**
+   * Write Ins
+   */
+  write_ins?: Array<WriteInCover>
   /**
    * Map X
    */

--- a/frontend/src/types/lodging.test.ts
+++ b/frontend/src/types/lodging.test.ts
@@ -258,7 +258,7 @@ const _exhaustiveLodgingUnit: Required<LodgingUnitRow> = {
   // nearest descendant's. Distinct from the three fields above, which stay
   // strictly this unit's own row: a room can be closed by a write-in it does
   // not hold, which is what a merge or a split does to one.
-  write_in: null,
+  write_ins: [],
   map_x: 0.5,
   map_y: 0.5,
 }

--- a/frontend/src/types/lodging.ts
+++ b/frontend/src/types/lodging.ts
@@ -56,7 +56,7 @@ export type RosterCountSummary = RosterCounts
 export type LodgingUnitRow = LodgingUnitSummary
 /**
  * The write-in covering a unit's space, resolved through the tree by the
- * server. Read it through `writeInOccupant`/`writeInSource`, never inline: the
+ * server. Read it through `writeInEntries`/`hasWriteIn`, never inline: the
  * point of naming the fact once is that the board's five consumers cannot
  * drift onto different spellings of it.
  */

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -4642,14 +4642,14 @@ class TestTheWireStopsSpellingAnOccupancyAsFamilyAvailableFalse:
     still reported `family_available_override = False`, because
     `is_family_available` -- and through it every count on the stats bar, and
     the board's own forest open-tint -- was derived from that one field. Every
-    consumer has since been re-pointed at the occupancy source (`write_in`, and
-    `writeInOccupant` on the client), so the field can go back to answering the
+    consumer has since been re-pointed at the occupancy source (`write_ins`, and
+    `writeInEntries` on the client), so the field can go back to answering the
     ONE question it is named for.
 
     | on the wire | what it means now |
     |---|---|
     | `family_available_override` | the staff<->family ROLE row, and nothing else |
-    | `write_in` | somebody is in this space -- the occupancy, resolved |
+    | `write_ins` | who is in this space -- the occupancy, resolved |
     | `is_family_available` | the DERIVED answer, which still folds both in |
 
     `is_family_available` is what does not move, and that is the point of the

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -1064,14 +1064,14 @@ class TestUnitsAndCounts:
         by_code = {u.code: u for u in roster.units}
         # The room holds no row of its own -- and is closed all the same.
         assert by_code["house-a"].family_available_override is None
-        assert by_code["house-a"].write_in is not None
-        assert by_code["house-a"].write_in.unit_id == "u1"
-        assert by_code["house-a"].write_in.occupant_name == "Liam Garcia"
-        assert by_code["house-a"].write_in.note == "Back Monday"
+        assert by_code["house-a"].write_ins != []
+        assert by_code["house-a"].write_ins[0].unit_id == "u1"
+        assert by_code["house-a"].write_ins[0].occupant_name == "Liam Garcia"
+        assert by_code["house-a"].write_ins[0].note == "Back Monday"
         # And the building still reads as its own, so the card that holds the
         # row does not start attributing it elsewhere.
-        assert by_code["house"].write_in is not None
-        assert by_code["house"].write_in.unit_code == "house"
+        assert by_code["house"].write_ins != []
+        assert by_code["house"].write_ins[0].unit_code == "house"
 
     @pytest.mark.asyncio
     async def test_a_write_in_on_a_room_reaches_the_building_over_it(self) -> None:
@@ -1089,9 +1089,9 @@ class TestUnitsAndCounts:
         roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
 
         by_code = {u.code: u for u in roster.units}
-        assert by_code["house"].write_in is not None
-        assert by_code["house"].write_in.unit_id == "u2"
-        assert by_code["house"].write_in.occupant_name == "Ava Martinez"
+        assert by_code["house"].write_ins != []
+        assert by_code["house"].write_ins[0].unit_id == "u2"
+        assert by_code["house"].write_ins[0].occupant_name == "Ava Martinez"
 
     @pytest.mark.asyncio
     async def test_an_ordinary_open_cabin_carries_no_cover_at_all(self) -> None:
@@ -1104,7 +1104,7 @@ class TestUnitsAndCounts:
         )
         roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
 
-        assert roster.units[0].write_in is None
+        assert roster.units[0].write_ins == []
 
     @pytest.mark.asyncio
     async def test_a_true_override_beats_a_false_default(self) -> None:
@@ -4184,9 +4184,9 @@ class TestWriteInCovers:
 
         covers = write_in_covers([house, room], self._written("house"))
 
-        assert covers["house-a"].unit_code == "house"
-        assert covers["house-a"].occupant_name == "Liam Garcia"
-        assert covers["house-a"].note == "Back Monday"
+        assert covers["house-a"][0].unit_code == "house"
+        assert covers["house-a"][0].occupant_name == "Liam Garcia"
+        assert covers["house-a"][0].note == "Back Monday"
 
     def test_a_building_surfaces_the_write_in_of_a_room_beneath_it(self) -> None:
         # The MERGE case, and the mirror of the one above: the row names a room
@@ -4197,8 +4197,8 @@ class TestWriteInCovers:
 
         covers = write_in_covers([house, written_room, other_room], self._written("house-a"))
 
-        assert covers["house"].unit_code == "house-a"
-        assert covers["house"].occupant_name == "Liam Garcia"
+        assert covers["house"][0].unit_code == "house-a"
+        assert covers["house"][0].occupant_name == "Liam Garcia"
 
     def test_a_sibling_room_is_not_covered(self) -> None:
         # The one direction that must NOT propagate. A caretaker in room A says
@@ -4213,7 +4213,7 @@ class TestWriteInCovers:
         covers = write_in_covers([house, written_room, other_room], self._written("house-a"))
 
         assert "house-b" not in covers
-        assert covers["house"].unit_code == "house-a"
+        assert covers["house"][0].unit_code == "house-a"
 
     def test_a_units_own_write_in_beats_an_inherited_one(self) -> None:
         house = self._unit("house", is_container=True, occupant_name="Liam Garcia")
@@ -4221,8 +4221,8 @@ class TestWriteInCovers:
 
         covers = write_in_covers([house, room], self._written("house", "house-a"))
 
-        assert covers["house-a"].unit_code == "house-a"
-        assert covers["house-a"].occupant_name == "Ava Martinez"
+        assert covers["house-a"][0].unit_code == "house-a"
+        assert covers["house-a"][0].occupant_name == "Ava Martinez"
 
     def test_the_nearest_ancestor_wins(self) -> None:
         block = self._unit("block", is_container=True, occupant_name="Ava Martinez")
@@ -4236,7 +4236,7 @@ class TestWriteInCovers:
 
         covers = write_in_covers([block, house, room], self._written("block", "house"))
 
-        assert covers["house-a"].unit_code == "house"
+        assert covers["house-a"][0].unit_code == "house"
 
     def test_a_release_is_not_a_write_in(self) -> None:
         # A ROLE release is a staff cabin OPENED to families for the weekend. It
@@ -4295,17 +4295,64 @@ class TestWriteInCovers:
 
         assert write_in_covers([written, other], self._written("")) == {}
 
-    def test_several_written_rooms_pick_one_deterministically(self) -> None:
-        # A building over two written-into rooms is closed either way; the
-        # point is that two identical payloads never disagree about WHICH row
-        # the card names, which a set-ordered walk would not guarantee.
+    def test_several_written_rooms_are_all_returned_in_code_order(self) -> None:
+        # A building over two written-into rooms carries BOTH, in `code` order
+        # so two identical payloads never disagree about the sequence a card
+        # draws them in. This used to return exactly one and drop the rest --
+        # kindred#2381, the merge half of the parity bug.
         house = self._unit("house", is_container=True, is_combined=True)
         room_b = self._unit("house-b", parent_code="house", occupant_name="Ava Martinez")
         room_a = self._unit("house-a", parent_code="house", occupant_name="Liam Garcia")
         written = self._written("house-a", "house-b")
 
-        assert write_in_covers([house, room_b, room_a], written)["house"].unit_code == "house-a"
-        assert write_in_covers([house, room_a, room_b], written)["house"].unit_code == "house-a"
+        for units in ([house, room_b, room_a], [house, room_a, room_b]):
+            assert [cover.unit_code for cover in write_in_covers(units, written)["house"]] == [
+                "house-a",
+                "house-b",
+            ]
+
+    def test_a_merged_building_surfaces_every_written_room_beneath_it(self) -> None:
+        """The reported case: four written-into rooms under one merged card.
+
+        A merged container draws in place of its rooms, so before kindred#2381
+        the four occupants collapsed to whichever room sorted first and the
+        other three were invisible -- and each clear silently re-populated the
+        card with the next one, which read as a failed click.
+        """
+        house = self._unit("house", is_container=True, is_combined=True)
+        rooms = [
+            self._unit("house-back", parent_code="house", occupant_name="Emma Johnson"),
+            self._unit("house-laundry", parent_code="house", occupant_name="Liam Garcia"),
+            self._unit("house-loft", parent_code="house", occupant_name="Olivia Martinez"),
+            self._unit("house-side", parent_code="house", occupant_name="Noah Chen"),
+        ]
+
+        covers = write_in_covers([house, *rooms], self._written(*(room.code for room in rooms)))
+
+        assert [cover.occupant_name for cover in covers["house"]] == [
+            "Emma Johnson",
+            "Liam Garcia",
+            "Olivia Martinez",
+            "Noah Chen",
+        ]
+        # Each room still answers for itself alone -- the collect-all runs
+        # DOWNWARD from the drawn card and never sideways.
+        for room in rooms:
+            assert [cover.unit_code for cover in covers[room.code]] == [room.code]
+
+    def test_the_descendant_walk_stops_at_the_nearest_written_room_on_each_branch(self) -> None:
+        # A written-into room inside a written-into wing is already inside that
+        # wing's space -- the wing's row speaks for it, and returning both to
+        # the building would print the same space twice. "Collect all" is
+        # per-branch nearest, not every descendant.
+        house = self._unit("house", is_container=True, is_combined=True)
+        wing = self._unit("house-a", parent_code="house", is_container=True, occupant_name="Emma Johnson")
+        bed = self._unit("house-a-1", parent_code="house-a", occupant_name="Liam Garcia")
+        other_wing = self._unit("house-b", parent_code="house", occupant_name="Olivia Martinez")
+
+        covers = write_in_covers([house, wing, bed, other_wing], self._written("house-a", "house-a-1", "house-b"))
+
+        assert [cover.unit_code for cover in covers["house"]] == ["house-a", "house-b"]
 
 
 class TestWriteInsResolveFromTheirOwnTable:
@@ -4356,9 +4403,9 @@ class TestWriteInsResolveFromTheirOwnTable:
         # answering both. See TestTheWireStopsSpellingAnOccupancyAsFamilyAvailableFalse.
         assert unit.family_available_override is None
         assert unit.is_family_available is False
-        assert unit.write_in is not None
-        assert unit.write_in.unit_id == "u1"
-        assert unit.write_in.occupant_name == "Liam Garcia"
+        assert unit.write_ins != []
+        assert unit.write_ins[0].unit_id == "u1"
+        assert unit.write_ins[0].occupant_name == "Liam Garcia"
 
     @pytest.mark.asyncio
     async def test_a_stale_availability_occupancy_row_no_longer_writes_anybody_in(self) -> None:
@@ -4385,7 +4432,7 @@ class TestWriteInsResolveFromTheirOwnTable:
         roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
 
         assert roster.units[0].is_family_available is False
-        assert roster.units[0].write_in is None
+        assert roster.units[0].write_ins == []
 
     @pytest.mark.asyncio
     async def test_a_role_release_still_comes_from_availability(self) -> None:
@@ -4412,7 +4459,7 @@ class TestWriteInsResolveFromTheirOwnTable:
         # A release names no occupant and closes nothing, so it must never
         # resolve to a cover -- inheriting one would silently open every room
         # beneath a released building.
-        assert unit.write_in is None
+        assert unit.write_ins == []
 
     @pytest.mark.asyncio
     async def test_a_write_in_outranks_a_release_on_the_same_unit(self) -> None:
@@ -4439,7 +4486,7 @@ class TestWriteInsResolveFromTheirOwnTable:
         assert unit.family_available_override is True
         assert unit.is_family_available is False
         assert unit.occupant_name == "Ava Martinez"
-        assert unit.write_in is not None
+        assert unit.write_ins != []
 
     @pytest.mark.asyncio
     async def test_the_roster_reads_the_write_in_table_for_this_weekend(self) -> None:
@@ -4539,7 +4586,7 @@ class TestWriteInsResolveFromTheirOwnTable:
 
         repo.fetch_write_ins.assert_awaited_once_with(2026, 1000001)
         assert repo.fetch_draft_write_ins.await_count == 0
-        assert roster.units[0].write_in is not None
+        assert roster.units[0].write_ins != []
 
     @pytest.mark.asyncio
     async def test_a_written_into_cabin_is_still_counted_as_reserved(self) -> None:
@@ -4582,10 +4629,10 @@ class TestWriteInsResolveFromTheirOwnTable:
 
         by_code = {u.code: u for u in roster.units}
         assert by_code["house-a"].family_available_override is None
-        assert by_code["house-a"].write_in is not None
-        assert by_code["house-a"].write_in.unit_id == "u1"
-        assert by_code["house-a"].write_in.occupant_name == "Liam Garcia"
-        assert by_code["house-a"].write_in.note == "Back Monday"
+        assert by_code["house-a"].write_ins != []
+        assert by_code["house-a"].write_ins[0].unit_id == "u1"
+        assert by_code["house-a"].write_ins[0].occupant_name == "Liam Garcia"
+        assert by_code["house-a"].write_ins[0].note == "Back Monday"
 
 
 class TestTheWireStopsSpellingAnOccupancyAsFamilyAvailableFalse:
@@ -4635,7 +4682,7 @@ class TestTheWireStopsSpellingAnOccupancyAsFamilyAvailableFalse:
         # THE HALF THAT MUST NOT MOVE. The derived answer still folds the
         # occupancy in, so nothing staff read changes.
         assert unit.is_family_available is False
-        assert unit.write_in is not None
+        assert unit.write_ins != []
         assert unit.occupant_name == "Liam Garcia"
 
     @pytest.mark.asyncio
@@ -4668,7 +4715,7 @@ class TestTheWireStopsSpellingAnOccupancyAsFamilyAvailableFalse:
         # safe direction: reading the release instead would open a cabin with
         # somebody sleeping in it.
         assert unit.is_family_available is False
-        assert unit.write_in is not None
+        assert unit.write_ins != []
 
     @pytest.mark.asyncio
     async def test_the_counts_do_not_move_when_the_shim_comes_out(self) -> None:
@@ -4716,7 +4763,7 @@ class TestTheWireStopsSpellingAnOccupancyAsFamilyAvailableFalse:
         unit = roster.units[0]
         assert unit.family_available_override is False
         assert unit.is_family_available is False
-        assert unit.write_in is None
+        assert unit.write_ins == []
 
 
 class TestAScenariosWriteInsReplaceTheLiveOnes:
@@ -4774,7 +4821,7 @@ class TestAScenariosWriteInsReplaceTheLiveOnes:
         roster = await LodgingRosterService(repo).build_roster(2026, 1000001, scenario="scn_1")
 
         unit = roster.units[0]
-        assert unit.write_in is None
+        assert unit.write_ins == []
         assert unit.family_available_override is None
         assert unit.is_family_available is True
         assert unit.occupant_name == ""
@@ -4803,8 +4850,8 @@ class TestAScenariosWriteInsReplaceTheLiveOnes:
         assert unit.is_family_available is False
         assert unit.occupant_name == "Olivia Chen"
         assert unit.reason == "Paper registration"
-        assert unit.write_in is not None
-        assert unit.write_in.unit_id == "u1"
+        assert unit.write_ins != []
+        assert unit.write_ins[0].unit_id == "u1"
 
     @pytest.mark.asyncio
     async def test_two_scenarios_can_write_the_same_family_into_different_cabins(self) -> None:
@@ -4863,9 +4910,9 @@ class TestAScenariosWriteInsReplaceTheLiveOnes:
         roster = await LodgingRosterService(repo).build_roster(2026, 1000001, scenario="scn_1")
 
         by_code = {u.code: u for u in roster.units}
-        assert by_code["house-a"].write_in is not None
-        assert by_code["house-a"].write_in.unit_id == "u1"
-        assert by_code["house-a"].write_in.occupant_name == "Olivia Chen"
+        assert by_code["house-a"].write_ins != []
+        assert by_code["house-a"].write_ins[0].unit_id == "u1"
+        assert by_code["house-a"].write_ins[0].occupant_name == "Olivia Chen"
 
     @pytest.mark.asyncio
     async def test_the_role_override_is_still_read_from_the_live_table_in_a_scenario(self) -> None:


### PR DESCRIPTION
Staff asked to write a paper registration into a cabin that a CampMinder family is already placed in — one paper registration and one CampMinder family sharing a cabin. A paper registration has no CampMinder record, so it cannot be placed on the board at all; a write-in is the only way to record that party. The write-in control vanished the moment a family was placed in the space, so **the one case the control exists for was the one case it refused**.

Owner ruling 2026-08-18 reverses #2090 symmetrically:

> *"we should be able to add families to any write in space, or add a write in to a family space — regardless of which came first."*

`names an occupant` and `closes the space` are now separate facts.

## The measured number: four refusals, not one

The issue body said *"Scope: frontend only"* and named **one** gate. Re-derived against the tree, **four** sites refused, across both directions of the ruling:

| Site | What it was | Direction it refused |
|---|---|---|
| `unitBadges.availabilityAction` | `if (occupied) return null` — plus the `occupied` parameter itself | write-in onto a family |
| `dragPlacement.resolveDrop` | `if (hasWriteIn(unit)) return null` — its own comment called it *"the load-bearing one"* | family onto a write-in |
| `LodgingUnitCard`'s `useDroppable` | `disabled: … \|\| held` | family onto a write-in |
| `LodgingUnitCard`'s `canPickFamily` | `… && !held && …` | family onto a write-in (#2080's picker) |

The last two are why a resolver-only fix would not have worked: `disabled` keeps dnd-kit from ever reporting `isOver`, so a drop the resolver accepts could never be aimed at the card, and the picker would stay absent for a placement drag performs happily. `resolvePickerPlacement` needed no edit at all — it is a thin adapter over `resolveDrop`, which is the whole point of it having no rules of its own.

The `occupied` argument is **deleted rather than defaulted or ignored**, in both `availabilityAction` and `UnitAvailabilityControl`'s props: a caller still holding an occupancy fact has nowhere to spell it, which is what stops the gate growing back by inches. `tsc` is the enforcer.

Every site carries the ruling that replaced the old one, in the place the old one sat. Without that, the next reader restores the guard on the strength of the comment already there.

## What deliberately did NOT change

- **The `hasWriteIn` gate in `availabilityAction` stays.** It is write-in **arity** (#2381 — one button cannot name which of four rows a click destroys), not occupancy. The two refuse the same card for unrelated reasons and are now named apart in the code.
- **`canPickFamily`'s `parties.length === 0` stays.** A second family reaches a shareable space by drag, which remains the deliberate path for a share. #2091 is unbuilt and nothing here invents its treatment.
- **The open-space forest tint still stands down on a written-into cabin**, on the surviving half of its reason: EMPTY and OPEN are different predicates, and a room somebody is sleeping in is not empty even though it is now placeable. The comment says which half died.
- **"Drop families here" still stands down** for the same reason — the well is not empty, a `WriteInCard` is sitting in it. The card remains a live drop target regardless.
- **No API behaviour change.** `is_family_available` (`api/services/lodging_rules.py`) still folds occupancy in, so the stats bar's "available" count stays conservative about a written-into space and a *released staff cabin* that is then written into still drops off the board via `isPlanningInventory`. Out of scope here, flagged rather than silently widened.
- `held` is renamed `writtenInto` throughout `LodgingUnitCard` — the surviving readers say **who is in it**, never that the space is shut.

## #2091's visual precedent, set on purpose

This draws a `FamilyCard` and a `WriteInCard` in one occupant well for the first time, and #2091 (*mark a space that holds two families*) is unbuilt — so whatever this ships becomes its precedent by default. The chosen form is the most conservative one available and is written down as such in the well's own comment: **one well, occupants stacked in the order they already stack, no divider, no new chip, no new colour**, the existing `CARD_FRAME`/`card-lodge` frames untouched. A shared space is not a new *kind* of card; it is a card with two occupants in it. If #2091 later wants a shared-space treatment it should extend this rather than contradict it.

## Known interaction with #2439 — read before merging

A write-in carries **no headcount** (`lodging_write_ins` has `occupant_name` and `note` and no count field), so once both occupants are in one space the free-bed figure **overstates**: a 10-bed cabin holding a party of 6 plus a written-in party of 3 reads **4 free** when 1 is. That is filed as **#2439** and ruled an *optional investigation, explicitly not a blocker* — an understated count on a space staff can share beats a space they could not share at all. The card's occupancy comment names #2439 and says not to "fix" it by guessing a headcount.

## ⚠️ Stacked on #2446 — this PR gets NO CI

Based on `feature/write-in-merge-split` (PR #2446, the Lane B card work for #2381 + #2431 + #2430), which it shares `unitBadges.ts` and `dragPlacement.ts` with. This repo's CI is `pull_request: branches: [main]`, so **a PR based on a feature branch runs nothing — an absence, not a failure.** Its only evidence is the local gates below.

The `Closes` line will also register nothing until #2446 merges and this body is re-saved.

Observed on this PR: `Validate PR title` passed, `auto-merge` skipped, and **CodeRabbit's green check is the "Review skipped: automatic reviews are disabled" no-op** — not a review. CodeRabbit was deliberately not requested: the wave's rolling quota is better spent on a PR that gets CI, and this one parks for the owner's eyes regardless.

## Independent review (round 2) — fixed in-branch

A second reader re-derived the change against the tree and the production
snapshot. No behaviour defect was found; the four gates are the right four and
the reversal is complete in both directions. What it did find is that the rule
#2432 reverses is still **asserted in eight places outside the gates**, and
each is what the next reader would restore it from. All eight are corrected
here (`ce540ab1`), comments and docs only:

| Where | What it still said |
|---|---|
| `docs/architecture/lodging-occupancy.md` | The whole *"What a hold represents"* section — write-in and placement are *"mutually exclusive states: a unit cannot be both held and occupied"* — naming the exact three code sites this PR struck as its proof. Rewritten around the 2026-08-18 ruling. |
| 5 API comments (`lodging_write_service.py` ×3, `lodging_repository.py`, `lodging_roster_service.py`) | Each gave *"kindred#2247's placement gate"* as the REASON write-ins are seeded into a scenario. That gate is gone; a reader who checked would find nothing there and could delete the seed, dropping every write-in occupant from seeded scenarios. The seed's real argument was always **disclosure**, and now says so. |
| `api/schemas/lodging.py` | *"an inherited write-in badges and **blocks placement**"* — it badges and discloses; it blocks nothing. |
| `needsFit.ts`, `needsFit.test.ts`, `LodgingUnitCard.test.tsx` | The board's signal vocabulary — `opacity-40` is owned by *"the invalid merge target and by a held space"*. This PR corrected the two copies inside `LodgingUnitCard.tsx` and left the canonical statement in `needsFit.ts` plus two test restatements. |
| `LodgingBoard.tsx` | `placeParty`'s copy of `resolvePickerPlacement`'s refusal list still led with *"a held space"*, disagreeing with the list in `dragPlacement.ts` this PR rewrote. |
| `unitBadges.ts` | The Write-in chip justified its slate tone by *"the underlying fact (this cabin is not available to a family this weekend)"*. The fact is **somebody is in it**. |
| `LodgingUnitCard.tsx` | The new ⚠️ said the picker has *"NO rules of its own by design"* — which reads as licence to delete the `parties.length === 0` gate listed three lines above. Qualified: that gate removes an affordance without removing an outcome, which is a scoping choice, not the drift. |

Checked against the production snapshot rather than by reading: of **16**
written-into units in the 2026 weekend, **8 already carry a draft placement**,
so the shared-occupant well is a state real data is in today, not a legacy-row
curiosity — and two write-ins name a paper registration explicitly, which is
the reported case. All 16 have a recorded capacity, so `countUnmeasuredSpaces`
reports the same number before and after.

Also verified, and the reason nothing here holds the PR: `place_party`
(`lodging_write_service.py`) performs an unconditional upsert with **no**
occupancy check, so the client-side reversal succeeds end to end rather than
optimistically moving and rolling back. And the released-staff-cabin edge is
**not widened** — `isPlanningInventory` keeps any unit that has a party on it,
and every case #2432 newly enables has one.

## Local evidence

- `bash scripts/pre-push-verify.sh` → **ALL CHECKS PASSED**, exit 0 (run bare, never piped)
- `vitest run` (full frontend): **450 files, 6956 tests passed**
- `tsc --noEmit`: clean. `eslint src/components/weekend`: **0 errors** (19 pre-existing warnings, byte-identical set before and after)
- `./scripts/dev/verify-no-hardcoded-lodging.sh` → OK
- Strict TDD: 9 tests written failing first — 4 RED in `dragPlacement.test.ts`, 4 RED in `LodgingUnitCard.test.tsx`, then green. The 3 tests that passed on first write were mutation-checked (well made either/or → RED; `wholesaleWriteIn` forced true → RED; `mergeDragActive` dropped from `disabled` → RED) and restored.

Fictional data throughout (Emma Johnson, Liam Garcia, Ava Martinez, Noah Johnson).

Closes #2432.

