### PR TITLE
fix(sync): reset Stats at the top of reconcile_request_lifecycle's Sync

### DIFF
--- a/pocketbase/sync/reconcile_request_lifecycle.go
+++ b/pocketbase/sync/reconcile_request_lifecycle.go
@@ -61,6 +61,12 @@ func (s *ReconcileLifecycleSync) WasSuccessful() bool {
 // to CAMPMINDER_SEASON_ID via ParseSeasonYear, matching the convention used
 // by every other yearless service in this package.
 func (s *ReconcileLifecycleSync) Sync(_ context.Context) error {
+	// Stats describe THIS run, not the process. The orchestrator registers one
+	// long-lived instance, so without this reset the first error of a process's
+	// life makes WasSuccessful() false — and applyCompletionStatus records every
+	// later run as failed — until the container restarts.
+	s.Stats = Stats{}
+
 	year := s.Year
 	if year == 0 {
 		var err error

--- a/pocketbase/sync/reconcile_request_lifecycle_test.go
+++ b/pocketbase/sync/reconcile_request_lifecycle_test.go
@@ -507,3 +507,54 @@ func TestReconcileRequestLifecycle_SuccessPathReturnsZeroMarkErrors(t *testing.T
 		t.Errorf("markErrors = %d, want 0", markErrors)
 	}
 }
+
+// TestReconcileLifecycleSync_ResetsStatsBetweenRunsOnSameInstance pins the
+// per-run contract for Stats on the ONE long-lived instance the orchestrator
+// registers (orchestrator.go registers a single ReconcileLifecycleSync for the
+// life of the process, plus one for the year-scoped path). A run's Stats.Errors
+// must describe that run alone: applyCompletionStatus derives a run's status
+// from stats.Errors > 0, so a counter that carries over makes every later run
+// record as failed, with a monotonically climbing errors_count, until the
+// container restarts.
+//
+// The instance is reused deliberately. A test that constructs a fresh service
+// per run cannot observe carry-over at all, which is how this class of bug
+// survives its own suite.
+func TestReconcileLifecycleSync_ResetsStatsBetweenRunsOnSameInstance(t *testing.T) {
+	t.Parallel()
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+
+	s := NewReconcileLifecycleSync(app)
+	s.SetYear(2025)
+
+	// Run 1 -- failure injected here and only here: the collections the
+	// reconciliation queries do not exist yet, so the attendees lookup errors
+	// out and the run records one error.
+	if syncErr := s.Sync(context.Background()); syncErr == nil {
+		t.Fatal("run 1: want an error from the missing collections to inject the failure, got nil")
+	}
+	if s.Stats.Errors != 1 {
+		t.Fatalf("run 1: Stats.Errors = %d, want 1 -- the failure injection did not take",
+			s.Stats.Errors)
+	}
+	if s.WasSuccessful() {
+		t.Fatal("run 1: WasSuccessful() = true, want false")
+	}
+
+	// Run 2 -- same instance, schema now present and nothing to reconcile.
+	setupReconcileCollections(t, app)
+	if syncErr := s.Sync(context.Background()); syncErr != nil {
+		t.Fatalf("run 2: Sync = %v, want nil", syncErr)
+	}
+	if s.Stats.Errors != 0 {
+		t.Errorf("run 2: Stats.Errors = %d, want 0 -- run 1's error carried over into a clean run",
+			s.Stats.Errors)
+	}
+	if !s.WasSuccessful() {
+		t.Error("run 2: WasSuccessful() = false, want true -- a clean run must not inherit run 1's error")
+	}
+}


### PR DESCRIPTION
The orchestrator registers **one** long-lived `ReconcileLifecycleSync` for the life of
the process (`orchestrator.go:2328`, plus `:1731` for the year-scoped path), and its
`Sync` only ever incremented `Stats.Errors` — it never reset the counter.

`WasSuccessful()` is `s.Stats.Errors == 0`, and `applyCompletionStatus` derives a run's
status from `stats.Errors > 0`. So the first error of a process's life made every later
run record as **failed**, however clean it was, with a monotonically climbing
`errors_count` that read as a since-boot total rather than a run total, and cleared only
on container restart.

Latent today rather than firing: all 5 recorded runs have `errors_count = 0`. It arms the
moment anything errors.

## The change

`s.Stats = Stats{}` at the top of `Sync`, matching the five siblings that already do it —
`bunks.go`, `bunk_plans.go`, `enrollment_snapshots.go`, `financial_lookups.go`,
`multi_workbook_export.go`. One line plus the comment explaining why it is load-bearing.

## The test

`TestReconcileLifecycleSync_ResetsStatsBetweenRunsOnSameInstance` runs `Sync` twice on
**one** instance, with a failure injected into the first run only (the collections the
reconciliation queries do not exist yet, so the attendees lookup errors out), then asserts
the second, clean run reports `WasSuccessful() == true` and `Stats.Errors == 0`.

Reusing the instance is the whole point. A test that constructs a fresh service per run
cannot observe carry-over at all, which is how this class of bug survives its own suite —
the same trap that let #2465 through. Verified by mutation: with the reset removed the new
test fails on run 2 with `Stats.Errors = 1, want 0`; with it restored the test passes.

## Verification

- `bash scripts/pre-push-verify.sh` — ALL CHECKS PASSED (go build, golangci-lint 0 issues, go test)
- `go test ./sync/` — ok, 282s
- `golangci-lint run ./...` — 0 issues

## Scope

Deliberately its own change so it is revertable on its own. `bunk_assignments.go` is
untouched — it belongs to the sibling change for #2465. The other accumulation sites the
same audit recorded (`persons.go`, `base_sync.go`'s `FieldDiffStats`, and the
stale-but-bounded maps) are left alone here; they stay written down in the issue body.

Closes #2468.
