### PR TITLE
fix(graph): search every prior-year cabin, and admit "last summer" to the path

### DIFF
--- a/bunking/sync/bunk_request_processor/data/repositories/attendee_repository.py
+++ b/bunking/sync/bunk_request_processor/data/repositories/attendee_repository.py
@@ -451,20 +451,40 @@ class AttendeeRepository:
         months = diff.days / 30.44  # Average days per month
         return int(abs(months))
 
-    def find_prior_year_bunkmates(self, requester_cm_id: int, session_cm_id: int, year: int) -> dict[str, Any]:
+    def find_prior_year_bunkmates(self, requester_cm_id: int, year: int) -> dict[str, Any]:
         """Find eligible bunkmates from prior year who are returning.
 
         This mirrors monolith's find_prior_year_bunkmates functionality,
         using bunk_assignments table instead of deprecated historical_bunking.
 
+        EVERY eligible prior-year cabin of the requester is searched, not one.
+        The method used to keep `assignments[0]` and take the bunk, the session
+        and therefore the whole peer pool from that single row; 66 of the 1,257
+        campers with a 2025 assignment held two or more, in different cabins
+        every time, so a real cabin of friends was unreachable for all of them.
+        `sort: "id"` (#2445) made that pick stable, not right — PocketBase
+        record ids are random, so which of a camper's three or four cabins won
+        was arbitrary.
+
+        There is one peer query per `(bunk, session)` pair rather than one
+        overall. 94.7% of requesters have exactly one pair, so this is normally
+        the same single query it always was.
+
         Args:
             requester_cm_id: The camper requesting continuity
-            session_cm_id: Current year session CM ID (used for checking returning)
             year: Current year
 
         Returns:
-            Dict with cm_ids, prior_bunk, prior_year, total_in_bunk, returning_count
-            Empty dict if no prior year assignment found or on error
+            Dict with cm_ids, prior_bunk_by_cm_id, prior_bunks, prior_year,
+            total_in_bunk (distinct peers across ALL prior cabins) and
+            returning_count. Empty dict if no prior year assignment found or on
+            error.
+
+            There is deliberately no single top-level `prior_bunk`: with every
+            cabin searched it could only name an arbitrary one of them, which
+            is what stamped the wrong cabin onto `last_year_bunk`. Use
+            `prior_bunk_by_cm_id[cm_id]` for the cabin that peer actually
+            shared with the requester.
         """
         # Imported at call time, not module scope: `bunking.graph` imports
         # `bunking.satisfaction`, which imports this package's `core.models`, so
@@ -476,18 +496,17 @@ class AttendeeRepository:
         try:
             previous_year = year - 1
 
-            # Find requester's bunk assignment from prior year.
+            # Find the requester's bunk assignments from prior year.
             #
             # The session-type predicate is pushed INTO the query so the
             # database returns only rows from a session that actually puts
             # children in a cabin. Without it a Family Camp DAY GROUP was
-            # eligible to be returned as a summer `prior_bunk`, and the whole
+            # eligible to be returned as a summer prior cabin, and the whole
             # day group then came back as "bunkmates" (#2426). `sort: "id"`
-            # breaks ties deterministically for the rarer case of two eligible
-            # rows -- PocketBase's get_full_list has no inherent order, so the
-            # winner could otherwise change between runs with no code change.
-            # Same predicate and same STABLE_SORT convention as
-            # `bunking/graph/social_graph_builder.py`, which already carries
+            # fixes the order the cabins are searched in, which decides the
+            # `cm_ids` order and therefore which of two same-named peers a
+            # resolution picks. Same predicate and same STABLE_SORT convention
+            # as `bunking/graph/social_graph_builder.py`, which already carries
             # this fix for its own query.
             type_clause = " || ".join(f'session.session_type = "{t}"' for t in LAST_YEAR_HISTORY_SESSION_TYPES)
             try:
@@ -502,71 +521,87 @@ class AttendeeRepository:
                 logger.exception("find_prior_year_bunkmates failed querying assignments for cm_id=%s", requester_cm_id)
                 return {}
 
+            # Only `year - 1` is ever searched, so a camper who skipped a season
+            # resolves nothing here by construction (#2457). Say so rather than
+            # returning silently — from a sync log the two are indistinguishable.
             if not assignments:
+                logger.debug(
+                    "No eligible %s bunk assignment for cm_id=%s; the prior-year bunkmate path only searches year-1",
+                    previous_year,
+                    requester_cm_id,
+                )
                 return {}
 
-            # Get the bunk from the assignment
-            requester_assignment = assignments[0]
-            expand = getattr(requester_assignment, "expand", {}) or {}
-            bunk_data = expand.get("bunk")
-            session_data = get_session_from_expand(requester_assignment)
+            # Collect every DISTINCT (bunk, session) pair the requester held.
+            # A bunk is a building: 42 of the 57 bunks carrying a 2025
+            # assignment served more than one session, so the pair — not the
+            # bunk — is the set of children the requester actually lived with.
+            cabins: dict[tuple[str, str], str] = {}
+            for assignment in assignments:
+                expand = getattr(assignment, "expand", {}) or {}
+                bunk_data = expand.get("bunk")
+                session_data = get_session_from_expand(assignment)
 
-            if not bunk_data:
+                bunk_id = getattr(bunk_data, "id", None) if bunk_data else None
+                session_id = getattr(session_data, "id", None) if session_data else None
+
+                # Without the session we cannot scope the bunk to a week, and an
+                # unscoped query would return the whole building -- which is the
+                # defect this method was fixed for. Skip THIS cabin; the
+                # requester's other cabins are still perfectly searchable.
+                if not bunk_id or not session_id:
+                    continue
+
+                cabins.setdefault((bunk_id, session_id), getattr(bunk_data, "name", None) or "")
+
+            if not cabins:
                 return {}
 
