### PR TITLE
feat(sync): capture cabin-value changes so each weekend's cabin becomes derivable

### DIFF
--- a/frontend/src/types/pocketbase-types.ts
+++ b/frontend/src/types/pocketbase-types.ts
@@ -56,6 +56,7 @@ export const Collections = {
   LodgingSlotMerges: 'lodging_slot_merges',
   LodgingUnitAliases: 'lodging_unit_aliases',
   LodgingUnits: 'lodging_units',
+  LodgingValueHistory: 'lodging_value_history',
   LodgingWriteIns: 'lodging_write_ins',
   LodgingWriteInsDraft: 'lodging_write_ins_draft',
   NormalizedMappings: 'normalized_mappings',
@@ -1212,6 +1213,21 @@ export type LodgingUnitsRecord<Tbeds = unknown> = {
   year: number
 }
 
+export type LodgingValueHistoryRecord = {
+  created: IsoAutoDateString
+  field_cm_id: number
+  household_cm_id?: number
+  id: string
+  is_genesis?: boolean
+  new_value?: string
+  observed_at?: IsoDateString
+  old_value?: string
+  person_cm_id?: number
+  source_changed_at?: string
+  source_field?: string
+  year: number
+}
+
 export type LodgingWriteInsRecord = {
   created: IsoAutoDateString
   id: string
@@ -1873,6 +1889,8 @@ export type LodgingUnitsResponse<Tbeds = unknown, Texpand = unknown> = Required<
   LodgingUnitsRecord<Tbeds>
 > &
   BaseSystemFields<Texpand>
+export type LodgingValueHistoryResponse<Texpand = unknown> = Required<LodgingValueHistoryRecord> &
+  BaseSystemFields<Texpand>
 export type LodgingWriteInsResponse<Texpand = unknown> = Required<LodgingWriteInsRecord> &
   BaseSystemFields<Texpand>
 export type LodgingWriteInsDraftResponse<Texpand = unknown> = Required<LodgingWriteInsDraftRecord> &
@@ -1993,6 +2011,7 @@ export type CollectionRecords = {
   lodging_slot_merges: LodgingSlotMergesRecord
   lodging_unit_aliases: LodgingUnitAliasesRecord
   lodging_units: LodgingUnitsRecord
+  lodging_value_history: LodgingValueHistoryRecord
   lodging_write_ins: LodgingWriteInsRecord
   lodging_write_ins_draft: LodgingWriteInsDraftRecord
   normalized_mappings: NormalizedMappingsRecord
@@ -2070,6 +2089,7 @@ export type CollectionResponses = {
   lodging_slot_merges: LodgingSlotMergesResponse
   lodging_unit_aliases: LodgingUnitAliasesResponse
   lodging_units: LodgingUnitsResponse
+  lodging_value_history: LodgingValueHistoryResponse
   lodging_write_ins: LodgingWriteInsResponse
   lodging_write_ins_draft: LodgingWriteInsDraftResponse
   normalized_mappings: NormalizedMappingsResponse

--- a/pocketbase/pb_migrations/1500000165_lodging_value_history.js
+++ b/pocketbase/pb_migrations/1500000165_lodging_value_history.js
@@ -1,0 +1,189 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * lodging_value_history — append-only capture of cabin-value changes.
+ *
+ * Dark on arrival for every reader. This migration creates one empty table and
+ * moves nothing; no published value changes because of it, and the seven open
+ * `ambiguous_session` rows in the lodging work queue stay exactly as they are.
+ * The write hook in pocketbase/sync/lodging_value_history.go fills it going
+ * forward. Deriving a weekend from these rows is a separate change.
+ *
+ * ── WHY: ONE SLOT, TWO WEEKENDS ─────────────────────────────────────────────
+ *
+ * `Family Camp Cabin` (cm_id 218072) is a HOUSEHOLD-grain custom field holding
+ * exactly one value per household per YEAR — `family_camp_registrations` is
+ * unique on (household, year). A household attending two family weekends
+ * therefore has one slot for two answers: when staff type the second weekend's
+ * cabin, the first weekend's is gone. The assignment ingest cannot tell which
+ * weekend a string belongs to, so it files `ambiguous_session` rather than
+ * guess (`sync/lodging_assignments_sync.go`, "flag, do not guess (spec 3.6)").
+ *
+ * Keeping what the source overwrites is what makes "which cabin was in effect
+ * for THIS weekend" answerable from recorded observations instead of from a
+ * timestamp heuristic that picks one weekend per observation and leaves the
+ * other blank.
+ *
+ * ── WHY NOT lodging_assignment_history ──────────────────────────────────────
+ *
+ * It is already a per-change table and it cannot serve this. `ingestValue`
+ * returns on `attr.Reason != attrSingleSession` BEFORE every `writeHistory`
+ * call, so it is blind in exactly the ambiguous case that needs it, and its
+ * organising key is `session` — the unknown. This table sits UPSTREAM of
+ * attribution, which is why it has no session column at all.
+ *
+ * ── SHAPE: FOUR DELIBERATE DEPARTURES FROM attendee_status_history ──────────
+ *
+ * 1500000057_attendee_status_history.js is the existing lookback-table shape in
+ * this codebase and this is modelled on it. It differs in four places, each on
+ * purpose:
+ *
+ *   1. NO `session` COLUMN. It is `required: true` there. Here the session is
+ *      the unknown the table exists to make derivable, so requiring one would
+ *      beg the question. Session is derived on read.
+ *
+ *   2. old_value / new_value are `text`, NOT `select`. `attendee_status_history`
+ *      can enumerate its statuses; there are 88 distinct hand-typed cabin
+ *      strings for 218072 across all years. A select rejects the first
+ *      unanticipated name and loses the change at the moment it matters.
+ *      `lodging_assignment_history` already learned this and says so at
+ *      `sync/lodging_assignments_sync.go`: "History records the OBSERVED label
+ *      whether or not it resolved -- old_unit / new_unit are TEXT for exactly
+ *      this reason."
+ *
+ *   3. DUAL CLOCK. `source_changed_at` is CampMinder's own `last_updated` for
+ *      the value; `observed_at` is when this sync saw it. They are different
+ *      facts and the retroactive-entry case needs both: 21 of 2025's household
+ *      cabin values were last edited in December, after every 2025 weekend.
+ *
+ *   4. THE CREATE BRANCH WRITES TOO, as `is_genesis`. The first observed cabin
+ *      is a fact worth keeping; `attendee_status_history` logs only
+ *      transitions.
+ *
+ * ── source_changed_at IS text, NOT date ─────────────────────────────────────
+ *
+ * The issue's shape sketch said `date`. The source column it copies is
+ * `household_custom_values.last_updated` / `person_custom_values.last_updated`,
+ * and BOTH are declared `type: "text"` (1500000029, and the person twin). It is
+ * stored here verbatim, in the same type, for two reasons: a `date` field would
+ * have to parse a CampMinder string, and a parse failure would reject the row
+ * and LOSE the change — the same failure mode the text-not-select call above
+ * avoids; and a value that does not round-trip identically to the source column
+ * cannot be joined back to it. `observed_at` stays a real `date` because it is
+ * our own clock and is always well-formed.
+ *
+ * ── RETENTION SCOPE: CABIN FIELDS ONLY ──────────────────────────────────────
+ *
+ * The write hook retains only `Family Camp Cabin` (218072, household) and
+ * `Reportable Family Camp Cabin` (223823, person). The medical-adjacent lodging
+ * fields — bathroom, CPAP, infant, opt-out — are held out NOT on the merits but
+ * because `api/routers/lodging.py` records a deliberate ruling that that
+ * surface has no access log and that one was removed on purpose; reversing that
+ * as a side effect of a cabin-attribution change would be the wrong way to
+ * reverse it. The scope lives in `lodgingRetainedHistoryFields` in
+ * `sync/lodging_value_history.go`, so widening it later is a Go edit and needs
+ * no migration.
+ *
+ * ── THE UNIQUE INDEX IS THE IDEMPOTENCY CONTRACT ────────────────────────────
+ *
+ * (year, field_cm_id, household_cm_id, person_cm_id, source_changed_at,
+ * new_value) — re-running a sync re-observes the same change, and the table is
+ * append-only, so without this a weekly sweep would stack duplicates. The Go
+ * side checks for the row before inserting so a re-run is quiet rather than a
+ * swallowed constraint error; the index is the guarantee behind that check.
+ *
+ * Exactly one of household_cm_id / person_cm_id is set per row, the other stays
+ * 0 — which is what keeps two grains in one table without a nullable relation,
+ * and why both are in the index rather than one nullable column.
+ *
+ * ── PocketBase v0.23 ────────────────────────────────────────────────────────
+ *
+ * Field properties are DIRECT. The wrapper object some older migrations used is
+ * silently ignored in v0.23 and the field falls back to PocketBase's default
+ * cap, so `old_value` / `new_value` would quietly become 5000-char fields
+ * instead of the 500 declared below.
+ */
+
+// VERBATIM from the sibling history table (1500000057) and the lodging
+// migrations. Do not paraphrase — the permission is read off
+// `cached_permissions` as a dotted string, and the plausible alternative
+// matches nothing and denies every write SILENTLY.
+const AUTHED_READ = '@request.auth.id != ""';
+const ADMIN_ONLY = '@request.auth.is_admin = true';
+
+// Used for the skip guard and the down arm. The `name:` inside the
+// `new Collection({...})` below is a LITERAL rather than this constant, and
+// that is load-bearing: scripts/dev/verify-migration-history.sh's CHECK 2 finds
+// the collections a migration CREATEs by regexing `name: "..."` out of the up
+// arm, and a constant reads as no collection at all.
+const HISTORY = 'lodging_value_history';
+
+migrate(
+  (app) => {
+    // Idempotent create. A re-run is a no-op rather than a boot failure on
+    // "Collection name must be unique"; this is not licence to accept whatever
+    // shape is already present, only to make the second run quiet.
+    let exists = false;
+    try {
+      app.findCollectionByNameOrId(HISTORY);
+      exists = true;
+    } catch {
+      // Not present — create it below.
+    }
+    if (exists) {
+      return;
+    }
+
+    app.save(
+      new Collection({
+        type: 'base',
+        name: 'lodging_value_history',
+        listRule: AUTHED_READ,
+        viewRule: AUTHED_READ,
+        // Written by the sync, never by the UI — same posture as
+        // attendee_status_history.
+        createRule: ADMIN_ONLY,
+        updateRule: ADMIN_ONLY,
+        deleteRule: ADMIN_ONLY,
+        fields: [
+          // CampMinder reuses ids across years — every data table carries the
+          // year that disambiguates them.
+          { type: 'number', name: 'year', required: true, presentable: false, min: 2010, max: 2100, onlyInt: true },
+          // The custom field this observation is about (218072 / 223823).
+          // Matching is on cm_id, never the user-editable display name.
+          { type: 'number', name: 'field_cm_id', required: true, presentable: false, min: 1, max: null, onlyInt: true },
+          // Exactly one of the two is set; the other stays 0. Neither is a
+          // relation: cross-table relationships in this repo key on CampMinder
+          // ids so they survive a resync that recreates a PocketBase row.
+          { type: 'number', name: 'household_cm_id', required: false, presentable: false, min: 0, max: null, onlyInt: true },
+          { type: 'number', name: 'person_cm_id', required: false, presentable: false, min: 0, max: null, onlyInt: true },
+          // The display name, for humans reading a row. Documentation, not the
+          // matching key — field_cm_id above is the contract.
+          { type: 'text', name: 'source_field', required: false, presentable: false, min: 0, max: 200, pattern: '' },
+          // Empty on a genesis row, and empty is also a legitimate NEW value
+          // (staff clearing a cabin), which is why neither is required.
+          { type: 'text', name: 'old_value', required: false, presentable: false, min: 0, max: 500, pattern: '' },
+          { type: 'text', name: 'new_value', required: false, presentable: false, min: 0, max: 500, pattern: '' },
+          // CampMinder's clock, verbatim and untyped — see the header.
+          { type: 'text', name: 'source_changed_at', required: false, presentable: false, min: 0, max: 100, pattern: '' },
+          // Our clock.
+          { type: 'date', name: 'observed_at', required: false, presentable: false, min: '', max: '' },
+          { type: 'bool', name: 'is_genesis', required: false, presentable: false },
+          { type: 'autodate', name: 'created', required: false, presentable: false, onCreate: true, onUpdate: false },
+        ],
+        indexes: [
+          'CREATE UNIQUE INDEX idx_lvh_observation ON lodging_value_history ' +
+            '(year, field_cm_id, household_cm_id, person_cm_id, source_changed_at, new_value)',
+          'CREATE INDEX idx_lvh_household_year ON lodging_value_history (household_cm_id, year)',
+          'CREATE INDEX idx_lvh_person_year ON lodging_value_history (person_cm_id, year)',
+        ],
+      })
+    );
+  },
+  (app) => {
+    try {
+      app.delete(app.findCollectionByNameOrId(HISTORY));
+    } catch {
+      // Already gone — nothing to undo.
+    }
+  }
+);

--- a/pocketbase/pb_migrations/1500000165_lodging_value_history.js
+++ b/pocketbase/pb_migrations/1500000165_lodging_value_history.js
@@ -3,8 +3,9 @@
  * lodging_value_history — append-only capture of cabin-value changes.
  *
  * Dark on arrival for every reader. This migration creates one empty table and
- * moves nothing; no published value changes because of it, and the seven open
- * `ambiguous_session` rows in the lodging work queue stay exactly as they are.
+ * moves nothing; no published value changes because of it, and the nine open
+ * `ambiguous_session` rows in the lodging work queue (8 distinct households,
+ * production snapshot 2026-08-18 22:11) stay exactly as they are.
  * The write hook in pocketbase/sync/lodging_value_history.go fills it going
  * forward. Deriving a weekend from these rows is a separate change.
  *
@@ -59,6 +60,16 @@
  *      is a fact worth keeping; `attendee_status_history` logs only
  *      transitions.
  *
+ *      ⚠️ `is_genesis` MEANS "the first observation THIS TABLE HOLDS for this
+ *      key", NOT "no earlier value existed". Do not read it as the latter. If
+ *      CampMinder stops returning the field entry for a household, the orphan
+ *      sweep deletes the `household_custom_values` row and no history is
+ *      written; a later re-entry then arrives at the CREATE branch and is
+ *      stamped `is_genesis` with an empty `old_value`, even though a different
+ *      cabin really did precede it. A reader deriving a weekend's cabin must
+ *      treat a genesis row as a floor on what is known, exactly as the backfill
+ *      is a floor rather than a history.
+ *
  * ── source_changed_at IS text, NOT date ─────────────────────────────────────
  *
  * The issue's shape sketch said `date`. The source column it copies is
@@ -86,10 +97,22 @@
  * ── THE UNIQUE INDEX IS THE IDEMPOTENCY CONTRACT ────────────────────────────
  *
  * (year, field_cm_id, household_cm_id, person_cm_id, source_changed_at,
- * new_value) — re-running a sync re-observes the same change, and the table is
- * append-only, so without this a weekly sweep would stack duplicates. The Go
- * side checks for the row before inserting so a re-run is quiet rather than a
- * swallowed constraint error; the index is the guarantee behind that check.
+ * old_value, new_value) — re-running a sync re-observes the same change, and
+ * the table is append-only, so without this a weekly sweep would stack
+ * duplicates. The Go side checks for the row before inserting so a re-run is
+ * quiet rather than a swallowed constraint error; the index is the guarantee
+ * behind that check.
+ *
+ * `old_value` IS IN THE KEY, and dropping it would be a silent data-loss bug
+ * rather than a tidier index. `source_changed_at` is empty whenever CampMinder
+ * returns no `lastUpdated` (the transform only sets it when present and
+ * non-empty), and without `old_value` the key then degenerates to
+ * (year, field, household, person, '', new_value): a household whose cabin goes
+ * A -> B -> A has its third, genuine observation matched against the first and
+ * SILENTLY DROPPED, leaving B as the last recorded state. With `old_value` the
+ * two are ('', A) and (B, A) and both survive. Latent today — every cabin row
+ * in the production snapshot carries a `last_updated` — but the transform
+ * explicitly anticipates the empty case, so the key does too.
  *
  * Exactly one of household_cm_id / person_cm_id is set per row, the other stays
  * 0 — which is what keeps two grains in one table without a nullable relation,
@@ -103,11 +126,12 @@
  * instead of the 500 declared below.
  */
 
-// VERBATIM from the sibling history table (1500000057) and the lodging
-// migrations. Do not paraphrase — the permission is read off
-// `cached_permissions` as a dotted string, and the plausible alternative
-// matches nothing and denies every write SILENTLY.
-const AUTHED_READ = '@request.auth.id != ""';
+// VERBATIM from the sibling history table (1500000057). Do not paraphrase —
+// these rule strings are matched literally, and a plausible-looking alternative
+// denies every request SILENTLY.
+//
+// Every rule on this collection is ADMIN_ONLY, reads included; see the create
+// site below for why that is tighter than attendee_status_history on purpose.
 const ADMIN_ONLY = '@request.auth.is_admin = true';
 
 // Used for the skip guard and the down arm. The `name:` inside the
@@ -137,8 +161,19 @@ migrate(
       new Collection({
         type: 'base',
         name: 'lodging_value_history',
-        listRule: AUTHED_READ,
-        viewRule: AUTHED_READ,
+        // ADMIN-ONLY READS, deliberately tighter than attendee_status_history.
+        // This table stores `household_custom_values` / `person_custom_values`
+        // values VERBATIM, and both of those source collections are
+        // admin-only reads. Publishing a copy at authed-read would hand every
+        // non-admin account cabin strings it cannot read from the source.
+        //
+        // The forward-looking half matters more than today's delta: the
+        // retention scope is a Go map, so widening it needs no migration --
+        // which means a later edit could copy admin-only, medical-adjacent
+        // answers into this table with nobody re-reading this rule. Matching
+        // the source tables now makes that safe by default.
+        listRule: ADMIN_ONLY,
+        viewRule: ADMIN_ONLY,
         // Written by the sync, never by the UI — same posture as
         // attendee_status_history.
         createRule: ADMIN_ONLY,
@@ -172,7 +207,8 @@ migrate(
         ],
         indexes: [
           'CREATE UNIQUE INDEX idx_lvh_observation ON lodging_value_history ' +
-            '(year, field_cm_id, household_cm_id, person_cm_id, source_changed_at, new_value)',
+            '(year, field_cm_id, household_cm_id, person_cm_id, source_changed_at, ' +
+            'old_value, new_value)',
           'CREATE INDEX idx_lvh_household_year ON lodging_value_history (household_cm_id, year)',
           'CREATE INDEX idx_lvh_person_year ON lodging_value_history (person_cm_id, year)',
         ],

--- a/pocketbase/sync/household_custom_field_values.go
+++ b/pocketbase/sync/household_custom_field_values.go
@@ -451,9 +451,14 @@ func (s *HouseholdCustomFieldValuesSync) processHouseholdCustomFieldValue(
 			return nil
 		}
 
-		// Value or lastUpdated changed - update record
+		// Value or lastUpdated changed - update record.
+		//
+		// oldValue is read BEFORE the Set loop below overwrites it: the cabin
+		// change capture (kindred#2482) needs old and new simultaneously, and
+		// this is the only point in the pipeline where both are in scope.
 		newValue, _ := pbData["value"].(string)
-		if existing.GetString("value") != newValue || existingLastUpdated != newLastUpdated {
+		oldValue := existing.GetString("value")
+		if oldValue != newValue || existingLastUpdated != newLastUpdated {
 			for key, val := range pbData {
 				existing.Set(key, val)
 			}
@@ -471,6 +476,20 @@ func (s *HouseholdCustomFieldValuesSync) processHouseholdCustomFieldValue(
 				s.Stats.Errors++
 			} else {
 				s.Stats.Updated++
+				// Capture the change, but only a VALUE change -- the branch
+				// condition above also fires on a bare last_updated bump, which
+				// is not a change to where anyone slept. No-op for any field
+				// outside the retention scope (lodging_value_history.go).
+				if oldValue != newValue {
+					logLodgingValueChange(s.App, &lodgingValueObservation{
+						Year:            year,
+						FieldCMID:       fieldCMID,
+						HouseholdCMID:   householdCMID,
+						OldValue:        oldValue,
+						NewValue:        newValue,
+						SourceChangedAt: newLastUpdated,
+					})
+				}
 			}
 		} else {
 			s.Stats.Skipped++
@@ -505,6 +524,18 @@ func (s *HouseholdCustomFieldValuesSync) processHouseholdCustomFieldValue(
 			// same key hits the "existing" branch (which the guard above now also
 			// short-circuits before it can be reached by a true duplicate).
 			existingRecords[yearScopedKey] = record
+			// The first observed cabin is a fact worth keeping, so the create
+			// branch writes history too, as is_genesis (kindred#2482).
+			newValue, _ := pbData["value"].(string)
+			newLastUpdated, _ := pbData["last_updated"].(string)
+			logLodgingValueChange(s.App, &lodgingValueObservation{
+				Year:            year,
+				FieldCMID:       fieldCMID,
+				HouseholdCMID:   householdCMID,
+				NewValue:        newValue,
+				SourceChangedAt: newLastUpdated,
+				IsGenesis:       true,
+			})
 		}
 	}
 

--- a/pocketbase/sync/lodging_value_history.go
+++ b/pocketbase/sync/lodging_value_history.go
@@ -1,0 +1,169 @@
+package sync
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// Cabin-value change capture (kindred#2482).
+//
+// WHY THIS TABLE EXISTS
+//
+// `Family Camp Cabin` (cm_id 218072) is a HOUSEHOLD-grain custom field holding
+// exactly one value per household per YEAR -- family_camp_registrations is
+// UNIQUE on (household, year). A household attending two family weekends
+// therefore has one slot for two answers, so when staff type the second
+// weekend's cabin the first weekend's is gone. The assignment ingest cannot tell
+// which weekend a string belongs to and files `ambiguous_session` rather than
+// guessing (lodging_assignments_sync.go, "flag, do not guess (spec 3.6)").
+//
+// This table keeps what the source overwrites, so the question "which cabin was
+// in effect for THIS weekend" becomes answerable from recorded observations
+// instead of a timestamp heuristic. Nothing in this file derives a session --
+// that read side is deliberately not built here, and no published value moves
+// because of this capture.
+//
+// WHY NOT lodging_assignment_history
+//
+// It is already a per-change table, and it cannot serve this: ingestValue
+// returns on `attr.Reason != attrSingleSession` BEFORE every writeHistory call,
+// so it is blind in exactly the ambiguous case that needs it, and its organizing
+// key is `session` -- the unknown. This table sits UPSTREAM of attribution.
+//
+// SHAPE NOTES (each a deliberate departure from attendee_status_history)
+//
+//   - No `session` column. It is required there; here it is the unknown.
+//   - old_value/new_value are TEXT, not select. 88 distinct hand-typed cabin
+//     strings exist across all years; a select would reject the first
+//     unanticipated name and lose the change at the moment it matters. The same
+//     reasoning is already written down for lodging_assignment_history's
+//     old_unit/new_unit.
+//   - Dual clock. source_changed_at is CampMinder's own last_updated;
+//     observed_at is when this sync saw it. They are different facts, and the
+//     retroactive-entry case needs both (21 of 2025's household cabin values
+//     were last edited in December, after every 2025 weekend).
+//   - The create branch writes too, as is_genesis. The first observed cabin is a
+//     fact worth keeping; attendee_status_history logs only transitions.
+
+// lodgingValueHistoryCollection is the append-only capture table created by
+// pb_migrations/1500000165_lodging_value_history.js.
+const lodgingValueHistoryCollection = "lodging_value_history"
+
+// lodgingRetainedHistoryFields is the RETENTION SCOPE, ruled as cabin fields
+// only: `Family Camp Cabin` (household grain) and `Reportable Family Camp Cabin`
+// (person grain). The value is the display name stamped into source_field.
+//
+// The other lodging source fields -- bathroom, CPAP, infant, opt-out
+// (lodging_fields.go) -- are held out NOT on the merits but because they are
+// medical-adjacent, and api/routers/lodging.py records a deliberate ruling that
+// that surface has no access log and that one was removed on purpose. Reversing
+// that as a side effect of a cabin-attribution change would be the wrong way to
+// reverse it. Dietary and transport answers are consumed once, when they are
+// relevant; where people slept is the field with a historical question attached.
+//
+// Widening the scope later is an edit to THIS map. It needs no migration.
+var lodgingRetainedHistoryFields = map[int]string{
+	cmIDFamilyCampCabin:           fieldNameFamilyCampCabin,
+	cmIDReportableFamilyCampCabin: fieldNameReportableFamilyCampCabin,
+}
+
+// lodgingValueObservation is one observed cabin-value change, on either grain.
+// Exactly one of HouseholdCMID / PersonCMID is set; the other stays 0, which is
+// what keeps the two grains in one table without a nullable relation.
+type lodgingValueObservation struct {
+	Year          int
+	FieldCMID     int
+	HouseholdCMID int
+	PersonCMID    int
+
+	OldValue string
+	NewValue string
+
+	// SourceChangedAt is CampMinder's last_updated for the value, verbatim. It
+	// is stored as text rather than parsed: CampMinder free-text date handling
+	// elsewhere in this repo has produced 7+ formats, and a strict parse that
+	// fails would discard the change rather than the timestamp.
+	SourceChangedAt string
+
+	// IsGenesis marks the first observation of a value rather than a transition.
+	IsGenesis bool
+}
+
+// recordLodgingValueChange appends one observation to lodging_value_history.
+//
+// It is a no-op for a field outside the retention scope, and for a genesis
+// observation of an empty value (a household with no cabin recorded yet is not a
+// fact about where anyone slept; a change TO empty still is, and takes the
+// transition path).
+//
+// Re-observing the same change is idempotent: the table carries a unique index
+// on (year, field_cm_id, household_cm_id, person_cm_id, source_changed_at,
+// new_value), and this checks for the row before inserting so a re-run neither
+// duplicates nor produces a constraint error to swallow.
+func recordLodgingValueChange(app core.App, obs *lodgingValueObservation) error {
+	sourceField, retained := lodgingRetainedHistoryFields[obs.FieldCMID]
+	if !retained {
+		return nil
+	}
+	if obs.IsGenesis && obs.NewValue == "" {
+		return nil
+	}
+
+	collection, err := app.FindCollectionByNameOrId(lodgingValueHistoryCollection)
+	if err != nil {
+		return fmt.Errorf("finding %s collection: %w", lodgingValueHistoryCollection, err)
+	}
+
+	const dedupe = "year = {:year} && field_cm_id = {:field} && household_cm_id = {:household} && " +
+		"person_cm_id = {:person} && source_changed_at = {:changed} && new_value = {:new}"
+	params := map[string]any{
+		"year": obs.Year, "field": obs.FieldCMID, "household": obs.HouseholdCMID,
+		"person": obs.PersonCMID, "changed": obs.SourceChangedAt, "new": obs.NewValue,
+	}
+	existing, err := app.FindRecordsByFilter(lodgingValueHistoryCollection, dedupe, "", 1, 0, params)
+	if err != nil {
+		return fmt.Errorf("checking for an existing %s row: %w", lodgingValueHistoryCollection, err)
+	}
+	if len(existing) > 0 {
+		return nil
+	}
+
+	record := core.NewRecord(collection)
+	record.Set("year", obs.Year)
+	record.Set("field_cm_id", obs.FieldCMID)
+	record.Set("household_cm_id", obs.HouseholdCMID)
+	record.Set("person_cm_id", obs.PersonCMID)
+	record.Set("source_field", sourceField)
+	record.Set("old_value", obs.OldValue)
+	record.Set("new_value", obs.NewValue)
+	record.Set("source_changed_at", obs.SourceChangedAt)
+	record.Set("observed_at", time.Now().UTC().Format("2006-01-02 15:04:05.000Z"))
+	record.Set("is_genesis", obs.IsGenesis)
+
+	if err := app.Save(record); err != nil {
+		return fmt.Errorf("saving %s row: %w", lodgingValueHistoryCollection, err)
+	}
+	return nil
+}
+
+// logLodgingValueChange is the call-site wrapper: capture is non-critical, so a
+// failure is logged and the custom-values sync carries on, mirroring how
+// attendees.go treats logStatusChange.
+//
+// DryRun is honored STRUCTURALLY rather than by a flag check here -- both call
+// sites sit after the custom-values App.Save, which DryRun returns before, so a
+// dry run cannot reach this at all.
+func logLodgingValueChange(app core.App, obs *lodgingValueObservation) {
+	if err := recordLodgingValueChange(app, obs); err != nil {
+		slog.Warn("Failed to record lodging value change",
+			"field_cm_id", obs.FieldCMID,
+			"household_cm_id", obs.HouseholdCMID,
+			"person_cm_id", obs.PersonCMID,
+			"year", obs.Year,
+			"is_genesis", obs.IsGenesis,
+			"error", err)
+	}
+}

--- a/pocketbase/sync/lodging_value_history.go
+++ b/pocketbase/sync/lodging_value_history.go
@@ -89,6 +89,15 @@ type lodgingValueObservation struct {
 	SourceChangedAt string
 
 	// IsGenesis marks the first observation of a value rather than a transition.
+	//
+	// It means "the first observation THIS TABLE HOLDS for this key", NOT "no
+	// earlier value existed", and a reader must not collapse the two. If
+	// CampMinder stops returning the field entry for a household, the orphan
+	// sweep deletes the custom-values row and nothing is captured; a later
+	// re-entry then reaches the create branch and is stamped IsGenesis with an
+	// empty OldValue even though a different cabin really did precede it. A
+	// genesis row is a floor on what is known, in the same sense the whole
+	// table is a floor rather than a history.
 	IsGenesis bool
 }
 
@@ -101,8 +110,10 @@ type lodgingValueObservation struct {
 //
 // Re-observing the same change is idempotent: the table carries a unique index
 // on (year, field_cm_id, household_cm_id, person_cm_id, source_changed_at,
-// new_value), and this checks for the row before inserting so a re-run neither
-// duplicates nor produces a constraint error to swallow.
+// old_value, new_value), and this checks for the row before inserting so a
+// re-run neither duplicates nor produces a constraint error to swallow. Keep
+// this predicate and that index in step -- the migration header explains why
+// old_value is load-bearing rather than decorative.
 func recordLodgingValueChange(app core.App, obs *lodgingValueObservation) error {
 	sourceField, retained := lodgingRetainedHistoryFields[obs.FieldCMID]
 	if !retained {
@@ -117,12 +128,46 @@ func recordLodgingValueChange(app core.App, obs *lodgingValueObservation) error 
 		return fmt.Errorf("finding %s collection: %w", lodgingValueHistoryCollection, err)
 	}
 
-	const dedupe = "year = {:year} && field_cm_id = {:field} && household_cm_id = {:household} && " +
-		"person_cm_id = {:person} && source_changed_at = {:changed} && new_value = {:new}"
+	// The two text halves of the dedupe key can legitimately be EMPTY, and a
+	// bound `field = {:param}` carrying "" does NOT match a stored empty string
+	// in PocketBase -- it has to be written as the literal `field = ''`.
+	// Getting this wrong is quiet in the worst way: the check misses its own
+	// row, the insert is re-attempted on every sync run, and the unique index
+	// turns that into a swallowed error logged forever. Both cases are real --
+	// `source_changed_at` is empty whenever CampMinder returns no `lastUpdated`
+	// (the transform only sets the field when it is present and non-empty), and
+	// `new_value` is empty when staff CLEAR a cabin, which is a transition this
+	// table exists to record.
+	dedupe := "year = {:year} && field_cm_id = {:field} && household_cm_id = {:household} && " +
+		"person_cm_id = {:person}"
 	params := map[string]any{
-		"year": obs.Year, "field": obs.FieldCMID, "household": obs.HouseholdCMID,
-		"person": obs.PersonCMID, "changed": obs.SourceChangedAt, "new": obs.NewValue,
+		"year": obs.Year, "field": obs.FieldCMID,
+		"household": obs.HouseholdCMID, "person": obs.PersonCMID,
 	}
+	if obs.SourceChangedAt == "" {
+		dedupe += " && source_changed_at = ''"
+	} else {
+		dedupe += " && source_changed_at = {:changed}"
+		params["changed"] = obs.SourceChangedAt
+	}
+	if obs.NewValue == "" {
+		dedupe += " && new_value = ''"
+	} else {
+		dedupe += " && new_value = {:new}"
+		params["new"] = obs.NewValue
+	}
+	// old_value is part of the key, not just of the payload. Without it, an
+	// empty source_changed_at degenerates the key to
+	// (year, field, household, person, '', new_value), and a cabin that goes
+	// A -> B -> A has its third observation matched against the first and
+	// silently dropped.
+	if obs.OldValue == "" {
+		dedupe += " && old_value = ''"
+	} else {
+		dedupe += " && old_value = {:old}"
+		params["old"] = obs.OldValue
+	}
+
 	existing, err := app.FindRecordsByFilter(lodgingValueHistoryCollection, dedupe, "", 1, 0, params)
 	if err != nil {
 		return fmt.Errorf("checking for an existing %s row: %w", lodgingValueHistoryCollection, err)

--- a/pocketbase/sync/lodging_value_history_test.go
+++ b/pocketbase/sync/lodging_value_history_test.go
@@ -1,0 +1,410 @@
+package sync
+
+// Tests for the cabin-value change capture (kindred#2482).
+//
+// The capture exists because `Family Camp Cabin` (cm_id 218072) holds ONE value
+// per household per YEAR, so a household attending two weekends overwrites its
+// own cabin and the sync cannot tell which weekend a string belonged to. These
+// tests pin the WRITE side only: that a change to a retained cabin field lands
+// an append-only row, that a bare last_updated bump does not, that non-cabin
+// fields are not retained at all, and that a dry run writes nothing.
+//
+// Nothing here derives a session from the captured rows -- that is deliberately
+// out of scope, and no published value changes as a result of this capture.
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+const (
+	testCabinValueOld = "Manzanita 3"
+	testCabinValueNew = "Manzanita 7"
+
+	testLastUpdatedGenesis    = "2026-05-14 09:00:00.000Z"
+	testLastUpdatedTransition = "2026-08-18 11:30:00.000Z"
+	testLastUpdatedBumpOnly   = "2026-08-19 07:15:00.000Z"
+)
+
+// addLodgingValueHistoryCollection mirrors the collection created by
+// pocketbase/pb_migrations/1500000165_lodging_value_history.js. The sync
+// package's fixtures build collections by hand (see the CI note on
+// TestLodgingTestsupportFixtureFieldsExistInProductionSchema), so this shape has
+// to be kept in step with that migration by hand too.
+func addLodgingValueHistoryCollection(t *testing.T, app core.App) {
+	t.Helper()
+
+	col := core.NewBaseCollection("lodging_value_history")
+	col.Fields.Add(&core.NumberField{Name: "year", Required: true, OnlyInt: true})
+	col.Fields.Add(&core.NumberField{Name: "field_cm_id", Required: true, OnlyInt: true})
+	col.Fields.Add(&core.NumberField{Name: "household_cm_id", OnlyInt: true})
+	col.Fields.Add(&core.NumberField{Name: "person_cm_id", OnlyInt: true})
+	col.Fields.Add(&core.TextField{Name: "source_field", Max: 200})
+	col.Fields.Add(&core.TextField{Name: "old_value", Max: 500})
+	col.Fields.Add(&core.TextField{Name: "new_value", Max: 500})
+	col.Fields.Add(&core.TextField{Name: "source_changed_at", Max: 100})
+	col.Fields.Add(&core.DateField{Name: "observed_at"})
+	col.Fields.Add(&core.BoolField{Name: "is_genesis"})
+	col.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
+
+	if err := app.Save(col); err != nil {
+		t.Fatalf("save lodging_value_history: %v", err)
+	}
+}
+
+func historyRows(t *testing.T, app core.App) []*core.Record {
+	t.Helper()
+	rows, err := app.FindRecordsByFilter("lodging_value_history", "", "created", 0, 0)
+	if err != nil {
+		t.Fatalf("re-query lodging_value_history: %v", err)
+	}
+	return rows
+}
+
+// newHouseholdCabinSync returns a service with its own ProcessedKeys, so the
+// duplicate-in-run guard does not fire across the steps of one test.
+func newHouseholdCabinSync(app core.App) *HouseholdCustomFieldValuesSync {
+	return &HouseholdCustomFieldValuesSync{
+		BaseSyncService: BaseSyncService{App: app, ProcessedKeys: map[string]bool{}, Stats: Stats{}},
+	}
+}
+
+func newPersonCabinSync(app core.App) *PersonCustomFieldValuesSync {
+	return &PersonCustomFieldValuesSync{
+		BaseSyncService: BaseSyncService{App: app, ProcessedKeys: map[string]bool{}, Stats: Stats{}},
+	}
+}
+
+// TestHouseholdCabinValueChangeIsCaptured walks the three cases that matter on
+// the household grain: the first observation (genesis), a real value change, and
+// a bare last_updated bump that must NOT be recorded as a change.
+func TestHouseholdCabinValueChangeIsCaptured(t *testing.T) {
+	t.Parallel()
+
+	app := newOrphanSweepTestApp(t, "household_custom_values",
+		"household", "field_definition", "value", "last_updated")
+	addLodgingValueHistoryCollection(t, app)
+
+	fieldDefMapping := map[int]string{cmIDFamilyCampCabin: testFieldDefPBID}
+	const householdCMID = 54321
+
+	// --- 1. genesis -------------------------------------------------------
+	create := newHouseholdCabinSync(app)
+	existing := map[string]*core.Record{}
+	if err := create.processHouseholdCustomFieldValue(
+		map[string]any{
+			"id": float64(cmIDFamilyCampCabin), "value": testCabinValueOld,
+			"lastUpdated": testLastUpdatedGenesis,
+		},
+		householdCMID, testHouseholdPBID, 2026, fieldDefMapping, existing); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	rows := historyRows(t, app)
+	if len(rows) != 1 {
+		t.Fatalf("after genesis: %d history rows, want 1", len(rows))
+	}
+	g := rows[0]
+	if !g.GetBool("is_genesis") {
+		t.Errorf("genesis row is_genesis = false, want true")
+	}
+	if g.GetString("old_value") != "" {
+		t.Errorf("genesis old_value = %q, want empty", g.GetString("old_value"))
+	}
+	if g.GetString("new_value") != testCabinValueOld {
+		t.Errorf("genesis new_value = %q, want %q", g.GetString("new_value"), testCabinValueOld)
+	}
+	if g.GetInt("household_cm_id") != householdCMID {
+		t.Errorf("genesis household_cm_id = %d, want %d", g.GetInt("household_cm_id"), householdCMID)
+	}
+	if g.GetInt("person_cm_id") != 0 {
+		t.Errorf("genesis person_cm_id = %d, want 0 on the household grain", g.GetInt("person_cm_id"))
+	}
+	if g.GetInt("field_cm_id") != cmIDFamilyCampCabin {
+		t.Errorf("genesis field_cm_id = %d, want %d", g.GetInt("field_cm_id"), cmIDFamilyCampCabin)
+	}
+	if g.GetString("source_field") != fieldNameFamilyCampCabin {
+		t.Errorf("genesis source_field = %q, want %q", g.GetString("source_field"), fieldNameFamilyCampCabin)
+	}
+	if g.GetString("source_changed_at") != testLastUpdatedGenesis {
+		t.Errorf("genesis source_changed_at = %q, want %q",
+			g.GetString("source_changed_at"), testLastUpdatedGenesis)
+	}
+	if g.GetString("observed_at") == "" {
+		t.Errorf("genesis observed_at is empty; the dual clock is the point")
+	}
+	if g.GetInt("year") != 2026 {
+		t.Errorf("genesis year = %d, want 2026", g.GetInt("year"))
+	}
+
+	seeded, err := app.FindRecordsByFilter("household_custom_values", "", "", 0, 0)
+	if err != nil || len(seeded) != 1 {
+		t.Fatalf("seed household_custom_values: %d rows, err=%v", len(seeded), err)
+	}
+	key := testHouseholdPBID + ":" + testFieldDefPBID + "|2026"
+
+	// --- 2. a real value change ------------------------------------------
+	change := newHouseholdCabinSync(app)
+	if err := change.processHouseholdCustomFieldValue(
+		map[string]any{
+			"id": float64(cmIDFamilyCampCabin), "value": testCabinValueNew,
+			"lastUpdated": testLastUpdatedTransition,
+		},
+		householdCMID, testHouseholdPBID, 2026, fieldDefMapping,
+		map[string]*core.Record{key: seeded[0]}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	rows = historyRows(t, app)
+	if len(rows) != 2 {
+		t.Fatalf("after value change: %d history rows, want 2", len(rows))
+	}
+	c := rows[1]
+	if c.GetBool("is_genesis") {
+		t.Errorf("transition row is_genesis = true, want false")
+	}
+	if c.GetString("old_value") != testCabinValueOld {
+		t.Errorf("transition old_value = %q, want %q", c.GetString("old_value"), testCabinValueOld)
+	}
+	if c.GetString("new_value") != testCabinValueNew {
+		t.Errorf("transition new_value = %q, want %q", c.GetString("new_value"), testCabinValueNew)
+	}
+	if c.GetString("source_changed_at") != testLastUpdatedTransition {
+		t.Errorf("transition source_changed_at = %q, want %q",
+			c.GetString("source_changed_at"), testLastUpdatedTransition)
+	}
+
+	// --- 3. a bare last_updated bump is NOT a change ----------------------
+	reloaded, reloadErr := app.FindRecordById("household_custom_values", seeded[0].Id)
+	if reloadErr != nil {
+		t.Fatalf("reload: %v", reloadErr)
+	}
+	bump := newHouseholdCabinSync(app)
+	if err := bump.processHouseholdCustomFieldValue(
+		map[string]any{
+			"id": float64(cmIDFamilyCampCabin), "value": testCabinValueNew,
+			"lastUpdated": testLastUpdatedBumpOnly,
+		},
+		householdCMID, testHouseholdPBID, 2026, fieldDefMapping,
+		map[string]*core.Record{key: reloaded}); err != nil {
+		t.Fatalf("last_updated bump: %v", err)
+	}
+
+	if got := len(historyRows(t, app)); got != 2 {
+		t.Errorf("a bare last_updated bump wrote history: %d rows, want 2", got)
+	}
+}
+
+// TestPersonCabinValueChangeIsCaptured is the person-grain twin: the
+// `Reportable Family Camp Cabin` field is retained too, keyed on person_cm_id.
+func TestPersonCabinValueChangeIsCaptured(t *testing.T) {
+	t.Parallel()
+
+	app := newOrphanSweepTestApp(t, "person_custom_values",
+		"person", "field_definition", "value", "last_updated")
+	addLodgingValueHistoryCollection(t, app)
+
+	fieldDefMapping := map[int]string{cmIDReportableFamilyCampCabin: testFieldDefPBIDPerson}
+	const personCMID = 12345
+
+	create := newPersonCabinSync(app)
+	if err := create.processPersonCustomFieldValue(
+		map[string]any{
+			"id": float64(cmIDReportableFamilyCampCabin), "value": testCabinValueOld,
+			"lastUpdated": testLastUpdatedGenesis,
+		},
+		personCMID, testPersonPBID, 2026, fieldDefMapping, map[string]*core.Record{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	rows := historyRows(t, app)
+	if len(rows) != 1 {
+		t.Fatalf("after genesis: %d history rows, want 1", len(rows))
+	}
+	if rows[0].GetInt("person_cm_id") != personCMID {
+		t.Errorf("person_cm_id = %d, want %d", rows[0].GetInt("person_cm_id"), personCMID)
+	}
+	if rows[0].GetInt("household_cm_id") != 0 {
+		t.Errorf("household_cm_id = %d, want 0 on the person grain", rows[0].GetInt("household_cm_id"))
+	}
+	if rows[0].GetString("source_field") != fieldNameReportableFamilyCampCabin {
+		t.Errorf("source_field = %q, want %q",
+			rows[0].GetString("source_field"), fieldNameReportableFamilyCampCabin)
+	}
+
+	seeded, err := app.FindRecordsByFilter("person_custom_values", "", "", 0, 0)
+	if err != nil || len(seeded) != 1 {
+		t.Fatalf("seed person_custom_values: %d rows, err=%v", len(seeded), err)
+	}
+	key := testPersonPBID + ":" + testFieldDefPBIDPerson + "|2026"
+
+	change := newPersonCabinSync(app)
+	if err := change.processPersonCustomFieldValue(
+		map[string]any{
+			"id": float64(cmIDReportableFamilyCampCabin), "value": testCabinValueNew,
+			"lastUpdated": testLastUpdatedTransition,
+		},
+		personCMID, testPersonPBID, 2026, fieldDefMapping,
+		map[string]*core.Record{key: seeded[0]}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	rows = historyRows(t, app)
+	if len(rows) != 2 {
+		t.Fatalf("after value change: %d history rows, want 2", len(rows))
+	}
+	if rows[1].GetString("old_value") != testCabinValueOld ||
+		rows[1].GetString("new_value") != testCabinValueNew {
+		t.Errorf("transition = %q -> %q, want %q -> %q",
+			rows[1].GetString("old_value"), rows[1].GetString("new_value"),
+			testCabinValueOld, testCabinValueNew)
+	}
+}
+
+// TestNonCabinFieldIsNotRetained pins the ruled retention scope: cabin fields
+// only. The medical-adjacent fields are held out on purpose (api/routers/
+// lodging.py records that this surface has no access log, deliberately), and
+// widening later is a change to the Go registry, not a migration.
+func TestNonCabinFieldIsNotRetained(t *testing.T) {
+	t.Parallel()
+
+	app := newOrphanSweepTestApp(t, "household_custom_values",
+		"household", "field_definition", "value", "last_updated")
+	addLodgingValueHistoryCollection(t, app)
+
+	// cmIDFamCampBathroom is one of the deliberately held-out fields.
+	fieldDefMapping := map[int]string{cmIDFamCampBathroom: testFieldDefPBID}
+
+	create := newHouseholdCabinSync(app)
+	if err := create.processHouseholdCustomFieldValue(
+		map[string]any{"id": float64(cmIDFamCampBathroom), "value": "Yes",
+			"lastUpdated": testLastUpdatedGenesis},
+		54321, testHouseholdPBID, 2026, fieldDefMapping, map[string]*core.Record{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	seeded, err := app.FindRecordsByFilter("household_custom_values", "", "", 0, 0)
+	if err != nil || len(seeded) != 1 {
+		t.Fatalf("seed: %d rows, err=%v", len(seeded), err)
+	}
+
+	change := newHouseholdCabinSync(app)
+	if err := change.processHouseholdCustomFieldValue(
+		map[string]any{"id": float64(cmIDFamCampBathroom), "value": "No",
+			"lastUpdated": testLastUpdatedTransition},
+		54321, testHouseholdPBID, 2026, fieldDefMapping,
+		map[string]*core.Record{testHouseholdPBID + ":" + testFieldDefPBID + "|2026": seeded[0]}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	if got := len(historyRows(t, app)); got != 0 {
+		t.Errorf("a held-out field wrote %d history rows; want 0", got)
+	}
+}
+
+// TestLodgingValueHistoryDryRunWritesNothing: the capture sits after the
+// custom-values Save, so DryRun's existing early return gates it structurally.
+func TestLodgingValueHistoryDryRunWritesNothing(t *testing.T) {
+	t.Parallel()
+
+	app := newOrphanSweepTestApp(t, "household_custom_values",
+		"household", "field_definition", "value", "last_updated")
+	addLodgingValueHistoryCollection(t, app)
+
+	fieldDefMapping := map[int]string{cmIDFamilyCampCabin: testFieldDefPBID}
+
+	dry := newHouseholdCabinSync(app)
+	dry.SetDryRun(true)
+	if err := dry.processHouseholdCustomFieldValue(
+		map[string]any{"id": float64(cmIDFamilyCampCabin), "value": testCabinValueOld,
+			"lastUpdated": testLastUpdatedGenesis},
+		54321, testHouseholdPBID, 2026, fieldDefMapping, map[string]*core.Record{}); err != nil {
+		t.Fatalf("dry create: %v", err)
+	}
+	if got := len(historyRows(t, app)); got != 0 {
+		t.Fatalf("dry-run create wrote %d history rows; want 0", got)
+	}
+
+	// Seed wet, then dry-run a change over it.
+	seed := newHouseholdCabinSync(app)
+	if err := seed.processHouseholdCustomFieldValue(
+		map[string]any{"id": float64(cmIDFamilyCampCabin), "value": testCabinValueOld,
+			"lastUpdated": testLastUpdatedGenesis},
+		54321, testHouseholdPBID, 2026, fieldDefMapping, map[string]*core.Record{}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	seeded, err := app.FindRecordsByFilter("household_custom_values", "", "", 0, 0)
+	if err != nil || len(seeded) != 1 {
+		t.Fatalf("seed: %d rows, err=%v", len(seeded), err)
+	}
+	before := len(historyRows(t, app))
+
+	dryUpdate := newHouseholdCabinSync(app)
+	dryUpdate.SetDryRun(true)
+	if err := dryUpdate.processHouseholdCustomFieldValue(
+		map[string]any{"id": float64(cmIDFamilyCampCabin), "value": testCabinValueNew,
+			"lastUpdated": testLastUpdatedTransition},
+		54321, testHouseholdPBID, 2026, fieldDefMapping,
+		map[string]*core.Record{testHouseholdPBID + ":" + testFieldDefPBID + "|2026": seeded[0]}); err != nil {
+		t.Fatalf("dry update: %v", err)
+	}
+	if got := len(historyRows(t, app)); got != before {
+		t.Errorf("dry-run update wrote history: %d rows, want %d", got, before)
+	}
+}
+
+// TestLodgingValueHistoryRepeatObservationIsIdempotent: the table is append-only
+// and carries a unique index on
+// (year, field_cm_id, household_cm_id, person_cm_id, source_changed_at, new_value).
+// Re-observing the same change -- which a re-run of the same sync does -- must
+// not add a second row or surface an error.
+func TestLodgingValueHistoryRepeatObservationIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	app := newOrphanSweepTestApp(t, "household_custom_values",
+		"household", "field_definition", "value", "last_updated")
+	addLodgingValueHistoryCollection(t, app)
+
+	obs := lodgingValueObservation{
+		Year:            2026,
+		FieldCMID:       cmIDFamilyCampCabin,
+		HouseholdCMID:   54321,
+		OldValue:        testCabinValueOld,
+		NewValue:        testCabinValueNew,
+		SourceChangedAt: testLastUpdatedTransition,
+	}
+	if err := recordLodgingValueChange(app, &obs); err != nil {
+		t.Fatalf("first observation: %v", err)
+	}
+	if err := recordLodgingValueChange(app, &obs); err != nil {
+		t.Fatalf("repeat observation: %v", err)
+	}
+	if got := len(historyRows(t, app)); got != 1 {
+		t.Errorf("repeat observation produced %d rows; want 1", got)
+	}
+}
+
+// TestLodgingValueHistorySkipsEmptyGenesis: a household with no cabin recorded
+// yet is not a fact about where anyone slept, so the first observation of an
+// empty string is not worth a genesis row. A change TO empty (staff clearing a
+// cabin) still is, and is covered by the transition path above.
+func TestLodgingValueHistorySkipsEmptyGenesis(t *testing.T) {
+	t.Parallel()
+
+	app := newOrphanSweepTestApp(t, "household_custom_values",
+		"household", "field_definition", "value", "last_updated")
+	addLodgingValueHistoryCollection(t, app)
+
+	fieldDefMapping := map[int]string{cmIDFamilyCampCabin: testFieldDefPBID}
+	create := newHouseholdCabinSync(app)
+	if err := create.processHouseholdCustomFieldValue(
+		map[string]any{"id": float64(cmIDFamilyCampCabin), "value": "",
+			"lastUpdated": testLastUpdatedGenesis},
+		54321, testHouseholdPBID, 2026, fieldDefMapping, map[string]*core.Record{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if got := len(historyRows(t, app)); got != 0 {
+		t.Errorf("an empty first observation wrote %d genesis rows; want 0", got)
+	}
+}

--- a/pocketbase/sync/lodging_value_history_test.go
+++ b/pocketbase/sync/lodging_value_history_test.go
@@ -48,6 +48,19 @@ func addLodgingValueHistoryCollection(t *testing.T, app core.App) {
 	col.Fields.Add(&core.BoolField{Name: "is_genesis"})
 	col.Fields.Add(&core.AutodateField{Name: "created", OnCreate: true})
 
+	// The indexes are part of the fixture, not decoration. Without
+	// idx_lvh_observation the "idempotency contract" the migration header names
+	// is never exercised: a typo in its column list, or dropping it outright,
+	// would ship green because the Go pre-check alone would carry every test.
+	// Keep this list byte-identical to the migration's.
+	col.Indexes = []string{
+		"CREATE UNIQUE INDEX idx_lvh_observation ON lodging_value_history " +
+			"(year, field_cm_id, household_cm_id, person_cm_id, source_changed_at, " +
+			"old_value, new_value)",
+		"CREATE INDEX idx_lvh_household_year ON lodging_value_history (household_cm_id, year)",
+		"CREATE INDEX idx_lvh_person_year ON lodging_value_history (person_cm_id, year)",
+	}
+
 	if err := app.Save(col); err != nil {
 		t.Fatalf("save lodging_value_history: %v", err)
 	}
@@ -60,6 +73,24 @@ func historyRows(t *testing.T, app core.App) []*core.Record {
 		t.Fatalf("re-query lodging_value_history: %v", err)
 	}
 	return rows
+}
+
+// theRow returns the single row matching genesis, and fails if there is not
+// exactly one. Deliberately NOT positional: `created` is a millisecond autodate
+// and two writes inside one test can land in the same millisecond, after which
+// SQLite is free to return either order and `rows[1]` stops meaning anything.
+func theRow(t *testing.T, app core.App, genesis bool) *core.Record {
+	t.Helper()
+	var found []*core.Record
+	for _, r := range historyRows(t, app) {
+		if r.GetBool("is_genesis") == genesis {
+			found = append(found, r)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("want exactly 1 row with is_genesis=%v, got %d", genesis, len(found))
+	}
+	return found[0]
 }
 
 // newHouseholdCabinSync returns a service with its own ProcessedKeys, so the
@@ -105,10 +136,7 @@ func TestHouseholdCabinValueChangeIsCaptured(t *testing.T) {
 	if len(rows) != 1 {
 		t.Fatalf("after genesis: %d history rows, want 1", len(rows))
 	}
-	g := rows[0]
-	if !g.GetBool("is_genesis") {
-		t.Errorf("genesis row is_genesis = false, want true")
-	}
+	g := theRow(t, app, true)
 	if g.GetString("old_value") != "" {
 		t.Errorf("genesis old_value = %q, want empty", g.GetString("old_value"))
 	}
@@ -160,10 +188,7 @@ func TestHouseholdCabinValueChangeIsCaptured(t *testing.T) {
 	if len(rows) != 2 {
 		t.Fatalf("after value change: %d history rows, want 2", len(rows))
 	}
-	c := rows[1]
-	if c.GetBool("is_genesis") {
-		t.Errorf("transition row is_genesis = true, want false")
-	}
+	c := theRow(t, app, false)
 	if c.GetString("old_value") != testCabinValueOld {
 		t.Errorf("transition old_value = %q, want %q", c.GetString("old_value"), testCabinValueOld)
 	}
@@ -222,15 +247,16 @@ func TestPersonCabinValueChangeIsCaptured(t *testing.T) {
 	if len(rows) != 1 {
 		t.Fatalf("after genesis: %d history rows, want 1", len(rows))
 	}
-	if rows[0].GetInt("person_cm_id") != personCMID {
-		t.Errorf("person_cm_id = %d, want %d", rows[0].GetInt("person_cm_id"), personCMID)
+	pg := theRow(t, app, true)
+	if pg.GetInt("person_cm_id") != personCMID {
+		t.Errorf("person_cm_id = %d, want %d", pg.GetInt("person_cm_id"), personCMID)
 	}
-	if rows[0].GetInt("household_cm_id") != 0 {
-		t.Errorf("household_cm_id = %d, want 0 on the person grain", rows[0].GetInt("household_cm_id"))
+	if pg.GetInt("household_cm_id") != 0 {
+		t.Errorf("household_cm_id = %d, want 0 on the person grain", pg.GetInt("household_cm_id"))
 	}
-	if rows[0].GetString("source_field") != fieldNameReportableFamilyCampCabin {
+	if pg.GetString("source_field") != fieldNameReportableFamilyCampCabin {
 		t.Errorf("source_field = %q, want %q",
-			rows[0].GetString("source_field"), fieldNameReportableFamilyCampCabin)
+			pg.GetString("source_field"), fieldNameReportableFamilyCampCabin)
 	}
 
 	seeded, err := app.FindRecordsByFilter("person_custom_values", "", "", 0, 0)
@@ -254,10 +280,11 @@ func TestPersonCabinValueChangeIsCaptured(t *testing.T) {
 	if len(rows) != 2 {
 		t.Fatalf("after value change: %d history rows, want 2", len(rows))
 	}
-	if rows[1].GetString("old_value") != testCabinValueOld ||
-		rows[1].GetString("new_value") != testCabinValueNew {
+	tr := theRow(t, app, false)
+	if tr.GetString("old_value") != testCabinValueOld ||
+		tr.GetString("new_value") != testCabinValueNew {
 		t.Errorf("transition = %q -> %q, want %q -> %q",
-			rows[1].GetString("old_value"), rows[1].GetString("new_value"),
+			tr.GetString("old_value"), tr.GetString("new_value"),
 			testCabinValueOld, testCabinValueNew)
 	}
 }
@@ -406,5 +433,123 @@ func TestLodgingValueHistorySkipsEmptyGenesis(t *testing.T) {
 	}
 	if got := len(historyRows(t, app)); got != 0 {
 		t.Errorf("an empty first observation wrote %d genesis rows; want 0", got)
+	}
+}
+
+// TestLodgingValueHistoryIdempotencyWithEmptyColumns pins the two dedupe-key
+// columns that can legitimately be EMPTY, which a naive `field = {:param}`
+// filter does not match:
+//
+//   - source_changed_at is empty whenever CampMinder returns no `lastUpdated`
+//     for the value (transformHouseholdCustomFieldValueToPB only sets the field
+//     when it is present and non-empty).
+//   - new_value is empty when staff CLEAR a cabin, which is a real transition
+//     this table is meant to record.
+//
+// Without this, the pre-insert check misses its own row and every sync run
+// re-attempts the insert: in production the unique index rejects it and the
+// swallowed error is logged on every run, and in any fixture without that index
+// the rows simply duplicate.
+func TestLodgingValueHistoryIdempotencyWithEmptyColumns(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		obs  lodgingValueObservation
+	}{
+		{
+			name: "empty source_changed_at",
+			obs: lodgingValueObservation{
+				Year: 2026, FieldCMID: cmIDFamilyCampCabin, HouseholdCMID: 54321,
+				NewValue: testCabinValueOld, SourceChangedAt: "", IsGenesis: true,
+			},
+		},
+		{
+			name: "empty new_value (staff cleared the cabin)",
+			obs: lodgingValueObservation{
+				Year: 2026, FieldCMID: cmIDFamilyCampCabin, HouseholdCMID: 54321,
+				OldValue: testCabinValueOld, NewValue: "",
+				SourceChangedAt: testLastUpdatedTransition,
+			},
+		},
+		{
+			name: "both empty",
+			obs: lodgingValueObservation{
+				Year: 2026, FieldCMID: cmIDReportableFamilyCampCabin, PersonCMID: 12345,
+				OldValue: testCabinValueOld, NewValue: "", SourceChangedAt: "",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := newOrphanSweepTestApp(t, "household_custom_values",
+				"household", "field_definition", "value", "last_updated")
+			addLodgingValueHistoryCollection(t, app)
+
+			obs := tc.obs
+			for i := range 2 {
+				if err := recordLodgingValueChange(app, &obs); err != nil {
+					t.Fatalf("observation %d: %v", i, err)
+				}
+			}
+			if got := len(historyRows(t, app)); got != 1 {
+				t.Errorf("two identical observations produced %d rows; want 1", got)
+			}
+		})
+	}
+}
+
+// TestLodgingValueHistoryKeepsAReturnToAPreviousCabin is the regression for the
+// degenerate-key case the migration header calls out. With an empty
+// `source_changed_at` -- which CampMinder produces whenever it returns no
+// `lastUpdated` -- a key without `old_value` collapses to
+// (year, field, household, person, ”, new_value), so a household whose cabin
+// goes A -> B -> A has its third, genuine observation matched against the first
+// and silently dropped, leaving B as the last recorded state.
+//
+// The fixture carries the real unique index, so this pins the index and the Go
+// pre-check together rather than only one of them.
+func TestLodgingValueHistoryKeepsAReturnToAPreviousCabin(t *testing.T) {
+	t.Parallel()
+
+	app := newOrphanSweepTestApp(t, "household_custom_values",
+		"household", "field_definition", "value", "last_updated")
+	addLodgingValueHistoryCollection(t, app)
+
+	base := lodgingValueObservation{
+		Year: 2026, FieldCMID: cmIDFamilyCampCabin, HouseholdCMID: 54321,
+		SourceChangedAt: "", // CampMinder returned no lastUpdated
+	}
+
+	genesis := base
+	genesis.NewValue, genesis.IsGenesis = testCabinValueOld, true
+	away := base
+	away.OldValue, away.NewValue = testCabinValueOld, testCabinValueNew
+	back := base
+	back.OldValue, back.NewValue = testCabinValueNew, testCabinValueOld
+
+	for i, obs := range []lodgingValueObservation{genesis, away, back} {
+		if err := recordLodgingValueChange(app, &obs); err != nil {
+			t.Fatalf("observation %d: %v", i, err)
+		}
+	}
+
+	rows := historyRows(t, app)
+	if len(rows) != 3 {
+		t.Fatalf("A -> B -> A produced %d rows; want 3 (the return was dropped)", len(rows))
+	}
+
+	// The return to the earlier cabin must be the one that survives as latest.
+	var returned bool
+	for _, r := range rows {
+		if r.GetString("old_value") == testCabinValueNew && r.GetString("new_value") == testCabinValueOld {
+			returned = true
+		}
+	}
+	if !returned {
+		t.Errorf("no row records the return %q -> %q", testCabinValueNew, testCabinValueOld)
 	}
 }

--- a/pocketbase/sync/person_custom_field_values.go
+++ b/pocketbase/sync/person_custom_field_values.go
@@ -460,9 +460,14 @@ func (s *PersonCustomFieldValuesSync) processPersonCustomFieldValue(
 			return nil
 		}
 
-		// Value or lastUpdated changed - update record
+		// Value or lastUpdated changed - update record.
+		//
+		// oldValue is read BEFORE the Set loop below overwrites it: the cabin
+		// change capture (kindred#2482) needs old and new simultaneously, and
+		// this is the only point in the pipeline where both are in scope.
 		newValue, _ := pbData["value"].(string)
-		if existing.GetString("value") != newValue || existingLastUpdated != newLastUpdated {
+		oldValue := existing.GetString("value")
+		if oldValue != newValue || existingLastUpdated != newLastUpdated {
 			for key, val := range pbData {
 				existing.Set(key, val)
 			}
@@ -480,6 +485,20 @@ func (s *PersonCustomFieldValuesSync) processPersonCustomFieldValue(
 				s.Stats.Errors++
 			} else {
 				s.Stats.Updated++
+				// Capture the change, but only a VALUE change -- the branch
+				// condition above also fires on a bare last_updated bump, which
+				// is not a change to where anyone slept. No-op for any field
+				// outside the retention scope (lodging_value_history.go).
+				if oldValue != newValue {
+					logLodgingValueChange(s.App, &lodgingValueObservation{
+						Year:            year,
+						FieldCMID:       fieldCMID,
+						PersonCMID:      personCMID,
+						OldValue:        oldValue,
+						NewValue:        newValue,
+						SourceChangedAt: newLastUpdated,
+					})
+				}
 			}
 		} else {
 			s.Stats.Skipped++
@@ -515,6 +534,18 @@ func (s *PersonCustomFieldValuesSync) processPersonCustomFieldValue(
 			// same key hits the "existing" branch (which the guard above now also
 			// short-circuits before it can be reached by a true duplicate).
 			existingRecords[yearScopedKey] = record
+			// The first observed cabin is a fact worth keeping, so the create
+			// branch writes history too, as is_genesis (kindred#2482).
+			newValue, _ := pbData["value"].(string)
+			newLastUpdated, _ := pbData["last_updated"].(string)
+			logLodgingValueChange(s.App, &lodgingValueObservation{
+				Year:            year,
+				FieldCMID:       fieldCMID,
+				PersonCMID:      personCMID,
+				NewValue:        newValue,
+				SourceChangedAt: newLastUpdated,
+				IsGenesis:       true,
+			})
 		}
 	}
 


### PR DESCRIPTION
`Family Camp Cabin` (cm_id 218072) is a household-grain custom field holding exactly one value
per household per year — `family_camp_registrations` is unique on `(household, year)`. A
household attending two family weekends therefore has one slot for two answers: when staff type
the second weekend's cabin, the first weekend's is gone. The assignment ingest cannot tell which
weekend a string belongs to, so it files `ambiguous_session` rather than guess
(`pocketbase/sync/lodging_assignments_sync.go`, `// flag, do not guess (spec 3.6)`).

**Measured, production snapshot at 2026-08-18 22:11: 9 open `ambiguous_session` rows across 8
distinct households for 2026, `occurrences = 1` each, all 9 on `Family Camp Cabin`.** Ten
households are enrolled in 2+ family weekends this year; 8 have written a cabin value and are
those 9 rows. Nothing today keeps the overwritten string: the only surviving copy of one is
`lodging_ingest_issues.raw_value`, and only by accident, because `RawValue` happens to be part
of `dedupKey()`.

This adds the capture, and only the capture.

## What lands

**`pocketbase/pb_migrations/1500000165_lodging_value_history.js`** — a new append-only table,
modelled on `1500000057_attendee_status_history.js` with four deliberate departures documented
in its header: no `session` column (session is the unknown, derived on read, not stored);
`old_value` / `new_value` are `text` rather than `select`, because there are 88 distinct
hand-typed cabin strings and a select would reject the first unanticipated name and lose the
change at the moment it matters; a dual clock, `source_changed_at` (CampMinder's own
`last_updated`) beside `observed_at` (when the sync saw it), because the retroactive-entry case
needs both — 21 of 2025's household cabin values were last edited in December, after every 2025
weekend; and the create branch writes too, as `is_genesis`, because the first observed cabin is
a fact worth keeping.

`source_changed_at` is `text`, **not** the `date` the issue's shape sketch named. The column it
copies — `household_custom_values.last_updated` and its person twin — is declared `text` in
`1500000029`. A `date` field would have to parse a CampMinder string, and a parse failure
rejects the row and loses the change, which is the same failure mode the text-not-select call
avoids for the value itself. The issue body has been corrected in place. `observed_at` stays a
real `date`: it is our own clock.

The collection's reads are **admin-only**, deliberately tighter than
`attendee_status_history`. It stores `household_custom_values` /
`person_custom_values` data verbatim and both of those source collections are admin-only, so
publishing a copy at authed-read would hand every non-admin account cabin strings it cannot read
from the source. The forward-looking half matters more: the retention scope is a Go map, so a
later widening needs no migration and nobody would re-read the access rule.

**`pocketbase/sync/lodging_value_history.go`** — the writer, plus
`lodgingRetainedHistoryFields`, the retention scope. Cabin fields only:
`Family Camp Cabin` (household) and `Reportable Family Camp Cabin` (person). The
medical-adjacent lodging fields — bathroom, CPAP, infant, opt-out — are held out **not on the
merits** but because `api/routers/lodging.py` records a deliberate ruling that that surface has
no access log and that one was removed on purpose; reversing that as a side effect of a
cabin-attribution change would be the wrong way to reverse it. Widening later is an edit to that
Go map and needs no migration.

**The write hook**, at the `existing.GetString("value") != newValue` comparison in
`processHouseholdCustomFieldValue` and `processPersonCustomFieldValue` — the only point where
old and new values are simultaneously in scope, mirroring where `logStatusChange` sits in
`attendees.go`. Three details that are load-bearing:

- It fires on a **value** change only. The enclosing branch condition is `value changed OR
  last_updated changed`, and a bare `last_updated` bump is not a change to where anyone slept.
- `oldValue` is read *before* the `Set` loop overwrites it.
- It sits **after** the custom-values `App.Save`, which is how `DryRun` is honored
  structurally — a dry run returns before it and cannot reach it — and also means history never
  claims a change that failed to persist. Failures are logged and swallowed; capture is
  non-critical and must not fail a sync.

**`frontend/src/types/pocketbase-types.ts`** — regenerated. It is `@generated` from live schema
introspection and CI diffs it against a scratch database built from `pb_migrations/` alone; a
new collection makes it stale. No hand edits, no component or style touched.

## What this deliberately does NOT do

**No published value moves.** Nothing reads the new table — verified by grep across Go, Python
and TypeScript; the only non-test references are the writer, the migration and the three
generated type-map lines. No cabin is assigned where the sync previously flagged
`ambiguous_session`, the attribution path is untouched, and all 9 open queue rows stay exactly
as they are. Deriving a weekend from these rows is a separate change and is not attempted here.

**One honest limit on what "captures every change" means.** The hook can only observe a change
the custom-values sync actually processes, and the existing fast path skips a record whose
`last_updated` is unchanged — so a value edited in CampMinder without its `last_updated` moving
is invisible here, exactly as it is invisible to `household_custom_values` itself today. That
is pre-existing behaviour this PR neither introduces nor fixes.

**The backfill is a floor, not a history — and there is no backfill in this PR at all.** Only
the current value and its `last_updated` survive in the source tables, so 2026's first
observations will all be stamped mid-May (64 of 75 values were last edited in 2026-05, 11 in
2026-04). A household with an April weekend and a September weekend reads "unknown for April".
The table earns from the next observed change forward. Do not read it as answering historical
questions on day one.

## Scan remediation

A floor-60 review found six issues; all six are fixed in this branch, none filed:

| # | Finding | Fix |
|---|---|---|
| 1 | The table published verbatim custom-values data at authed-read while both source collections are admin-only | reads are now admin-only, which also makes widening the Go retention map safe by default |
| 2 | `is_genesis` read as "no earlier value existed", which an orphan sweep followed by re-entry makes false | documented as "the first observation this table holds", in both the migration header and the Go type |
| 3 | With an empty `source_changed_at` the dedupe key degenerated and a cabin going A → B → A had its third observation silently dropped | `old_value` joins the dedupe predicate and the unique index; regression test added |
| 4 | The test fixture had no indexes, so the "idempotency contract" was never exercised | the fixture now carries the migration's three indexes verbatim |
| 5 | Assertions indexed `rows[1]` after sorting on a millisecond autodate that can tie | rows are selected by `is_genesis`, never by position |
| 6 | The migration header's row count disagreed with the evidence it cited | corrected to nine rows across eight households |

Separately, found before the scan and fixed the same way: the dedupe pre-check bound
`source_changed_at` and `new_value` as parameters, and a bound `""` does not match a stored
empty string in PocketBase — so a value with no `lastUpdated`, or a cleared cabin, re-attempted
its insert on every run and the unique index turned that into an error logged forever.

## Verification

Local, all exit 0: `go build ./...`; `go test ./...` in `pocketbase/` (full suite);
`golangci-lint run --config ../.golangci.yml` — **0 issues** (CI-only, not in pre-push);
`eslint` on the new migration; `scripts/dev/verify-migration-history.sh`;
`bash scripts/pre-push-verify.sh` — ALL CHECKS PASSED, including the frontend prettier, eslint,
tsc and vitest lanes.

The migration was applied to a scratch database built from `pb_migrations/` alone and the
produced schema inspected directly: the 500/200/100-char caps landed as declared rather than
falling back to PocketBase's 5000 default, and all three indexes exist. `1500000165` is the next
free number — the highest on `origin/main` is `1500000164`.

Nine tests, written failing first. Every one that was green on first write was
mutation-checked: dropping the retention-scope guard, the empty-genesis guard, the dedupe
pre-check, the value-changed guard, moving the genesis write ahead of the `DryRun` return, the
literal-`''` empty comparison, and removing `old_value` from both the predicate and the index
each turned its own test red, and each was restored.

The migration was also reverted and re-applied on a scratch database (`migrate down 1` then
`migrate up`) to confirm the down arm drops the collection cleanly and the up arm rebuilds it.

Closes #2482.
