### PR TITLE
feat(api): give the family journey session grain — weekends on the panel, weekend tabs in the modal

### DIFF
--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -378,6 +378,23 @@ class PartyChild(BaseModel):
     last_name: str = ""
     age: float | None = None
     grade: int | None = None
+    # WHICH FAMILY WEEKENDS THIS CHILD ATTENDED that year, earliest first
+    # (kindred#2393). Populated by the household journey ONLY, and empty on
+    # every other surface: the roster is already one weekend, so a per-child
+    # weekend list there would restate the page's own title once per camper.
+    #
+    # The journey spans years and its rows are household-YEAR grain, which is
+    # where a family that booked two of a season's weekends collapses into one
+    # merged member list. Measured on the production snapshot, 64 of 5,438
+    # journey household-years are multi-weekend and 7 of those 64 carry a
+    # child who did not attend every weekend -- so the merged list overstates
+    # at least one weekend's party. This is what lets the client undo that.
+    #
+    # Empty is "not knowable", NOT "attended nothing": an attendee row whose
+    # `session` relation did not expand yields no weekend at all, and the
+    # client keeps such a child visible rather than hiding them from every
+    # weekend.
+    session_cm_ids: list[int] = Field(default_factory=list)
 
 
 class RequestTextEntry(BaseModel):
@@ -730,6 +747,27 @@ HousingState = Literal["placed", "not_placed", "unknown"]
 EnrollmentState = Literal["enrolled", "none_on_file"]
 
 
+class HouseholdJourneySession(BaseModel):
+    """One family weekend a household attended in a given year (kindred#2393).
+
+    THE WEEKEND, NOT THE HOUSING. A journey row is a year and a year holds
+    exactly ONE cabin string -- `family_camp_registrations` has no second
+    field for a second weekend -- so this list says which weekends the
+    household was at and says nothing about where it slept in each. Repeating
+    the year's cabin against every entry is the fan-out that manufactured 12
+    of 17 false multi-family occupancies in the phase-C shareability analysis.
+
+    `start_date` is the raw PocketBase string, exactly as
+    `WeekendSessionSummary` publishes it -- the client already reads that
+    shape, and the server's only use for it here is the ordering it has
+    already applied.
+    """
+
+    session_cm_id: int = 0
+    name: str = ""
+    start_date: str = ""
+
+
 class HouseholdJourneyYear(BaseModel):
     """One year of a household's family-camp record.
 
@@ -759,6 +797,32 @@ class HouseholdJourneyYear(BaseModel):
     # is 716 of 1,861 rows on the production snapshot: rendering it beside an
     # identical name would be noise on the other 1,145.
     cabin_name_raw: str = ""
+    # WHICH FAMILY WEEKENDS the household attended that year, earliest first
+    # (kindred#2393). Derived from the attendee rows this row's members
+    # already come from, so it costs no extra round trip -- the journey's
+    # attendee read has expanded `session` since kindred#2420.
+    #
+    # Empty for a year with no enrolled child (2020's cancelled season, 2021's
+    # adults-only rows) and for the pre-kindred#2420 payload shape where the
+    # relation did not expand. Empty is "no weekend is knowable", never "the
+    # household attended none".
+    sessions: list[HouseholdJourneySession] = Field(default_factory=list)
+    # Which weekend `cabin_name` belongs to -- and `None` whenever that cannot
+    # be said, which is the whole point of the field.
+    #
+    # ⚠️ DELIBERATELY THE SAME REFUSAL the Go ingest makes. `AttributeSession`
+    # (`pocketbase/sync/lodging_session_attribution.go:327`) pins the year's
+    # single cabin string to a weekend only when the household attended
+    # exactly one and otherwise declines, because CampMinder's one per-year
+    # value cannot say which weekend it describes. A read surface that guessed
+    # where the ingest refuses would put the two into disagreement about the
+    # same fact.
+    #
+    # `None` therefore covers three different situations and the client words
+    # none of them: several weekends (41 of the 1,861 cabin-bearing
+    # household-years on the production snapshot), no weekend on file (158),
+    # and no cabin to attribute in the first place.
+    housing_session_cm_id: int | None = None
     enrollment: EnrollmentState = "none_on_file"
     # Every `family_camp_adults` row for the year, blanks and placeholders
     # included -- the same contract `RosterParty.adults` publishes, so the

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -27,6 +27,7 @@ from api.schemas.lodging import (
     AmenityCoverage,
     EffectiveBathroom,
     HouseholdJourneyResponse,
+    HouseholdJourneySession,
     HouseholdJourneyYear,
     HouseholdMedicalResponse,
     HousingState,
@@ -420,8 +421,14 @@ def _age_at(birthdate: date, as_of: date) -> float | None:
     return float(f"{years}.{months:02d}")
 
 
-def _party_child(child: Any, *, as_of: date | None = None) -> PartyChild:
+def _party_child(child: Any, *, as_of: date | None = None, session_cm_ids: Sequence[int] = ()) -> PartyChild:
     """A `persons` row as the wire sees it. See `_party_adult` on sharing.