-            bunk_id = getattr(bunk_data, "id", None)
-            bunk_name = getattr(bunk_data, "name", None)
-            session_id = getattr(session_data, "id", None) if session_data else None
+            # Union the peer sets, each still scoped to its own (bunk, session)
+            # pair. The first cabin to contribute a peer owns them, so a child
+            # the requester lived with twice is listed once.
+            prior_bunk_by_cm_id: dict[int, str] = {}
+            peer_cm_ids: list[int] = []
+            for (bunk_id, session_id), bunk_name in cabins.items():
+                # Same `sort: "id"` STABLE_SORT convention as the query above,
+                # and for the same reason: `_try_prior_bunkmate_resolution`
+                # returns the FIRST camper in `cm_ids` whose name matches the
+                # target, so two cabinmates sharing a first name are separated
+                # by nothing but the order this query happened to return.
+                bunkmates = self.pb.collection("bunk_assignments").get_full_list(
+                    query_params={
+                        "filter": f'bunk = "{bunk_id}" && year = {previous_year} && session = "{session_id}"',
+                        "expand": "person",
+                        "sort": "id",
+                    }
+                )
 
-            # Without the session we cannot scope the bunk to a week, and an
-            # unscoped query would return the whole building -- which is the
-            # defect this method is being fixed for. Return nothing instead.
-            if not bunk_id or not session_id:
-                return {}
-
-            # Find all campers in that bunk for prior year, IN THAT SESSION. A
-            # bunk is a building: 42 of the 57 bunks carrying a 2025 assignment
-            # served more than one session, so filtering on bunk + year alone
-            # returned children the requester never met (median peer set 29
-            # against a session-scoped 8).
-            #
-            # Same `sort: "id"` STABLE_SORT convention as the query above, and
-            # for the same reason: `_try_prior_bunkmate_resolution` returns the
-            # FIRST camper in `cm_ids` whose name matches the target, so two
-            # cabinmates sharing a first name are separated by nothing but the
-            # order this query happened to return.
-            bunkmates = self.pb.collection("bunk_assignments").get_full_list(
-                query_params={
-                    "filter": f'bunk = "{bunk_id}" && year = {previous_year} && session = "{session_id}"',
-                    "expand": "person",
-                    "sort": "id",
-                }
-            )
-
-            if not bunkmates:
-                return {}
-
-            # Extract bunkmate CM IDs (excluding requester)
-            bunkmate_cm_ids = []
-            for assignment in bunkmates:
-                person_data = get_person_from_expand(assignment)
-                if person_data:
+                for assignment in bunkmates:
+                    person_data = get_person_from_expand(assignment)
+                    if not person_data:
+                        continue
                     cm_id = getattr(person_data, "cm_id", None)
-                    if cm_id and cm_id != requester_cm_id:
-                        bunkmate_cm_ids.append(cm_id)
+                    if not cm_id or cm_id == requester_cm_id or cm_id in prior_bunk_by_cm_id:
+                        continue
+                    prior_bunk_by_cm_id[cm_id] = bunk_name
+                    peer_cm_ids.append(cm_id)
 
-            if not bunkmate_cm_ids:
+            if not peer_cm_ids:
                 return {}
 
-            # Check which bunkmates are returning this year
-            sessions_map = self.bulk_get_sessions_for_persons(bunkmate_cm_ids, year)
-            returning_ids = [cm_id for cm_id in bunkmate_cm_ids if cm_id in sessions_map]
+            # Check which bunkmates are returning this year. Deliberately not
+            # narrowed to the requester's current session: a camper in Session 4
+            # this year must still be able to request a friend from Session 1
+            # last year.
+            sessions_map = self.bulk_get_sessions_for_persons(peer_cm_ids, year)
+            returning_ids = [cm_id for cm_id in peer_cm_ids if cm_id in sessions_map]
 
             return {
                 "cm_ids": returning_ids,
-                "prior_bunk": bunk_name,
+                "prior_bunk_by_cm_id": {cm_id: prior_bunk_by_cm_id[cm_id] for cm_id in returning_ids},
+                "prior_bunks": list(dict.fromkeys(cabins.values())),
                 "prior_year": previous_year,
-                "total_in_bunk": len(bunkmate_cm_ids),
+                "total_in_bunk": len(peer_cm_ids),
                 "returning_count": len(returning_ids),
             }
 

--- a/bunking/sync/bunk_request_processor/services/context_builder.py
+++ b/bunking/sync/bunk_request_processor/services/context_builder.py
@@ -128,7 +128,6 @@ class ContextBuilder:
                 try:
                     prior_bunkmates = self.attendee_repository.find_prior_year_bunkmates(
                         requester_cm_id,
-                        session_cm_id,
                         year,
                     )
                     additional_context["previous_year_bunkmates"] = prior_bunkmates or None
@@ -359,7 +358,7 @@ class ContextBuilder:
         # Get prior year bunkmates to populate was_bunkmate flag
         prior_bunkmate_ids: set[int] = set()
         try:
-            prior_data = self.attendee_repository.find_prior_year_bunkmates(requester_cm_id, session_cm_id, year)
+            prior_data = self.attendee_repository.find_prior_year_bunkmates(requester_cm_id, year)
             if prior_data and prior_data.get("cm_ids"):
                 prior_bunkmate_ids = set(prior_data["cm_ids"])
         except Exception as e:

--- a/bunking/sync/bunk_request_processor/services/phase2_resolution_service.py
+++ b/bunking/sync/bunk_request_processor/services/phase2_resolution_service.py
@@ -14,6 +14,31 @@ from ..shared.nickname_groups import find_nickname_variations, names_match_via_n
 
 logger = get_logger(__name__)
 
+# Temporal markers that admit a request to the prior-year bunkmate path.
+#
+# Both branches of `_has_last_year_context` test this ONE list. They used to
+# disagree — the keyword branch carried three patterns and the raw-text branch
+# tested the single string "last year" — so `from before` was admitted or
+# refused depending only on which branch happened to see it.
+#
+# The raw-text branch is the live one: `keywords_found` reaches
+# `ParsedRequest.metadata` from a single producer (`integration/openai_provider.py`)
+# whose schema asks the model for PRIORITY keywords, never temporal markers, so
+# the keyword branch has never fired on a production request. Widening the
+# keyword list alone would have changed nothing (#2457).
+#
+# Deliberately NOT here: bare "before" and bare year numbers. "2024"/"2025"
+# appear in unrelated contexts, and the resolver only ever searches `year - 1`
+# anyway, so a year number could not steer it even if matched.
+LAST_YEAR_CONTEXT_PATTERNS: tuple[str, ...] = (
+    "last year",
+    "last summer",
+    "previous year",
+    "previous summer",
+    "last yr",
+    "from before",
+)
+
 
 class ResolutionCase:
     """Container for parsed requests that need resolution"""
