### PR TITLE
fix(frontend): a click no longer holds a non-pinning tooltip open through focus

### DIFF
--- a/frontend/src/components/ui/Tooltip.test.tsx
+++ b/frontend/src/components/ui/Tooltip.test.tsx
@@ -212,6 +212,53 @@ describe('Tooltip — a purely informational trigger (pinOnClick={false})', () =
     expect(screen.getByRole('tooltip')).toBeInTheDocument()
   })
 
+  it('does not stay open after a REAL pointer click — the one a browser focuses', () => {
+    /*
+     * THE REGRESSION THIS FILE MISSED FIRST TIME.
+     *
+     * `open` is `hovering || focused || pinned`, and a browser FOCUSES a
+     * <button> on pointer-down. So suppressing `pinned` alone left the bubble
+     * held open by `focused` after the pointer left — the exact symptom
+     * pinOnClick={false} exists to prevent, reported on the family history
+     * modal after the first fix shipped.
+     *
+     * The first version of this test used `fireEvent.click` alone. jsdom does
+     * not synthesise focus from a click, so it passed against behaviour that
+     * had not changed. This fires the sequence a browser really produces.
+     */
+    renderChip({ pinOnClick: false })
+    fireEvent.pointerEnter(trigger())
+    fireEvent.pointerDown(trigger())
+    fireEvent.focus(trigger())
+    fireEvent.click(trigger())
+    fireEvent.pointerOut(trigger(), { relatedTarget: document.body })
+
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+  })
+
+  it('still opens on a KEYBOARD focus, which arrives with no pointer press', () => {
+    // The other half: suppressing pointer-driven focus must not make the
+    // trigger unreachable by Tab. No pointerdown precedes this focus.
+    renderChip({ pinOnClick: false })
+    fireEvent.focus(trigger())
+
+    expect(screen.getByRole('tooltip')).toBeInTheDocument()
+  })
+
+  it('re-opens on a Tab return after an earlier pointer click', () => {
+    // The pointer flag must not latch. Click it, leave, then Tab back.
+    renderChip({ pinOnClick: false })
+    fireEvent.pointerEnter(trigger())
+    fireEvent.pointerDown(trigger())
+    fireEvent.focus(trigger())
+    fireEvent.click(trigger())
+    fireEvent.pointerOut(trigger(), { relatedTarget: document.body })
+    fireEvent.blur(trigger())
+
+    fireEvent.focus(trigger())
+    expect(screen.getByRole('tooltip')).toBeInTheDocument()
+  })
+
   it('leaves the tap-pins default alone for every other trigger', () => {
     renderChip()
     fireEvent.pointerEnter(trigger())

--- a/frontend/src/components/ui/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip.tsx
@@ -145,6 +145,19 @@ export function Tooltip({
 }: TooltipProps) {
   const triggerRef = useRef<HTMLButtonElement>(null)
   const bubbleRef = useRef<HTMLDivElement>(null)
+  /**
+   * Did the focus about to arrive come from a POINTER press?
+   *
+   * A browser focuses a <button> on pointer-down, so on a `pinOnClick={false}`
+   * trigger a click would otherwise hold the bubble open through `focused`
+   * long after the pointer left — the very thing that opt-out exists to
+   * prevent. A ref rather than state: it is read inside the focus handler that
+   * fires in the same tick, and re-rendering on it would buy nothing.
+   *
+   * Cleared on blur, so a later Tab return is keyboard focus again and opens
+   * the bubble normally.
+   */
+  const focusCameFromPointer = useRef(false)
 
   const [hovering, setHovering] = useState(false)
   const [focused, setFocused] = useState(false)
@@ -252,6 +265,9 @@ export function Tooltip({
           setDismissed(false)
           setHovering(true)
         }}
+        onPointerDown={() => {
+          focusCameFromPointer.current = true
+        }}
         // No "did the pointer land on the bubble" guard here, deliberately.
         // React synthesises leave AND enter from the SAME native `pointerout`,
         // so a pointer moving straight from the trigger onto the bubble runs
@@ -262,9 +278,16 @@ export function Tooltip({
           setHovering(false)
         }}
         onFocus={() => {
+          // A pointer press focuses this button as a side effect. On a trigger
+          // that has opted out of pinning, honouring that focus would keep the
+          // bubble open after the pointer left and look identical to the pin
+          // the opt-out removed. Keyboard focus arrives with no preceding
+          // pointer press and still opens it.
+          if (!pinOnClick && focusCameFromPointer.current) return
           setFocused(true)
         }}
         onBlur={() => {
+          focusCameFromPointer.current = false
           setFocused(false)
           setPinned(false)
           setDismissed(false)


### PR DESCRIPTION
fix(frontend): a click no longer holds a non-pinning tooltip open through focus

#2453 gave the journey card's provenance name `pinOnClick={false}` so a click
would leave no residue. It did not work, and the test that claimed it did was
the reason nobody noticed.

`open` is `hovering || focused || pinned`. A browser focuses a <button> on
pointer-down, so suppressing `pinned` alone left the bubble held open by
`focused` after the pointer left -- visually identical to the pin that was
supposedly removed. Reported on the family history modal: clicking a prior
year's cabin name stuck its tooltip open.

The test passed because it fired `fireEvent.click` alone, and jsdom does not
synthesise focus from a click. It asserted against a sequence a browser never
produces.

## Fix

A `focusCameFromPointer` ref, set on the trigger's `pointerdown` and cleared on
blur. A `pinOnClick={false}` trigger ignores focus that arrived that way, so a
click leaves nothing behind once the pointer goes. Keyboard focus arrives with
no preceding pointer press and still opens the bubble, and the flag does not
latch -- a Tab return after an earlier click opens it again.

Three tests, each mutation-checked: the real pointer sequence
(pointerenter -> pointerdown -> focus -> click -> pointerout), a bare keyboard
focus, and the Tab return.

## Not done

The tap-pins default is untouched for every other trigger, which is most of
them: a bubble a staff member opened deliberately still stays readable while
they work beside it. Only a trigger that has opted out changes behaviour.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

