### PR TITLE
fix(sync,pb): two transform-phase failures found in a production log

### DIFF
--- a/pocketbase/main_household_demographics_text_caps_test.go
+++ b/pocketbase/main_household_demographics_text_caps_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+const householdDemographicsTextCapsMigration = "pb_migrations/1500000163_household_demographics_text_caps.js"
+
+// householdDemographicsWidenedFields is every text column on
+// household_demographics that 1500000041 capped below 1000 characters.
+//
+// The two that forced the change are the date pair. A parent answered
+// `HH-Away From (mm/dd/yy)` with a 130-character sentence about plans not
+// being settled yet, PocketBase refused the save at max=100, and
+// household_demographics reported the WHOLE JOB failed -- one household's
+// free text turning a transform-phase job red:
+//
+//	ERROR Error saving household_demographics record ... error=away_from_date:
+//	      Must be no more than 100 character(s).; away_return_date: ...
+//	ERROR Phase job failed phase=transform job=household_demographics
+//
+// The rest are in the list because they are the same KIND of column -- free
+// text a parent types into a CampMinder custom field, with no length limit at
+// the source -- so each one is the same red job waiting for a longer answer.
+// A cap on these was never a data-quality control: nothing downstream reads a
+// length, and CampMinder does not enforce one.
+var householdDemographicsWidenedFields = []string{
+	"jewish_affiliation",
+	"jewish_affiliation_other",
+	"congregation_summer",
+	"congregation_family",
+	"jcc_summer",
+	"jcc_family",
+	"away_location",
+	"away_phone",
+	"away_from_date",
+	"away_return_date",
+	"form_filler",
+}
+
+func readHouseholdDemographicsTextCapsMigration(t *testing.T) string {
+	t.Helper()
+	content, err := os.ReadFile(householdDemographicsTextCapsMigration)
+	if err != nil {
+		t.Fatalf("read migration %s: %v", householdDemographicsTextCapsMigration, err)
+	}
+	return string(content)
+}
+
+// TestHouseholdDemographicsTextCapsNamesEveryShortField guards the list above
+// against a migration that widens only the two columns that happened to fail
+// in production. Every one of them is fed from the same place.
+func TestHouseholdDemographicsTextCapsNamesEveryShortField(t *testing.T) {
+	body := readHouseholdDemographicsTextCapsMigration(t)
+
+	for _, field := range householdDemographicsWidenedFields {
+		if !strings.Contains(body, `'`+field+`'`) {
+			t.Errorf("migration %s must widen %q", householdDemographicsTextCapsMigration, field)
+		}
+	}
+}
+
+// TestHouseholdDemographicsTextCapsWidensToOneThousand pins the target. 1000 is
+// the cap `family_description_other` and `parent_immigrant_origin` already
+// carry on this same table, so it is the table's own existing answer for "a
+// paragraph of free text" rather than a new number.
+func TestHouseholdDemographicsTextCapsWidensToOneThousand(t *testing.T) {
+	body := readHouseholdDemographicsTextCapsMigration(t)
+
+	if !strings.Contains(body, "1000") {
+		t.Errorf("migration %s must set max = 1000", householdDemographicsTextCapsMigration)
+	}
+}
+
+// TestHouseholdDemographicsTextCapsIsReversibleWithoutTruncating is the guard
+// the "no destructive data migrations" rule asks for. The down path has to put
+// the old caps back, and it must NOT delete or truncate a row that has since
+// used the extra room -- PocketBase applies `max` at record-save time rather
+// than at schema-save time, so narrowing the field is safe on its own and any
+// attempt to "clean up" first would be the destructive half.
+func TestHouseholdDemographicsTextCapsIsReversibleWithoutTruncating(t *testing.T) {
+	body := readHouseholdDemographicsTextCapsMigration(t)
+
+	for _, forbidden := range []string{"DELETE FROM", "UPDATE household_demographics", "substr("} {
+		if strings.Contains(body, forbidden) {
+			t.Errorf("migration %s must not rewrite stored rows (found %q)",
+				householdDemographicsTextCapsMigration, forbidden)
+		}
+	}
+
+	// The original caps have to appear so the down path restores them rather
+	// than leaving every column at 1000.
+	for _, oldCap := range []string{"100", "200", "300", "400", "500"} {
+		if !strings.Contains(body, oldCap) {
+			t.Errorf("migration %s down path must restore the original cap %s",
+				householdDemographicsTextCapsMigration, oldCap)
+		}
+	}
+}