@@ -177,7 +202,6 @@ class Phase2ResolutionService:
                     prior_result = self._try_prior_bunkmate_resolution(
                         target_name=parsed.target_name,
                         requester_cm_id=parse_result.parse_request.requester_cm_id,
-                        session_cm_id=parse_result.parse_request.session_cm_id,
                         year=parse_result.parse_request.year,
                     )
                     if prior_result and prior_result.is_resolved:
@@ -823,30 +847,35 @@ class Phase2ResolutionService:
         }
 
     def _has_last_year_context(self, parsed_request: ParsedRequest) -> bool:
-        """Detect if a request has "last year" context keywords.
+        """Detect if a request refers to a previous season.
 
-        - Check metadata.keywords_found for "last year" variants
-        - Check raw_text for "last year" pattern
+        This is the ONLY gate on `_try_prior_bunkmate_resolution`, which is the
+        highest-confidence resolution the pipeline has (0.95 full name / 0.90
+        first name). It tested the single phrasing "last year", so a parent
+        writing "last summer" — arguably the more natural way to put it — was
+        never offered the cabin evidence at all (#2457).
+
+        Both branches test `LAST_YEAR_CONTEXT_PATTERNS`; see that constant for
+        why the raw-text branch is the one that matters.
 
         Args:
             parsed_request: The parsed request to check
 
         Returns:
-            True if "last year" context detected
+            True if previous-season context detected
         """
         # Check keywords in metadata (from AI parsing)
         keywords = parsed_request.metadata.get("keywords_found", []) if parsed_request.metadata else []
-        keyword_patterns = ["from last year", "last year", "from before"]
-        has_keyword_context = any(kw in str(keywords).lower() for kw in keyword_patterns)
-        if has_keyword_context:
+        if any(pattern in str(keywords).lower() for pattern in LAST_YEAR_CONTEXT_PATTERNS):
             return True
 
-        # Check raw text (fallback if keywords not parsed)
-        raw_text = getattr(parsed_request, "raw_text", "") or ""
-        return "last year" in raw_text.lower()
+        # Check raw text (fallback if keywords not parsed -- in practice the
+        # only branch that has ever fired)
+        raw_text = (getattr(parsed_request, "raw_text", "") or "").lower()
+        return any(pattern in raw_text for pattern in LAST_YEAR_CONTEXT_PATTERNS)
 
     def _try_prior_bunkmate_resolution(
-        self, target_name: str, requester_cm_id: int, session_cm_id: int, year: int
+        self, target_name: str, requester_cm_id: int, year: int
     ) -> ResolutionResult | None:
         """Try to resolve target name from prior year bunkmates.
 
@@ -854,10 +883,14 @@ class Phase2ResolutionService:
         - Check if target name matches any bunkmate (full name → 0.95, first name → 0.90)
         - Add metadata: found_in_last_years_bunk, last_year_bunk
 
+        `last_year_bunk` names the cabin the MATCHED peer was in. It used to be
+        a single top-level value stamped onto every match, which named an
+        arbitrary one of the requester's cabins once all of them are searched
+        (#2456) — and that string is the evidence a staff reviewer reads.
+
         Args:
             target_name: Name to resolve
             requester_cm_id: Person making the request
-            session_cm_id: Current session CM ID
             year: Current year
 
         Returns:
@@ -868,12 +901,12 @@ class Phase2ResolutionService:
 
         try:
             # Get prior year bunkmates
-            prior_data = self.attendee_repository.find_prior_year_bunkmates(requester_cm_id, session_cm_id, year)
+            prior_data = self.attendee_repository.find_prior_year_bunkmates(requester_cm_id, year)
             if not prior_data or not prior_data.get("cm_ids"):
                 return None
 
             bunkmate_ids = prior_data["cm_ids"]
-            prior_bunk = prior_data.get("prior_bunk", "")
+            prior_bunk_by_cm_id = prior_data.get("prior_bunk_by_cm_id", {})
             normalized_target = normalize_name(target_name)
 
             # Check each bunkmate for name match
@@ -897,7 +930,7 @@ class Phase2ResolutionService:
                         method="prior_bunkmate_exact",
                         metadata={
                             "found_in_last_years_bunk": True,
-                            "last_year_bunk": prior_bunk,
+                            "last_year_bunk": prior_bunk_by_cm_id.get(bunkmate_id, ""),
                         },
                     )
 
@@ -915,7 +948,7 @@ class Phase2ResolutionService:
                             method="prior_bunkmate_first_name",
                             metadata={
                                 "found_in_last_years_bunk": True,
-                                "last_year_bunk": prior_bunk,
+                                "last_year_bunk": prior_bunk_by_cm_id.get(bunkmate_id, ""),
                             },
                         )
 

--- a/tests/unit/sync/bunk_request_processor/data/repositories/test_prior_year_bunkmates.py
+++ b/tests/unit/sync/bunk_request_processor/data/repositories/test_prior_year_bunkmates.py
@@ -4,7 +4,9 @@ Three defects are pinned here:
 
 1. the first query had no ``session_type`` predicate, so a Family Camp day
    group was eligible to be returned as a summer ``prior_bunk``;
-2. it had no sort, then took ``assignments[0]`` — an arbitrary pick;
+2. it had no sort, then took ``assignments[0]`` — an arbitrary pick (the
+   pick itself is gone in #2456; every eligible cabin is searched, and
+   ``test_prior_year_multi_cabin.py`` pins that);
 3. the second query filtered on ``bunk`` + ``year`` with no session, and a bunk
    is a building reused by successive sessions, so the returned "bunkmates"
    were largely children the requester never met.
@@ -64,7 +66,7 @@ class TestFindPriorYearBunkmatesSessionScope:
     def test_first_query_filters_session_type_and_sorts_deterministically(self, captured):
         repo = self._repo(captured, lambda _query_params: [])
 
-        repo.find_prior_year_bunkmates(requester_cm_id=1001, session_cm_id=123, year=2026)
+        repo.find_prior_year_bunkmates(requester_cm_id=1001, year=2026)
 
         assert len(captured) == 1
         filter_str = captured[0]["filter"]
@@ -85,7 +87,7 @@ class TestFindPriorYearBunkmatesSessionScope:
         repo = self._repo(captured, responder)
         repo.bulk_get_sessions_for_persons = Mock(return_value={2002: 4321})  # type: ignore[method-assign]
 
