### PR TITLE
feat(sync,api,frontend): resolve step-free access into needs_step_free and publish ramp coverage

### DIFF
--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -115,6 +115,30 @@ Shareability = Literal["unknown", "shareable", "single_party"]
 # means "nobody has said", not "there is no power". See `amenity_coverage`.
 AmenityCoverage = Literal["all", "some", "none", "unknown"]
 
+# The registry's own step-free assessment, mirrored from the `has_ramp` select
+# added by migration 1500000131 (kindred#2438). THREE values plus blank, and
+# the blank is the load-bearing one: it means NOT ASSESSED, which is neither
+# "yes" nor "no". That migration's comment says why it is not a bool -- "a bool
+# maps every unassessed cabin to false, which asserts 'no ramp' about cabins
+# nobody has looked at" -- and reading it as one reports 0 of 118 units while
+# erasing all 14 staff assessments.
+RampAssessment = Literal["", "yes", "no", "partial"]
+
+# How much of a slot is step-free, resolved over its LEAF descendants
+# (kindred#2438). FIVE grades rather than `AmenityCoverage`'s four, because the
+# supply column is three-valued and a qualified ramp is a real answer with
+# nowhere to go in a boolean grain:
+#
+#   all      every answering room is fully step-free
+#   some     at least one is, but not all
+#   partial  NO room is, but at least one has a qualified ramp
+#   none     every answering room answered `no`
+#   unknown  nothing answers -- blank, unconfirmed, or no active room left
+#
+# See `ramp_coverage` in `api/services/lodging_rules.py` for why `partial`
+# folds into neither of its neighbours.
+RampCoverage = Literal["all", "some", "partial", "none", "unknown"]
+
 # The STAFF-OWNED weekend status, from lodging_session_status (1500000142).
 # Unlike every other vocabulary in this module it mirrors no Go ingest, because
 # there is no ingest: CampMinder's Sessions API has no status concept at all,
@@ -229,6 +253,29 @@ class LodgingUnitSummary(BaseModel):
     # units carry `has_fridge`, four of those also carry `has_shared_fridge`,
     # and none carries shared without the parent.
     fridge_coverage: AmenityCoverage = "unknown"
+    # The registry's own step-free fact about THIS ROW, published beside its
+    # resolution exactly as `has_power` and `has_fridge` are (kindred#2438).
+    #
+    # ⚠️ NOT the field a drop is judged against -- `ramp_coverage` below is,
+    # and reading this instead reintroduces the container trap AND the
+    # truthiness trap at once: `has_ramp` is a STRING, so `'no'` is truthy, and
+    # a consumer filtering on it renders "step-free" on the four cabins staff
+    # assessed as explicitly having no ramp. Blank means NOT ASSESSED (104 of
+    # 118 production rows) and is never coerced to "no".
+    has_ramp: RampAssessment = ""
+    # The step-free twin of `power_coverage` and `fridge_coverage`, resolved
+    # over the same leaf walk and defaulting to "unknown" for the same reason:
+    # a payload built without the resolution pass must not claim an unmet need.
+    # Fourteen of 118 production units carry an assessment (5 yes / 5 partial /
+    # 4 no), so almost every unit resolves "unknown" today -- which is the
+    # honest answer, not a gap.
+    ramp_coverage: RampCoverage = "unknown"
+    # ⚠️ INDEPENDENT of `has_ramp` above, measured: `has_ramp = 'yes'` splits 2
+    # `is_accessible` true / 3 false, and the 4 explicit `no`s plus 5
+    # `partial`s are invisible to this flag, which reads them identically to
+    # the 104 rows nobody has looked at. No fold in either direction is
+    # information-preserving (kindred#2438), and #2327's ruling -- accessible
+    # draws only when TRUE -- is unchanged by the ramp dimension.
     is_accessible: bool = False
     is_confirmed: bool = False
     is_active: bool = False
@@ -532,6 +579,24 @@ class AccessibilityFlagSummary(BaseModel):
     # board hatches a unit for this and never dims one -- see `needsFit.ts`,
     # where the mark it feeds changes `background-image` and nothing else.
     needs_fridge: bool = False
+    # kindred#2438. The second need resolved out of the housing narrative, and
+    # the one the registry has always been able to answer: `lodging_units`
+    # has carried `has_ramp` since migration 1500000131 and nothing read it.
+    #
+    # ⚠️ ROUTED DIFFERENTLY from `needs_fridge` above, and the difference is
+    # measured. Fridge reads the accommodation narrative alone; this reads the
+    # BATHROOM narrative too, because 5 of the 14 mobility households on the
+    # 2026 snapshot narrate only through that field and 3 through both -- a
+    # family explaining why it needs a private bathroom is often explaining
+    # that someone cannot walk to the shared one.
+    #
+    # ⚠️ NOT GATED on `needs_accommodation`. All 6 fridge households are gated;
+    # only 11 of the 14 mobility households are.
+    #
+    # DERIVED IN THE SYNC LAYER and ADVISORY, on the same terms as the flag
+    # above: only the boolean crosses into this payload, and the mark it feeds
+    # hatches a unit card rather than refusing a drop.
+    needs_step_free: bool = False
     # True when the family said they can only attend WITH the accommodation
     # in place: `FAM CAMP-Opt Out VIP` = "Yes, please register regardless of
     # cabin type" means they will come either way, so the need is a warning;

--- a/api/services/lodging_repository.py
+++ b/api/services/lodging_repository.py
@@ -845,9 +845,10 @@ class LodgingRepository:
 
         Carries the ingest-derived request layer -- share_cabin_gate,
         wants_near / wants_with / wants_similar_ages, request_text -- and the
