### PR TITLE
fix(sync): bunk staff assignments no longer created by one sync and deleted by the next

### DIFF
--- a/pocketbase/sync/bunk_assignments.go
+++ b/pocketbase/sync/bunk_assignments.go
@@ -81,7 +81,7 @@ func (s *BunkAssignmentsSync) Sync(ctx context.Context) error {
 	// We need to build keys based on person/session CampMinder IDs stored during creation
 	year := s.Client.GetSeasonID()
 
-	existingAssignments, err := s.preloadExistingAssignments(year)
+	existingAssignments, existingByPersonBunk, err := s.preloadExistingAssignments(year)
 	if err != nil {
 		return err
 	}
@@ -196,17 +196,13 @@ func (s *BunkAssignmentsSync) Sync(ctx context.Context) error {
 				// full ladder; ambiguous is only ever true on the staff path,
 				// where a (bunkPlan, bunk) key has more than one candidate
 				// session and guessing would be worse than skipping (kindred#2264).
-				sessionID, ambiguous := s.resolveAssignmentSession(personCMID, bunkPlanID, bunkID, bunkPlanSessions)
-				if ambiguous {
-					candidateCount := len(s.bunkPlanBunkToSession[fmt.Sprintf("%d:%d", bunkPlanID, bunkID)])
-					slog.Warn("Ambiguous (bunkPlan, bunk) staff session lookup, skipping assignment",
-						"bunkPlanCMID", bunkPlanID, "bunkCMID", bunkID, "personCMID", personCMID,
-						"candidateCount", candidateCount)
-					s.Stats.Skipped++
-					continue
-				}
-				if sessionID == 0 {
-					s.Stats.Skipped++
+				// Both no-session outcomes go through one wrapper because both
+				// owe the same bookkeeping before they skip -- counting the
+				// failure where it can be seen, and keeping the assignment's
+				// stored rows out of the orphan sweep (kindred#2465).
+				sessionID, unresolved := s.resolveSessionOrTrackUnresolved(
+					personCMID, bunkPlanID, bunkID, bunkPlanSessions, existingByPersonBunk, year)
+				if unresolved {
 					continue
 				}
 
@@ -254,7 +250,11 @@ func (s *BunkAssignmentsSync) Sync(ctx context.Context) error {
 	}
 
 	// Use extra stats to show fetched count
-	s.LogSyncComplete("Bunk assignments", fmt.Sprintf("fetched=%d assignments", totalAssignments))
+	// unresolved_session is named in the completion line, not left to the JSON
+	// alone: it is the counter an operator watches to know kindred#2465 has not
+	// come back, and LogSyncComplete's own stats string cannot show it.
+	s.LogSyncComplete("Bunk assignments", fmt.Sprintf("fetched=%d assignments, unresolved_session=%d",
+		totalAssignments, s.Stats.UnresolvedSession))
 
 	return nil
 }
@@ -264,6 +264,34 @@ func (s *BunkAssignmentsSync) loadMappings() error {
 	slog.Info("Loading valid CampMinder IDs")
 
 	year := s.Client.GetSeasonID()
+
+	// Every map this function builds describes THIS run and is rebuilt from
+	// scratch here (kindred#2465). The orchestrator constructs one
+	// BunkAssignmentsSync at boot and dispatches every scheduled run to it, so
+	// without this the append-shaped maps -- personEnrollments,
+	// bunkPlanSessionsList, bunkPlanBunkToSession -- gained a full extra copy of
+	// their contents every hour: a (bunkPlan, bunk) pair with ONE bunk_plans row
+	// behind it read as two candidates on run 2, resolveStaffSession called that
+	// ambiguous, the assignment was skipped without being tracked, and
+	// deleteOrphans deleted the row for being untracked. 262 rows for 70 active
+	// bunk staff, every hour, restored only by a container restart. The same
+	// accumulation silently disabled kindred#2259/#2264's bunk-specific
+	// narrowing on the camper path from run 2 onward.
+	//
+	// It belongs HERE, not in Sync()'s reset block: loadMappings is the only
+	// writer of all eight, and bunkPBIDToCMID must be rebuilt before the
+	// bunk_plans pass below reads it -- which the existing load order already
+	// guarantees. The constructor's make() calls stay: several tests build
+	// BunkAssignmentsSync as a struct literal and never call loadMappings.
+	// stranded_assignment_cleanup.go's Sync() names the same hazard for Stats.
+	s.validPersonCMIDs = make(map[int]bool)
+	s.validBunkCMIDs = make(map[int]bool)
+	s.validSessionCMIDs = make(map[int]bool)
+	s.personEnrollments = make(map[int][]int)
+	s.bunkPlanSessionsList = make(map[int][]int)
+	s.staffPersonCMIDs = make(map[int]bool)
+	s.bunkPlanBunkToSession = make(map[string][]int)
+	s.bunkPBIDToCMID = make(map[string]int)
 
 	// Load person enrollments: personCMID -> list of sessionCMIDs they're enrolled in
 	// This is the source of truth for which session a person belongs to
@@ -408,7 +436,16 @@ func (s *BunkAssignmentsSync) loadMappings() error {
 // two is silently lost. See the write key in processAssignment and the
 // orphan key in deleteOrphans -- all three (plus this preload key, the
 // fourth of the grain) must move together.
-func (s *BunkAssignmentsSync) preloadExistingAssignments(year int) (map[string]*core.Record, error) {
+//
+// The second return is an index of the same rows by "personCMID:bunkCMID" ->
+// the tracking keys ("personCMID:sessionCMID:bunkCMID") they were stored
+// under. It exists for the branch that cannot name a session
+// (resolveSessionOrTrackUnresolved): person and bunk are the two thirds of the
+// grain an unresolved assignment still knows, and this is how it finds the
+// stored rows to keep from the sweep (kindred#2465, the kindred#2394 pattern).
+func (s *BunkAssignmentsSync) preloadExistingAssignments(
+	year int,
+) (existing map[string]*core.Record, byPersonBunk map[string][]string, err error) {
 	filter := fmt.Sprintf("year = %d", year)
 
 	assignmentMappings, err := s.BuildRecordCMIDMappings("bunk_assignments", filter, map[string]string{
@@ -417,10 +454,11 @@ func (s *BunkAssignmentsSync) preloadExistingAssignments(year int) (map[string]*
 		"bunk":    "bunks",
 	})
 	if err != nil {
-		return nil, fmt.Errorf("loading assignment mappings: %w", err)
+		return nil, nil, fmt.Errorf("loading assignment mappings: %w", err)
 	}
 
-	return s.PreloadCompositeRecords(
+	byPersonBunk = make(map[string][]string)
+	existing, err = s.PreloadCompositeRecords(
 		"bunk_assignments", filter, func(record *core.Record) (string, bool) {
 			mapping := assignmentMappings[record.Id]
 			personCMID := mapping["personCMID"]
@@ -430,10 +468,73 @@ func (s *BunkAssignmentsSync) preloadExistingAssignments(year int) (map[string]*
 
 			if personCMID > 0 && sessionCMID > 0 && bunkCMID > 0 && recordYear > 0 {
 				key := fmt.Sprintf("%d:%d:%d:%d", personCMID, sessionCMID, bunkCMID, int(recordYear))
+				personBunk := fmt.Sprintf("%d:%d", personCMID, bunkCMID)
+				byPersonBunk[personBunk] = append(byPersonBunk[personBunk],
+					fmt.Sprintf("%d:%d:%d", personCMID, sessionCMID, bunkCMID))
 				return key, true
 			}
 			return "", false
 		})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return existing, byPersonBunk, nil
+}
+
+// resolveSessionOrTrackUnresolved runs the resolution ladder for one
+// CampMinder assignment and, when it comes back with no session, does the
+// bookkeeping the skip needs: log the ambiguity, count it somewhere an
+// operator can see it, and keep the rows this assignment already has on disk
+// out of the orphan sweep. unresolved being true means the caller must skip
+// this assignment.
+//
+// The tracking is the load-bearing half (kindred#2465, the kindred#2394
+// pattern). Both skip branches used to `continue` before
+// TrackProcessedCompositeKey, so the assignment was absent from ProcessedKeys
+// and deleteOrphans read absence as "CampMinder no longer returns this row"
+// and deleted it. That is the opposite of what the run observed -- CampMinder
+// returned this person in this bunk, the run just could not say which session.
+// persons.go's transformPersonToPB skip carries the same patch for the same
+// symptom -- "Skipped and orphaned are different facts, and this branch only
+// ever meant the first one."
+//
+// Session is the one third of the (person, session, bunk) grain an unresolved
+// assignment does not know, so the keys come from the person:bunk index off
+// preloadExistingAssignments -- every stored session for this person in this
+// bunk. That is deliberately wider than one row: if a shared bunk gave a
+// staffer two stored assignments, an unresolvable run must keep both, because
+// it has no basis for choosing between them.
+func (s *BunkAssignmentsSync) resolveSessionOrTrackUnresolved(
+	personCMID, bunkPlanID, bunkID int,
+	bunkPlanSessions []int,
+	existingByPersonBunk map[string][]string,
+	year int,
+) (sessionID int, unresolved bool) {
+	sessionID, ambiguous := s.resolveAssignmentSession(personCMID, bunkPlanID, bunkID, bunkPlanSessions)
+	if !ambiguous && sessionID != 0 {
+		return sessionID, false
+	}
+
+	if ambiguous {
+		key := fmt.Sprintf("%d:%d", bunkPlanID, bunkID)
+		slog.Warn("Ambiguous (bunkPlan, bunk) staff session lookup, skipping assignment",
+			"bunkPlanCMID", bunkPlanID, "bunkCMID", bunkID, "personCMID", personCMID,
+			"candidateCount", len(distinctSessions(s.bunkPlanBunkToSession[key])))
+	}
+
+	// Skipped keeps its existing meaning -- no row was written -- and
+	// UnresolvedSession names the subset of it that is a resolution failure
+	// rather than an unchanged row. See Stats.UnresolvedSession for why one
+	// counter could not do both jobs.
+	s.Stats.Skipped++
+	s.Stats.UnresolvedSession++
+
+	for _, trackingKey := range existingByPersonBunk[fmt.Sprintf("%d:%d", personCMID, bunkID)] {
+		s.TrackProcessedCompositeKey(trackingKey, year)
+	}
+
+	return 0, true
 }
 
 // findMatchingSession finds the session that a person is enrolled in that also belongs to the bunk plan.
@@ -498,17 +599,50 @@ func (s *BunkAssignmentsSync) resolveViaBunk(personSessions []int, bunkPlanID, b
 		personSessionSet[sessionID] = true
 	}
 
-	match, matches := 0, 0
+	// DISTINCT sessions, not candidate occurrences (kindred#2465). candidates
+	// legitimately lists the same session more than once -- there is one entry
+	// per bunk_plans row, and loadMappings deliberately keeps every one of them
+	// (kindred#2264) -- so counting occurrences made a bunk that is listed twice
+	// under a single session look like two competing answers and silently
+	// dropped this narrowing in favor of the plan-wide fallback.
+	match := 0
+	matched := make(map[int]bool, len(candidates))
 	for _, sessionID := range candidates {
 		if personSessionSet[sessionID] {
 			match = sessionID
-			matches++
+			matched[sessionID] = true
 		}
 	}
-	if matches == 1 {
+	if len(matched) == 1 {
 		return match, true
 	}
 	return 0, false
+}
+
+// distinctSessions returns the candidate session CM IDs with duplicates
+// removed, preserving first-seen order.
+//
+// bunkPlanBunkToSession holds one entry per bunk_plans row, so a bunk listed
+// under one session by two rows of the same plan appears twice -- and every
+// read site must decide on how many DIFFERENT sessions it names, never on how
+// many entries there are (kindred#2465). Deduping here rather than at the
+// build site is deliberate: the build site's duplicates are real data, and
+// TestLoadMappings_KeepsEveryCandidateSessionForASharedBunk pins them as a
+// kindred#2264 regression guard.
+func distinctSessions(candidates []int) []int {
+	if len(candidates) < 2 {
+		return candidates
+	}
+	seen := make(map[int]bool, len(candidates))
+	out := make([]int, 0, len(candidates))
+	for _, sessionID := range candidates {
+		if seen[sessionID] {
+			continue
+		}
+		seen[sessionID] = true
+		out = append(out, sessionID)
+	}
+	return out
 }
 
 // resolveStaffSession looks up the session(s) a specific (bunkPlan, bunk)
@@ -522,7 +656,13 @@ func (s *BunkAssignmentsSync) resolveViaBunk(personSessions []int, bunkPlanID, b
 // an arbitrary session with no error and no log line.
 func (s *BunkAssignmentsSync) resolveStaffSession(bunkPlanID, bunkID int) (sessionID int, ambiguous bool) {
 	key := fmt.Sprintf("%d:%d", bunkPlanID, bunkID)
-	candidates := s.bunkPlanBunkToSession[key]
+	// DISTINCT, not len(candidates) (kindred#2465): the raw list holds one entry
+	// per bunk_plans row, so before the map was rebuilt per run this switch was
+	// reading the number of syncs since boot rather than anything in the
+	// database, and reported every staff assignment in the season ambiguous from
+	// run 2 onward. Rebuilding the map fixed the cause; deciding on distinct
+	// sessions is what makes this switch mean what it says either way.
+	candidates := distinctSessions(s.bunkPlanBunkToSession[key])
 	switch len(candidates) {
 	case 0:
 		return 0, false

--- a/pocketbase/sync/bunk_assignments.go
+++ b/pocketbase/sync/bunk_assignments.go
@@ -148,79 +148,7 @@ func (s *BunkAssignmentsSync) Sync(ctx context.Context) error {
 
 		// Process each result
 		for _, result := range assignments {
-			bunkIDFloat, ok := result["BunkID"].(float64)
-			if !ok {
-				slog.Warn("Missing or invalid BunkID in result")
-				continue
-			}
-			bunkID := int(bunkIDFloat)
-
-			bunkPlanIDFloat, ok := result["BunkPlanID"].(float64)
-			if !ok {
-				slog.Warn("Missing or invalid BunkPlanID in result")
-				continue
-			}
-			bunkPlanID := int(bunkPlanIDFloat)
-
-			// Get the assignments array from this result
-			assignmentsArray, ok := result["Assignments"].([]any)
-			if !ok {
-				slog.Warn("No Assignments array in result")
-				continue
-			}
-
-			// Get the list of sessions this bunk plan applies to
-			bunkPlanSessions := s.bunkPlanSessionsList[bunkPlanID]
-			if len(bunkPlanSessions) == 0 {
-				slog.Warn("No sessions found for bunk plan, skipping", "bunkPlanID", bunkPlanID)
-				continue
-			}
-
-			// Process each assignment in the array
-			for _, assignment := range assignmentsArray {
-				assignmentData, ok := assignment.(map[string]any)
-				if !ok {
-					slog.Warn("Invalid assignment data type")
-					continue
-				}
-
-				// Get the person ID to look up their enrollment
-				personID, ok := assignmentData["PersonID"].(float64)
-				if !ok {
-					slog.Warn("No PersonID in assignment")
-					continue
-				}
-				personCMID := int(personID)
-
-				// Find the correct session. See resolveAssignmentSession for the
-				// full ladder; ambiguous is only ever true on the staff path,
-				// where a (bunkPlan, bunk) key has more than one candidate
-				// session and guessing would be worse than skipping (kindred#2264).
-				// Both no-session outcomes go through one wrapper because both
-				// owe the same bookkeeping before they skip -- counting the
-				// failure where it can be seen, and keeping the assignment's
-				// stored rows out of the orphan sweep (kindred#2465).
-				sessionID, unresolved := s.resolveSessionOrTrackUnresolved(
-					personCMID, bunkPlanID, bunkID, bunkPlanSessions, existingByPersonBunk, year)
-				if unresolved {
-					continue
-				}
-
-				// Add BunkID, BunkPlanID, and SessionID to the assignment data
-				assignmentData["BunkID"] = float64(bunkID)
-				assignmentData["BunkPlanID"] = float64(bunkPlanID)
-				assignmentData["SessionID"] = float64(sessionID)
-
-				if err := s.processAssignment(assignmentData, existingAssignments); err != nil {
-					if errors.Is(err, errRejectedRecord) {
-						slog.Warn("Rejected assignment", "error", err)
-						s.Stats.Rejected++
-					} else {
-						slog.Error("Error processing assignment", "error", err)
-						s.Stats.Errors++
-					}
-				}
-			}
+			s.processResultGroup(result, existingAssignments, existingByPersonBunk, year)
 		}
 
 		page++
@@ -439,8 +367,10 @@ func (s *BunkAssignmentsSync) loadMappings() error {
 //
 // The second return is an index of the same rows by "personCMID:bunkCMID" ->
 // the tracking keys ("personCMID:sessionCMID:bunkCMID") they were stored
-// under. It exists for the branch that cannot name a session
-// (resolveSessionOrTrackUnresolved): person and bunk are the two thirds of the
+// under -- the fourth site in this file built on that tracking format,
+// alongside processAssignment, protectNonActiveStaffAssignments and the orphan
+// key deleteOrphans rebuilds. It exists for the branch that cannot name a
+// session (resolveSessionOrTrackUnresolved): person and bunk are the two thirds of the
 // grain an unresolved assignment still knows, and this is how it finds the
 // stored rows to keep from the sweep (kindred#2465, the kindred#2394 pattern).
 func (s *BunkAssignmentsSync) preloadExistingAssignments(
@@ -599,12 +529,13 @@ func (s *BunkAssignmentsSync) resolveViaBunk(personSessions []int, bunkPlanID, b
 		personSessionSet[sessionID] = true
 	}
 
-	// DISTINCT sessions, not candidate occurrences (kindred#2465). candidates
-	// legitimately lists the same session more than once -- there is one entry
-	// per bunk_plans row, and loadMappings deliberately keeps every one of them
-	// (kindred#2264) -- so counting occurrences made a bunk that is listed twice
-	// under a single session look like two competing answers and silently
-	// dropped this narrowing in favor of the plan-wide fallback.
+	// DISTINCT sessions, not candidate occurrences (kindred#2465). On a clean
+	// run this changes nothing -- see distinctSessions for why a duplicate
+	// inside one map key is a bug rather than data. What it buys is that a
+	// RECURRENCE of the run-to-run accumulation degrades into the right answer:
+	// counting occurrences is what made a bunk listed under a single session
+	// look like two competing answers, silently dropping this narrowing in
+	// favor of the plan-wide fallback from run 2 onward.
 	match := 0
 	matched := make(map[int]bool, len(candidates))
 	for _, sessionID := range candidates {
@@ -622,13 +553,28 @@ func (s *BunkAssignmentsSync) resolveViaBunk(personSessions []int, bunkPlanID, b
 // distinctSessions returns the candidate session CM IDs with duplicates
 // removed, preserving first-seen order.
 //
-// bunkPlanBunkToSession holds one entry per bunk_plans row, so a bunk listed
-// under one session by two rows of the same plan appears twice -- and every
-// read site must decide on how many DIFFERENT sessions it names, never on how
-// many entries there are (kindred#2465). Deduping here rather than at the
-// build site is deliberate: the build site's duplicates are real data, and
-// TestLoadMappings_KeepsEveryCandidateSessionForASharedBunk pins them as a
-// kindred#2264 regression guard.
+// On a clean run it is a NO-OP, and saying so plainly is the point.
+// bunkPlanBunkToSession is keyed "bunkPlanCMID:bunkCMID", and bunk_plans
+// carries a unique index on (year, bunk, session, cm_id) -- see
+// pb_migrations/1500000017_bunk_plans.js -- so the rows behind any ONE map key
+// differ only in session. Within a key the same session cannot legitimately
+// repeat: a duplicate there is not data, it is a bug.
+//
+// It exists as defense against a RECURRENCE of that bug. kindred#2465 was one
+// instance reused across scheduled runs with append-only maps, so every hour
+// added another copy of every candidate; a read site that decides on how many
+// ENTRIES there are rather than how many DIFFERENT sessions they name mistakes
+// that accumulation for ambiguity, and for bunk staff that meant an untracked
+// skip and a deleted row. Rebuilding the maps per run (loadMappings) removed
+// the cause; this keeps the read sites correct either way.
+//
+// Deduping here rather than at the build site is still deliberate, but the
+// reason is the SIBLING map, not this one: bunkPlanSessionsList legitimately
+// holds one entry per bunk_plans row, which
+// TestLoadMappings_KeepsEveryCandidateSessionForASharedBunk pins as [A, A, B]
+// for a plan whose shared bunk spans two sessions. That same test pins
+// bunkPlanBunkToSession duplicate-FREE ([A, B]) for that bunk. Nothing here
+// licenses the build site to start emitting duplicates it does not emit today.
 func distinctSessions(candidates []int) []int {
 	if len(candidates) < 2 {
 		return candidates
@@ -706,6 +652,112 @@ func (s *BunkAssignmentsSync) resolveAssignmentSession(
 	return 0, false
 }
 
+// processResultGroup handles one entry of a CampMinder bunk-assignments page:
+// the (bunkPlan, bunk) pair and every assignment CampMinder returned for it.
+//
+// It is a method rather than an inline block so the group-level skips below
+// are reachable from a test. Client is a concrete *campminder.Client, so
+// Sync() itself cannot be driven without an HTTP fake, and the skips are
+// precisely the branches kindred#2465 showed nobody was pinning.
+func (s *BunkAssignmentsSync) processResultGroup(
+	result map[string]any,
+	existingAssignments map[string]*core.Record,
+	existingByPersonBunk map[string][]string,
+	year int,
+) {
+	// The three shape checks below are the only skips in this file that stay
+	// untracked, and they are the one case where that is right: a result with
+	// no BunkID, no BunkPlanID or no Assignments array names no person and no
+	// bunk, so there is no key to keep from the sweep and nothing to count
+	// against a grain. Every skip that DOES know a person and a bunk goes
+	// through resolveSessionOrTrackUnresolved instead.
+	bunkIDFloat, ok := result["BunkID"].(float64)
+	if !ok {
+		slog.Warn("Missing or invalid BunkID in result")
+		return
+	}
+	bunkID := int(bunkIDFloat)
+
+	bunkPlanIDFloat, ok := result["BunkPlanID"].(float64)
+	if !ok {
+		slog.Warn("Missing or invalid BunkPlanID in result")
+		return
+	}
+	bunkPlanID := int(bunkPlanIDFloat)
+
+	// Get the assignments array from this result
+	assignmentsArray, ok := result["Assignments"].([]any)
+	if !ok {
+		slog.Warn("No Assignments array in result")
+		return
+	}
+
+	// Get the list of sessions this bunk plan applies to. Warned once for the
+	// group, but deliberately NOT skipped as a group (kindred#2465): dropping
+	// the whole (bunkPlan, bunk) pair here is the same untracked-skip mechanism
+	// the wrapper below exists to close, only a group at a time -- every
+	// assignment under it would be missing from ProcessedKeys and deleteOrphans
+	// would read that absence as "CampMinder dropped these rows".
+	//
+	// Falling through cannot write a row to the wrong session: loadMappings
+	// gates bunkPlanSessionsList and bunkPlanBunkToSession on the same
+	// `bpCMID > 0 && sessionCMID > 0`, so an empty plan-session list guarantees
+	// an empty candidate list too, and every step of the resolution ladder
+	// fails. Each assignment therefore lands in the unresolved branch, which is
+	// the honest place for it.
+	bunkPlanSessions := s.bunkPlanSessionsList[bunkPlanID]
+	if len(bunkPlanSessions) == 0 {
+		slog.Warn("No sessions found for bunk plan, every assignment under it is unresolved",
+			"bunkPlanID", bunkPlanID, "bunkCMID", bunkID, "assignments", len(assignmentsArray))
+	}
+
+	// Process each assignment in the array
+	for _, assignment := range assignmentsArray {
+		assignmentData, ok := assignment.(map[string]any)
+		if !ok {
+			slog.Warn("Invalid assignment data type")
+			continue
+		}
+
+		// Get the person ID to look up their enrollment
+		personID, ok := assignmentData["PersonID"].(float64)
+		if !ok {
+			slog.Warn("No PersonID in assignment")
+			continue
+		}
+		personCMID := int(personID)
+
+		// Find the correct session. See resolveAssignmentSession for the
+		// full ladder; ambiguous is only ever true on the staff path,
+		// where a (bunkPlan, bunk) key has more than one candidate
+		// session and guessing would be worse than skipping (kindred#2264).
+		// Both no-session outcomes go through one wrapper because both
+		// owe the same bookkeeping before they skip -- counting the
+		// failure where it can be seen, and keeping the assignment's
+		// stored rows out of the orphan sweep (kindred#2465).
+		sessionID, unresolved := s.resolveSessionOrTrackUnresolved(
+			personCMID, bunkPlanID, bunkID, bunkPlanSessions, existingByPersonBunk, year)
+		if unresolved {
+			continue
+		}
+
+		// Add BunkID, BunkPlanID, and SessionID to the assignment data
+		assignmentData["BunkID"] = float64(bunkID)
+		assignmentData["BunkPlanID"] = float64(bunkPlanID)
+		assignmentData["SessionID"] = float64(sessionID)
+
+		if err := s.processAssignment(assignmentData, existingAssignments); err != nil {
+			if errors.Is(err, errRejectedRecord) {
+				slog.Warn("Rejected assignment", "error", err)
+				s.Stats.Rejected++
+			} else {
+				slog.Error("Error processing assignment", "error", err)
+				s.Stats.Errors++
+			}
+		}
+	}
+}
+
 // processAssignment processes a single bunk assignment using pre-loaded existing assignments
 func (s *BunkAssignmentsSync) processAssignment(
 	assignmentData map[string]any,
@@ -739,10 +791,14 @@ func (s *BunkAssignmentsSync) processAssignment(
 	bunkPlanCMID := int(bunkPlanID)
 
 	// Track this assignment as processed using base class tracking. The key
-	// includes bunk (kindred#2259) so it matches the ORPHAN key deleteOrphans
-	// rebuilds and the one protectNonActiveStaffAssignments writes for
-	// protected non-active staff -- all three must move together, or a run
-	// after this one deletes the very rows this widening exists to keep.
+	// includes bunk (kindred#2259), and FOUR sites now build that same
+	// person:session:bunk tracking format: this one, the ORPHAN key
+	// deleteOrphans rebuilds, the one protectNonActiveStaffAssignments writes
+	// for protected non-active staff, and -- since kindred#2465 -- the values
+	// preloadExistingAssignments indexes by person:bunk, which
+	// resolveSessionOrTrackUnresolved re-tracks when a run cannot name the
+	// session. All four must move together, or a run after this one deletes
+	// the very rows this widening exists to keep.
 	s.TrackProcessedCompositeKey(fmt.Sprintf("%d:%d:%d", personCMID, sessionCMID, bunkCMID), s.Client.GetSeasonID())
 
 	// Validate person exists
@@ -986,8 +1042,12 @@ func (s *BunkAssignmentsSync) deleteOrphans() error {
 				}
 				// For composite records, append year to the composite key.
 				// This must match TrackProcessedCompositeKey's format exactly
-				// (person:session:bunk, then "|" + year) -- processAssignment
-				// and protectNonActiveStaffAssignments both build it that way.
+				// (person:session:bunk, then "|" + year). Three sites feed that
+				// format in: processAssignment, protectNonActiveStaffAssignments,
+				// and preloadExistingAssignments' person:bunk index, whose values
+				// resolveSessionOrTrackUnresolved re-tracks for an assignment it
+				// could not resolve (kindred#2465). Change the shape in one and
+				// the other three stop matching -- which reads here as an orphan.
 				key := fmt.Sprintf("%d:%d:%d|%d", personCMID, sessionCMID, bunkCMID, int(year))
 				return key, true
 			}

--- a/pocketbase/sync/bunk_assignments_grain_test.go
+++ b/pocketbase/sync/bunk_assignments_grain_test.go
@@ -99,6 +99,23 @@ func bunkAssignmentsForYear(t *testing.T, app core.App, year int) []*core.Record
 	return rows
 }
 
+// assignmentCMIDsForYear returns the set of bunk_assignments cm_ids stored for
+// the given year. Counting rows says a sweep deleted the right NUMBER; naming
+// the survivors says it deleted the right ROWS, which is what a test that
+// pins "this one is kept and that one is not" actually needs.
+func assignmentCMIDsForYear(t *testing.T, app core.App, year int) map[int]bool {
+	t.Helper()
+	out := make(map[int]bool)
+	for _, row := range bunkAssignmentsForYear(t, app, year) {
+		cmID, ok := row.Get("cm_id").(float64)
+		if !ok {
+			t.Fatalf("bunk_assignments row %s has no numeric cm_id", row.Id)
+		}
+		out[int(cmID)] = true
+	}
+	return out
+}
+
 // TestProcessAssignment_MultiSessionPlanDisambiguatedByBunk is the
 // regression test kindred#2259's acceptance checklist asks for: "a
 // bunk_assignments sync test where one bunk plan covers two sessions, one
@@ -580,6 +597,18 @@ func TestBunkAssignment_StaffRowSurvivesASecondRunOnTheSameInstance(t *testing.T
 	const planCMID = 8005
 	const sessionCMID = 5501
 	const bunkCMID = 6501
+	// The counselor's own row, as processAssignment writes it (730000 + person).
+	const staffAssignmentCMID = 730000 + staffPersonCMID
+	// Two campers who really did leave, one per run: their stored rows are the
+	// proof that the sweep is DOING something. Without them a run that swept
+	// nothing at all -- guard refusal, empty orphan set, a no-op DeleteOrphans
+	// -- would satisfy every "the staff row is still here" assertion below.
+	// kindred#2294 settled this shape on
+	// TestProtectThenSweepOrphans_DismissedStaffAssignmentSurvivesSweep.
+	const departedRunOneCMID = 9000014
+	const departedRunTwoCMID = 9000015
+	const departedRunOneAssignmentCMID = 740003
+	const departedRunTwoAssignmentCMID = 740004
 
 	// Three campers share the bunk with the counselor. They are not decoration:
 	// OrphanSweepGuard refuses a sweep whose computed set is under half of what
@@ -610,6 +639,14 @@ func TestBunkAssignment_StaffRowSurvivesASecondRunOnTheSameInstance(t *testing.T
 	saveRec(t, app, "staff", map[string]any{
 		"person_id": staffPersonCMID, "bunk_staff": true, "status": "active", "year": year,
 	})
+	departedRunOne := saveRec(t, app, "persons", map[string]any{"cm_id": departedRunOneCMID, "year": year})
+	departedRunTwo := saveRec(t, app, "persons", map[string]any{"cm_id": departedRunTwoCMID, "year": year})
+	// Stored by an earlier run and absent from this run's feed: a real orphan,
+	// seeded before run 1 so run 1's sweep has something it must delete.
+	saveRec(t, app, "bunk_assignments", map[string]any{
+		"cm_id": departedRunOneAssignmentCMID, "person": departedRunOne.Id,
+		"session": session.Id, "bunk": bunk.Id, "year": year,
+	})
 
 	// ONE instance, reused across both runs -- the orchestrator's actual shape.
 	s := NewBunkAssignmentsSync(app, newParallelTestCampMinderClient(t, year))
@@ -617,9 +654,16 @@ func TestBunkAssignment_StaffRowSurvivesASecondRunOnTheSameInstance(t *testing.T
 	// runOnce mirrors Sync()'s body over the four assignments CampMinder returns
 	// for this bunk: the same per-run reset Sync() performs at its top, the real
 	// loadMappings, the real preload, the real resolution ladder, and -- on the
-	// skip branch -- exactly what Sync()'s loop does today, which is to count a
-	// Skipped and continue WITHOUT tracking the key. That last detail is the
-	// whole mechanism: the untracked key is what deleteOrphans then deletes.
+	// skip branch -- what Sync()'s loop DID, before this fix: count a Skipped and
+	// continue WITHOUT tracking the key. That last detail is the whole mechanism;
+	// the untracked key is what deleteOrphans then deletes.
+	//
+	// Sync() no longer has that branch -- it routes both no-session outcomes
+	// through resolveSessionOrTrackUnresolved, which tracks -- and hand-rolling
+	// the OLD shape here is deliberate. It isolates the map reset: with the
+	// tracking wrapper standing in, reverting loadMappings' reset alone would
+	// still keep the row, and this test would stop pinning the bug it is named
+	// for. Verified by mutation both ways.
 	runOnce := func(t *testing.T) (staffSession int, staffAmbiguous bool) {
 		t.Helper()
 
@@ -668,9 +712,21 @@ func TestBunkAssignment_StaffRowSurvivesASecondRunOnTheSameInstance(t *testing.T
 	if sessionID, ambiguous := runOnce(t); ambiguous || sessionID != sessionCMID {
 		t.Fatalf("run 1: staff resolution = (%d, ambiguous=%v), want (%d, false)", sessionID, ambiguous, sessionCMID)
 	}
-	if rows := bunkAssignmentsForYear(t, app, year); len(rows) != 4 {
-		t.Fatalf("run 1: bunk_assignments rows = %d, want 4 (3 campers + 1 counselor)", len(rows))
+	afterRunOne := assignmentCMIDsForYear(t, app, year)
+	if len(afterRunOne) != 4 {
+		t.Fatalf("run 1: bunk_assignments rows = %d, want 4 (3 campers + 1 counselor); survivors = %v",
+			len(afterRunOne), afterRunOne)
 	}
+	if afterRunOne[departedRunOneAssignmentCMID] {
+		t.Fatalf("run 1: the departed camper's row (cm_id %d) survived -- if the sweep deletes nothing, "+
+			"every surviving-row assertion in this test is vacuous", departedRunOneAssignmentCMID)
+	}
+
+	// Run 2 gets its own orphan, for the same reason run 1 did.
+	saveRec(t, app, "bunk_assignments", map[string]any{
+		"cm_id": departedRunTwoAssignmentCMID, "person": departedRunTwo.Id,
+		"session": session.Id, "bunk": bunk.Id, "year": year,
+	})
 
 	sessionID, ambiguous := runOnce(t)
 
@@ -695,9 +751,18 @@ func TestBunkAssignment_StaffRowSurvivesASecondRunOnTheSameInstance(t *testing.T
 	// flat skipped_count. The counter that CAN see it is asserted in
 	// TestBunkAssignment_UnresolvedAssignmentIsCountedAndKeptFromTheSweep.
 
-	if rows := bunkAssignmentsForYear(t, app, year); len(rows) != 4 {
-		t.Errorf("after run 2: bunk_assignments rows = %d, want 4 -- the staff assignment must survive the "+
-			"hourly sync, not be swept as an orphan the run never tracked", len(rows))
+	afterRunTwo := assignmentCMIDsForYear(t, app, year)
+	if !afterRunTwo[staffAssignmentCMID] {
+		t.Errorf("after run 2: the counselor's row (cm_id %d) is gone -- the staff assignment must survive "+
+			"the hourly sync, not be swept as an orphan the run never tracked", staffAssignmentCMID)
+	}
+	if afterRunTwo[departedRunTwoAssignmentCMID] {
+		t.Errorf("after run 2: the departed camper's row (cm_id %d) survived -- run 2's sweep did nothing, "+
+			"so the assertion above proves nothing", departedRunTwoAssignmentCMID)
+	}
+	if len(afterRunTwo) != 4 {
+		t.Errorf("after run 2: bunk_assignments rows = %d, want 4 (3 campers + 1 counselor); survivors = %v",
+			len(afterRunTwo), afterRunTwo)
 	}
 }
 
@@ -830,15 +895,40 @@ func TestBunkAssignment_UnresolvedAssignmentIsCountedAndKeptFromTheSweep(t *test
 
 	const year = 2026
 	const staffPersonCMID = 9000009
+	const departedCamperCMID = 9000013
 	const planCMID = 8008
 	const sessionACMID = 5801
 	const sessionBCMID = 5802
 	const bunkCMID = 6801
+	const staffAssignmentCMID = 740001
+	const departedAssignmentCMID = 740002
+
+	// Three campers who resolve normally. They are load-bearing fixture, not
+	// scenery: OrphanSweepGuard refuses a sweep outright when the computed set
+	// is EMPTY, so with only the staff row in play, deleting the tracking this
+	// test exists to pin would abort the sweep instead of destroying anything,
+	// and the row-count assertion below would never be reached. The test would
+	// still go red -- on protectThenSweepOrphans returning an error -- which
+	// says nothing about whether tracking kept the row. Three resolving campers
+	// keep the computed set non-empty so the sweep genuinely runs, which is the
+	// shape production had: the 262 staff rows sat in a table whose camper rows
+	// still resolved and still tracked. Sibling test
+	// TestBunkAssignmentGrain_SecondSyncRunNeitherLosesNorDuplicates widens its
+	// fixture for the same reason.
+	camperCMIDs := []int{9000010, 9000011, 9000012}
 
 	saveRec(t, app, "persons", map[string]any{"cm_id": staffPersonCMID, "year": year})
 	sessionA := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": sessionACMID, "year": year})
 	sessionB := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": sessionBCMID, "year": year})
 	bunk := saveRec(t, app, "bunks", map[string]any{"cm_id": bunkCMID, "year": year})
+	for _, camperCMID := range camperCMIDs {
+		saveRec(t, app, "persons", map[string]any{"cm_id": camperCMID, "year": year})
+		// Enrolled in session A only, so resolveViaBunk narrows the plan's two
+		// candidate sessions down to one for them and they resolve cleanly.
+		saveRec(t, app, "attendees", map[string]any{
+			"person_id": camperCMID, "session": sessionA.Id, "status_id": 2, "year": year,
+		})
+	}
 	// The family-camp shape: ONE bunk under TWO sessions of one plan. Genuinely
 	// ambiguous in the database, not an artifact of a reused instance.
 	saveRec(t, app, "bunk_plans", map[string]any{
@@ -850,6 +940,12 @@ func TestBunkAssignment_UnresolvedAssignmentIsCountedAndKeptFromTheSweep(t *test
 	saveRec(t, app, "staff", map[string]any{
 		"person_id": staffPersonCMID, "bunk_staff": true, "status": "active", "year": year,
 	})
+	// A camper who really has left: stored from an earlier run, and this run's
+	// feed does not mention them. The sweep MUST delete this row, or the test
+	// would pass simply because the sweep did nothing at all -- the shape
+	// kindred#2294 settled on for
+	// TestProtectThenSweepOrphans_DismissedStaffAssignmentSurvivesSweep.
+	departed := saveRec(t, app, "persons", map[string]any{"cm_id": departedCamperCMID, "year": year})
 
 	s := NewBunkAssignmentsSync(app, newParallelTestCampMinderClient(t, year))
 	if loadErr := s.loadMappings(); loadErr != nil {
@@ -864,15 +960,39 @@ func TestBunkAssignment_UnresolvedAssignmentIsCountedAndKeptFromTheSweep(t *test
 		t.Fatalf("find person: %v", err)
 	}
 	saveRec(t, app, "bunk_assignments", map[string]any{
-		"cm_id": 740001, "person": person.Id, "session": sessionA.Id, "bunk": bunk.Id, "year": year,
+		"cm_id": staffAssignmentCMID, "person": person.Id,
+		"session": sessionA.Id, "bunk": bunk.Id, "year": year,
+	})
+	saveRec(t, app, "bunk_assignments", map[string]any{
+		"cm_id": departedAssignmentCMID, "person": departed.Id,
+		"session": sessionA.Id, "bunk": bunk.Id, "year": year,
 	})
 
 	existing, existingByPersonBunk, err := s.preloadExistingAssignments(year)
 	if err != nil {
 		t.Fatalf("preloadExistingAssignments: %v", err)
 	}
-	if len(existing) != 1 {
-		t.Fatalf("existing = %d, want 1", len(existing))
+	if len(existing) != 2 {
+		t.Fatalf("existing = %d, want 2 (the staffer's stored row and the departed camper's)", len(existing))
+	}
+
+	// The campers go through the same wrapper the staffer does, and resolve.
+	for _, camperCMID := range camperCMIDs {
+		camperSession, camperUnresolved := s.resolveSessionOrTrackUnresolved(
+			camperCMID, planCMID, bunkCMID, s.bunkPlanSessionsList[planCMID], existingByPersonBunk, year)
+		if camperUnresolved || camperSession != sessionACMID {
+			t.Fatalf("camper %d resolution = (%d, unresolved=%v), want (%d, false)",
+				camperCMID, camperSession, camperUnresolved, sessionACMID)
+		}
+		if err := s.processAssignment(map[string]any{
+			"PersonID":   float64(camperCMID),
+			"BunkID":     float64(bunkCMID),
+			"BunkPlanID": float64(planCMID),
+			"SessionID":  float64(camperSession),
+			"ID":         float64(740000 + camperCMID),
+		}, existing); err != nil {
+			t.Fatalf("processAssignment(camper %d): %v", camperCMID, err)
+		}
 	}
 
 	sessionID, unresolved := s.resolveSessionOrTrackUnresolved(
@@ -887,8 +1007,8 @@ func TestBunkAssignment_UnresolvedAssignmentIsCountedAndKeptFromTheSweep(t *test
 			"own, or it hides inside Skipped alongside every unchanged row", s.Stats.UnresolvedSession)
 	}
 	if s.Stats.Skipped != 1 {
-		t.Errorf("Stats.Skipped = %d, want 1 -- the new counter is a named subset of Skipped, not a "+
-			"replacement for it", s.Stats.Skipped)
+		t.Errorf("Stats.Skipped = %d, want 1 -- the three campers were CREATED, not skipped, so the only "+
+			"Skipped here is the staffer, and the new counter is a named subset of it", s.Stats.Skipped)
 	}
 
 	// The row the run could not resolve must be tracked as processed, so the
@@ -897,8 +1017,89 @@ func TestBunkAssignment_UnresolvedAssignmentIsCountedAndKeptFromTheSweep(t *test
 	if err := s.protectThenSweepOrphans(year); err != nil {
 		t.Fatalf("protectThenSweepOrphans: %v", err)
 	}
-	if rows := bunkAssignmentsForYear(t, app, year); len(rows) != 1 {
-		t.Errorf("after the sweep: bunk_assignments rows = %d, want 1 -- an assignment the run SAW but "+
-			"could not resolve is not an orphan (kindred#2394)", len(rows))
+	survivors := assignmentCMIDsForYear(t, app, year)
+	if !survivors[staffAssignmentCMID] {
+		t.Errorf("after the sweep: the unresolved staffer's row (cm_id %d) is gone -- an assignment the "+
+			"run SAW but could not resolve is not an orphan (kindred#2394)", staffAssignmentCMID)
+	}
+	if survivors[departedAssignmentCMID] {
+		t.Errorf("after the sweep: the departed camper's row (cm_id %d) survived -- if the sweep deletes "+
+			"nothing, the assertion above proves nothing either", departedAssignmentCMID)
+	}
+	if len(survivors) != 4 {
+		t.Errorf("after the sweep: bunk_assignments rows = %d, want 4 (3 campers + the unresolved "+
+			"staffer); survivors = %v", len(survivors), survivors)
+	}
+}
+
+// TestProcessResultGroup_PlanWithNoSessionsStillTracksItsAssignments pins the
+// last untracked skip in the assignment loop -- one line above the two
+// kindred#2465 closed, and the same mechanism.
+//
+// When a bunk plan has no sessions the loop used to drop the ENTIRE
+// (bunkPlan, bunk) group with a warning, without counting it and without
+// tracking a single key. Every assignment in that group was therefore absent
+// from ProcessedKeys, and deleteOrphans reads absence as "CampMinder no longer
+// returns this row" and deletes it -- exactly the path that deleted 262 staff
+// rows an hour.
+//
+// The trigger is narrow, which is why it outlived kindred#2465's own two:
+// loadMappings gates both bunkPlanSessionsList and bunkPlanBunkToSession on
+// `bpCMID > 0 && sessionCMID > 0`, and bunk_plans.session is required in
+// production, so emptying the list needs a dangling session relation or a null
+// cm_id. Narrow is not the same as impossible, and the blast radius is a whole
+// group rather than one assignment.
+//
+// Because the same gate builds both maps, an empty plan-session list
+// guarantees an empty bunkPlanBunkToSession entry too -- so every step of the
+// resolution ladder fails and no assignment here can be written to a wrong
+// session. The only correct handling is the one the other skips already use:
+// count it, and keep the rows already on disk out of the sweep.
+func TestProcessResultGroup_PlanWithNoSessionsStillTracksItsAssignments(t *testing.T) {
+	t.Parallel()
+
+	const year = 2026
+	const personCMID = 9000011
+	const sessionCMID = 5901
+	const bunkCMID = 6901
+	const planCMID = 8009
+
+	s := &BunkAssignmentsSync{}
+	s.ProcessedKeys = make(map[string]bool)
+	// No bunkPlanSessionsList entry for planCMID, and no bunkPlanBunkToSession
+	// entry either: that is the state loadMappings leaves behind for a plan
+	// whose only bunk_plans row could not be resolved to a session cm_id.
+
+	existingByPersonBunk := map[string][]string{
+		fmt.Sprintf("%d:%d", personCMID, bunkCMID): {
+			fmt.Sprintf("%d:%d:%d", personCMID, sessionCMID, bunkCMID),
+		},
+	}
+
+	result := map[string]any{
+		"BunkID":     float64(bunkCMID),
+		"BunkPlanID": float64(planCMID),
+		"Assignments": []any{
+			map[string]any{"PersonID": float64(personCMID), "ID": float64(750001)},
+		},
+	}
+
+	s.processResultGroup(result, nil, existingByPersonBunk, year)
+
+	if s.Stats.UnresolvedSession != 1 {
+		t.Errorf("Stats.UnresolvedSession = %d, want 1 -- an assignment under a session-less bunk plan "+
+			"is a resolution failure and has to be counted as one, not dropped silently",
+			s.Stats.UnresolvedSession)
+	}
+	if s.Stats.Skipped != 1 {
+		t.Errorf("Stats.Skipped = %d, want 1 -- no row was written, which is what Skipped counts here",
+			s.Stats.Skipped)
+	}
+
+	wantKey := fmt.Sprintf("%d:%d:%d|%d", personCMID, sessionCMID, bunkCMID, year)
+	if !s.ProcessedKeys[wantKey] {
+		t.Errorf("ProcessedKeys = %v, want it to contain %q -- the run SAW this person in this bunk, so "+
+			"its stored row must be kept from the orphan sweep (kindred#2394, kindred#2465)",
+			s.ProcessedKeys, wantKey)
 	}
 }

--- a/pocketbase/sync/bunk_assignments_grain_test.go
+++ b/pocketbase/sync/bunk_assignments_grain_test.go
@@ -160,7 +160,7 @@ func TestProcessAssignment_MultiSessionPlanDisambiguatedByBunk(t *testing.T) {
 	s.validSessionCMIDs = map[int]bool{sessionACMID: true, sessionBCMID: true}
 	s.validBunkCMIDs = map[int]bool{bunkACMID: true, bunkBCMID: true}
 
-	existing, err := s.preloadExistingAssignments(year)
+	existing, _, err := s.preloadExistingAssignments(year)
 	if err != nil {
 		t.Fatalf("preloadExistingAssignments: %v", err)
 	}
@@ -282,7 +282,7 @@ func TestProcessAssignment_FamilyStylePlanPreservesBothRowsImprecisely(t *testin
 	s.validSessionCMIDs = map[int]bool{sessionACMID: true, sessionBCMID: true}
 	s.validBunkCMIDs = map[int]bool{bunkXCMID: true, bunkYCMID: true}
 
-	existing, err := s.preloadExistingAssignments(year)
+	existing, _, err := s.preloadExistingAssignments(year)
 	if err != nil {
 		t.Fatalf("preloadExistingAssignments: %v", err)
 	}
@@ -393,7 +393,7 @@ func TestBunkAssignmentGrain_SecondSyncRunNeitherLosesNorDuplicates(t *testing.T
 		t.Helper()
 		s := newSync()
 
-		existing, err := s.preloadExistingAssignments(year)
+		existing, _, err := s.preloadExistingAssignments(year)
 		if err != nil {
 			t.Fatalf("preloadExistingAssignments: %v", err)
 		}
@@ -540,5 +540,365 @@ func TestLoadMappings_KeepsEveryCandidateSessionForASharedBunk(t *testing.T) {
 	}
 	if sessionCMID, ambiguous := s.resolveStaffSession(planCMID, soloBunkCMID); ambiguous || sessionCMID != sessionACMID {
 		t.Errorf("resolveStaffSession(solo bunk) = (%d, %v), want (%d, false)", sessionCMID, ambiguous, sessionACMID)
+	}
+}
+
+// TestBunkAssignment_StaffRowSurvivesASecondRunOnTheSameInstance pins
+// kindred#2465: the orchestrator constructs ONE BunkAssignmentsSync at boot
+// and dispatches every scheduled run to it, but loadMappings only ever
+// APPENDED to bunkPlanSessionsList and bunkPlanBunkToSession. Run 2 therefore
+// read run 1's candidates still sitting in the map plus its own fresh copy,
+// so a (bunkPlan, bunk) pair with exactly ONE session in the database
+// presented as two candidates, resolveStaffSession called it ambiguous, the
+// assignment was skipped without ever being tracked as processed, and
+// deleteOrphans read "untracked" as "CampMinder dropped it" and deleted the
+// row. In production that was 262 rows for 70 active bunk staff, deleted
+// every hour, restored only by a container restart.
+//
+// Why TestBunkAssignmentGrain_SecondSyncRunNeitherLosesNorDuplicates does not
+// catch it, and what this test does differently: that test's newSync() closure
+// builds a FRESH instance per run AND hand-assigns the maps, so the real
+// loadMappings never executes at all. This one uses a single instance across
+// both runs and drives the production loadMappings, which is the only place
+// the accumulation is observable.
+//
+// The tightest assertion is the map one -- two loadMappings() calls over one
+// bunk_plans row must leave one candidate, not two. The run-2 resolution and
+// surviving-row assertions are what make the consequence legible.
+func TestBunkAssignment_StaffRowSurvivesASecondRunOnTheSameInstance(t *testing.T) {
+	t.Parallel()
+
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupBunkAssignmentGrainCollections(t, app)
+
+	const year = 2026
+	const staffPersonCMID = 9000005
+	const planCMID = 8005
+	const sessionCMID = 5501
+	const bunkCMID = 6501
+
+	// Three campers share the bunk with the counselor. They are not decoration:
+	// OrphanSweepGuard refuses a sweep whose computed set is under half of what
+	// is on disk, so a fixture holding ONLY the staff row would have the guard
+	// stop the deletion and hide the bug. Production has no such luck -- the 262
+	// staff rows sat inside a table whose camper rows still resolved and still
+	// tracked, so the guard's floor was met and the sweep ran. This fixture is
+	// that shape in miniature: 3 of 4 rows keep tracking, 1 does not.
+	camperCMIDs := []int{9000006, 9000007, 9000008}
+
+	saveRec(t, app, "persons", map[string]any{"cm_id": staffPersonCMID, "year": year})
+	session := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": sessionCMID, "year": year})
+	bunk := saveRec(t, app, "bunks", map[string]any{"cm_id": bunkCMID, "year": year})
+	for _, camperCMID := range camperCMIDs {
+		saveRec(t, app, "persons", map[string]any{"cm_id": camperCMID, "year": year})
+		saveRec(t, app, "attendees", map[string]any{
+			"person_id": camperCMID, "session": session.Id, "status_id": 2, "year": year,
+		})
+	}
+	// Exactly ONE bunk_plans row: this (plan, bunk) pair is unambiguous in the
+	// database. Any ambiguity a run reports is manufactured in memory.
+	saveRec(t, app, "bunk_plans", map[string]any{
+		"cm_id": planCMID, "bunk": bunk.Id, "session": session.Id, "year": year,
+	})
+	// A bunk staffer: active, bunk_staff, and NOT in attendees -- which is why
+	// resolveAssignmentSession falls all the way through to resolveStaffSession
+	// for them (staff have no enrollment to intersect).
+	saveRec(t, app, "staff", map[string]any{
+		"person_id": staffPersonCMID, "bunk_staff": true, "status": "active", "year": year,
+	})
+
+	// ONE instance, reused across both runs -- the orchestrator's actual shape.
+	s := NewBunkAssignmentsSync(app, newParallelTestCampMinderClient(t, year))
+
+	// runOnce mirrors Sync()'s body over the four assignments CampMinder returns
+	// for this bunk: the same per-run reset Sync() performs at its top, the real
+	// loadMappings, the real preload, the real resolution ladder, and -- on the
+	// skip branch -- exactly what Sync()'s loop does today, which is to count a
+	// Skipped and continue WITHOUT tracking the key. That last detail is the
+	// whole mechanism: the untracked key is what deleteOrphans then deletes.
+	runOnce := func(t *testing.T) (staffSession int, staffAmbiguous bool) {
+		t.Helper()
+
+		s.Stats = Stats{}
+		s.SyncSuccessful = false
+		s.ClearProcessedKeys()
+
+		if err := s.loadMappings(); err != nil {
+			t.Fatalf("loadMappings: %v", err)
+		}
+
+		existing, _, err := s.preloadExistingAssignments(year)
+		if err != nil {
+			t.Fatalf("preloadExistingAssignments: %v", err)
+		}
+
+		for _, personCMID := range append([]int{staffPersonCMID}, camperCMIDs...) {
+			sessionID, ambiguous := s.resolveAssignmentSession(
+				personCMID, planCMID, bunkCMID, s.bunkPlanSessionsList[planCMID])
+			if personCMID == staffPersonCMID {
+				staffSession, staffAmbiguous = sessionID, ambiguous
+			}
+			if ambiguous || sessionID == 0 {
+				s.Stats.Skipped++
+				continue
+			}
+			assignmentData := map[string]any{
+				"PersonID":   float64(personCMID),
+				"BunkID":     float64(bunkCMID),
+				"BunkPlanID": float64(planCMID),
+				"SessionID":  float64(sessionID),
+				"ID":         float64(730000 + personCMID),
+			}
+			if err := s.processAssignment(assignmentData, existing); err != nil {
+				t.Fatalf("processAssignment(person=%d): %v", personCMID, err)
+			}
+		}
+
+		s.SyncSuccessful = true // Sync() sets this after a successful first page fetch
+		if err := s.protectThenSweepOrphans(year); err != nil {
+			t.Fatalf("protectThenSweepOrphans: %v", err)
+		}
+		return staffSession, staffAmbiguous
+	}
+
+	if sessionID, ambiguous := runOnce(t); ambiguous || sessionID != sessionCMID {
+		t.Fatalf("run 1: staff resolution = (%d, ambiguous=%v), want (%d, false)", sessionID, ambiguous, sessionCMID)
+	}
+	if rows := bunkAssignmentsForYear(t, app, year); len(rows) != 4 {
+		t.Fatalf("run 1: bunk_assignments rows = %d, want 4 (3 campers + 1 counselor)", len(rows))
+	}
+
+	sessionID, ambiguous := runOnce(t)
+
+	bunkKey := fmt.Sprintf("%d:%d", planCMID, bunkCMID)
+	if got := s.bunkPlanBunkToSession[bunkKey]; len(got) != 1 {
+		t.Errorf("after two loadMappings() calls on one instance, bunkPlanBunkToSession[%q] = %v "+
+			"(%d candidates), want exactly 1 -- the maps must be rebuilt per run, not appended to",
+			bunkKey, got, len(got))
+	}
+	if ambiguous {
+		t.Errorf("run 2: staff resolution reported ambiguous for a (plan, bunk) pair with ONE bunk_plans " +
+			"row -- candidateCount is counting runs since boot, not sessions in the database")
+	}
+	if sessionID != sessionCMID {
+		t.Errorf("run 2: staff resolved session = %d, want %d", sessionID, sessionCMID)
+	}
+	// Deliberately NOT asserted here: Stats.Skipped. On this run it reads 4 --
+	// three legitimate no-change skips from base_sync's ProcessCompositeRecord
+	// for the campers, plus the one ambiguous staff skip -- and it read 4 before
+	// the sweep destroyed anything too. That indistinguishability is the reason
+	// kindred#2465 ran for 119 hourly syncs reporting status='success' with a
+	// flat skipped_count. The counter that CAN see it is asserted in
+	// TestBunkAssignment_UnresolvedAssignmentIsCountedAndKeptFromTheSweep.
+
+	if rows := bunkAssignmentsForYear(t, app, year); len(rows) != 4 {
+		t.Errorf("after run 2: bunk_assignments rows = %d, want 4 -- the staff assignment must survive the "+
+			"hourly sync, not be swept as an orphan the run never tracked", len(rows))
+	}
+}
+
+// TestResolveViaBunk_DecidesOnDISTINCTSessions pins the camper-side half of
+// kindred#2465. resolveViaBunk counted matches per candidate OCCURRENCE, so
+// once the accumulated map held the same session twice, matches == 2 and the
+// kindred#2264 bunk-specific narrowing silently reverted to the plan-wide
+// findMatchingSession fallback from run 2 onward.
+//
+// The decision belongs at the READ site, not the build site: duplicates within
+// a single run are legitimate (one entry per bunk_plans row -- see
+// TestLoadMappings_KeepsEveryCandidateSessionForASharedBunk, which pins
+// [A, A, B] deliberately), so what must change is what "ambiguous" counts.
+func TestResolveViaBunk_DecidesOnDISTINCTSessions(t *testing.T) {
+	t.Parallel()
+
+	const planCMID = 8006
+	const sessionACMID = 5601
+	const sessionBCMID = 5602
+	const bunkCMID = 6601
+	key := fmt.Sprintf("%d:%d", planCMID, bunkCMID)
+
+	t.Run("one session listed twice still narrows", func(t *testing.T) {
+		t.Parallel()
+		s := &BunkAssignmentsSync{}
+		s.bunkPlanBunkToSession = map[string][]int{key: {sessionACMID, sessionACMID}}
+
+		got, ok := s.resolveViaBunk([]int{sessionACMID}, planCMID, bunkCMID)
+		if !ok || got != sessionACMID {
+			t.Errorf("resolveViaBunk = (%d, %v), want (%d, true) -- two entries naming ONE session "+
+				"are one candidate, not two", got, ok, sessionACMID)
+		}
+	})
+
+	t.Run("two genuinely different sessions still refuse to narrow", func(t *testing.T) {
+		t.Parallel()
+		s := &BunkAssignmentsSync{}
+		s.bunkPlanBunkToSession = map[string][]int{key: {sessionACMID, sessionBCMID}}
+
+		got, ok := s.resolveViaBunk([]int{sessionACMID, sessionBCMID}, planCMID, bunkCMID)
+		if ok || got != 0 {
+			t.Errorf("resolveViaBunk = (%d, %v), want (0, false) -- a bunk shared across two sessions "+
+				"the person is enrolled in must fall back to findMatchingSession (kindred#2264)", got, ok)
+		}
+	})
+}
+
+// TestResolveStaffSession_DecidesOnDISTINCTSessions pins the staff-side half
+// of kindred#2465: switching on len(candidates) made the RUN COUNT the
+// ambiguity signal. It must switch on the number of distinct sessions, while
+// keeping the kindred#2264 behavior for a bunk genuinely shared across two
+// sessions of one plan.
+func TestResolveStaffSession_DecidesOnDISTINCTSessions(t *testing.T) {
+	t.Parallel()
+
+	const planCMID = 8007
+	const sessionACMID = 5701
+	const sessionBCMID = 5702
+	const bunkCMID = 6701
+	key := fmt.Sprintf("%d:%d", planCMID, bunkCMID)
+
+	t.Run("one session listed twice is not ambiguous", func(t *testing.T) {
+		t.Parallel()
+		s := &BunkAssignmentsSync{}
+		s.bunkPlanBunkToSession = map[string][]int{key: {sessionACMID, sessionACMID}}
+
+		got, ambiguous := s.resolveStaffSession(planCMID, bunkCMID)
+		if ambiguous || got != sessionACMID {
+			t.Errorf("resolveStaffSession = (%d, %v), want (%d, false) -- one session listed twice "+
+				"is one candidate", got, ambiguous, sessionACMID)
+		}
+	})
+
+	t.Run("two distinct sessions stay ambiguous", func(t *testing.T) {
+		t.Parallel()
+		s := &BunkAssignmentsSync{}
+		s.bunkPlanBunkToSession = map[string][]int{key: {sessionACMID, sessionACMID, sessionBCMID}}
+
+		got, ambiguous := s.resolveStaffSession(planCMID, bunkCMID)
+		if !ambiguous || got != 0 {
+			t.Errorf("resolveStaffSession = (%d, %v), want (0, true) -- a bunk under two sessions of "+
+				"one plan is genuinely ambiguous and must still be skipped (kindred#2264)", got, ambiguous)
+		}
+	})
+
+	t.Run("no candidates is not ambiguous", func(t *testing.T) {
+		t.Parallel()
+		s := &BunkAssignmentsSync{}
+		s.bunkPlanBunkToSession = map[string][]int{}
+
+		got, ambiguous := s.resolveStaffSession(planCMID, bunkCMID)
+		if ambiguous || got != 0 {
+			t.Errorf("resolveStaffSession = (%d, %v), want (0, false)", got, ambiguous)
+		}
+	})
+}
+
+// TestBunkAssignment_UnresolvedAssignmentIsCountedAndKeptFromTheSweep pins the
+// two halves of kindred#2465 that are correct on their own terms even with the
+// map accumulation fixed, because a (plan, bunk) pair CAN be genuinely
+// ambiguous (kindred#2264: a family-camp bunk listed under every session of
+// its plan) and a run can genuinely fail to resolve a session:
+//
+//  1. An unresolved assignment gets its own counter. Folded into Stats.Skipped
+//     it is invisible -- base_sync's ProcessCompositeRecord increments the same
+//     field for every unchanged row, so on a steady-state run Skipped is
+//     roughly the whole table. That is why 119 destructive hourly runs all read
+//     status='success' with a flat skipped_count.
+//
+//  2. An unresolved assignment does NOT hand its existing row to deleteOrphans.
+//     The run SAW this person in this bunk; it just could not name the session.
+//     Absence from ProcessedKeys means "CampMinder no longer returns this",
+//     which is the opposite of what happened. This is persons.go:487-508's
+//     kindred#2394 patch applied to the same symptom: "Skipped and orphaned are
+//     different facts, and this branch only ever meant the first one."
+//
+// Skipped keeps incrementing alongside the new counter: no row was written, and
+// that is what Skipped has always counted here. The new field is a named subset
+// of it, not a replacement -- unlike Stats.DuplicateStaffStatus, whose branch
+// never touched Skipped in the first place.
+func TestBunkAssignment_UnresolvedAssignmentIsCountedAndKeptFromTheSweep(t *testing.T) {
+	t.Parallel()
+
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+	setupBunkAssignmentGrainCollections(t, app)
+
+	const year = 2026
+	const staffPersonCMID = 9000009
+	const planCMID = 8008
+	const sessionACMID = 5801
+	const sessionBCMID = 5802
+	const bunkCMID = 6801
+
+	saveRec(t, app, "persons", map[string]any{"cm_id": staffPersonCMID, "year": year})
+	sessionA := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": sessionACMID, "year": year})
+	sessionB := saveRec(t, app, "camp_sessions", map[string]any{"cm_id": sessionBCMID, "year": year})
+	bunk := saveRec(t, app, "bunks", map[string]any{"cm_id": bunkCMID, "year": year})
+	// The family-camp shape: ONE bunk under TWO sessions of one plan. Genuinely
+	// ambiguous in the database, not an artifact of a reused instance.
+	saveRec(t, app, "bunk_plans", map[string]any{
+		"cm_id": planCMID, "bunk": bunk.Id, "session": sessionA.Id, "year": year,
+	})
+	saveRec(t, app, "bunk_plans", map[string]any{
+		"cm_id": planCMID, "bunk": bunk.Id, "session": sessionB.Id, "year": year,
+	})
+	saveRec(t, app, "staff", map[string]any{
+		"person_id": staffPersonCMID, "bunk_staff": true, "status": "active", "year": year,
+	})
+
+	s := NewBunkAssignmentsSync(app, newParallelTestCampMinderClient(t, year))
+	if loadErr := s.loadMappings(); loadErr != nil {
+		t.Fatalf("loadMappings: %v", loadErr)
+	}
+
+	// A row already on disk from a run that COULD name the session -- e.g. the
+	// historical backfill, or a season before the bunk was shared. Its survival
+	// is the whole point: nothing upstream said this staffer left.
+	person, err := app.FindFirstRecordByFilter("persons", fmt.Sprintf("cm_id = %d", staffPersonCMID))
+	if err != nil {
+		t.Fatalf("find person: %v", err)
+	}
+	saveRec(t, app, "bunk_assignments", map[string]any{
+		"cm_id": 740001, "person": person.Id, "session": sessionA.Id, "bunk": bunk.Id, "year": year,
+	})
+
+	existing, existingByPersonBunk, err := s.preloadExistingAssignments(year)
+	if err != nil {
+		t.Fatalf("preloadExistingAssignments: %v", err)
+	}
+	if len(existing) != 1 {
+		t.Fatalf("existing = %d, want 1", len(existing))
+	}
+
+	sessionID, unresolved := s.resolveSessionOrTrackUnresolved(
+		staffPersonCMID, planCMID, bunkCMID, s.bunkPlanSessionsList[planCMID], existingByPersonBunk, year)
+	if !unresolved || sessionID != 0 {
+		t.Fatalf("resolveSessionOrTrackUnresolved = (%d, %v), want (0, true) -- a bunk under two sessions "+
+			"of one plan is genuinely ambiguous for staff (kindred#2264)", sessionID, unresolved)
+	}
+
+	if s.Stats.UnresolvedSession != 1 {
+		t.Errorf("Stats.UnresolvedSession = %d, want 1 -- an unresolved assignment needs a counter of its "+
+			"own, or it hides inside Skipped alongside every unchanged row", s.Stats.UnresolvedSession)
+	}
+	if s.Stats.Skipped != 1 {
+		t.Errorf("Stats.Skipped = %d, want 1 -- the new counter is a named subset of Skipped, not a "+
+			"replacement for it", s.Stats.Skipped)
+	}
+
+	// The row the run could not resolve must be tracked as processed, so the
+	// sweep reads it as "seen, could not key" rather than "gone from CampMinder".
+	s.SyncSuccessful = true
+	if err := s.protectThenSweepOrphans(year); err != nil {
+		t.Fatalf("protectThenSweepOrphans: %v", err)
+	}
+	if rows := bunkAssignmentsForYear(t, app, year); len(rows) != 1 {
+		t.Errorf("after the sweep: bunk_assignments rows = %d, want 1 -- an assignment the run SAW but "+
+			"could not resolve is not an orphan (kindred#2394)", len(rows))
 	}
 }

--- a/pocketbase/sync/bunk_assignments_grain_test.go
+++ b/pocketbase/sync/bunk_assignments_grain_test.go
@@ -611,12 +611,16 @@ func TestBunkAssignment_StaffRowSurvivesASecondRunOnTheSameInstance(t *testing.T
 	const departedRunTwoAssignmentCMID = 740004
 
 	// Three campers share the bunk with the counselor. They are not decoration:
-	// OrphanSweepGuard refuses a sweep whose computed set is under half of what
-	// is on disk, so a fixture holding ONLY the staff row would have the guard
-	// stop the deletion and hide the bug. Production has no such luck -- the 262
-	// staff rows sat inside a table whose camper rows still resolved and still
-	// tracked, so the guard's floor was met and the sweep ran. This fixture is
-	// that shape in miniature: 3 of 4 rows keep tracking, 1 does not.
+	// OrphanSweepGuard refuses a sweep outright when the computed set is EMPTY,
+	// at any table size, so a fixture holding ONLY the staff row would have the
+	// guard stop the deletion and hide the bug -- the test would go red on a
+	// guard error rather than on a destroyed row, which pins the guard and not
+	// the tracking. (Its ratio arm is not what saves such a fixture: that one
+	// only applies from OrphanSweepMinRows = 20 rows up, and nothing here is
+	// near that.) Production had no such luck -- the 262 staff rows sat inside a
+	// table whose camper rows still resolved and still tracked, so the computed
+	// set was never empty and the sweep ran. This fixture is that shape in
+	// miniature: 3 of 4 rows keep tracking, 1 does not.
 	camperCMIDs := []int{9000006, 9000007, 9000008}
 
 	saveRec(t, app, "persons", map[string]any{"cm_id": staffPersonCMID, "year": year})

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -389,9 +389,15 @@ type Stats struct {
 	// Unlike DuplicateStaffStatus, the branches that write this ALSO increment Skipped, and
 	// deliberately: no row was written, which is what Skipped has always counted at these
 	// sites, so this is a named subset rather than a replacement and skipped_count keeps its
-	// existing meaning. Not persisted to the sync_runs table (sync_runs.go) -- that would
-	// need a new migration column; the counter reaches the live Sync tab via this JSON field
-	// and the service's own completion log line.
+	// existing meaning. Not persisted to the sync_runs table (sync_runs.go) -- that would need
+	// a new migration column.
+	//
+	// It rides along in the sync-status JSON this struct serializes to, but nothing DISPLAYS
+	// it: SyncTab.tsx picks its badges from a hardcoded list (created / updated / skipped /
+	// skipped_values / errors) in two places and unresolved_session is in neither -- zero hits
+	// for it anywhere in frontend/src. The acceptance surface kindred#2465 names is the
+	// bunk_assignments completion log line, which does print it; a badge is frontend work and
+	// outside that issue.
 	UnresolvedSession int `json:"unresolved_session,omitempty"`
 	// Expanded tracks many-to-many expansions (e.g., bunk plans)
 	Expanded int `json:"expanded,omitempty"`

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -373,6 +373,26 @@ type Stats struct {
 	// -- that would need a new migration column, which is out of scope here; the counter
 	// still reaches the live Sync tab via this JSON field.
 	DuplicateStaffStatus int `json:"duplicate_staff_status,omitempty"`
+	// UnresolvedSession counts bunk_assignments the run fetched from CampMinder but could
+	// not attach to a session (kindred#2465) -- either the (bunkPlan, bunk) pair named more
+	// than one candidate session for a staff member, or no step of the resolution ladder
+	// matched at all. Nothing but bunk_assignments.go increments it.
+	//
+	// Its own field for the reason Stats.DuplicateStaffStatus is: base_sync.go's
+	// ProcessCompositeRecord increments Skipped for every unchanged row, so on a
+	// steady-state run Skipped is roughly the whole table and an unresolved assignment is
+	// invisible inside it. That is not hypothetical -- kindred#2465 deleted 262 staff rows
+	// an hour for 119 consecutive runs, every one of them reporting status='success' with a
+	// flat skipped_count, because the rows only moved from the no-change bucket into the
+	// ambiguous one and both buckets were this same counter.
+	//
+	// Unlike DuplicateStaffStatus, the branches that write this ALSO increment Skipped, and
+	// deliberately: no row was written, which is what Skipped has always counted at these
+	// sites, so this is a named subset rather than a replacement and skipped_count keeps its
+	// existing meaning. Not persisted to the sync_runs table (sync_runs.go) -- that would
+	// need a new migration column; the counter reaches the live Sync tab via this JSON field
+	// and the service's own completion log line.
+	UnresolvedSession int `json:"unresolved_session,omitempty"`
 	// Expanded tracks many-to-many expansions (e.g., bunk plans)
 	Expanded int `json:"expanded,omitempty"`
 	// AlreadyProcessed tracks records already processed (for process_requests)


### PR DESCRIPTION
The orchestrator constructs one BunkAssignmentsSync at boot and dispatches
every scheduled run to it, but loadMappings only ever APPENDED to the maps it
builds. From run 2 onward each hourly sync read the previous run's candidates
still sitting in the map alongside its own fresh copy, so a (bunkPlan, bunk)
pair with exactly ONE bunk_plans row behind it presented as two candidate
sessions. resolveStaffSession switched on len(candidates), called that
ambiguous, and skipped -- and the skip continued before
TrackProcessedCompositeKey, so the row was absent from the processed set and
deleteOrphans read absence as "CampMinder no longer returns this" and deleted
it. 262 rows for 70 active bunk staff, deleted every hour, restored only by a
container restart.

Four interlocking changes; shipping any one alone leaves the others armed.

Re-make all eight maps at the top of loadMappings. Not in Sync()'s reset block:
loadMappings is their only writer, and bunkPBIDToCMID must be rebuilt before
the bunk_plans pass reads it, which the existing load order guarantees. The
constructor's make() calls stay -- several tests build the struct literally and
never call loadMappings. stranded_assignment_cleanup.go carries the same reset
for Stats and names the same hazard.

Decide on DISTINCT sessions at both read sites. resolveStaffSession switched on
the raw candidate count; resolveViaBunk counted matches per candidate
OCCURRENCE. The decision belongs at the read sites, not the build site: a list
legitimately holds one entry per bunk_plans row, and deduping on insert would
erase kindred#2264's regression guard.

Give an unresolved assignment its own counter, Stats.UnresolvedSession. Folded
into Stats.Skipped it was invisible -- base_sync increments the same field for
every unchanged row -- which is why 119 destructive runs all reported
status='success' with a flat skipped_count while the rows merely moved from the
no-change bucket into the ambiguous one. Skipped still increments too, so the
persisted skipped_count keeps its meaning; the new field is a named subset.
No migration: like SkippedValues it is not persisted to sync_runs.

Track the keys before both skips, from a person:bunk index off
preloadExistingAssignments. The run SAW this person in this bunk and only
failed to name the session; absence from ProcessedKeys claims the opposite.
This is persons.go's kindred#2394 patch applied to the same symptom.

Also restored by the map reset, and worth stating because it was silent: the
same accumulation disabled kindred#2259/#2264's bunk-specific camper narrowing
from run 2 onward, reverting it to the plan-wide fallback. That is a latent
regression, not a second live bug -- no 2026 row shows the collapse signature.

Verifying this in production needs care: deploying restarts the container,
which clears the maps, so the FIRST run after deploy looks healthy whether or
not the fix is real. The acceptance test is the run after that -- staff
assignments must still be present on the following hour. Watch
unresolved_session in the bunk_assignments completion line, not skipped_count.

Tests, written failing first: a two-run test on ONE instance driving the real
loadMappings (the existing two-run test builds a fresh instance per run AND
hand-assigns the maps, which is why it was green through all of this), plus
read-site tests for both distinct-session decisions and one for the counter and
the unresolved-key tracking. All five mutations checked red.

Closes #2465.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bunk-assignment synchronization across multiple sessions and repeated sync runs.
  * Prevented valid assignments from being duplicated, incorrectly removed, or merged across bunks.
  * Improved handling of ambiguous, unresolved, or session-less assignments.
  * Ensured departed assignments are removed while valid unresolved records are preserved.
  * Fixed stale matching data from affecting subsequent synchronization runs.

* **New Features**
  * Sync results now report the number of bunk assignments that could not be matched to a session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

Added in review remediation (see the review-remediation comment for the mutation
transcripts):

A FIFTH interlocking skip, pre-existing and one line above the two above. The
assignment loop dropped an entire (bunkPlan, bunk) group on
`len(bunkPlanSessions) == 0` without tracking OR counting -- the same
untracked-skip-feeds-the-sweep mechanism, a whole group at a time. It now warns
once for the group and falls through, so every assignment routes through
resolveSessionOrTrackUnresolved. That cannot write a row to a wrong session:
loadMappings gates bunkPlanSessionsList and bunkPlanBunkToSession on the same
`sessionCMID > 0`, so an empty plan-session list guarantees an empty candidate
list and every step of the ladder fails. The trigger is narrow -- bunk_plans.session
is required, so it needs a dangling relation or a null cm_id -- and the blast
radius is a group rather than a row.

Sync()'s per-result body moved into processResultGroup to make that branch
reachable from a test at all: Client is a concrete *campminder.Client, so Sync()
cannot be driven without an HTTP fake, which is why nothing pinned these
branches. The extraction is mechanical -- three `continue`s became `return`s.
The three shape checks above it (missing BunkID, missing BunkPlanID, no
Assignments array) deliberately stay untracked and now say why: they name no
person and no bunk, so there is no key to keep from the sweep.

Both new DB-backed tests were also re-shaped. Each seeds enough resolving rows
that OrphanSweepGuard's empty-computed-set arm cannot fire, and an unrelated
stored row the sweep MUST delete -- so removing the tracking now fails on the
row that was destroyed rather than on the guard refusing, and a sweep that did
nothing at all can no longer satisfy them.