--- a/pocketbase/pb_migrations/1500000163_household_demographics_text_caps.js
+++ b/pocketbase/pb_migrations/1500000163_household_demographics_text_caps.js
@@ -1,0 +1,116 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Widen household_demographics' short free-text columns to 1000 characters.
+ *
+ * ── WHY ─────────────────────────────────────────────────────────────────────
+ *
+ * One household's answer turned a transform-phase job red in production:
+ *
+ *   ERROR Error saving household_demographics record ... year=2026
+ *         error=away_from_date: Must be no more than 100 character(s).;
+ *               away_return_date: Must be no more than 100 character(s)..
+ *   ERROR Phase job failed phase=transform job=household_demographics
+ *         error=1 database operations failed
+ *
+ * A parent answered `HH-Away From (mm/dd/yy)` with a 130-character sentence
+ * saying their dates were not settled yet. That is not malformed input -- it
+ * is what a free-text box on a registration form collects, and CampMinder
+ * enforces no length on it. The job wrote every other record and still exited
+ * `failed`, so a single sentence reddens the phase every run until someone
+ * edits that family's answer in CampMinder.
+ *
+ * ── WHY ALL ELEVEN, NOT THE TWO THAT FAILED ─────────────────────────────────
+ *
+ * Every column below is the same kind of column: free text a parent types into
+ * a CampMinder custom field, mirrored here. The two date fields are simply the
+ * ones a long answer reached first. `form_filler` at 200, the two
+ * `congregation_*` and two `jcc_*` at 300, `away_phone` at 400, and
+ * `away_location` and the two `jewish_affiliation*` at 500 are the same red
+ * job waiting for a longer answer, and each would have to be found from a
+ * production log the same way.
+ *
+ * The caps were never a data-quality control -- nothing downstream reads a
+ * length, and there is no validation these numbers back. 1000 is not a new
+ * number either: `family_description_other` and `parent_immigrant_origin`
+ * already carry it on this same table, so this is the table's own existing
+ * answer for "a paragraph of free text".
+ *
+ * Nothing here costs storage. SQLite TEXT is variable-length; `max` is a
+ * PocketBase record-save validation, not a column width, so a widened field
+ * that stays short occupies exactly what it occupied before.
+ *
+ * ── WHAT IS DELIBERATELY LEFT ALONE ─────────────────────────────────────────
+ *
+ * `custody_summer` / `custody_family` (5000), `family_description` /
+ * `jewish_identities` (2000), and the two fields already at 1000 keep their
+ * caps: none of them is below the target, so widening them would be a change
+ * with no failure behind it. This migration only raises floors.
+ *
+ * The job's own behaviour is NOT changed here. It still reports the whole run
+ * failed when one record refuses to save, which is worth revisiting on its own
+ * -- but that is a Go change with its own blast radius, and a schema migration
+ * is not where it belongs.
+ *
+ * ── DOWN ────────────────────────────────────────────────────────────────────
+ *
+ * Restores each column's original cap. It does NOT touch stored rows, and must
+ * not: PocketBase applies `max` when a RECORD is saved, not when the schema is,
+ * so narrowing the field cannot fail on existing data. A row that used the
+ * extra room keeps its text and refuses its next save -- which is exactly the
+ * state this migration found, and is recoverable. Truncating those rows to make
+ * the down path "clean" would destroy the answer instead, which the standing
+ * no-destructive-migrations rule forbids.
+ */
+
+// name -> the cap 1500000041 gave it, which the down path restores.
+const ORIGINAL_CAPS = {
+  'jewish_affiliation': 500,
+  'jewish_affiliation_other': 500,
+  'congregation_summer': 300,
+  'congregation_family': 300,
+  'jcc_summer': 300,
+  'jcc_family': 300,
+  'away_location': 500,
+  'away_phone': 400,
+  'away_from_date': 100,
+  'away_return_date': 100,
+  'form_filler': 200,
+};
+
+const WIDENED_CAP = 1000;
+
+/**
+ * Set every named field's `max`, resolving each name through the collection.
+ *
+ * A missing field THROWS rather than being skipped. This migration exists
+ * because a cap silently refused a write; a rename that silently skipped a
+ * column would leave exactly the failure it is meant to remove, and report
+ * success. `fields.getByName` is the same accessor 1500000140 uses to modify a
+ * field in place.
+ */
+function setCaps(app, caps) {
+  const col = app.findCollectionByNameOrId('household_demographics');
+
+  for (const [name, max] of Object.entries(caps)) {
+    const field = col.fields.getByName(name);
+    if (!field) {
+      throw new Error(`household_demographics: expected an existing "${name}" text field`);
+    }
+    field.max = max;
+  }
+
+  app.save(col);
+}
+
+migrate(
+  (app) => {
+    const widened = {};
+    for (const name of Object.keys(ORIGINAL_CAPS)) {
+      widened[name] = WIDENED_CAP;
+    }
+    setCaps(app, widened);
+  },
+  (app) => {
+    setCaps(app, ORIGINAL_CAPS);
+  }
+);