-        result = repo.find_prior_year_bunkmates(requester_cm_id=1001, session_cm_id=123, year=2026)
+        result = repo.find_prior_year_bunkmates(requester_cm_id=1001, year=2026)
 
         assert len(captured) == 2
         bunkmate_filter = captured[1]["filter"]
@@ -93,7 +95,7 @@ class TestFindPriorYearBunkmatesSessionScope:
         assert "year = 2025" in bunkmate_filter
         assert 'session = "sess_1"' in bunkmate_filter
 
-        assert result["prior_bunk"] == "Cabin 7"
+        assert result["prior_bunk_by_cm_id"] == {2002: "Cabin 7"}
         assert result["cm_ids"] == [2002]
         assert result["total_in_bunk"] == 1
         assert result["returning_count"] == 1
@@ -108,7 +110,7 @@ class TestFindPriorYearBunkmatesSessionScope:
 
         repo = self._repo(captured, lambda _query_params: [requester_row])
 
-        result = repo.find_prior_year_bunkmates(requester_cm_id=1001, session_cm_id=123, year=2026)
+        result = repo.find_prior_year_bunkmates(requester_cm_id=1001, year=2026)
 
         assert result == {}
         assert len(captured) == 1, "must not fall back to an unscoped bunkmate query"
@@ -130,7 +132,7 @@ class TestFindPriorYearBunkmatesSessionScope:
 
         repo = self._repo(captured, responder)
 
-        repo.find_prior_year_bunkmates(requester_cm_id=1001, session_cm_id=123, year=2026)
+        repo.find_prior_year_bunkmates(requester_cm_id=1001, year=2026)
 
         assert len(captured) == 2
         assert captured[1].get("sort") == "id"

