### PR TITLE
fix(api): clear-assignments refuses a scenario-less call instead of deleting production

### DIFF
--- a/api/routers/solver.py
+++ b/api/routers/solver.py
@@ -907,7 +907,11 @@ async def clear_session_assignments(
     request: ClearAssignmentsRequest,
     user: AuthUser = Depends(require_permission(Permission.BUNKING_MANAGE)),
 ) -> dict[str, Any]:
-    """Clear all assignments for a session and its related sessions."""
+    """Clear all assignments for a session and its related sessions' scenario draft."""
+    # Refuse before touching PocketBase: clearing is a delete, and production
+    # bunk assignments are read-only for the solver, same as writes (kindred#2473).
+    scenario = _require_scenario(request.scenario)
+
     try:
         # Build session context from request (validates session exists for year)
         ctx = await build_session_context(session_cm_id, request.year, pb)
@@ -916,18 +920,11 @@ async def clear_session_assignments(
         deletions_by_session: defaultdict[int, int] = defaultdict(int)
         total_deleted = 0
 
-        if request.scenario:
-            collection_name = "bunk_assignments_draft"
-            base_filter = f'scenario = "{request.scenario}"'
-        else:
-            collection_name = "bunk_assignments"
-            base_filter = ""
+        collection_name = BUNK_ASSIGNMENTS_DRAFT
+        base_filter = f'scenario = "{scenario}"'
 
         for sid in ctx.related_session_ids:
-            if base_filter:
-                filter_str = f"{base_filter} && session.cm_id = {sid} && year = {ctx.year}"
-            else:
-                filter_str = f"session.cm_id = {sid} && year = {ctx.year}"
+            filter_str = f"{base_filter} && session.cm_id = {sid} && year = {ctx.year}"
 
             assignments = await asyncio.to_thread(
                 pb.collection(collection_name).get_full_list, query_params={"filter": filter_str}
@@ -960,15 +957,12 @@ async def clear_session_assignments(
         # assignments materially changes the social graph, so any cached
         # rendering would be stale.
         for sid in ctx.related_session_ids:
-            if request.scenario:
-                graph_cache.invalidate_scenario(int(sid), int(ctx.year), request.scenario)
-            else:
-                graph_cache.invalidate_session(int(sid), int(ctx.year))
+            graph_cache.invalidate_scenario(int(sid), int(ctx.year), scenario)
 
         return {
             "message": f"Cleared {total_deleted} assignments across {len(ctx.related_session_ids)} related sessions",
             "total_deleted": total_deleted,
-            "scenario": request.scenario,
+            "scenario": scenario,
             "session_breakdown": breakdown,
         }
 

--- a/tests/unit/api/routers/test_draft_writes_invalidate_cache.py
+++ b/tests/unit/api/routers/test_draft_writes_invalidate_cache.py
@@ -148,7 +148,12 @@ class TestApplySolverResultsInvalidatesCache:
 
 
 class TestClearSessionAssignmentsInvalidatesCache:
-    """Bulk-clearing draft (or prod) assignments must drop the matching cache."""
+    """Clearing a scenario's draft assignments must drop the matching cache slot.
+
+    Production is out of reach here — kindred#2473: a scenario-less clear is
+    refused with a 422 before any PocketBase call, so there is no production
+    cache slot to invalidate any more.
+    """
 
     def _run(self, *, scenario: str | None) -> MagicMock:
         from api.routers.solver import router
@@ -172,19 +177,30 @@ class TestClearSessionAssignmentsInvalidatesCache:
             body: dict[str, Any] = {"year": 2026, "session_cm_id": 1235404}
             if scenario is not None:
                 body["scenario"] = scenario
-            client = TestClient(app)
+            client = TestClient(app, raise_server_exceptions=False)
             resp = client.post("/api/sessions/1235404/clear-assignments", json=body)
-            assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
 
-        return mock_cache
+        return mock_cache, resp  # type: ignore[return-value]
 
     def test_scenario_clear_invalidates_scenario_slot(self) -> None:
-        cache = self._run(scenario="scn_abc123")
+        cache, resp = self._run(scenario="scn_abc123")
+        assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
         cache.invalidate_scenario.assert_called_once_with(1235404, 2026, "scn_abc123")
 
-    def test_prod_clear_invalidates_session_slot(self) -> None:
-        cache = self._run(scenario=None)
-        cache.invalidate_session.assert_called_once_with(1235404, 2026)
+    def test_prod_clear_is_refused_and_invalidates_nothing(self) -> None:
+        """kindred#2473: production is read-only for the solver, same as writes.
+
+        This was ``test_prod_clear_invalidates_session_slot`` before #2473 — it
+        asserted the old production behaviour (200 + session-slot invalidation).
+        It now asserts the refusal and that nothing is invalidated, since there
+        is no write (or delete) to go stale. Spec change, not a test bent to
+        fit the code, mirroring what #2471 did to this same file's apply-side
+        counterpart.
+        """
+        cache, resp = self._run(scenario=None)
+        assert resp.status_code == 422, f"Expected a refusal, got {resp.status_code}: {resp.text}"
+        cache.invalidate_session.assert_not_called()
+        cache.invalidate_scenario.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/api/routers/test_solver_never_writes_production.py
+++ b/tests/unit/api/routers/test_solver_never_writes_production.py
@@ -204,6 +204,30 @@ def _run_client(runs: dict[str, Any]) -> Iterator[TestClient]:
         yield TestClient(app, raise_server_exceptions=False)
 
 
+@contextmanager
+def _clear_client(pb: RecordingPB, cache: MagicMock) -> Iterator[TestClient]:
+    from api.routers.solver import router
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = _admin
+
+    with (
+        patch("api.routers.solver.pb", pb),
+        patch("api.routers.solver.graph_cache", cache),
+        patch("api.routers.solver.build_session_context", AsyncMock(return_value=_session_context_stub())),
+    ):
+        yield TestClient(app, raise_server_exceptions=False)
+
+
+def _clear_body(scenario: str | None, **overrides: Any) -> dict[str, Any]:
+    body: dict[str, Any] = {"session_cm_id": SESSION_CM_ID, "year": YEAR}
+    if scenario is not None:
+        body["scenario"] = scenario
+    body.update(overrides)
+    return body
+
+
 # ---------------------------------------------------------------------------
 # The class guard: no write to bunk_assignments, ever
 # ---------------------------------------------------------------------------
@@ -235,41 +259,68 @@ class TestSolverNeverWritesProduction:
         assert pb.mutated(PRODUCTION_COLLECTION) == []
         assert pb.mutated(DRAFT_COLLECTION), "The scenario apply must still write the draft table"
 
-    def test_apply_function_never_names_the_production_collection(self) -> None:
-        """Secondary tripwire: re-adding a production write means naming the table.
+    def test_clear_assignments_without_scenario_never_deletes_from_production(self) -> None:
+        """The delete side of the same rule (kindred#2473).
 
-        Both spellings count — the literal and the ``BUNK_ASSIGNMENTS`` constant
-        from ``api/constants/collections.py``.
+        Unlike the old apply-time production branch, a delete-by-id has nothing
+        to fail validation on — so this is the one mutating path that could
+        actually change production data. Same class guard, opposite verb.
+        """
+        existing = SimpleNamespace(id="assignment_pb_1")
+        pb = RecordingPB(lists={PRODUCTION_COLLECTION: [existing], "camp_sessions": []})
+
+        with _clear_client(pb, MagicMock()) as client:
+            client.post(
+                f"/api/sessions/{SESSION_CM_ID}/clear-assignments",
+                json=_clear_body(scenario=None),
+            )
+
+        assert pb.mutated(PRODUCTION_COLLECTION) == [], (
+            f"clear-assignments mutated {PRODUCTION_COLLECTION}: {pb.mutated(PRODUCTION_COLLECTION)}. "
+            "Production is read-only for the solver — deletes belong to a scenario draft, same as writes."
+        )
+
+    def test_router_never_names_the_production_collection_for_a_mutation(self) -> None:
+        """Source-level tripwire, run across every mutating solver-router endpoint.
+
+        One rule pinning the class: any function here that writes *or deletes*
+        ``bunk_assignments`` by naming it (the literal or the ``BUNK_ASSIGNMENTS``
+        constant from ``api/constants/collections.py``) fails. Extending the list
+        of functions below — rather than adding a second, endpoint-specific AST
+        test — is what keeps this a class-level guard instead of one that only
+        happens to cover today's known offenders.
 
         This is a cheap, fast source-level check, and it is foolable: a
         module-level alias for the production collection (e.g. ``_ALIAS =
-        BUNK_ASSIGNMENTS`` referenced inside the function) walks past this
-        AST scan without ever naming ``BUNK_ASSIGNMENTS`` or the literal
-        directly. The load-bearing coverage is the *behavioral* tests above
-        (``test_apply_without_scenario_never_touches_production`` and
-        ``test_apply_with_scenario_never_touches_production``), which assert
-        against a ``RecordingPB`` and catch a bypass like that regardless of
-        how the write got there. Do not simplify this suite down to just this
-        AST check — it only catches the naive re-introduction.
+        BUNK_ASSIGNMENTS`` referenced inside the function) walks past this AST
+        scan without ever naming ``BUNK_ASSIGNMENTS`` or the literal directly.
+        The load-bearing coverage is the *behavioral* tests above, which assert
+        against a ``RecordingPB`` and catch a bypass like that regardless of how
+        the write or delete got there. Do not simplify this suite down to just
+        this AST check — it only catches the naive re-introduction.
         """
-        from api.routers.solver import apply_solver_results
+        from api.routers.solver import apply_solver_results, clear_session_assignments
 
-        tree = ast.parse(textwrap.dedent(inspect.getsource(apply_solver_results)))
-        offenders: list[str] = []
-        for node in ast.walk(tree):
-            if (
-                isinstance(node, ast.Constant)
-                and isinstance(node.value, str)
-                and PRODUCTION_COLLECTION in node.value
-                and DRAFT_COLLECTION not in node.value
-            ):
-                offenders.append(node.value)
-            if isinstance(node, ast.Name) and node.id == "BUNK_ASSIGNMENTS":
-                offenders.append(node.id)
+        offenders: dict[str, list[str]] = {}
+        for fn in (apply_solver_results, clear_session_assignments):
+            tree = ast.parse(textwrap.dedent(inspect.getsource(fn)))
+            found: list[str] = []
+            for node in ast.walk(tree):
+                if (
+                    isinstance(node, ast.Constant)
+                    and isinstance(node.value, str)
+                    and PRODUCTION_COLLECTION in node.value
+                    and DRAFT_COLLECTION not in node.value
+                ):
+                    found.append(node.value)
+                if isinstance(node, ast.Name) and node.id == "BUNK_ASSIGNMENTS":
+                    found.append(node.id)
+            if found:
+                offenders[fn.__name__] = found
 
-        assert offenders == [], (
-            f"apply_solver_results names the production collection: {offenders}. "
-            "Solver output applies to a scenario; production is read-only."
+        assert offenders == {}, (
+            f"Solver router function(s) name the production collection: {offenders}. "
+            "Production is read-only for the solver — no write, and no delete."
         )
 
 
@@ -370,6 +421,62 @@ class TestRunCreationRequiresScenario:
 
         assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
         assert len(runs) == 1
+
+
+# ---------------------------------------------------------------------------
+# Refusal at clear-assignments time (kindred#2473)
+# ---------------------------------------------------------------------------
+
+
+class TestClearAssignmentsRequiresScenario:
+    """clear-assignments reuses run-creation's refusal shape and message, not a second one."""
+
+    @pytest.mark.parametrize("scenario", [None, "", "   "])
+    def test_clear_without_scenario_is_refused(self, scenario: str | None) -> None:
+        existing = SimpleNamespace(id="assignment_pb_1")
+        pb = RecordingPB(lists={PRODUCTION_COLLECTION: [existing], "camp_sessions": []})
+
+        with _clear_client(pb, MagicMock()) as client:
+            resp = client.post(
+                f"/api/sessions/{SESSION_CM_ID}/clear-assignments",
+                json=_clear_body(scenario=scenario),
+            )
+
+        assert resp.status_code == 422, f"Expected a refusal, got {resp.status_code}: {resp.text}"
+        assert "scenario" in resp.text.lower()
+        assert pb.mutations == [], f"A refused clear must delete nothing: {pb.mutations}"
+
+    def test_clear_refusal_reuses_run_creation_message(self) -> None:
+        """Same refusal shape as PR #2471 — one message, not a second one invented here."""
+        pb = RecordingPB(lists={"camp_sessions": []})
+
+        with _clear_client(pb, MagicMock()) as client:
+            clear_resp = client.post(
+                f"/api/sessions/{SESSION_CM_ID}/clear-assignments",
+                json=_clear_body(scenario=None),
+            )
+
+        with _run_client({}) as client:
+            run_resp = client.post("/api/solver/run", json={"session_cm_id": SESSION_CM_ID, "year": YEAR})
+
+        assert clear_resp.status_code == run_resp.status_code == 422
+        assert clear_resp.json()["detail"] == run_resp.json()["detail"]
+
+    def test_clear_with_scenario_still_deletes_the_draft(self) -> None:
+        existing = SimpleNamespace(id="draft_pb_1")
+        pb = RecordingPB(lists={DRAFT_COLLECTION: [existing], "camp_sessions": []})
+        cache = MagicMock()
+
+        with _clear_client(pb, cache) as client:
+            resp = client.post(
+                f"/api/sessions/{SESSION_CM_ID}/clear-assignments",
+                json=_clear_body(scenario="scn_abc123"),
+            )
+
+        assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
+        assert pb.mutated(DRAFT_COLLECTION), "The legal path must still delete the scenario draft"
+        assert pb.mutated(PRODUCTION_COLLECTION) == []
+        cache.invalidate_scenario.assert_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Production bunk assignments are read-only for the solver. `clear_session_assignments` took a scenario-less request down an `else` branch that deleted straight from `bunk_assignments` by record id — unlike PR #2471's write-side branch, this one had nothing to fail validation on, so it actually worked and could delete production rows.

The owner's ruling settles both readings the issue left open: it is not a staff admin operation ("not allowed even in admin — it's faster to just resync"), and it must refuse without a scenario, exactly as apply now does after #2471.

Reuses #2471's `_require_scenario` helper and its 422 detail message verbatim, rather than inventing a second refusal shape. The production branch is deleted outright, same treatment as apply's.

The issue's own severity argument (recovery needs a container restart, per #2465) no longer holds — PR #2472 fixed the underlying accumulation bug, so a resync now recreates swept rows. The reason to fix this is the product rule that production is read-only for the solver, not data loss, and this PR does not restate the weaker argument.

## Tests

In the same two files #2471 already used for this rule:

- `test_solver_never_writes_production.py`'s class-level guard is extended to also pin deletes, not just writes — one rule covering both `apply_solver_results` and `clear_session_assignments`, so the next production-touching path added to either function is still caught. A behavioral test drives clear-assignments through a `RecordingPB` and asserts no delete reaches `bunk_assignments`; the AST tripwire now walks both functions for the production collection name.
- New refusal tests for clear-assignments (missing/blank/whitespace scenario, a scenario-having call still deletes the draft), and one that asserts the clear refusal's message is byte-identical to run-creation's.
- `test_draft_writes_invalidate_cache.py`'s `test_prod_clear_invalidates_session_slot` asserted the old production behaviour (200 + session-slot invalidation). It now asserts the refusal and that nothing is invalidated — a spec change, not a test bent to fit the code, mirroring what #2471 did to this file's apply-side counterpart.

Both guards were mutation-checked: reverting the collection/filter back to `bunk_assignments` with no scenario filter fails the class guard's behavioral test and its AST tripwire.

## Deliberately not touched

- `POST /api/solver/run-sweep` still creates scenario-less runs with a `session_cm_id`. A sweep is a benchmark that never applies; refusing it would remove the session-based sweep feature, a bigger product call than this issue settles.
- The hourly orphan sweep (`pocketbase/sync/bunk_assignments.go`, #2465/#2472) is untouched — a different mechanism, already fixed separately.

## Verification

`bash scripts/pre-push-verify.sh` — ALL CHECKS PASSED (ruff format, ruff check, mypy, 6419 passed / 14 skipped). Pre-push (pushed run): 6580 passed / 41 skipped.

Closes #2473.