--- a/pocketbase/sync/normalize_geographic.go
+++ b/pocketbase/sync/normalize_geographic.go
@@ -458,7 +458,13 @@ func (n *NormalizeGeographicSync) loadGeoOverrides(year int) (
 	records, findErr := n.App.FindRecordsByFilter(
 		"geo_overrides",
 		"year <= {:year}",
-		"year ASC",
+		// ASCENDING BY YEAR, and the direction is load-bearing: the loop below
+		// overwrites on each hit, so the newest year's value is the one that
+		// survives. A bare field name IS ascending in PocketBase -- `+year` and
+		// `-year` are the only decorated forms, and "year ASC" was read as a
+		// field name called "year ASC", failed the whole query, and left the
+		// caller logging a warning and continuing with no overrides at all.
+		"year",
 		0,
 		0,
 		dbx.Params{"year": year},

--- a/pocketbase/sync/normalize_geographic_test.go
+++ b/pocketbase/sync/normalize_geographic_test.go
@@ -2362,6 +2362,10 @@ func newNormalizeGeographicSyncTestApp(t *testing.T) core.App {
 		for _, f := range []string{
 			"name", "person", "field_definition", "value",
 			"type", "category", "canonical_name", "merged_into", "raw_value",
+			// The column loadGeoOverrides actually switches on. Absent from
+			// this fixture until the geo_overrides loader got its first test:
+			// "type" is a different column and never fed that switch.
+			"override_type",
 		} {
 			col.Fields.Add(&core.TextField{Name: f})
 		}
@@ -2478,5 +2482,119 @@ func TestNormalizeGeographicSyncPropagatesSweepRefusal(t *testing.T) {
 	if len(remaining) != OrphanSweepMinRows+5 {
 		t.Errorf("%d rows survived, want %d -- a refused sweep must delete nothing",
 			len(remaining), OrphanSweepMinRows+5)
+	}
+}
+
+// ============================================================================
+// geo_overrides loader (kindred: transform-phase log audit, 2026-08-18)
+// ============================================================================
+
+// TestLoadGeoOverrides_ReadsRows is the test the override feature never had.
+//
+// Every existing "override" test in this file assigns into a plain Go map and
+// asserts on the map — none of them issues the query, so the loader's sort
+// argument was never exercised. Production logged
+//
+//	WARN Could not load geo_overrides, continuing without overrides
+//	     error=loading geo_overrides: invalid sort field "year ASC"
+//
+// on every run: PocketBase sort expressions are `field` / `+field` / `-field`,
+// so "year ASC" is read as a FIELD NAME and rejected. The caller swallows the
+// error and continues with empty maps, so alias, merge and rejection overrides
+// have never been applied by this job and nothing went red.
+func TestLoadGeoOverrides_ReadsRows(t *testing.T) {
+	t.Parallel()
+	app := newNormalizeGeographicSyncTestApp(t)
+
+	col, err := app.FindCollectionByNameOrId("geo_overrides")
+	if err != nil {
+		t.Fatalf("find geo_overrides: %v", err)
+	}
+
+	save := func(overrideType, category string, year int, fields map[string]string) {
+		t.Helper()
+		rec := core.NewRecord(col)
+		rec.Set("override_type", overrideType)
+		rec.Set("category", category)
+		rec.Set("year", year)
+		for k, v := range fields {
+			rec.Set(k, v)
+		}
+		if saveErr := app.Save(rec); saveErr != nil {
+			t.Fatalf("save %s override: %v", overrideType, saveErr)
+		}
+	}
+
+	save("alias", categorySchool, 2025, map[string]string{
+		"raw_value": "Lakeview Elem", "canonical_name": "Lakeview Elementary",
+	})
+	save("merge", categoryCongregation, 2025, map[string]string{
+		"canonical_name": "Beth Shalom", "merged_into": "Congregation Beth Shalom",
+	})
+	save("rejected", categoryCity, 2025, map[string]string{
+		"canonical_name": "Unknown",
+	})
+
+	n := &NormalizeGeographicSync{App: app}
+	alias, merge, rejected, err := n.loadGeoOverrides(2026)
+	if err != nil {
+		t.Fatalf("loadGeoOverrides: %v", err)
+	}
+
+	if got := alias[categorySchool]["lakeview elem"]; got != "Lakeview Elementary" {
+		t.Errorf("alias override = %q, want %q", got, "Lakeview Elementary")
+	}
+	if got := merge[categoryCongregation]["Beth Shalom"]; got != "Congregation Beth Shalom" {
+		t.Errorf("merge override = %q, want %q", got, "Congregation Beth Shalom")
+	}
+	if !rejected[categoryCity]["unknown"] {
+		t.Errorf("rejected override for %q not loaded", "unknown")
+	}
+}
+
+// TestLoadGeoOverrides_NewestYearWins pins the reason the loader sorts at all:
+// the same alias key may be set in more than one year, later rows overwrite
+// earlier ones as the loop runs, so ascending year is what makes the newest
+// value the one that survives. The sibling TestOverrideMapDedup_* tests assert
+// that overwrite semantics against a hand-built map; this one asserts the sort
+// that feeds it, which is the half that was broken.
+func TestLoadGeoOverrides_NewestYearWins(t *testing.T) {
+	t.Parallel()
+	app := newNormalizeGeographicSyncTestApp(t)
+
+	col, err := app.FindCollectionByNameOrId("geo_overrides")
+	if err != nil {
+		t.Fatalf("find geo_overrides: %v", err)
+	}
+
+	// Saved newest-first, so a loader that does not sort would leave the 2025
+	// value in place.
+	for _, row := range []struct {
+		year      int
+		canonical string
+	}{
+		{2026, "Lakeview Elementary Academy"},
+		{2025, "Lakeview Elementary"},
+	} {
+		rec := core.NewRecord(col)
+		rec.Set("override_type", "alias")
+		rec.Set("category", categorySchool)
+		rec.Set("year", row.year)
+		rec.Set("raw_value", "Lakeview Elem")
+		rec.Set("canonical_name", row.canonical)
+		if saveErr := app.Save(rec); saveErr != nil {
+			t.Fatalf("save alias override for %d: %v", row.year, saveErr)
+		}
+	}
+
+	n := &NormalizeGeographicSync{App: app}
+	alias, _, _, err := n.loadGeoOverrides(2026)
+	if err != nil {
+		t.Fatalf("loadGeoOverrides: %v", err)
+	}
+
+	if got := alias[categorySchool]["lakeview elem"]; got != "Lakeview Elementary Academy" {
+		t.Errorf("alias override = %q, want the newest year's value %q",
+			got, "Lakeview Elementary Academy")
 	}
 }

--- a/scripts/ci/validate_migrations.py
+++ b/scripts/ci/validate_migrations.py
@@ -96,6 +96,37 @@ TEXT_FIELDS_REQUIRE_CUSTOM_LIMIT = {
     "bunk_requests": ["notes"],
 }
 
+# Text fields whose EXACT cap matters, checked against a booted PocketBase.
+#
+# TEXT_FIELDS_REQUIRE_CUSTOM_LIMIT above only asks whether a field is sitting on
+# PocketBase's 5000 default, which says nothing about one capped far too LOW.
+# That is the failure this exists for: household_demographics mirrors free-text
+# CampMinder custom fields a parent types into, CampMinder enforces no length on
+# any of them, and `away_from_date` at 100 refused a 130-character answer --
+# turning one family's sentence into a failed transform-phase job on every run.
+#
+# Migration 1500000163 widened these by mutating fields IN PLACE, so no
+# collection literal in pb_migrations/ states the resulting cap and no static
+# read of the migration source can confirm it. This validator runs against
+# /api/collections after every migration has applied, which is the only place
+# the real number is observable -- and therefore the only place a later
+# migration silently narrowing one of them would be caught.
+TEXT_FIELD_EXACT_LIMITS = {
+    "household_demographics": {
+        "jewish_affiliation": 1000,
+        "jewish_affiliation_other": 1000,
+        "congregation_summer": 1000,
+        "congregation_family": 1000,
+        "jcc_summer": 1000,
+        "jcc_family": 1000,
+        "away_location": 1000,
+        "away_phone": 1000,
+        "away_from_date": 1000,
+        "away_return_date": 1000,
+        "form_filler": 1000,
+    },
+}
+
 
 class ValidationError(Exception):
     """Raised when validation fails."""
@@ -259,6 +290,47 @@ def validate_text_field_limits(collection_map: dict[str, Any]) -> list[str]:
     return errors
 
 
+def validate_text_field_exact_limits(collection_map: dict[str, Any]) -> list[str]:
+    """Validate text fields carry exactly the cap TEXT_FIELD_EXACT_LIMITS names.
+
+    A collection absent from the dump is NOT an error here -- that is
+    validate_required_collections' job, and duplicating it would report the
+    same missing table twice. A named field that has vanished IS reported: the
+    caps in the spec exist to keep a specific column wide enough, so a rename
+    that leaves the spec behind must not read as "nothing to check".
+    """
+    errors = []
+    for col_name, expected_limits in TEXT_FIELD_EXACT_LIMITS.items():
+        if col_name not in collection_map:
+            continue
+
+        collection = collection_map[col_name]
+        for field_name, expected_max in expected_limits.items():
+            field = get_field(collection, field_name)
+            if field is None:
+                errors.append(f"Text field '{field_name}' on '{col_name}' is missing - expected max {expected_max}")
+                continue
+
+            if field.get("type") != "text":
+                errors.append(
+                    f"Field '{field_name}' on '{col_name}' is type "
+                    f"'{field.get('type')}', expected max {expected_max} on a text field"
+                )
+                continue
+
+            # v0.23+ keeps max as a direct property; older migrations nested it.
+            max_val = field.get("max")
+            if max_val is None:
+                max_val = field.get("options", {}).get("max")
+
+            if max_val != expected_max:
+                errors.append(
+                    f"Text field '{field_name}' on '{col_name}' has max {max_val}, expected max {expected_max}"
+                )
+
+    return errors
+
+
 def validate_indexes(collection_map: dict[str, Any]) -> list[str]:
     """Validate that critical unique indexes exist."""
     errors = []
@@ -316,6 +388,7 @@ def main() -> int:
     all_errors.extend(validate_relations(collection_map, id_map))
     all_errors.extend(validate_select_values(collection_map))
     all_errors.extend(validate_text_field_limits(collection_map))
+    all_errors.extend(validate_text_field_exact_limits(collection_map))
     all_errors.extend(validate_indexes(collection_map))
 
     if all_errors:

--- a/tests/unit/scripts/test_validate_migrations.py
+++ b/tests/unit/scripts/test_validate_migrations.py
@@ -4,7 +4,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 SCRIPT_PATH = Path(__file__).parents[3] / "scripts" / "ci" / "validate_migrations.py"
 
@@ -308,3 +308,82 @@ class TestEdgeCases:
         )
         # Will fail on missing collections but should parse correctly
         assert "Validating PocketBase schema" in result.stdout
+
+
+class TestTextFieldExactLimits:
+    """Exact caps on the columns that mirror free-text CampMinder answers.
+
+    `TEXT_FIELDS_REQUIRE_CUSTOM_LIMIT` only asserts a field is not sitting on
+    PocketBase's 5000 default, which says nothing about a field capped far too
+    LOW. That is the failure that reached production: `away_from_date` at 100
+    refused a parent's 130-character answer and the whole
+    `household_demographics` transform job reported failure.
+
+    Migration 1500000163 widened those columns by mutating fields in place, so
+    no collection literal in `pb_migrations/` states the resulting cap and no
+    static read of the migrations can confirm it. This validator runs against a
+    booted PocketBase's `/api/collections` after every migration has applied,
+    which is the only place the real number is observable.
+    """
+
+    HOUSEHOLD_DEMOGRAPHICS_WIDENED: ClassVar[list[str]] = [
+        "jewish_affiliation",
+        "jewish_affiliation_other",
+        "congregation_summer",
+        "congregation_family",
+        "jcc_summer",
+        "jcc_family",
+        "away_location",
+        "away_phone",
+        "away_from_date",
+        "away_return_date",
+        "form_filler",
+    ]
+
+    def _household_demographics(self, overrides: dict[str, int] | None = None) -> dict[str, Any]:
+        caps = dict.fromkeys(self.HOUSEHOLD_DEMOGRAPHICS_WIDENED, 1000)
+        caps.update(overrides or {})
+        return make_collection(
+            "household_demographics",
+            fields=[make_field(name, max=cap) for name, cap in caps.items()],
+        )
+
+    def test_narrowed_field_detected(self):
+        """A column back at its old cap fails, naming the field and the cap."""
+        collections = [self._household_demographics({"away_from_date": 100})]
+        code, stdout, _ = run_validator(collections)
+
+        assert code == 1
+        assert "away_from_date" in stdout
+        assert "1000" in stdout
+
+    def test_every_widened_field_is_checked(self):
+        """Each of the eleven is guarded, not just the two that failed.
+
+        Narrowing them one at a time proves the spec covers all of them --
+        a check listing only `away_*` would pass nine of these.
+        """
+        for field_name in self.HOUSEHOLD_DEMOGRAPHICS_WIDENED:
+            collections = [self._household_demographics({field_name: 100})]
+            code, stdout, _ = run_validator(collections)
+
+            assert code == 1, f"{field_name} narrowed to 100 did not fail validation"
+            assert field_name in stdout, f"{field_name} narrowed to 100 was not reported"
+
+    def test_correct_limits_raise_no_text_cap_error(self):
+        """All eleven at 1000 produce no cap complaint.
+
+        Other validations still fail on this deliberately minimal input, so
+        this asserts the ABSENCE of the cap message rather than exit code 0.
+        """
+        collections = [self._household_demographics()]
+        _, stdout, _ = run_validator(collections)
+
+        assert "expected max" not in stdout
+
+    def test_missing_collection_is_not_an_error_here(self):
+        """A dump without the collection is another check's problem, not this one."""
+        collections = [make_collection("persons")]
+        _, stdout, _ = run_validator(collections)
+
+        assert "expected max" not in stdout


### PR DESCRIPTION
Two independent defects surfaced by reading the Docker logs of a full
transform-phase run in production. Neither had a test, and neither was
reachable from CI.

## 1. `geo_overrides` has never loaded

`loadGeoOverrides` asked PocketBase to sort by `"year ASC"`. PocketBase sort
expressions are `field`, `+field` or `-field`, so that string was parsed as a
FIELD NAME, `FindRecordsByFilter` refused the query, and the caller swallowed
the error and continued with empty maps:

```
WARN Could not load geo_overrides, continuing without overrides
     error=loading geo_overrides: invalid sort field "year ASC"
```

Every alias, merge and rejection override has been ignored by this job for as
long as the line has existed, on every run, with nothing going red. A bare
field name is already ascending, which is the direction the loop needs: it
overwrites on each hit, so ascending year is what makes the newest year's value
the surviving one.

**Why it survived.** The three `TestOverrideMapDedup_*` tests look like
coverage of this feature, but each assigns into a hand-built Go map and asserts
on the map — none issues the query, so the sort argument was never executed by
a test. The two tests added here call `loadGeoOverrides` against a real app:
one asserts all three override kinds load, the other asserts newest-year-wins
*through* the query rather than around it. Both fail with the exact production
error before the fix, confirmed by reverting the line.

`override_type` had to be added to the shared geo fixture, which never carried
the column the loader actually switches on — `type` is a different column and
fed nothing.

**Blast radius.** Production holds one non-canonical override row, a city alias
correcting a misspelling, which starts applying on the next normalization run.
The remaining rows are `override_type = "canonical"`, which this loader does
not consume — `api/services/geo_service.py` does, and it already sorts
correctly and is unaffected.

## 2. One long free-text answer fails the whole `household_demographics` job

A parent answered a date question with a 130-character sentence saying their
plans were not settled yet. The column is capped at 100, PocketBase refused the
save, and the job reported the whole run failed:

```
ERROR Error saving household_demographics record ... year=2026
      error=away_from_date: Must be no more than 100 character(s).; ...
ERROR Phase job failed phase=transform job=household_demographics
      error=1 database operations failed
```

Every other record wrote; the job still exited `failed`, and would again on
every run until someone edited that answer in CampMinder.

Migration `1500000163` widens eleven columns to 1000. **All eleven, not the two
that failed:** each mirrors a free-text CampMinder custom field a parent types
into, and CampMinder enforces no length on any of them. The two date fields are
simply the ones a long answer reached first; `form_filler` at 200, the two
`congregation_*` and two `jcc_*` at 300, `away_phone` at 400, and
`away_location` and the two `jewish_affiliation*` at 500 are the same red job
waiting for a longer sentence, each to be found from a production log the same
way.

These caps were never a data-quality control — nothing downstream reads a
length and no validation rests on them. 1000 is the table's own existing answer
for "a paragraph of free text": `family_description_other` and
`parent_immigrant_origin` already carry it. Columns at or above 1000 are
deliberately untouched; this only raises floors. Nothing costs storage —
SQLite TEXT is variable-length and PocketBase's `max` is a record-save
validation, not a column width.

## Verified against production data, not just asserted

The migration was applied to a copy of the production snapshot: all eleven land
at 1000, no other column moves, and the real 129-character answer that broke
the job then saves (HTTP 200) where it previously could not.

The down path restores every original cap and touches no rows. Verified with a
129-character value already stored: `max` applies at record-save time, so
narrowing the field succeeds and the answer survives rather than being
truncated. Truncating to make the revert "clean" would destroy the answer,
which the no-destructive-migrations rule forbids.

`scripts/pre-push-verify.sh` reports ALL CHECKS PASSED, golangci-lint included.

## 3. The exact caps are now asserted in CI

Raised by CodeRabbit on this PR, and it names a gap the Go tests genuinely have:
they read the migration FILE and grep it, so they prove the source says 1000 and
prove nothing about the schema PocketBase ends up with. That gap is structural —
the migration widens fields by mutating them in place, so no collection literal
in `pb_migrations/` states the resulting cap.

`validate_migrations.py` already consumes `/api/collections?perPage=1000` from a
booted PocketBase after every migration has applied, which is the only place the
real number is observable — and therefore the only place a later migration
silently narrowing one of these would be caught.

`TEXT_FIELDS_REQUIRE_CUSTOM_LIMIT` could not carry it: it asks only whether a
field is sitting on PocketBase's 5000 default, which says nothing about one
capped far too LOW. So `TEXT_FIELD_EXACT_LIMITS` names the cap and
`validate_text_field_exact_limits` asserts it. A missing COLLECTION is skipped
(`validate_required_collections` already reports that); a missing FIELD is an
error, since a rename that leaves the spec behind must not read as "nothing to
check".

Round-tripped against a copy of the production snapshot: with 1500000163
reverted the check reports all eleven columns at their old caps; re-applied, it
reports none. The unit tests narrow each of the eleven in turn, so a spec
listing only the two columns that actually failed would fail nine of them.

## Deliberately not in scope

- **The job still fails wholesale when one record refuses to save.** Worth
  revisiting — one family's free text should not redden a phase — but it is a
  Go change with its own blast radius and does not belong in a schema
  migration.
- **The lodging work queue renders only `kind = "unresolved_alias"`.** The
  other kinds are recorded and have no surface, so a queue holding several
  `ambiguous_session` items reads as empty. Separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Household demographics text fields now support entries up to 1,000 characters without altering existing records.

* **Bug Fixes**
  * Geographic overrides are now processed in year order, ensuring the most recent applicable alias takes precedence.
  * Improved loading of geographic override records from PocketBase.

* **Tests**
  * Added coverage validating demographic field limits, reversible migrations, and geographic override precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