--- a/tests/unit/sync/bunk_request_processor/data/repositories/test_prior_year_multi_cabin.py
+++ b/tests/unit/sync/bunk_request_processor/data/repositories/test_prior_year_multi_cabin.py
@@ -1,0 +1,273 @@
+"""``find_prior_year_bunkmates`` must search EVERY prior-year cabin (#2456).
+
+#2445 scoped the peer query to the requester's own ``(bunk, session)`` pair,
+which was right, and made this pre-existing limitation visible: the method
+queries all of the requester's eligible prior-year assignments and then keeps
+exactly one of them (``assignments[0]``). Every cabin but that one is
+unreachable, and ``sort: "id"`` only makes the pick *stable* — PocketBase
+record ids are random, so which cabin wins is arbitrary.
+
+A multi-session camper therefore has one of their three or four prior cabins
+searched, and the ``last_year_bunk`` metadata names whichever cabin won rather
+than the cabin the matched peer was actually in.
+"""
+
+import inspect
+import logging
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from bunking.sync.bunk_request_processor.data.repositories.attendee_repository import (
+    AttendeeRepository,
+)
+
+
+def _assignment(person_cm_id: int, bunk_id: str, bunk_name: str, session_id: str) -> Mock:
+    """Build a bunk_assignments record whose expand looks like PocketBase's."""
+    assignment = Mock(spec=["expand", "year"])
+    assignment.year = 2025
+    person = Mock(spec=["cm_id"])
+    person.cm_id = person_cm_id
+    bunk = Mock(spec=["id", "name"])
+    bunk.id = bunk_id
+    bunk.name = bunk_name
+    session = Mock(spec=["id"])
+    session.id = session_id
+    assignment.expand = {"person": person, "bunk": bunk, "session": session}
+    return assignment
+
+
+def _repo(
+    captured: list[dict[str, Any]],
+    responder: Callable[[dict[str, Any]], list[Any]],
+    returning: dict[int, Any] | None = None,
+) -> AttendeeRepository:
+    pb = Mock()
+    collection = Mock()
+
+    def _get_full_list(**kwargs):
+        query_params = kwargs.get("query_params", {})
+        captured.append(query_params)
+        return responder(query_params)
+
+    collection.get_full_list.side_effect = _get_full_list
+    pb.collection = Mock(return_value=collection)
+    repo = AttendeeRepository(pb)
+    repo.bulk_get_sessions_for_persons = Mock(  # type: ignore[method-assign]
+        return_value=returning if returning is not None else {}
+    )
+    return repo
+
+
+def _two_cabin_responder(
+    requester_rows: list[Mock], peers_by_bunk: dict[str, list[Mock]]
+) -> Callable[[dict[str, Any]], list[Mock]]:
+    """Answer the requester query, then each per-cabin peer query."""
+
+    def responder(query_params: dict[str, Any]) -> list[Mock]:
+        filter_str = query_params["filter"]
+        if "person.cm_id" in filter_str:
+            return requester_rows
+        for bunk_id, rows in peers_by_bunk.items():
+            if f'bunk = "{bunk_id}"' in filter_str:
+                return rows
+        return []
+
+    return responder
+
+
+class TestEveryPriorCabinIsSearched:
+    @pytest.fixture
+    def captured(self) -> list[dict[str, Any]]:
+        return []
+
+    def test_peers_from_all_prior_cabins_are_returned(self, captured):
+        """One cabin searched is the defect; the union is the fix."""
+        requester_rows = [
+            _assignment(1001, "bunk_A", "Cabin 7", "sess_1"),
+            _assignment(1001, "bunk_B", "Cabin 3", "sess_2"),
+        ]
+        peers = {
+            "bunk_A": [
+                _assignment(1001, "bunk_A", "Cabin 7", "sess_1"),
+                _assignment(2002, "bunk_A", "Cabin 7", "sess_1"),
+            ],
+            "bunk_B": [
+                _assignment(1001, "bunk_B", "Cabin 3", "sess_2"),
+                _assignment(3003, "bunk_B", "Cabin 3", "sess_2"),
+            ],
+        }
+        repo = _repo(captured, _two_cabin_responder(requester_rows, peers), returning={2002: 1, 3003: 1})
+
+        result = repo.find_prior_year_bunkmates(requester_cm_id=1001, year=2026)
+
+        assert result["cm_ids"] == [2002, 3003]
+        assert result["total_in_bunk"] == 2
+        assert result["returning_count"] == 2
+
+    def test_each_cabin_gets_its_own_session_scoped_query(self, captured):
+        """#2445's scoping is per cabin, not abandoned — one query per pair."""
+        requester_rows = [
+            _assignment(1001, "bunk_A", "Cabin 7", "sess_1"),
+            _assignment(1001, "bunk_B", "Cabin 3", "sess_2"),
+        ]
+        peers = {
+            "bunk_A": [_assignment(2002, "bunk_A", "Cabin 7", "sess_1")],
+            "bunk_B": [_assignment(3003, "bunk_B", "Cabin 3", "sess_2")],
+        }
+        repo = _repo(captured, _two_cabin_responder(requester_rows, peers), returning={2002: 1, 3003: 1})
+
+        repo.find_prior_year_bunkmates(requester_cm_id=1001, year=2026)
+
+        peer_filters = [q["filter"] for q in captured[1:]]
+        assert len(peer_filters) == 2
+        assert any('bunk = "bunk_A"' in f and 'session = "sess_1"' in f for f in peer_filters)
+        assert any('bunk = "bunk_B"' in f and 'session = "sess_2"' in f for f in peer_filters)
+        assert all("year = 2025" in f for f in peer_filters)
+        assert all(q.get("sort") == "id" for q in captured[1:])
+
+    def test_the_same_building_in_two_sessions_is_two_cabins(self, captured):
+        """A bunk is a building. Same bunk, different session = different children."""
+        requester_rows = [
+            _assignment(1001, "bunk_A", "Cabin 7", "sess_1"),
+            _assignment(1001, "bunk_A", "Cabin 7", "sess_2"),
+        ]
+
+        def responder(query_params):
+            if "person.cm_id" in query_params["filter"]:
+                return requester_rows
+            if 'session = "sess_1"' in query_params["filter"]:
+                return [_assignment(2002, "bunk_A", "Cabin 7", "sess_1")]
+            return [_assignment(3003, "bunk_A", "Cabin 7", "sess_2")]
+
+        repo = _repo(captured, responder, returning={2002: 1, 3003: 1})
+
+        result = repo.find_prior_year_bunkmates(requester_cm_id=1001, year=2026)
+
+        assert result["cm_ids"] == [2002, 3003]
+
+    def test_a_peer_shared_by_two_cabins_appears_once(self, captured):
+        requester_rows = [
+            _assignment(1001, "bunk_A", "Cabin 7", "sess_1"),
+            _assignment(1001, "bunk_B", "Cabin 3", "sess_2"),
+        ]
+        peers = {
+            "bunk_A": [_assignment(2002, "bunk_A", "Cabin 7", "sess_1")],
+            "bunk_B": [_assignment(2002, "bunk_B", "Cabin 3", "sess_2")],
+        }
+        repo = _repo(captured, _two_cabin_responder(requester_rows, peers), returning={2002: 1})
+
+        result = repo.find_prior_year_bunkmates(requester_cm_id=1001, year=2026)
+
+        assert result["cm_ids"] == [2002]
+        assert result["total_in_bunk"] == 1
+
+    def test_a_cabin_with_no_session_is_skipped_not_fatal(self, captured):
+        """An unscopable row must not cost the requester their other cabins.
+
+        Returning the whole building was #2445's defect; dropping the lookup
+        entirely because one row lacks a session is a different way to lose it.
+        """
+        unscopable = _assignment(1001, "bunk_A", "Cabin 7", "sess_1")
+        unscopable.expand = {
+            "person": unscopable.expand["person"],
+            "bunk": unscopable.expand["bunk"],
+        }
+        requester_rows = [unscopable, _assignment(1001, "bunk_B", "Cabin 3", "sess_2")]
+        peers = {"bunk_B": [_assignment(3003, "bunk_B", "Cabin 3", "sess_2")]}
+        repo = _repo(captured, _two_cabin_responder(requester_rows, peers), returning={3003: 1})
+
+        result = repo.find_prior_year_bunkmates(requester_cm_id=1001, year=2026)
+
+        assert result["cm_ids"] == [3003]
+        peer_filters = [q["filter"] for q in captured[1:]]
+        assert len(peer_filters) == 1, "the unscopable cabin must not be queried"
+        assert 'bunk = "bunk_B"' in peer_filters[0]
+
+
+class TestMatchedPeerCarriesItsOwnCabin:
+    @pytest.fixture
+    def captured(self) -> list[dict[str, Any]]:
+        return []
+
+    def test_each_peer_maps_to_the_cabin_they_actually_shared(self, captured):
+        """``last_year_bunk`` named whichever cabin won the pick, for every peer."""
+        requester_rows = [
+            _assignment(1001, "bunk_A", "Cabin 7", "sess_1"),
+            _assignment(1001, "bunk_B", "Cabin 3", "sess_2"),
+        ]
+        peers = {
+            "bunk_A": [_assignment(2002, "bunk_A", "Cabin 7", "sess_1")],
+            "bunk_B": [_assignment(3003, "bunk_B", "Cabin 3", "sess_2")],
+        }
+        repo = _repo(captured, _two_cabin_responder(requester_rows, peers), returning={2002: 1, 3003: 1})
+
+        result = repo.find_prior_year_bunkmates(requester_cm_id=1001, year=2026)
+
+        assert result["prior_bunk_by_cm_id"] == {2002: "Cabin 7", 3003: "Cabin 3"}
+        assert set(result["prior_bunk_by_cm_id"]) == set(result["cm_ids"])
+
+    def test_prior_bunks_lists_every_cabin_searched(self, captured):
+        requester_rows = [
+            _assignment(1001, "bunk_A", "Cabin 7", "sess_1"),
+            _assignment(1001, "bunk_B", "Cabin 3", "sess_2"),
+        ]
+        peers = {"bunk_A": [_assignment(2002, "bunk_A", "Cabin 7", "sess_1")]}
+        repo = _repo(captured, _two_cabin_responder(requester_rows, peers), returning={2002: 1})
+
+        result = repo.find_prior_year_bunkmates(requester_cm_id=1001, year=2026)
+
+        assert result["prior_bunks"] == ["Cabin 7", "Cabin 3"]
+
+    def test_no_single_top_level_prior_bunk_is_returned(self, captured):
+        """A singular key would still name an arbitrary cabin for every peer."""
+        requester_rows = [
+            _assignment(1001, "bunk_A", "Cabin 7", "sess_1"),
+            _assignment(1001, "bunk_B", "Cabin 3", "sess_2"),
+        ]
+        peers = {"bunk_A": [_assignment(2002, "bunk_A", "Cabin 7", "sess_1")]}
+        repo = _repo(captured, _two_cabin_responder(requester_rows, peers), returning={2002: 1})
+
+        result = repo.find_prior_year_bunkmates(requester_cm_id=1001, year=2026)
+
+        assert "prior_bunk" not in result
+
+
+class TestUnusedSessionParameterIsGone:
+    def test_signature_does_not_take_session_cm_id(self):
+        """It was documented as narrowing the pool and never read.
+
+        That it does not narrow is deliberate — a camper in a late session this
+        year must still reach friends from an early session last year — so the
+        parameter goes rather than the behaviour.
+        """
+        params = inspect.signature(AttendeeRepository.find_prior_year_bunkmates).parameters
+
+        assert "session_cm_id" not in params
+        assert list(params) == ["self", "requester_cm_id", "year"]
+
+
+class TestSkippedSeasonIsDiagnosable:
+    @pytest.fixture
+    def captured(self) -> list[dict[str, Any]]:
+        return []
+
+    def test_no_prior_year_assignment_logs_a_debug_line(self, captured, caplog):
+        """The path only ever looks at ``year - 1`` (#2457).
+
+        A camper who skipped a season resolves nothing here by construction, and
+        a bare ``return {}`` makes that indistinguishable from a bug in a sync
+        log.
+        """
+        repo = _repo(captured, lambda _query_params: [])
+
+        with caplog.at_level(logging.DEBUG):
+            result = repo.find_prior_year_bunkmates(requester_cm_id=1001, year=2026)
+
+        assert result == {}
+        assert any("1001" in record.getMessage() and "2025" in record.getMessage() for record in caplog.records), (
+            f"expected a debug line naming the requester and the year searched; got {[r.getMessage() for r in caplog.records]}"
+        )

