### PR TITLE
fix(frontend): the weekend board stops toasting successful writes

### DIFF
--- a/frontend/src/hooks/useUnitAvailability.test.tsx
+++ b/frontend/src/hooks/useUnitAvailability.test.tsx
@@ -169,9 +169,9 @@ describe('useUnitAvailability', () => {
     /*
      * Owner ruling, 2026-08-18: no toast for adding or removing a write-in.
      *
-     *   > "idk what 'Clouds Rest Laundry Room follows its usual role again' is
-     *   >  needed for, if anything. dont think we need toasts for adding or
-     *   >  removing write ins."
+     *   > "idk what '<cabin> follows its usual role again' is needed for, if
+     *   >  anything. dont think we need toasts for adding or removing write
+     *   >  ins."
      *
      * This hook was the only mutation on the weekend board that confirmed
      * success in a toast. `useLodgingPlacement` (place/move/unplace a family)

--- a/frontend/src/hooks/useUnitAvailability.test.tsx
+++ b/frontend/src/hooks/useUnitAvailability.test.tsx
@@ -165,28 +165,43 @@ describe('useUnitAvailability', () => {
     })
   })
 
-  it('confirms a write-in by NAMING the occupant, which is the fact just asserted', async () => {
-    // The toast is what a staff member checks the card against. "Cedar 1 is
-    // held for this weekend" said neither what happened nor to whom.
+  it('stays SILENT on success, like every other direct-manipulation write on this board', async () => {
+    /*
+     * Owner ruling, 2026-08-18: no toast for adding or removing a write-in.
+     *
+     *   > "idk what 'Clouds Rest Laundry Room follows its usual role again' is
+     *   >  needed for, if anything. dont think we need toasts for adding or
+     *   >  removing write ins."
+     *
+     * This hook was the only mutation on the weekend board that confirmed
+     * success in a toast. `useLodgingPlacement` (place/move/unplace a family)
+     * and `useUnitMerge` (merge/split a building) both raise errors only, and
+     * the board redraws either way — the card IS the confirmation.
+     *
+     * Asserted as "no success toast at all", not "a different string", so a
+     * future re-introduction fails here rather than passing with new wording.
+     */
     const { result } = renderAvailability()
 
     await act(async () => {
       await result.current.setAvailability(WRITE_IN)
     })
 
-    expect(toastSuccess).toHaveBeenCalledWith(
-      'Emma Johnson is written into Cedar 1 for this weekend'
-    )
+    expect(toastSuccess).not.toHaveBeenCalled()
   })
 
