### PR TITLE
feat(metrics): distinguish no-coverage years from zero cancellations in historical trends

### DIFF
--- a/api/schemas/metrics.py
+++ b/api/schemas/metrics.py
@@ -420,6 +420,15 @@ class YearMetrics(BaseModel):
     new_vs_returning: NewVsReturning = Field(description="New vs returning breakdown")
     total_cancelled: int = Field(default=0, description="Total cancelled campers for this year")
     cancellation_rate: float = Field(default=0.0, description="Cancelled / (enrolled + cancelled)")
+    has_cancellation_data: bool = Field(
+        default=True,
+        description=(
+            "Whether attendee_status_history holds any rows for this year at all. "
+            "attendee_status_history only began being written in 2026, so prior years "
+            "have no coverage and total_cancelled/cancellation_rate are unmeasured, not "
+            "zero -- consumers should render 'no data' rather than the fabricated 0/0.0%."
+        ),
+    )
 
 
 class HistoricalTrendsResponse(BaseModel):

--- a/api/services/historical_service.py
+++ b/api/services/historical_service.py
@@ -97,15 +97,25 @@ class HistoricalService:
             # Cancellations use the SAME scope (session_types/session_cm_id/duration) and the
             # same distinct-person grain as the enrolled denominator above -- see #2434, where
             # an unscoped, row-counted numerator inflated the rendered rate ~2.4x.
+            #
+            # cancel_transitions is None when the underlying fetch failed (see
+            # _fetch_cancellation_transitions) -- that failure must not be reported as a
+            # confidently-measured zero: fold it into has_cancellation_data so the count and
+            # the coverage flag can never disagree about whether this year was actually
+            # measured this call.
+            cancellation_fetch_failed = cancel_transitions is None
             filtered_cancellations = self._filter_attendees(
-                cancel_transitions, sessions, session_types, session_cm_id, session_name, duration
+                cancel_transitions or [], sessions, session_types, session_cm_id, session_name, duration
             )
             cancelled_person_ids = {
                 pid for t in filtered_cancellations if (pid := getattr(t, "person_id", None)) is not None
             }
             cancel_count = len(cancelled_person_ids)
+            year_has_cancellation_data = has_cancellation_data and not cancellation_fetch_failed
 
-            year_metric = self._compute_year_metrics(year, person_ids, persons, cancel_count, has_cancellation_data)
+            year_metric = self._compute_year_metrics(
+                year, person_ids, persons, cancel_count, year_has_cancellation_data
+            )
             year_metrics_list.append(year_metric)
 
         return HistoricalTrendsResponse(years=year_metrics_list)
@@ -162,7 +172,7 @@ class HistoricalService:
 
         return None
 
-    async def _fetch_cancellation_transitions(self, year: int) -> list[Any]:
+    async def _fetch_cancellation_transitions(self, year: int) -> list[Any] | None:
         """Fetch raw cancellation status-transition rows for a year.
 
         Returns the unfiltered rows so the caller can scope them by
@@ -170,12 +180,17 @@ class HistoricalService:
         denominator (see calculate_historical_trends), and dedupe by
         person_id for the correct grain. No repository defines a
         pre-aggregated ``fetch_cancellation_count`` -- see #2434.
+
+        Returns ``None`` (not ``[]``) on a repository failure, so the caller
+        can distinguish "queried, zero rows" from "never queried" -- a fetch
+        failure must not be reported as a confidently-measured zero
+        cancellation count (see #2443's has_cancellation_data).
         """
         try:
             result: list[Any] = await self.repo.fetch_status_transitions(year, ["cancelled", "withdrawn", "dismissed"])
             return result
         except Exception:
-            return []
+            return None
 
     async def _fetch_cancellation_data_coverage(self, year: int) -> bool:
         """Whether attendee_status_history has ANY rows for this year.

--- a/api/services/historical_service.py
+++ b/api/services/historical_service.py
@@ -74,17 +74,19 @@ class HistoricalService:
         person_futures = [self.repo.fetch_persons(y) for y in years]
         session_futures = [self.repo.fetch_sessions(y, session_types=session_types) for y in years]
         cancel_futures = [self._fetch_cancellation_transitions(y) for y in years]
+        coverage_futures = [self._fetch_cancellation_data_coverage(y) for y in years]
 
         all_attendees = await asyncio.gather(*attendee_futures)
         all_persons = await asyncio.gather(*person_futures)
         all_sessions = await asyncio.gather(*session_futures)
         all_cancel_transitions = await asyncio.gather(*cancel_futures)
+        all_coverage = await asyncio.gather(*coverage_futures)
 
         # Compute metrics for each year
         year_metrics_list: list[YearMetrics] = []
 
-        for year, attendees, persons, sessions, cancel_transitions in zip(
-            years, all_attendees, all_persons, all_sessions, all_cancel_transitions, strict=True
+        for year, attendees, persons, sessions, cancel_transitions, has_cancellation_data in zip(
+            years, all_attendees, all_persons, all_sessions, all_cancel_transitions, all_coverage, strict=True
         ):
             # Filter attendees by session type and/or session name
             filtered = self._filter_attendees(attendees, sessions, session_types, session_cm_id, session_name, duration)
@@ -103,7 +105,7 @@ class HistoricalService:
             }
             cancel_count = len(cancelled_person_ids)
 
-            year_metric = self._compute_year_metrics(year, person_ids, persons, cancel_count)
+            year_metric = self._compute_year_metrics(year, person_ids, persons, cancel_count, has_cancellation_data)
             year_metrics_list.append(year_metric)
 
         return HistoricalTrendsResponse(years=year_metrics_list)
@@ -175,8 +177,29 @@ class HistoricalService:
         except Exception:
             return []
 
+    async def _fetch_cancellation_data_coverage(self, year: int) -> bool:
+        """Whether attendee_status_history has ANY rows for this year.
+
+        Not filtered by session_types, session_cm_id, duration, or status --
+        coverage is a year-level fact, independent of the scoping applied to
+        the enrolled/cancelled counts. Reuses the existing, already-defined
+        ``fetch_status_history(year, old_status=None, new_statuses=None)``
+        probe (both filters default) rather than adding a new repository
+        method -- see #2443.
+        """
+        try:
+            rows: list[Any] = await self.repo.fetch_status_history(year)
+            return len(rows) > 0
+        except Exception:
+            return False
+
     def _compute_year_metrics(
-        self, year: int, person_ids: set[int], persons: dict[int, Any], total_cancelled: int = 0
+        self,
+        year: int,
+        person_ids: set[int],
+        persons: dict[int, Any],
+        total_cancelled: int = 0,
+        has_cancellation_data: bool = True,
     ) -> YearMetrics:
         """Compute metrics for a single year from deduplicated person IDs.
 
@@ -220,4 +243,5 @@ class HistoricalService:
             new_vs_returning=new_vs_returning,
             total_cancelled=total_cancelled,
             cancellation_rate=cancellation_rate,
+            has_cancellation_data=has_cancellation_data,
         )

--- a/frontend/src/components/metrics/TrendLineChart.test.tsx
+++ b/frontend/src/components/metrics/TrendLineChart.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { TrendLineChart } from './TrendLineChart'
+import { computeCoverageBands } from './cssChartUtils'
 import type { YearMetrics } from '../../types/metrics'
 
 let capturedStrokeLinecaps: string[] = []
@@ -77,5 +78,114 @@ describe('TrendLineChart', () => {
         expect(capturedStrokeLinecaps.every((v) => v === 'round')).toBe(true)
       }
     )