--- a/tests/unit/sync/bunk_request_processor/services/test_context_builder.py
+++ b/tests/unit/sync/bunk_request_processor/services/test_context_builder.py
@@ -1151,7 +1151,8 @@ class TestNeedsHistoricalContextFetchesPriorBunkmates:
         mock_attendee_repo = Mock()
         mock_attendee_repo.find_prior_year_bunkmates.return_value = {
             "cm_ids": [100, 101, 102],
-            "prior_bunk": "B-7",
+            "prior_bunk_by_cm_id": {100: "B-7", 101: "B-7", 102: "B-4"},
+            "prior_bunks": ["B-7", "B-4"],
             "prior_year": 2024,
             "total_in_bunk": 5,
             "returning_count": 3,
@@ -1175,9 +1176,10 @@ class TestNeedsHistoricalContextFetchesPriorBunkmates:
         )
 
         # Must call find_prior_year_bunkmates
+        # No session is passed: the current session deliberately does not narrow
+        # the prior-year pool, and the parameter that implied it did is gone (#2456).
         mock_attendee_repo.find_prior_year_bunkmates.assert_called_once_with(
             11111,  # requester_cm_id
-            1000002,  # session_cm_id
             2025,  # year
         )
 
@@ -1186,12 +1188,13 @@ class TestNeedsHistoricalContextFetchesPriorBunkmates:
 
         The context should have:
         - previous_year: int (year - 1)
-        - previous_year_bunkmates: dict with cm_ids, prior_bunk, etc.
+        - previous_year_bunkmates: dict with cm_ids, prior_bunk_by_cm_id, etc.
         """
         mock_attendee_repo = Mock()
         mock_attendee_repo.find_prior_year_bunkmates.return_value = {
             "cm_ids": [100, 101, 102],
-            "prior_bunk": "B-7",
+            "prior_bunk_by_cm_id": {100: "B-7", 101: "B-7", 102: "B-4"},
+            "prior_bunks": ["B-7", "B-4"],
             "prior_year": 2024,
             "total_in_bunk": 5,
             "returning_count": 3,
@@ -1219,7 +1222,7 @@ class TestNeedsHistoricalContextFetchesPriorBunkmates:
         prior_data = context.additional_context.get("previous_year_bunkmates")
         assert prior_data is not None
         assert prior_data["cm_ids"] == [100, 101, 102]
-        assert prior_data["prior_bunk"] == "B-7"
+        assert prior_data["prior_bunk_by_cm_id"][100] == "B-7"
         assert prior_data["returning_count"] == 3
 
     def test_needs_historical_false_does_not_call_find_prior_year_bunkmates(self):

--- a/tests/unit/sync/bunk_request_processor/services/test_last_year_context_gate.py
+++ b/tests/unit/sync/bunk_request_processor/services/test_last_year_context_gate.py
@@ -1,0 +1,112 @@
+"""Tests for the temporal gate that admits a request to the prior-year bunkmate path (#2457).
+
+``Phase2ResolutionService._has_last_year_context`` is the ONLY gate on
+``_try_prior_bunkmate_resolution`` — the highest-confidence resolution the
+pipeline has (0.95 full name / 0.90 first name). It tested one string,
+``"last year"``, so a parent writing "last summer" never reached it.
+
+Two things are pinned here:
+
+1. the gate admits the common phrasings, not just ``last year``;
+2. the keyword branch and the raw-text branch test the SAME patterns. They
+   disagreed: the keyword list carried ``from before`` and the raw-text
+   fallback did not, so the same phrase was admitted or refused depending on
+   which branch saw it.
+
+The raw-text branch is the live one. ``keywords_found`` reaches
+``ParsedRequest.metadata`` from a single producer whose schema asks the model
+for *priority* keywords, never temporal markers, so the keyword branch has
+never fired in production — a test that only exercised it would pass against a
+gate that still drops every real request.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from bunking.sync.bunk_request_processor.core.models import ParsedRequest, RequestType
+from bunking.sync.bunk_request_processor.services.phase2_resolution_service import (
+    LAST_YEAR_CONTEXT_PATTERNS,
+    Phase2ResolutionService,
+)
+
+WIDENED_PHRASINGS = [
+    "last year",
+    "last summer",
+    "previous year",
+    "previous summer",
+    "last yr",
+]
+
+
+def _service() -> Phase2ResolutionService:
+    return Phase2ResolutionService(resolution_pipeline=Mock())
+
+
+def _parsed(raw_text: str, keywords: list[str] | None = None) -> ParsedRequest:
+    metadata: dict[str, object] = {}
+    if keywords is not None:
+        metadata["keywords_found"] = keywords
+    return ParsedRequest(
+        raw_text=raw_text,
+        request_type=RequestType.BUNK_WITH,
+        target_name="Emma",
+        age_preference=None,
+        source_field="bunk_request_form",
+        confidence=0.8,
+        csv_position=1,
+        metadata=metadata,
+    )
+
+
+class TestRawTextBranchIsWidened:
+    """The live branch. A gate widened only in the keyword list is a no-op."""
+
+    @pytest.mark.parametrize("phrasing", WIDENED_PHRASINGS)
+    def test_phrasing_in_raw_text_admits_the_request(self, phrasing):
+        parsed = _parsed(f"Please put her with Emma from {phrasing}")
+
+        assert _service()._has_last_year_context(parsed) is True
+
+    @pytest.mark.parametrize("phrasing", WIDENED_PHRASINGS)
+    def test_phrasing_is_matched_case_insensitively(self, phrasing):
+        parsed = _parsed(f"Bunk with Emma from {phrasing.upper()}")
+
+        assert _service()._has_last_year_context(parsed) is True
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Bunk with Emma",
+            "She was in cabin 7 before",  # bare "before" must NOT admit
+            "Bunk with Emma, she was here in 2024",  # a bare year must NOT admit
+            "Emma had a great 2025",
+        ],
+    )
+    def test_text_without_a_temporal_marker_is_not_admitted(self, text):
+        """Over-widening is as much a defect as under-widening.
+
+        Bare ``before`` and a bare year number appear in unrelated contexts, and
+        the resolver only ever looks at ``year - 1`` anyway.
+        """
+        assert _service()._has_last_year_context(_parsed(text)) is False
+
+
+class TestBothBranchesTestTheSamePatterns:
+    """The two branches must not disagree about what counts as temporal context."""
+
+    @pytest.mark.parametrize("pattern", LAST_YEAR_CONTEXT_PATTERNS)
+    def test_pattern_admits_from_raw_text_alone(self, pattern):
+        assert _service()._has_last_year_context(_parsed(f"bunk with Emma {pattern}")) is True
+
+    @pytest.mark.parametrize("pattern", LAST_YEAR_CONTEXT_PATTERNS)
+    def test_pattern_admits_from_keywords_alone(self, pattern):
+        parsed = _parsed("bunk with Emma", keywords=[pattern])
+
+        assert _service()._has_last_year_context(parsed) is True
+
+    def test_from_before_is_carried_by_both_branches(self):
+        """The asymmetry that existed: keywords admitted it, raw text did not."""
+        assert "from before" in LAST_YEAR_CONTEXT_PATTERNS
+        assert _service()._has_last_year_context(_parsed("bunk with Emma from before")) is True
+        assert _service()._has_last_year_context(_parsed("bunk with Emma", keywords=["from before"])) is True

