### PR TITLE
test(pb): serialise the three registry tests that reach the swapped globals

### DIFF
--- a/pocketbase/lodging/registry_test.go
+++ b/pocketbase/lodging/registry_test.go
@@ -212,6 +212,25 @@ const fixtureRegistry = `{
 }`
 
 // withRegistryBasePath points the path resolution at a temp tree for one test.
+//
+// registryBasePath and registryAbsoluteRoots (registry.go) are package globals,
+// and registryCandidatePaths reads both on the live path of SeedRegistry,
+// RegistryFilePresent and RegistryHasRows. A test that swaps either one and
+// runs under t.Parallel() races every other test's read of the same global —
+// -race trips, and even when it doesn't, two overlapping swaps restore in
+// completion (not nesting) order, so a test can resolve the registry file out
+// of a different test's temp tree (kindred#2451; the same defect kindred#2337
+// fixed for pocketbase/sync's captureSweepLogs).
+//
+// Fix chosen: drop t.Parallel() from the handful of tests that call
+// withRegistryBasePath/withRegistryAbsoluteRoots (TestSeedRegistryStampsTheSeason,
+// TestFindByCodeAndYearIgnoresOtherYears, TestSeedRegistryLeavesNothingBehindWhenAPassFails —
+// directly or via withYearFixtureRegistry), rather than a mutex (silences -race but
+// leaves the wrong-file hazard) or threading the base path through SeedRegistry's
+// production signatures (the only fix that removes the shared state, but it touches
+// a shared package's public API for a test-only bug). ./lodging/ shares a CI shard
+// with ./sync/ (kindred#2288) and runs in ~58s under -race; serializing three of the
+// package's 118 tests costs nothing measurable against that budget.
 func withRegistryBasePath(t *testing.T, base string) {
 	t.Helper()
 	prev := registryBasePath
@@ -1091,7 +1110,6 @@ func withYearFixtureRegistry(t *testing.T) {
 }
 
 func TestSeedRegistryStampsTheSeason(t *testing.T) {
-	t.Parallel()
 	app := newRegistryTestApp(t)
 	withYearFixtureRegistry(t)
 
@@ -1108,7 +1126,6 @@ func TestSeedRegistryStampsTheSeason(t *testing.T) {
 }
 
 func TestFindByCodeAndYearIgnoresOtherYears(t *testing.T) {
-	t.Parallel()
 	app := newRegistryTestApp(t)
 	withYearFixtureRegistry(t)
 
@@ -1266,7 +1283,6 @@ func TestSeedRegistrySecondSeasonIsANoOpOnceOneSeasonHasRows(t *testing.T) {
 // to land all-or-nothing instead, so a failed bootstrap leaves an empty
 // registry the next boot will retry from scratch.
 func TestSeedRegistryLeavesNothingBehindWhenAPassFails(t *testing.T) {
-	t.Parallel()
 	app := newRegistryTestApp(t)
 	withYearFixtureRegistry(t)
 	lift := failUnitCreate(app, "test-unit-a-room-1") // the second of two units

--- a/pocketbase/main_test_parallelism_test.go
+++ b/pocketbase/main_test_parallelism_test.go
@@ -202,6 +202,15 @@ var serialGroups = []struct {
 			"TestSeedRegistryWithNoConfigAnywhereIsANoOp",
 			"TestSeedRegistryFileErrorIsNotTaggedAsARowCheckFailure",
 			"TestClassifyShareability",
+			// kindred#2451: these three reach the same globals (the last two
+			// via withYearFixtureRegistry -> withRegistryBasePath) and were
+			// still running t.Parallel() -- that gap is what let
+			// TestSeedRegistryLeavesNothingBehindWhenAPassFails observe
+			// another test's temp tree and fail with "0 units after the
+			// retry; want 2" instead of a race report.
+			"TestSeedRegistryStampsTheSeason",
+			"TestFindByCodeAndYearIgnoresOtherYears",
+			"TestSeedRegistryLeavesNothingBehindWhenAPassFails",
 		},
 	},
 	{


### PR DESCRIPTION
`pocketbase/lodging`'s `registryBasePath`/`registryAbsoluteRoots` package globals were swapped
by `withRegistryBasePath`/`withRegistryAbsoluteRoots` under `t.Parallel()` in three tests
(`TestSeedRegistryStampsTheSeason`, `TestFindByCodeAndYearIgnoresOtherYears`,
`TestSeedRegistryLeavesNothingBehindWhenAPassFails` — the third directly, the first two via
`withYearFixtureRegistry`). Overlapping swaps restore in completion order rather than nesting
order, so one test could resolve the registry file out of a different test's temp tree — a wrong
answer, not only a `-race` complaint. Measured: `go test ./lodging/ -run Registry -count=50
-parallel 16` failed `TestSeedRegistryLeavesNothingBehindWhenAPassFails` with
`registry_test.go:1292: 0 units after the retry; want 2`.

## Fix

Drop `t.Parallel()` from the three tests that reach the globals (option 1 from #2451, the
campaign's chosen fix). A mutex would silence `-race` but leave the wrong-file hazard; threading
the base path through `SeedRegistry`'s production signatures is the only fix that removes the
shared state, but it touches a shared package's public API for a test-only bug, so it is not
taken here. The justification, including the CI-shard cost, is now a comment at
`withRegistryBasePath` (`pocketbase/lodging/registry_test.go`) — `./lodging/` shares a CI shard
with `./sync/` and runs in ~58s under `-race`; serializing 3 of the package's 118 tests is not
measurable against that budget.

`main_test_parallelism_test.go`'s AST guard (`TestSyncAndLodgingTestsRunInParallel`) requires
every top-level test in `sync`/`lodging` to be parallel unless listed in `serialGroups` with a
reason — the three tests are added to the existing "swaps the registryBasePath /
registryAbsoluteRoots globals" group there.

## What was NOT done

- The `-race` data-race claim in the original issue is not confirmed and was not chased further:
  `-race -count=5` on `./lodging/` passes clean in ~59s, and `-race -count=30` hits Go's 600s
  default timeout before printing a single failure. The wrong-answer mode above is the real,
  reliably-reproducing defect and is what this PR targets.
- Options 2 (mutex) and 3 (thread the path through production signatures) from #2451 were
  deliberately not taken — see above.
- No production code in `pocketbase/lodging/registry.go` changes; this is test-only.

## Issue body correction

The original issue body named four call sites incorrectly (`TestApplyRollForwardCopiesEveryUnitAndArea`
does not exist in this file; `TestRegistryFixtureRejectsYearOutsideProductionRange` never calls
either helper; most of the twelve tests listed as `-race` failures never ran under `t.Parallel()`
in the first place). Body corrected and audited in a comment on #2451 before this PR was opened.

## Verification

- `cd pocketbase && go test ./lodging/ -run Registry -count=50 -parallel 16` — clean.
- `cd pocketbase && go test -race ./lodging/ -count=1` — clean over 10 consecutive runs.
- `cd pocketbase && go test . -run TestSyncAndLodgingTestsRunInParallel -v` — clean (AST shard
  guard still passes with the three tests added to `serialGroups`).
- `golangci-lint run ./lodging/... ./.` — 0 issues.
- `bash scripts/pre-push-verify.sh` — clean.

Closes #2451.
