### PR TITLE
fix(sync): dedupe family_camp_adults rows that coalesce to the same adult

### DIFF
--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -1033,6 +1033,13 @@ func (s *FamilyCampDerivedSync) processAdults(
 		}
 	}
 
+	// Dedupe rows that coalesce to the same adult (kindred#2483) BEFORE the
+	// admission filter below, so a merged slot's survivor is judged for
+	// admission exactly like any other adult.
+	for _, adults := range adultMap {
+		dedupeAdultSlots(adults)
+	}
+
 	// Convert map to slice, only include adults with a real name somewhere.
 	// kindred#1946: the email/gender arms this filter used to carry let 194
 	// wholly nameless rows into production -- an adult with only a gender
@@ -1049,6 +1056,128 @@ func (s *FamilyCampDerivedSync) processAdults(
 	}
 
 	return result
+}
+
+// coalescedAdultName reproduces the API's `_adult_display_name` coalesce
+// (`api/services/lodging_roster_service.py`) so the dedupe key groups the
+// same way the read path does: `name` (the household column of record) if
+// set, otherwise the split first/last columns joined and trimmed.
+func coalescedAdultName(a *adultData) string {
+	if a.name != "" {
+		return a.name
+	}
+	return strings.TrimSpace(strings.TrimSpace(a.firstName) + " " + strings.TrimSpace(a.lastName))
+}
+
+// dedupeAdultSlots collapses adult slots within one household that coalesce
+// to the same casefolded display name with a non-conflicting date of birth
+// (kindred#2483 -- see the correction on the issue for why name alone is
+// unsafe: it merges 27 groups of genuinely different people who share a
+// name, sample DOB pairs include a child and an adult).
+//
+// "Non-conflicting" means the group's non-empty date_of_birth values are all
+// equal, or at most one slot in the group carries a DOB at all. A plain
+// equality key is not enough -- one of the two reported 2026 pairs has a
+// blank DOB on one side, so it looks like a single non-empty DOB, not an
+// equal pair. Any group with two or more DISTINCT non-empty DOBs is refused
+// entirely, matching the issue's measurement (MERGE 15 / REFUSE 27 over all
+// years; 2026 merges = exactly 2).
+//
+// Deleting a losing slot's map entry removes it from processAdults' result,
+// which is also what marks its stored row (if any) unprocessed for this run
+// -- the existing orphan sweep in deleteOrphanedAdults then deletes it, the
+// same path kindred#2335 already uses for rows the computed set no longer
+// accounts for. That is the intended outcome here: the duplicate slot is
+// destroyed, not archived (owner ruling 2026-08-19 -- this trades away the
+// raw-slot evidence deliberately).
+//
+// The survivor is the LOWEST adult_number in the group. adult_number is the
+// one deterministic ordering available here (Go map iteration is not), and
+// it mirrors "first-wins" -- Adult 1 is filled first on the form.
+func dedupeAdultSlots(adults map[int]*adultData) {
+	groups := make(map[string][]*adultData, len(adults))
+	for _, adult := range adults {
+		key := strings.ToLower(coalescedAdultName(adult))
+		if key == "" {
+			continue // nameless slots are not a duplicate of anything; left to the admission filter
+		}
+		groups[key] = append(groups[key], adult)
+	}
+
+	for _, group := range groups {
+		if len(group) < 2 {
+			continue
+		}
+		if adultGroupDOBConflicts(group) {
+			continue // 27-groups-of-different-people case: leave every slot as its own adult
+		}
+
+		slices.SortFunc(group, func(a, b *adultData) int {
+			return a.adultNumber - b.adultNumber
+		})
+		survivor := group[0]
+		for _, loser := range group[1:] {
+			mergeAdultSlot(survivor, loser)
+			delete(adults, loser.adultNumber)
+		}
+	}
+}
+
+// adultGroupDOBConflicts reports whether a same-name group holds two or more
+// DISTINCT non-empty date_of_birth values -- the signal that the group is
+// actually different people who share a name, not one person duplicated
+// across slots. date_of_birth is normalised (normalizeDateOfBirth) before it
+// ever reaches processAdults' map, so a straight string comparison is a
+// straight date comparison.
+func adultGroupDOBConflicts(group []*adultData) bool {
+	seen := ""
+	for _, adult := range group {
+		if adult.dateOfBirth == "" {
+			continue
+		}
+		if seen == "" {
+			seen = adult.dateOfBirth
+			continue
+		}
+		if adult.dateOfBirth != seen {
+			return true
+		}
+	}
+	return false
+}
+
+// mergeAdultSlot folds loser's non-blank attributes onto survivor using the
+// SAME per-field merge policy processAdults already applies when two
+// siblings answer for one slot (kindred#2483 ruling: reuse mergeFirstNonEmpty
+// rather than invent a second merge implementation). email keeps its
+// existing preferEmail validity tie-break rather than plain first-wins, for
+// the same reason the sibling-merge loop above does.
+func mergeAdultSlot(survivor, loser *adultData) {
+	survivor.name = survivor.mergeFirstNonEmpty("name", survivor.name, loser.name)
+	survivor.firstName = survivor.mergeFirstNonEmpty("first_name", survivor.firstName, loser.firstName)
+	survivor.lastName = survivor.mergeFirstNonEmpty("last_name", survivor.lastName, loser.lastName)
+	survivor.pronouns = survivor.mergeFirstNonEmpty("pronouns", survivor.pronouns, loser.pronouns)
+	survivor.gender = survivor.mergeFirstNonEmpty("gender", survivor.gender, loser.gender)
+	survivor.dateOfBirth = survivor.mergeFirstNonEmpty("date_of_birth", survivor.dateOfBirth, loser.dateOfBirth)
+	survivor.relationship = survivor.mergeFirstNonEmpty(
+		"relationship_to_camper", survivor.relationship, loser.relationship)
+
+	if loser.email != "" {
+		if preferEmail(survivor.email, loser.email) {
+			if !sameAnswer(survivor.email, loser.email) {
+				survivor.noteConflict("email", survivor.email)
+			}
+			survivor.email = loser.email
+		} else if !sameAnswer(survivor.email, loser.email) {
+			survivor.noteConflict("email", loser.email)
+		}
+	}
+
+	for column, others := range loser.conflicts {
+		for _, other := range others {
+			survivor.noteConflict(column, other)
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -3753,11 +3753,16 @@ func TestProcessAdultsDedupesCoalescedNameMatch(t *testing.T) {
 	t.Parallel()
 	s := &FamilyCampDerivedSync{}
 
+	// A local constant rather than the literal three times: goconst counts
+	// repeated string literals across the package and this name is already
+	// used in other sync tests.
+	const wantMergedName = "Emma Johnson"
+
 	householdValues := []customValueEntry{
-		{householdPBID: "hh_1", fieldName: "Family Camp Adult 1", value: "Emma Johnson"},
+		{householdPBID: "hh_1", fieldName: "Family Camp Adult 1", value: wantMergedName},
 	}
 	personValues := []customValueEntry{
-		{householdPBID: "hh_1", fieldName: "Family Camp-P2 First Name", value: "Emma Johnson"},
+		{householdPBID: "hh_1", fieldName: "Family Camp-P2 First Name", value: wantMergedName},
 		{householdPBID: "hh_1", fieldName: "Family Camp Adult 2 Email", value: "test@example.com"},
 		{householdPBID: "hh_1", fieldName: "Family Camp DOB 2", value: "1980-06-15"},
 	}
@@ -3771,8 +3776,8 @@ func TestProcessAdultsDedupesCoalescedNameMatch(t *testing.T) {
 	if got.adultNumber != 1 {
 		t.Errorf("survivor adult_number = %d, want 1 (lower slot wins)", got.adultNumber)
 	}
-	if got.name != "Emma Johnson" {
-		t.Errorf("survivor name = %q, want %q", got.name, "Emma Johnson")
+	if got.name != wantMergedName {
+		t.Errorf("survivor name = %q, want %q", got.name, wantMergedName)
 	}
 	// Field survival: the losing slot's email and date_of_birth must attach
 	// to the survivor rather than being dropped.

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -3741,3 +3741,118 @@ func TestProcessMedicalAccommodationExplainCarriesSuccessorSpellings(t *testing.
 		t.Errorf("accommodationExplain = %q", meds[0].accommodationExplain)
 	}
 }
+
+// TestProcessAdultsDedupesCoalescedNameMatch pins kindred#2483: two adult
+// slots in the same household that coalesce to the identical casefolded
+// display name, with non-conflicting dates of birth, are the same human
+// counted twice. This is the exact reproduction from the issue -- one slot
+// carries the name in the household `name` column, the other carries it
+// (mislabeled, per the doc comment above processAdults) in `first_name`,
+// plus an email and a date_of_birth the other slot never answered.
+func TestProcessAdultsDedupesCoalescedNameMatch(t *testing.T) {
+	t.Parallel()
+	s := &FamilyCampDerivedSync{}
+
+	householdValues := []customValueEntry{
+		{householdPBID: "hh_1", fieldName: "Family Camp Adult 1", value: "Emma Johnson"},
+	}
+	personValues := []customValueEntry{
+		{householdPBID: "hh_1", fieldName: "Family Camp-P2 First Name", value: "Emma Johnson"},
+		{householdPBID: "hh_1", fieldName: "Family Camp Adult 2 Email", value: "test@example.com"},
+		{householdPBID: "hh_1", fieldName: "Family Camp DOB 2", value: "1980-06-15"},
+	}
+
+	adults := s.processAdults(householdValues, personValues)
+
+	if len(adults) != 1 {
+		t.Fatalf("expected the duplicate slot collapsed to 1 adult, got %d: %+v", len(adults), adults)
+	}
+	got := adults[0]
+	if got.adultNumber != 1 {
+		t.Errorf("survivor adult_number = %d, want 1 (lower slot wins)", got.adultNumber)
+	}
+	if got.name != "Emma Johnson" {
+		t.Errorf("survivor name = %q, want %q", got.name, "Emma Johnson")
+	}
+	// Field survival: the losing slot's email and date_of_birth must attach
+	// to the survivor rather than being dropped.
+	if got.email != "test@example.com" {
+		t.Errorf("survivor email = %q, want the losing slot's email to attach", got.email)
+	}
+	if got.dateOfBirth != "1980-06-15" {
+		t.Errorf("survivor date_of_birth = %q, want the losing slot's DOB to attach", got.dateOfBirth)
+	}
+}
+
+// TestProcessAdultsDedupesCaseOnlyNameMatch pins the second reported 2026
+// pair: a byte-exact comparison misses this one, only casefolding catches
+// it, matching the pattern is_attending_adult_name already uses.
+func TestProcessAdultsDedupesCaseOnlyNameMatch(t *testing.T) {
+	t.Parallel()
+	s := &FamilyCampDerivedSync{}
+
+	personValues := []customValueEntry{
+		{householdPBID: "hh_1", fieldName: "Family Camp-P1 First Name", value: "Liam Garcia"},
+		{householdPBID: "hh_1", fieldName: "Family Camp Adult 1 Email", value: "test@example.com"},
+		{householdPBID: "hh_1", fieldName: "Family Camp DOB 1", value: "1985-03-22"},
+		{householdPBID: "hh_1", fieldName: "Family Camp-P2 First Name", value: "liam garcia"},
+		{householdPBID: "hh_1", fieldName: "Family Camp DOB 2", value: "1985-03-22"},
+	}
+
+	adults := s.processAdults(nil, personValues)
+
+	if len(adults) != 1 {
+		t.Fatalf("expected the case-only duplicate collapsed to 1 adult, got %d: %+v", len(adults), adults)
+	}
+	if adults[0].firstName != "Liam Garcia" {
+		t.Errorf("survivor first_name = %q, want the first-loaded spelling kept", adults[0].firstName)
+	}
+	if adults[0].email != "test@example.com" {
+		t.Errorf("survivor email = %q, want the only email to attach", adults[0].email)
+	}
+}
+
+// TestProcessAdultsRefusesConflictingDOBSameName pins the falsification in
+// the issue's correction: a name-only key would merge 27 groups of DIFFERENT
+// people who happen to share a name. Same casefolded name with a genuinely
+// conflicting (both populated, unequal) date_of_birth must NOT be merged.
+func TestProcessAdultsRefusesConflictingDOBSameName(t *testing.T) {
+	t.Parallel()
+	s := &FamilyCampDerivedSync{}
+
+	personValues := []customValueEntry{
+		{householdPBID: "hh_1", fieldName: "Family Camp-P1 First Name", value: "Noah Smith"},
+		{householdPBID: "hh_1", fieldName: "Family Camp DOB 1", value: "2013-05-03"},
+		{householdPBID: "hh_1", fieldName: "Family Camp-P2 First Name", value: "Noah Smith"},
+		{householdPBID: "hh_1", fieldName: "Family Camp DOB 2", value: "1960-08-07"},
+	}
+
+	adults := s.processAdults(nil, personValues)
+
+	if len(adults) != 2 {
+		t.Fatalf("conflicting DOB must refuse the merge -- expected 2 adults, got %d: %+v", len(adults), adults)
+	}
+}
+
+// TestProcessAdultsDedupesHandlesThreeRowGroup pins the n>2 requirement:
+// one production 2024 group holds three rows for the same person, and the
+// merge must not assume a pair.
+func TestProcessAdultsDedupesHandlesThreeRowGroup(t *testing.T) {
+	t.Parallel()
+	s := &FamilyCampDerivedSync{}
+
+	householdValues := []customValueEntry{
+		{householdPBID: "hh_1", fieldName: "Family Camp Adult 1", value: "Sofia Nguyen"},
+		{householdPBID: "hh_1", fieldName: "Family Camp Adult 3", value: "Sofia Nguyen"},
+		{householdPBID: "hh_1", fieldName: "Family Camp Adult 5", value: "sofia nguyen"},
+	}
+
+	adults := s.processAdults(householdValues, nil)
+
+	if len(adults) != 1 {
+		t.Fatalf("expected the three-row group collapsed to 1 adult, got %d: %+v", len(adults), adults)
+	}
+	if adults[0].adultNumber != 1 {
+		t.Errorf("survivor adult_number = %d, want 1 (lowest slot wins)", adults[0].adultNumber)
+	}
+}


### PR DESCRIPTION
## Bug

`family_camp_adults` could hold the same human twice in one household: two non-blank adult
slots that coalesce (`name`, or `first_name`+`last_name`) to the identical casefolded display
name. Nothing deduped it, so `is_attending_adult_name` counted both, overcounting
`party_size`/beds-needed downstream and double-rendering the person in any person-grained
roster view.

## The corrected key

A name-only key is unsafe. Measured against the production snapshot, grouping
`family_camp_adults` by household + casefolded coalesced name across **all years** finds
**42 groups**, but **27 of them are two different humans who happen to share a name** (sample
DOB pairs: `05/03/2013` vs `8/7/1960` — a child and an adult).

**The key that works:** same casefolded coalesced name **and non-conflicting DOB**, where
non-conflicting means the group's non-empty dates of birth are all equal, or **at most one
slot in the group carries a DOB at all**. A plain equality key is not enough — it misses one
of the two reported 2026 pairs, which has a blank DOB on one side.

Measured (SQL replay against `family_camp_adults`, all years): **MERGE 15 / REFUSE 27**.
**2026 merges = exactly 2** — the two pairs this issue originally reported, and the exact
staff-facing movement this PR produces: 2 households' adult headcount (and therefore
beds-needed) drops by one.

## The fix

Dedupe happens in `pocketbase/sync/family_camp_derived.go`'s `processAdults`, at write time,
before the existing nameless-row admission filter:

- `dedupeAdultSlots` groups a household's adult slots by casefolded coalesced name and refuses
  the whole group if two or more DISTINCT non-empty DOBs are present (`adultGroupDOBConflicts`).
- Handles groups larger than a pair — one 2024 production group holds three rows for the same
  person.
- The survivor is the lowest `adult_number` in the group (deterministic; Go map iteration order
  is not).
- `mergeAdultSlot` folds the losing slot's non-blank fields onto the survivor using the SAME
  per-field policy `processAdults` already applies for sibling-vs-sibling merges
  (`mergeFirstNonEmpty` for name/first/last/pronouns/gender/DOB/relationship, `preferEmail` for
  email) — reusing kindred#2275's merge helper rather than writing a second policy on the same
  table.
- A dropped slot's key is simply not written for this run, so the existing orphan sweep in
  `deleteOrphanedAdults` deletes its stored row on the next sync — the same path kindred#2335
  already uses for rows the computed set no longer accounts for.

This knowingly destroys the duplicate raw slot as evidence (the owner ruling on #2483 accepts
that trade explicitly, in exchange for fixing every consumer of `family_camp_adults` at once).

## Scope guard — what this PR deliberately does NOT do

- No change to `api/services/lodging_roster_service.py` or `api/schemas/lodging.py` — those
  belong to other issues.
- No PocketBase migration — this is a data-shape fix inside the existing schema.
- No re-grain of `family_camp_adults` — the (household, year, adult_number) grain from
  kindred#2275/#2335 is unchanged; this only decides which *rows* get written to it.

Closes #2483.
