### PR TITLE
feat(sync): insert a bounded daily family-camp custom-values pass between source and transform

### DIFF
--- a/pocketbase/sync/family_camp_daily_cadence_test.go
+++ b/pocketbase/sync/family_camp_daily_cadence_test.go
@@ -1,0 +1,389 @@
+package sync
+
+import (
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+)
+
+// cadenceTestApp builds a throwaway app carrying only the collections the
+// bounded daily family-camp cadence pass touches (kindred#2482). It is
+// deliberately separate from newSyncTestApp: that shared fixture's attendees
+// collection has no "status" text field (only status_id), and the resolver's
+// existing enrolled-only path filters on the text column
+// (`status = 'enrolled'`), so a test exercising both the enrolled-only and
+// any-status paths needs both columns present.
+func cadenceTestApp(t *testing.T) core.App {
+	t.Helper()
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	sessions := core.NewBaseCollection("camp_sessions")
+	sessions.Fields.Add(&core.NumberField{Name: "cm_id"})
+	sessions.Fields.Add(&core.TextField{Name: "name"})
+	sessions.Fields.Add(&core.TextField{Name: "session_type"})
+	sessions.Fields.Add(&core.NumberField{Name: "parent_id"})
+	sessions.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(sessions); err != nil {
+		t.Fatalf("save camp_sessions: %v", err)
+	}
+
+	households := core.NewBaseCollection("households")
+	households.Fields.Add(&core.NumberField{Name: "cm_id"})
+	households.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(households); err != nil {
+		t.Fatalf("save households: %v", err)
+	}
+
+	persons := core.NewBaseCollection("persons")
+	persons.Fields.Add(&core.NumberField{Name: "cm_id"})
+	persons.Fields.Add(&core.NumberField{Name: "household_id"})
+	persons.Fields.Add(&core.RelationField{Name: "household", CollectionId: households.Id, MaxSelect: 1})
+	persons.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(persons); err != nil {
+		t.Fatalf("save persons: %v", err)
+	}
+
+	attendees := core.NewBaseCollection("attendees")
+	attendees.Fields.Add(&core.RelationField{Name: "person", CollectionId: persons.Id, MaxSelect: 1})
+	attendees.Fields.Add(&core.NumberField{Name: "person_id"})
+	attendees.Fields.Add(&core.RelationField{Name: "session", CollectionId: sessions.Id, MaxSelect: 1})
+	attendees.Fields.Add(&core.TextField{Name: "status"})
+	attendees.Fields.Add(&core.NumberField{Name: "status_id"})
+	attendees.Fields.Add(&core.NumberField{Name: "year"})
+	if err := app.Save(attendees); err != nil {
+		t.Fatalf("save attendees: %v", err)
+	}
+
+	return app
+}
+
+func cadenceAddSession(t *testing.T, app core.App, cmID int, sessionType string, year int) string {
+	t.Helper()
+	return saveRecord(t, app, "camp_sessions", map[string]any{
+		"cm_id": cmID, "name": sessionType, "session_type": sessionType, "year": year,
+	})
+}
+
+func cadenceAddHousehold(t *testing.T, app core.App, cmID, year int) string {
+	t.Helper()
+	return saveRecord(t, app, "households", map[string]any{"cm_id": cmID, "year": year})
+}
+
+func cadenceAddPerson(t *testing.T, app core.App, cmID, householdCMID, year int, householdPBID string) string {
+	t.Helper()
+	return saveRecord(t, app, "persons", map[string]any{
+		"cm_id": cmID, "household_id": householdCMID, "household": householdPBID, "year": year,
+	})
+}
+
+func cadenceAddAttendee(
+	t *testing.T, app core.App, personPBID, sessionPBID, status string, personCMID, statusID, year int,
+) {
+	t.Helper()
+	saveRecord(t, app, "attendees", map[string]any{
+		"person": personPBID, "person_id": personCMID, "session": sessionPBID,
+		"status": status, "status_id": statusID, "year": year,
+	})
+}
+
+func intsSorted(ids []int) []int {
+	out := append([]int(nil), ids...)
+	sort.Ints(out)
+	return out
+}
+
+func intsEqual(a, b []int) bool {
+	a, b = intsSorted(a), intsSorted(b)
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestSessionResolver_AnyStatus_IncludesNonEnrolled pins the sibling-function
+// shape ruled in kindred#2482: GetPersonIDsForSession's enrolled-only
+// behavior is UNCHANGED (manual `?session=` runs must stay enrolled-only),
+// while the new AnyStatus sibling observes a household moving in or out of
+// enrolled -- a cancellation or waitlist entry -- which is the entire point
+// of the bounded daily pass.
+func TestSessionResolver_AnyStatus_IncludesNonEnrolled(t *testing.T) {
+	t.Parallel()
+	app := cadenceTestApp(t)
+	const year = 2026
+
+	sessionPB := cadenceAddSession(t, app, 1309514, sessionTypeFamily, year)
+
+	hh1 := cadenceAddHousehold(t, app, 501, year)
+	hh2 := cadenceAddHousehold(t, app, 502, year)
+	hh3 := cadenceAddHousehold(t, app, 503, year)
+
+	p1 := cadenceAddPerson(t, app, 601, 501, year, hh1)
+	p2 := cadenceAddPerson(t, app, 602, 502, year, hh2)
+	p3 := cadenceAddPerson(t, app, 603, 503, year, hh3)
+
+	cadenceAddAttendee(t, app, p1, sessionPB, "enrolled", 601, statusIDActiveEnrolled, year)
+	cadenceAddAttendee(t, app, p2, sessionPB, "cancelled", 602, 32, year)
+	cadenceAddAttendee(t, app, p3, sessionPB, "waitlisted", 603, 8, year)
+
+	resolver := NewSessionResolver(app)
+
+	enrolledOnly, err := resolver.GetPersonIDsForSession("1309514", year)
+	if err != nil {
+		t.Fatalf("GetPersonIDsForSession: %v", err)
+	}
+	if !intsEqual(enrolledOnly, []int{601}) {
+		t.Errorf("GetPersonIDsForSession (enrolled-only) = %v, want [601] -- manual ?session= runs "+
+			"must stay enrolled-only", enrolledOnly)
+	}
+
+	anyStatus, err := resolver.GetPersonIDsForSessionAnyStatus("1309514", year)
+	if err != nil {
+		t.Fatalf("GetPersonIDsForSessionAnyStatus: %v", err)
+	}
+	if !intsEqual(anyStatus, []int{601, 602, 603}) {
+		t.Errorf("GetPersonIDsForSessionAnyStatus = %v, want [601 602 603]", anyStatus)
+	}
+
+	enrolledHH, err := resolver.GetHouseholdIDsForSession("1309514", year)
+	if err != nil {
+		t.Fatalf("GetHouseholdIDsForSession: %v", err)
+	}
+	if !intsEqual(enrolledHH, []int{501}) {
+		t.Errorf("GetHouseholdIDsForSession (enrolled-only) = %v, want [501]", enrolledHH)
+	}
+
+	anyStatusHH, err := resolver.GetHouseholdIDsForSessionAnyStatus("1309514", year)
+	if err != nil {
+		t.Fatalf("GetHouseholdIDsForSessionAnyStatus: %v", err)
+	}
+	if !intsEqual(anyStatusHH, []int{501, 502, 503}) {
+		t.Errorf("GetHouseholdIDsForSessionAnyStatus = %v, want [501 502 503]", anyStatusHH)
+	}
+}
+
+// TestGetFamilyCampIDsAnyStatus_SpansWeekendsExcludesOtherSessions pins the
+// cohort-selection shape ruled in kindred#2482: the bounded daily pass's
+// cohort must come from attendees across EVERY family-camp weekend (any
+// status), unioned and deduplicated, and must NOT pick up a non-family
+// session's attendees even if a person also attends one.
+func TestGetFamilyCampIDsAnyStatus_SpansWeekendsExcludesOtherSessions(t *testing.T) {
+	t.Parallel()
+	app := cadenceTestApp(t)
+	const year = 2026
+
+	fc2 := cadenceAddSession(t, app, 1001, sessionTypeFamily, year)
+	fc3 := cadenceAddSession(t, app, 1002, sessionTypeFamily, year)
+	summerSession := cadenceAddSession(t, app, 2001, sessionTypeMain, year)
+
+	hhFC2 := cadenceAddHousehold(t, app, 701, year)
+	hhFC3 := cadenceAddHousehold(t, app, 702, year)
+	hhSummerOnly := cadenceAddHousehold(t, app, 703, year)
+	hhBothWeekends := cadenceAddHousehold(t, app, 704, year)
+
+	pFC2 := cadenceAddPerson(t, app, 801, 701, year, hhFC2)
+	pFC3 := cadenceAddPerson(t, app, 802, 702, year, hhFC3)
+	pSummerOnly := cadenceAddPerson(t, app, 803, 703, year, hhSummerOnly)
+	pBoth := cadenceAddPerson(t, app, 804, 704, year, hhBothWeekends)
+
+	cadenceAddAttendee(t, app, pFC2, fc2, "enrolled", 801, statusIDActiveEnrolled, year)
+	cadenceAddAttendee(t, app, pFC3, fc3, "cancelled", 802, 32, year)
+	cadenceAddAttendee(t, app, pSummerOnly, summerSession, "enrolled", 803, statusIDActiveEnrolled, year)
+	cadenceAddAttendee(t, app, pBoth, fc2, "waitlisted", 804, 8, year)
+	cadenceAddAttendee(t, app, pBoth, fc3, "enrolled", 804, statusIDActiveEnrolled, year)
+
+	resolver := NewSessionResolver(app)
+
+	personIDs, err := resolver.GetFamilyCampPersonIDsAnyStatus(year)
+	if err != nil {
+		t.Fatalf("GetFamilyCampPersonIDsAnyStatus: %v", err)
+	}
+	if !intsEqual(personIDs, []int{801, 802, 804}) {
+		t.Errorf("GetFamilyCampPersonIDsAnyStatus = %v, want [801 802 804] "+
+			"(803 is summer-only and must be excluded)", personIDs)
+	}
+
+	householdIDs, err := resolver.GetFamilyCampHouseholdIDsAnyStatus(year)
+	if err != nil {
+		t.Fatalf("GetFamilyCampHouseholdIDsAnyStatus: %v", err)
+	}
+	if !intsEqual(householdIDs, []int{701, 702, 704}) {
+		t.Errorf("GetFamilyCampHouseholdIDsAnyStatus = %v, want [701 702 704]", householdIDs)
+	}
+}
+
+// TestPersonCustomFieldValuesSync_FamilyCampBounded pins the bounded-mode
+// wiring on the sync service itself: when FamilyCampBounded is set,
+// getPersonIDsToSync must use the any-status family-camp cohort instead of
+// the Session filter or the year-wide fallback, and the plain Session=""
+// (unbounded) behavior must be untouched.
+func TestPersonCustomFieldValuesSync_FamilyCampBounded(t *testing.T) {
+	t.Parallel()
+	app := cadenceTestApp(t)
+	const year = 2026
+
+	fc2 := cadenceAddSession(t, app, 1001, sessionTypeFamily, year)
+	summerSession := cadenceAddSession(t, app, 2001, sessionTypeMain, year)
+
+	hhFC := cadenceAddHousehold(t, app, 701, year)
+	hhSummer := cadenceAddHousehold(t, app, 702, year)
+
+	pFC := cadenceAddPerson(t, app, 801, 701, year, hhFC)
+	pSummer := cadenceAddPerson(t, app, 802, 702, year, hhSummer)
+
+	cadenceAddAttendee(t, app, pFC, fc2, "cancelled", 801, 32, year)
+	cadenceAddAttendee(t, app, pSummer, summerSession, "enrolled", 802, statusIDActiveEnrolled, year)
+
+	sync := NewPersonCustomFieldValuesSync(app, nil)
+	sync.FamilyCampBounded = true
+
+	ids, err := sync.getPersonIDsToSync(year)
+	if err != nil {
+		t.Fatalf("getPersonIDsToSync: %v", err)
+	}
+	if !intsEqual(ids, []int{801}) {
+		t.Errorf("getPersonIDsToSync (bounded) = %v, want [801] "+
+			"(cancelled family-camp attendee, any status)", ids)
+	}
+}
+
+func TestHouseholdCustomFieldValuesSync_FamilyCampBounded(t *testing.T) {
+	t.Parallel()
+	app := cadenceTestApp(t)
+	const year = 2026
+
+	fc2 := cadenceAddSession(t, app, 1001, sessionTypeFamily, year)
+	summerSession := cadenceAddSession(t, app, 2001, sessionTypeMain, year)
+
+	hhFC := cadenceAddHousehold(t, app, 701, year)
+	hhSummer := cadenceAddHousehold(t, app, 702, year)
+
+	pFC := cadenceAddPerson(t, app, 801, 701, year, hhFC)
+	pSummer := cadenceAddPerson(t, app, 802, 702, year, hhSummer)
+
+	cadenceAddAttendee(t, app, pFC, fc2, "waitlisted", 801, 8, year)
+	cadenceAddAttendee(t, app, pSummer, summerSession, "enrolled", 802, statusIDActiveEnrolled, year)
+
+	sync := NewHouseholdCustomFieldValuesSync(app, nil)
+	sync.FamilyCampBounded = true
+
+	ids, err := sync.getHouseholdIDsToSync(year)
+	if err != nil {
+		t.Fatalf("getHouseholdIDsToSync: %v", err)
+	}
+	if !intsEqual(ids, []int{701}) {
+		t.Errorf("getHouseholdIDsToSync (bounded) = %v, want [701]", ids)
+	}
+}
+
+// TestGetDailySyncJobs_FamilyCampBoundedPassBetweenSourceAndTransform pins
+// the ordering ruled in kindred#2482: the bounded daily custom-values pass
+// must sit strictly after financial_transactions (the last source job) and
+// strictly before family_camp_derived (the first transform job that reads
+// custom values). A future edit to the hardcoded job list must not silently
+// undo this -- that is the entire point of the ruling, since the daily job
+// not honoring its own phase order is the bug this fixes.
+func TestGetDailySyncJobs_FamilyCampBoundedPassBetweenSourceAndTransform(t *testing.T) {
+	t.Parallel()
+	jobs := getDailySyncJobs()
+
+	pos := make(map[string]int, len(jobs))
+	for i, j := range jobs {
+		pos[j] = i
+	}
+
+	for _, want := range []string{"person_custom_values_family_camp", "household_custom_values_family_camp"} {
+		if _, ok := pos[want]; !ok {
+			t.Fatalf("getDailySyncJobs missing %q: %v", want, jobs)
+		}
+	}
+
+	sourceEnd, ok := pos["financial_transactions"]
+	if !ok {
+		t.Fatalf("financial_transactions missing from daily sync jobs: %v", jobs)
+	}
+	transformStart, ok := pos["family_camp_derived"]
+	if !ok {
+		t.Fatalf("family_camp_derived missing from daily sync jobs: %v", jobs)
+	}
+
+	for _, boundedJob := range []string{"person_custom_values_family_camp", "household_custom_values_family_camp"} {
+		p := pos[boundedJob]
+		if p <= sourceEnd {
+			t.Errorf("%s (pos %d) must run after financial_transactions (pos %d)", boundedJob, p, sourceEnd)
+		}
+		if p >= transformStart {
+			t.Errorf("%s (pos %d) must run before family_camp_derived (pos %d)", boundedJob, p, transformStart)
+		}
+	}
+
+	// The weekly unrestricted sweep's job names must NOT appear in the daily
+	// list -- the ruling retains them as weekly-only, on the "0 4 * * 0" cron,
+	// not as part of the daily run.
+	for _, unrestricted := range []string{"person_custom_values", "household_custom_values"} {
+		if _, ok := pos[unrestricted]; ok {
+			t.Errorf("getDailySyncJobs must not include the unrestricted %q -- "+
+				"the weekly sweep stays weekly-only", unrestricted)
+		}
+	}
+}
+
+// TestSyncJobMeta_FamilyCampBoundedJobsAreExpensivePhase asserts the new
+// bounded jobs are registered in syncJobMeta as PhaseExpensive, consistent
+// with the unrestricted person_custom_values/household_custom_values jobs
+// they sit alongside -- both make 1 CampMinder API call per entity.
+func TestSyncJobMeta_FamilyCampBoundedJobsAreExpensivePhase(t *testing.T) {
+	t.Parallel()
+	for _, id := range []string{"person_custom_values_family_camp", "household_custom_values_family_camp"} {
+		if got := GetPhaseForJob(id); got != PhaseExpensive {
+			t.Errorf("GetPhaseForJob(%q) = %q, want %q", id, got, PhaseExpensive)
+		}
+	}
+
+	expensive := GetJobsForPhase(PhaseExpensive)
+	for _, id := range []string{"person_custom_values_family_camp", "household_custom_values_family_camp"} {
+		found := false
+		for _, j := range expensive {
+			if j == id {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("GetJobsForPhase(PhaseExpensive) missing %q: %v", id, expensive)
+		}
+	}
+}
+
+// TestWeeklyCustomValuesCronRetained pins the RETAIN half of the kindred#2482
+// ruling: the weekly unrestricted sweep's cron schedule ("0 4 * * 0") and its
+// handler must survive untouched. Reads scheduler.go's source the same way
+// TestCamperHistoryServiceFullyRemoved reads orchestrator.go -- a live
+// scheduler needs a real cron.Cron and cannot be introspected for its
+// schedule strings, so the source text is the only place to pin this.
+func TestWeeklyCustomValuesCronRetained(t *testing.T) {
+	t.Parallel()
+	bodyBytes, err := os.ReadFile("scheduler.go")
+	if err != nil {
+		t.Fatalf("read scheduler.go: %v", err)
+	}
+	body := string(bodyBytes)
+	if !strings.Contains(body, `"0 4 * * 0"`) {
+		t.Error("scheduler.go no longer schedules the weekly custom-values sweep at 0 4 * * 0")
+	}
+	if !strings.Contains(body, "runCustomValuesSync") {
+		t.Error("scheduler.go no longer wires the weekly cron to runCustomValuesSync")
+	}
+}

--- a/pocketbase/sync/household_custom_field_values.go
+++ b/pocketbase/sync/household_custom_field_values.go
@@ -16,8 +16,12 @@ import (
 // Service name constant - uses new table name
 const serviceNameHouseholdCustomValues = "household_custom_values"
 
-// HouseholdCustomFieldValuesSync handles syncing custom field values for households from CampMinder
-// This is an ON-DEMAND sync (not part of daily sync) because it requires 1 API call per household
+// HouseholdCustomFieldValuesSync handles syncing custom field values for households from
+// CampMinder. The unrestricted instance (Session=DefaultSession) is ON-DEMAND -- weekly cron +
+// manual runs only -- because a year-wide sweep is 1 API call per household. A second,
+// FamilyCampBounded instance of this same type IS part of the daily cron (kindred#2482): scoped
+// to family-camp attendees, it stays cheap enough to run daily. See orchestrator.go's
+// getDailySyncJobs and the "household_custom_values_family_camp" registration.
 type HouseholdCustomFieldValuesSync struct {
 	BaseSyncService
 	Session     string                 // Session filter: "all", "1", "2", "2a", "3", "4", etc.

--- a/pocketbase/sync/household_custom_field_values.go
+++ b/pocketbase/sync/household_custom_field_values.go
@@ -22,6 +22,14 @@ type HouseholdCustomFieldValuesSync struct {
 	BaseSyncService
 	Session     string                 // Session filter: "all", "1", "2", "2a", "3", "4", etc.
 	rateLimiter *ratelimit.RateLimiter // Rate limiter for API calls
+
+	// FamilyCampBounded selects the bounded daily family-camp cohort (any attendee status,
+	// via SessionResolver.GetFamilyCampHouseholdIDsAnyStatus) instead of Session or the
+	// year-wide fallback. Set only on the dedicated "household_custom_values_family_camp"
+	// service instance registered for the daily cron (kindred#2482) -- the plain
+	// "household_custom_values" instance used by the weekly sweep and manual runs leaves
+	// this false.
+	FamilyCampBounded bool
 }
 
 // NewHouseholdCustomFieldValuesSync creates a new household custom field values sync service
@@ -251,6 +259,23 @@ func (s *HouseholdCustomFieldValuesSync) preloadFieldDefMapping() (map[int]strin
 
 // getHouseholdIDsToSync returns the list of household CampMinder IDs to sync based on session filter
 func (s *HouseholdCustomFieldValuesSync) getHouseholdIDsToSync(year int) ([]int, error) {
+	// Bounded daily family-camp pass (kindred#2482): any attendee status, across every
+	// family-camp weekend, resolved via attendees rather than Session so it can span
+	// multiple weekend sessions in one run.
+	if s.FamilyCampBounded {
+		resolver := NewSessionResolver(s.App)
+		householdIDs, err := resolver.GetFamilyCampHouseholdIDsAnyStatus(year)
+		if err != nil {
+			return nil, err
+		}
+
+		s.DebugLog("Resolved family-camp bounded cohort to household IDs",
+			"count", len(householdIDs),
+			"year", year)
+
+		return householdIDs, nil
+	}
+
 	// Use session resolver if session filter is specified
 	if s.Session != "" && s.Session != DefaultSession {
 		resolver := NewSessionResolver(s.App)

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -104,6 +104,13 @@ var syncJobMeta = []JobMeta{
 	// Expensive phase - Custom values (on-demand, rate limited)
 	{"person_custom_values", PhaseExpensive, "Person custom field values"},
 	{"household_custom_values", PhaseExpensive, "Household custom field values"},
+	// Bounded daily family-camp pass (kindred#2482): same API cost per entity as the two
+	// above, scoped to family-camp attendees (any status) and run as part of the daily
+	// cron -- see getDailySyncJobs.
+	{"person_custom_values_family_camp", PhaseExpensive,
+		"Person custom field values -- bounded daily pass, family-camp attendees, any status"},
+	{"household_custom_values_family_camp", PhaseExpensive,
+		"Household custom field values -- bounded daily pass, family-camp attendees, any status"},
 
 	// Transform phase - PocketBase → PocketBase
 	{"family_camp_derived", PhaseTransform, "Compute family camp tables from custom values"},
@@ -1216,9 +1223,20 @@ func getDailySyncJobs() []string {
 		"bunk_assignments",       // Depends on sessions, persons, bunks
 		"staff",                  // Staff sync: depends on divisions, bunks, persons
 		"financial_transactions", // Source data: depends on sessions, persons, households, divisions
-		// Transform phase: derived tables run daily using latest source data
-		// and existing custom values from the most recent weekly sync.
-		// New enrollments, session changes, etc. are reflected immediately.
+		// Bounded daily family-camp custom-values pass (kindred#2482), inserted here --
+		// between the source jobs above and the transform jobs below -- so the transform
+		// phase sees today's cabin answers instead of up to 7 days stale ones. Scoped to
+		// family-camp attendees (any status, via SessionResolver's attendees-backed
+		// cohort) so it stays cheap: ~11.5 min for ~450 households against the weekly
+		// sweep's ~43 min for everyone. The weekly unrestricted sweep (Scheduler, cron
+		// "0 4 * * 0") is UNCHANGED and still refreshes every other custom-values
+		// consumer -- dietary, transportation, financial aid, staff skills, and so on.
+		"person_custom_values_family_camp",
+		"household_custom_values_family_camp",
+		// Transform phase: derived tables run daily using the freshest source data, plus
+		// today's family-camp custom values (the bounded pass immediately above) and every
+		// other custom value from the most recent weekly sync. New enrollments, session
+		// changes, etc. are reflected immediately.
 		"family_camp_derived",
 		"lodging_assignments", // Derived: cabin custom fields -> lodging_assignments (+ history)
 		"staff_skills",
@@ -2390,6 +2408,17 @@ func (o *Orchestrator) InitializeSyncServices() error {
 	// These require N API calls (one per entity) so are triggered manually
 	o.RegisterService("person_custom_values", NewPersonCustomFieldValuesSync(o.app, client))
 	o.RegisterService("household_custom_values", NewHouseholdCustomFieldValuesSync(o.app, client))
+
+	// Bounded daily family-camp custom-values pass (kindred#2482) -- distinct service
+	// instances from the two above, scoped via FamilyCampBounded to family-camp attendees
+	// (any status) rather than Session. Part of the daily cron: see getDailySyncJobs.
+	familyCampPersonValues := NewPersonCustomFieldValuesSync(o.app, client)
+	familyCampPersonValues.FamilyCampBounded = true
+	o.RegisterService("person_custom_values_family_camp", familyCampPersonValues)
+
+	familyCampHouseholdValues := NewHouseholdCustomFieldValuesSync(o.app, client)
+	familyCampHouseholdValues.FamilyCampBounded = true
+	o.RegisterService("household_custom_values_family_camp", familyCampHouseholdValues)
 
 	// Family camp derived tables (computes from custom values - on-demand)
 	o.RegisterService("family_camp_derived", NewFamilyCampDerivedSync(o.app))

--- a/pocketbase/sync/person_custom_field_values.go
+++ b/pocketbase/sync/person_custom_field_values.go
@@ -22,6 +22,14 @@ type PersonCustomFieldValuesSync struct {
 	BaseSyncService
 	Session     string                 // Session filter: "all", "1", "2", "2a", "3", "4", etc.
 	rateLimiter *ratelimit.RateLimiter // Rate limiter for API calls
+
+	// FamilyCampBounded selects the bounded daily family-camp cohort (any attendee status,
+	// via SessionResolver.GetFamilyCampPersonIDsAnyStatus) instead of Session or the
+	// year-wide fallback. Set only on the dedicated "person_custom_values_family_camp"
+	// service instance registered for the daily cron (kindred#2482) -- the plain
+	// "person_custom_values" instance used by the weekly sweep and manual runs leaves this
+	// false.
+	FamilyCampBounded bool
 }
 
 // NewPersonCustomFieldValuesSync creates a new person custom field values sync service
@@ -255,6 +263,23 @@ func (s *PersonCustomFieldValuesSync) preloadFieldDefMapping() (map[int]string, 
 
 // getPersonIDsToSync returns the list of person CampMinder IDs to sync based on session filter
 func (s *PersonCustomFieldValuesSync) getPersonIDsToSync(year int) ([]int, error) {
+	// Bounded daily family-camp pass (kindred#2482): any attendee status, across every
+	// family-camp weekend, resolved via attendees rather than Session so it can span
+	// multiple weekend sessions in one run.
+	if s.FamilyCampBounded {
+		resolver := NewSessionResolver(s.App)
+		personIDs, err := resolver.GetFamilyCampPersonIDsAnyStatus(year)
+		if err != nil {
+			return nil, err
+		}
+
+		s.DebugLog("Resolved family-camp bounded cohort to person IDs",
+			"count", len(personIDs),
+			"year", year)
+
+		return personIDs, nil
+	}
+
 	// Use session resolver if session filter is specified
 	if s.Session != "" && s.Session != DefaultSession {
 		resolver := NewSessionResolver(s.App)

--- a/pocketbase/sync/person_custom_field_values.go
+++ b/pocketbase/sync/person_custom_field_values.go
@@ -16,8 +16,12 @@ import (
 // Service name constant - uses new table name
 const serviceNamePersonCustomValues = "person_custom_values"
 
-// PersonCustomFieldValuesSync handles syncing custom field values for persons from CampMinder
-// This is an ON-DEMAND sync (not part of daily sync) because it requires 1 API call per person
+// PersonCustomFieldValuesSync handles syncing custom field values for persons from CampMinder.
+// The unrestricted instance (Session=DefaultSession) is ON-DEMAND -- weekly cron + manual runs
+// only -- because a year-wide sweep is 1 API call per person. A second, FamilyCampBounded
+// instance of this same type IS part of the daily cron (kindred#2482): scoped to family-camp
+// attendees, it stays cheap enough to run daily. See orchestrator.go's getDailySyncJobs and the
+// "person_custom_values_family_camp" registration.
 type PersonCustomFieldValuesSync struct {
 	BaseSyncService
 	Session     string                 // Session filter: "all", "1", "2", "2a", "3", "4", etc.

--- a/pocketbase/sync/session_resolver.go
+++ b/pocketbase/sync/session_resolver.go
@@ -100,7 +100,28 @@ func (r *SessionResolver) ResolveSessionCMIDs(session string, year int) ([]int, 
 
 // GetPersonIDsForSession returns CampMinder person IDs for persons enrolled in the specified session.
 // For "all" or empty session, returns nil (caller should handle all persons case).
+//
+// Enrolled-only. This backs manual `?session=` runs, where enrolled-only is the correct
+// behavior -- see GetPersonIDsForSessionAnyStatus for the status-agnostic sibling.
 func (r *SessionResolver) GetPersonIDsForSession(session string, year int) ([]int, error) {
+	return r.personIDsForSession(session, year, true)
+}
+
+// GetPersonIDsForSessionAnyStatus is GetPersonIDsForSession's status-agnostic sibling
+// (kindred#2482). It returns persons attached to the session regardless of attendee status --
+// enrolled, cancelled, waitlisted, and so on. It exists for the bounded daily family-camp
+// custom-values pass, which must observe a household moving IN or OUT of enrolled: a
+// cancellation or a waitlist entry is exactly the transition the pass exists to catch, so
+// filtering it out would defeat the point.
+//
+// Deliberately a sibling, not a relaxation of GetPersonIDsForSession: that function's
+// enrolled-only behavior also backs manual `?session=` runs, where enrolled-only remains
+// correct.
+func (r *SessionResolver) GetPersonIDsForSessionAnyStatus(session string, year int) ([]int, error) {
+	return r.personIDsForSession(session, year, false)
+}
+
+func (r *SessionResolver) personIDsForSession(session string, year int, enrolledOnly bool) ([]int, error) {
 	cmIDs, err := r.ResolveSessionCMIDs(session, year)
 	if err != nil {
 		return nil, err
@@ -118,7 +139,10 @@ func (r *SessionResolver) GetPersonIDsForSession(session string, year int) ([]in
 	sessionFilter := "(" + strings.Join(sessionConditions, " || ") + ")"
 
 	// Query attendees for persons in target sessions
-	filter := fmt.Sprintf("year = %d && status = 'enrolled' && %s", year, sessionFilter)
+	filter := fmt.Sprintf("year = %d && %s", year, sessionFilter)
+	if enrolledOnly {
+		filter = fmt.Sprintf("year = %d && status = 'enrolled' && %s", year, sessionFilter)
+	}
 	attendees, err := r.app.FindRecordsByFilter("attendees", filter, "", 0, 0)
 	if err != nil {
 		return nil, fmt.Errorf("querying attendees: %w", err)
@@ -143,7 +167,21 @@ func (r *SessionResolver) GetPersonIDsForSession(session string, year int) ([]in
 // GetHouseholdIDsForSession returns CampMinder household IDs for households
 // with persons enrolled in the specified session.
 // For "all" or empty session, returns nil (caller should handle all households case).
+//
+// Enrolled-only. This backs manual `?session=` runs -- see
+// GetHouseholdIDsForSessionAnyStatus for the status-agnostic sibling.
 func (r *SessionResolver) GetHouseholdIDsForSession(session string, year int) ([]int, error) {
+	return r.householdIDsForSession(session, year, true)
+}
+
+// GetHouseholdIDsForSessionAnyStatus is GetHouseholdIDsForSession's status-agnostic sibling
+// (kindred#2482) -- see GetPersonIDsForSessionAnyStatus's doc comment for why this is a
+// sibling function rather than a relaxation of the shared enrolled-only path.
+func (r *SessionResolver) GetHouseholdIDsForSessionAnyStatus(session string, year int) ([]int, error) {
+	return r.householdIDsForSession(session, year, false)
+}
+
+func (r *SessionResolver) householdIDsForSession(session string, year int, enrolledOnly bool) ([]int, error) {
 	cmIDs, err := r.ResolveSessionCMIDs(session, year)
 	if err != nil {
 		return nil, err
@@ -161,7 +199,10 @@ func (r *SessionResolver) GetHouseholdIDsForSession(session string, year int) ([
 	sessionFilter := "(" + strings.Join(sessionConditions, " || ") + ")"
 
 	// Query attendees for persons in target sessions, then get their households
-	filter := fmt.Sprintf("year = %d && status = 'enrolled' && %s", year, sessionFilter)
+	filter := fmt.Sprintf("year = %d && %s", year, sessionFilter)
+	if enrolledOnly {
+		filter = fmt.Sprintf("year = %d && status = 'enrolled' && %s", year, sessionFilter)
+	}
 	attendees, err := r.app.FindRecordsByFilter("attendees", filter, "", 0, 0)
 	if err != nil {
 		return nil, fmt.Errorf("querying attendees: %w", err)
@@ -217,4 +258,85 @@ func (r *SessionResolver) GetHouseholdIDsForSession(session string, year int) ([
 	}
 
 	return householdIDs, nil
+}
+
+// GetFamilyCampSessionCMIDs returns the CampMinder ids of every family-camp weekend session
+// in the given year (session_type = "family").
+//
+// This is the entry point for the bounded daily custom-values pass (kindred#2482). The pass's
+// cohort must come from a table that already knows about sessions -- not from custom values --
+// because the weekend cabin value IS a custom value: reading custom values to decide who to
+// sync custom values for is circular.
+func (r *SessionResolver) GetFamilyCampSessionCMIDs(year int) ([]int, error) {
+	filter := fmt.Sprintf("year = %d && session_type = '%s'", year, sessionTypeFamily)
+	sessions, err := r.app.FindRecordsByFilter("camp_sessions", filter, "", 0, 0)
+	if err != nil {
+		return nil, fmt.Errorf("querying family-camp sessions: %w", err)
+	}
+
+	cmIDs := make([]int, 0, len(sessions))
+	for _, s := range sessions {
+		if cmID, ok := s.Get("cm_id").(float64); ok && cmID > 0 {
+			cmIDs = append(cmIDs, int(cmID))
+		}
+	}
+
+	return cmIDs, nil
+}
+
+// GetFamilyCampPersonIDsAnyStatus returns the union, across every family-camp weekend in the
+// year, of GetPersonIDsForSessionAnyStatus -- the bounded daily pass's person cohort
+// (kindred#2482). Any status, deliberately: the pass exists to observe a household moving in
+// or out of enrolled, so a cancelled or waitlisted attendee belongs in the cohort exactly as
+// much as an enrolled one.
+func (r *SessionResolver) GetFamilyCampPersonIDsAnyStatus(year int) ([]int, error) {
+	sessionCMIDs, err := r.GetFamilyCampSessionCMIDs(year)
+	if err != nil {
+		return nil, err
+	}
+
+	idSet := make(map[int]bool)
+	for _, cmID := range sessionCMIDs {
+		ids, err := r.GetPersonIDsForSessionAnyStatus(strconv.Itoa(cmID), year)
+		if err != nil {
+			return nil, err
+		}
+		for _, id := range ids {
+			idSet[id] = true
+		}
+	}
+
+	result := make([]int, 0, len(idSet))
+	for id := range idSet {
+		result = append(result, id)
+	}
+
+	return result, nil
+}
+
+// GetFamilyCampHouseholdIDsAnyStatus is GetFamilyCampPersonIDsAnyStatus's household twin
+// (kindred#2482).
+func (r *SessionResolver) GetFamilyCampHouseholdIDsAnyStatus(year int) ([]int, error) {
+	sessionCMIDs, err := r.GetFamilyCampSessionCMIDs(year)
+	if err != nil {
+		return nil, err
+	}
+
+	idSet := make(map[int]bool)
+	for _, cmID := range sessionCMIDs {
+		ids, err := r.GetHouseholdIDsForSessionAnyStatus(strconv.Itoa(cmID), year)
+		if err != nil {
+			return nil, err
+		}
+		for _, id := range ids {
+			idSet[id] = true
+		}
+	}
+
+	result := make([]int, 0, len(idSet))
+	for id := range idSet {
+		result = append(result, id)
+	}
+
+	return result, nil
 }


### PR DESCRIPTION
## What

Cadence half of #2482 (owner-ruled 2026-08-19). Adds a **bounded daily custom-values pass** for
family-camp attendees, inserted into the daily sync between the source jobs and the transform
jobs. Does **not** implement the capture half (the `lodging_value_history` table / write hook) —
that is separate scope. **This PR closes nothing on its own; it is the prerequisite for the
capture half.**

## The defect this fixes

`getDailySyncJobs()` in `pocketbase/sync/orchestrator.go` jumps straight from the source jobs
(ending at `financial_transactions`) to the transform jobs (starting at `family_camp_derived`),
even though `GetAllPhases()` already declares the intended order
`[PhaseSource, PhaseExpensive, PhaseTransform, ...]` and `person_custom_values` /
`household_custom_values` are already registered as `PhaseExpensive`. Because the daily cron
never ran a `PhaseExpensive` job, every daily run transformed fresh source data against custom
values up to 7 days stale (the weekly sweep runs Sunday 04:00) — and `family_camp_derived`,
which writes `needs_fridge` and resolves the cabin/accommodation fields, is in that transform
list.

## The fix

- **`session_resolver.go`**: `GetPersonIDsForSession` / `GetHouseholdIDsForSession` hardcoded
  `status = 'enrolled'`. Per the ruling, the bounded pass must observe a household moving *in or
  out of* enrolled (a cancellation or waitlist entry), so enrolled-only would defeat the point.
  Added status-agnostic **siblings** — `GetPersonIDsForSessionAnyStatus` /
  `GetHouseholdIDsForSessionAnyStatus` — rather than relaxing the existing functions, because
  those back manual `?session=` runs where enrolled-only stays correct. Also added
  `GetFamilyCampSessionCMIDs` / `GetFamilyCampPersonIDsAnyStatus` /
  `GetFamilyCampHouseholdIDsAnyStatus`, which union the any-status cohort across every
  family-camp weekend session in the year (the cohort is selected via `attendees`, not custom
  values — reading custom values to decide who to sync custom values for would be circular).
- **`person_custom_field_values.go`** / **`household_custom_field_values.go`**: added a
  `FamilyCampBounded` field. When set, `getPersonIDsToSync` / `getHouseholdIDsToSync` use the new
  any-status family-camp cohort instead of `Session` or the year-wide fallback. The plain
  `Session=""` (unbounded) path used by the weekly sweep and manual runs is untouched.
- **`orchestrator.go`**: registers two new dedicated service instances,
  `person_custom_values_family_camp` and `household_custom_values_family_camp`
  (`FamilyCampBounded = true`), distinct from the existing `person_custom_values` /
  `household_custom_values` singletons. Inserted into `getDailySyncJobs()` between
  `financial_transactions` and `family_camp_derived`, and updated that function's stale comment
  about "custom values from the most recent weekly sync." Added both new jobs to `syncJobMeta`
  as `PhaseExpensive`. **Left `GetDefaultUnifiedSyncJobs` (the manual `service=all` API trigger)
  untouched** — the ruling is specifically about the daily cron flow.
- **`scheduler.go`**: **unchanged.** The weekly unrestricted sweep (`0 4 * * 0`,
  `runCustomValuesSync`) is retained exactly as-is — `person_custom_values` feeds
  `household_demographics`, `camper_dietary`, `camper_transportation`, and
  `financial_aid_applications`, none of which this bounded pass touches.

## Measured cost (from `sync_runs`, one recorded full batch, 2026-08-16)

| | value |
|---|---|
| unrestricted pair (weekly), wall clock | 2,584 s = 43.1 min (2,596 persons / 2,070 households) |
| bounded family-camp cohort, any status | 781 persons / 447 households ⇒ ~11.5 min |
| daily run today | ~5 min |
| **projected daily run with this pass** | **~16.5 min**, against the daily cron's unbounded context (no fixed timeout on `RunDailySync`) |

n=1 for the per-entity rates (`sync_runs` only begins 2026-08-14) — re-measure once a few daily
runs exist under this change.

## What this deliberately does NOT do

- No `lodging_value_history` migration and no write-hook changes — that's the capture half,
  tracked separately on #2482.
- No changes to `family_camp_derived.go`.
- No changes to `GetDefaultUnifiedSyncJobs` / the manual `service=all` API trigger — only the
  daily cron's `getDailySyncJobs()`.
- No relaxation of `GetPersonIDsForSession` / `GetHouseholdIDsForSession`'s enrolled-only
  behavior — manual `?session=` runs are unaffected.

## Testing

New test file `pocketbase/sync/family_camp_daily_cadence_test.go`:
- `TestSessionResolver_AnyStatus_IncludesNonEnrolled` — pins enrolled-only vs. any-status on both
  the person and household resolvers.
- `TestGetFamilyCampIDsAnyStatus_SpansWeekendsExcludesOtherSessions` — cohort spans every
  family-camp weekend, excludes a non-family session's attendees.
- `TestPersonCustomFieldValuesSync_FamilyCampBounded` /
  `TestHouseholdCustomFieldValuesSync_FamilyCampBounded` — bounded-mode wiring on the sync
  services themselves.
- `TestGetDailySyncJobs_FamilyCampBoundedPassBetweenSourceAndTransform` — ordering: strictly
  after `financial_transactions`, strictly before `family_camp_derived`; asserts the unrestricted
  job names stay out of the daily list.
- `TestSyncJobMeta_FamilyCampBoundedJobsAreExpensivePhase` — new jobs registered as
  `PhaseExpensive`.
- `TestWeeklyCustomValuesCronRetained` — pins `scheduler.go`'s `0 4 * * 0` / `runCustomValuesSync`
  survive untouched.

All new tests were written first, verified failing (compile error against the not-yet-added
symbols), then made to pass. Two were mutation-checked by deliberately breaking the
implementation and confirming red before restoring.

```
cd pocketbase && go build ./...      # PASS
cd pocketbase && go vet ./...        # PASS
cd pocketbase && go test ./...       # PASS
bash scripts/pre-push-verify.sh      # PASS (go build, golangci-lint, go test -race)
```

The parent issue (kindred#2482) stays open -- this PR is the cadence half only; the capture half (the `lodging_value_history` table and write hook) is separate, future work.