+  })
+})
+
+// ============================================================================
+// #2443 — no-coverage years render a greyed band, not a fabricated zero.
+//
+// The x-axis is a categorical `point` scale with zero bandwidth (recharts
+// ^3.10.1, combineRealScaleType for type:'category' inside LineChart), so a
+// ReferenceArea drawn against it lands tick-to-tick, not slot-to-slot, and
+// this chart's visible axis is drawn in the DOM by ChartCard, not by
+// recharts -- see the issue body's build-risk analysis. This ships the
+// named DOM-layer fallback instead: a band positioned by the SAME
+// edge-aligned percentage math VerticalXAxis uses for the year labels
+// (cssChartUtils.ts, edgeAligned branch: left = i/(n-1)*100%, with the
+// same rightPadding reduction), so alignment is correct by construction
+// rather than asserted from the SVG scale.
+// ============================================================================
+
+describe('computeCoverageBands', () => {
+  it('returns no bands when every year has coverage', () => {
+    expect(computeCoverageBands([true, true, true])).toEqual([])
+  })
+
+  it('returns no bands for fewer than 2 points', () => {
+    expect(computeCoverageBands([false])).toEqual([])
+    expect(computeCoverageBands([])).toEqual([])
+  })
+
+  it('covers a leading run of uncovered years, stopping halfway to the first covered year', () => {
+    // 5 years, 2022-2025 uncovered (indices 0-3), 2026 covered (index 4).
+    const bands = computeCoverageBands([false, false, false, false, true])
+    expect(bands).toHaveLength(1)
+    expect(bands[0]!.leftPct).toBeCloseTo(0, 5)
+    // rightIndex = 3 + 0.5 = 3.5 of 4 -> 87.5%
+    expect(bands[0]!.widthPct).toBeCloseTo(87.5, 5)
+  })
+
+  it('covers a trailing run of uncovered years', () => {
+    const bands = computeCoverageBands([true, true, false, false])
+    expect(bands).toHaveLength(1)
+    // leftIndex = 2 - 0.5 = 1.5 of 3 -> 50%
+    expect(bands[0]!.leftPct).toBeCloseTo(50, 5)
+    // rightIndex = min(3, 3.5) = 3 -> 100%; width = 100-50 = 50
+    expect(bands[0]!.widthPct).toBeCloseTo(50, 5)
+  })
+
+  it('covers a middle run bounded by coverage on both sides', () => {
+    const bands = computeCoverageBands([true, false, false, true, true])
+    expect(bands).toHaveLength(1)
+    // leftIndex = 1-0.5=0.5 of 4 -> 12.5%; rightIndex = 2+0.5=2.5 of 4 -> 62.5%
+    expect(bands[0]!.leftPct).toBeCloseTo(12.5, 5)
+    expect(bands[0]!.widthPct).toBeCloseTo(50, 5)
+  })
+
+  it('returns one band per contiguous uncovered run', () => {
+    const bands = computeCoverageBands([false, true, false, true])
+    expect(bands).toHaveLength(2)
+  })
+})
+
+describe('TrendLineChart — coverage band rendering (#2443)', () => {
+  const coverageData: YearMetrics[] = [
+    {
+      year: 2022,
+      total_enrolled: 0,
+      by_gender: [],
+      new_vs_returning: {
+        new_count: 0,
+        returning_count: 0,
+        new_percentage: 0,
+        returning_percentage: 0,
+      },
+      total_cancelled: 0,
+      cancellation_rate: 0,
+      has_cancellation_data: false,
+    },
+    {
+      year: 2026,
+      total_enrolled: 100,
+      by_gender: [],
+      new_vs_returning: {
+        new_count: 40,
+        returning_count: 60,
+        new_percentage: 40,
+        returning_percentage: 60,
+      },
+      total_cancelled: 276,
+      cancellation_rate: 43.9,
+      has_cancellation_data: true,
+    },
+  ]
+
+  it('renders a coverage band for the cancellation_rate metric when a year lacks data', () => {
+    render(
+      <TrendLineChart data={coverageData} title="Cancellation Rate" metric="cancellation_rate" />
+    )
+    expect(screen.getAllByTestId('coverage-band').length).toBeGreaterThan(0)
+  })
+
+  it('renders no coverage band when every year has data', () => {
+    const covered = coverageData.map((y) => ({ ...y, has_cancellation_data: true }))
+    render(<TrendLineChart data={covered} title="Cancellation Rate" metric="cancellation_rate" />)
+    expect(screen.queryByTestId('coverage-band')).not.toBeInTheDocument()
+  })
+
+  it('renders no coverage band for metrics other than cancellation_rate', () => {
+    // total_enrolled has no coverage concept -- the band is scoped to cancellation data only.
+    render(<TrendLineChart data={coverageData} title="Total Enrolled" metric="total" />)
+    expect(screen.queryByTestId('coverage-band')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/metrics/TrendLineChart.tsx
+++ b/frontend/src/components/metrics/TrendLineChart.tsx
@@ -17,7 +17,7 @@ import {
 import { useMemo } from 'react'
 import type { YearMetrics } from '../../types/metrics'
 import { ChartCard } from './ChartCard'
-import { getNiceTicks, calculateVerticalLayout } from './cssChartUtils'
+import { getNiceTicks, calculateVerticalLayout, computeCoverageBands } from './cssChartUtils'
 import { formatLabelListValue, formatLabelListPercent } from '../../utils/chartFormatters'
 
 const COLORS = {
@@ -79,6 +79,18 @@ export function TrendLineChart({
           cancellation_rate: yearData.cancellation_rate ?? 0,
         }
       }),
+    [data, metric]
+  )
+
+  // #2443 -- greyed band(s) behind years with no attendee_status_history
+  // coverage, scoped to the cancellation-rate metric (the only one with a
+  // coverage concept -- enrollment/gender/new-vs-returning are always
+  // measured).
+  const coverageBands = useMemo(
+    () =>
+      metric === 'cancellation_rate'
+        ? computeCoverageBands(data.map((d) => d.has_cancellation_data !== false))
+        : [],
     [data, metric]
   )
 
@@ -159,6 +171,22 @@ export function TrendLineChart({
       xAxisRightPadding={20}
       {...(legendItems.length > 1 && { legend: legendItems })}
     >
+      {coverageBands.length > 0 && (
+        // Reduced-width box mirrors the recharts LineChart margin (right: 20,
+        // matching xAxisRightPadding above) and VerticalXAxis's own inner div
+        // (cssChartUtils.ts, edgeAligned branch), so percentages inside it
+        // land on the same pixels as the year labels below the chart.
+        <div className="pointer-events-none absolute inset-0" style={{ right: '20px' }}>
+          {coverageBands.map((band, i) => (
+            <div
+              key={i}
+              data-testid="coverage-band"
+              className="bg-muted-foreground/10 absolute inset-y-0"
+              style={{ left: `${band.leftPct}%`, width: `${band.widthPct}%` }}
+            />
+          ))}
+        </div>
+      )}
       <ResponsiveContainer width="100%" height={barsHeight}>
         <LineChart
           data={chartData}

--- a/frontend/src/components/metrics/cssChartUtils.ts
+++ b/frontend/src/components/metrics/cssChartUtils.ts
@@ -29,6 +29,52 @@ export function getYAxisMarginLeft(width: YAxisWidth = 'w-8'): string {
   return width === 'w-10' ? '3rem' : '2.5rem'
 }
 
+/**
+ * #2443 -- compute greyed-band extents for contiguous runs of years without
+ * attendee_status_history coverage (has_cancellation_data === false).
+ *
+ * A recharts `ReferenceArea` was tried first and rejected: `TrendLineChart`'s
+ * x-axis is a categorical `point` scale with zero bandwidth (recharts
+ * ^3.10.1, `combineRealScaleType` for `type:'category'` inside `LineChart`),
+ * so a ReferenceArea lands tick-to-tick rather than covering each year's
+ * share of the axis, and the visible axis is drawn in the DOM by ChartCard
+ * (this file's `VerticalXAxis`), not by recharts -- see the issue body's
+ * build-risk analysis. This ships the issue's named fallback instead: a
+ * DOM-layer band using the SAME edge-aligned percentage math `VerticalXAxis`
+ * uses below to place the year labels (`left = i/(n-1) * 100%` inside a box
+ * reduced by the same right padding), so the band's alignment with the
+ * labels is correct by construction rather than asserted from the SVG scale.
+ *
+ * Each band's edges sit halfway between the last/first uncovered index and
+ * its covered neighbor -- e.g. for [uncovered, uncovered, covered] it spans
+ * from the left edge to halfway between index 1 and index 2, so it reads as
+ * "behind the uncovered years" rather than stopping dead on a tick.
+ */
+export function computeCoverageBands(
+  covered: boolean[]
+): Array<{ leftPct: number; widthPct: number }> {
+  const n = covered.length
+  if (n < 2) return []
+
+  const bands: Array<{ leftPct: number; widthPct: number }> = []
+  let i = 0
+  while (i < n) {
+    if (covered[i]) {
+      i++
+      continue
+    }
+    let j = i
+    while (j < n && !covered[j]) j++
+    // Uncovered run is [i, j-1].
+    const leftIndex = Math.max(0, i - 0.5)
+    const rightIndex = Math.min(n - 1, j - 1 + 0.5)
+    const leftPct = (leftIndex / (n - 1)) * 100
+    bands.push({ leftPct, widthPct: ((rightIndex - leftIndex) / (n - 1)) * 100 })
+    i = j
+  }
+  return bands
+}
+
 function pickNiceResidual(residual: number): number {
   if (residual <= 1.5) return 1
   if (residual <= 3) return 2

--- a/frontend/src/pages/metrics/trends/TrendsOverview.test.tsx
+++ b/frontend/src/pages/metrics/trends/TrendsOverview.test.tsx
@@ -4,7 +4,7 @@
  * Tests are written FIRST before implementation (TDD).
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, within, fireEvent } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 // --- module mocks ---
@@ -83,11 +83,11 @@ const mockHistoricalYear = {
 }
 
 vi.mock('../../../hooks/useMetrics', () => ({
-  useHistoricalTrends: () => ({
+  useHistoricalTrends: vi.fn(() => ({
     data: { years: [mockHistoricalYear] },
     isLoading: false,
     error: null,
-  }),
+  })),
 }))
 
 // Stub out recharts to avoid ResizeObserver issues in jsdom
@@ -117,6 +117,7 @@ function renderWithClient() {
 // Import after mocks are set up
 import TrendsOverview from './TrendsOverview'
 import { useRetentionTrends } from '../../../hooks/useRetentionTrends'
+import { useHistoricalTrends } from '../../../hooks/useMetrics'
 
 describe('TrendsOverview — Camp → Teen checkbox', () => {
   beforeEach(() => {
@@ -182,5 +183,88 @@ describe('TrendsOverview — teen-pipeline flag gating', () => {
       2026,
       expect.objectContaining({ includeTeenPipeline: false })
     )
+  })
+})
+
+describe('TrendsOverview — no-coverage years render em-dash, not fabricated zero (#2443)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockMetricsSession.includeTeenPipeline = false
+    vi.mocked(useRetentionTrends).mockReturnValue(
+      mockRetentionTrends as unknown as ReturnType<typeof useRetentionTrends>
+    )
+  })
+
+  it('renders an em-dash for Cancelled/Cancel % when has_cancellation_data is false', () => {
+    vi.mocked(useHistoricalTrends).mockReturnValue({
+      data: {
+        years: [
+          {
+            ...mockHistoricalYear,
+            year: 2022,
+            total_cancelled: 0,
+            cancellation_rate: 0,
+            has_cancellation_data: false,
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useHistoricalTrends>)
+
+    renderWithClient()
+
+    const table = screen.getByRole('table')
+    const row = within(table).getByText('2022').closest('tr')
+    expect(row).not.toBeNull()
+    const cells = row ? Array.from(row.querySelectorAll('td')).map((td) => td.textContent) : []
+    // Cancelled and Cancel % are the last two columns.
+    expect(cells.at(-2)).toBe('—')
+    expect(cells.at(-1)).toBe('—')
+  })
+
+  it('renders the real numbers when has_cancellation_data is true', () => {
+    vi.mocked(useHistoricalTrends).mockReturnValue({
+      data: {
+        years: [
+          {
+            ...mockHistoricalYear,
+            year: 2026,
+            total_cancelled: 276,
+            cancellation_rate: 43.9,
+            has_cancellation_data: true,
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useHistoricalTrends>)
+
+    renderWithClient()
+
+    const table = screen.getByRole('table')
+    const row = within(table).getByText('2026').closest('tr')
+    expect(row).not.toBeNull()
+    const cells = row ? Array.from(row.querySelectorAll('td')).map((td) => td.textContent) : []
+    expect(cells.at(-2)).toBe('276')
+    expect(cells.at(-1)).toBe('43.9%')
+  })
+
+  it('treats has_cancellation_data as true when the field is absent (backward compat)', () => {
+    vi.mocked(useHistoricalTrends).mockReturnValue({
+      data: {
+        years: [{ ...mockHistoricalYear, year: 2026, total_cancelled: 5, cancellation_rate: 4.5 }],
+      },
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useHistoricalTrends>)
+
+    renderWithClient()
+
+    const table = screen.getByRole('table')
+    const row = within(table).getByText('2026').closest('tr')
+    const cells = row ? Array.from(row.querySelectorAll('td')).map((td) => td.textContent) : []
+    expect(cells.at(-2)).toBe('5')
+    expect(cells.at(-1)).toBe('4.5%')
   })
 })

--- a/frontend/src/pages/metrics/trends/TrendsOverview.tsx
+++ b/frontend/src/pages/metrics/trends/TrendsOverview.tsx
@@ -356,10 +356,14 @@ export default function TrendsOverview() {
                       {femaleCount.toLocaleString()}
                     </td>
                     <td className="text-foreground px-4 py-3 text-right">
-                      {(year.total_cancelled ?? 0).toLocaleString()}
+                      {year.has_cancellation_data === false
+                        ? '—'
+                        : (year.total_cancelled ?? 0).toLocaleString()}
                     </td>
                     <td className="text-muted-foreground px-4 py-3 text-right">
-                      {(year.cancellation_rate ?? 0).toFixed(1)}%
+                      {year.has_cancellation_data === false
+                        ? '—'
+                        : `${(year.cancellation_rate ?? 0).toFixed(1)}%`}
                     </td>
                   </tr>
                 )

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -7456,6 +7456,12 @@ export type YearMetrics = {
    * Cancelled / (enrolled + cancelled)
    */
   cancellation_rate?: number
+  /**
+   * Has Cancellation Data
+   *
+   * Whether attendee_status_history holds any rows for this year at all. attendee_status_history only began being written in 2026, so prior years have no coverage and total_cancelled/cancellation_rate are unmeasured, not zero -- consumers should render 'no data' rather than the fabricated 0/0.0%.
+   */
+  has_cancellation_data?: boolean
 }
 
 /**

--- a/frontend/src/types/metrics.ts
+++ b/frontend/src/types/metrics.ts
@@ -273,6 +273,13 @@ export interface YearMetrics {
   new_vs_returning: NewVsReturning
   total_cancelled?: number
   cancellation_rate?: number
+  /**
+   * Whether attendee_status_history holds any rows for this year at all.
+   * When false, total_cancelled/cancellation_rate were never measured (not
+   * a measured zero) -- render "no data", not 0 / 0.0%. Defaults to true
+   * for backward compatibility with callers built before this field existed.
+   */
+  has_cancellation_data?: boolean
 }
 
 export interface HistoricalTrendsResponse {

--- a/tests/unit/api/services/test_historical_service.py
+++ b/tests/unit/api/services/test_historical_service.py
@@ -899,3 +899,39 @@ class TestCancellationDataCoverage:
         year_dict = {y.year: y for y in result.years}
         assert year_dict[2022].has_cancellation_data is False
         assert year_dict[2026].has_cancellation_data is True
+
+    @pytest.mark.asyncio
+    async def test_coverage_false_when_cancellation_fetch_fails_even_if_history_probe_succeeds(
+        self, mock_repository: MagicMock
+    ) -> None:
+        """A failed fetch_status_transitions must NOT be reported as a
+        confidently-measured zero cancellation count.
+
+        Regression test (scan-it finding on #2443's own PR): coverage was
+        wired to a separate probe (fetch_status_history) from the count
+        (fetch_status_transitions). A repository fetch error was already
+        swallowed to total_cancelled=0 (pre-existing) -- but adding
+        has_cancellation_data without tying it to that same failure makes
+        the wrong number look MORE trustworthy, not less: has_cancellation_data
+        would read True (the unrelated history probe succeeded) while the
+        cancellation count itself was never actually measured this call.
+        """
+        from api.services.historical_service import HistoricalService
+
+        async def failing_fetch_status_transitions(year: int, statuses: Any) -> list[Any]:
+            raise RuntimeError("simulated repository failure")
+
+        mock_repository.fetch_status_transitions = AsyncMock(side_effect=failing_fetch_status_transitions)
+        # The unrelated year-level coverage probe succeeds and has rows.
+        mock_repository.fetch_status_history = AsyncMock(
+            return_value=[make_mock_transition(9001, 5001, new_status="enrolled")]
+        )
+
+        service = HistoricalService(mock_repository)
+        result = await service.calculate_historical_trends(years=[2026])
+
+        year_metric = result.years[0]
+        # The cancellation count was never actually measured this call --
+        # the flag must say so, not present total_cancelled=0 as trustworthy.
+        assert year_metric.has_cancellation_data is False
+        assert year_metric.total_cancelled == 0

--- a/tests/unit/api/services/test_historical_service.py
+++ b/tests/unit/api/services/test_historical_service.py
@@ -90,6 +90,7 @@ def _make_repo_with_defaults() -> MagicMock:
     repo.fetch_persons = AsyncMock(return_value={})
     repo.fetch_sessions = AsyncMock(return_value={})
     repo.fetch_status_transitions = AsyncMock(return_value=[])
+    repo.fetch_status_history = AsyncMock(return_value=[])
     return repo
 
 
@@ -811,3 +812,90 @@ class TestHistoricalServiceSessionFiltering:
         assert year_dict[2024].total_enrolled == 0
         # 2025 has Session 2 with 1 camper
         assert year_dict[2025].total_enrolled == 1
+
+
+# ============================================================================
+# TestCancellationDataCoverage - #2443: distinguish no-coverage years from
+# measured-zero years. attendee_status_history holds rows for only one year
+# in production; other years in the trend window must be flagged as
+# uncovered rather than rendering a fabricated 0 / 0.0%.
+# ============================================================================
+
+
+class TestCancellationDataCoverage:
+    """has_cancellation_data reflects whether attendee_status_history has ANY
+    rows for that year -- not filtered by session_types or status, because
+    coverage is a year-level fact (per the issue's suggested fix)."""
+
+    @pytest.fixture
+    def mock_repository(self) -> MagicMock:
+        return _make_repo_with_defaults()
+
+    @pytest.mark.asyncio
+    async def test_has_cancellation_data_false_when_no_history_rows(self, mock_repository: MagicMock) -> None:
+        """A year with zero attendee_status_history rows is uncovered, not zero."""
+        from api.services.historical_service import HistoricalService
+
+        mock_repository.fetch_status_history = AsyncMock(return_value=[])
+
+        service = HistoricalService(mock_repository)
+        result = await service.calculate_historical_trends(years=[2022])
+
+        assert result.years[0].has_cancellation_data is False
+
+    @pytest.mark.asyncio
+    async def test_has_cancellation_data_true_when_history_rows_exist(self, mock_repository: MagicMock) -> None:
+        """A year with any attendee_status_history rows is covered, even if
+        none of those rows are cancellations -- coverage != cancellation count."""
+        from api.services.historical_service import HistoricalService
+
+        # Only an "enrolled" transition -- no cancellations at all this year,
+        # but the table DOES have rows, so this is a measured zero, not a gap.
+        history_row = make_mock_transition(9001, 5001, new_status="enrolled")
+
+        mock_repository.fetch_status_history = AsyncMock(return_value=[history_row])
+        mock_repository.fetch_status_transitions = AsyncMock(return_value=[])
+
+        service = HistoricalService(mock_repository)
+        result = await service.calculate_historical_trends(years=[2026])
+
+        assert result.years[0].has_cancellation_data is True
+        assert result.years[0].total_cancelled == 0
+
+    @pytest.mark.asyncio
+    async def test_coverage_probe_called_per_year_unfiltered(self, mock_repository: MagicMock) -> None:
+        """fetch_status_history is called with the year alone (both status
+        filters left at their defaults) -- the year-level coverage question,
+        not a filtered one. Do NOT add a new repository method (see #2443)."""
+        from api.services.historical_service import HistoricalService
+
+        mock_repository.fetch_status_history = AsyncMock(return_value=[])
+
+        service = HistoricalService(mock_repository)
+        await service.calculate_historical_trends(years=[2023, 2024])
+
+        calls = mock_repository.fetch_status_history.call_args_list
+        called_years = {c.args[0] if c.args else c.kwargs.get("year") for c in calls}
+        assert called_years == {2023, 2024}
+        for c in calls:
+            # No positional/keyword status filters -- year alone.
+            assert len(c.args) <= 1
+            assert "old_status" not in c.kwargs
+            assert "new_statuses" not in c.kwargs
+
+    @pytest.mark.asyncio
+    async def test_coverage_independent_per_year(self, mock_repository: MagicMock) -> None:
+        """Each year's coverage flag is independent -- 2026 covered, 2022 not."""
+        from api.services.historical_service import HistoricalService
+
+        async def mock_fetch_status_history(year: int, old_status: Any = None, new_statuses: Any = None) -> list[Any]:
+            return [make_mock_transition(9001, 5001)] if year == 2026 else []
+
+        mock_repository.fetch_status_history = AsyncMock(side_effect=mock_fetch_status_history)
+
+        service = HistoricalService(mock_repository)
+        result = await service.calculate_historical_trends(years=[2022, 2026])
+
+        year_dict = {y.year: y for y in result.years}
+        assert year_dict[2022].has_cancellation_data is False
+        assert year_dict[2026].has_cancellation_data is True


### PR DESCRIPTION
## Summary

`attendee_status_history` only holds rows for one year in production (coverage began 2026), but the historical-trends endpoint requests a five-year window regardless, so the cancellation-rate trend rendered `0, 0, 0, 0, X` — four fabricated zeroes indistinguishable from a measured zero-cancellation year.

Adds `YearMetrics.has_cancellation_data`, set from the existing `fetch_status_history(year)` probe (both status filters left at their defaults, so it answers the year-level coverage question) — **no new repository method**, per the issue's warning about repeating the `hasattr`-guard trap PR #2444 fixed.

## Both consumers

- **Year-by-Year Summary table**: `Cancelled`/`Cancel %` render an em-dash (`—`) when `has_cancellation_data` is false, instead of `0` / `0.0%`. This is the house convention for "no data" (`SessionBunkHeatmap`, `DrillDownModal`, `RegistrationOverview`) — **adopted here as a default, explicitly vetoable by the owner**, per the issue.
- **Cancellation Rate trend chart**: a greyed band behind uncovered years.

### ★ Before/after — this changes what a staff-facing number means

```
Year-by-Year Summary, cancellation columns
  before: 2022 -> 0 / 0.0%   2023 -> 0 / 0.0%   2024 -> 0 / 0.0%   2025 -> 0 / 0.0%   2026 -> 276 / X%
  after:  2022 -> — / —      2023 -> — / —      2024 -> — / —      2025 -> — / —      2026 -> 276 / X%
Cancellation-rate trend chart
  before: a line through four zeroes rising to 2026
  after:  a greyed band across 2022-2025, the line drawn for 2026 only
```

No population, arithmetic, or denominator changes — only the distinction between *measured zero* and *never measured*.

## Chart rendering — the named build risk, and which route shipped

The issue flagged a build risk before estimating: `TrendLineChart`'s x-axis is a categorical `point` scale with zero bandwidth (recharts `^3.10.1`, `combineRealScaleType` for `type:'category'` inside `LineChart`), so a `ReferenceArea` would land tick-to-tick rather than covering each year's share of the axis — and the visible axis is drawn in the DOM by `ChartCard`, not by recharts. That analysis was already verified against the installed library and cited exact file/line evidence, so **this PR ships the issue's named DOM-layer fallback directly rather than building the broken SVG path first and reverting it**:

- `computeCoverageBands` (new, in `cssChartUtils.ts`) computes band extents using the **same edge-aligned percentage math** `VerticalXAxis` already uses to place the year labels (`left = i/(n-1) * 100%`, reduced by the same right padding) — so the band's alignment with the labels is correct by construction, not asserted from the SVG scale.
- Verified with: unit tests on the band-extent math (leading/trailing/middle uncovered runs, multiple runs) and component tests asserting the band renders/doesn't render per `has_cancellation_data` input and per metric.
- **Not yet eyeballed in a live browser** — this is a chart-rendering change and holds for the owner's visual check.

## Type coupling

`api/schemas/metrics.py` (source of truth) → regenerated `frontend/src/types/api-generated/types.gen.ts` (`npm run generate:api-types`, diff is whitespace-clean via `git diff -w`) → hand-maintained `frontend/src/types/metrics.ts` (the one the UI actually imports).

## Deliberately NOT done

No change to the existing chart-visibility gate (`TrendsOverview.tsx`, `data.years.some(y => (y.total_cancelled ?? 0) > 0)`) — a separate, pre-existing asymmetry the issue only notes in passing, out of scope here.

## Test plan

- [x] `uv run pytest tests/unit/api/services/test_historical_service.py` — 27 passed, including 4 new coverage tests (TDD: written first, verified red, then implemented)
- [x] `uv run pytest tests/` (full, `SKIP_POCKETBASE_TESTS=true -n auto`) — 6578 passed, 41 skipped
- [x] `cd frontend && npx vitest run` — 449/450 files green; the one failure (`PostCheckPopout.test.tsx`) is an unrelated pre-existing flake, confirmed by re-running that file in isolation (3/3 pass)
- [x] `bash scripts/pre-push-verify.sh` — ALL CHECKS PASSED (pytest, prettier, eslint, tsc, vitest)
- [x] Mutation-checked both new frontend guards (table em-dash condition, chart band condition) by breaking each and confirming the pinning test goes red, then restored

## Merge gate

This is GUI-affecting (`TrendLineChart.tsx`, `TrendsOverview.tsx`) **and** changes what a staff-facing number means (measured-zero vs never-measured). Per this repo's standing rule, it holds for the owner's eyes before merge regardless of CI color.

Closes #2443.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Historical cancellation metrics now distinguish unavailable data from measured zero cancellations.
  - Trend charts display shaded coverage bands for years without cancellation history.
- **Improvements**
  - Cancellation totals and rates show an em dash when historical data is unavailable, preventing misleading values.
  - Other trend metrics continue to display normally without coverage shading.
  - Existing data remains backward compatible when coverage information is not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->