### PR TITLE
fix(api): the Returning badge requires an enrolled prior weekend, not any household row

### DIFF
--- a/api/services/lodging_repository.py
+++ b/api/services/lodging_repository.py
@@ -761,26 +761,58 @@ class LodgingRepository:
 
     @cached_by_year(lodging_cache)
     async def fetch_prior_household_cm_ids(self, year: int) -> set[int]:
-        """CampMinder ids of every household seen in an EARLIER year.
+        """CampMinder ids of every household with an ENROLLED weekend attendee
+        in an EARLIER year -- the returning-family signal (kindred#2475).
 
-        This is the returning-family signal: households rows are per-year, so
-        a cm_id present before `year` means the family has been here before.
+        This used to page `households` on a bare `year < {year}`, with no
+        enrollment predicate at all. A `households` row exists for a year
+        because a *person* record existed that year -- registration,
+        waitlist, cancellation and inquiry alike, since `households` carries
+        no status column of its own. That badged a family Returning off a
+        year they only ever cancelled or waitlisted (21 of 396 badged
+        2026 households on the production snapshot, 8-11% in settled years).
 
-        The expensive one -- 20,256 rows on 2026 prod data for one boolean
-        per party (kindred#1966). #1966/#1976 already bought back the
-        round-trip cost (batch=PAGE_SIZE, 21 requests instead of 203) and
-        explicitly rejected narrowing the filter to the current year's
-        household ids: a 250-term OR clause returns HTTP 400 (undocumented,
-        fails closed), so there is no query-shape lever left to pull. Caching
-        is what is left, and it is safe here for the same reason as
-        fetch_households: year-scoped, sync-written only. See
-        api/services/lodging_cache.py.
+        `attendees` is where enrollment actually lives, so this reads THAT
+        table instead: `status_id = 2` (`ACTIVE_ENROLLED_FILTER`) is the
+        single source of truth for enrollment everywhere else in this file,
+        and `_attendee_weekend_session_filter` keeps summer sessions
+        (main/embedded/ag/quest/...) from counting as a prior weekend visit.
+
+        Bridged through `person.household_id` (the CampMinder id) rather than
+        `person.household` (the PocketBase relation): this is a cross-YEAR
+        read, exactly like `fetch_household_family_attendees`, and
+        `household` is a relation into the year-scoped `households` table --
+        it can only ever match one season. `household_id` is the identity
+        thread across seasons (CLAUDE.md section 1).
+
+        Deliberately NOT `persons.years_at_camp`: it counts only SUMMER
+        attendance and is blind to weekends (225 of 360 genuine 2026
+        returners have `max(years_at_camp) = 0`) -- it would misclassify most
+        real returners as first-time.
+
+        `attendees` is the pricier table to page here (each row expands
+        `person`), but this is still the once-per-year cross-season read
+        #1966/#1976 already bought the round-trip cost down for
+        (batch=PAGE_SIZE); caching is what is left, and it is safe here for
+        the same reason as fetch_households: year-scoped, sync-written only.
+        See api/services/lodging_cache.py.
         """
         rows = await self._page(
-            HOUSEHOLDS,
-            query_params={"filter": f"year < {year}", "fields": "cm_id", "sort": STABLE_SORT},
+            ATTENDEES,
+            query_params={
+                "filter": (f"year < {year} && ({_attendee_weekend_session_filter()}) && {ACTIVE_ENROLLED_FILTER}"),
+                "expand": "person",
+                "sort": STABLE_SORT,
+            },
         )
-        return {int(getattr(row, "cm_id", 0)) for row in rows if getattr(row, "cm_id", 0)}
+        ids: set[int] = set()
+        for row in rows:
+            expand = getattr(row, "expand", None) or {}
+            person = expand.get("person") if isinstance(expand, dict) else None
+            household_id = int(getattr(person, "household_id", 0) or 0) if person is not None else 0
+            if household_id:
+                ids.add(household_id)
+        return ids
 
     @cached_by_year(lodging_cache)
     async def fetch_family_camp_adults(self, year: int) -> dict[str, list[Any]]:

--- a/api/services/lodging_repository.py
+++ b/api/services/lodging_repository.py
@@ -119,10 +119,14 @@ STABLE_SORT = "id"
 #
 # The SDK's `get_full_list(batch: int = 100, ...)` defaults to 100 and recurses
 # once per page, so a read is round-trip-bound rather than row-bound.
-# `fetch_prior_household_cm_ids` pages every household from every prior year --
-# 20,256 rows on 2026 data -- which at the default is 203 requests and ~2.3s of
-# the roster's ~3.1s, to produce one boolean per party. At 1000 it is 21
-# requests and ~1.0s (#1966).
+# `fetch_prior_household_cm_ids` pages every ENROLLED weekend attendee from
+# every prior year (kindred#2475 moved it off `households`, which had no
+# enrollment predicate at all) -- at the default batch of 100 that is still a
+# round-trip-bound read over thousands of rows to produce one boolean per
+# party. At 1000 it was 21 requests and ~1.0s against the smaller `households`
+# read this replaced (#1966); the `attendees` read is pricier per row (each
+# expands `person`), but the same round-trip-bound argument for PAGE_SIZE
+# applies to it unchanged.
 #
 # Applied in ONE place, `_page`, rather than at each call site: `batch` is a
 # parameter of `get_full_list` itself and NOT a member of `query_params`, so

--- a/tests/unit/api/services/test_lodging_repository.py
+++ b/tests/unit/api/services/test_lodging_repository.py
@@ -885,17 +885,75 @@ class TestFetchUnits:
 
 
 class TestFetchPriorHouseholdCmIds:
+    """kindred#2475: the returning-family signal must be an ENROLLED prior
+    attendance, not a bare `households` row -- a household row exists for a
+    year a family only cancelled or waitlisted, `households` carries no
+    status column at all, and the old bare `year < {year}` read on
+    `households` badged those families Returning anyway.
+    """
+
     @pytest.mark.asyncio
-    async def test_returns_cm_ids_from_earlier_years_only(self, repo: LodgingRepository, pb: MagicMock) -> None:
+    async def test_returns_household_ids_from_enrolled_weekend_attendees_only(
+        self, repo: LodgingRepository, pb: MagicMock
+    ) -> None:
+        enrolled_person = _record(household_id=2000001)
         pb.collection.return_value.get_full_list.return_value = [
-            _record(cm_id=2000001),
-            _record(cm_id=2000002),
+            _record(expand={"person": enrolled_person}),
         ]
 
         result = await repo.fetch_prior_household_cm_ids(2026)
 
-        assert "year < 2026" in _last_query(pb)["filter"]
-        assert result == {2000001, 2000002}
+        pb.collection.assert_called_with("attendees")
+        filter_str = _last_query(pb)["filter"]
+        assert "year < 2026" in filter_str
+        assert "status_id = 2" in filter_str
+        assert _last_query(pb)["expand"] == "person"
+        assert result == {2000001}
+
+    @pytest.mark.asyncio
+    async def test_a_cancelled_or_waitlisted_only_household_is_not_returning(
+        self, repo: LodgingRepository, pb: MagicMock
+    ) -> None:
+        """The literal reported bug: a household whose only prior rows are
+        cancelled/waitlisted attendees has no ENROLLED row, so ACTIVE_ENROLLED_FILTER
+        (status_id = 2) excludes it at the PocketBase filter -- the mock never
+        returns a row for it, exactly as the real filter would not.
+        """
+        pb.collection.return_value.get_full_list.return_value = []
+
+        result = await repo.fetch_prior_household_cm_ids(2026)
+
+        assert result == set()
+
+    @pytest.mark.asyncio
+    async def test_filters_to_weekend_session_types_through_the_relation(
+        self, repo: LodgingRepository, pb: MagicMock
+    ) -> None:
+        """Same weekend types as `_weekend_type_filter`, but through the
+        `session.` relation prefix -- summer's main/embedded/ag/quest
+        sessions must not count as a prior weekend visit.
+        """
+        pb.collection.return_value.get_full_list.return_value = []
+
+        await repo.fetch_prior_household_cm_ids(2026)
+
+        filter_str = _last_query(pb)["filter"]
+        for session_type in WEEKEND_SESSION_TYPES:
+            assert f'session.session_type = "{session_type}"' in filter_str
+
+    @pytest.mark.asyncio
+    async def test_a_person_with_no_household_id_contributes_nothing(
+        self, repo: LodgingRepository, pb: MagicMock
+    ) -> None:
+        pb.collection.return_value.get_full_list.return_value = [
+            _record(expand={"person": _record(household_id=0)}),
+            _record(expand={}),
+            _record(expand=None),
+        ]
+
+        result = await repo.fetch_prior_household_cm_ids(2026)
+
+        assert result == set()
 
 
 class TestFetchFamilyCampAdults:


### PR DESCRIPTION
## What was wrong

`fetch_prior_household_cm_ids` (`api/services/lodging_repository.py`) computed the weekend
"Returning" badge's prior-year signal by paging `households` on a bare `year < {year}` — no
enrollment predicate at all. A `households` row exists for a year because a *person* record
existed that year: registration, waitlist, cancellation and inquiry alike, since `households`
carries no status column of its own. That badged a family "Returning" off a year they only ever
cancelled or waitlisted — the exact bug reported from the weekend housing board (kindred-feedback#120).

The file already documented the fix it wasn't applying to itself:
`status_id = 2` is called "the single source of truth for enrollment" at `:580-581`, and the
2020-cancelled-season trap is spelled out at `:615-618`. Verified independently against the
production snapshot: 2020 has 1,264 family/adult attendee rows and **0** enrolled, while 1,981
`households` rows for that year fed the badge anyway.

## The fix

`fetch_prior_household_cm_ids` now reads `attendees` instead of `households`: filtered to
`status_id = 2` (`ACTIVE_ENROLLED_FILTER`) on a family/adult session (`_attendee_weekend_session_filter`,
already used elsewhere in this file for the same weekend/summer split), for years before the
requested one, bridged to the household through `person.household_id` — the CampMinder id, not
the PocketBase relation, because this is a cross-year read exactly like the existing
`fetch_household_family_attendees`.

Deliberately **not** `persons.years_at_camp`: it counts only summer attendance and is blind to
weekends entirely — 225 of 360 genuine 2026 returners have `max(years_at_camp) = 0`, so that
signal would misclassify most real returners as first-time.

## What moved — CORRECTED after independent verification (see PR comment)

The originally-drafted number below undercounted the population this PR actually flips. The
`_attendee_weekend_session_filter()` predicate this fix adds does not only exclude
cancelled/waitlisted-only households — it also excludes a household whose only prior ENROLLED
attendance was a **summer** session, because that predicate requires a family/adult session
type. That second bucket is the "summer-only" half of kindred#2475, which the issue explicitly
marks as **owner-ruled but not cleared to build without asking first**.

Independently re-measured against the read-only production snapshot
(`pocketbase/pb_data/data-prod.db`), replicating the exact predicates this function now uses:

| bucket | households (2026) | this PR's actual effect |
|---|---:|---|
| no prior ENROLLED row of any kind (cancelled/waitlisted-only) | 21 | flips to first-time — the bug as reported |
| prior ENROLLED row, but **summer session only**, never a weekend session | 15 | **also flips to first-time** — this is kindred#2475's "summer-only" half, which the issue says is not ruled for building yet |
| genuine returners (enrolled prior weekend attendee) | 360 | stays Returning |
| **total flip** | **36 of 396** | |

Confirmed by direct SQL against the same predicates the code uses
(`ACTIVE_ENROLLED_FILTER` = `status_id = 2`, `WEEKEND_SESSION_TYPES` = `family`/`adult`): if the
fix used `status_id = 2` alone, with **no** session-type restriction, the flip count is exactly
**21** — matching kindred#2475's own table. Adding `_attendee_weekend_session_filter()` (the
predicate actually shipped in this PR) is what pulls in the other 15.

The two households from the original report have prior status sets of exactly `{waitlisted}` and
`{cancelled, waitlisted}` — both in the 21-bucket, so the reported bug is fixed either way. The
open question is only whether the additional 15-household effect is acceptable to ship now or
should wait, per kindred#2475's "ask before building" note.

2026 is only ~16% placed on the snapshot, so any 2026 count here is a floor, not a final tally —
the settled-year figures in kindred#2475 (34/443 in 2025, 55/502 in 2024, 53/471 in 2023) are the
more reliable measurements of blast radius, and the same 21-vs-36-style split applies to each of
those years (see the issue's own "summer-only" column).

## Scope — this PR's actual reach vs. its intent

kindred#2475 also names a second half: a family whose *only* prior visit was a **summer** session
should read as first-time to Family Camp. That half is **owner-ruled but mechanism-blocked** per
the issue, and the issue says explicitly that separating the two is "not ruled, so ask before
building":

> "we can't accurately calculate the returning as first time to family camp until we fix the
> prior year enrolled but not housing and no kids / cancelled actually fix i think"

This PR does not touch `pocketbase/sync/family_camp_derived.go` or `api/schemas/lodging.py`, and
does not build any new machinery toward the summer-only half. **However**, as verified above, the
query shape it does ship functionally resolves that half's badge outcome too, as a side effect of
adding the weekend-session-type predicate needed to fix the reported bug. That was not the stated
intent and needs an explicit owner call: keep the broader (36-household) fix as shipped, or narrow
`fetch_prior_household_cm_ids` back to `status_id = 2` with no session-type restriction so only the
21-household cancelled/waitlisted-only case flips, leaving the summer-only case as Returning until
kindred#2305 lands.

## Files touched

- `api/services/lodging_repository.py` — `fetch_prior_household_cm_ids`
- `tests/unit/api/services/test_lodging_repository.py` — new coverage for the enrolled-only
  filter, the weekend-session-type restriction, and the cancelled/waitlisted-only case

## Holds for the owner's eyes

This is a **condition 8** hold (a staff-facing number's meaning changes) with zero frontend files
touched. It does not merge itself — see the campaign report and the PR comment for the corrected
number, the population that moves, and the scope decision this now needs.

Refs kindred#2475 (partial — cancelled/waitlisted-only half by intent; summer-only half affected
in practice, pending an owner call on whether that's acceptable).