--- a/tests/unit/sync/bunk_request_processor/services/test_prior_bunkmate_metadata.py
+++ b/tests/unit/sync/bunk_request_processor/services/test_prior_bunkmate_metadata.py
@@ -1,0 +1,98 @@
+"""``last_year_bunk`` must name the cabin the MATCHED peer was in (#2456).
+
+``_try_prior_bunkmate_resolution`` read a single top-level ``prior_bunk`` off
+the repository result and stamped it on every match. Once all of the
+requester's prior cabins are searched, that key names an arbitrary one of them,
+so a peer from Cabin 3 was reported as having been in Cabin 7. The metadata is
+the evidence a staff reviewer reads, so it has to be the peer's own cabin.
+"""
+
+import inspect
+from unittest.mock import Mock
+
+import pytest
+
+from bunking.sync.bunk_request_processor.core.models import Person
+from bunking.sync.bunk_request_processor.services.phase2_resolution_service import (
+    Phase2ResolutionService,
+)
+
+
+def _person(cm_id: int, first_name: str, last_name: str) -> Person:
+    return Person(cm_id=cm_id, first_name=first_name, last_name=last_name, grade=5)
+
+
+PEERS = {
+    2002: _person(2002, "Emma", "Johnson"),
+    3003: _person(3003, "Liam", "Garcia"),
+}
+
+
+@pytest.fixture
+def service() -> Phase2ResolutionService:
+    attendee_repository = Mock()
+    attendee_repository.find_prior_year_bunkmates.return_value = {
+        "cm_ids": [2002, 3003],
+        "prior_bunk_by_cm_id": {2002: "Cabin 7", 3003: "Cabin 3"},
+        "prior_bunks": ["Cabin 7", "Cabin 3"],
+        "prior_year": 2025,
+        "total_in_bunk": 2,
+        "returning_count": 2,
+    }
+    person_repository = Mock()
+    person_repository.find_by_cm_id.side_effect = PEERS.get
+    return Phase2ResolutionService(
+        resolution_pipeline=Mock(),
+        attendee_repository=attendee_repository,
+        person_repository=person_repository,
+    )
+
+
+class TestMatchedPeerCabinInMetadata:
+    def test_full_name_match_reports_the_peers_own_cabin(self, service):
+        result = service._try_prior_bunkmate_resolution(
+            target_name="Liam Garcia",
+            requester_cm_id=1001,
+            year=2026,
+        )
+
+        assert result is not None
+        assert result.confidence == 0.95
+        assert result.method == "prior_bunkmate_exact"
+        assert result.metadata["last_year_bunk"] == "Cabin 3"
+
+    def test_first_name_match_reports_the_peers_own_cabin(self, service):
+        result = service._try_prior_bunkmate_resolution(
+            target_name="Liam",
+            requester_cm_id=1001,
+            year=2026,
+        )
+
+        assert result is not None
+        assert result.confidence == 0.90
+        assert result.method == "prior_bunkmate_first_name"
+        assert result.metadata["last_year_bunk"] == "Cabin 3"
+
+    def test_the_first_cabins_peer_still_reports_its_own_cabin(self, service):
+        result = service._try_prior_bunkmate_resolution(
+            target_name="Emma Johnson",
+            requester_cm_id=1001,
+            year=2026,
+        )
+
+        assert result is not None
+        assert result.metadata["last_year_bunk"] == "Cabin 7"
+
+
+class TestUnusedSessionParameterIsGone:
+    def test_signature_does_not_take_session_cm_id(self):
+        """It existed only to pass to a repository call that ignored it."""
+        params = inspect.signature(Phase2ResolutionService._try_prior_bunkmate_resolution).parameters
+
+        assert "session_cm_id" not in params
+        assert list(params) == ["self", "target_name", "requester_cm_id", "year"]
+
+    def test_repository_is_called_without_a_session(self, service):
+        service._try_prior_bunkmate_resolution(target_name="Emma Johnson", requester_cm_id=1001, year=2026)
+
+        service.attendee_repository.find_prior_year_bunkmates.assert_called_once_with(1001, 2026)