-        five narrative-free housing flags -- needs_private_bathroom,
-        needs_power, needs_accommodation, has_infant, and needs_fridge since
-        kindred#2224. Read those columns; do not re-derive them from
+        six narrative-free housing flags -- needs_private_bathroom,
+        needs_power, needs_accommodation, has_infant, needs_fridge since
+        kindred#2224, and needs_step_free since kindred#2438. Read those
+        columns; do not re-derive them from
         share_cabin_preference / shared_cabin_modes_raw, which are the raw
         profile values kept for provenance.
 

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -24,7 +24,6 @@ from api.constants.lodging import INFANT_BED_EXEMPT_MONTHS, is_attending_adult_n
 from api.schemas.lodging import (
     MEDICAL_NARRATIVE_FIELD_NAMES,
     AccessibilityFlagSummary,
-    AmenityCoverage,
     EffectiveBathroom,
     HouseholdJourneyResponse,
     HouseholdJourneySession,
@@ -35,6 +34,7 @@ from api.schemas.lodging import (
     PartyAdult,
     PartyChild,
     ProximityKind,
+    RampAssessment,
     RequestTextBlock,
     RequestTextEntry,
     RosterCounts,
@@ -61,6 +61,7 @@ from api.services.lodging_rules import (
     container_bathroom,
     effective_bathroom,
     is_family_available,
+    ramp_coverage,
     request_text_authorship,
     request_text_source_order,
     unit_capacity,
@@ -135,6 +136,29 @@ def _i(record: Any, field: str, default: int = 0) -> int:
         return int(value)
     except TypeError, ValueError:
         return default
+
+
+def _ramp_assessment(value: str) -> RampAssessment:
+    """Rail a raw `has_ramp` string to the select's own vocabulary.
+
+    NOT a defence against the registry loader: migration 1500000131 declares
+    `has_ramp` as a PocketBase `select` with `values: ['yes','no','partial']`,
+    and PB validates that on save, so `registry.go`'s write of a typo'd value
+    fails the save rather than persisting it. This rails two OTHER directions,
+    both real. A later migration may WIDEN the value list -- that is how a
+    select grows -- and a grade this code has never heard of must read as NOT
+    ASSESSED rather than fall through `ramp_coverage`'s chain to `none`, which
+    is a claim. And `_s` is total over a record that lacks the attribute
+    entirely, which is what a summary built before the column existed looks
+    like.
+
+    Blank already means NOT ASSESSED -- 104 of the 118 production rows are
+    blank -- and coercing either case to "no" is the inversion the select
+    exists to prevent.
+    """
+    if value in ("yes", "no", "partial"):
+        return cast(RampAssessment, value)
+    return ""
 
 
 def _b(record: Any, field: str) -> bool:
@@ -1055,7 +1079,9 @@ def _resolve_power_coverage(units: list[LodgingUnitSummary], index: _BathroomInd
     pointing at the pre-resolution copies, which is exactly the kind of drift
     the one-index-per-call rule above exists to prevent.
     """
-    _resolve_amenity_coverage(units, index, answer=lambda room: room.has_power, target="power_coverage")
+    _resolve_amenity_coverage(
+        units, index, answer=lambda room: room.has_power, grade=amenity_coverage, target="power_coverage"
+    )
 
 
 def _resolve_fridge_coverage(units: list[LodgingUnitSummary], index: _BathroomIndex) -> None:
@@ -1090,18 +1116,60 @@ def _resolve_fridge_coverage(units: list[LodgingUnitSummary], index: _BathroomIn
         units,
         index,
         answer=lambda room: room.has_fridge or room.has_shared_fridge,
+        grade=amenity_coverage,
         target="fridge_coverage",
     )
 
 
-def _resolve_amenity_coverage(
+def _resolve_ramp_coverage(units: list[LodgingUnitSummary], index: _BathroomIndex) -> None:
+    """Fill in every unit's `ramp_coverage` in place — kindred#2438.
+
+    The third resolver over the one leaf walk, and every rule
+    `_resolve_power_coverage` established applies here unchanged: a container's
+    registry row describes the CONTAINER, an unconfirmed row means "nobody has
+    said", a deactivated room does not answer for its building, and a container
+    with no active room left reports `unknown` rather than falling back to its
+    own flag. One of the 14 production assessments IS on a container, and it is
+    ignored for exactly that reason.
+
+    TWO things are this function's own, and both come from `has_ramp` being a
+    three-value select rather than a bool:
+
+    1. A room answers in a THREE-VALUE vocabulary, so the verdict is graded by
+       `ramp_coverage` rather than `amenity_coverage` and carries a fifth
+       grade, `partial`. See that function for why `partial` folds into neither
+       `none` nor `some`.
+    2. BLANK IS NOT `no`. `_resolve_power_coverage`'s `None` case covers only
+       the unconfirmed ROW; here the field itself can be unanswered on a
+       confirmed row, and 104 of 118 production units are. So blank maps to
+       `None` — not assessed — and the building reports `unknown`. Reading it
+       as `no` would mark almost the whole registry step-free-hostile on
+       evidence nobody recorded, which is the inversion migration 1500000131
+       made the column a select to prevent.
+
+    An unrecognised string maps to `None` too — see `_ramp_assessment` for the
+    two directions that can produce one, neither of which is the registry
+    loader. An unreadable answer is no answer, never a claim in either
+    direction.
+    """
+    _resolve_amenity_coverage(
+        units,
+        index,
+        answer=lambda room: room.has_ramp or None,
+        grade=ramp_coverage,
+        target="ramp_coverage",
+    )
+
+
+def _resolve_amenity_coverage[Answer](
     units: list[LodgingUnitSummary],
     index: _BathroomIndex,
     *,
-    answer: Callable[[LodgingUnitSummary], bool],
+    answer: Callable[[LodgingUnitSummary], Answer | None],
+    grade: Callable[[Sequence[Answer | None]], str],
     target: str,
 ) -> None:
-    """The one leaf walk both resolvers above run.
+    """The one leaf walk all three resolvers above run.
 
     Parameterised on WHICH flag a room answers with and WHICH field receives
     the verdict, so a second amenity is a call site rather than a second
@@ -1109,6 +1177,14 @@ def _resolve_amenity_coverage(
     inactive rooms do not answer, unconfirmed rooms answer `None` — live here
     once; the reasoning for each lives in `_resolve_power_coverage`, which is
     the function that established them.
+
+    `Answer` is the vocabulary a ROOM answers in — `bool` for the boolean
+    flags, `str` for `has_ramp`'s three-value select — and `grade` is
+    parameterised alongside it for ONE reason, not for generality
+    (kindred#2438): `has_ramp` is a three-value select, so its rooms answer
+    `"yes"` / `"partial"` / `"no"` rather than a bool and need
+    `ramp_coverage`'s five-grade verdict. The WALK is what must not be
+    duplicated; which vocabulary a room answers in is the caller's business.
     """
     for unit in units:
         rooms = [
@@ -1120,14 +1196,11 @@ def _resolve_amenity_coverage(
         setattr(
             unit,
             target,
-            cast(
-                AmenityCoverage,
-                # `None` where nobody has confirmed the row: an unconfirmed
-                # `has_power = False` means "nobody has said", never "there is
-                # no power" -- the same gate `rosterAttention` already applies
-                # to the roster's own fit check.
-                amenity_coverage([answer(room) if room.is_confirmed else None for room in answering]),
-            ),
+            # `None` where nobody has confirmed the row: an unconfirmed
+            # `has_power = False` means "nobody has said", never "there is
+            # no power" -- the same gate `rosterAttention` already applies
+            # to the roster's own fit check.
+            grade([answer(room) if room.is_confirmed else None for room in answering]),
         )
 
 
@@ -1374,6 +1447,9 @@ class LodgingRosterService:
         # reasoning as above: `build_summary` carries no `units`, so resolving
         # coverage there would be work no response can read.
         _resolve_fridge_coverage(unit_summaries, unit_index)
+        # The same walk, one dimension over (kindred#2438), and the third and
+        # last read of it. Same path-only reasoning as above.
+        _resolve_ramp_coverage(unit_summaries, unit_index)
         # A SECOND PASS, and it has to be: a unit's cover can come from a row
         # on a unit built after it, so there is no order in which one pass over
         # `_build_units` would see every own-row it needs.
@@ -1993,6 +2069,11 @@ class LodgingRosterService:
                     has_ac=_b(unit, "has_ac"),
                     has_fridge=_b(unit, "has_fridge"),
                     has_shared_fridge=_b(unit, "has_shared_fridge"),
+                    # RAILED to the select's own vocabulary, not cast, so a
+                    # grade this code has never heard of reads as NOT ASSESSED
+                    # rather than leaking into the payload's Literal
+                    # (kindred#2438). See `_ramp_assessment`.
+                    has_ramp=_ramp_assessment(_s(unit, "has_ramp")),
                     is_accessible=_b(unit, "is_accessible"),
                     is_confirmed=_b(unit, "is_confirmed"),
                     is_active=_b(unit, "is_active"),
@@ -2457,6 +2538,11 @@ class LodgingRosterService:
             # above are: the derivation runs over RAW per-person narrative
             # values in the sync layer, and this service cannot see them.
             needs_fridge=_b(registration, "needs_fridge"),
+            # kindred#2438, and read from the column for the same reason: the
+            # derivation runs over RAW per-person narrative values in the sync
+            # layer, across BOTH housing narratives, and this service cannot
+            # see them.
+            needs_step_free=_b(registration, "needs_step_free"),
         )
 
     # --------------------------------------------------------------- counts

--- a/api/services/lodging_rules.py
+++ b/api/services/lodging_rules.py
@@ -223,6 +223,65 @@ def amenity_coverage(values: Sequence[bool | None]) -> str:
     return "none"
 
 
+def ramp_coverage(values: Sequence[str | None]) -> str:
+    """How much of a slot is step-free — kindred#2438.
+
+    The twin of `amenity_coverage` above, and a SEPARATE function for one
+    reason: `has_ramp` is a three-value select (`yes` / `no` / `partial`, blank
+    = NOT ASSESSED) rather than a bool, so a room can answer "qualified" and
+    the boolean grain has nowhere to put that. Migration 1500000131 made it a
+    select deliberately -- "a bool maps every unassessed cabin to false, which
+    asserts 'no ramp' about cabins nobody has looked at" -- and a boolean read
+    of it reports 0 of 118 units, erasing all 14 staff assessments (5 `yes`,
+    5 `partial`, 4 `no`, 104 blank on the production snapshot).
+
+    It does not walk anything, exactly as `amenity_coverage` does not: the
+    caller resolves which rooms answer, and `_BathroomIndex.leaf_codes_under`
+    is the ONE walk over that tree.
+
+    Args:
+        values: one entry per unit that answers for the slot -- `"yes"`,
+            `"partial"` or `"no"`. `None` means NO ANSWER, and it covers both
+            an unconfirmed row and an assessed-nobody blank; the caller maps
+            an unrecognised string to `None` too, because an unreadable answer
+            is not a claim in either direction.
+
+    Returns:
+        "all" | "some" | "partial" | "none" | "unknown".
+
+        FIVE grades, one more than the boolean amenities carry, and each is a
+        different claim:
+
+            all      every answering room is fully step-free
+            some     at least one is, but not all -- the reading that invites
+                     the placement landing in one of the others
+            partial  NO room is, but at least one has a qualified ramp
+            none     every answering room answered `no`
+            unknown  nothing answers
+
+        `partial` does not fold into `none`, because that would re-erase 5 of
+        the 14 assessments in the exact direction the select exists to prevent,
+        and 3 of those 5 carry the qualifier text in `notes`. It does not fold
+        into `some` either: "no room is step-free but one has a ramp with a
+        lip" is a weaker claim than "some rooms are step-free", and collapsing
+        them would make the grade order lie.
+
+        `unknown` whenever ANY contributing unit is unanswered -- the same
+        all-or-nothing evidence bar `amenity_coverage` states, and it matters
+        far more here: 104 of 118 units are blank, so a looser bar would grade
+        buildings step-free on the strength of the rooms somebody got to.
+    """
+    if not values or any(value is None for value in values):
+        return "unknown"
+    if all(value == "yes" for value in values):
+        return "all"
+    if any(value == "yes" for value in values):
+        return "some"
+    if any(value == "partial" for value in values):
+        return "partial"
+    return "none"
+
+
 def container_bathroom(leaf_bathroom_groups: frozenset[str]) -> tuple[str, str]:
     """A container's bathroom, inherited from its leaf descendants.
 

--- a/docs/reference/lodging-registry.md
+++ b/docs/reference/lodging-registry.md
@@ -210,6 +210,7 @@ loud on purpose, rather than a silently empty registry.
       "has_lights": true,
 
       "has_ramp": "partial",    // yes | no | partial; "" or absent = NOT ASSESSED
+                                //   read by the roster as ramp_coverage (#2438)
       "max_beds": 14,           // total sleeping spots. NOT sleeps — see below
 
       "shareability": "shareable"  // shareable | single_party; absent = not curated
@@ -333,6 +334,17 @@ default and splits fields by how much damage writing them could do:
 Two further rules: an empty `has_ramp` never overwrites a real assessment, and
 `notes` are filled only when the database has none — replacing free text a staff
 member wrote would destroy it.
+
+Since kindred#2438 `has_ramp` is no longer write-only: the weekend roster
+publishes it as `ramp_coverage`, resolved over a unit's LEAF descendants exactly
+as `power_coverage` and `fridge_coverage` are, and the board grades a family's
+`needs_step_free` flag against it. Two things follow for anyone editing this
+file. **Blank still means NOT ASSESSED and resolves `unknown`, never `none`** —
+104 of the 118 units are blank, so writing `no` into them would mark almost the
+whole registry step-free-hostile on evidence nobody recorded. And **`partial` is
+carried through** as its own grade rather than folded into either neighbour, so
+the ramp qualifier a `partial` unit records in `notes` stays the thing staff are
+being pointed at.
 
 `parent_unit` is compared as a **code**. The database stores it as a relation —
 a record id — so comparing raw values reports every parented unit as needing a

--- a/frontend/src/components/weekend/needsFit.test.ts
+++ b/frontend/src/components/weekend/needsFit.test.ts
@@ -27,6 +27,8 @@ function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
     has_fridge: false,
     has_shared_fridge: false,
     fridge_coverage: 'none',
+    has_ramp: '',
+    ramp_coverage: 'none',
     ...overrides,
   }
 }
@@ -196,6 +198,122 @@ describe('resolveNeedsFit — the fridge dimension (kindred#2224)', () => {
         unit({ power_coverage: 'none', fridge_coverage: 'all' })
       )
     ).toBe('fits')
+  })
+})
+
+describe('resolveNeedsFit — the step-free dimension (kindred#2438)', () => {
+  /*
+   * Dimension three, and the first one whose supply column is NOT a boolean.
+   * `has_ramp` is a three-value select (`yes` / `no` / `partial`, blank = NOT
+   * ASSESSED, migration 1500000131), which is why `ramp_coverage` carries a
+   * fifth grade the other two do not.
+   *
+   * Measured on the 2026 snapshot, household grain, both housing narratives:
+   * 14 of the 86 households carrying any narrative describe a mobility or
+   * step-free need, against 6 naming a fridge — more than twice the signal that
+   * justified shipping the fridge dimension. Supply: 14 of 118 units carry a
+   * staff assessment (5 yes / 5 partial / 4 no), which a BOOLEAN read of the
+   * select reports as 0 of 118. 2026 is only 16% placed, so 14 is the SHAPE of
+   * the demand, not a rate.
+   */
+  it('marks a space where no room is step-free as unmet', () => {
+    expect(
+      resolveNeedsFit(party({ flags: { needs_step_free: true } }), unit({ ramp_coverage: 'none' }))
+    ).toBe('unmet')
+  })
+
+  it('marks a space where only SOME rooms are step-free as unmet, not partial', () => {
+    // ⚠️ NOT the fridge reading. This is the `is_accessible` reasoning the
+    // module doc already spells out: a building advertising two step-free
+    // rooms out of ten invites precisely the placement that lands in one of
+    // the other eight. A fridge one room over is still a fridge a family can
+    // use; a ramp one room over is not.
+    expect(
+      resolveNeedsFit(party({ flags: { needs_step_free: true } }), unit({ ramp_coverage: 'some' }))
+    ).toBe('unmet')
+  })
+
+  it('marks a space whose best room is a QUALIFIED ramp as partial', () => {
+    // The fifth grade, and the reason the supply column is a select. Three of
+    // the five production `partial` units carry the ramp qualifier in `notes`
+    // — "look at this one" is exactly what the softer hatch says.
+    expect(
+      resolveNeedsFit(
+        party({ flags: { needs_step_free: true } }),
+        unit({ ramp_coverage: 'partial' })
+      )
+    ).toBe('partial')
+  })
+
+  it('marks nothing when every room is step-free', () => {
+    expect(
+      resolveNeedsFit(party({ flags: { needs_step_free: true } }), unit({ ramp_coverage: 'all' }))
+    ).toBe('fits')
+  })
+
+  it('marks nothing when nobody has assessed the space', () => {
+    // 104 of 118 production units are blank. Marking them would assert "no
+    // ramp" about cabins nobody has looked at — the exact inversion the select
+    // exists to prevent, and the reason the server resolves `unknown`.
+    expect(
+      resolveNeedsFit(
+        party({ flags: { needs_step_free: true } }),
+        unit({ ramp_coverage: 'unknown' })
+      )
+    ).toBe('fits')
+  })
+
+  it('never reads the raw has_ramp — a truthy string would invert the mark', () => {
+    // `has_ramp` is a STRING, so `'no'` is TRUTHY. Any consumer filtering on
+    // truthiness renders "step-free" on the four cabins staff assessed as
+    // explicitly having NO ramp. The resolved field is the only safe read, and
+    // this pins that the dimension takes it.
+    expect(
+      resolveNeedsFit(
+        party({ flags: { needs_step_free: true } }),
+        unit({ has_ramp: 'no', ramp_coverage: 'all' })
+      )
+    ).toBe('fits')
+    expect(
+      resolveNeedsFit(
+        party({ flags: { needs_step_free: true } }),
+        unit({ has_ramp: 'yes', ramp_coverage: 'none' })
+      )
+    ).toBe('unmet')
+  })
+
+  it('leaves a family that did not ask unmarked', () => {
+    expect(resolveNeedsFit(party(), unit({ ramp_coverage: 'none' }))).toBe('fits')
+  })
+
+  it('keeps the three dimensions independent', () => {
+    expect(
+      resolveNeedsFit(
+        party({ flags: { needs_step_free: true } }),
+        unit({ power_coverage: 'none', fridge_coverage: 'none', ramp_coverage: 'all' })
+      )
+    ).toBe('fits')
+    expect(
+      resolveNeedsFit(
+        party({ flags: { needs_power: true } }),
+        unit({ power_coverage: 'all', ramp_coverage: 'none' })
+      )
+    ).toBe('fits')
+  })
+
+  it('takes the WORSE of a soft ramp verdict and a hard one', () => {
+    expect(
+      resolveNeedsFit(
+        party({ flags: { needs_power: true, needs_step_free: true } }),
+        unit({ power_coverage: 'none', ramp_coverage: 'partial' })
+      )
+    ).toBe('unmet')
+    expect(
+      resolveNeedsFit(
+        party({ flags: { needs_power: true, needs_step_free: true } }),
+        unit({ power_coverage: 'all', ramp_coverage: 'partial' })
+      )
+    ).toBe('partial')
   })
 })
 

--- a/frontend/src/components/weekend/needsFit.ts
+++ b/frontend/src/components/weekend/needsFit.ts
@@ -41,6 +41,21 @@ import type { AccessibilityFlags, LodgingUnitRow, RosterPartyRow } from '../../t
  */
 type AmenityCoverage = NonNullable<LodgingUnitRow['power_coverage']>
 
+/**
+ * The step-free grade, and the one vocabulary that is NOT `AmenityCoverage`.
+ *
+ * `has_ramp` is a three-value select — `yes` / `no` / `partial`, blank = NOT
+ * ASSESSED (migration 1500000131) — so a room can answer "qualified" and the
+ * boolean grain has nowhere to put that. `ramp_coverage` therefore carries a
+ * fifth grade, `partial`, meaning NO room is fully step-free but at least one
+ * has a qualified ramp. Derived from the generated type for the same reason
+ * `AmenityCoverage` is.
+ */
+type RampCoverage = NonNullable<LodgingUnitRow['ramp_coverage']>
+
+/** Every grade any dimension's resolved coverage field can report. */
+type Coverage = AmenityCoverage | RampCoverage
+
 /** Worst first. The order of this array IS the precedence. */
 const FIT_ORDER = ['unmet', 'partial', 'fits'] as const
 
@@ -72,6 +87,13 @@ export function worseOf(a: NeedsFit, b: NeedsFit): NeedsFit {
  * exactly one object literal: no new glyph, no new colour, no new chip, and
  * no change to this function.
  *
+ * `needs_step_free` (kindred#2438) is the third, and it is the honest
+ * counter-example: it cost one object literal AND one branch in
+ * `resolveNeedsFit`, because its supply column is a three-value select rather
+ * than a bool and `ramp_coverage` carries a grade the boolean amenities have
+ * no word for. That is a property of the REGISTRY, not a sign dimension one
+ * was built wrong — and it is still no new glyph, no new colour, no new chip.
+ *
  * `someIs` is the per-criterion nuance the grain deliberately does NOT carry,
  * because the three grains do not mean the same thing for every criterion.
  * For power, a building where some rooms have it is a real improvement on one
@@ -88,7 +110,7 @@ interface NeedsDimension {
   /** The household's asked-for need. */
   readonly flag: keyof AccessibilityFlags
   /** The unit's answer, resolved server-side over its leaf descendants. */
-  readonly coverage: (unit: LodgingUnitRow) => AmenityCoverage
+  readonly coverage: (unit: LodgingUnitRow) => Coverage
   /** What a partially-covered space reads as for THIS criterion. */
   readonly someIs: Exclude<NeedsFit, 'fits'>
 }
@@ -128,6 +150,34 @@ const NEEDS_DIMENSIONS: readonly NeedsDimension[] = [
     // fridge a family can use.
     someIs: 'partial',
   },
+  {
+    // kindred#2438. The third dimension, and the first whose supply column was
+    // already in the registry: `lodging_units.has_ramp` has recorded step-free
+    // access since migration 1500000131 and nothing in the product read it.
+    //
+    // Demand, measured on the 2026 snapshot at household grain across BOTH
+    // housing narratives: 14 of the 86 households carrying any narrative
+    // describe a mobility or step-free need, against 6 naming a fridge. Supply:
+    // 14 of 118 units carry a staff assessment — 5 `yes`, 5 `partial`, 4 `no`,
+    // 104 blank. A BOOLEAN read of that select reports 0 of 118 and erases all
+    // 14, which is how the column came to look empty. 2026 is only 16% placed,
+    // so 14 is the SHAPE of the demand, not a rate.
+    flag: 'needs_step_free',
+    // `ramp_coverage`, never the raw `has_ramp` — and here that is not only the
+    // container trap the two entries above spell out. `has_ramp` is a STRING,
+    // so `'no'` is TRUTHY: any consumer testing it for truthiness renders
+    // "step-free" on the four cabins staff assessed as explicitly having no
+    // ramp, the exact inversion the select exists to prevent.
+    coverage: (unit) => unit.ramp_coverage ?? 'unknown',
+    // ⚠️ NOT the fridge reading — this one takes the `is_accessible` shape the
+    // module doc above describes, and for the reason stated there: a building
+    // advertising two step-free rooms out of ten invites precisely the
+    // placement that lands in one of the other eight. What settles it against
+    // fridge is the shared-fridge ruling's own logic in reverse: a fridge one
+    // room over is still a fridge a family can use, and a ramp one room over
+    // is not.
+    someIs: 'unmet',
+  },
 ]
 
 /**
@@ -146,7 +196,22 @@ export function resolveNeedsFit(party: RosterPartyRow, unit: LodgingUnitRow): Ne
     if (party.flags?.[dimension.flag] !== true) continue
     const coverage = dimension.coverage(unit)
     const verdict: NeedsFit =
-      coverage === 'none' ? 'unmet' : coverage === 'some' ? dimension.someIs : 'fits'
+      coverage === 'none'
+        ? 'unmet'
+        : coverage === 'some'
+          ? dimension.someIs
+          : // The fifth grade, reachable only from `ramp_coverage`
+            // (kindred#2438), and mapped here rather than through a second
+            // per-dimension knob beside `someIs` because unlike SOME it does
+            // not mean different things to different criteria: it says the
+            // space itself is QUALIFIED — a ramp with a lip — which is a
+            // softer statement than "nothing here" in every reading of it.
+            // Softer than `some`, deliberately: `some` is about a building
+            // whose rooms disagree, and the risk there is the placement
+            // landing in the wrong one.
+            coverage === 'partial'
+            ? 'partial'
+            : 'fits'
     worst = worseOf(verdict, worst)
   }
   return worst

--- a/frontend/src/components/weekend/placementCandidates.ts
+++ b/frontend/src/components/weekend/placementCandidates.ts
@@ -49,14 +49,16 @@
  *
  * ⚠️ THE TWO TABLES HAVE DIVERGED, and the divergence is a live decision
  * rather than an oversight. `needsFit` was seeded with power ALONE; kindred#2224
- * added `needs_fridge` there and NOT here, so a family whose accommodation
- * narrative asks for a fridge is hatched mid-drag on a fridgeless cabin and
- * annotated `fits` in this picker (and reported `settled` by
- * `rosterAttention`'s `VERIFIABLE_NEEDS`, which does not carry it either).
- * Whether the fridge need earns a sentence here and a roster-row reason there
- * is a staff-copy question that belongs with kindred#2072's ruled glyph set
- * (bathroom · power · fridge) — it is not settled by this comment. Until it
- * is, do not assume silence here means the need does not apply.
+ * added `needs_fridge` there and NOT here, and kindred#2438 added
+ * `needs_step_free` on the same terms — so a family whose housing narrative
+ * asks for a fridge or for step-free access is hatched mid-drag on a cabin
+ * that cannot supply it and annotated `fits` in this picker (and reported
+ * `settled` by `rosterAttention`'s `VERIFIABLE_NEEDS`, which carries neither).
+ * Whether those needs earn a sentence here and a roster-row reason there is a
+ * staff-copy question that belongs with kindred#2072's ruled glyph set
+ * (bathroom · power · fridge) — it is not settled by this comment, and the
+ * step-free need is not in that ruled set at all. Until it is, do not assume
+ * silence here means the need does not apply.
  *
  * The power rule is stated in both places. ⚠️ CHANGE ONE, CHANGE
  * BOTH — same field (`power_coverage`, never the raw `has_power`), same

--- a/frontend/src/components/weekend/rosterAttention.ts
+++ b/frontend/src/components/weekend/rosterAttention.ts
@@ -56,17 +56,21 @@ export const ATTENTION_LABEL: Record<AttentionLevel, string> = {
  * from the household's ages rather than asked for, so it informs which cabin
  * suits them without being an unfulfilled request.
  *
- * ⚠️ `needs_fridge` (kindred#2224) is a DIFFERENT kind of absence, and it is
- * NOT settled. Unlike `needs_accommodation` it does name an amenity the
- * registry answers (`fridge_coverage`), and `needsFit.ts` already grades it
- * for the drag-time hatch — so a placed family with an unmet fridge need
- * currently reports `settled` here while the same family+cabin pair hatches
- * mid-drag. Wiring it is not mechanical: the two entries below read a RAW
- * unit field, and a fridge entry cannot, because the owner's 2026-08-15
- * ruling ("a shared fridge IS a fridge") and the container trap both live in
- * the server-resolved `fridge_coverage` rather than in `has_fridge`. It also
- * puts new words in front of staff. Both belong with kindred#2072's ruled
- * glyph set (bathroom · power · fridge), not here.
+ * ⚠️ `needs_fridge` (kindred#2224) and `needs_step_free` (kindred#2438) are a
+ * DIFFERENT kind of absence, and neither is settled. Unlike
+ * `needs_accommodation` both name an amenity the registry answers
+ * (`fridge_coverage`, `ramp_coverage`), and `needsFit.ts` already grades both
+ * for the drag-time hatch — so a placed family with an unmet fridge or
+ * step-free need currently reports `settled` here while the same family+cabin
+ * pair hatches mid-drag. Wiring either is not mechanical: the two entries
+ * below read a RAW unit field, and neither of these can, because the owner's
+ * 2026-08-15 ruling ("a shared fridge IS a fridge") and the container trap
+ * live in the server-resolved `fridge_coverage`, while `has_ramp` is a
+ * three-value select whose `'no'` is a TRUTHY string — reading it raw would
+ * report "step-free" on the four cabins staff assessed as having no ramp. It
+ * also puts new words in front of staff. Both belong with kindred#2072's ruled
+ * glyph set (bathroom · power · fridge), not here — and note the step-free
+ * need is not in that ruled set at all.
  */
 const VERIFIABLE_NEEDS = [
   {

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -81,6 +81,10 @@ export type AccessibilityFlagSummary = {
    */
   needs_fridge?: boolean
   /**
+   * Needs Step Free
+   */
+  needs_step_free?: boolean
+  /**
    * Accommodation Is Mandatory
    */
   accommodation_is_mandatory?: boolean
@@ -2234,6 +2238,14 @@ export type LodgingUnitSummary = {
    * Fridge Coverage
    */
   fridge_coverage?: 'all' | 'some' | 'none' | 'unknown'
+  /**
+   * Has Ramp
+   */
+  has_ramp?: '' | 'yes' | 'no' | 'partial'
+  /**
+   * Ramp Coverage
+   */
+  ramp_coverage?: 'all' | 'some' | 'partial' | 'none' | 'unknown'
   /**
    * Is Accessible
    */

--- a/frontend/src/types/lodging.test.ts
+++ b/frontend/src/types/lodging.test.ts
@@ -282,6 +282,15 @@ const _exhaustiveLodgingUnit: Required<LodgingUnitRow> = {
   // container's row describes the CONTAINER, so this is what a drop is judged
   // against; `has_fridge` above stays the registry's own fact about the row.
   fridge_coverage: 'none',
+  // THREE-VALUE select plus blank, never a bool (kindred#2438). `'no'` is a
+  // TRUTHY string, so anything filtering this on truthiness renders the glyph
+  // on the four cabins staff assessed as having no ramp — which is why the
+  // reader surface is `ramp_coverage` below and this is only the row's fact.
+  has_ramp: '',
+  // The step-free twin of `power_coverage`, resolved over the same leaf walk,
+  // and the only one of the three that carries a `partial` grade: a ramp with
+  // a lip is a real answer a boolean amenity has nowhere to put.
+  ramp_coverage: 'none',
   is_accessible: false,
   is_confirmed: true,
   is_active: true,

--- a/frontend/src/types/pocketbase-types.ts
+++ b/frontend/src/types/pocketbase-types.ts
@@ -688,6 +688,7 @@ export type FamilyCampRegistrationsRecord = {
   needs_fridge?: boolean
   needs_power?: boolean
   needs_private_bathroom?: boolean
+  needs_step_free?: boolean
   notes?: string
   opt_out_vip?: boolean
   request_last_updated?: IsoDateString

--- a/pocketbase/pb_migrations/1500000167_family_camp_registrations_needs_step_free.js
+++ b/pocketbase/pb_migrations/1500000167_family_camp_registrations_needs_step_free.js
@@ -1,0 +1,81 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: add `needs_step_free` to family_camp_registrations. kindred#2438.
+ *
+ * ONE ADDITIVE BOOLEAN, the exact shape 1500000164 added for `needs_fridge`.
+ * The row grain is unchanged and stays (household, year).
+ *
+ * WHY IT EXISTS. The registry has recorded step-free access since 1500000131 --
+ * `has_ramp`, a THREE-VALUE select (`yes`/`no`/`partial`, blank = not assessed)
+ * -- and nothing in the product ever read it. The demand side had never been
+ * measured at all. Measured now on the production snapshot, 2026, at the
+ * household grain and across BOTH narrative fields: of the 86 households
+ * carrying any narrative, 14 describe a mobility or step-free need, against 6
+ * naming cold storage. The mobility signal is more than TWICE the fridge signal
+ * that justified shipping a whole need dimension in 1500000164.
+ *
+ * Supply, over all 118 units: 104 blank, 4 `no`, 5 `partial`, 5 `yes` -- 14
+ * staff assessments. Reading that select as a BOOL reports 0 of 118 and erases
+ * every one of them, which is how the column came to look empty.
+ *
+ * ⚠️ NOT GATED ON needs_accommodation. All 6 fridge households are
+ * accommodation-gated; only 11 of the 14 mobility households are. The other 3
+ * narrate the need through the bathroom question and answer no gate at all, so
+ * this flag joins the has-some-data guard in processRegistrations rather than
+ * sitting behind the gate -- otherwise those rows are dropped before they are
+ * written.
+ *
+ * WHAT THIS COLUMN IS NOT: the narrative. It is a DERIVED BOOLEAN, and that is
+ * the split migration 1500000126 drew -- family_camp_medical is admin-gated on
+ * all five rules and holds the sentence; this table holds only flags, because
+ * the sentences name individuals' conditions. `bathroom_explain` and
+ * `accommodation_explain` stay where they are and nothing here duplicates them.
+ *
+ * ADVISORY, NEVER A REFUSAL. Keyword resolution over family-authored prose is
+ * wrong sometimes, so the flag hatches a unit card and never dims one. The
+ * derivation prefers RECALL over precision for the same reason 1500000164
+ * states: a false positive costs a mark staff overrule at a glance, a false
+ * negative returns the household to prose nobody parses.
+ *
+ * BACKFILL: none, deliberately, and there is nothing to recover. The narrative
+ * columns this derives from carry text for 2026 ONLY (86 households; every
+ * prior year is empty), so this is a 2026-forward signal with no history --
+ * and a prior-year `false` is the absence of an input, never a measured "did
+ * not ask". A migration could not compute it either: the input is a
+ * person-partition custom value that needs the household collapse.
+ * family_camp_derived must be RE-RUN for 2026 after this ships or the column
+ * stays empty everywhere.
+ *
+ * PocketBase v0.23 syntax: fields.add(new Field({...})) on an existing
+ * collection, properties DIRECT rather than inside options{}. A bare
+ * add({...}) silently does nothing. addField() is a no-op when the column
+ * already exists, because PB records an applied migration by FILENAME -- a
+ * later edit to this file would never re-run on a database that has already
+ * seen it, and `Set` on a missing column is a silent no-op that simply never
+ * persists. `has_infant` hit exactly that.
+ */
+
+/**
+ * Adds a field unless the collection already has one by that name.
+ * @param {core.Collection} collection
+ * @param {core.Field} field
+ */
+function addField(collection, field) {
+  if (!collection.fields.getByName(field.name)) {
+    collection.fields.add(field);
+  }
+}
+
+migrate((app) => {
+  const regs = app.findCollectionByNameOrId("family_camp_registrations");
+
+  addField(regs, new Field({
+    type: "bool", name: "needs_step_free", required: false, presentable: false
+  }));
+
+  app.save(regs);
+}, (app) => {
+  const regs = app.findCollectionByNameOrId("family_camp_registrations");
+  regs.fields.removeByName("needs_step_free");
+  app.save(regs);
+});

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -346,6 +346,11 @@ type registrationData struct {
 	// admin-gated and absent from every export (lodging_medical_narrative_test.go).
 	needsFridge bool
 
+	// kindred#2438. The step-free twin of needsFridge, and the reason it is a
+	// SEPARATE derivation rather than a wider keyword list on the same one: it
+	// routes BOTH narrative fields. See stepFreeKeywords.
+	needsStepFree bool
+
 	// Housing-suitability signal rather than an accessibility need (kindred#1876).
 	hasInfant bool
 
@@ -1606,6 +1611,20 @@ func (s *FamilyCampDerivedSync) processRegistrations(
 			if isAccommodationExplainField(v.fieldName) {
 				reg.needsFridge = reg.needsFridge || mentionsFridge(v.value)
 			}
+			// The step-free need reads BOTH narratives, and that difference is
+			// measured rather than defensive (kindred#2438). Copying the fridge
+			// route verbatim would lose more than a third of this signal: on
+			// the 2026 snapshot 5 of the 14 mobility households narrate ONLY
+			// through the bathroom field and 3 through both, against 0 of the 6
+			// fridge households. A family explaining why it needs a private bathroom
+			// is often explaining that someone cannot walk to the shared one.
+			//
+			// The two routes stay separate for the same measured reason: no
+			// fridge ask lands in the bathroom field, so widening one must not
+			// widen the other.
+			if isAccommodationExplainField(v.fieldName) || isBathroomExplainField(v.fieldName) {
+				reg.needsStepFree = reg.needsStepFree || mentionsStepFree(v.value)
+			}
 		}
 	}
 
@@ -1649,6 +1668,12 @@ func (s *FamilyCampDerivedSync) processRegistrations(
 			// only parseable answer is the narrative-derived need would be the
 			// row dropped before it is written.
 			reg.needsFridge ||
+			// And needs_step_free more so than the fridge line above: 3 of the
+			// 14 mobility households on the 2026 snapshot are NOT
+			// accommodation-gated, against 0 of the 6 fridge households, so
+			// this is a guard entry with rows actually behind it rather than a
+			// defensive one (kindred#2438).
+			reg.needsStepFree ||
 			// accommodationIsMandatory belongs here for the same reason as the
 			// rest, and more so: it is the blocker signal, and a household whose
 			// only answer is the blocker was the one row that got dropped before
@@ -1717,6 +1742,110 @@ func mentionsFridge(text string) bool {
 		}
 	}
 	return false
+}
+
+// bathroomExplainFieldNames routes the bathroom NARRATIVE, by literal display
+// name, in both places that read it: processMedical (which stores the sentence)
+// and processRegistrations (which derives needs_step_free from it and stores
+// nothing). ONE list, for the reason accommodationExplainFieldNames states
+// above -- two copies of a name-keyed route drift the moment a generation is
+// added.
+//
+// "Housing-Bathroom" (cm_id 274059) is the Camper partition and "Bathroom-Yes"
+// (274054) the Adult twin. Unlike the accommodation list this carries NO
+// defensive successors: that list has them because CampMinder demonstrably
+// misspells "Accommodation" with one m -- it is how the live adult gate is
+// spelled -- and no comparable misspelling of these two has ever been observed.
+// The name-routing fragility is identical, so a rename here would silently stop
+// population too; inventing spellings nobody has seen is a guess, and this
+// comment is the warning instead.
+var bathroomExplainFieldNames = []string{
+	"Housing-Bathroom",
+	"Bathroom-Yes",
+}
+
+// isBathroomExplainField reports whether name routes the bathroom narrative.
+func isBathroomExplainField(name string) bool {
+	return slices.Contains(bathroomExplainFieldNames, name)
+}
+
+// stepFreeKeywords is the recall surface for needs_step_free (kindred#2438).
+//
+// RECALL OVER PRECISION, for the reason fridgeKeywords states: the flag is
+// ADVISORY -- it hatches a unit card, it never refuses a drop -- so a false
+// positive costs a mark staff overrule at a glance while a false negative costs
+// the ask entirely and returns the household to prose nobody parses.
+//
+// Measured over BOTH narrative fields on the production snapshot, 2026,
+// household grain: this surface finds 14 of the 86 households carrying any
+// narrative, against 6 for fridge. Contributions, so the surface can be argued
+// rather than inherited:
+//
+//	"walk"          -- 10, and as a SUBSTRING, so it also catches
+//	                   walking/walkway. Every one of the ten reads as a genuine
+//	                   step-free ask on inspection.
+//	"mobilit"       -- 2, one of them new.
+//	"knee" / "hip"  -- 3 and 3, THREE of them new. Every knee/hip mention in
+//	                   the corpus, in every year, is a mobility limitation:
+//	                   a joint replacement, a post-surgical recovery, or a
+//	                   stated limit on how far someone can walk. Zero false
+//	                   positives, which is why a diagnosis word earns its place
+//	                   in an otherwise ask-shaped list. (Aggregate only -- the
+//	                   narratives themselves are PHI and are not quoted here.)
+//	"crutch"        -- 1, none new.
+//
+// Every other entry matches 0 households today and is kept because each is the
+// plain word for an ask `has_ramp` answers. 2026 is only 16% placed, so 14 is
+// the SHAPE of the demand, not a rate.
+//
+// DELIBERATELY EXCLUDED: bare "close to". It matches 5 households, and it is
+// PROXIMITY rather than step-free access -- a different ask, which the registry
+// answers with `map_x`/`map_y` and `near_bathhouse` rather than with `has_ramp`,
+// so a household flagged on it would be hatched against a column that cannot
+// speak to what they asked for. The mobility-bearing one of the five is already
+// caught by "knee"; the three that remain uncaught are a child who needs to be
+// near activities, a family recalling a past illness, and a bathroom-proximity
+// request that `needs_private_bathroom` already carries. None is a step-free
+// ask. (This is the one exclusion, and it is a PRECISION judgement made against
+// a specific supply column -- not a retreat from the recall rule above.)
+//
+// SUBSTRING matching, as fridgeKeywords uses, because the input is unvalidated
+// prose and anything stricter loses answers to punctuation and compounding:
+// "walk" has to catch walking and walkway, "mobilit" has to catch mobility and
+// mobilities, "stair" has to catch stairs and stairway.
+var stepFreeKeywords = []string{
+	"walk", "mobilit", "wheelchair", "scooter", "crutch",
+	"knee", "stair", "steps",
+	"ground floor", "single level", "one level",
+}
+
+// stepFreeWordPattern holds the three keywords that must match as WHOLE WORDS.
+//
+// Substring matching is the rule above and it is right for the rest, but these
+// three are short enough to sit inside common, unrelated words: "hip" is in
+// RELATIONSHIP and SHIPPING, "cane" is in HURRICANE, "ramp" is in CRAMP. None
+// of those says anything about mobility, so firing on them is not the
+// near-miss that recall-over-precision buys -- it is an unrelated word, and it
+// would mark a household that asked for nothing of the kind.
+//
+// Deliberately still generous WITHIN the word: the plural and the hyphenated
+// compound both match ("hips", "post-op hip", "ramps", "canes"), because \b
+// treats the hyphen as a boundary.
+var stepFreeWordPattern = regexp.MustCompile(`\b(hips?|canes?|ramps?)\b`)
+
+// mentionsStepFree reports whether a free-text answer describes a mobility or
+// step-free access need. Case-insensitive substring matching, exactly as
+// mentionsFridge does and for the same reason: the input is unvalidated
+// family-authored prose, so anything stricter loses answers to punctuation and
+// compounding.
+func mentionsStepFree(text string) bool {
+	lower := strings.ToLower(text)
+	for _, kw := range stepFreeKeywords {
+		if strings.Contains(lower, kw) {
+			return true
+		}
+	}
+	return stepFreeWordPattern.MatchString(lower)
 }
 
 // cpapAnswer is the result of classifying one answer to a CPAP field.
@@ -2069,9 +2198,12 @@ func (s *FamilyCampDerivedSync) processMedical(personValues []customValueEntry) 
 		// describe named individuals' medical circumstances, so they live only
 		// here -- family_camp_medical is admin-gated on all five rules and is
 		// absent from every export config (lodging_medical_narrative_test.go asserts that).
-		bathroomKeys := []string{"Housing-Bathroom", "Bathroom-Yes"}
-		bathroomParts := make([]string, 0, len(bathroomKeys))
-		for _, key := range bathroomKeys {
+		// bathroomExplainFieldNames is the ONE routing list, shared with
+		// processRegistrations' needs_step_free derivation (kindred#2438) so a
+		// generation added for one is added for both -- the same discipline
+		// accommodationExplainFieldNames below already follows.
+		bathroomParts := make([]string, 0, len(bathroomExplainFieldNames))
+		for _, key := range bathroomExplainFieldNames {
 			bathroomParts = append(bathroomParts, fields.parts(key)...)
 		}
 		med.bathroomExplain = s.joinMedicalColumn(householdID, "bathroom_explain", bathroomParts)
@@ -2526,6 +2658,7 @@ func (s *FamilyCampDerivedSync) registrationNeedsUpdate(existing *core.Record, r
 		existing.GetBool("accommodation_is_mandatory") != reg.accommodationIsMandatory ||
 		existing.GetBool("has_infant") != reg.hasInfant ||
 		existing.GetBool("needs_fridge") != reg.needsFridge ||
+		existing.GetBool("needs_step_free") != reg.needsStepFree ||
 		existing.GetString("share_eligibility") != normalizedEligibility ||
 		existing.GetString("share_eligibility_source") != normalizedSource ||
 		existing.GetBool("share_answers_conflict") != reg.shareAnswersConflict ||
@@ -2550,6 +2683,7 @@ func setRegistrationRequestFields(record *core.Record, reg *registrationData) {
 	record.Set("accommodation_is_mandatory", reg.accommodationIsMandatory)
 	record.Set("has_infant", reg.hasInfant)
 	record.Set("needs_fridge", reg.needsFridge)
+	record.Set("needs_step_free", reg.needsStepFree)
 	// The board's placement verdict. share_cabin_gate above stays the raw
 	// REGISTRATION answer; this is the resolved one, and the Family Camp
 	// information form outranks the gate wherever both were answered.

--- a/pocketbase/sync/family_camp_derived_replay_test.go
+++ b/pocketbase/sync/family_camp_derived_replay_test.go
@@ -112,7 +112,7 @@ func newFamilyCampReplayTestApp(t *testing.T) core.App {
 	boolean(regs, "needs_accommodation", "opt_out_vip", "wants_near", "wants_with",
 		"wants_similar_ages", "needs_private_bathroom", "needs_power",
 		"accommodation_is_mandatory", "has_infant", "share_answers_conflict",
-		"needs_fridge")
+		"needs_fridge", "needs_step_free")
 	text(regs, enrollmentStatusColumn)
 	save(regs)
 

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -3861,3 +3861,222 @@ func TestProcessAdultsDedupesHandlesThreeRowGroup(t *testing.T) {
 		t.Errorf("survivor adult_number = %d, want 1 (lowest slot wins)", adults[0].adultNumber)
 	}
 }
+
+// -------------------------------------------------------------- needs_step_free
+//
+// kindred#2438. The third graded need dimension, mirroring needs_fridge
+// (kindred#2224) one column over: the family's ask is resolved out of the same
+// free-text narrative, and the registry answers it with `has_ramp`.
+//
+// Measured on the production snapshot, 2026, at the household grain and over
+// BOTH narrative fields: 86 households carry any narrative at all, 6 name cold
+// storage, and 14 describe a mobility or step-free need -- more than twice the
+// signal that justified shipping needs_fridge. Supply: 14 of 118 units carry a
+// staff `has_ramp` assessment (5 yes / 5 partial / 4 no), which a boolean read
+// of that three-value select reports as 0.
+//
+// The narrative is PHI-adjacent, so only the BOOLEAN is derived here; the
+// sentence stays in family_camp_medical, which is admin-gated and absent from
+// every export.
+
+func TestProcessRegistrationsDerivesNeedsStepFreeFromTheAccommodationNarrative(t *testing.T) {
+	t.Parallel()
+	s := NewFamilyCampDerivedSync(nil)
+
+	regs := s.processRegistrations(nil, []customValueEntry{
+		{householdPBID: "hh_johnson", fieldName: "Housing Accommodation", value: "Yes"},
+		{householdPBID: "hh_johnson", fieldName: "Housing Accommodation-Yes",
+			value: "One adult in our party cannot manage a long uphill walk"},
+	})
+	if len(regs) != 1 {
+		t.Fatalf("registrations = %d, want 1", len(regs))
+	}
+	if !regs[0].needsStepFree {
+		t.Error("an accommodation narrative describing limited walking did not set needsStepFree")
+	}
+}
+
+// ⚠️ THE ROUTING TRAP. needs_fridge reads the accommodation narrative ALONE,
+// and copying that routing verbatim loses more than a third of this signal: on
+// the 2026 snapshot 5 of the 14 mobility households narrate ONLY through the
+// bathroom field and 3 through both, against 0 of the 6 fridge households. It makes
+// sense -- a family explaining why they need a private bathroom is often
+// explaining that someone cannot walk to the shared one.
+func TestProcessRegistrationsDerivesNeedsStepFreeFromTheBathroomNarrative(t *testing.T) {
+	t.Parallel()
+
+	// Both partitions of the bathroom narrative: "Housing-Bathroom" is the
+	// Camper key (cm_id 274059) and "Bathroom-Yes" the Adult twin (274054).
+	for _, name := range []string{"Housing-Bathroom", "Bathroom-Yes"} {
+		s := NewFamilyCampDerivedSync(nil)
+		regs := s.processRegistrations(nil, []customValueEntry{
+			{householdPBID: "hh_garcia", fieldName: name,
+				value: "Grandmother uses crutches and cannot manage the steps to the bathhouse"},
+		})
+		if len(regs) != 1 || !regs[0].needsStepFree {
+			t.Errorf("field %q did not route into needsStepFree", name)
+		}
+	}
+}
+
+// The two routings stay DISTINCT. needs_fridge deliberately reads only the
+// accommodation narrative (kindred#2224 measured 0 fridge asks in the bathroom
+// field), so widening the step-free route must not widen the fridge one with it.
+func TestProcessRegistrationsDoesNotDeriveNeedsFridgeFromTheBathroomNarrative(t *testing.T) {
+	t.Parallel()
+	s := NewFamilyCampDerivedSync(nil)
+
+	regs := s.processRegistrations(nil, []customValueEntry{
+		// A gate answer, so the row survives the has-some-data guard on
+		// something other than the flag under test.
+		{householdPBID: "hh_garcia", fieldName: "Housing Accommodation", value: "Yes"},
+		{householdPBID: "hh_garcia", fieldName: "Housing-Bathroom",
+			value: "we would like a fridge in the cabin"},
+	})
+	if len(regs) != 1 {
+		t.Fatalf("registrations = %d, want 1", len(regs))
+	}
+	if regs[0].needsFridge {
+		t.Error("the bathroom narrative set needsFridge -- the fridge route reads accommodation only")
+	}
+}
+
+// RECALL OVER PRECISION, on the same reasoning as mentionsFridge: the flag is
+// ADVISORY -- it hatches a card and never refuses a drop -- so a false positive
+// costs a mark staff overrule at a glance while a false negative costs the ask.
+func TestMentionsStepFreeVocabulary(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		text string
+		want bool
+	}{
+		// "walk" carries most of the signal on its own: 10 of the 14 2026
+		// households, as a SUBSTRING so it also catches walking/walkway.
+		{"cannot walk to the bathhouse in the dark", true},
+		{"trouble walking on uneven ground", true},
+		{"somewhere with an even walkway from the parking area", true},
+		{"limited mobility", true},
+		{"MOBILITY ISSUES, please", true},
+		{"she walks on crutches", true},
+		// Zero households on the 2026 snapshot, kept for recall: each is the
+		// plain word for an ask the registry's has_ramp column answers.
+		{"we need a wheelchair accessible cabin", true},
+		{"a cabin with a ramp", true},
+		{"cannot manage stairs", true},
+		{"no steps please", true},
+		{"a ground floor room", true},
+		{"anywhere on a single level", true},
+		{"one level, no climbing", true},
+		{"he uses a mobility scooter", true},
+		{"dad walks with a cane", true},
+		// Diagnosis words, admitted on evidence rather than on shape: every
+		// knee/hip mention in the corpus, in every year, is a mobility
+		// limitation -- a joint replacement, a post-surgical recovery, or a
+		// stated limit on distance -- and three are households nothing else in
+		// this surface catches.
+		{"her knee replacement is still healing", true},
+		{"post-op hip, cannot manage a slope", true},
+		// ⚠️ "hip" MUST match as a whole word. As a bare substring it fires on
+		// "relationship" and "shipping", which are ordinary words in a family
+		// narrative and say nothing about mobility -- a false positive that
+		// recall-over-precision does not buy, because it is not a near-miss on
+		// the ask, it is an unrelated word. "cane" and "ramp" are the same
+		// shape ("hurricane", "cramp"), so they take the same rule.
+		{"our family relationship with camp goes back years", false},
+		{"shipping the trunk ahead of time", false},
+		{"the hurricane year, 2024", false},
+		{"she gets leg cramps at night", false},
+		{"", false},
+		{"We need a private bathroom", false},
+		{"a mini fridge for insulin", false},
+		// Deliberately OUT of the surface. Bare "close to" matches 5 of the 86
+		// 2026 narrative households and is PROXIMITY, not step-free access --
+		// the registry answers it with map coordinates and near_bathhouse, not
+		// with has_ramp, so flagging on it hatches cards against a column that
+		// cannot speak to the ask.
+		{"please put us close to the dining hall", false},
+	} {
+		if got := mentionsStepFree(tc.text); got != tc.want {
+			t.Errorf("mentionsStepFree(%q) = %v, want %v", tc.text, got, tc.want)
+		}
+	}
+}
+
+// ⚠️ THE GATE TRAP. 3 of the 14 2026 mobility households are NOT
+// accommodation-gated, so needs_step_free has to join the has-some-data guard
+// that decides whether a registration row is written at all -- otherwise those
+// three rows are dropped before they are stored, and the flag is invisible for
+// exactly the households nothing else records.
+func TestProcessRegistrationsStepFreeOnlyHouseholdSurvives(t *testing.T) {
+	t.Parallel()
+	s := NewFamilyCampDerivedSync(nil)
+
+	regs := s.processRegistrations(nil, []customValueEntry{
+		{householdPBID: "hh_lee", fieldName: "Housing-Bathroom",
+			value: "cannot walk far from the parking area"},
+	})
+	if len(regs) != 1 {
+		t.Fatalf("registrations = %d, want 1 -- the ungated step-free household was dropped", len(regs))
+	}
+	if !regs[0].needsStepFree {
+		t.Error("needsStepFree not set")
+	}
+	if regs[0].needsAccommodation {
+		t.Error("needsAccommodation set -- this household answered no gate question at all")
+	}
+}
+
+// PHI CONTAINMENT, the same bar needs_fridge holds. The mobility narrative names
+// individuals and their conditions; only the boolean may reach
+// family_camp_registrations, which is not admin-gated.
+func TestProcessRegistrationsNeverStoresTheMobilityNarrative(t *testing.T) {
+	t.Parallel()
+	s := NewFamilyCampDerivedSync(nil)
+
+	const narrative = "Grandmother has late-stage neuropathy and cannot walk on gravel"
+	regs := s.processRegistrations(nil, []customValueEntry{
+		{householdPBID: "hh_lee", fieldName: "Housing-Bathroom", value: narrative},
+	})
+	if len(regs) != 1 {
+		t.Fatalf("registrations = %d, want 1", len(regs))
+	}
+	for column, stored := range map[string]string{
+		"notes":                  regs[0].notes,
+		"goals":                  regs[0].goals,
+		"special_occasions":      regs[0].specialOccasions,
+		"request_text":           regs[0].requestText,
+		"cabin_assignment":       regs[0].cabinAssignment,
+		"share_cabin_preference": regs[0].shareCabinPreference,
+		"shared_cabin_modes_raw": regs[0].sharedCabinModesRaw,
+		"arrival_eta":            regs[0].arrivalETA,
+	} {
+		if strings.Contains(stored, "neuropathy") {
+			t.Errorf("registration column %s carries the medical narrative: %q", column, stored)
+		}
+	}
+}
+
+// ONE routing list, shared by processMedical (which stores the sentence) and
+// processRegistrations (which derives a boolean and stores nothing) -- the same
+// discipline accommodationExplainFieldNames already follows, and for the same
+// reason: two copies of a name-keyed route drift the moment a generation is
+// added, which is how the Adult accommodation twin came to be read in one of
+// the two and not the other.
+func TestProcessMedicalBathroomExplainUsesTheSharedRoutingList(t *testing.T) {
+	t.Parallel()
+	ts := time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC)
+
+	for _, name := range bathroomExplainFieldNames {
+		s := NewFamilyCampDerivedSync(nil)
+		meds := s.processMedical([]customValueEntry{
+			{householdPBID: "hh_lee", fieldName: name, value: "narrative for " + name, lastUpdated: ts},
+		})
+		if len(meds) != 1 {
+			t.Fatalf("field %q: medical rows = %d, want 1", name, len(meds))
+		}
+		if !strings.Contains(meds[0].bathroomExplain, "narrative for "+name) {
+			t.Errorf("field %q: bathroomExplain = %q", name, meds[0].bathroomExplain)
+		}
+	}
+}

--- a/scripts/dev/verify-family-camp-request-fields.sh
+++ b/scripts/dev/verify-family-camp-request-fields.sh
@@ -20,7 +20,7 @@ has_field() {
 for f in share_cabin_gate wants_near wants_with request_text request_source_field \
          request_last_updated needs_private_bathroom needs_power \
          accommodation_is_mandatory has_infant \
-         needs_fridge; do
+         needs_fridge needs_step_free; do
   [[ "$(has_field family_camp_registrations "$f")" -eq 1 ]] \
     || note "family_camp_registrations.$f missing"
 done

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -72,6 +72,12 @@ def _unit(
     # kindred#2224): a shared fridge IS a fridge. Zero of the 118 production
     # units carry shared without the parent.
     has_shared_fridge: bool = False,
+    # THREE-VALUE select, not a bool (migration 1500000131): "yes" / "no" /
+    # "partial", and blank = NOT ASSESSED. A bool read of it reports 0 of 118
+    # and erases all 14 staff assessments, which is the trap kindred#2438
+    # exists to undo -- so the fixture default is the blank string, exactly as
+    # 104 of the 118 production rows are.
+    has_ramp: str = "",
     # False builds the default RIDGE area (honouring `area_sort_order`); True
     # resolves the expanded `area` relation to None -- the missing-area case.
     area_missing: bool = False,
@@ -94,6 +100,7 @@ def _unit(
         has_ac=False,
         has_fridge=has_fridge,
         has_shared_fridge=has_shared_fridge,
+        has_ramp=has_ramp,
         is_accessible=False,
         map_x=map_x,
         map_y=map_y,
@@ -2748,6 +2755,22 @@ class TestMedicalFlagsAndNarrative:
         assert roster.parties[0].flags.needs_fridge is True
 
     @pytest.mark.asyncio
+    async def test_step_free_need_comes_from_the_derived_column(self) -> None:
+        """kindred#2438. Derived in the SYNC layer from BOTH housing narratives
+        and read here as a column, for the same reason `needs_fridge` above is:
+        the narrative is PHI-adjacent, so only the boolean crosses into a
+        payload this service builds."""
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_households={"hh_1": _household(title="The Chen Family")},
+            fetch_attendees_for_session=[_child(cm_id=1000001, first="Olivia", last="Chen", age=10, grade=5)],
+            fetch_family_camp_registrations={"hh_1": _rec(needs_step_free=True)},
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.parties[0].flags.needs_step_free is True
+
+    @pytest.mark.asyncio
     async def test_has_infant_reaches_the_roster(self) -> None:
         """kindred#1876: Adult-Infant was loaded every sync and discarded. An
         infant changes what a unit has to provide, so it reaches the board."""
@@ -4045,6 +4068,187 @@ class TestUnitFridgeCoverage:
 
         assert roster.units[0].power_coverage == "all"
         assert roster.units[0].fridge_coverage == "none"
+
+
+class TestUnitRampCoverage:
+    """kindred#2438 -- `LodgingUnitSummary.ramp_coverage`, the third resolved
+    supply grade, over the same leaf walk as power and fridge.
+
+    ONE thing separates it from either: `has_ramp` is a THREE-VALUE select
+    (`yes` / `no` / `partial`, blank = NOT ASSESSED), added deliberately as a
+    select in migration 1500000131 because "a bool maps every unassessed cabin
+    to false, which asserts 'no ramp' about cabins nobody has looked at". The
+    production distribution is 104 blank / 4 `no` / 5 `partial` / 5 `yes` -- 14
+    staff assessments a bool read reports as 0.
+
+    So the verdict carries a FIFTH grade the boolean amenities do not:
+
+        all      every answering room is fully step-free
+        some     at least one is, but not all
+        partial  none is, but at least one is a qualified ramp
+        none     every answering room answered `no`
+        unknown  nothing answers -- blank, unconfirmed, or no active room
+
+    `partial` is its own grade rather than folding into `none`, because folding
+    it would re-erase 5 of the 14 assessments in the very direction the select
+    exists to prevent; and rather than folding into `some`, because "no room is
+    step-free but one has a ramp with a lip" is not "some rooms are step-free".
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_leaf_answers_for_itself(self) -> None:
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("u1", "ridge-1", "Ridge 1", sleeps=4, has_ramp="yes"),
+                _unit("u2", "ridge-2", "Ridge 2", sleeps=4, has_ramp="no"),
+                _unit("u3", "ridge-3", "Ridge 3", sleeps=4, has_ramp="partial"),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        by_code = {u.code: u for u in roster.units}
+        assert by_code["ridge-1"].ramp_coverage == "all"
+        assert by_code["ridge-2"].ramp_coverage == "none"
+        assert by_code["ridge-3"].ramp_coverage == "partial"
+
+    @pytest.mark.asyncio
+    async def test_blank_is_unknown_never_none(self) -> None:
+        """THE TRAP THIS DIMENSION EXISTS TO AVOID. 104 of the 118 production
+        units are blank, so reading blank as `no` would mark almost the whole
+        registry step-free-hostile on evidence nobody recorded."""
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[_unit("u1", "ridge-1", "Ridge 1", sleeps=4, has_ramp="")],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.units[0].ramp_coverage == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_an_unrecognised_value_is_unknown_not_a_yes(self) -> None:
+        """PocketBase validates the select on save, so this state does not
+        arrive through the registry loader. It pins the railing against the two
+        directions that CAN produce it: a later migration widening the value
+        list, and a record built before the column existed. A grade this code
+        has never heard of must read as NOT ASSESSED, never as a claim."""
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[_unit("u1", "ridge-1", "Ridge 1", sleeps=4, has_ramp="Yes, but a lip")],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.units[0].has_ramp == ""
+        assert roster.units[0].ramp_coverage == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_a_container_inherits_from_its_rooms_not_its_own_row(self) -> None:
+        """One of the 14 assessments IS on a container, and it is ignored for
+        the same reason `has_power` on a container is: the row describes the
+        building, not the rooms staff place families into."""
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("c1", "gt-lodge", "Lodge", is_container=True, has_ramp="no"),
+                _unit("u1", "gt-lodge-1", "Lodge 1", sleeps=4, has_ramp="yes", parent_unit="c1"),
+                _unit("u2", "gt-lodge-2", "Lodge 2", sleeps=4, has_ramp="yes", parent_unit="c1"),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        by_code = {u.code: u for u in roster.units}
+        assert by_code["gt-lodge"].ramp_coverage == "all"
+        assert by_code["gt-lodge"].has_ramp == "no"
+
+    @pytest.mark.asyncio
+    async def test_a_split_building_is_some(self) -> None:
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("c1", "gt-lodge", "Lodge", is_container=True, has_ramp="yes"),
+                _unit("u1", "gt-lodge-1", "Lodge 1", sleeps=4, has_ramp="yes", parent_unit="c1"),
+                _unit("u2", "gt-lodge-2", "Lodge 2", sleeps=4, has_ramp="no", parent_unit="c1"),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert {u.code: u.ramp_coverage for u in roster.units}["gt-lodge"] == "some"
+
+    @pytest.mark.asyncio
+    async def test_a_building_whose_best_room_is_qualified_is_partial_not_none(self) -> None:
+        """The grade a boolean amenity has no room for. Three of the five
+        production `partial` units carry the qualifier in `notes`; collapsing
+        them into `none` would throw away the one thing staff wrote down."""
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("c1", "gt-lodge", "Lodge", is_container=True),
+                _unit("u1", "gt-lodge-1", "Lodge 1", sleeps=4, has_ramp="partial", parent_unit="c1"),
+                _unit("u2", "gt-lodge-2", "Lodge 2", sleeps=4, has_ramp="no", parent_unit="c1"),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert {u.code: u.ramp_coverage for u in roster.units}["gt-lodge"] == "partial"
+
+    @pytest.mark.asyncio
+    async def test_one_unassessed_room_makes_the_whole_building_unknown(self) -> None:
+        """The same all-or-nothing evidence bar `amenity_coverage` already
+        applies to an unconfirmed row: a building is not step-free on the
+        strength of the rooms somebody happened to get to."""
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("c1", "gt-lodge", "Lodge", is_container=True),
+                _unit("u1", "gt-lodge-1", "Lodge 1", sleeps=4, has_ramp="yes", parent_unit="c1"),
+                _unit("u2", "gt-lodge-2", "Lodge 2", sleeps=4, has_ramp="", parent_unit="c1"),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert {u.code: u.ramp_coverage for u in roster.units}["gt-lodge"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_an_unconfirmed_room_is_unknown_not_unmet(self) -> None:
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[_unit("u1", "ridge-1", "Ridge 1", sleeps=4, is_confirmed=False, has_ramp="no")],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.units[0].ramp_coverage == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_ramp_is_independent_of_is_accessible(self) -> None:
+        """NEITHER COLUMN DETERMINES THE OTHER, measured: `has_ramp = 'yes'`
+        splits 2 `is_accessible` true / 3 false, and the 4 `no`s plus 5
+        `partial`s are invisible to `is_accessible` entirely. So no fold in
+        either direction is information-preserving, and this resolver reads one
+        column only."""
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[_unit("u1", "ridge-1", "Ridge 1", sleeps=4, has_ramp="yes")],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.units[0].ramp_coverage == "all"
+        assert roster.units[0].is_accessible is False
+
+    @pytest.mark.asyncio
+    async def test_the_three_coverages_are_resolved_independently(self) -> None:
+        """One walk, three answers. Adding the third must not let any of them
+        borrow a verdict from another."""
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("u1", "ridge-1", "Ridge 1", sleeps=4, has_power=True, has_fridge=False, has_ramp="no"),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.units[0].power_coverage == "all"
+        assert roster.units[0].fridge_coverage == "none"
+        assert roster.units[0].ramp_coverage == "none"
 
 
 def _journey_repo(**overrides: Any) -> MagicMock:

--- a/tests/unit/api/services/test_lodging_rules.py
+++ b/tests/unit/api/services/test_lodging_rules.py
@@ -26,6 +26,7 @@ from api.services.lodging_rules import (
     container_bathroom,
     effective_bathroom,
     is_family_available,
+    ramp_coverage,
     request_text_authorship,
     request_text_source_order,
     unit_capacity,
@@ -228,6 +229,57 @@ class TestAmenityCoverage:
         assert amenity_coverage([True, None]) == "unknown"
         assert amenity_coverage([False, None]) == "unknown"
         assert amenity_coverage([None]) == "unknown"
+
+
+class TestRampCoverage:
+    """kindred#2438. The step-free twin of `amenity_coverage`, and the reason
+    it is a separate function rather than a call into that one: `has_ramp` is a
+    THREE-VALUE select, so a room can answer "qualified" and no boolean grain
+    has anywhere to put that.
+
+    Migration 1500000131 made it a select on purpose -- "a bool maps every
+    unassessed cabin to false, which asserts 'no ramp' about cabins nobody has
+    looked at". The production distribution is 104 blank / 4 `no` / 5 `partial`
+    / 5 `yes`; a bool read reports 0 of 118 and erases all 14 assessments.
+
+    Five grades, worst-known first: `none` < `partial` < `some` < `all`, plus
+    `unknown` for the absence of evidence.
+    """
+
+    def test_every_room_step_free_is_all(self) -> None:
+        assert ramp_coverage(["yes", "yes"]) == "all"
+
+    def test_every_room_refused_is_none(self) -> None:
+        assert ramp_coverage(["no", "no"]) == "none"
+
+    def test_a_mixed_set_is_some(self) -> None:
+        assert ramp_coverage(["yes", "no"]) == "some"
+        assert ramp_coverage(["yes", "partial"]) == "some"
+
+    def test_qualified_without_a_full_yes_is_partial(self) -> None:
+        """The grade a boolean amenity has no room for, and the one that must
+        NOT collapse into `none`: three of the five production `partial` units
+        carry the ramp qualifier in `notes`, which is the record of somebody
+        having gone and looked."""
+        assert ramp_coverage(["partial"]) == "partial"
+        assert ramp_coverage(["partial", "no"]) == "partial"
+
+    def test_partial_is_not_some(self) -> None:
+        """`some` says at least one room IS step-free, which invites the
+        placement that lands in one of the others. `partial` says none is, and
+        the two are different claims."""
+        assert ramp_coverage(["partial", "partial"]) != "some"
+
+    def test_blank_is_unknown_never_none(self) -> None:
+        """104 of 118 production units are blank. Reading blank as `no` marks
+        almost the whole registry step-free-hostile on evidence nobody
+        recorded -- the exact inversion the select exists to prevent."""
+        assert ramp_coverage([None]) == "unknown"
+        assert ramp_coverage(["yes", None]) == "unknown"
+        assert ramp_coverage(["no", None]) == "unknown"
+
+    def test_nothing_to_judge_is_unknown(self) -> None:
+        assert ramp_coverage([]) == "unknown"
 
 
 class TestRequestTextSourceRegistry:


### PR DESCRIPTION
## The defect

The registry has recorded step-free access since migration `1500000131` and the
product never read it. `lodging_units.has_ramp` is a **three-value select** —
`yes` / `no` / `partial`, blank = NOT ASSESSED — and the only reference to it
anywhere under `frontend/src/` was the generated type. It was absent from
`api/` and `bunking/` entirely.

It also *looked* empty, and that is why it stayed unread. A **boolean** read of
a three-value select reports `has_ramp` true on **0 of 118 units**, which is
the figure a prior pass acted on. The real distribution, measured over all 118
rows of `pocketbase/pb_data/data-prod.db`:

| `has_ramp` | `is_accessible` false | `is_accessible` true | total |
|---|---:|---:|---:|
| *(blank — not assessed)* | 104 | 0 | **104** |
| `no` | 4 | 0 | **4** |
| `partial` | 5 | 0 | **5** |
| `yes` | 3 | 2 | **5** |

**14 staff assessments**, which the boolean read erased. Neither column
determines the other: `has_ramp = 'yes'` splits 2 `is_accessible` true / 3
false, and the 4 explicit `no`s plus 5 `partial`s are invisible to
`is_accessible`, which reads them identically to the 104 nobody has looked at.
No fold in either direction is information-preserving.

Nobody had measured the **demand** side at all. Measured at the exact grain
`fridgeKeywords` uses — both narrative fields on `family_camp_medical`, 2026,
household grain, case-insensitive substring:

| signal | 2026 households |
|---|---:|
| carrying **any** narrative text | 86 |
| **fridge** (the shipped `fridgeKeywords` verbatim) | **6** |
| **mobility / step-free** (this PR's surface) | **14** |
| both | 1 |

**The mobility signal is more than twice the fridge signal that justified
shipping a whole need dimension in #2462.** 2026 is only ~16% placed, so 14 is
the SHAPE of the demand, not a rate.

## The change

`needs_step_free` (demand) + `ramp_coverage` (supply), mirroring
`needs_fridge` + `fridge_coverage` one dimension over.

**Sync (`family_camp_derived.go`)** — a new `needs_step_free` boolean on
`family_camp_registrations` (migration `1500000167`), OR'd across the **raw
per-person** narrative values, never the collapsed `family_camp_medical`
columns whose first-non-empty flatten has already discarded sibling narratives.
`bathroomExplainFieldNames` is lifted out of `processMedical`'s local slice to
package level, so the sentence-storing reader and the boolean-deriving reader
share ONE routing list — the discipline `accommodationExplainFieldNames`
already follows.

**⚠️ It routes BOTH narratives, and copying the fridge routing verbatim would
have lost more than a third of the signal.** `needs_fridge` reads the
accommodation narrative alone, which sufficed because 0 of the 6 fridge
households narrate elsewhere. Mobility does not split that way:

| narrative field | fridge households | mobility households |
|---|---:|---:|
| `accommodation_explain` only | 6 | 6 |
| `bathroom_explain` only | 0 | 5 |
| both | 0 | 3 |
| **union** | **6** | **14** |

A family explaining why it needs a private bathroom is often explaining that
someone cannot walk to the shared one. The two routes stay separate for the
same measured reason, and a test pins that the bathroom narrative does not set
`needs_fridge`.

**⚠️ It is NOT accommodation-gated.** All 6 fridge households carry
`needs_accommodation`; only **11 of the 14** mobility households do. So
`needs_step_free` joins the has-some-data guard that decides whether a
registration row is written at all — without that, those 3 rows are dropped
before they are stored, and the flag is missing for exactly the households
nothing else records.

The keyword surface prefers **recall over precision**, for the reason
`fridgeKeywords` states: the flag is advisory, it hatches a card and never
refuses a drop. Contributions, so the surface can be argued rather than
inherited: `walk` finds 10 (a substring, so it also catches *walking* /
*walkway*, and every one of the ten reads as a genuine step-free ask on
inspection); `mobilit` 2, one of them new; `knee` and `hip` 3 each, **three of
them new**; `crutch` 1, none new. The rest match 0 today and are kept because
each is the plain word for an ask `has_ramp` answers.

`knee` / `hip` are diagnosis words in an otherwise ask-shaped list, and they
are admitted on evidence rather than shape: **every knee/hip mention in the
corpus, in every year, is a mobility limitation** — a joint replacement, a
post-surgical recovery, or a stated limit on how far someone can walk. Zero
false positives. (Aggregate only: the narratives are PHI and are not quoted,
here or in the code.)

**`hip`, `cane` and `ramp` match as WHOLE WORDS**, not as substrings. Each is
short enough to sit inside a common unrelated word — *relationship*,
*shipping*, *hurricane*, *cramp* — and firing on those is not the near-miss
recall-over-precision buys, it is a household that asked for nothing of the
kind. The other eleven keywords stay substrings, because `walk` has to catch
*walking* and *walkway*. Both false-positive words are pinned as negative
cases. On the 2026 snapshot the boundary rule changes no count: still 14
households, 6 / 5 / 3 across the narrative fields, 11 gated.

One candidate is **deliberately excluded**: bare `close to`, 5 households. It
is **proximity**, not step-free access — a different ask, which the registry
answers with `map_x`/`map_y` and `near_bathhouse` rather than with `has_ramp`,
so a household flagged on it would be hatched against a column that cannot
speak to what they asked for. The mobility-bearing one of the five is caught by
`knee`; the three that remain uncaught are a child who needs to be near
activities, a family recalling a past illness, and a bathroom-proximity request
`needs_private_bathroom` already carries. None is a step-free ask.

**API** — `LodgingUnitSummary` gains `has_ramp` (the row's own fact) and
`ramp_coverage` (the resolution); `AccessibilityFlagSummary` gains
`needs_step_free`. `_resolve_ramp_coverage` runs over the SAME leaf walk as
power and fridge; the walk is now parameterised on the vocabulary a room
answers in as well as on the field that receives the verdict, so there is still
exactly one traversal of the tree.

**`ramp_coverage` carries a fifth grade the boolean amenities have no word
for**, and settling it was this issue's one piece of real design work:

| grade | meaning |
|---|---|
| `all` | every answering room is fully step-free |
| `some` | at least one is, but not all |
| `partial` | **no** room is, but at least one has a qualified ramp |
| `none` | every answering room answered `no` |
| `unknown` | nothing answers — blank, unconfirmed, or no active room left |

`partial` folds into neither neighbour. Folding it into `none` would re-erase 5
of the 14 assessments in the exact direction the select exists to prevent — and
3 of those 5 carry the ramp qualifier in `notes`, which is the record of
somebody having gone and looked. Folding it into `some` would make the order
lie: "no room is step-free but one has a ramp with a lip" is a weaker claim
than "some rooms are step-free".

**⚠️ Blank resolves `unknown`, never `none`.** 104 of 118 units are blank, so
reading blank as "no ramp" would mark almost the whole registry
step-free-hostile on evidence nobody recorded. An unrecognised string rails to
blank too — **not** as a defence against the registry loader, which cannot
produce one (PocketBase validates the select on save), but against a later
migration widening the value list and against a record built before the column
existed. A grade this code has never heard of must read as "not assessed",
never fall through to a claim.

**Frontend** — one further `NEEDS_DIMENSIONS` entry, reading `ramp_coverage`
and **never** the raw `has_ramp`. That is not only the container trap the other
two entries spell out: `has_ramp` is a STRING, so `'no'` is **truthy**, and any
consumer filtering on truthiness renders "step-free" on the four cabins staff
assessed as explicitly having no ramp. A test pins both directions.

`someIs: 'unmet'`, **not** the fridge reading. This takes the `is_accessible`
shape the module doc already reasons out: a building advertising two step-free
rooms out of ten invites precisely the placement that lands in one of the other
eight. What separates it from fridge is the shared-fridge ruling's own logic in
reverse — a fridge one room over is still usable, a ramp one room over is not.

This dimension cost one object literal **and one branch** in `resolveNeedsFit`,
which is the honest counter-example to that module's "a second dimension is a
further entry in this array and nothing else". The extra branch is a property
of the REGISTRY — a three-value supply column — not a sign the first dimension
was built wrong, and the module doc now says so. Still no new glyph, no new
colour, no new chip.

## ⚠️ Post-merge step, required

**`family_camp_derived` must be RE-RUN for 2026 or `needs_step_free` stays
empty on every row.** The migration is additive and computes nothing — the
input is a person-partition custom value that needs the household collapse, so
no migration could. Verified: the migration applies cleanly to a 771 MB
production-shaped database, preserves all 3,932 registration rows, and leaves
the column at 0 until the sync runs.

## ⚠️ 2026-forward only. There is no history to recover

`family_camp_medical` carries narrative text for **2026 alone** — 86 households
— and every prior year is empty. So this is a 2026-forward signal, exactly as
`needs_fridge` is. **A backfill would recover nothing**, and a prior-year
`false` is the absence of an input, never a measured "did not ask". Do not read
one as a false negative.

## PHI containment

The mobility narrative names individuals and their conditions. **Only the
boolean leaves the sync layer.** The sentences stay in `family_camp_medical`,
which is admin-gated on all five rules and absent from every export config. A
test pins that no registration text column ever receives the narrative, and
mutation-checking it turns it red.

## Deliberately NOT done

- **No rendering work.** No new glyph, no new colour, no new chip, no admin
  control for `has_ramp`. #2072 owns the card's visual treatment, and its ruled
  glyph set is bathroom · power · fridge — step-free is not in it. Adding
  `has_ramp` to `AMENITY_FLAGS` would have hit the truthiness inversion above;
  it needs its own three-state control, which is not this PR.
- **`is_accessible` is untouched.** #2327's ruling — accessible draws only when
  true — stands, and the two columns stay independent because neither
  determines the other.
- **`rosterAttention` and `placementCandidates` are not wired**, for the same
  reason #2224 left fridge out of them: both read a RAW unit field and neither
  of these needs can, and wiring them puts new words in front of staff. Their
  divergence comments are updated to name the third need rather than left
  claiming the tables differ by one entry.
- **No backfill**, per the section above.

## Verification

- `bash scripts/pre-push-verify.sh` → **ALL CHECKS PASSED** (exit 0), including
  `golangci-lint` and `eslint`.
- Migration `1500000167` applied to a scratch database built from
  `pb_migrations/` alone, reverted with `migrate down`, and re-applied — the
  column is gone after the down and back after the up, and
  `scripts/dev/verify-family-camp-request-fields.sh` reports OK at each step.
  That script now covers `needs_step_free`, so a dropped column is caught.
- Also applied to a 771 MB production-shaped dev database: OK, 3,932
  registration rows intact.
- `pocketbase-types.ts` regenerated from the scratch migrated database (not
  from local dev `data.db`); `types.gen.ts` regenerated from the OpenAPI
  schema. Both diffs are additive only.
- Every new test was written failing first and run red before implementation,
  then mutation-checked. Dropping the bathroom route, dropping
  `needs_step_free` from the survival guard, dropping `walk` from the keyword
  surface, dropping `Bathroom-Yes` from the shared routing list, letting blank
  answer as a value instead of `None`, dropping the resolver call, unrailing an
  unrecognised `has_ramp`, folding `partial` into `none`, dropping the flag
  read, flipping `someIs` to `partial`, mapping the `partial` grade to `fits`,
  and pointing the dimension at the raw `has_ramp` each turned the intended
  test red, and only that test.

## Review record

Scanned on-branch and reviewed by CodeRabbit. Four findings in this PR's own
code, all fixed here; three findings against sibling commits already merged to
`main` were out of scope and left alone.

1. **PHI in source comments (major).** The keyword-surface comment quoted three
   health narratives verbatim from the production corpus to justify admitting
   `knee` / `hip`, and two test fixtures were verbatim corpus text. The repo
   rule is absolute — no real personal information in code, tests, comments,
   docs, commits or PRs — so the justification is now a categorical description
   with no quoted text, the fixtures are clearly synthetic, and the branch was
   **force-pushed as a single squashed commit** so the quoted text is in no
   reachable commit. The PR body and the audit comment on the issue were
   scrubbed too.
2. **`hip` matched as a substring (minor, correctness).** It fired on
   *relationship* and *shipping*; `cane` on *hurricane* and `ramp` on *cramp*.
   Those three now match as whole words while the other eleven keywords stay
   substrings. All four false-positive words are pinned as negative cases, and
   the boundary rule changes no count on the snapshot.
3. **A false premise in a docstring.** The railing on an unrecognised `has_ramp`
   was justified by "PocketBase stores it as a plain string and the loader
   writes whatever the JSON holds" — wrong: migration `1500000131` declares a
   `select` with a fixed value list and PB validates it on save. The railing is
   still right, for two reasons that are true (a later migration widening the
   list, and a record built before the column existed), and the docstrings, the
   test's own justification and this body now say so.
4. **A stale docstring this PR created.** `fetch_family_camp_registrations`
   still said **five** housing flags after this PR added a sixth — in the very
   docstring that tells callers to read the columns rather than re-derive them.

## Issue body accuracy

The issue body's own measurement said 10 mobility households and 84 with any
narrative. Re-run on the same snapshot at the same grain, this branch measures
**11** on the body's narrower surface and **86** narrative households; the body
flagged 10-vs-11 as unresolved and said to re-run rather than trust it, which
is what happened.

The shipped surface is wider than the body's, at **14**, and that is a
deliberate choice the body invited ("pick the surface deliberately … take
recall over precision"). It also corrects two figures the body gives for the
narrower surface: the bathroom-only split is **5**, not 4, and its claim that
the `close to` households which are step-free asks are already caught by `walk`
is **false** — one of them is caught only by `knee`. The gate split the body
predicted (3 ungated) reproduces exactly at the wider count: 11 of 14 gated.
Nothing about the ruling turns on any of it; the code comments carry the
re-measured figures.

The migration number in the body (`1500000165`) was contested between three
issues and re-derived at branch time; `1500000167` is the first free number on
this branch.

Closes #2438.