-  it('confirms a nameless write-in without pretending to a name', async () => {
+  it('stays silent when a write-in is REMOVED, too', async () => {
+    // The clear branch — the one that said "<cabin> follows its usual role
+    // again", which is the message that prompted the ruling. Removing a
+    // write-in is the X on its own card; the card disappearing is the
+    // confirmation.
     const { result } = renderAvailability()
 
     await act(async () => {
-      await result.current.setAvailability({ ...WRITE_IN, occupantName: '  ' })
+      await result.current.setAvailability({ ...WRITE_IN, familyAvailable: null, occupantName: '' })
     })
 
-    expect(toastSuccess).toHaveBeenCalledWith('Cedar 1 is written in for this weekend')
+    expect(toastSuccess).not.toHaveBeenCalled()
   })
 
   it('says what a refused write was, rather than leaving the card looking saved', async () => {

--- a/frontend/src/hooks/useUnitAvailability.ts
+++ b/frontend/src/hooks/useUnitAvailability.ts
@@ -28,11 +28,33 @@
  * The placement hook has one because dnd-kit drops the card the moment the
  * pointer is released, so an invalidate-only path rubber-bands it back into
  * its old cabin for the seconds `build_roster` takes. Nothing here moves under
- * the pointer: the control disables itself, the toast confirms, and the board
- * redraws when the roster returns. Patching the cache optimistically would have
+ * the pointer: the control disables itself and the board redraws when the
+ * roster returns. Patching the cache optimistically would have
  * to patch every cached scenario of the weekend — the same reason the
  * invalidation is a prefix — for a click that is not a direct-manipulation
  * gesture.
+ *
+ * ## No success toast (owner ruling, 2026-08-18)
+ *
+ * This hook was the ONLY mutation on the weekend board that confirmed success
+ * in a toast. `useLodgingPlacement` (place, move and unplace a family) and
+ * `useUnitMerge` (merge and split a building) both raise errors only, and the
+ * ruling settled the inconsistency in their favour:
+ *
+ *   > "dont think we need toasts for adding or removing write ins"
+ *
+ * The card IS the confirmation — a write-in appears in the well, or its card
+ * goes away — so the toast restated what the board had already redrawn. The
+ * clear branch was the worst of the three: "<cabin> follows its usual role
+ * again" described an internal availability state rather than the thing the
+ * staff member had just done, which is what prompted the ruling.
+ *
+ * ⚠️ A DELIBERATE divergence from summer, stated here because the root
+ * CLAUDE.md requires one to be justified where it happens:
+ * `session/useCamperMovement.ts` fires `toast.success('Camper moved
+ * successfully')`. Summer's move changes a value in a dense table where
+ * nothing else marks the write; this board draws or removes a whole card.
+ * Errors still toast on both surfaces.
  */
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useCallback } from 'react'
@@ -92,23 +114,6 @@ export interface UseUnitAvailabilityReturn {
   pendingUnitId: string
 }
 
-/**
- * Outcome wording, matching the badge vocabulary in `unitBadges.ts`.
- *
- * The write-in line NAMES the occupant, because that is the fact the staff
- * member just asserted and the one they can check the card against. It falls
- * back to the cabin alone if the name is somehow empty — the write schema is
- * permissive where the control is not — rather than confirming a blank.
- */
-function confirmation({ unitName, familyAvailable, occupantName }: AvailabilityIntent): string {
-  if (familyAvailable === null) return `${unitName} follows its usual role again`
-  if (familyAvailable) return `${unitName} is released to families for this weekend`
-  const named = occupantName.trim()
-  return named === ''
-    ? `${unitName} is written in for this weekend`
-    : `${named} is written into ${unitName} for this weekend`
-}
-
 export function useUnitAvailability({
   year,
   sessionCmId,
@@ -128,10 +133,6 @@ export function useUnitAvailability({
         occupantName: intent.occupantName,
         reason: intent.reason,
       })
-    },
-
-    onSuccess: (_result, intent) => {
-      toast.success(confirmation(intent))
     },
 
     onError: (error) => {

--- a/frontend/src/hooks/useWeekendFriendGroups.test.tsx
+++ b/frontend/src/hooks/useWeekendFriendGroups.test.tsx
@@ -154,7 +154,38 @@ describe('a membership write is not finished until the list it was computed from
       await result.current.mutations.updateGroupAsync('grp_1', { name: 'Lake cabins' })
     })
 
-    expect(toastSuccess).toHaveBeenCalledWith('Group updated')
+    // The write landed — evidenced by the call itself, not by a toast, since
+    // the weekend board no longer confirms a success in one.
+    expect(updateFriendGroup).toHaveBeenCalled()
+    expect(toastError).not.toHaveBeenCalled()
+  })
+
+  it('stays SILENT on a successful create, update or dissolve', async () => {
+    /*
+     * Owner ruling, 2026-08-18: "lets lose the toasts on success for weekend".
+     *
+     * The weekend board's other direct-manipulation writes — placing a family,
+     * merging a building, writing an occupant in — all raise errors only and
+     * let the redraw be the confirmation. Friend groups were one of the two
+     * places on this surface that still announced success, and a group
+     * appearing or its chips disappearing already says the same thing.
+     *
+     * Errors are untouched: a refused write must never look saved.
+     */
+    createFriendGroup.mockResolvedValue({ group_id: 'grp_2', name: 'Lake cabins' })
+    updateFriendGroup.mockResolvedValue({ group_id: 'grp_1' })
+    deleteFriendGroup.mockResolvedValue(undefined)
+
+    const { result } = renderHook(useBoth, { wrapper })
+    await waitFor(() => {
+      expect(result.current.query.isSuccess).toBe(true)
+    })
+
+    await act(async () => {
+      await result.current.mutations.updateGroupAsync('grp_1', { name: 'Lake cabins' })
+    })
+
+    expect(toastSuccess).not.toHaveBeenCalled()
     expect(toastError).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/hooks/useWeekendFriendGroups.ts
+++ b/frontend/src/hooks/useWeekendFriendGroups.ts
@@ -102,9 +102,22 @@ export interface FriendGroupMutations {
  *
  * There is no optimistic layer, for the reason `useUnitAvailability` gives for
  * not having one: nothing here moves under the pointer. The action bar
- * disables itself, a toast confirms, and the list redraws when the invalidated
- * query returns. An optimistic patch would have to synthesise a `group_id`
- * the server has not issued yet.
+ * disables itself and the list redraws when the invalidated query returns. An
+ * optimistic patch would have to synthesise a `group_id` the server has not
+ * issued yet.
+ *
+ * ## No success toast (owner ruling, 2026-08-18)
+ *
+ *   > "lets lose the toasts on success for weekend"
+ *
+ * These three writes announced "Created <name>", "Group updated" and "Group
+ * dissolved". Every other direct-manipulation write on the weekend board —
+ * `useLodgingPlacement`, `useUnitMerge`, `useUnitAvailability` — raises errors
+ * only and lets the redraw be the confirmation, and a group appearing or its
+ * chips vanishing already says the same thing.
+ *
+ * Errors are untouched on all three paths, including `create`'s deliberate
+ * invalidate-on-failure: a partially-written group must still become visible.
  */
 export function useFriendGroupMutations(year: number, sessionCmId: number): FriendGroupMutations {
   const { fetchWithAuth } = useApiWithAuth()
@@ -119,8 +132,7 @@ export function useFriendGroupMutations(year: number, sessionCmId: number): Frie
    * ABSOLUTE `household_cm_ids` list computed from the CACHED group. Re-enable
    * the card's controls the moment the PATCH answers and the next add is
    * computed from the pre-write membership, so the server's `_replace_members`
-   * deletes whatever the first write added — with a success toast and no error
-   * anywhere. Summer cannot hit this: `LockGroupPanel` adds one
+   * deletes whatever the first write added — silently, with no error anywhere. Summer cannot hit this: `LockGroupPanel` adds one
    * `locked_group_members` row and removes one row, so two overlapping edits
    * compose instead of overwriting.
    *
@@ -140,12 +152,9 @@ export function useFriendGroupMutations(year: number, sessionCmId: number): Frie
 
   const create = useMutation({
     mutationFn: (body: FriendGroupCreate) => createFriendGroup(fetchWithAuth, body),
-    onSuccess: async (group) => {
-      // `||`, not `??`: '' is the real stored value for an unnamed group, so
-      // `??` would toast "Created " with a trailing space. Same trap
-      // `partyKey.ts` documents at length.
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- '' is a real stored value meaning "unnamed"
-      toast.success(`Created ${group.name || 'the group'}`)
+    onSuccess: async () => {
+      // NO SUCCESS TOAST — see the note at the top of this file. The group
+      // appearing in the list is the confirmation.
       await invalidate()
     },
     onError: (error: Error) => {
@@ -165,7 +174,6 @@ export function useFriendGroupMutations(year: number, sessionCmId: number): Frie
     mutationFn: ({ groupId, body }: { groupId: string; body: FriendGroupUpdate }) =>
       updateFriendGroup(fetchWithAuth, groupId, body),
     onSuccess: async () => {
-      toast.success('Group updated')
       await invalidate()
     },
     onError: (error: Error) => toast.error(error.message),
@@ -174,7 +182,6 @@ export function useFriendGroupMutations(year: number, sessionCmId: number): Frie
   const remove = useMutation({
     mutationFn: (groupId: string) => deleteFriendGroup(fetchWithAuth, groupId),
     onSuccess: async () => {
-      toast.success('Group dissolved')
       await invalidate()
     },
     onError: (error: Error) => toast.error(error.message),


### PR DESCRIPTION
fix(frontend): stop toasting a successful write-in, clear or release

`useUnitAvailability` was the only mutation on the weekend board that confirmed
success in a toast. `useLodgingPlacement` (place, move and unplace a family)
and `useUnitMerge` (merge and split a building) both raise errors only, so the
board already answered this question two other ways and this hook disagreed.

The card is the confirmation: a write-in appears in the well, or its card goes
away. The toast restated what the board had just redrawn.

The clear branch was the worst of the three -- "<cabin> follows its usual role
again" named an internal availability state rather than the thing the staff
member had done, and it is the message that prompted the ruling.

`confirmation()` goes with it rather than being left unreferenced, and the
now-empty `onSuccess` handler with that; the cache invalidation was already in
`onSettled` and is untouched.

## Deliberate divergence from summer, stated at the divergence

The root CLAUDE.md requires a weekend surface that departs from summer to say
why where it happens. Summer DOES toast a move --
`session/useCamperMovement.ts` fires `toast.success('Camper moved
successfully')`. Summer's move changes a value in a dense table where nothing
else marks the write; this board draws or removes a whole card. Recorded in the
hook's own doc block.

## Not done

Error toasts are untouched on every path -- a refused write must never look
saved. Nothing about the write payload, the invalidation prefixes or the
pending-unit gate changed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