--- a/tests/unit/sync/bunk_request_processor/test_historical_bunking_verification.py
+++ b/tests/unit/sync/bunk_request_processor/test_historical_bunking_verification.py
@@ -160,7 +160,7 @@ class TestWasBunkmateFlag:
         mock_pb.collection = Mock(return_value=mock_collection)
 
         # Call the method
-        result = attendee_repo.find_prior_year_bunkmates(requester_cm_id=1001, session_cm_id=123, year=2025)
+        result = attendee_repo.find_prior_year_bunkmates(requester_cm_id=1001, year=2025)
 
         # Verify was_bunkmate flag is set
         assert result is not None


### PR DESCRIPTION
The prior-year bunkmate path is the highest-confidence resolution the request
pipeline has — 0.95 for a full-name match, 0.90 for a first name, both above the
0.85 `resolved` threshold, so it feeds the solver directly as a constraint. Two
independent defects kept requests away from it. They land together because both
edit `services/phase2_resolution_service.py`.

## The gate admitted one phrasing (#2457)

`_has_last_year_context` is the only gate on `_try_prior_bunkmate_resolution`. It
had two branches, and the live one tested the single string `"last year"`.
"Last summer" — arguably the more natural way for a parent to write it — was
never offered the cabin evidence at all. Measured on the production snapshot: 12
requests say last summer / last yr but not last year, none of them carry a
`prior_bunkmate_*` method, and 3 landed below the `resolved` threshold. Adding
`previous year` brings the yield to 16.

The obvious edit would have been a no-op. `keyword_patterns` — the first branch,
and the one that reads like the place to widen — has never fired in production:
`keywords_found` reaches `ParsedRequest.metadata` from a single producer whose
schema asks the model for *priority* keywords, never temporal markers. 639 rows
carry a non-empty `keywords_found` and 0 contain any of the three gate patterns.
Every prior-bunkmate resolution ever made was admitted by the raw-text fallback.

Both branches now test one module-level `LAST_YEAR_CONTEXT_PATTERNS`. That also
closes an asymmetry that was real in the code: the keyword list carried
`from before` and the raw-text branch did not, so the same phrase was admitted or
refused depending only on which branch saw it. Deliberately excluded are bare
`before` and bare year numbers — `2024`/`2025` appear in unrelated contexts, and
the resolver only ever searches `year - 1` anyway.

## Only one of a camper's prior cabins was searched (#2456)

`find_prior_year_bunkmates` queried every eligible prior-year assignment and then
kept `assignments[0]`. The bunk, the session and therefore the whole peer pool
came from that one row. 66 of the 1,257 campers with a 2025 assignment held two
or more — in *different* cabins every time, and typically three or four of them —
so for all 66 a real cabin of friends was unreachable. #2445's `sort: "id"` made
that pick stable, not right: PocketBase record ids are random, so which cabin won
was arbitrary and never changed.

Every distinct `(bunk, session)` pair is now searched and the peer sets unioned,
each still scoped to its own pair as #2445 established — a bunk is a building,
and 42 of the 57 bunks carrying a 2025 assignment served more than one session.
94.7% of requesters have exactly one pair, so this is normally the same single
query it always was. A row that cannot be scoped to a session now skips that one
cabin instead of abandoning the lookup, so one bad row no longer costs a camper
their other cabins.

`last_year_bunk` follows from that. It was a single top-level `prior_bunk`
stamped onto every match, which with several cabins in play could only name an
arbitrary one of them — and that string is the evidence a staff reviewer reads.
The repository now returns `prior_bunk_by_cm_id`, and each match reports the
cabin that peer actually shared with the requester. There is no top-level
`prior_bunk` any more, because any such key would be a lie by construction.

## `session_cm_id` is gone

It was documented as *"used for checking returning"* and never read in the
function body. That it does not narrow the pool is correct and deliberate — a
camper in Session 4 this year must still be able to request a friend from
Session 1 last year — so the parameter goes rather than the behaviour. All three
callers updated (`phase2_resolution_service.py`, `context_builder.py` twice), plus
`_try_prior_bunkmate_resolution`, which carried it only to pass it along.

## A skipped season is now diagnosable

The path only ever looks at `year - 1`. A camper who sat out a season resolves
nothing here by construction, and a bare `return {}` made that indistinguishable
from a bug in a sync log. It now logs a debug line naming the requester and the
year searched. The year range is unchanged.

## Deliberately not done

The same one-per-key collapse exists in `data/cache/temporal_name_cache.py`:
`_load_historical_bunking` keeps one record per `(person, year)`, so
`verify_bunk_together` also knows only one cabin per person per year. Fixing it
means changing `_historical_bunking`'s value from a record to a collection, which
changes the public `get_historical_info` return type, and turns
`verify_bunk_together` from a comparison into a cross-product intersection over
requester and target cabin sets. That is a materially bigger change with its own
measurement question, so it is left for a separate pass rather than widened into
this one silently.

## Tests

Written failing first, and mutation-checked afterwards — reverting the raw-text
gate to `"last year"`, restricting the cabin loop to the first pair, and stamping
an arbitrary cabin on every match each turn the new assertions red.

- `test_last_year_context_gate.py` — both branches admit every widened phrasing,
  neither admits bare `before` or a bare year.
- `test_prior_year_multi_cabin.py` — the peer union, one session-scoped query per
  cabin, same building in two sessions counted as two cabins, a peer shared by two
  cabins listed once, an unscopable row skipped rather than fatal, and the debug
  line for a skipped season.
- `test_prior_bunkmate_metadata.py` — `last_year_bunk` names the matched peer's
  own cabin at both confidence levels.

Four existing tests changed to match the new contract, all of it spec the issues
asked for: the dropped `session_cm_id` at three call sites, and
`prior_bunk` → `prior_bunk_by_cm_id`.

Closes #2456.
Closes #2457.