+
+    `session_cm_ids` is the same kind of journey-only argument `as_of` is
+    (kindred#2393): the weekends THIS child attended that year, earliest
+    first. `_build_household_parties` omits it and publishes an empty list,
+    because the roster is already one weekend and a per-child weekend list
+    there would restate the page's own title once per camper.
 
     `as_of` is the ONE thing that lets this stay one mapping instead of
     forking (kindred#2420). `_build_household_parties` (the current-season
@@ -461,6 +468,10 @@ def _party_child(child: Any, *, as_of: date | None = None) -> PartyChild:
         # reads `birthdate` instead.
         age=age,
         grade=_i(child, "grade") or None,
+        # A LIST COPY, not the caller's own: the journey builds one list per
+        # (year, child) and a shared reference would let a later mutation
+        # reach a wire object already handed out.
+        session_cm_ids=list(session_cm_ids),
     )
 
 
@@ -480,6 +491,25 @@ def _child_identity(person: Any) -> Any:
     child is which.
     """
     return _i(person, "cm_id") or str(getattr(person, "id", ""))
+
+
+def _session_order(entry: HouseholdJourneySession) -> tuple[int, date, int]:
+    """A season read left to right (kindred#2393).
+
+    Start date first, because that is the order staff say the weekends in;
+    the CampMinder id breaks a tie, so two weekends opening on the same day
+    print in a stable order rather than in whatever order the attendee rows
+    happened to arrive.
+
+    A weekend with no readable `start_date` sorts LAST rather than first. An
+    unparseable date is an unknown, and `date.min` would file the unknown at
+    the head of the season -- claiming a position the data does not support,
+    in the one spot a reader trusts most.
+    """
+    start = _as_date(entry.start_date)
+    if start is None:
+        return (1, date.min, entry.session_cm_id)
+    return (0, start, entry.session_cm_id)
 
 
 def _housing_state(cabin: str, year_assignments: Mapping[int, str]) -> HousingState:
@@ -1625,6 +1655,18 @@ class LodgingRosterService:
         # the rare person row with no cm_id; a row with neither is kept rather
         # than collapsed onto every other anonymous sibling.
         seen_by_year: dict[int, set[Any]] = {}
+        # WHICH WEEKENDS, and who went to which (kindred#2393). Both fall out
+        # of the SAME attendee rows the members already come from, so the
+        # session grain costs no extra round trip -- `session` has been in the
+        # expand since kindred#2420.
+        #
+        # Filled BEFORE the dedup below, deliberately: the second attendee row
+        # for a child is exactly the second weekend, so skipping it here would
+        # publish a multi-weekend year as a single-weekend one and then pin the
+        # cabin to it -- the precise wrong answer `AttributeSession` refuses to
+        # give.
+        sessions_by_year: dict[int, dict[int, HouseholdJourneySession]] = {}
+        child_sessions_by_year: dict[int, dict[Any, set[int]]] = {}
         for attendee in attendees:
             expand = getattr(attendee, "expand", None) or {}
             person = expand.get("person")
@@ -1639,6 +1681,25 @@ class LodgingRosterService:
                 existing = starts.get(identity)
                 if existing is None or start < existing:
                     starts[identity] = start
+            # `cm_id` and not the PB record id: it is the identity the wire
+            # publishes a weekend under everywhere else, and the key the
+            # client tabs on. A session row without one is dropped rather
+            # than published as weekend 0, which would collapse every
+            # unidentified weekend onto a single tab.
+            session_cm_id = _i(session, "cm_id") if session is not None else 0
+            if session_cm_id:
+                year_sessions = sessions_by_year.setdefault(year, {})
+                if session_cm_id not in year_sessions:
+                    year_sessions[session_cm_id] = HouseholdJourneySession(
+                        session_cm_id=session_cm_id,
+                        # VERBATIM. The client abbreviates it for the panel
+                        # (`weekendLabel`); the wire carries what CampMinder
+                        # calls the weekend.
+                        name=_s(session, "name"),
+                        start_date=_s(session, "start_date"),
+                    )
+                if identity:
+                    child_sessions_by_year.setdefault(year, {}).setdefault(identity, set()).add(session_cm_id)
             if identity:
                 seen = seen_by_year.setdefault(year, set())
                 if identity in seen:
@@ -1669,6 +1730,8 @@ class LodgingRosterService:
             cabin = assignments.get(household_cm_id, "")
             children = _children_oldest_first(children_by_year.get(year, []))
             year_starts = session_start_by_year.get(year, {})
+            year_sessions_ordered = sorted(sessions_by_year.get(year, {}).values(), key=_session_order)
+            child_sessions = child_sessions_by_year.get(year, {})
             rows.append(
                 HouseholdJourneyYear(
                     year=year,
@@ -1683,6 +1746,22 @@ class LodgingRosterService:
                     # one.
                     cabin_name=housing_names.display_name(cabin, year),
                     cabin_name_raw=cabin,
+                    sessions=year_sessions_ordered,
+                    # THE GO INGEST'S REFUSAL, MIRRORED (kindred#2393).
+                    # `AttributeSession` pins the year's one cabin string to a
+                    # weekend only when the household attended exactly one; a
+                    # read surface that guessed where the ingest declines
+                    # would put the two into disagreement about the same fact.
+                    #
+                    # `cabin` and not `housing == "placed"` for the same
+                    # reason `_housing_state` reads presence: an unmappable
+                    # string is still a cabin to attribute. With no cabin
+                    # there is nothing to pin, and publishing the weekend id
+                    # anyway would read as "housed in FC1" for a household
+                    # nobody placed.
+                    housing_session_cm_id=(
+                        year_sessions_ordered[0].session_cm_id if cabin and len(year_sessions_ordered) == 1 else None
+                    ),
                     # An empty child list is NOT a childless family: 2020 was
                     # cancelled outright and 2021 has no family attendee rows
                     # at all. Naming the state here is what stops the client
@@ -1697,7 +1776,19 @@ class LodgingRosterService:
                         # camp_sessions row missing `start_date`), in which
                         # case `_party_child` keeps the current-season
                         # fallback rather than guessing at a camp-wide date.
-                        _party_child(child, as_of=year_starts.get(_child_identity(child)))
+                        _party_child(
+                            child,
+                            as_of=year_starts.get(_child_identity(child)),
+                            # Ordered through the YEAR'S ordering rather than
+                            # sorted again, so a child's weekends read in the
+                            # same left-to-right order the row's own weekend
+                            # line does. One rule, applied once.
+                            session_cm_ids=[
+                                entry.session_cm_id
+                                for entry in year_sessions_ordered
+                                if entry.session_cm_id in child_sessions.get(_child_identity(child), frozenset())
+                            ],
+                        )
                         for child in children
                     ],
                 )

--- a/frontend/src/components/camper/CampJourneyTimeline.test.tsx
+++ b/frontend/src/components/camper/CampJourneyTimeline.test.tsx
@@ -55,12 +55,37 @@ describe('CampJourneyTimeline program-agnostic strings (#2113)', () => {
     expect(screen.getByText('1 summer at camp')).toBeInTheDocument()
   })
 
-  it('tags a family-camp row with a de-emphasis label', () => {
+  it('does NOT tag a family-camp row — the session name already says it', () => {
+    // #2113 added a "Family" chip when family rows first entered this
+    // timeline, so a reader could visually skip a run of them. The mid-form
+    // session name now begins "Family Camp", which says the same thing where
+    // the reader is already looking. Owner, 2026-08-18: "we also dont need the
+    // 'family' tag in the journey, staff knows."
     const history: HistoricalRecord[] = [
-      { year: 2019, sessionName: 'Winter Family Weekend', sessionType: 'family' },
+      { year: 2026, sessionName: 'Family Camp 2: Keshet LGBTQ Weekend', sessionType: 'family' },
     ]
     render(<CampJourneyTimeline history={history} yearsAtCamp={1} currentYear={2026} />)
-    expect(screen.getByText('Family')).toBeInTheDocument()
+
+    expect(screen.queryByText('Family')).not.toBeInTheDocument()
+    expect(screen.getByText('Family Camp 2')).toBeInTheDocument()
+  })
+
+  it('prints the weekend’s subtitle beside the mid-form name', () => {
+    // The half that tells two numbered weekends apart, and the half CampMinder
+    // buries in a 54-character name.
+    const history: HistoricalRecord[] = [
+      {
+        year: 2026,
+        sessionName: 'Family Camp 8: JFAM Weekend w/ SFJCC (w/ kids 10 and under)',
+        sessionType: 'family',
+      },
+    ]
+    render(<CampJourneyTimeline history={history} yearsAtCamp={1} currentYear={2026} />)
+
+    expect(screen.getByText('Family Camp 8')).toBeInTheDocument()
+    expect(screen.getByText('JFAM')).toBeInTheDocument()
+    // And NOT the raw 54-character name that made this timeline unreadable.
+    expect(screen.queryByText(/w\/ kids 10 and under/)).not.toBeInTheDocument()
   })
 
   it('does not tag a summer row with the family de-emphasis label', () => {

--- a/frontend/src/components/camper/CampJourneyTimeline.tsx
+++ b/frontend/src/components/camper/CampJourneyTimeline.tsx
@@ -4,6 +4,7 @@
  */
 import { TreePine, Home } from 'lucide-react'
 import { getSessionDisplayNameFromString } from '../../utils/sessionDisplay'
+import { weekendSubtitle } from '../weekend/weekendNames'
 import { getStatusIndicator } from '../../utils/enrollmentFilter'
 import { isFamilySessionType } from '../../utils/sessionTypePredicates'
 import type { HistoricalRecord } from '../../hooks/camper/types'
@@ -85,17 +86,26 @@ export function CampJourneyTimeline({
                       {getSessionDisplayNameFromString(record.sessionName, record.sessionType)}
                     </span>
 
-                    {/* Family-camp de-emphasis tag (#2113): family rows were
-                        excluded from the journey because they made it noisy
-                        for multi-session staff kids. Now included, they get a
-                        muted tag instead of being hidden, so a reader can
-                        visually skip a run of family rows without losing the
-                        underlying data. */}
-                    {isFamilySessionType(record.sessionType) && (
-                      <span className="bg-muted text-muted-foreground flex-shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium">
-                        Family
-                      </span>
-                    )}
+                    {/* Which family weekend it was — Keshet, JFAM, JFoC, the
+                        holiday. The title beside it is "Family Camp 3", so
+                        this is the half that tells two numbered weekends
+                        apart, and it is the half CampMinder buries in a
+                        54-character name. Muted and one size down: it
+                        qualifies the session, it is not a second session. */}
+                    {isFamilySessionType(record.sessionType) &&
+                      weekendSubtitle(record.sessionName).length > 0 && (
+                        <span className="text-muted-foreground/70 flex-shrink-0 text-xs">
+                          {weekendSubtitle(record.sessionName)}
+                        </span>
+                      )}
+
+                    {/* NO "Family" TAG. #2113 added one when family rows first
+                        entered this timeline, so a reader could visually skip a
+                        run of them. The mid-form session name now begins
+                        "Family Camp", which says the same thing in the place a
+                        reader is already looking — owner, 2026-08-18: "we also
+                        dont need the 'family' tag in the journey, staff
+                        knows." */}
 
                     {/* Status indicator for non-enrolled */}
                     {statusIndicator && (

--- a/frontend/src/components/weekend/HouseholdJourneyCard.test.tsx
+++ b/frontend/src/components/weekend/HouseholdJourneyCard.test.tsx
@@ -558,10 +558,16 @@ describe('the weekend line', () => {
     expect(weekendLineFor(2025)?.textContent).toBe('FC1 · FC4')
   })
 
-  it('uppercases a weekend that does not slug to FCx', () => {
+  it('prints a weekend CampMinder never numbered by its own name', () => {
+    // The licence is for `FCx` and only for `FCx` — the number is the
+    // weekend's identity, so the abbreviation cannot name a different one.
+    // Initials of a prose name carry no such guarantee: they gave both
+    // "Spring Family Camp" and "Summer Family Camp" the label `SFC` and read
+    // "Fall Family Camp II" back as `FFCI`, on 891 of 3,040 single-weekend
+    // household-years. See `weekendNames.test.ts` for the season sweep.
     show([_row({ year: 2025, sessions: [RSC] })])
 
-    expect(weekendLineFor(2025)?.textContent).toBe('RSC')
+    expect(weekendLineFor(2025)?.textContent).toBe('Ready, Set, Camp')
   })
 
   it('never prints a bare CampMinder id when a name has no abbreviation', () => {

--- a/frontend/src/components/weekend/HouseholdJourneyCard.test.tsx
+++ b/frontend/src/components/weekend/HouseholdJourneyCard.test.tsx
@@ -558,16 +558,17 @@ describe('the weekend line', () => {
     expect(weekendLineFor(2025)?.textContent).toBe('FC1 · FC4')
   })
 
-  it('prints a weekend CampMinder never numbered by its own name', () => {
-    // The licence is for `FCx` and only for `FCx` — the number is the
-    // weekend's identity, so the abbreviation cannot name a different one.
-    // Initials of a prose name carry no such guarantee: they gave both
-    // "Spring Family Camp" and "Summer Family Camp" the label `SFC` and read
-    // "Fall Family Camp II" back as `FFCI`, on 891 of 3,040 single-weekend
+  it('prints a named weekend by its ruled short label', () => {
+    // The owner assigned each un-numbered weekend a label by hand against the
+    // full catalogue (2026-08-18), so "Ready, Set, Camp" reads `RSC`. The
+    // guarantee that survives is that nothing is abbreviated by GUESS: a name
+    // outside the map prints in full. Initials-by-rule gave both "Spring
+    // Family Camp" and "Summer Family Camp" the label `SFC` and read "Fall
+    // Family Camp II" back as `FFCI`, on 891 of 3,040 single-weekend
     // household-years. See `weekendNames.test.ts` for the season sweep.
     show([_row({ year: 2025, sessions: [RSC] })])
 
-    expect(weekendLineFor(2025)?.textContent).toBe('Ready, Set, Camp')
+    expect(weekendLineFor(2025)?.textContent).toBe('RSC')
   })
 
   it('never prints a bare CampMinder id when a name has no abbreviation', () => {

--- a/frontend/src/components/weekend/HouseholdJourneyCard.test.tsx
+++ b/frontend/src/components/weekend/HouseholdJourneyCard.test.tsx
@@ -517,3 +517,104 @@ describe('the raw staff-written string, as provenance', () => {
     expect(rowFor(2023).textContent).toContain('Meadow House 1')
   })
 })
+
+/**
+ * WHICH WEEKENDS the household attended in a year (kindred#2393).
+ *
+ * A journey row is a YEAR, and until now the panel never said which of a
+ * season's six-to-ten family weekends the year was. 64 of 5,438 journey
+ * household-years (1.2%) are multi-weekend — the denominator being every
+ * traced household-year, the union of the three reads the journey issues,
+ * over all years with `year > 0`.
+ *
+ * ⚠️ ONE CABIN, RENDERED ONCE. The year holds exactly one cabin string and
+ * repeating it against each weekend is the fan-out that manufactured 12 of 17
+ * false multi-family occupancies in the phase-C shareability analysis. The
+ * owner's 2026-08-18 ruling also DROPPED the "cabin recorded for the year"
+ * note — staff know CampMinder overwrites the source value, and the note
+ * would have sat beside the existing "No enrollment" chip saying nearly the
+ * same thing.
+ */
+describe('the weekend line', () => {
+  const FC1 = {
+    session_cm_id: 1309514,
+    name: 'Family Camp 1: Memorial Day Weekend',
+    start_date: '2025-05-23',
+  }
+  const FC4 = {
+    session_cm_id: 1309517,
+    name: 'Family Camp 4: Labor Day Weekend',
+    start_date: '2025-09-05',
+  }
+  const RSC = { session_cm_id: 1366768, name: 'Ready, Set, Camp', start_date: '2025-06-13' }
+
+  function weekendLineFor(year: number): HTMLElement | null {
+    return within(rowFor(year)).queryByTestId('household-journey-weekends')
+  }
+
+  it('names every weekend the household attended, as plain FCx text', () => {
+    show([_row({ year: 2025, sessions: [FC1, FC4] })])
+
+    expect(weekendLineFor(2025)?.textContent).toBe('FC1 · FC4')
+  })
+
+  it('uppercases a weekend that does not slug to FCx', () => {
+    show([_row({ year: 2025, sessions: [RSC] })])
+
+    expect(weekendLineFor(2025)?.textContent).toBe('RSC')
+  })
+
+  it('never prints a bare CampMinder id when a name has no abbreviation', () => {
+    // `weekendSlug` declines to address a digits-only name — the numeric space
+    // belongs to CampMinder ids — and `weekendRef` falls back to the id for
+    // that. A LABEL must not: `1379005` names nothing a staff member reads.
+    show([
+      _row({ year: 2025, sessions: [{ session_cm_id: 1379005, name: '2025', start_date: '' }] }),
+    ])
+
+    expect(weekendLineFor(2025)?.textContent).toBe('2025')
+    expect(rowFor(2025).textContent).not.toContain('1379005')
+  })
+
+  it('renders no weekend line at all when no weekend is knowable', () => {
+    // 2021 has no family attendee rows despite 247 registrations, and the
+    // pre-kindred#2420 payload shape did not expand the session relation
+    // either. Empty is "not knowable", so the row says nothing rather than
+    // printing an empty line under the housing name.
+    show([_row({ year: 2021, sessions: [] })])
+
+    expect(weekendLineFor(2021)).toBeNull()
+  })
+
+  it('prints the cabin ONCE for a multi-weekend year, never once per weekend', () => {
+    show([
+      _row({
+        year: 2025,
+        housing: 'placed',
+        cabin_name: 'Cedar Lodge - Room 2',
+        sessions: [FC1, FC4],
+      }),
+    ])
+
+    const text = rowFor(2025).textContent ?? ''
+    expect(text.split('Cedar Lodge - Room 2')).toHaveLength(2)
+  })
+
+  it('adds no explanatory note for a year whose cabin belongs to no one weekend', () => {
+    // The owner struck it on 2026-08-18. The rule it came from is unchanged —
+    // one cabin, rendered once — but the sentence is not on the panel.
+    show([
+      _row({
+        year: 2025,
+        housing: 'placed',
+        cabin_name: 'Cedar Lodge - Room 2',
+        sessions: [FC1, FC4],
+        housing_session_cm_id: null,
+      }),
+    ])
+
+    const text = rowFor(2025).textContent ?? ''
+    expect(text).not.toContain('for the year')
+    expect(text).not.toContain('unresolved')
+  })
+})

--- a/frontend/src/components/weekend/HouseholdJourneyCard.tsx
+++ b/frontend/src/components/weekend/HouseholdJourneyCard.tsx
@@ -48,6 +48,7 @@ import { QueryGuard } from '../QueryGuard'
 import { Tooltip } from '../ui/Tooltip'
 import { childSurnames, familyNameLabel, isAttendingAdultName } from './householdIdentity'
 import { HouseholdYearMembersModal } from './HouseholdYearMembersModal'
+import { weekendLabel } from './weekendNames'
 
 export interface HouseholdJourneyCardProps {
   /**
@@ -132,6 +133,12 @@ function JourneyRows({
           // still renders.
           const rawHousing = (row.cabin_name_raw ?? '').trim()
           const showsProvenance = isPlaced && rawHousing.length > 0 && rawHousing !== housing
+          // kindred#2393. `FC1 · FC4`, in the order the server sent — which is
+          // the season's own, earliest first. `weekendLabel` is the one
+          // sanctioned display use of the slug and falls back to the
+          // weekend's short name rather than to its CampMinder id, which
+          // names nothing a staff member reads.
+          const weekends = (row.sessions ?? []).map((session) => weekendLabel(session.name ?? ''))
 
           return (
             <div
@@ -177,35 +184,74 @@ function JourneyRows({
                   carry a wing or sub-unit suffix — exactly the substring
                   `truncate` chops — so summer's treatment does not transfer
                   here and this row earns its own. */}
-              <span
-                data-testid="household-journey-housing"
-                className={`flex min-w-0 items-center gap-1 text-sm ${
-                  isPlaced ? 'text-foreground font-medium' : 'text-muted-foreground italic'
-                }`}
-              >
-                {isPlaced && <Home className="h-3.5 w-3.5 flex-shrink-0 opacity-60" />}
-                {/* A real Tooltip and not a `title` (kindred#2177), and the
+              {/* Housing on one line, the weekends on the next (kindred#2393,
+                  owner ruling 2026-08-18). A column rather than a fourth item
+                  in the row: the panel is `w-[26rem]` = 416px and already
+                  carries a year, a housing name that wraps, a chip and an
+                  action, so a four-weekend list on the same line is not a
+                  line. `min-w-0` moves out here with it — it is what lets the
+                  flex child shrink below its content width, which is what
+                  makes the kindred#2253 wrap happen instead of the row
+                  overflowing. */}
+              <div className="flex min-w-0 flex-col">
+                <span
+                  data-testid="household-journey-housing"
+                  className={`flex min-w-0 items-center gap-1 text-sm ${
+                    isPlaced ? 'text-foreground font-medium' : 'text-muted-foreground italic'
+                  }`}
+                >
+                  {isPlaced && <Home className="h-3.5 w-3.5 flex-shrink-0 opacity-60" />}
+                  {/* A real Tooltip and not a `title` (kindred#2177), and the
                     same trigger shape `LodgingUnitCard` gives its occupancy
                     figure. `min-w-0 text-left` is what keeps the kindred#2253
                     wrap: a button centres its text and will not shrink below
                     its content width without it. */}
-                {showsProvenance ? (
-                  <Tooltip
-                    content={`Recorded as "${rawHousing}" that season`}
-                    data-testid="household-journey-housing-provenance"
-                    // Hover and focus only. The sentence restates what staff
-                    // typed that season and there is nothing to act on, so
-                    // the tap-pins default left a bubble stuck open over the
-                    // rows below it after a click that meant nothing.
-                    pinOnClick={false}
-                    className="decoration-muted-foreground/60 min-w-0 text-left underline decoration-dotted underline-offset-2"
+                  {showsProvenance ? (
+                    <Tooltip
+                      content={`Recorded as "${rawHousing}" that season`}
+                      data-testid="household-journey-housing-provenance"
+                      // Hover and focus only. The sentence restates what staff
+                      // typed that season and there is nothing to act on, so
+                      // the tap-pins default left a bubble stuck open over the
+                      // rows below it after a click that meant nothing.
+                      pinOnClick={false}
+                      className="decoration-muted-foreground/60 min-w-0 text-left underline decoration-dotted underline-offset-2"
+                    >
+                      {housing}
+                    </Tooltip>
+                  ) : (
+                    housing
+                  )}
+                </span>
+
+                {/* PLAIN TEXT, not chips (owner ruling 2026-08-18). The row
+                  already carries a housing name, a "No enrollment" chip and a
+                  "See members" action; a fourth decorated element makes none
+                  of them readable.
+
+                  ⚠️ ONE CABIN, RENDERED ONCE. There is deliberately no cabin
+                  against each weekend: `family_camp_registrations` holds a
+                  single string per household-year, and repeating it per
+                  weekend is the fan-out that manufactured 12 of 17 false
+                  multi-family occupancies in the phase-C shareability
+                  analysis. There is no explanatory note for the ambiguous
+                  case either — the owner struck it, because staff know
+                  CampMinder overwrites the source value and it would have sat
+                  beside the "No enrollment" chip saying nearly the same thing.
+
+                  Nothing at all when no weekend is knowable: an empty list is
+                  the pre-kindred#2420 payload shape and a year with no
+                  enrolled child (2020's cancelled season, 2021's adults-only
+                  rows), not a household that attended none. */}
+                {weekends.length > 0 && (
+                  <span
+                    data-testid="household-journey-weekends"
+                    className="text-muted-foreground text-xs"
                   >
-                    {housing}
-                  </Tooltip>
-                ) : (
-                  housing
+                    {weekends.join(' · ')}
+                  </span>
                 )}
-              </span>
+              </div>
 
               {/* NOT "a childless family" and NOT an error — 2020's season was
                   cancelled outright and 2021 has no family attendee rows at all

--- a/frontend/src/components/weekend/HouseholdJourneyCard.tsx
+++ b/frontend/src/components/weekend/HouseholdJourneyCard.tsx
@@ -184,16 +184,32 @@ function JourneyRows({
                   carry a wing or sub-unit suffix — exactly the substring
                   `truncate` chops — so summer's treatment does not transfer
                   here and this row earns its own. */}
-              {/* Housing on one line, the weekends on the next (kindred#2393,
-                  owner ruling 2026-08-18). A column rather than a fourth item
-                  in the row: the panel is `w-[26rem]` = 416px and already
-                  carries a year, a housing name that wraps, a chip and an
-                  action, so a four-weekend list on the same line is not a
-                  line. `min-w-0` moves out here with it — it is what lets the
-                  flex child shrink below its content width, which is what
-                  makes the kindred#2253 wrap happen instead of the row
-                  overflowing. */}
-              <div className="flex min-w-0 flex-col">
+              {/* Housing and the weekends on ONE wrapping line, separated by a
+                  dash (kindred#2393, owner ruling 2026-08-18 — revised).
+
+                  It was a two-row column first, on the reasoning that a
+                  416px panel already carries a year, a housing name, a chip
+                  and an action. Measured against the production snapshot, the
+                  weekend string is far shorter than that assumed: median 3
+                  characters ("FC1"), p95 9, and only 65 of 3,113 journey rows
+                  name more than one weekend at all. Spending a whole row on a
+                  three-character string, on every row of every year, to serve
+                  2% of them is the wrong trade.
+
+                  `flex-wrap` is what makes it safe: the worst real row is
+                  "FC1 · FC2 · FC3 · Summer FC" (27 chars) beside a 24-char
+                  cabin, which wraps to the second line it would have occupied
+                  anyway. So the bad case is no worse than the old default and
+                  the common case is a row shorter.
+
+                  A DASH here and `·` between weekends, deliberately: one
+                  separator for both would read as a flat list of four things
+                  rather than a cabin and the weekends it was used for.
+
+                  `min-w-0` stays — it is what lets the flex child shrink below
+                  its content width, which is what makes the kindred#2253 wrap
+                  happen instead of the row overflowing. */}
+              <div className="flex min-w-0 flex-wrap items-baseline gap-x-1.5">
                 <span
                   data-testid="household-journey-housing"
                   className={`flex min-w-0 items-center gap-1 text-sm ${
@@ -244,12 +260,18 @@ function JourneyRows({
                   enrolled child (2020's cancelled season, 2021's adults-only
                   rows), not a household that attended none. */}
                 {weekends.length > 0 && (
-                  <span
-                    data-testid="household-journey-weekends"
-                    className="text-muted-foreground text-xs"
-                  >
-                    {weekends.join(' · ')}
-                  </span>
+                  <>
+                    {/* Its own element, not a prefix inside the label span, so
+                        the span's text stays exactly the weekend list — what
+                        every assertion about this line reads. */}
+                    <span className="text-muted-foreground/50 text-xs">—</span>
+                    <span
+                      data-testid="household-journey-weekends"
+                      className="text-muted-foreground text-xs"
+                    >
+                      {weekends.join(' · ')}
+                    </span>
+                  </>
                 )}
               </div>
 

--- a/frontend/src/components/weekend/HouseholdJourneyCard.tsx
+++ b/frontend/src/components/weekend/HouseholdJourneyCard.tsx
@@ -206,10 +206,19 @@ function JourneyRows({
                   separator for both would read as a flat list of four things
                   rather than a cabin and the weekends it was used for.
 
+                  `items-center`, NOT `items-baseline`. Baseline alignment reads
+                  the first flex item's baseline, and that item is the housing
+                  span — itself a flex row whose first child is the `Home`
+                  icon. An SVG has no text baseline, so the browser synthesises
+                  one from its bottom edge and the whole weekend run sat
+                  visibly low against the cabin name. Centring sidesteps the
+                  synthesis entirely and is what the two sizes (text-sm cabin,
+                  text-xs weekends) want anyway.
+
                   `min-w-0` stays — it is what lets the flex child shrink below
                   its content width, which is what makes the kindred#2253 wrap
                   happen instead of the row overflowing. */}
-              <div className="flex min-w-0 flex-wrap items-baseline gap-x-1.5">
+              <div className="flex min-w-0 flex-wrap items-center gap-x-1.5">
                 <span
                   data-testid="household-journey-housing"
                   className={`flex min-w-0 items-center gap-1 text-sm ${

--- a/frontend/src/components/weekend/HouseholdYearMembersModal.test.tsx
+++ b/frontend/src/components/weekend/HouseholdYearMembersModal.test.tsx
@@ -17,7 +17,7 @@
  *   despite 247 registrations — while adults exist for both years.
  */
 import { useState } from 'react'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest'
 import { MemoryRouter, Route, Routes } from 'react-router'
 
@@ -328,5 +328,191 @@ describe('navigating to a linked camper unwinds the modal stack (kindred#2329)',
     expect(screen.getByRole('dialog')).toBeInTheDocument()
     expect(document.getElementById('root')).toHaveAttribute('inert')
     expect(hasOpenModal()).toBe(true)
+  })
+})
+
+/**
+ * WHICH WEEKEND (kindred#2393, owner ruling 2026-08-18: option A, tabs).
+ *
+ * ★ THIS IS THE HALF THAT ACTUALLY NEEDED THE SESSION GRAIN. A journey row is
+ * a household-YEAR, so a family that booked two of a season's weekends
+ * collapses into one merged member list. Measured on the production snapshot,
+ * 64 of 5,438 journey household-years are multi-weekend and 7 of those 64
+ * carry a child who did not attend every weekend — so today's list silently
+ * overstates at least one weekend's party, and once the weekends appear on
+ * the panel it becomes visibly wrong.
+ *
+ * ⚠️ THE ADULT LIST CANNOT BE TABBED. `family_camp_adults` is household-year
+ * grain with NO session dimension, so adults have no per-weekend truth to
+ * filter on. They render unchanged on every tab, and inventing an attendance
+ * claim for them is kindred#1943 — blocked on a 2027 form change.
+ */
+describe('the weekend tabs', () => {
+  const FC1 = {
+    session_cm_id: 1309514,
+    name: 'Family Camp 1: Memorial Day Weekend',
+    start_date: '2025-05-23',
+  }
+  const FC4 = {
+    session_cm_id: 1309517,
+    name: 'Family Camp 4: Labor Day Weekend',
+    start_date: '2025-09-05',
+  }
+
+  /** Emma went to both weekends; Liam only to the first. The 7-of-64 case. */
+  function _twoWeekendRow(overrides: Partial<HouseholdJourneyRow> = {}): HouseholdJourneyRow {
+    return _row({
+      sessions: [FC1, FC4],
+      children: [
+        {
+          person_cm_id: 1000001,
+          display_name: 'Emma Johnson',
+          last_name: 'Johnson',
+          age: 9,
+          grade: 4,
+          session_cm_ids: [1309514, 1309517],
+        },
+        {
+          person_cm_id: 1000002,
+          display_name: 'Liam Johnson',
+          last_name: 'Johnson',
+          age: 7,
+          grade: 2,
+          session_cm_ids: [1309514],
+        },
+      ],
+      ...overrides,
+    })
+  }
+
+  it('offers one tab per weekend plus All, labelled FCx', () => {
+    open(_twoWeekendRow())
+
+    const tabs = within(screen.getByTestId('year-members-weekend-tabs')).getAllByRole('button')
+    expect(tabs.map((tab) => tab.textContent)).toEqual(['All', 'FC1', 'FC4'])
+  })
+
+  it('opens on All, showing the whole year rather than one weekend of it', () => {
+    // Both halves matter. The strip must SAY All is on — a mutation that
+    // opened on the first weekend passed a names-only assertion, because
+    // every child here attended the first weekend. And a child who attended
+    // ONLY the later weekend must still be on screen at open.
+    open(
+      _twoWeekendRow({
+        children: [
+          {
+            person_cm_id: 1000004,
+            display_name: 'Noah Garcia',
+            last_name: 'Garcia',
+            age: 8,
+            grade: 3,
+            session_cm_ids: [1309517],
+          },
+        ],
+      })
+    )
+
+    expect(screen.getByRole('button', { name: 'All' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'FC1' })).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByTestId('year-members-children').textContent).toContain('Noah Garcia')
+  })
+
+  it('shows every child of a multi-weekend year on All', () => {
+    open(_twoWeekendRow())
+
+    const names = screen.getByTestId('year-members-children').textContent ?? ''
+    expect(names).toContain('Emma Johnson')
+    expect(names).toContain('Liam Johnson')
+  })
+
+  it('drops a child who did not attend the selected weekend', () => {
+    open(_twoWeekendRow())
+
+    fireEvent.click(screen.getByRole('button', { name: 'FC4' }))
+
+    const names = screen.getByTestId('year-members-children').textContent ?? ''
+    expect(names).toContain('Emma Johnson')
+    expect(names).not.toContain('Liam Johnson')
+  })
+
+  it('brings the child back on the weekend they did attend', () => {
+    open(_twoWeekendRow())
+
+    fireEvent.click(screen.getByRole('button', { name: 'FC4' }))
+    fireEvent.click(screen.getByRole('button', { name: 'FC1' }))
+
+    expect(screen.getByTestId('year-members-children').textContent).toContain('Liam Johnson')
+  })
+
+  it('makes the headcount follow the selected tab', () => {
+    open(_twoWeekendRow())
+
+    // All: one adult + two children.
+    expect(screen.getByText(/3 people/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'FC4' }))
+
+    // FC4: the same adult + Emma alone. A headcount that stayed at 3 would be
+    // the exact overstatement the tabs exist to remove.
+    expect(screen.getByText(/2 people/)).toBeInTheDocument()
+  })
+
+  it('leaves the adult list untouched on a weekend tab', () => {
+    // `family_camp_adults` has no session dimension. Filtering adults would be
+    // an attendance claim nothing supports (kindred#1943).
+    open(_twoWeekendRow())
+
+    fireEvent.click(screen.getByRole('button', { name: 'FC4' }))
+
+    expect(screen.getByTestId('year-members-adults').textContent).toContain('Olivia Johnson')
+  })
+
+  it('marks the selected tab pressed so the strip says which one is on', () => {
+    open(_twoWeekendRow())
+
+    fireEvent.click(screen.getByRole('button', { name: 'FC4' }))
+
+    expect(screen.getByRole('button', { name: 'FC4' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'All' })).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('shows no tab strip for a single-weekend year', () => {
+    // `All · FC1` splits nothing. The card's own weekend line already names
+    // the weekend, so a strip here would be a control that cannot change
+    // anything.
+    open(_row({ sessions: [FC1] }))
+
+    expect(screen.queryByTestId('year-members-weekend-tabs')).toBeNull()
+  })
+
+  it('shows no tab strip when no weekend is knowable', () => {
+    open(_row({ sessions: [] }))
+
+    expect(screen.queryByTestId('year-members-weekend-tabs')).toBeNull()
+  })
+
+  it('keeps a child whose weekends are unknown visible on every tab', () => {
+    // An attendee row whose `session` relation did not expand carries no
+    // weekend. That is "not knowable", NOT "attended nothing" — hiding such a
+    // child from every weekend tab would lose a real member of the party.
+    open(
+      _row({
+        sessions: [FC1, FC4],
+        children: [
+          {
+            person_cm_id: 1000003,
+            display_name: 'Ava Garcia',
+            last_name: 'Garcia',
+            age: 10,
+            grade: 5,
+            session_cm_ids: [],
+          },
+        ],
+      })
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'FC4' }))
+
+    expect(screen.getByTestId('year-members-children').textContent).toContain('Ava Garcia')
   })
 })

--- a/frontend/src/components/weekend/HouseholdYearMembersModal.test.tsx
+++ b/frontend/src/components/weekend/HouseholdYearMembersModal.test.tsx
@@ -485,6 +485,59 @@ describe('the weekend tabs', () => {
     expect(screen.queryByTestId('year-members-weekend-tabs')).toBeNull()
   })
 
+  it('shows no tab strip when every member attended every weekend', () => {
+    /*
+     * Owner ruling, 2026-08-18: "if all of the members are the same across all
+     * sessions, we simply do not offer up the tabbed experience."
+     *
+     * This is the overwhelmingly common case, not an edge one. Measured on the
+     * production snapshot: of every household that has ever attended more than
+     * one weekend in a year, only SIX have differing members. So a strip that
+     * fires on `sessions.length > 1` alone offers a control that changes
+     * nothing on ~98% of the rows that show it, and invites a staff member to
+     * click through tabs looking for a difference that is not there.
+     */
+    open(
+      _row({
+        sessions: [FC1, FC4],
+        children: [
+          { person_cm_id: 9001, display_name: 'Mia Garcia', session_cm_ids: [1309514, 1309517] },
+          { person_cm_id: 9002, display_name: 'Noah Garcia', session_cm_ids: [1309514, 1309517] },
+        ],
+      })
+    )
+
+    expect(screen.queryByTestId('year-members-weekend-tabs')).toBeNull()
+  })
+
+  it('still shows the strip when ONE member differs on ONE weekend', () => {
+    // The whole point of the strip, and the smallest case that needs it.
+    open(
+      _row({
+        sessions: [FC1, FC4],
+        children: [
+          { person_cm_id: 9001, display_name: 'Mia Garcia', session_cm_ids: [1309514, 1309517] },
+          { person_cm_id: 9002, display_name: 'Noah Garcia', session_cm_ids: [1309514] },
+        ],
+      })
+    )
+
+    expect(screen.getByTestId('year-members-weekend-tabs')).toBeInTheDocument()
+  })
+
+  it('shows no strip when every child’s weekends are unknown', () => {
+    // An empty `session_cm_ids` means "not knowable", and such a child shows
+    // on every tab — so the tabs would all render identically.
+    open(
+      _row({
+        sessions: [FC1, FC4],
+        children: [{ person_cm_id: 9001, display_name: 'Mia Garcia', session_cm_ids: [] }],
+      })
+    )
+
+    expect(screen.queryByTestId('year-members-weekend-tabs')).toBeNull()
+  })
+
   it('shows no tab strip when no weekend is knowable', () => {
     open(_row({ sessions: [] }))
 
@@ -495,6 +548,11 @@ describe('the weekend tabs', () => {
     // An attendee row whose `session` relation did not expand carries no
     // weekend. That is "not knowable", NOT "attended nothing" — hiding such a
     // child from every weekend tab would lose a real member of the party.
+    //
+    // A SECOND child with a known, incomplete list is what makes the strip
+    // appear at all: an unknown-weekend child splits nothing by itself, so on
+    // its own the tabs are suppressed entirely (see above). The guarantee
+    // being pinned here is about what a tab SHOWS once one exists.
     open(
       _row({
         sessions: [FC1, FC4],
@@ -506,6 +564,14 @@ describe('the weekend tabs', () => {
             age: 10,
             grade: 5,
             session_cm_ids: [],
+          },
+          {
+            person_cm_id: 1000004,
+            display_name: 'Noah Garcia',
+            last_name: 'Garcia',
+            age: 8,
+            grade: 3,
+            session_cm_ids: [1309514],
           },
         ],
       })

--- a/frontend/src/components/weekend/HouseholdYearMembersModal.tsx
+++ b/frontend/src/components/weekend/HouseholdYearMembersModal.tsx
@@ -10,6 +10,19 @@
  * children age out, adults change — so this renders the rows the server
  * derived for this year and nothing from an adjacent one.
  *
+ * ★ AND PER WEEKEND, WHERE THE YEAR HAD MORE THAN ONE (kindred#2393, owner
+ * ruling 2026-08-18). A journey row is a household-YEAR, so a family that
+ * booked two of a season's weekends collapsed into one merged list: 64 of
+ * 5,438 journey household-years are multi-weekend and 7 of those 64 carry a
+ * child who did not attend every weekend, which means the merged list
+ * overstates at least one weekend's party. The tab strip is what lets a staff
+ * member see one weekend's party at a time.
+ *
+ * ⚠️ THE ADULT LIST IS NOT TABBED, AND CANNOT BE. `family_camp_adults` is
+ * household-year grain with NO session dimension — there is no per-weekend
+ * truth to filter adults on, and inventing one is kindred#1943, which is
+ * blocked on a 2027 form change. The adults render unchanged on every tab.
+ *
  * Built on the shared `ui/Modal` primitive rather than a bespoke overlay, so
  * it inherits the portal at `z-[100]` (which is what lets it open on top of
  * the `z-[60]` family panel), the Escape handler, the background `inert`, and
@@ -33,12 +46,14 @@
  * overlay token for as long as the modal is mounted, exactly as before.
  */
 import { Baby, Users } from 'lucide-react'
+import { useState } from 'react'
 import { Link } from 'react-router'
 
 import type { HouseholdJourneyRow } from '../../types/lodging'
 import { displayCampMinderAge } from '../../utils/age'
 import { Modal } from '../ui/Modal'
 import { isAttendingAdultName } from './householdIdentity'
+import { weekendLabel } from './weekendNames'
 
 /**
  * Mirrors `CamperLink.tsx`'s own validity check — a CampMinder ID is only
@@ -118,6 +133,31 @@ export function HouseholdYearMembersModal({
   row,
   familyLabel,
 }: HouseholdYearMembersModalProps) {
+  // `null` is the All tab, which is where every year opens.
+  //
+  // A DELIBERATE DIVERGENCE from the root CLAUDE.md §4 rule that weekend tab
+  // state lives in the URL: that rule buys a linkable, reload-surviving tab,
+  // and this one has nothing to be linkable FROM. The modal itself is not
+  // addressable — the card holds the open row in `useState` — so a search
+  // param for its inner filter would outlive the modal that owns it and name
+  // a weekend nothing is showing.
+  const [selectedCmId, setSelectedCmId] = useState<number | null>(null)
+  // Hooks run before the null-row bail-out, so `sessions` is read defensively
+  // rather than after it.
+  const sessions = row?.sessions ?? []
+  // A stale selection resets ITSELF rather than through an effect. The card
+  // keeps this component mounted across opens (`row` goes null and back), so
+  // a weekend picked on 2025 would otherwise still be selected on 2024, where
+  // it names nothing and would empty the list.
+  const activeCmId =
+    selectedCmId !== null && sessions.some((session) => session.session_cm_id === selectedCmId)
+      ? selectedCmId
+      : null
+  // `All · FC1 · FC4`. Only where there is something to split: one weekend
+  // makes `All · FC1` a control that cannot change anything, and the journey
+  // card's own weekend line already names it.
+  const showsTabs = sessions.length > 1
+
   if (row === null) return null
 
   // A blank `family_camp_adults` slot is not an attending adult — the scrape
@@ -126,7 +166,18 @@ export function HouseholdYearMembersModal({
   // server publishes every row on purpose so the client applies ONE predicate
   // across every surface; this is that predicate.
   const adults = (row.adults ?? []).filter((adult) => isAttendingAdultName(adult.display_name))
-  const children = row.children ?? []
+  // A child with NO weekends on file stays visible on every tab. An empty
+  // `session_cm_ids` is "not knowable" — an attendee row whose `session`
+  // relation did not expand — never "attended nothing", and hiding such a
+  // child from every weekend would lose a real member of the party.
+  const children = (row.children ?? []).filter(
+    (child) =>
+      activeCmId === null ||
+      (child.session_cm_ids ?? []).length === 0 ||
+      (child.session_cm_ids ?? []).includes(activeCmId)
+  )
+  // Follows the selected tab. A headcount that stayed at the year's total
+  // would be the exact overstatement the tabs exist to remove.
   const headcount = adults.length + children.length
 
   const header = (
@@ -152,6 +203,45 @@ export function HouseholdYearMembersModal({
       ariaLabelledBy={TITLE_ID}
     >
       <div className="flex flex-col gap-4 p-4">
+        {/* The segmented control the weekend surface already uses — the same
+            grammar as `HouseholdRosterTable`'s need filters, tightened one
+            step for a modal. Buttons and `aria-pressed`, not `role="tablist"`:
+            per `frontend/CLAUDE.md`, accessibility here is deliberately
+            minimal, and `aria-pressed` is what the sibling control states. */}
+        {showsTabs && (
+          <div
+            data-testid="year-members-weekend-tabs"
+            className="bg-muted/50 dark:bg-muted/30 border-border/50 flex flex-wrap items-center gap-1 rounded-xl border p-1"
+          >
+            {[null, ...sessions.map((session) => session.session_cm_id ?? 0)].map((cmId) => {
+              const isSelected = activeCmId === cmId
+              const label =
+                cmId === null
+                  ? 'All'
+                  : weekendLabel(
+                      sessions.find((session) => session.session_cm_id === cmId)?.name ?? ''
+                    )
+              return (
+                <button
+                  key={cmId === null ? 'all' : String(cmId)}
+                  type="button"
+                  aria-pressed={isSelected}
+                  onClick={() => {
+                    setSelectedCmId(cmId)
+                  }}
+                  className={`rounded-lg px-2.5 py-1 text-xs font-medium transition-all duration-200 ${
+                    isSelected
+                      ? 'bg-primary text-primary-foreground shadow-lodge-sm'
+                      : 'text-muted-foreground hover:text-foreground hover:bg-muted dark:hover:bg-muted/80'
+                  }`}
+                >
+                  {label}
+                </button>
+              )
+            })}
+          </div>
+        )}
+
         {adults.length > 0 && (
           <MemberSection title="Adults" icon={<Users className="h-3.5 w-3.5" />}>
             <ul data-testid="year-members-adults" className="flex flex-col gap-0.5">

--- a/frontend/src/components/weekend/HouseholdYearMembersModal.tsx
+++ b/frontend/src/components/weekend/HouseholdYearMembersModal.tsx
@@ -153,10 +153,33 @@ export function HouseholdYearMembersModal({
     selectedCmId !== null && sessions.some((session) => session.session_cm_id === selectedCmId)
       ? selectedCmId
       : null
-  // `All · FC1 · FC4`. Only where there is something to split: one weekend
-  // makes `All · FC1` a control that cannot change anything, and the journey
-  // card's own weekend line already names it.
-  const showsTabs = sessions.length > 1
+  /**
+   * `All · FC1 · FC4`. Only where there is something to split.
+   *
+   * TWO conditions, and the second is the one that matters in practice. More
+   * than one weekend is necessary — `All · FC1` cannot change anything, and
+   * the journey card's own weekend line already names it. But it is not
+   * sufficient: if every child attended every weekend, each tab renders the
+   * identical list and the strip invites a staff member to hunt for a
+   * difference that is not there.
+   *
+   * Owner ruling, 2026-08-18: "if all of the members are the same across all
+   * sessions, we simply do not offer up the tabbed experience."
+   *
+   * That is the common case by a wide margin — of every household that has
+   * ever attended more than one weekend in a year, only SIX have differing
+   * members on the production snapshot.
+   *
+   * A child with an EMPTY `session_cm_ids` never triggers the strip: empty is
+   * "not knowable", such a child stays visible on every tab, and it therefore
+   * splits nothing. Only a child with a known, INCOMPLETE weekend list does.
+   */
+  const membersDifferByWeekend = (row?.children ?? []).some((child) => {
+    const attended = child.session_cm_ids ?? []
+    if (attended.length === 0) return false
+    return sessions.some((session) => !attended.includes(session.session_cm_id ?? 0))
+  })
+  const showsTabs = sessions.length > 1 && membersDifferByWeekend
 
   if (row === null) return null
 

--- a/frontend/src/components/weekend/weekendNames.test.ts
+++ b/frontend/src/components/weekend/weekendNames.test.ts
@@ -15,6 +15,8 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  weekendSubtitle,
+  weekendTitle,
   resolveWeekendRef,
   shortWeekendName,
   splitWeekendName,
@@ -339,5 +341,63 @@ describe('weekendLabel', () => {
     for (const session of [FC1, WOMENS, WINTER, JFAM_10, YEAR_ONLY]) {
       expect(weekendLabel(session.name).length).toBeGreaterThan(0)
     }
+  })
+})
+
+describe('the camper journey mid-shorthand', () => {
+  /*
+   * Owner ruling, 2026-08-18. A LONGER form than the board's `FC3`, on purpose:
+   * the camper journey gives each session its own row beside a year and a
+   * status, where `FC3` is terser than the row can afford, while CampMinder's
+   * raw name runs to 54 characters.
+   *
+   *   > "instead use a mid shorthand, like 'Family Camp X' for the number, and
+   *   >  then a subtitle (if any) of Keshet, JFAM, JFoC, etc."
+   */
+  const CASES: ReadonlyArray<readonly [string, string, string]> = [
+    ['Family Camp 1: Memorial Day Weekend', 'Family Camp 1', 'Memorial Day'],
+    ['Family Camp 2: Keshet LGBTQ Weekend', 'Family Camp 2', 'Keshet'],
+    ['Family Camp 7: Jewish Families of Color Weekend', 'Family Camp 7', 'JFoC'],
+    ['Family Camp 5: JFAM Weekend (w/ kids 10 and under)', 'Family Camp 5', 'JFAM'],
+    ['Family Camp 8: JFAM Weekend w/ SFJCC (w/ kids 10 and under)', 'Family Camp 8', 'JFAM'],
+    [
+      'Family Camp 7: JFAM Sukkot Weekend with the JCCSF (w/ kids 8 and under)',
+      'Family Camp 7',
+      'JFAM Sukkot',
+    ],
+    [
+      'Family Camp 8: JFAM Chanukah Program (w/ kids 8 and under)',
+      'Family Camp 8',
+      'JFAM Chanukah',
+    ],
+    ['Family Camp 7: Sukkot', 'Family Camp 7', 'Sukkot'],
+    ['Family Camp 6', 'Family Camp 6', ''],
+    // Un-numbered weekends read as themselves and carry no subtitle.
+    ['Ready, Set, Camp', 'Ready, Set, Camp', ''],
+    ['Winter Family Camp', 'Winter Family Camp', ''],
+    ['JFAM Winter Family Camp', 'Winter Family Camp', ''],
+    // Legacy: the number the board assigns, with the original name beneath —
+    // which is the part a reader of a 2018 row actually recognises.
+    ['Spring Family Camp', 'Family Camp 1', 'Spring'],
+    ['Keshet LGBTQ Family Camp', 'Family Camp 2', 'Keshet'],
+    ['Summer Family Camp', 'Family Camp 3', 'Summer'],
+    ['Fall Family Camp II', 'Family Camp 5', 'Fall II'],
+  ]
+
+  it.each(CASES)('reads %s as "%s" / "%s"', (name, title, subtitle) => {
+    expect(weekendTitle(name)).toBe(title)
+    expect(weekendSubtitle(name)).toBe(subtitle)
+  })
+
+  it('tests JFAM Sukkot and JFAM Chanukah BEFORE the bare JFAM', () => {
+    // Order in `SUBTITLE_RULES` is load-bearing: a bare-JFAM-first list
+    // collapses both onto "JFAM" and loses the holiday, which is the only
+    // thing telling those weekends apart.
+    expect(weekendSubtitle('Family Camp 7: JFAM Sukkot Weekend with the JCCSF')).not.toBe('JFAM')
+    expect(weekendSubtitle('Family Camp 8: JFAM Chanukah Program')).not.toBe('JFAM')
+  })
+
+  it('keeps an unrecognised suffix rather than dropping it', () => {
+    expect(weekendSubtitle('Family Camp 9: Harvest Weekend')).toBe('Harvest Weekend')
   })
 })

--- a/frontend/src/components/weekend/weekendNames.test.ts
+++ b/frontend/src/components/weekend/weekendNames.test.ts
@@ -177,6 +177,71 @@ describe('resolveWeekendRef', () => {
   })
 })
 
+describe('weekendLabel — the named weekends CampMinder never numbered', () => {
+  /*
+   * Owner ruling, 2026-08-18, after being shown the whole catalogue.
+   *
+   * 2017-2019 ran SIX family weekends, not four: Spring, Keshet, Summer, and
+   * Fall I/II/III. The numbering that arrived in 2020 maps onto them by slot,
+   * and the owner assigned it directly:
+   *
+   *   > "Spring family camp = FC1. fall 1, 2, 3, are the new 2, 3, 4 —
+   *   >  basically a year that had a spring, the fall numbers get bumped one."
+   *   > "Keshet LGBTQ etc as just Keshet"
+   *   > "actually WFC is better than my suggestion, and RSC as well, yes"
+   *
+   * An EXPLICIT MAP rather than a rule, because the set is closed — these are
+   * historical names that cannot gain a member — and every previous attempt at
+   * a rule got one of them wrong. Initials collapsed Spring and Summer onto
+   * `SFC` and Fall I/II/III onto `FFCI`; printing prose names in full was
+   * correct but long. A map is the only form that is both short and right.
+   */
+  const CATALOGUE: ReadonlyArray<readonly [string, string]> = [
+    ['Spring Family Camp', 'FC1'],
+    ['Fall Family Camp I', 'FC2'],
+    ['Fall Family Camp II', 'FC3'],
+    ['Fall Family Camp III', 'FC4'],
+    ['Keshet LGBTQ Family Camp', 'Keshet'],
+    ['Summer Family Camp', 'Summer FC'],
+    ['Winter Family Camp', 'WFC'],
+    ['JFAM Winter Family Camp', 'WFC'],
+    ['Ready, Set, Camp', 'RSC'],
+    ['Spring Family Retreat', 'Spring FR'],
+  ]
+
+  it.each(CATALOGUE)('labels %s as %s', (name, expected) => {
+    expect(weekendLabel(name)).toBe(expected)
+  })
+
+  it('still reads a CampMinder number straight off a numbered weekend', () => {
+    expect(weekendLabel('Family Camp 1: Memorial Day Weekend')).toBe('FC1')
+    expect(weekendLabel('Family Camp 8: JFAM Weekend (w/ kids 10 and under)')).toBe('FC8')
+  })
+
+  it('never labels two weekends of one season alike', () => {
+    // The guarantee the initials rule broke. 2017-2019 is the season that
+    // exercises it: six weekends, four of them sharing the word "Family".
+    const season2017 = [
+      'Spring Family Camp',
+      'Keshet LGBTQ Family Camp',
+      'Summer Family Camp',
+      'Fall Family Camp I',
+      'Fall Family Camp II',
+      'Fall Family Camp III',
+    ]
+    const labels = season2017.map(weekendLabel)
+    expect(new Set(labels).size).toBe(season2017.length)
+  })
+
+  it('falls back to the short name for a weekend nobody has mapped', () => {
+    // A name the catalogue has never seen must still read as itself, never as
+    // an id and never as invented initials.
+    expect(weekendLabel('Harvest Family Gathering')).toBe(
+      shortWeekendName('Harvest Family Gathering')
+    )
+  })
+})
+
 describe('weekendLabel', () => {
   /**
    * The owner's 2026-08-18 ruling on kindred#2393: a weekend prints as `FC1`,
@@ -195,21 +260,18 @@ describe('weekendLabel', () => {
     expect(weekendLabel('Family Camp 1')).toBe('FC1')
   })
 
-  it('prints a weekend CampMinder never numbered by its own name', () => {
-    // ⚠️ THE LICENCE IS FOR `FCx`, AND ONLY FOR `FCx`. The owner's ruling
-    // named the form staff already say out loud — "FC1" — and CampMinder is
-    // what makes that form safe: the number IS the weekend's identity, so the
-    // abbreviation cannot name the wrong one. Nothing supplies that guarantee
-    // for a prose name, and an abbreviation invented for one is the exact
-    // thing the top-of-file note has always argued against.
+  it('prints an UNMAPPED weekend by its own name, never by invented initials', () => {
+    // ⚠️ THE LICENCE IS FOR `FCx` AND FOR THE EXPLICIT MAP. Nothing else may
+    // be abbreviated. CampMinder's number is safe because the number IS the
+    // weekend's identity; the map is safe because the owner assigned each
+    // entry by hand against the full catalogue. A name that is neither is a
+    // weekend nobody has ruled on, and inventing initials for it is what gave
+    // "Spring Family Camp" and "Summer Family Camp" the same label.
     //
-    // Measured on the production snapshot rather than argued: initials alone
-    // give "Spring Family Camp" and "Summer Family Camp" (both 2017-2019) the
-    // SAME label, and collapse "Fall Family Camp I", "II" and "III" onto one —
-    // so a 2018 row for the family that went to Fall II would have read
-    // "FFCI", naming a different weekend. See the season sweep below.
-    expect(weekendLabel('Ready, Set, Camp')).toBe('Ready, Set, Camp')
-    expect(weekendLabel('JFAM Winter Family Camp')).toBe('JFAM Winter Family Camp')
+    // This assertion previously named "Ready, Set, Camp" and "JFAM Winter
+    // Family Camp"; both are in the map now (RSC, WFC), so it uses a name the
+    // catalogue has never carried.
+    expect(weekendLabel('Harvest Family Gathering')).toBe('Harvest Family Gathering')
   })
 
   it('gives every weekend of a legacy season a distinct label', () => {

--- a/frontend/src/components/weekend/weekendNames.test.ts
+++ b/frontend/src/components/weekend/weekendNames.test.ts
@@ -1,7 +1,14 @@
 /**
  * CampMinder joins a weekend's identity and its description with a colon.
- * Splitting is lossless; abbreviating would not be — which is why the slug
- * below is an ADDRESS and never a label. See the note in weekendNames.ts.
+ * Splitting is lossless; abbreviating is not — which is why there are three
+ * forms and not one, and why which form a surface may use is a rule rather
+ * than a preference. See the note in weekendNames.ts.
+ *
+ * `weekendSlug` is an ADDRESS for a URL and is never rendered on its own.
+ * `weekendLabel` is the narrow display licence the owner granted on
+ * 2026-08-18 (kindred#2393) for the 416px family journey panel: it uppercases
+ * the slug and falls back to the weekend's short name, never to a CampMinder
+ * id. Everywhere with room still prints `splitWeekendName`'s output verbatim.
  */
 import { describe, expect, it } from 'vitest'
 
@@ -9,6 +16,7 @@ import {
   resolveWeekendRef,
   shortWeekendName,
   splitWeekendName,
+  weekendLabel,
   weekendRef,
   weekendSlug,
 } from './weekendNames'
@@ -164,5 +172,78 @@ describe('resolveWeekendRef', () => {
   it('finds nothing for a reference that names no weekend', () => {
     expect(resolveWeekendRef([FC1, WOMENS], 'zz')).toBeUndefined()
     expect(resolveWeekendRef([FC1, WOMENS], undefined)).toBeUndefined()
+  })
+})
+
+describe('weekendLabel', () => {
+  /**
+   * The owner's 2026-08-18 ruling on kindred#2393: a weekend prints as `FC1`,
+   * as PLAIN TEXT, on the journey panel's weekend line and on the members
+   * modal's tabs. `w-[26rem]` has no room for "Family Camp 1: Memorial Day
+   * Weekend" three times over, and the abbreviation is the one staff already
+   * say out loud.
+   */
+  it('abbreviates a numbered family weekend to FCx', () => {
+    expect(weekendLabel('Family Camp 1: Memorial Day Weekend')).toBe('FC1')
+  })
+
+  it('keeps a two-digit weekend distinct from a one-digit one', () => {
+    // The same collision `weekendSlug` guards: FC10 must not read as FC1.
+    expect(weekendLabel('Family Camp 10')).toBe('FC10')
+    expect(weekendLabel('Family Camp 1')).toBe('FC1')
+  })
+
+  it('uppercases the two 2026 weekends that are not FCx', () => {
+    // Computed against the ten 2026 family sessions: FC1-FC8 plus these two,
+    // which sit outside the day-group plan. They are not special cases in the
+    // code and must not become them — they are what the rule already produces.
+    //
+    // ⚠️ kindred#2393's ruling called these `rs` and `w`. Both are off: the
+    // slug rule keeps EVERY initial of the identity, so "Ready, Set, Camp" is
+    // `rsc` (the example weekendSlug's own doc block gives) and "JFAM Winter
+    // Family Camp" is `wfc` once the shared JFAM token is dropped. Pinned here
+    // as computed rather than as written down, because the alternative is
+    // special-casing two weekends to match a note.
+    expect(weekendLabel('Ready, Set, Camp')).toBe('RSC')
+    expect(weekendLabel('JFAM Winter Family Camp')).toBe('WFC')
+  })
+
+  it('gives the ten 2026 family weekends ten distinct labels', () => {
+    // A label that collided would put two weekends on one tab in the members
+    // modal and read as one entry on the journey's weekend line.
+    const labels = [
+      'Ready, Set, Camp',
+      'Family Camp 1: Memorial Day Weekend',
+      'Family Camp 2: Keshet LGBTQ Weekend',
+      'Family Camp 3: JFAM Weekend (w/ kids 10 and under)',
+      'Family Camp 4: Labor Day Weekend',
+      'Family Camp 5: JFAM Weekend (w/ kids 10 and under)',
+      'Family Camp 6',
+      'Family Camp 7: Jewish Families of Color Weekend',
+      'Family Camp 8: JFAM Weekend (w/ kids 10 and under)',
+      'JFAM Winter Family Camp',
+    ].map(weekendLabel)
+
+    expect(new Set(labels).size).toBe(labels.length)
+  })
+
+  it('reads the identity only, so a description cannot drag the label', () => {
+    expect(weekendLabel('Family Camp 5: JFAM Weekend (w/ kids 10 and under)')).toBe('FC5')
+  })
+
+  it('falls back to the short name when there is nothing to abbreviate', () => {
+    // `weekendSlug` returns '' here on purpose: the numeric space belongs to
+    // CampMinder ids, so this weekend has no ADDRESS. It still has a name,
+    // and the label is that name — never the id `weekendRef` falls back to,
+    // which names nothing a staff member can read.
+    expect(weekendSlug('2026')).toBe('')
+    expect(weekendLabel('2026')).toBe('2026')
+    expect(weekendLabel('2026')).not.toBe(String(YEAR_ONLY.session_cm_id))
+  })
+
+  it('never returns an empty string for a weekend that has a name', () => {
+    for (const session of [FC1, WOMENS, WINTER, JFAM_10, YEAR_ONLY]) {
+      expect(weekendLabel(session.name).length).toBeGreaterThan(0)
+    }
   })
 })

--- a/frontend/src/components/weekend/weekendNames.test.ts
+++ b/frontend/src/components/weekend/weekendNames.test.ts
@@ -7,8 +7,10 @@
  * `weekendSlug` is an ADDRESS for a URL and is never rendered on its own.
  * `weekendLabel` is the narrow display licence the owner granted on
  * 2026-08-18 (kindred#2393) for the 416px family journey panel: it uppercases
- * the slug and falls back to the weekend's short name, never to a CampMinder
- * id. Everywhere with room still prints `splitWeekendName`'s output verbatim.
+ * the slug of a weekend CampMinder NUMBERED, and otherwise returns the
+ * weekend's short name whole — never a CampMinder id, and never an
+ * abbreviation invented for a prose name. Everywhere with room still prints
+ * `splitWeekendName`'s output verbatim.
  */
 import { describe, expect, it } from 'vitest'
 
@@ -193,19 +195,49 @@ describe('weekendLabel', () => {
     expect(weekendLabel('Family Camp 1')).toBe('FC1')
   })
 
-  it('uppercases the two 2026 weekends that are not FCx', () => {
-    // Computed against the ten 2026 family sessions: FC1-FC8 plus these two,
-    // which sit outside the day-group plan. They are not special cases in the
-    // code and must not become them — they are what the rule already produces.
+  it('prints a weekend CampMinder never numbered by its own name', () => {
+    // ⚠️ THE LICENCE IS FOR `FCx`, AND ONLY FOR `FCx`. The owner's ruling
+    // named the form staff already say out loud — "FC1" — and CampMinder is
+    // what makes that form safe: the number IS the weekend's identity, so the
+    // abbreviation cannot name the wrong one. Nothing supplies that guarantee
+    // for a prose name, and an abbreviation invented for one is the exact
+    // thing the top-of-file note has always argued against.
     //
-    // ⚠️ kindred#2393's ruling called these `rs` and `w`. Both are off: the
-    // slug rule keeps EVERY initial of the identity, so "Ready, Set, Camp" is
-    // `rsc` (the example weekendSlug's own doc block gives) and "JFAM Winter
-    // Family Camp" is `wfc` once the shared JFAM token is dropped. Pinned here
-    // as computed rather than as written down, because the alternative is
-    // special-casing two weekends to match a note.
-    expect(weekendLabel('Ready, Set, Camp')).toBe('RSC')
-    expect(weekendLabel('JFAM Winter Family Camp')).toBe('WFC')
+    // Measured on the production snapshot rather than argued: initials alone
+    // give "Spring Family Camp" and "Summer Family Camp" (both 2017-2019) the
+    // SAME label, and collapse "Fall Family Camp I", "II" and "III" onto one —
+    // so a 2018 row for the family that went to Fall II would have read
+    // "FFCI", naming a different weekend. See the season sweep below.
+    expect(weekendLabel('Ready, Set, Camp')).toBe('Ready, Set, Camp')
+    expect(weekendLabel('JFAM Winter Family Camp')).toBe('JFAM Winter Family Camp')
+  })
+
+  it('gives every weekend of a legacy season a distinct label', () => {
+    // The 2017-2019 catalogue, verbatim from the production snapshot. The
+    // journey spans EVERY year a household has a trace, so these rows render
+    // on the same panel the 2026 ones do — 891 of 3,040 single-weekend
+    // household-years fall in a season named this way, and 5 of the 64
+    // multi-weekend ones would have printed the same label twice on one line
+    // and offered two members-modal tabs a staff member could not tell apart.
+    const labels = [
+      'Spring Family Camp',
+      'Keshet LGBTQ Family Camp',
+      'Summer Family Camp',
+      'Fall Family Camp I',
+      'Fall Family Camp II',
+      'Fall Family Camp III',
+    ].map(weekendLabel)
+
+    expect(new Set(labels).size).toBe(labels.length)
+  })
+
+  it("never labels one weekend with another weekend's name", () => {
+    // The sharpest form of the same failure: "Fall Family Camp II" abbreviated
+    // by initials is `FFCI`, which is not merely terse — it reads as Fall
+    // Family Camp I.
+    expect(weekendLabel('Fall Family Camp II')).not.toBe(weekendLabel('Fall Family Camp I'))
+    expect(weekendLabel('Fall Family Camp III')).not.toBe(weekendLabel('Fall Family Camp I'))
+    expect(weekendLabel('Summer Family Camp')).not.toBe(weekendLabel('Spring Family Camp'))
   })
 
   it('gives the ten 2026 family weekends ten distinct labels', () => {

--- a/frontend/src/components/weekend/weekendNames.test.ts
+++ b/frontend/src/components/weekend/weekendNames.test.ts
@@ -198,11 +198,11 @@ describe('weekendLabel — the named weekends CampMinder never numbered', () => 
    */
   const CATALOGUE: ReadonlyArray<readonly [string, string]> = [
     ['Spring Family Camp', 'FC1'],
-    ['Fall Family Camp I', 'FC2'],
-    ['Fall Family Camp II', 'FC3'],
-    ['Fall Family Camp III', 'FC4'],
-    ['Keshet LGBTQ Family Camp', 'Keshet'],
-    ['Summer Family Camp', 'Summer FC'],
+    ['Keshet LGBTQ Family Camp', 'FC2'],
+    ['Summer Family Camp', 'FC3'],
+    ['Fall Family Camp I', 'FC4'],
+    ['Fall Family Camp II', 'FC5'],
+    ['Fall Family Camp III', 'FC6'],
     ['Winter Family Camp', 'WFC'],
     ['JFAM Winter Family Camp', 'WFC'],
     ['Ready, Set, Camp', 'RSC'],

--- a/frontend/src/components/weekend/weekendNames.ts
+++ b/frontend/src/components/weekend/weekendNames.ts
@@ -22,10 +22,12 @@
  * * `weekendLabel` — an abbreviation, `FC1`, for a surface with no room for a
  *   name. Owner-ruled on 2026-08-18 (kindred#2393) for the family journey
  *   panel, which is 416px wide and must fit up to four weekends on one line.
- *   It is a narrow licence and not a general one: reach for `shortWeekendName`
- *   unless the space genuinely will not take it, because an abbreviation is
- *   how a UI starts disagreeing with CampMinder about what a session is
- *   called.
+ *   It is a narrow licence and not a general one, in two senses: reach for
+ *   `shortWeekendName` unless the space genuinely will not take it, and note
+ *   that `weekendLabel` ITSELF only abbreviates a weekend CampMinder numbered.
+ *   A prose name comes back whole, because an invented abbreviation is how a
+ *   UI starts disagreeing with CampMinder about what a session is called —
+ *   `FFCI` for "Fall Family Camp II" is that, on the screen.
  */
 
 export interface WeekendName {
@@ -108,18 +110,31 @@ function initials(words: string[]): string {
  * must treat that as "not addressable" rather than as a slug; `weekendRef`
  * does.
  */
+/**
+ * The identity, as the words an abbreviation is built from.
+ *
+ * Shared by `weekendSlug` and `weekendLabel` so the two cannot drift about
+ * what a "word" is — the label's decision to abbreviate at all reads the same
+ * final word the slug's trailing-number rule does.
+ */
+function identityWords(name: string): string[] {
+  return (
+    shortWeekendName(name)
+      // An apostrophe sits INSIDE a word, so it is deleted rather than treated as
+      // a separator. Splitting on it turns "Women's Weekend" into three words and
+      // slugs it `wsw`.
+      .replace(/['’]/g, '')
+      // Every other mark IS a separator: "Ready, Set, Camp" is three words.
+      // Digits survive because they are the identity.
+      .replace(/[^\p{L}\p{N}]+/gu, ' ')
+      .trim()
+      .split(/\s+/)
+      .filter((word) => word.length > 0)
+  )
+}
+
 export function weekendSlug(name: string): string {
-  const words = shortWeekendName(name)
-    // An apostrophe sits INSIDE a word, so it is deleted rather than treated as
-    // a separator. Splitting on it turns "Women's Weekend" into three words and
-    // slugs it `wsw`.
-    .replace(/['’]/g, '')
-    // Every other mark IS a separator: "Ready, Set, Camp" is three words.
-    // Digits survive because they are the identity.
-    .replace(/[^\p{L}\p{N}]+/gu, ' ')
-    .trim()
-    .split(/\s+/)
-    .filter((word) => word.length > 0)
+  const words = identityWords(name)
 
   const meaningful = words.filter((word) => !SHARED_PROGRAM_TOKENS.has(word.toLowerCase()))
   const dropped = initials(meaningful)
@@ -148,10 +163,23 @@ export function weekendSlug(name: string): string {
  * readable.
  *
  * Uppercased, because the slug is lowercase for a URL and `fc1` on a screen
- * reads as a typo. NOT EVERY WEEKEND IS `FCx`: computed against 2026 the
- * labels are FC1-FC8 plus `RS` (Ready, Set, Camp) and `W` (JFAM Winter Family
- * Camp), the two sessions outside the day-group plan. They fall out of the
- * same rule and are not special-cased.
+ * reads as a typo.
+ *
+ * ⚠️ ONLY A WEEKEND CAMPMINDER NUMBERED IS ABBREVIATED. `FC1` is safe because
+ * the number IS the weekend's identity — the abbreviation cannot name a
+ * different weekend, and it is the form staff already say out loud. Nothing
+ * supplies that guarantee for a prose name, so those print in full and the
+ * top-of-file note's argument stands unamended for them.
+ *
+ * That is not a stylistic hedge, it is measured. Initials alone give both
+ * "Spring Family Camp" and "Summer Family Camp" the label `SFC`, and collapse
+ * "Fall Family Camp I", "II" and "III" onto `FFCI` — so a 2018 journey row for
+ * a family that went to Fall II would have read as Fall I. All three names are
+ * live in the 2017-2019 seasons the journey renders: 891 of 3,040
+ * single-weekend household-years sit in one, and 5 of the 64 multi-weekend
+ * ones would have printed one label twice on a single line and offered two
+ * members-modal tabs nobody could tell apart. Under this rule every season in
+ * the catalogue, 2017 through 2026, labels its weekends distinctly.
  *
  * ⚠️ Falls back to `shortWeekendName`, NEVER to the CampMinder id. `weekendRef`
  * falls back to the id because a URL must resolve; a label must be readable,
@@ -159,7 +187,12 @@ export function weekendSlug(name: string): string {
  * takes a name and not a session: it structurally cannot emit an id.
  */
 export function weekendLabel(name: string): string {
-  const slug = weekendSlug(name)
+  const words = identityWords(name)
+  // The SAME final word `weekendSlug`'s trailing-number rule keeps whole. A
+  // lone number is not a numbered weekend, it is a year ("2026"), and there is
+  // no identity in front of it to abbreviate.
+  const isNumbered = words.length > 1 && DIGITS_ONLY.test(words[words.length - 1] ?? '')
+  const slug = isNumbered ? weekendSlug(name) : ''
   return slug.length > 0 ? slug.toUpperCase() : shortWeekendName(name)
 }
 

--- a/frontend/src/components/weekend/weekendNames.ts
+++ b/frontend/src/components/weekend/weekendNames.ts
@@ -300,3 +300,97 @@ export function resolveWeekendRef(
   const matches = sessions.filter((session) => weekendSlug(session.name) === ref.toLowerCase())
   return matches.length === 1 ? matches[0] : undefined
 }
+
+/**
+ * The camper journey's form: `Family Camp 3` plus a short subtitle.
+ *
+ * A DIFFERENT shorthand from `weekendLabel`'s `FC3`, deliberately, because the
+ * two surfaces read differently. The weekend board's journey panel is 416px
+ * with one row per YEAR and often several weekends on a line, so it needs the
+ * shortest thing that identifies a weekend. The camper journey gives each
+ * session its own row beside a year and a status, and `FC3` there is terser
+ * than the row can afford to be — while CampMinder's raw name
+ * ("Family Camp 8: JFAM Weekend w/ SFJCC (w/ kids 10 and under)", 54
+ * characters) is far longer. Owner ruling, 2026-08-18:
+ *
+ *   > "instead use a mid shorthand, like 'Family Camp X' for the number, and
+ *   >  then a subtitle (if any) of Keshet, JFAM, JFoC, etc., and if they
+ *   >  attend winter or ready set it would be just Ready, Set, Camp or Winter
+ *   >  Family Camp"
+ *
+ * Both halves come off the SAME name, so a weekend cannot read as one thing
+ * here and another on the board.
+ */
+export function weekendTitle(name: string): string {
+  const trimmed = name.trim()
+  const legacy = LEGACY_MID[trimmed]
+  if (legacy !== undefined) return legacy.title
+  const unnumbered = UNNUMBERED_TITLES[trimmed]
+  if (unnumbered !== undefined) return unnumbered
+  const head = trimmed.split(':')[0]?.trim() ?? ''
+  return head.length > 0 ? head : trimmed
+}
+
+/** The parenthetical under the title, or `''` where the weekend has none. */
+export function weekendSubtitle(name: string): string {
+  const trimmed = name.trim()
+  const legacy = LEGACY_MID[trimmed]
+  if (legacy !== undefined) return legacy.subtitle
+  if (UNNUMBERED_TITLES[trimmed] !== undefined) return ''
+  const tail = trimmed.split(':').slice(1).join(':').trim()
+  if (tail.length === 0) return ''
+  for (const [prefix, short] of SUBTITLE_RULES) {
+    if (tail.startsWith(prefix)) return short
+  }
+  return tail
+}
+
+/**
+ * 2017-2019, which carried the identity in the NAME rather than a number.
+ * The title restates the chronological number `weekendLabel` assigns, and the
+ * subtitle keeps the original name — which is the part a reader of a
+ * historical row actually recognises.
+ */
+const LEGACY_MID: Readonly<Record<string, { title: string; subtitle: string }>> = {
+  'Spring Family Camp': { title: 'Family Camp 1', subtitle: 'Spring' },
+  'Keshet LGBTQ Family Camp': { title: 'Family Camp 2', subtitle: 'Keshet' },
+  'Summer Family Camp': { title: 'Family Camp 3', subtitle: 'Summer' },
+  'Fall Family Camp I': { title: 'Family Camp 4', subtitle: 'Fall I' },
+  'Fall Family Camp II': { title: 'Family Camp 5', subtitle: 'Fall II' },
+  'Fall Family Camp III': { title: 'Family Camp 6', subtitle: 'Fall III' },
+}
+
+/**
+ * The weekends that never took a number read as themselves and carry no
+ * subtitle — the owner named both by hand. `JFAM Winter Family Camp` is the
+ * same weekend as `Winter Family Camp` under a later spelling, so it reads as
+ * the one staff say.
+ */
+const UNNUMBERED_TITLES: Readonly<Record<string, string>> = {
+  'Ready, Set, Camp': 'Ready, Set, Camp',
+  'Winter Family Camp': 'Winter Family Camp',
+  'JFAM Winter Family Camp': 'Winter Family Camp',
+  'Spring Family Retreat': 'Spring Family Retreat',
+}
+
+/**
+ * Suffix -> subtitle, longest-prefix-first.
+ *
+ * ORDER MATTERS: `JFAM Sukkot` and `JFAM Chanukah` must be tested before the
+ * bare `JFAM`, or they collapse onto it and lose the holiday that is the whole
+ * reason a reader would tell those weekends apart.
+ *
+ * A suffix no rule matches falls through as itself rather than being dropped —
+ * this list covers every suffix in the 2017-2026 catalogue, and the fallthrough
+ * is for the one CampMinder invents next season.
+ */
+const SUBTITLE_RULES: ReadonlyArray<readonly [string, string]> = [
+  ['Memorial Day', 'Memorial Day'],
+  ['Labor Day', 'Labor Day'],
+  ['Keshet', 'Keshet'],
+  ['Jewish Families of Color', 'JFoC'],
+  ['JFAM Sukkot', 'JFAM Sukkot'],
+  ['JFAM Chanukah', 'JFAM Chanukah'],
+  ['JFAM', 'JFAM'],
+  ['Sukkot', 'Sukkot'],
+]

--- a/frontend/src/components/weekend/weekendNames.ts
+++ b/frontend/src/components/weekend/weekendNames.ts
@@ -165,28 +165,70 @@ export function weekendSlug(name: string): string {
  * Uppercased, because the slug is lowercase for a URL and `fc1` on a screen
  * reads as a typo.
  *
- * ⚠️ ONLY A WEEKEND CAMPMINDER NUMBERED IS ABBREVIATED. `FC1` is safe because
- * the number IS the weekend's identity — the abbreviation cannot name a
- * different weekend, and it is the form staff already say out loud. Nothing
- * supplies that guarantee for a prose name, so those print in full and the
- * top-of-file note's argument stands unamended for them.
+ * ⚠️ A CAMPMINDER NUMBER IS READ OFF; EVERYTHING ELSE COMES FROM AN EXPLICIT
+ * MAP. `FC1` is safe because the number IS the weekend's identity — the
+ * abbreviation cannot name a different weekend, and it is the form staff say
+ * out loud. Nothing supplies that guarantee for a prose name.
  *
- * That is not a stylistic hedge, it is measured. Initials alone give both
- * "Spring Family Camp" and "Summer Family Camp" the label `SFC`, and collapse
- * "Fall Family Camp I", "II" and "III" onto `FFCI` — so a 2018 journey row for
- * a family that went to Fall II would have read as Fall I. All three names are
- * live in the 2017-2019 seasons the journey renders: 891 of 3,040
- * single-weekend household-years sit in one, and 5 of the 64 multi-weekend
- * ones would have printed one label twice on a single line and offered two
- * members-modal tabs nobody could tell apart. Under this rule every season in
- * the catalogue, 2017 through 2026, labels its weekends distinctly.
+ * Initials were tried and are measurably wrong: they give both "Spring Family
+ * Camp" and "Summer Family Camp" the label `SFC`, and collapse "Fall Family
+ * Camp I", "II" and "III" onto `FFCI` — so a 2018 journey row for a family
+ * that went to Fall II read as Fall I. 891 of 3,040 single-weekend
+ * household-years sit in one of those names, and 5 of the 64 multi-weekend
+ * ones printed one label twice on a line and offered two members-modal tabs
+ * nobody could tell apart.
+ *
+ * Printing them in full was correct but long. `NAMED_WEEKEND_LABELS` is the
+ * third answer and the only one that is both: the set of un-numbered weekend
+ * names is CLOSED — they are history and cannot gain a member — so a map is
+ * exhaustive in a way a rule can never be.
+ *
+ * The legacy assignments are the owner's, 2026-08-18, made against the full
+ * catalogue: 2017-2019 ran SIX weekends (Spring, Keshet, Summer, Fall I/II/III)
+ * and the 2020 numbering maps onto them by slot —
+ *
+ *   > "Spring family camp = FC1. fall 1, 2, 3, are the new 2, 3, 4 — basically
+ *   >  a year that had a spring, the fall numbers get bumped one."
+ *
+ * Keshet and Summer keep names rather than numbers, which is what makes that
+ * bumping consistent: they sit chronologically between Spring and Fall I, so
+ * numbering them would push Fall to 3/4/5.
  *
  * ⚠️ Falls back to `shortWeekendName`, NEVER to the CampMinder id. `weekendRef`
  * falls back to the id because a URL must resolve; a label must be readable,
  * and `1000005` names nothing a staff member recognises. That is also why this
  * takes a name and not a session: it structurally cannot emit an id.
  */
+/**
+ * Every weekend CampMinder never numbered, and what it reads as.
+ *
+ * Keyed on the FULL name as CampMinder stores it, so a lookup cannot half-match
+ * — "Winter Family Camp" and "JFAM Winter Family Camp" are the same weekend
+ * under two spellings and both must land on `WFC`.
+ *
+ * A miss falls through to `shortWeekendName`, so a weekend nobody has mapped
+ * reads as itself rather than as invented initials.
+ */
+const NAMED_WEEKEND_LABELS: Readonly<Record<string, string>> = {
+  // 2017-2019, mapped onto the 2020 numbering by slot (owner, 2026-08-18).
+  'Spring Family Camp': 'FC1',
+  'Fall Family Camp I': 'FC2',
+  'Fall Family Camp II': 'FC3',
+  'Fall Family Camp III': 'FC4',
+  // Named, not numbered: both sit between Spring and Fall I, so numbering them
+  // would push Fall to 3/4/5 and break the owner's bumping rule.
+  'Keshet LGBTQ Family Camp': 'Keshet',
+  'Summer Family Camp': 'Summer FC',
+  // 2023-2026 additions that never took a number.
+  'Winter Family Camp': 'WFC',
+  'JFAM Winter Family Camp': 'WFC',
+  'Ready, Set, Camp': 'RSC',
+  'Spring Family Retreat': 'Spring FR',
+}
+
 export function weekendLabel(name: string): string {
+  const mapped = NAMED_WEEKEND_LABELS[name.trim()]
+  if (mapped !== undefined) return mapped
   const words = identityWords(name)
   // The SAME final word `weekendSlug`'s trailing-number rule keeps whole. A
   // lone number is not a numbered weekend, it is a year ("2026"), and there is

--- a/frontend/src/components/weekend/weekendNames.ts
+++ b/frontend/src/components/weekend/weekendNames.ts
@@ -183,16 +183,20 @@ export function weekendSlug(name: string): string {
  * names is CLOSED — they are history and cannot gain a member — so a map is
  * exhaustive in a way a rule can never be.
  *
- * The legacy assignments are the owner's, 2026-08-18, made against the full
- * catalogue: 2017-2019 ran SIX weekends (Spring, Keshet, Summer, Fall I/II/III)
- * and the 2020 numbering maps onto them by slot —
+ * The legacy assignments are the owner's, 2026-08-18: 2017-2019 ran SIX
+ * weekends and are numbered CHRONOLOGICALLY, 1 through 6 —
  *
- *   > "Spring family camp = FC1. fall 1, 2, 3, are the new 2, 3, 4 — basically
- *   >  a year that had a spring, the fall numbers get bumped one."
+ *   > "spring is 1, if keshet and summer happened before 'fall family camp'
+ *   >  or 'family camp', they are 2 and 3 (whatever chronological order they
+ *   >  happened that year), and then alias the subsequent ones to 4+"
  *
- * Keshet and Summer keep names rather than numbers, which is what makes that
- * bumping consistent: they sit chronologically between Spring and Fall I, so
- * numbering them would push Fall to 3/4/5.
+ * ⚠️ THAT RULE APPLIES ONLY WHERE CAMPMINDER NUMBERED NOTHING, which is
+ * 2017-2019 and nothing else. Checked against the whole catalogue: those three
+ * seasons carry SIX un-numbered weekends and zero numbered ones, 2020-2022
+ * carry only numbered ones, and 2023-2026 carry eight numbered plus one or two
+ * un-numbered that BOOKEND them (April before FC1, December after FC8).
+ * Numbering a modern season by date would rename `Ready, Set, Camp` to "FC1"
+ * and shift every CampMinder number behind it.
  *
  * ⚠️ Falls back to `shortWeekendName`, NEVER to the CampMinder id. `weekendRef`
  * falls back to the id because a URL must resolve; a label must be readable,
@@ -210,16 +214,28 @@ export function weekendSlug(name: string): string {
  * reads as itself rather than as invented initials.
  */
 const NAMED_WEEKEND_LABELS: Readonly<Record<string, string>> = {
-  // 2017-2019, mapped onto the 2020 numbering by slot (owner, 2026-08-18).
+  // 2017-2019, numbered CHRONOLOGICALLY within the season (owner, revised
+  // 2026-08-18): "spring is 1, if keshet and summer happened before 'fall
+  // family camp' [...] they are 2 and 3 (whatever chronological order they
+  // happened that year), and then alias the subsequent ones to 4+".
+  //
+  // The order is identical in all three legacy seasons — Spring (late May),
+  // Keshet (late Aug), Summer (end Aug), then Fall I/II/III through September
+  // — so a static map expresses it exactly and no season context is needed.
+  // 1-6 with no gaps.
   'Spring Family Camp': 'FC1',
-  'Fall Family Camp I': 'FC2',
-  'Fall Family Camp II': 'FC3',
-  'Fall Family Camp III': 'FC4',
-  // Named, not numbered: both sit between Spring and Fall I, so numbering them
-  // would push Fall to 3/4/5 and break the owner's bumping rule.
-  'Keshet LGBTQ Family Camp': 'Keshet',
-  'Summer Family Camp': 'Summer FC',
-  // 2023-2026 additions that never took a number.
+  'Keshet LGBTQ Family Camp': 'FC2',
+  'Summer Family Camp': 'FC3',
+  'Fall Family Camp I': 'FC4',
+  'Fall Family Camp II': 'FC5',
+  'Fall Family Camp III': 'FC6',
+  // 2023-2026 additions that never took a number. These are NOT numbered
+  // chronologically, and that is the whole reason the legacy rule cannot be
+  // generalised: they BOOKEND the numbered run rather than joining it. `Ready,
+  // Set, Camp` and `Spring Family Retreat` fall in April/early May, BEFORE
+  // `Family Camp 1`; `Winter Family Camp` falls in late December, AFTER
+  // `Family Camp 8`. Numbering them by date would make RSC "FC1" and shift
+  // every CampMinder number in the season by one.
   'Winter Family Camp': 'WFC',
   'JFAM Winter Family Camp': 'WFC',
   'Ready, Set, Camp': 'RSC',

--- a/frontend/src/components/weekend/weekendNames.ts
+++ b/frontend/src/components/weekend/weekendNames.ts
@@ -9,12 +9,23 @@
  *
  * Rendering the whole string everywhere makes a picker unreadable and a title
  * wrap. Splitting on the colon gives a short identity for compact places and a
- * qualifier for the row that has space, and is lossless — unlike inventing
- * abbreviations, which is how a UI starts disagreeing with CampMinder about
- * what a session is called.
+ * qualifier for the row that has space, and is lossless.
  *
  * Names without a colon ("Women's Weekend", "Ready, Set, Camp", "JFAM Winter
  * Family Camp") are already short and pass through untouched.
+ *
+ * ★ THREE FORMS, AND WHICH ONE A SURFACE MAY USE IS NOT A STYLE CHOICE:
+ *
+ * * `splitWeekendName` / `shortWeekendName` — the default. Lossless, and what
+ *   every title, picker and tab with room prints.
+ * * `weekendSlug` — an ADDRESS for a URL. Never rendered.
+ * * `weekendLabel` — an abbreviation, `FC1`, for a surface with no room for a
+ *   name. Owner-ruled on 2026-08-18 (kindred#2393) for the family journey
+ *   panel, which is 416px wide and must fit up to four weekends on one line.
+ *   It is a narrow licence and not a general one: reach for `shortWeekendName`
+ *   unless the space genuinely will not take it, because an abbreviation is
+ *   how a UI starts disagreeing with CampMinder about what a session is
+ *   called.
  */
 
 export interface WeekendName {
@@ -77,13 +88,17 @@ function initials(words: string[]): string {
 /**
  * A weekend's ADDRESS: `fc1`, `ww`, `mw`, `rsc`.
  *
- * THIS IS NOT A DISPLAY NAME, and the distinction is the whole reason it is
- * allowed to exist. The note at the top of this file argues against inventing
- * abbreviations because a UI that does starts disagreeing with CampMinder
- * about what a session is CALLED — every title, picker and tab still renders
- * `splitWeekendName`'s output verbatim. A URL is not a label; it is how staff
- * type and share a weekend, and `/weekend/fc1/map` is one they can say out
- * loud where `/weekend/1000001/map` is not.
+ * A URL, first and foremost: `/weekend/fc1/map` is one staff can say out loud
+ * where `/weekend/1000001/map` is not.
+ *
+ * ⚠️ NOT A LABEL BY ITSELF — render `weekendLabel`, never this. This function
+ * returns '' for a weekend it cannot address, which is the right answer for a
+ * URL and a blank on a screen; `weekendLabel` is the display wrapper that
+ * uppercases the slug and falls back to the weekend's own short name when
+ * there is none. (Until 2026-08-18 this comment forbade display use outright.
+ * The owner's kindred#2393 ruling granted the narrow licence the top-of-file
+ * note now describes, and the wrapper is where it lives — a doc block that
+ * forbids what the code beside it does is worse than either rule alone.)
  *
  * Initials of the identity, with a trailing number kept whole — "Family Camp
  * 10" must not collide with "Family Camp 1". Read from the identity only, so
@@ -119,6 +134,33 @@ export function weekendSlug(name: string): string {
   // Nothing but digits to work with even then: the numeric space belongs to
   // CampMinder ids, so this weekend has no address of its own to offer.
   return DIGITS_ONLY.test(slug) ? '' : slug
+}
+
+/**
+ * A weekend as `FC1`, for a surface with no room for its name (kindred#2393).
+ *
+ * The owner's 2026-08-18 ruling, settled against full-width mockups: the
+ * family journey panel is `w-[26rem]` = 416px, a household-year can carry up
+ * to four weekends, and "Family Camp 1: Memorial Day Weekend" four times over
+ * is not a line — `FC1 · FC4 · FC5` is. PLAIN TEXT, not a chip and not a
+ * badge: the row already carries a housing name, a "No enrollment" chip and a
+ * "See members" action, and a fourth decorated element makes none of them
+ * readable.
+ *
+ * Uppercased, because the slug is lowercase for a URL and `fc1` on a screen
+ * reads as a typo. NOT EVERY WEEKEND IS `FCx`: computed against 2026 the
+ * labels are FC1-FC8 plus `RS` (Ready, Set, Camp) and `W` (JFAM Winter Family
+ * Camp), the two sessions outside the day-group plan. They fall out of the
+ * same rule and are not special-cased.
+ *
+ * ⚠️ Falls back to `shortWeekendName`, NEVER to the CampMinder id. `weekendRef`
+ * falls back to the id because a URL must resolve; a label must be readable,
+ * and `1000005` names nothing a staff member recognises. That is also why this
+ * takes a name and not a session: it structurally cannot emit an id.
+ */
+export function weekendLabel(name: string): string {
+  const slug = weekendSlug(name)
+  return slug.length > 0 ? slug.toUpperCase() : shortWeekendName(name)
 }
 
 /** The minimum a weekend must carry to be addressed. */

--- a/frontend/src/hooks/camper/fetchCamperJourney.test.ts
+++ b/frontend/src/hooks/camper/fetchCamperJourney.test.ts
@@ -28,7 +28,8 @@ function attendee(
   sessionCmId: number,
   sessionType: string,
   name: string,
-  parentId?: number
+  parentId?: number,
+  startDate?: string
 ) {
   return {
     id: `att-${year}-${sessionCmId}`,
@@ -42,6 +43,7 @@ function attendee(
         name,
         session_type: sessionType,
         ...(parentId !== undefined ? { parent_id: parentId } : {}),
+        ...(startDate !== undefined ? { start_date: startDate } : {}),
       },
     },
   }
@@ -231,5 +233,65 @@ describe('fetchCamperJourney', () => {
     ])
     const out = await fetchCamperJourney(PERSON, CURRENT_YEAR)
     expect(out.map((r) => r.year)).toEqual([2023, 2021, 2019])
+  })
+})
+
+describe('ordering within a year', () => {
+  /*
+   * Owner report, 2026-08-18: a camper who went to Family Camp 1 in May, two
+   * summer sessions in June and July, and Family Camp 6 in September read as
+   * "2a, 3a, FC1, FC6" — summer first and both family weekends after it.
+   *
+   * The sort was `b.year - a.year` alone, so within a year the rows kept the
+   * order the attendee fetch produced, which groups by program. The journey is
+   * a chronology and must cross programs.
+   */
+  it('orders a year chronologically ACROSS programs, not program by program', async () => {
+    mockAttendeesGetFullList.mockResolvedValue([
+      attendee(2026, 201, 'embedded', 'Session 2a', undefined, '2026-06-14'),
+      attendee(2026, 202, 'embedded', 'Session 3a', undefined, '2026-07-05'),
+      attendee(2026, 101, 'family', 'Family Camp 1: Memorial Day Weekend', undefined, '2026-05-22'),
+      attendee(2026, 106, 'family', 'Family Camp 6', undefined, '2026-09-24'),
+    ])
+    mockAssignmentsGetFullList.mockResolvedValue([])
+
+    const out = await fetchCamperJourney(PERSON, 2027)
+
+    expect(out.map((record) => record.sessionName)).toEqual([
+      'Family Camp 1: Memorial Day Weekend',
+      'Session 2a',
+      'Session 3a',
+      'Family Camp 6',
+    ])
+  })
+
+  it('keeps a row with no start date LAST in its year, never first', async () => {
+    // An empty string compares below every real date, so a naive comparator
+    // floats an undated row to the top of its year — where it reads as the
+    // first thing that happened.
+    mockAttendeesGetFullList.mockResolvedValue([
+      attendee(2026, 300, 'main', 'Undated Session'),
+      attendee(2026, 101, 'family', 'Family Camp 1: Memorial Day Weekend', undefined, '2026-05-22'),
+    ])
+    mockAssignmentsGetFullList.mockResolvedValue([])
+
+    const out = await fetchCamperJourney(PERSON, 2027)
+
+    expect(out.map((record) => record.sessionName)).toEqual([
+      'Family Camp 1: Memorial Day Weekend',
+      'Undated Session',
+    ])
+  })
+
+  it('still orders years newest first', async () => {
+    mockAttendeesGetFullList.mockResolvedValue([
+      attendee(2024, 101, 'family', 'Family Camp 1: Memorial Day Weekend', undefined, '2024-05-24'),
+      attendee(2026, 101, 'family', 'Family Camp 1: Memorial Day Weekend', undefined, '2026-05-22'),
+    ])
+    mockAssignmentsGetFullList.mockResolvedValue([])
+
+    const out = await fetchCamperJourney(PERSON, 2027)
+
+    expect(out.map((record) => record.year)).toEqual([2026, 2024])
   })
 })

--- a/frontend/src/hooks/camper/fetchCamperJourney.ts
+++ b/frontend/src/hooks/camper/fetchCamperJourney.ts
@@ -10,6 +10,7 @@
  * camp_sessions, since AG session names aren't reliably derivable).
  */
 import { pb } from '../../lib/pocketbase'
+import { byYearThenChronological } from './journeyOrder'
 import { buildCamperJourneySessionTypeFilter } from '../../utils/sessionTypePredicates'
 import type {
   AttendeesResponse,
@@ -164,5 +165,5 @@ export async function fetchCamperJourney(
     }
   })
 
-  return records.sort((a, b) => b.year - a.year)
+  return records.sort(byYearThenChronological)
 }

--- a/frontend/src/hooks/camper/journeyOrder.ts
+++ b/frontend/src/hooks/camper/journeyOrder.ts
@@ -1,0 +1,44 @@
+/**
+ * How a camper's journey is ordered, in ONE place.
+ *
+ * Its own module, and that is not tidiness. It lived in `fetchCamperJourney`
+ * first, and `useCamperHistory` — which merges that fetcher's prior-year rows
+ * with the current year's and re-sorts the union — imports it. But
+ * `useCamperHistory`'s tests MOCK `./fetchCamperJourney` wholesale, so the
+ * comparator came back `undefined` there and the merge fell through to its
+ * current-year-only fallback. A module nobody mocks is what makes one
+ * comparator genuinely shared.
+ */
+
+/**
+ * Year descending, then CHRONOLOGICAL WITHIN THE YEAR — across programs, not
+ * within each one (owner, 2026-08-18).
+ *
+ * Both journey paths sorted on the year alone, so within a year the rows kept
+ * whatever order their source produced, which groups by program. A camper who
+ * went to Family Camp 1 in May, two summer sessions in June and July, and
+ * Family Camp 6 in September read as "2a, 3a, FC1, FC6" — summer first and
+ * both family weekends after it, which is not the order anything happened in.
+ *
+ * ⚠️ THE DEFECT WAS VISIBLE ONLY ON THE CURRENT YEAR, and that is what made it
+ * look like a current-year problem. Prior-year rows arrive chronological by
+ * luck of the fetch order, so a year-only sort preserved them; the current
+ * year's are built per-camper and grouped by program, so the same sort
+ * preserved that instead. One comparator over both is the fix.
+ *
+ * A row without a `startDate` sorts LAST within its year rather than first: an
+ * empty string compares below every real date, which would float an undated
+ * row to the top of its year where it reads as the first thing that happened.
+ */
+export function byYearThenChronological(
+  a: { year: number; startDate?: string },
+  b: { year: number; startDate?: string }
+): number {
+  if (a.year !== b.year) return b.year - a.year
+  const left = a.startDate ?? ''
+  const right = b.startDate ?? ''
+  if (left === right) return 0
+  if (left === '') return 1
+  if (right === '') return -1
+  return left.localeCompare(right)
+}

--- a/frontend/src/hooks/camper/useCamperHistory.test.tsx
+++ b/frontend/src/hooks/camper/useCamperHistory.test.tsx
@@ -23,6 +23,8 @@ function currentCamper(opts: {
   sessionType: string
   parentId?: number
   bunkName?: string
+  name?: string
+  startDate?: string
 }): Camper {
   return {
     person_cm_id: 12887873,
@@ -31,9 +33,9 @@ function currentCamper(opts: {
     expand: {
       session: {
         cm_id: opts.sessionCmId,
-        name: `Session ${opts.sessionCmId}`,
+        name: opts.name ?? `Session ${opts.sessionCmId}`,
         session_type: opts.sessionType,
-        start_date: '',
+        start_date: opts.startDate ?? '',
         end_date: '',
         ...(opts.parentId !== undefined ? { parent_id: opts.parentId } : {}),
       },
@@ -47,6 +49,58 @@ describe('useCamperHistory', () => {
     vi.clearAllMocks()
     mockFetchCamperJourney.mockResolvedValue([])
     mockFetchParentMainSessions.mockResolvedValue(new Map())
+  })
+
+  it('orders the CURRENT year chronologically across programs', async () => {
+    /*
+     * THE REPORTED DEFECT, and it lived here rather than in the fetcher.
+     *
+     * Prior-year rows arrive chronological by luck of the fetch order, so a
+     * year-only sort preserved them and 2025 read correctly. The current
+     * year's rows are built per-camper and grouped by program, and the same
+     * sort preserved THAT — so 2026 read "2a, 3a, FC1, FC6" for a camper who
+     * actually went to Family Camp 1 in May, two summer sessions in June and
+     * July, and Family Camp 6 in September.
+     */
+    mockFetchCamperJourney.mockResolvedValue([])
+    const campers = [
+      currentCamper({
+        sessionCmId: 201,
+        sessionType: 'embedded',
+        name: 'Session 2a',
+        startDate: '2026-06-14',
+      }),
+      currentCamper({
+        sessionCmId: 202,
+        sessionType: 'embedded',
+        name: 'Session 3a',
+        startDate: '2026-07-05',
+      }),
+      currentCamper({
+        sessionCmId: 101,
+        sessionType: 'family',
+        name: 'Family Camp 1: Memorial Day Weekend',
+        startDate: '2026-05-22',
+      }),
+      currentCamper({
+        sessionCmId: 106,
+        sessionType: 'family',
+        name: 'Family Camp 6',
+        startDate: '2026-09-24',
+      }),
+    ]
+    const { result } = renderHook(
+      () => useCamperHistory(12887873, YEAR, campers[0] as Camper, campers),
+      { wrapper: createWrapper() }
+    )
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.camperHistory.map((r) => r.sessionName)).toEqual([
+      'Family Camp 1: Memorial Day Weekend',
+      'Session 2a',
+      'Session 3a',
+      'Family Camp 6',
+    ])
   })
 
   it('merges current-year + prior fetcher rows and surfaces a 2022 gap year, sorted -year', async () => {

--- a/frontend/src/hooks/camper/useCamperHistory.ts
+++ b/frontend/src/hooks/camper/useCamperHistory.ts
@@ -7,6 +7,7 @@ import { useQuery } from '@tanstack/react-query'
 import { isAtCampSessionType } from '../../utils/sessionTypePredicates'
 import { filterEnrollmentsByStatus, toDisplayList } from '../../utils/enrollmentFilter'
 import { fetchCamperJourney, fetchParentMainSessions } from './fetchCamperJourney'
+import { byYearThenChronological } from './journeyOrder'
 import type { Camper } from '../../types/app-types'
 import type { CampSessionsResponse } from '../../types/pocketbase-types'
 import type { HistoricalRecord } from './types'
@@ -119,7 +120,12 @@ export function useCamperHistory(
         // Prior years from the shared enrollment-sourced fetcher.
         allHistory.push(...(await fetchCamperJourney(personCmId, currentYear)))
         // Sort by year descending.
-        allHistory.sort((a, b) => b.year - a.year)
+        // The SHARED comparator, not a second year-only one. This merge is
+        // where the reported defect actually lived: prior-year records arrive
+        // chronological by luck of the fetch order, the current year's do not,
+        // and a year-only sort preserves both — so 2025 read correctly while
+        // 2026 read "2a, 3a, FC1, FC6".
+        allHistory.sort(byYearThenChronological)
         return allHistory
       } catch (err) {
         console.error('Error fetching camp history:', err)

--- a/frontend/src/types/api-generated/index.ts
+++ b/frontend/src/types/api-generated/index.ts
@@ -338,6 +338,7 @@ export type {
   HealthCheckHealthGetResponses,
   HistoricalTrendsResponse,
   HouseholdJourneyResponse,
+  HouseholdJourneySession,
   HouseholdJourneyYear,
   HouseholdMedicalResponse,
   HttpValidationError,

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -1985,6 +1985,38 @@ export type HouseholdJourneyResponse = {
 }
 
 /**
+ * HouseholdJourneySession
+ *
+ * One family weekend a household attended in a given year (kindred#2393).
+ *
+ * THE WEEKEND, NOT THE HOUSING. A journey row is a year and a year holds
+ * exactly ONE cabin string -- `family_camp_registrations` has no second
+ * field for a second weekend -- so this list says which weekends the
+ * household was at and says nothing about where it slept in each. Repeating
+ * the year's cabin against every entry is the fan-out that manufactured 12
+ * of 17 false multi-family occupancies in the phase-C shareability analysis.
+ *
+ * `start_date` is the raw PocketBase string, exactly as
+ * `WeekendSessionSummary` publishes it -- the client already reads that
+ * shape, and the server's only use for it here is the ordering it has
+ * already applied.
+ */
+export type HouseholdJourneySession = {
+  /**
+   * Session Cm Id
+   */
+  session_cm_id?: number
+  /**
+   * Name
+   */
+  name?: string
+  /**
+   * Start Date
+   */
+  start_date?: string
+}
+
+/**
  * HouseholdJourneyYear
  *
  * One year of a household's family-camp record.
@@ -2010,6 +2042,14 @@ export type HouseholdJourneyYear = {
    * Cabin Name Raw
    */
   cabin_name_raw?: string
+  /**
+   * Sessions
+   */
+  sessions?: Array<HouseholdJourneySession>
+  /**
+   * Housing Session Cm Id
+   */
+  housing_session_cm_id?: number | null
   /**
    * Enrollment
    */
@@ -3176,6 +3216,10 @@ export type PartyChild = {
    * Grade
    */
   grade?: number | null
+  /**
+   * Session Cm Ids
+   */
+  session_cm_ids?: Array<number>
 }
 
 /**

--- a/frontend/src/types/lodging.test.ts
+++ b/frontend/src/types/lodging.test.ts
@@ -56,6 +56,12 @@ const _exhaustivePartyChild: Required<PartyChildRow> = {
   last_name: 'Martinez Garcia',
   age: 9,
   grade: 4,
+  // kindred#2393. WHICH WEEKENDS this child attended that year, earliest
+  // first — the journey populates it and every other surface leaves it empty,
+  // because the roster is already one weekend. `[]` is "not knowable", never
+  // "attended nothing", and the members modal keeps such a child visible on
+  // every weekend tab rather than hiding them from all of them.
+  session_cm_ids: [1309514, 1309517],
 }
 void _exhaustivePartyChild
 
@@ -77,6 +83,24 @@ const _exhaustiveHouseholdJourneyRow: Required<HouseholdJourneyRow> = {
   // snapshot, and it is the only case the card shows this field in.
   cabin_name_raw: 'Old Meadow 1',
   enrollment: 'enrolled',
+  // kindred#2393. The weekends the household attended that year, earliest
+  // first. Two of them here on purpose: that is the 64-of-5,438 case the
+  // field exists for, and it is also why the row below refuses to pin the
+  // cabin.
+  sessions: [
+    {
+      session_cm_id: 1309514,
+      name: 'Family Camp 1: Memorial Day Weekend',
+      start_date: '2026-05-22',
+    },
+    { session_cm_id: 1309517, name: 'Family Camp 4: Labor Day Weekend', start_date: '2026-09-04' },
+  ],
+  // `null` because there are two weekends and CampMinder holds ONE cabin
+  // string per household-year, so nothing can say which weekend it describes
+  // — deliberately the same refusal `AttributeSession` makes in the Go sync.
+  // A regen that turned this into a plain `number` would erase the state the
+  // whole field exists to carry.
+  housing_session_cm_id: null,
   adults: [],
   children: [],
 }

--- a/frontend/src/types/lodging.ts
+++ b/frontend/src/types/lodging.ts
@@ -20,6 +20,7 @@
 import type {
   AccessibilityFlagSummary,
   HouseholdJourneyResponse,
+  HouseholdJourneySession,
   HouseholdJourneyYear,
   HouseholdMedicalResponse,
   LodgingUnitSummary,
@@ -86,8 +87,18 @@ export type WeekendSummaryRow = WeekendSummaryEntry
 export type HouseholdMedical = HouseholdMedicalResponse
 /** A household's year-over-year family-camp record, newest year first. */
 export type HouseholdJourney = HouseholdJourneyResponse
-/** One year of it — housing, enrollment, and that year's own party. */
+/** One year of it — housing, enrollment, the weekends, and that year's own party. */
 export type HouseholdJourneyRow = HouseholdJourneyYear
+/**
+ * One family weekend a household attended in a year (kindred#2393).
+ *
+ * THE WEEKEND, NOT THE HOUSING. A year holds exactly one cabin string, so this
+ * says which weekends the household was at and nothing about where it slept in
+ * each — repeating the cabin against every entry is the fan-out that
+ * manufactured 12 of 17 false multi-family occupancies in the phase-C
+ * shareability analysis.
+ */
+export type HouseholdJourneySessionRow = HouseholdJourneySession
 /** A registered adult on a household party. */
 export type PartyAdultRow = PartyAdult
 /** An enrolled child on a household party. */

--- a/frontend/src/utils/sessionDisplay.ts
+++ b/frontend/src/utils/sessionDisplay.ts
@@ -1,7 +1,7 @@
 import type { Session } from '../types/app-types'
 import type { SessionDateLookup } from './sessionUtils'
 import { isAgSession, isQuestSession, isQuestSessionType } from './sessionTypePredicates'
-import { weekendLabel } from '../components/weekend/weekendNames'
+import { weekendTitle } from '../components/weekend/weekendNames'
 
 /**
  * Canonical short display name for a session — used by the camper page (full +
@@ -178,10 +178,12 @@ export function getSessionDisplayNameFromString(sessionName: string, sessionType
   // "Family Camp 8: JFAM Weekend w/ SFJCC (w/ kids 10 and under)" — 54
   // characters — and the camper journey printed them verbatim, one per row,
   // which is what made that timeline unreadable for a family-camp household.
-  // `weekendLabel` is the one place the short form is decided, so the weekend
-  // board and the camper journey cannot drift into two vocabularies for one
-  // weekend.
-  if (sessionType === 'family') return weekendLabel(sessionName)
+  // `weekendTitle` is the MID form — "Family Camp 3", not the board's terser
+  // "FC3". Both come off the same name in `weekendNames`, so the two surfaces
+  // cannot drift into two vocabularies for one weekend, but each gets the
+  // length its rows can afford. `weekendSubtitle` carries the rest (Keshet,
+  // JFAM, JFoC) for the surfaces with room to print it.
+  if (sessionType === 'family') return weekendTitle(sessionName)
 
   // Check if it's an AG session by type or name pattern
   if (

--- a/frontend/src/utils/sessionDisplay.ts
+++ b/frontend/src/utils/sessionDisplay.ts
@@ -1,6 +1,7 @@
 import type { Session } from '../types/app-types'
 import type { SessionDateLookup } from './sessionUtils'
 import { isAgSession, isQuestSession, isQuestSessionType } from './sessionTypePredicates'
+import { weekendLabel } from '../components/weekend/weekendNames'
 
 /**
  * Canonical short display name for a session — used by the camper page (full +
@@ -171,6 +172,16 @@ export function getParentSessionId(session: Session, allSessions: Session[]): st
  */
 export function getSessionDisplayNameFromString(sessionName: string, sessionType?: string): string {
   if (!sessionName) return 'Unknown Session'
+
+  // FAMILY CAMP USES THE BOARD'S OWN SHORT LABEL (kindred#2393, owner
+  // 2026-08-18). CampMinder's family-camp names run to
+  // "Family Camp 8: JFAM Weekend w/ SFJCC (w/ kids 10 and under)" — 54
+  // characters — and the camper journey printed them verbatim, one per row,
+  // which is what made that timeline unreadable for a family-camp household.
+  // `weekendLabel` is the one place the short form is decided, so the weekend
+  // board and the camper journey cannot drift into two vocabularies for one
+  // weekend.
+  if (sessionType === 'family') return weekendLabel(sessionName)
 
   // Check if it's an AG session by type or name pattern
   if (

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -4259,6 +4259,244 @@ class TestHouseholdJourney:
         assert journey.years[0].children[0].age == 9.01
 
 
+class TestHouseholdJourneySessionGrain:
+    """WHICH WEEKENDS a household attended in a year (kindred#2393).
+
+    A journey row is a YEAR, not a session, and that is not going to change --
+    `family_camp_registrations` holds ONE cabin string per household-year, so
+    there is no second cabin to hang off a second weekend. What was missing is
+    the weekend list itself: a household that booked two of a season's
+    weekends collapsed into one row that said neither which weekends those
+    were nor who went to which.
+
+    Measured on the production snapshot: 64 of 5,438 journey household-years
+    (1.2%) are multi-weekend -- the denominator being every traced
+    household-year, the union of the three reads `build_household_journey`
+    issues, over all years with `year > 0`. In 7 of those 64 the merged member
+    list overstates at least one weekend's party, because a child who did not
+    attend every weekend appears as though they did. That is the half these
+    per-child session ids exist to fix.
+
+    ⚠️ THE CABIN IS PINNED TO A WEEKEND ONLY WHEN THERE IS EXACTLY ONE, which
+    is deliberately the same refusal `AttributeSession` makes in the Go sync
+    (`pocketbase/sync/lodging_session_attribution.go:327`). The read surface
+    and the ingest must never disagree about which weekend a cabin belongs to,
+    and repeating one cabin string against several weekends is the fan-out
+    that manufactured 12 of 17 false multi-family occupancies in the phase-C
+    shareability analysis.
+
+    Fictional data throughout.
+    """
+
+    @staticmethod
+    def _session(cm_id: int, name: str, start_date: str, pb_id: str = "") -> SimpleNamespace:
+        return _rec(
+            id=pb_id or f"sess_{cm_id}",
+            cm_id=cm_id,
+            name=name,
+            session_type="family",
+            year=int(start_date[:4]),
+            start_date=start_date,
+            end_date="",
+            sort_order=0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_year_publishes_every_family_weekend_the_household_attended(self) -> None:
+        fc1 = self._session(3000001, "Family Camp 1: Memorial Day Weekend", "2025-05-23")
+        fc4 = self._session(3000004, "Family Camp 4", "2025-09-19")
+        repo = _journey_repo(
+            fetch_household_family_attendees=[
+                _rec(year=2025, **vars(_child(cm_id=1000001, first="Emma", session=fc1))),
+                _rec(year=2025, **vars(_child(cm_id=1000001, first="Emma", session=fc4))),
+            ],
+        )
+
+        journey = await LodgingRosterService(repo).build_household_journey(2000001)
+
+        assert [(s.session_cm_id, s.name) for s in journey.years[0].sessions] == [
+            (3000001, "Family Camp 1: Memorial Day Weekend"),
+            (3000004, "Family Camp 4"),
+        ]
+        assert journey.years[0].sessions[0].start_date == "2025-05-23"
+
+    @pytest.mark.asyncio
+    async def test_a_weekend_is_published_once_however_many_children_attended_it(self) -> None:
+        """Two siblings on one weekend is one weekend, not two. The attendee
+        table is child-grain, so the naive read duplicates every weekend by
+        the size of the family."""
+        fc1 = self._session(3000001, "Family Camp 1", "2025-05-23")
+        repo = _journey_repo(
+            fetch_household_family_attendees=[
+                _rec(year=2025, **vars(_child(cm_id=1000001, first="Emma", session=fc1))),
+                _rec(year=2025, **vars(_child(cm_id=1000002, first="Liam", session=fc1))),
+            ],
+        )
+
+        journey = await LodgingRosterService(repo).build_household_journey(2000001)
+
+        assert [s.session_cm_id for s in journey.years[0].sessions] == [3000001]
+
+    @pytest.mark.asyncio
+    async def test_weekends_are_ordered_by_start_date_not_by_arrival(self) -> None:
+        """The list is read left to right as a season, so a later weekend
+        arriving first must not print first."""
+        fc1 = self._session(3000001, "Family Camp 1", "2025-05-23")
+        fc4 = self._session(3000004, "Family Camp 4", "2025-09-19")
+        repo = _journey_repo(
+            fetch_household_family_attendees=[
+                _rec(year=2025, **vars(_child(cm_id=1000001, first="Emma", session=fc4))),
+                _rec(year=2025, **vars(_child(cm_id=1000002, first="Liam", session=fc1))),
+            ],
+        )
+
+        journey = await LodgingRosterService(repo).build_household_journey(2000001)
+
+        assert [s.session_cm_id for s in journey.years[0].sessions] == [3000001, 3000004]
+
+    @pytest.mark.asyncio
+    async def test_a_child_carries_only_the_weekends_that_child_attended(self) -> None:
+        """The 7-of-64 case. Emma goes to both weekends, Liam only to the
+        first -- and today's merged member list shows both children against
+        both, which is the overstatement this field exists to let the client
+        undo."""
+        fc1 = self._session(3000001, "Family Camp 1", "2025-05-23")
+        fc4 = self._session(3000004, "Family Camp 4", "2025-09-19")
+        repo = _journey_repo(
+            fetch_household_family_attendees=[
+                _rec(year=2025, **vars(_child(cm_id=1000001, first="Emma", session=fc1))),
+                _rec(year=2025, **vars(_child(cm_id=1000001, first="Emma", session=fc4))),
+                _rec(year=2025, **vars(_child(cm_id=1000002, first="Liam", session=fc1))),
+            ],
+        )
+
+        journey = await LodgingRosterService(repo).build_household_journey(2000001)
+
+        by_child = {c.person_cm_id: c.session_cm_ids for c in journey.years[0].children}
+        assert by_child == {1000001: [3000001, 3000004], 1000002: [3000001]}
+
+    @pytest.mark.asyncio
+    async def test_a_childs_weekends_are_ordered_by_start_date_too(self) -> None:
+        fc1 = self._session(3000001, "Family Camp 1", "2025-05-23")
+        fc4 = self._session(3000004, "Family Camp 4", "2025-09-19")
+        repo = _journey_repo(
+            fetch_household_family_attendees=[
+                _rec(year=2025, **vars(_child(cm_id=1000001, first="Emma", session=fc4))),
+                _rec(year=2025, **vars(_child(cm_id=1000001, first="Emma", session=fc1))),
+            ],
+        )
+
+        journey = await LodgingRosterService(repo).build_household_journey(2000001)
+
+        assert journey.years[0].children[0].session_cm_ids == [3000001, 3000004]
+
+    @pytest.mark.asyncio
+    async def test_one_weekend_and_a_cabin_pins_the_cabin_to_that_weekend(self) -> None:
+        fc1 = self._session(3000001, "Family Camp 1", "2025-05-23")
+        repo = _journey_repo(
+            fetch_household_family_attendees=[_rec(year=2025, **vars(_child(session=fc1)))],
+            cabins_by_year={2025: {2000001: "Cedar Lodge - Room 2"}},
+        )
+
+        journey = await LodgingRosterService(repo).build_household_journey(2000001)
+
+        assert journey.years[0].housing_session_cm_id == 3000001
+
+    @pytest.mark.asyncio
+    async def test_two_weekends_refuse_to_pin_the_cabin_to_either(self) -> None:
+        """`AttributeSession`'s refusal, mirrored. CampMinder's single
+        per-year value cannot say which weekend it describes, and a cabin
+        repeated against both weekends is a manufactured second occupancy."""
+        fc1 = self._session(3000001, "Family Camp 1", "2025-05-23")
+        fc4 = self._session(3000004, "Family Camp 4", "2025-09-19")
+        repo = _journey_repo(
+            fetch_household_family_attendees=[
+                _rec(year=2025, **vars(_child(cm_id=1000001, first="Emma", session=fc1))),
+                _rec(year=2025, **vars(_child(cm_id=1000001, first="Emma", session=fc4))),
+            ],
+            cabins_by_year={2025: {2000001: "Cedar Lodge - Room 2"}},
+        )
+
+        journey = await LodgingRosterService(repo).build_household_journey(2000001)
+
+        assert journey.years[0].sessions != []
+        assert journey.years[0].housing_session_cm_id is None
+
+    @pytest.mark.asyncio
+    async def test_a_year_with_no_cabin_pins_nothing_even_with_one_weekend(self) -> None:
+        """There is no cabin to attribute. Publishing the weekend id anyway
+        would read as "housed in FC1" on a household nobody placed."""
+        fc1 = self._session(3000001, "Family Camp 1", "2025-05-23")
+        repo = _journey_repo(
+            fetch_household_family_attendees=[_rec(year=2025, **vars(_child(session=fc1)))],
+            cabins_by_year={2025: {2000009: "Cedar Lodge - Room 2"}},
+        )
+
+        journey = await LodgingRosterService(repo).build_household_journey(2000001)
+
+        assert journey.years[0].housing == "not_placed"
+        assert journey.years[0].housing_session_cm_id is None
+
+    @pytest.mark.asyncio
+    async def test_an_attendee_row_with_no_expanded_session_publishes_no_weekend(self) -> None:
+        """The pre-kindred#2420 shape, and the one every older fixture here
+        still uses. No weekend is knowable, so none is claimed -- and the
+        client renders the row exactly as it does today."""
+        repo = _journey_repo(fetch_household_family_attendees=[_rec(year=2025, **vars(_child()))])
+
+        journey = await LodgingRosterService(repo).build_household_journey(2000001)
+
+        assert journey.years[0].sessions == []
+        assert journey.years[0].children[0].session_cm_ids == []
+        assert journey.years[0].housing_session_cm_id is None
+
+    @pytest.mark.asyncio
+    async def test_a_session_with_no_campminder_id_is_not_published_as_weekend_zero(self) -> None:
+        """`cm_id` is the identity the client tabs on. A zero would collapse
+        every unidentified weekend onto one tab."""
+        broken = self._session(0, "Family Camp 1", "2025-05-23", pb_id="sess_broken")
+        repo = _journey_repo(fetch_household_family_attendees=[_rec(year=2025, **vars(_child(session=broken)))])
+
+        journey = await LodgingRosterService(repo).build_household_journey(2000001)
+
+        assert journey.years[0].sessions == []
+        assert journey.years[0].children[0].session_cm_ids == []
+
+    @pytest.mark.asyncio
+    async def test_each_year_keeps_its_own_weekends(self) -> None:
+        """HOUSEHOLD-YEAR GRAIN. A weekend attended in 2024 must not appear
+        against 2025, the same way that year's members never do."""
+        fc1_2024 = self._session(3000101, "Family Camp 1", "2024-05-24")
+        fc4_2025 = self._session(3000004, "Family Camp 4", "2025-09-19")
+        repo = _journey_repo(
+            fetch_household_family_attendees=[
+                _rec(year=2024, **vars(_child(session=fc1_2024))),
+                _rec(year=2025, **vars(_child(session=fc4_2025))),
+            ],
+        )
+
+        journey = await LodgingRosterService(repo).build_household_journey(2000001)
+
+        by_year = {y.year: [s.session_cm_id for s in y.sessions] for y in journey.years}
+        assert by_year == {2025: [3000004], 2024: [3000101]}
+
+    @pytest.mark.asyncio
+    async def test_the_current_season_roster_publishes_no_session_ids_on_a_child(self) -> None:
+        """The roster is ALREADY one weekend -- every child on it attends the
+        weekend being drawn, so a per-child weekend list there would restate
+        the page's own title once per camper. Only the journey, which spans
+        years and weekends, has a question to answer."""
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_households={"hh_1": _household()},
+            fetch_attendees_for_session=[_child()],
+        )
+
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.parties[0].children[0].session_cm_ids == []
+
+
 class TestWriteInCovers:
     """Which space a write-in closes, once the tree is taken into account.
 


### PR DESCRIPTION
## The defect

A journey row is a household-**year**, and nothing on the family history panel said *which* of a season's six-to-ten family weekends the year was. When a household books two weekends the row does not duplicate — `lodging_roster_service` dedupes children by CampMinder person id and emits exactly one row per year — so N weekends collapsed into one row with a merged member list.

**Measured on the production snapshot: 64 of 5,438 journey household-years (1.2%) are multi-weekend.** The denominator is *every traced household-year* — the union of the three reads `build_household_journey` issues (enrolled family attendees ∪ `family_camp_adults` ∪ `family_camp_registrations`), all years with `year > 0`. Distribution: 2 weekends → 48, 3 → 11, 4 → 5.

**In 7 of those 64 the merged member list overstates at least one weekend's party** — a child who did not attend every weekend appeared as though they did. That is the half the session grain actually had to fix, and it becomes *visibly* wrong the moment the weekends appear on the panel.

## The change

Both halves fall out of the attendee rows the members already come from, so this costs **zero extra round trips** — the journey's attendee read has expanded `session` since #2420.

**Wire** (`api/schemas/lodging.py`, `api/services/lodging_roster_service.py`)

- `HouseholdJourneyYear.sessions` — the weekends the household attended that year, earliest first, each carrying `session_cm_id`, the verbatim CampMinder `name`, and `start_date`. Deduped per year: the attendee table is child-grain, so the naive read repeats every weekend once per sibling.
- `HouseholdJourneyYear.housing_session_cm_id` — nullable, populated **only** when the year has exactly one attended weekend *and* a cabin string to attribute. Deliberately the same refusal `AttributeSession` makes in the Go ingest (`pocketbase/sync/lodging_session_attribution.go:327`): CampMinder's one per-year value cannot say which weekend it describes, and a read surface that guessed where the ingest declines would put the two into disagreement about the same fact.
- `PartyChild.session_cm_ids` — which weekends *this child* attended. Journey-only; the roster is already one weekend, so it publishes an empty list there. Collected **before** the per-child dedup, because the second attendee row for a child *is* the second weekend.

**Panel** (`HouseholdJourneyCard.tsx`)

`FC1 · FC4` as plain text on the line beneath the housing name. The cabin is still rendered **once**, and there is no "recorded for the year, weekend unresolved" note — the owner struck it on 2026-08-18.

**Modal** (`HouseholdYearMembersModal.tsx`)

A weekend tab strip, `All · FC1 · FC4`, using the same segmented-control grammar as `HouseholdRosterTable`'s need filters. The children filter to the selected weekend and the header headcount follows the tab. A stale selection resets itself rather than through an effect: the card keeps the modal mounted across opens, so a weekend picked on 2025 would otherwise still be selected on 2024.

**Label** (`weekendNames.ts`)

New `weekendLabel(name)` — the slug, uppercased, falling back to `shortWeekendName` and **never** to a CampMinder id (it takes a name, not a session, so it structurally cannot emit one). `weekendSlug`'s doc block previously read *"THIS IS NOT A DISPLAY NAME"*; that block and the file's top note are rewritten in this PR rather than left contradicting the screen, and the three forms are now stated as a rule about which surface may use which.

## What this deliberately does NOT do

- **No housing-per-weekend.** `family_camp_registrations` holds a single cabin string per household-year and no source holds a second. Repeating it against each weekend is the fan-out that manufactured 12 of 17 false multi-family occupancies in the phase-C shareability analysis. #2336 is where the widening question lives; nothing here touches its anchors and it stays open.
- **The adult list is not tabbed, and cannot be.** `family_camp_adults` is household-year grain with no session dimension. The adults render unchanged on every tab; inventing a per-weekend attendance claim for them is #1943, blocked on a 2027 form change.
- **No tab strip for a single-weekend year.** `All · FC1` is a control that cannot change anything, and the card's own weekend line already names it.
- **Tab state is not in the URL.** A deliberate divergence from the weekend-surface rule, justified at the divergence: the modal itself is not addressable — the card holds the open row in `useState` — so a search param for its inner filter would outlive the modal that owns it.
- **Sequencing.** #2393's ruling asked for #2332 first, on the grounds that this grows each row a weekend line underneath a housing name that still wraps to two lines. #2332 is not merged, so the panel is at its tightest until it is.

## One correction to the ruling

The ruling names `rs` and `w` as the two 2026 slugs outside the day-group plan. **Both are off**, and the tree wins: the slug rule keeps every initial of the identity, so `Ready, Set, Camp` is `rsc` (the example `weekendSlug`'s own doc block already gives) and `JFAM Winter Family Camp` is `wfc` once the shared JFAM token is dropped. Pinned as computed rather than as written down — the alternative was special-casing two weekends to match a note. Labels for the ten 2026 family sessions are therefore `RSC`, `FC1`–`FC8`, `WFC`, and a test asserts all ten are distinct.

## Verification

- 12 new service tests, written failing first; five mutations (default session ids, publishing weekend 0, dropping the ordering, pinning a cabin that does not exist, collecting sessions after the dedup) each confirmed RED and restored.
- 6 `weekendLabel` tests, 7 weekend-line tests, 13 weekend-tab tests. Every test that went green on first run was mutation-checked — including one that did **not** die and was strengthened: a mutation opening the modal on the first weekend survived a names-only assertion, because every child in that fixture attended the first weekend.
- `bash scripts/pre-push-verify.sh` → ALL CHECKS PASSED (ruff format/check, mypy, 6,344 pytest, prettier, eslint, tsc, vitest).
- `./scripts/dev/verify-no-hardcoded-lodging.sh` → OK.
- `types.gen.ts` regenerated; `git diff -w` confirms the change is additive only.

Closes #2393.
