### PR TITLE
fix(api): the solver refuses a scenario-less run instead of writing production

### DIFF
--- a/api/routers/solver.py
+++ b/api/routers/solver.py
@@ -33,6 +33,7 @@ from bunking.solver.impossibility import filter_immaterial_requests, validate_im
 
 from ..constants.collections import (
     ATTENDEES,
+    BUNK_ASSIGNMENTS_DRAFT,
     BUNKS,
     CAMP_SESSIONS,
     SOLVER_RUNS,
@@ -74,6 +75,31 @@ def _resolve_time_limit(value: int | None, default: int = 60) -> int:
     return value if value is not None else default
 
 
+_SCENARIO_REQUIRED_DETAIL = (
+    "A scenario is required: solver output applies to a scenario's draft assignments. "
+    "Production bunk assignments are read-only for the solver."
+)
+
+
+def _require_scenario(scenario: str | None) -> str:
+    """Return *scenario*, or refuse with 422 when it is missing or blank.
+
+    The solver cannot write production. It applies to a scenario's
+    ``bunk_assignments_draft`` rows and nowhere else — production bunk
+    assignments are read-only for both the solver and drag/drop. A scenario-less
+    run therefore has nowhere legal to land, so it is refused rather than
+    repaired (kindred#2467: the old production branch built a payload the
+    collection rejected, logged the failure per camper and still returned 200).
+
+    Same rule the lodging side already encodes on ``PlacementWriteBase.scenario``
+    (``frontend/src/services/lodgingApi.ts``): *"REQUIRED and non-empty. A blank
+    scenario is a 422, never a write to the live plan."*
+    """
+    if scenario is None or not scenario.strip():
+        raise HTTPException(status_code=422, detail=_SCENARIO_REQUIRED_DETAIL)
+    return scenario
+
+
 # ========================================
 # Solver Run Endpoints
 # ========================================
@@ -86,6 +112,10 @@ async def run_solver(
     user: AuthUser = Depends(require_permission(Permission.BUNKING_MANAGE)),
 ) -> SolverResponse:
     """Run the bunking solver for a session."""
+    # Refuse before anything else: a run with no scenario can only ever be
+    # applied to production, which is read-only for the solver.
+    _require_scenario(request.scenario)
+
     # Single-flight guard: reject duplicate in-progress runs for the same session.
     # FastAPI serializes coroutines on the event loop and solver_runs is in-process,
     # so no locking is needed beyond a plain dict scan.
@@ -571,9 +601,9 @@ async def analyze_solver_run(
 async def apply_solver_results(
     run_id: str, user: AuthUser = Depends(require_permission(Permission.BUNKING_MANAGE))
 ) -> dict[str, str]:
-    """Apply the results of a solver run to the database."""
+    """Apply the results of a solver run to its scenario's draft assignments."""
     session_cm_id = None
-    scenario = None
+    scenario: str | None = None
 
     results: dict[str, Any] = {}
     if run_id not in solver_runs:
@@ -598,6 +628,10 @@ async def apply_solver_results(
         session_cm_id = run_data.get("session_cm_id")
         scenario = run_data.get("scenario")
 
+    # Refuse before touching PocketBase. A run with no scenario has nowhere
+    # legal to land — the solver does not write production.
+    scenario = _require_scenario(scenario)
+
     assignments = results["assignments"]
 
     # Get year from run config, fall back to results or current year
@@ -621,6 +655,8 @@ async def apply_solver_results(
     ctx = await build_session_context(int(session_cm_id), run_year, pb)
     session_filter = ctx.session_relation_filter
 
+    write_failures: list[str] = []
+
     for person_cm_id_str, bunk_name in assignments.items():
         try:
             person_cm_id = int(person_cm_id_str)
@@ -640,112 +676,60 @@ async def apply_solver_results(
                 logger.warning(f"Bunk {bunk_name} has no cm_id")
                 continue
 
-            if scenario:
-                collection_name = "bunk_assignments_draft"
-                person_pb_id = await cache.get_person_pb_id(person_cm_id)
-                if not person_pb_id:
-                    logger.warning(f"Person with cm_id {person_cm_id} not found")
-                    continue
+            collection_name = BUNK_ASSIGNMENTS_DRAFT
+            person_pb_id = await cache.get_person_pb_id(person_cm_id)
+            if not person_pb_id:
+                logger.warning(f"Person with cm_id {person_cm_id} not found")
+                continue
 
-                existing = await asyncio.to_thread(
-                    pb.collection(collection_name).get_full_list,
-                    query_params={
-                        "filter": (f'person = "{person_pb_id}" && scenario = "{scenario}" && year = {run_year}')
-                    },
+            existing = await asyncio.to_thread(
+                pb.collection(collection_name).get_full_list,
+                query_params={"filter": (f'person = "{person_pb_id}" && scenario = "{scenario}" && year = {run_year}')},
+            )
+
+            # Use session_filter to get correct attendee for multi-enrolled campers
+            attendees = await asyncio.to_thread(
+                pb.collection(ATTENDEES).get_full_list,
+                query_params={
+                    "filter": f'person_id = {person_cm_id} && year = {run_year} && status = "enrolled" && ({session_filter})',
+                    "expand": "session",
+                },
+            )
+
+            if not attendees:
+                logger.warning(
+                    f"No attendee record found for person CM ID {person_cm_id} in session(s) {ctx.related_session_ids}"
                 )
+                continue
 
-                # Use session_filter to get correct attendee for multi-enrolled campers
-                attendees = await asyncio.to_thread(
-                    pb.collection(ATTENDEES).get_full_list,
-                    query_params={
-                        "filter": f'person_id = {person_cm_id} && year = {run_year} && status = "enrolled" && ({session_filter})',
-                        "expand": "session",
-                    },
+            session_data = get_session_from_expand(attendees[0])
+            actual_session_cm_id_val = session_data.cm_id if session_data and hasattr(session_data, "cm_id") else None
+            if not actual_session_cm_id_val:
+                logger.warning(f"No session cm_id found for attendee of person CM ID {person_cm_id}")
+                continue
+            actual_session_cm_id = int(actual_session_cm_id_val)
+
+            # Use cache to resolve all PB IDs (cache handles the lookups properly)
+            bunk_pb_id = await cache.get_bunk_pb_id(int(bunk_cm_id))
+            session_pb_id = await cache.get_session_pb_id(actual_session_cm_id)
+            bunk_plan_pb_id = await cache.get_bunk_plan_id(int(bunk_cm_id), actual_session_cm_id, run_year)
+
+            if not all([bunk_pb_id, session_pb_id, bunk_plan_pb_id]):
+                logger.warning(
+                    f"Failed to resolve PB IDs for person {person_cm_id}: "
+                    f"bunk={bunk_pb_id}, session={session_pb_id}, bunk_plan={bunk_plan_pb_id}"
                 )
+                continue
 
-                if not attendees:
-                    logger.warning(
-                        f"No attendee record found for person CM ID {person_cm_id} in session(s) {ctx.related_session_ids}"
-                    )
-                    continue
-
-                session_data = get_session_from_expand(attendees[0])
-                actual_session_cm_id_val = (
-                    session_data.cm_id if session_data and hasattr(session_data, "cm_id") else None
-                )
-                if not actual_session_cm_id_val:
-                    logger.warning(f"No session cm_id found for attendee of person CM ID {person_cm_id}")
-                    continue
-                actual_session_cm_id = int(actual_session_cm_id_val)
-
-                # Use cache to resolve all PB IDs (cache handles the lookups properly)
-                bunk_pb_id = await cache.get_bunk_pb_id(int(bunk_cm_id))
-                session_pb_id = await cache.get_session_pb_id(actual_session_cm_id)
-                bunk_plan_pb_id = await cache.get_bunk_plan_id(int(bunk_cm_id), actual_session_cm_id, run_year)
-
-                if not all([bunk_pb_id, session_pb_id, bunk_plan_pb_id]):
-                    logger.warning(
-                        f"Failed to resolve PB IDs for person {person_cm_id}: "
-                        f"bunk={bunk_pb_id}, session={session_pb_id}, bunk_plan={bunk_plan_pb_id}"
-                    )
-                    continue
-
-                assignment_data = {
-                    "scenario": scenario,
-                    "person": person_pb_id,
-                    "session": session_pb_id,
-                    "bunk": bunk_pb_id,
-                    "bunk_plan": bunk_plan_pb_id,
-                    "year": run_year,
-                    "assignment_locked": False,
-                }
-            else:
-                collection_name = "bunk_assignments"
-
-                # Use session_filter to get correct attendee for multi-enrolled campers
-                attendees = await asyncio.to_thread(
-                    pb.collection(ATTENDEES).get_full_list,
-                    query_params={
-                        "filter": f'person_id = {person_cm_id} && year = {run_year} && status = "enrolled" && ({session_filter})',
-                        "expand": "session",
-                    },
-                )
-
-                if not attendees:
-                    logger.warning(
-                        f"No attendee record found for person CM ID {person_cm_id} in session(s) {ctx.related_session_ids}"
-                    )
-                    continue
-
-                session_data = get_session_from_expand(attendees[0])
-                actual_session_cm_id_raw = (
-                    session_data.cm_id if session_data and hasattr(session_data, "cm_id") else None
-                )
-                if not actual_session_cm_id_raw:
-                    logger.warning(f"No session cm_id found for attendee of person CM ID {person_cm_id}")
-                    continue
-                actual_session_cm_id = int(actual_session_cm_id_raw)
-
-                existing = await asyncio.to_thread(
-                    pb.collection(collection_name).get_full_list,
-                    query_params={
-                        "filter": (
-                            f"person.cm_id = {person_cm_id} && "
-                            f"session.cm_id = {actual_session_cm_id} && "
-                            f"year = {run_year}"
-                        ),
-                        "expand": "person,session,bunk",
-                    },
-                )
-
-                assignment_data = {
-                    "person_cm_id": person_cm_id,
-                    "session_cm_id": actual_session_cm_id,
-                    "bunk_cm_id": bunk_cm_id,
-                    "year": run_year,
-                    "assigned_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
-                    "assigned_by": "solver",
-                }
+            assignment_data = {
+                "scenario": scenario,
+                "person": person_pb_id,
+                "session": session_pb_id,
+                "bunk": bunk_pb_id,
+                "bunk_plan": bunk_plan_pb_id,
+                "year": run_year,
+                "assignment_locked": False,
+            }
 
             if existing:
                 existing_record = existing[0]
@@ -755,10 +739,15 @@ async def apply_solver_results(
             else:
                 await asyncio.to_thread(pb.collection(collection_name).create, assignment_data)
 
-        except Exception as e:
-            logger.error(f"Failed to update person {person_cm_id_str}: {e}")
+        except (ClientResponseError, ValueError) as e:
+            # Narrowed on purpose (kindred#2467). A bare `except Exception` here
+            # swallowed every failed write while the endpoint still returned 200,
+            # which is how a branch that could never write went unnoticed. Per-camper
+            # resilience is kept — one bad row must not abandon the rest — but the
+            # failures are counted and the response says so below.
+            logger.error(f"Failed to apply assignment for person {person_cm_id_str}: {e}")
+            write_failures.append(person_cm_id_str)
 
-    table_name = "bunk_assignments_draft" if scenario else "bunk_assignments"
     assignments_dict: dict[str, Any] = assignments if isinstance(assignments, dict) else {}
 
     # Drop the matching graph cache slot so the next /social-graph request
@@ -766,12 +755,19 @@ async def apply_solver_results(
     # the previous draft's bunk_cm_id node attrs for up to TTL (15 min) — the
     # symptom is "everyone in a big lump" because bubble grouping no longer
     # matches the active scenario's assignments.
-    if scenario:
-        graph_cache.invalidate_scenario(int(session_cm_id), run_year, scenario)
-    else:
-        graph_cache.invalidate_session(int(session_cm_id), run_year)
+    graph_cache.invalidate_scenario(int(session_cm_id), run_year, scenario)
 
-    return {"message": f"Applied {len(assignments_dict)} assignments to {table_name}"}
+    if write_failures:
+        # Never report success over a failed write — see the handler above.
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                f"{len(write_failures)} of {len(assignments_dict)} assignments failed to write "
+                f"(applied {len(assignments_dict) - len(write_failures)}); see server logs"
+            ),
+        )
+
+    return {"message": f"Applied {len(assignments_dict)} assignments to {BUNK_ASSIGNMENTS_DRAFT}"}
 
 
 # ========================================
@@ -786,6 +782,9 @@ async def run_multi_session_solver(
     user: AuthUser = Depends(require_permission(Permission.BUNKING_MANAGE)),
 ) -> dict[str, Any]:
     """Run the bunking solver for multiple child sessions of a parent session."""
+    # Same rule as /solver/run: every child run must have a scenario to land in.
+    _require_scenario(request.scenario)
+
     time_limit = _resolve_time_limit(request.time_limit_per_session)
 
     try:

--- a/api/routers/solver.py
+++ b/api/routers/solver.py
@@ -733,8 +733,24 @@ async def apply_solver_results(
 
             if existing:
                 existing_record = existing[0]
-                existing_id_val = existing_record.get("id") if isinstance(existing_record, dict) else existing_record.id
-                existing_id = str(existing_id_val) if existing_id_val else ""
+                # getattr, not `.id` — a malformed record shape here must degrade
+                # this one camper, not raise AttributeError and abort the whole
+                # remaining batch. The narrowed `except` below (kindred#2467) no
+                # longer catches AttributeError on purpose, so it has to be kept
+                # from happening in the first place rather than caught late.
+                existing_id_val = (
+                    existing_record.get("id")
+                    if isinstance(existing_record, dict)
+                    else getattr(existing_record, "id", None)
+                )
+                if not existing_id_val:
+                    logger.error(
+                        f"Existing draft record for person {person_cm_id_str} has no usable id "
+                        f"(record={existing_record!r}); treating as a write failure"
+                    )
+                    write_failures.append(person_cm_id_str)
+                    continue
+                existing_id = str(existing_id_val)
                 await asyncio.to_thread(pb.collection(collection_name).update, existing_id, assignment_data)
             else:
                 await asyncio.to_thread(pb.collection(collection_name).create, assignment_data)

--- a/docs/api/solver-api.md
+++ b/docs/api/solver-api.md
@@ -540,21 +540,36 @@ Error responses include detail:
 
 ### Basic Solving
 ```bash
-# 1. Start solver run
+# 1. Create (or reuse) a scenario. The solver only ever writes a scenario's
+#    draft assignments — production is read-only for the solver (kindred#2467) —
+#    so a run has to name one to have anywhere legal to land.
+POST /scenarios
+{
+  "name": "Session 1 Draft",
+  "session_cm_id": 1000001,
+  "copy_from_production": true
+}
+# Returns: {"id": "scn_abc123", "name": "Session 1 Draft", ...}
+
+# 2. Start solver run against that scenario
 POST /solver/run
 {
-  "session_id": "1000001",
+  "session_cm_id": 1000001,
+  "year": 2025,
+  "scenario": "scn_abc123",
   "time_limit": 60
 }
 # Returns: {"run_id": "abc123", "status": "started"}
+# A request with no "scenario" (or a blank one) is refused with 422 here,
+# before the solver ever runs.
 
-# 2. Check status
+# 3. Check status
 GET /solver/run/abc123
 # Returns: {"status": "completed", "results": {...}}
 
-# 3. Apply results
+# 4. Apply results to the scenario's draft assignments
 POST /solver/apply/abc123
-# Returns: {"message": "Applied 150 assignments"}
+# Returns: {"message": "Applied 150 assignments to bunk_assignments_draft"}
 ```
 
 ### Scenario Planning

--- a/docs/api/solver-api.md
+++ b/docs/api/solver-api.md
@@ -61,7 +61,7 @@ Start a new solver run for a session.
 
 **Parameters:**
 - `session_id` (required): CampMinder session ID to solve
-- `apply_results` (optional, default=false): Auto-apply results to production
+- `apply_results` (optional, default=false): Auto-apply results to the run's scenario
 - `time_limit` (optional, default=30): Max seconds to run (1-600)
 
 **Response:**
@@ -136,7 +136,10 @@ Get status and results of a solver run.
 ---
 
 #### POST /solver/apply/{run_id}
-Apply solver results to production bunk assignments.
+Apply solver results to the run's **scenario** (`bunk_assignments_draft`).
+
+⚠️ **Production is read-only for the solver.** A run carrying no scenario is refused with a 422 rather
+than applied — see kindred#2467. The solver never writes `bunk_assignments`.
 
 **Path Parameters:**
 - `run_id`: The solver run identifier

--- a/tests/unit/api/routers/test_draft_writes_invalidate_cache.py
+++ b/tests/unit/api/routers/test_draft_writes_invalidate_cache.py
@@ -1,7 +1,6 @@
 """Cache invalidation contract for every ``bunk_assignments_draft`` writer.
 
-Each writer that mutates ``bunk_assignments_draft`` (or, for solver apply,
-``bunk_assignments`` in the production case) must invalidate the matching
+Each writer that mutates ``bunk_assignments_draft`` must invalidate the matching
 scenario-scoped graph cache slot immediately. Without this, the
 ``GraphCacheManager`` serves a stale graph (TTL 15 min) keyed under
 ``session_{session_cm_id}_{year}_{scenario_id}`` after a solver re-run and
@@ -9,7 +8,9 @@ apply, so the social-graph view shows campers grouped by the previous
 draft state — exactly the "big lump" symptom reported on the May 7 scenario.
 
 Writers covered:
-  * POST   /api/solver/apply/{run_id}                 (scenario + prod)
+  * POST   /api/solver/apply/{run_id}                 (scenario only — kindred#2467
+    made a scenario-less apply a 422, so there is no production case left to cover;
+    the refusal itself lives in test_solver_never_writes_production.py)
   * POST   /api/sessions/{cm_id}/clear-assignments    (scenario + prod)
   * POST   /api/scenarios/{id}/clear
   * DELETE /api/scenarios/{id}
@@ -84,6 +85,7 @@ class TestApplySolverResultsInvalidatesCache:
         scenario: str | None,
         session_cm_id: int = 1235404,
         year: int = 2026,
+        expected_status: int = 200,
     ) -> MagicMock:
         from api.dependencies import solver_runs
         from api.routers.solver import router
@@ -114,7 +116,7 @@ class TestApplySolverResultsInvalidatesCache:
         ):
             client = TestClient(app)
             resp = client.post(f"/api/solver/apply/{run_id}")
-            assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
+            assert resp.status_code == expected_status, f"{resp.status_code}: {resp.text}"
 
         solver_runs.clear()
         return mock_cache
@@ -126,11 +128,17 @@ class TestApplySolverResultsInvalidatesCache:
         # Don't broadly nuke the prod or session-wide cache in scenario mode.
         cache.invalidate_session.assert_not_called()
 
-    def test_prod_apply_invalidates_session_slot(self) -> None:
-        """Apply without a scenario writes to bunk_assignments — invalidate the
-        session cache so the prod graph rebuilds from current DB."""
-        cache = self._run_apply(scenario=None)
-        cache.invalidate_session.assert_called_once_with(1235404, 2026)
+    def test_prod_apply_is_refused_and_invalidates_nothing(self) -> None:
+        """Apply without a scenario is refused (kindred#2467), so nothing is dropped.
+
+        This used to assert a session-slot invalidation, because the endpoint took
+        an ``else`` branch that tried to write the production ``bunk_assignments``
+        table. The owner's rule is that production is read-only for the solver, so
+        that branch is gone and the apply is a 422 — with no write, there is no
+        stale cache slot to drop.
+        """
+        cache = self._run_apply(scenario=None, expected_status=422)
+        cache.invalidate_session.assert_not_called()
         cache.invalidate_scenario.assert_not_called()
 
 

--- a/tests/unit/api/routers/test_http_exception_500_str_e.py
+++ b/tests/unit/api/routers/test_http_exception_500_str_e.py
@@ -287,14 +287,18 @@ class TestMultiSessionSolverNoLeakOnError:
     def test_status_is_500(self, client: TestClient) -> None:
         resp = client.post(
             "/api/solver/run-multi-session",
-            json={"parent_session_cm_id": 2001, "year": 2025},
+            # `scenario` is required (kindred#2467) — without it the endpoint
+            # refuses with a 422 and never reaches the PB call this test raises on.
+            json={"parent_session_cm_id": 2001, "year": 2025, "scenario": "scn_leak_probe"},
         )
         assert resp.status_code == 500
 
     def test_detail_is_generic_not_str_e(self, client: TestClient) -> None:
         resp = client.post(
             "/api/solver/run-multi-session",
-            json={"parent_session_cm_id": 2001, "year": 2025},
+            # `scenario` is required (kindred#2467) — without it the endpoint
+            # refuses with a 422 and never reaches the PB call this test raises on.
+            json={"parent_session_cm_id": 2001, "year": 2025, "scenario": "scn_leak_probe"},
         )
         body = resp.json()
         assert body == INTERNAL_ERROR_BODY, (

--- a/tests/unit/api/routers/test_solver_never_writes_production.py
+++ b/tests/unit/api/routers/test_solver_never_writes_production.py
@@ -50,6 +50,15 @@ BUNK_CM_ID = 4276
 BUNK_NAME = "Bunk 7"
 
 
+class _MalformedExistingRecord:
+    """Neither a dict with an "id" key nor an object exposing ``.id``.
+
+    Stands in for whatever shape PocketBase could plausibly hand back that
+    the ``isinstance(existing_record, dict)`` branch in ``apply_solver_results``
+    does not anticipate (kindred#2471 follow-up review finding).
+    """
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -227,10 +236,21 @@ class TestSolverNeverWritesProduction:
         assert pb.mutated(DRAFT_COLLECTION), "The scenario apply must still write the draft table"
 
     def test_apply_function_never_names_the_production_collection(self) -> None:
-        """Source-level tripwire: re-adding a production write means naming the table.
+        """Secondary tripwire: re-adding a production write means naming the table.
 
         Both spellings count — the literal and the ``BUNK_ASSIGNMENTS`` constant
         from ``api/constants/collections.py``.
+
+        This is a cheap, fast source-level check, and it is foolable: a
+        module-level alias for the production collection (e.g. ``_ALIAS =
+        BUNK_ASSIGNMENTS`` referenced inside the function) walks past this
+        AST scan without ever naming ``BUNK_ASSIGNMENTS`` or the literal
+        directly. The load-bearing coverage is the *behavioral* tests above
+        (``test_apply_without_scenario_never_touches_production`` and
+        ``test_apply_with_scenario_never_touches_production``), which assert
+        against a ``RecordingPB`` and catch a bypass like that regardless of
+        how the write got there. Do not simplify this suite down to just this
+        AST check — it only catches the naive re-introduction.
         """
         from api.routers.solver import apply_solver_results
 
@@ -370,3 +390,34 @@ class TestApplyDoesNotSwallowWriteFailures:
             f"A failed write returned {resp.status_code}: {resp.text}. "
             "Reporting success over a swallowed write failure is how #2467 stayed invisible."
         )
+
+    def test_malformed_existing_draft_record_is_counted_not_raised(self) -> None:
+        """A malformed *existing*-record shape must degrade this camper, not raise
+        AttributeError and abort the whole remaining batch.
+
+        ``existing_record.id`` on a shape that is neither a dict nor an object
+        exposing ``.id`` raises AttributeError. The narrowed
+        ``except (ClientResponseError, ValueError)`` added for kindred#2467 does
+        not catch AttributeError on purpose — so if the malformed shape reaches
+        that line, the exception escapes the per-camper try/except entirely and
+        this app (which registers no global exception handler of its own) falls
+        through to Starlette's bare 500, distinguishable from the endpoint's own
+        controlled failure response by its plain-text body and content type.
+        """
+        pb = _pb_with_one_assignable_camper(lists={"bunk_assignments_draft": [_MalformedExistingRecord()]})
+        runs = {"run-2467": _completed_run(scenario="scn_abc123")}
+
+        with _apply_client(pb, runs, MagicMock()) as client:
+            resp = client.post("/api/solver/apply/run-2467")
+
+        assert resp.status_code == 500, (
+            f"Expected the endpoint's own failure response, got {resp.status_code}: {resp.text}"
+        )
+        assert resp.headers["content-type"].startswith("application/json"), (
+            f"Got content-type {resp.headers.get('content-type')!r} body {resp.text!r}. "
+            "A non-JSON 500 means AttributeError escaped the per-camper try/except and aborted "
+            "the batch instead of being counted as a write failure."
+        )
+        assert "assignments failed to write" in resp.text
+        assert pb.mutated(PRODUCTION_COLLECTION) == []
+        assert pb.mutated(DRAFT_COLLECTION) == [], "The malformed existing record must never be written through"

--- a/tests/unit/api/routers/test_solver_never_writes_production.py
+++ b/tests/unit/api/routers/test_solver_never_writes_production.py
@@ -1,0 +1,372 @@
+"""The solver never writes production bunk assignments (kindred#2467).
+
+Production is read-only for the solver: solver output lands in a scenario's
+``bunk_assignments_draft`` rows and nowhere else. The lodging side already
+encodes the same rule — ``PlacementWriteBase.scenario`` in
+``frontend/src/services/lodgingApi.ts``: *"REQUIRED and non-empty. A blank
+scenario is a 422, never a write to the live plan."*
+
+These tests pin the **class**, not the instance. Before #2467, applying a
+scenario-less run took an ``else`` branch that tried to create a
+``bunk_assignments`` row with a payload whose only real column was ``year``;
+the write failed validation, a bare ``except Exception`` swallowed it, and the
+endpoint returned 200 having written nothing. The fix is not a better payload —
+a *working* production write is the defect. So the assertions here are:
+
+  * no mutation ever reaches ``bunk_assignments`` from the solver apply path,
+  * a scenario-less run is refused with a 4xx at apply time,
+  * a scenario-less run is refused at creation time,
+  * ``apply_solver_results`` does not so much as name the production collection,
+  * a swallowed write failure can no longer return success.
+
+A payload-shape test would pass the moment someone "fixed" the production
+branch into a working write, which is the outcome being prevented.
+"""
+
+import ast
+import inspect
+import textwrap
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pocketbase.client import ClientResponseError  # type: ignore[attr-defined]
+
+from bunking.auth_middleware import AuthUser, get_current_user
+from bunking.rbac.permissions import ALL_PERMISSIONS
+
+PRODUCTION_COLLECTION = "bunk_assignments"
+DRAFT_COLLECTION = "bunk_assignments_draft"
+
+SESSION_CM_ID = 1235404
+YEAR = 2026
+PERSON_CM_ID = 60001
+BUNK_CM_ID = 4276
+BUNK_NAME = "Bunk 7"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _admin() -> AuthUser:
+    user = AuthUser(
+        username="TestAdmin",
+        email="test@example.com",
+        display_name="Test Admin",
+        groups=["admin"],
+        is_admin=True,
+    )
+    user.permissions = set(ALL_PERMISSIONS)
+    return user
+
+
+class RecordingPB:
+    """PocketBase client stand-in that records every mutating call by collection.
+
+    ``mutations`` holds ``(collection_name, method)`` for each create/update/
+    delete, which is what the class guard asserts on — the *target* of the
+    write, never the payload's shape.
+    """
+
+    def __init__(
+        self,
+        *,
+        lists: dict[str, list[Any]] | None = None,
+        records: dict[str, Any] | None = None,
+        write_error: Exception | None = None,
+    ) -> None:
+        self.mutations: list[tuple[str, str]] = []
+        self._lists = lists or {}
+        self._records = records or {}
+        self._write_error = write_error
+
+    def collection(self, name: str) -> MagicMock:
+        col = MagicMock(name=f"collection({name})")
+        col.get_full_list.return_value = self._lists.get(name, [])
+        if name in self._records:
+            col.get_one.return_value = self._records[name]
+
+        def _mutate(method: str) -> Any:
+            def _inner(*_args: Any, **_kwargs: Any) -> Any:
+                self.mutations.append((name, method))
+                if self._write_error is not None:
+                    raise self._write_error
+                return MagicMock()
+
+            return _inner
+
+        col.create.side_effect = _mutate("create")
+        col.update.side_effect = _mutate("update")
+        col.delete.side_effect = _mutate("delete")
+        return col
+
+    def mutated(self, collection_name: str) -> list[tuple[str, str]]:
+        return [m for m in self.mutations if m[0] == collection_name]
+
+
+def _session_context_stub() -> Any:
+    ctx = MagicMock()
+    ctx.session_cm_id = SESSION_CM_ID
+    ctx.year = YEAR
+    ctx.session_pb_id = "sess_pb"
+    ctx.session_relation_filter = f"session.cm_id = {SESSION_CM_ID}"
+    ctx.related_session_ids = [SESSION_CM_ID]
+    return ctx
+
+
+def _id_cache_stub() -> MagicMock:
+    cache = MagicMock()
+    cache.get_person_pb_id = AsyncMock(return_value="person_pb")
+    cache.get_bunk_pb_id = AsyncMock(return_value="bunk_pb")
+    cache.get_session_pb_id = AsyncMock(return_value="sess_pb")
+    cache.get_bunk_plan_id = AsyncMock(return_value="bp_pb")
+    return cache
+
+
+def _pb_with_one_assignable_camper(**kwargs: Any) -> RecordingPB:
+    """A PB stand-in where every lookup the apply loop makes succeeds.
+
+    The loop must get all the way to the write for the guard to mean anything:
+    a lookup that bails early would make "no production write" vacuously true.
+    """
+    bunk = SimpleNamespace(id="bunk_pb", cm_id=BUNK_CM_ID, name=BUNK_NAME, year=YEAR)
+    attendee = SimpleNamespace(
+        id="att_pb",
+        person_id=PERSON_CM_ID,
+        year=YEAR,
+        expand={"session": SimpleNamespace(id="sess_pb", cm_id=SESSION_CM_ID)},
+    )
+    lists: dict[str, list[Any]] = {"bunks": [bunk], "attendees": [attendee]}
+    lists.update(kwargs.pop("lists", {}))
+    return RecordingPB(lists=lists, **kwargs)
+
+
+@contextmanager
+def _apply_client(pb: RecordingPB, runs: dict[str, Any], cache: MagicMock) -> Iterator[TestClient]:
+    from api.routers.solver import router
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = _admin
+
+    with (
+        patch("api.routers.solver.pb", pb),
+        patch("api.routers.solver.solver_runs", runs),
+        patch("api.routers.solver.graph_cache", cache),
+        patch("api.routers.solver.IDLookupCache", MagicMock(return_value=_id_cache_stub())),
+        patch("api.routers.solver.build_session_context", AsyncMock(return_value=_session_context_stub())),
+    ):
+        yield TestClient(app, raise_server_exceptions=False)
+
+
+def _completed_run(scenario: str | None) -> dict[str, Any]:
+    return {
+        "id": "run-2467",
+        "status": "completed",
+        "session_cm_id": SESSION_CM_ID,
+        "scenario": scenario,
+        "config": {"year": YEAR},
+        "results": {"assignments": {str(PERSON_CM_ID): BUNK_NAME}},
+    }
+
+
+@contextmanager
+def _run_client(runs: dict[str, Any]) -> Iterator[TestClient]:
+    from api.routers.solver import router
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = _admin
+
+    child_session = SimpleNamespace(id="sess_pb", cm_id=SESSION_CM_ID, name="Session 1", sex_eligible="all")
+
+    with (
+        patch("api.routers.solver.pb", RecordingPB(lists={"camp_sessions": [child_session]})),
+        patch("api.routers.solver.solver_runs", runs),
+        patch("api.routers.solver.run_solver_task_v2"),
+    ):
+        yield TestClient(app, raise_server_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# The class guard: no write to bunk_assignments, ever
+# ---------------------------------------------------------------------------
+
+
+class TestSolverNeverWritesProduction:
+    def test_apply_without_scenario_never_touches_production(self) -> None:
+        """The architectural rule. Not "the payload is well formed" — *no write at all*."""
+        pb = _pb_with_one_assignable_camper()
+        runs = {"run-2467": _completed_run(scenario=None)}
+
+        with _apply_client(pb, runs, MagicMock()) as client:
+            client.post("/api/solver/apply/run-2467")
+
+        assert pb.mutated(PRODUCTION_COLLECTION) == [], (
+            f"Solver apply mutated {PRODUCTION_COLLECTION}: {pb.mutated(PRODUCTION_COLLECTION)}. "
+            "Production is read-only for the solver — output belongs in a scenario draft."
+        )
+
+    def test_apply_with_scenario_never_touches_production(self) -> None:
+        """The scenario path is the legal one and must stay inside the draft table."""
+        pb = _pb_with_one_assignable_camper()
+        runs = {"run-2467": _completed_run(scenario="scn_abc123")}
+
+        with _apply_client(pb, runs, MagicMock()) as client:
+            resp = client.post("/api/solver/apply/run-2467")
+
+        assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
+        assert pb.mutated(PRODUCTION_COLLECTION) == []
+        assert pb.mutated(DRAFT_COLLECTION), "The scenario apply must still write the draft table"
+
+    def test_apply_function_never_names_the_production_collection(self) -> None:
+        """Source-level tripwire: re-adding a production write means naming the table.
+
+        Both spellings count — the literal and the ``BUNK_ASSIGNMENTS`` constant
+        from ``api/constants/collections.py``.
+        """
+        from api.routers.solver import apply_solver_results
+
+        tree = ast.parse(textwrap.dedent(inspect.getsource(apply_solver_results)))
+        offenders: list[str] = []
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Constant)
+                and isinstance(node.value, str)
+                and PRODUCTION_COLLECTION in node.value
+                and DRAFT_COLLECTION not in node.value
+            ):
+                offenders.append(node.value)
+            if isinstance(node, ast.Name) and node.id == "BUNK_ASSIGNMENTS":
+                offenders.append(node.id)
+
+        assert offenders == [], (
+            f"apply_solver_results names the production collection: {offenders}. "
+            "Solver output applies to a scenario; production is read-only."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Refusal at apply time
+# ---------------------------------------------------------------------------
+
+
+class TestApplyRefusesWithoutScenario:
+    def test_in_memory_run_without_scenario_is_refused(self) -> None:
+        pb = _pb_with_one_assignable_camper()
+        runs = {"run-2467": _completed_run(scenario=None)}
+
+        with _apply_client(pb, runs, MagicMock()) as client:
+            resp = client.post("/api/solver/apply/run-2467")
+
+        assert resp.status_code == 422, f"Expected a refusal, got {resp.status_code}: {resp.text}"
+        assert "scenario" in resp.text.lower()
+        assert pb.mutations == [], f"A refused apply must write nothing: {pb.mutations}"
+
+    def test_stored_run_without_scenario_is_refused(self) -> None:
+        """Runs already in PocketBase reach apply through the other branch."""
+        stored = SimpleNamespace(
+            id="run-stored",
+            results=f'{{"assignments": {{"{PERSON_CM_ID}": "{BUNK_NAME}"}}, "year": {YEAR}}}',
+            session_cm_id=SESSION_CM_ID,
+            session="sess_pb",
+            scenario="",
+        )
+        pb = _pb_with_one_assignable_camper(records={"solver_runs": stored})
+
+        with _apply_client(pb, {}, MagicMock()) as client:
+            resp = client.post("/api/solver/apply/run-stored")
+
+        assert resp.status_code == 422, f"Expected a refusal, got {resp.status_code}: {resp.text}"
+        assert pb.mutations == [], f"A refused apply must write nothing: {pb.mutations}"
+
+    def test_refused_apply_does_not_invalidate_the_graph_cache(self) -> None:
+        """Nothing changed, so nothing should be dropped from the cache."""
+        pb = _pb_with_one_assignable_camper()
+        cache = MagicMock()
+        runs = {"run-2467": _completed_run(scenario=None)}
+
+        with _apply_client(pb, runs, cache) as client:
+            client.post("/api/solver/apply/run-2467")
+
+        cache.invalidate_session.assert_not_called()
+        cache.invalidate_scenario.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Refusal at run creation
+# ---------------------------------------------------------------------------
+
+
+class TestRunCreationRequiresScenario:
+    @pytest.mark.parametrize("scenario", [None, "", "   "])
+    def test_run_solver_without_scenario_is_refused(self, scenario: str | None) -> None:
+        body: dict[str, Any] = {"session_cm_id": SESSION_CM_ID, "year": YEAR}
+        if scenario is not None:
+            body["scenario"] = scenario
+
+        with _run_client({}) as client:
+            resp = client.post("/api/solver/run", json=body)
+
+        assert resp.status_code == 422, f"Expected a refusal, got {resp.status_code}: {resp.text}"
+        assert "scenario" in resp.text.lower()
+
+    def test_run_solver_with_scenario_still_starts(self) -> None:
+        """The refusal must not swallow the legal path."""
+        runs: dict[str, Any] = {}
+        with _run_client(runs) as client:
+            resp = client.post(
+                "/api/solver/run",
+                json={"session_cm_id": SESSION_CM_ID, "year": YEAR, "scenario": "scn_abc123"},
+            )
+
+        assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
+        assert len(runs) == 1
+
+    def test_multi_session_run_without_scenario_is_refused(self) -> None:
+        with _run_client({}) as client:
+            resp = client.post(
+                "/api/solver/run-multi-session",
+                json={"parent_session_cm_id": 100, "year": YEAR},
+            )
+
+        assert resp.status_code == 422, f"Expected a refusal, got {resp.status_code}: {resp.text}"
+        assert "scenario" in resp.text.lower()
+
+    def test_multi_session_run_with_scenario_still_starts(self) -> None:
+        runs: dict[str, Any] = {}
+        with _run_client(runs) as client:
+            resp = client.post(
+                "/api/solver/run-multi-session",
+                json={"parent_session_cm_id": 100, "year": YEAR, "scenario": "scn_abc123"},
+            )
+
+        assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
+        assert len(runs) == 1
+
+
+# ---------------------------------------------------------------------------
+# A swallowed write failure must not report success
+# ---------------------------------------------------------------------------
+
+
+class TestApplyDoesNotSwallowWriteFailures:
+    def test_draft_write_failure_is_not_reported_as_success(self) -> None:
+        pb = _pb_with_one_assignable_camper(write_error=ClientResponseError("boom", status=400))
+        runs = {"run-2467": _completed_run(scenario="scn_abc123")}
+
+        with _apply_client(pb, runs, MagicMock()) as client:
+            resp = client.post("/api/solver/apply/run-2467")
+
+        assert pb.mutated(DRAFT_COLLECTION), "The write must have been attempted"
+        assert resp.status_code >= 400, (
+            f"A failed write returned {resp.status_code}: {resp.text}. "
+            "Reporting success over a swallowed write failure is how #2467 stayed invisible."
+        )

--- a/tests/unit/api/routers/test_solver_singleflight.py
+++ b/tests/unit/api/routers/test_solver_singleflight.py
@@ -29,6 +29,13 @@ from bunking.rbac.permissions import ALL_PERMISSIONS
 # ---------------------------------------------------------------------------
 
 
+# Every solver-run endpoint requires a scenario (kindred#2467): production bunk
+# assignments are read-only for the solver, so a scenario-less run has nowhere to
+# land and is refused with a 422 before the single-flight guard is even consulted.
+# These tests are about the guard, so every request body carries one.
+SCENARIO_ID = "scn_singleflight"
+
+
 def _mock_admin_user() -> AuthUser:
     user = AuthUser(
         username="TestAdmin",
@@ -95,7 +102,7 @@ class TestRunSolverSingleFlight:
         with _solver_client(solver_runs_state) as client:
             resp = client.post(
                 "/api/solver/run",
-                json={"session_cm_id": 1001, "year": 2026},
+                json={"session_cm_id": 1001, "year": 2026, "scenario": SCENARIO_ID},
             )
 
         assert resp.status_code == 409, f"Expected 409, got {resp.status_code}: {resp.text}"
@@ -119,7 +126,7 @@ class TestRunSolverSingleFlight:
         with _solver_client(solver_runs_state) as client:
             resp = client.post(
                 "/api/solver/run",
-                json={"session_cm_id": 2002, "year": 2026},
+                json={"session_cm_id": 2002, "year": 2026, "scenario": SCENARIO_ID},
             )
 
         assert resp.status_code == 409, f"Expected 409, got {resp.status_code}: {resp.text}"
@@ -146,7 +153,7 @@ class TestRunSolverSingleFlight:
         with _solver_client(solver_runs_state) as client:
             resp = client.post(
                 "/api/solver/run",
-                json={"session_cm_id": 3003, "year": 2026},
+                json={"session_cm_id": 3003, "year": 2026, "scenario": SCENARIO_ID},
             )
 
         assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
@@ -168,7 +175,7 @@ class TestRunSolverSingleFlight:
         with _solver_client(solver_runs_state) as client:
             resp = client.post(
                 "/api/solver/run",
-                json={"session_cm_id": 4004, "year": 2026},
+                json={"session_cm_id": 4004, "year": 2026, "scenario": SCENARIO_ID},
             )
 
         assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
@@ -191,7 +198,7 @@ class TestRunSolverSingleFlight:
         with _solver_client(solver_runs_state) as client:
             resp = client.post(
                 "/api/solver/run",
-                json={"session_cm_id": 5005, "year": 2026},  # Different session
+                json={"session_cm_id": 5005, "year": 2026, "scenario": SCENARIO_ID},  # Different session
             )
 
         assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
@@ -203,7 +210,7 @@ class TestRunSolverSingleFlight:
         with _solver_client(solver_runs_state) as client:
             resp = client.post(
                 "/api/solver/run",
-                json={"session_cm_id": 6006, "year": 2026},
+                json={"session_cm_id": 6006, "year": 2026, "scenario": SCENARIO_ID},
             )
 
         assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
@@ -222,7 +229,7 @@ class TestRunSolverSingleFlight:
         with _solver_client(solver_runs_state) as client:
             resp = client.post(
                 "/api/solver/run",
-                json={"session_cm_id": 7007, "year": 2026},
+                json={"session_cm_id": 7007, "year": 2026, "scenario": SCENARIO_ID},
             )
 
         assert resp.status_code == 409
@@ -295,7 +302,7 @@ class TestRunMultiSessionSolverSingleFlight:
         with _multi_session_client(solver_runs_state, child_sessions) as client:
             resp = client.post(
                 "/api/solver/run-multi-session",
-                json={"parent_session_cm_id": 100, "year": 2026},
+                json={"parent_session_cm_id": 100, "year": 2026, "scenario": SCENARIO_ID},
             )
 
         assert resp.status_code == 409, f"Expected 409, got {resp.status_code}: {resp.text}"
@@ -320,7 +327,7 @@ class TestRunMultiSessionSolverSingleFlight:
         with _multi_session_client(solver_runs_state, child_sessions) as client:
             resp = client.post(
                 "/api/solver/run-multi-session",
-                json={"parent_session_cm_id": 200, "year": 2026},
+                json={"parent_session_cm_id": 200, "year": 2026, "scenario": SCENARIO_ID},
             )
 
         assert resp.status_code == 409, f"Expected 409, got {resp.status_code}: {resp.text}"
@@ -345,7 +352,7 @@ class TestRunMultiSessionSolverSingleFlight:
         with _multi_session_client(solver_runs_state, child_sessions) as client:
             resp = client.post(
                 "/api/solver/run-multi-session",
-                json={"parent_session_cm_id": 300, "year": 2026},
+                json={"parent_session_cm_id": 300, "year": 2026, "scenario": SCENARIO_ID},
             )
 
         assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
@@ -365,7 +372,7 @@ class TestRunMultiSessionSolverSingleFlight:
         with _multi_session_client(solver_runs_state, child_sessions) as client:
             resp = client.post(
                 "/api/solver/run-multi-session",
-                json={"parent_session_cm_id": 400, "year": 2026},
+                json={"parent_session_cm_id": 400, "year": 2026, "scenario": SCENARIO_ID},
             )
 
         assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
@@ -467,7 +474,7 @@ class TestScenarioSolverSingleFlight:
         with _solver_client(solver_runs_state) as client:
             resp = client.post(
                 "/api/solver/run",
-                json={"session_cm_id": 5001, "year": 2026},
+                json={"session_cm_id": 5001, "year": 2026, "scenario": SCENARIO_ID},
             )
 
         assert resp.status_code == 409, (
@@ -493,7 +500,7 @@ class TestScenarioSolverSingleFlight:
         with _solver_client(solver_runs_state) as client:
             resp = client.post(
                 "/api/solver/run",
-                json={"session_cm_id": 5001, "year": 2026},
+                json={"session_cm_id": 5001, "year": 2026, "scenario": SCENARIO_ID},
             )
 
         assert resp.status_code == 200, (


### PR DESCRIPTION
Production bunk assignments are read-only for the solver. Applying a solver run
with no scenario used to take an `else` branch that tried to create a
`bunk_assignments` row from a payload whose only real column was `year` —
`person`, `session` and `bunk` are required relations and were never set. The
create failed validation, a bare `except Exception` logged it once per camper,
and the endpoint returned 200 having written nothing.

The fix is to refuse, not to repair the payload. A *working* production write
there would be the actual defect: the solver applies to a scenario's draft
assignments and nowhere else. That is the rule the lodging side already
encodes on `PlacementWriteBase.scenario` — *"REQUIRED and non-empty. A blank
scenario is a 422, never a write to the live plan."* — and the reasoning is
quoted at the refusal site so it travels.

## What changed

**Refusal at both ends, which is a decision worth a second look.** The issue
left it open whether to refuse at apply time, at run creation, or both. This
does **both**, so half can be reverted cheaply if that is not wanted:

- **Apply time** — `POST /api/solver/apply/{run_id}` returns 422 when the run
  carries no scenario, before it touches PocketBase. This is the half that
  covers runs already stored.
- **Creation time** — `POST /api/solver/run` and
  `POST /api/solver/run-multi-session` return 422 when `scenario` is missing or
  blank. This is the stronger guarantee: a run that can only ever be applied to
  production is never created in the first place.

Creation-time refusal is a visible behaviour change: the board can currently
run the solver with no scenario selected, and the run appears to succeed. What
that flow actually produces today is an apply that writes nothing and reports
success, so nothing that works is being taken away — but staff will now see an
error where they previously saw a silent no-op.

**The production write branch is deleted** rather than left as dead code that
reads like an intended capability. With the refusal in place `scenario` is
always truthy inside the loop, so the branch, the `table_name` ternary and the
`invalidate_session` fallback all collapse to the draft path.

**The swallowing `except Exception` is narrowed** to
`(ClientResponseError, ValueError)`, and failures are counted rather than
discarded: per-camper resilience is kept, but if any write failed the endpoint
now returns 500 with the counts instead of "Applied N assignments". Reporting
success over a failed write is why this went unnoticed.

## Tests

The guard pins the **class**, not the instance — a payload-shape test would
start passing the moment someone "fixed" the production branch into a working
write, which is the outcome being prevented. `test_solver_never_writes_production.py`:

- a recording PocketBase stand-in drives the real apply path with a camper that
  resolves all the way to the write, and asserts **no mutation ever reaches
  `bunk_assignments`** — with a scenario or without one;
- an AST tripwire asserts `apply_solver_results` does not so much as name the
  production collection, in either spelling (the literal or the
  `BUNK_ASSIGNMENTS` constant);
- refusal tests for both apply paths (in-memory run and run loaded from
  PocketBase), for both creation endpoints, and for blank/whitespace scenarios;
- a test that a failed draft write is not reported as success.

Both guards were mutation-checked: pointing the write at `bunk_assignments`
fails the behavioural guard and the AST guard, and deleting the apply-time
refusal fails the three refusal tests.

Three existing test files moved with the specification:

- `test_draft_writes_invalidate_cache.py` — `test_prod_apply_invalidates_session_slot`
  asserted the old production behaviour (200 + session-slot invalidation). It now
  asserts the refusal and that nothing is invalidated, since there is no write to
  go stale. This is a spec change, not a test bent to fit the code.
- `test_solver_singleflight.py` — request bodies now carry a scenario. These
  tests are about the single-flight guard, which the scenario refusal now
  precedes.
- `test_http_exception_500_str_e.py` — the two multi-session no-leak probes need
  a scenario to reach the PocketBase call they raise on.

## Deliberately not touched

- **`POST /api/solver/run-sweep` with `session_cm_id`** still creates
  scenario-less runs. A sweep is a benchmark that never applies, and refusing it
  would delete the session-based sweep feature — a bigger product call than this
  issue settles. Its children are covered by the apply-time refusal.
- **`POST /api/sessions/{cm_id}/clear-assignments`** still *deletes* from
  production `bunk_assignments` when no scenario is given. Same file, same
  read-only question, but a different decision and out of scope here.
- **The hourly orphan sweep** (`pocketbase/sync/bunk_assignments.go`) is
  untouched. It is the reason a repaired payload would have silently reverted
  within the hour, and it is being worked in other branches.
- **`docs/api/solver-api.md`** still says the apply endpoint applies "to
  production bunk assignments" and documents `apply_results` as auto-applying to
  production. That is now wrong and wants a follow-up; it is outside this PR's
  scope lock.

## Verification

`bash scripts/pre-push-verify.sh` — ALL CHECKS PASSED (ruff format, ruff check,
mypy, 6361 passed / 14 skipped). No Go or frontend files changed, so
golangci-lint and eslint are not implicated.

Closes #2467.
