### PR TITLE
feat(sync): Family Camp roster builder and export endpoint

### DIFF
--- a/frontend/src/hooks/useSheetsWorkbooks.test.ts
+++ b/frontend/src/hooks/useSheetsWorkbooks.test.ts
@@ -1,0 +1,78 @@
+/**
+ * TDD tests for useSheetsWorkbooks.
+ *
+ * The admin Sheets tab is about the DATA export workbooks — Globals and one per
+ * year. Family Camp roster workbooks (kindred#2433) share the sheets_workbooks
+ * collection but are a different surface: one per weekend, in a Drive folder
+ * with a deliberately narrower audience, reached through the roster toolbar
+ * rather than here.
+ *
+ * They must not reach this list. SheetsTab renders every non-globals row as
+ * `String(workbook.year)`, so 2026's eight enrolled weekends would arrive as
+ * eight rows all labelled "2026", indistinguishable from the real 2026 data
+ * workbook and each linking somewhere else.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockGetFullList = vi.fn()
+
+vi.mock('../lib/pocketbase', () => ({
+  pb: {
+    collection: vi.fn(() => ({
+      getFullList: mockGetFullList,
+    })),
+  },
+}))
+
+describe('useSheetsWorkbooks', () => {
+  beforeEach(() => {
+    mockGetFullList.mockReset()
+    mockGetFullList.mockResolvedValue([])
+  })
+
+  describe('SHEETS_WORKBOOK_LIST_FILTER', () => {
+    it('excludes Family Camp roster workbooks', async () => {
+      const { SHEETS_WORKBOOK_LIST_FILTER } = await import('./useSheetsWorkbooks')
+      expect(SHEETS_WORKBOOK_LIST_FILTER).toContain('fc_roster')
+      expect(SHEETS_WORKBOOK_LIST_FILTER).toMatch(/workbook_type\s*!=/)
+    })
+
+    it('is applied to the sheets_workbooks query', async () => {
+      const { fetchSheetsWorkbooks, SHEETS_WORKBOOK_LIST_FILTER } =
+        await import('./useSheetsWorkbooks')
+
+      await fetchSheetsWorkbooks()
+
+      expect(mockGetFullList).toHaveBeenCalledTimes(1)
+      expect(mockGetFullList).toHaveBeenCalledWith(
+        expect.objectContaining({ filter: SHEETS_WORKBOOK_LIST_FILTER })
+      )
+    })
+
+    it('keeps the existing year-descending sort', async () => {
+      const { fetchSheetsWorkbooks } = await import('./useSheetsWorkbooks')
+
+      await fetchSheetsWorkbooks()
+
+      expect(mockGetFullList).toHaveBeenCalledWith(
+        expect.objectContaining({ sort: '-year,workbook_type' })
+      )
+    })
+
+    // The hook has always swallowed a failed load and rendered an empty tab
+    // rather than an error. Pinned so the filter change does not alter it.
+    it('returns an empty list when the query fails', async () => {
+      const { fetchSheetsWorkbooks } = await import('./useSheetsWorkbooks')
+      mockGetFullList.mockRejectedValue(new Error('offline'))
+
+      await expect(fetchSheetsWorkbooks()).resolves.toEqual([])
+    })
+  })
+
+  describe('hook export', () => {
+    it('exports useSheetsWorkbooks', async () => {
+      const module = await import('./useSheetsWorkbooks')
+      expect(typeof module.useSheetsWorkbooks).toBe('function')
+    })
+  })
+})

--- a/frontend/src/hooks/useSheetsWorkbooks.ts
+++ b/frontend/src/hooks/useSheetsWorkbooks.ts
@@ -62,7 +62,7 @@ export async function fetchSheetsWorkbooks(): Promise<SheetsWorkbook[]> {
  */
 export function useSheetsWorkbooks() {
   return useQuery({
-    queryKey: ['sheets-workbooks'],
+    queryKey: queryKeys.sheetsWorkbooks(),
     queryFn: fetchSheetsWorkbooks,
     // Refetch every 30 seconds to catch status updates
     refetchInterval: 30000,
@@ -108,7 +108,7 @@ export function useMultiWorkbookExport() {
         })
       }
       // Invalidate workbooks to show status change
-      void queryClient.invalidateQueries({ queryKey: ['sheets-workbooks'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.sheetsWorkbooks() })
       void queryClient.invalidateQueries({ queryKey: queryKeys.syncStatus() })
     },
     onError: (error) => {
@@ -143,7 +143,7 @@ export function useRefreshMasterIndex() {
           borderLeft: '4px solid hsl(160, 100%, 21%)',
         },
       })
-      void queryClient.invalidateQueries({ queryKey: ['sheets-workbooks'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.sheetsWorkbooks() })
     },
     onError: (error) => {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error'

--- a/frontend/src/hooks/useSheetsWorkbooks.ts
+++ b/frontend/src/hooks/useSheetsWorkbooks.ts
@@ -13,8 +13,10 @@ import toast from 'react-hot-toast'
 export interface SheetsWorkbook {
   id: string
   spreadsheet_id: string
-  workbook_type: 'globals' | 'year'
+  workbook_type: 'globals' | 'year' | 'fc_roster'
   year: number
+  /** Set only on fc_roster workbooks: the weekend they belong to. */
+  session_cm_id?: number
   title: string
   url: string
   tab_count: number
@@ -26,22 +28,42 @@ export interface SheetsWorkbook {
 }
 
 /**
- * Fetch all sheets workbooks ordered by year descending
+ * Family Camp roster workbooks share the sheets_workbooks collection but are a
+ * different surface from the data export this tab is about: one per weekend, in
+ * a Drive folder with a deliberately narrower audience, reached through the
+ * roster toolbar rather than here (kindred#2433).
+ *
+ * Excluding them is not cosmetic. SheetsTab labels every non-globals row with
+ * `String(workbook.year)`, so 2026's eight enrolled weekends would render as
+ * eight rows all reading "2026", sitting beside the real 2026 data workbook and
+ * each opening something else.
+ */
+export const SHEETS_WORKBOOK_LIST_FILTER = 'workbook_type != "fc_roster"'
+
+/**
+ * Fetch the data-export workbooks, ordered by year descending.
+ *
+ * Exported separately from the hook so the filter is testable without rendering.
+ */
+export async function fetchSheetsWorkbooks(): Promise<SheetsWorkbook[]> {
+  try {
+    return await pb.collection('sheets_workbooks').getFullList<SheetsWorkbook>({
+      filter: SHEETS_WORKBOOK_LIST_FILTER,
+      sort: '-year,workbook_type',
+    })
+  } catch (error) {
+    console.error('Failed to load sheets workbooks:', error)
+    return []
+  }
+}
+
+/**
+ * Hook to fetch the data-export workbooks for the admin Sheets tab.
  */
 export function useSheetsWorkbooks() {
   return useQuery({
     queryKey: ['sheets-workbooks'],
-    queryFn: async (): Promise<SheetsWorkbook[]> => {
-      try {
-        const records = await pb.collection('sheets_workbooks').getFullList<SheetsWorkbook>({
-          sort: '-year,workbook_type',
-        })
-        return records
-      } catch (error) {
-        console.error('Failed to load sheets workbooks:', error)
-        return []
-      }
-    },
+    queryFn: fetchSheetsWorkbooks,
     // Refetch every 30 seconds to catch status updates
     refetchInterval: 30000,
   })

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -550,6 +550,12 @@ export const queryKeys = {
   lodgingUnitsPrefix: () => ['lodging-units'] as const,
   lodgingIngestIssuesPrefix: () => ['lodging-ingest-issues'] as const,
   lodgingRollForwardPreviewPrefix: () => ['lodging-roll-forward-preview'] as const,
+  /**
+   * The admin Sheets tab's workbook list. Not year-keyed: one query returns
+   * every workbook and the tab groups them itself. Family Camp roster workbooks
+   * are filtered out of it at the query — see `useSheetsWorkbooks`.
+   */
+  sheetsWorkbooks: () => ['sheets-workbooks'] as const,
 }
 
 /**

--- a/pocketbase/google/branding.go
+++ b/pocketbase/google/branding.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 )
 
@@ -107,4 +108,24 @@ func FormatWorkbookTitle(workbookType string, year int) string {
 	}
 
 	return fmt.Sprintf("%s%s CM Data - %d", prefix, campName, year)
+}
+
+// FormatRosterWorkbookTitle generates the title of one Family Camp weekend's
+// roster workbook: "{session name} {year} Roster". kindred#2433.
+//
+// The camp name is deliberately absent, unlike FormatWorkbookTitle: these
+// workbooks sit in a folder that is entirely this camp's, and what staff pick
+// one out of that folder by is the weekend.
+//
+// The "(DEV) " prefix matters more here than for the data workbooks. Prod and
+// dev roster folders are two values of ONE env var
+// (GOOGLE_DRIVE_ROSTER_FOLDER_ID), so nothing but that id separates a dev run
+// from the real folder, and the service account can write anywhere on the shared
+// drive. The prefix is the second signal.
+func FormatRosterWorkbookTitle(sessionName string, year int) string {
+	prefix := ""
+	if isDevEnvironment() {
+		prefix = devPrefix
+	}
+	return fmt.Sprintf("%s%s %d Roster", prefix, strings.TrimSpace(sessionName), year)
 }

--- a/pocketbase/google/branding_test.go
+++ b/pocketbase/google/branding_test.go
@@ -435,3 +435,47 @@ func TestIsDevEnvironment(t *testing.T) {
 		})
 	}
 }
+
+// The Family Camp roster workbook title. kindred#2433.
+//
+// Unlike the data workbooks, the camp name is NOT in it: these live in a folder
+// that is entirely this camp's, and the session name is what staff pick a
+// workbook out of a folder by.
+
+func TestFormatRosterWorkbookTitle(t *testing.T) {
+	resetBrandingCache()
+	t.Setenv("IS_DOCKER", "true")
+
+	title := FormatRosterWorkbookTitle("Family Camp 2: Keshet LGBTQ Weekend", 2026)
+	expected := "Family Camp 2: Keshet LGBTQ Weekend 2026 Roster"
+	if title != expected {
+		t.Errorf("FormatRosterWorkbookTitle = %q, want %q", title, expected)
+	}
+}
+
+// TestFormatRosterWorkbookTitleMarksDev pins the second signal that a run is not
+// production. It matters more here than for the data workbooks: prod and dev
+// roster folders are configured by two values of ONE env var, so a mispointed id
+// is the only thing between a dev run and the real folder.
+func TestFormatRosterWorkbookTitleMarksDev(t *testing.T) {
+	resetBrandingCache()
+	t.Setenv("IS_DOCKER", "")
+
+	title := FormatRosterWorkbookTitle("Family Camp 6", 2026)
+	expected := "(DEV) Family Camp 6 2026 Roster"
+	if title != expected {
+		t.Errorf("FormatRosterWorkbookTitle = %q, want %q", title, expected)
+	}
+}
+
+// TestFormatRosterWorkbookTitleTrimsTheSessionName keeps a stray space in
+// CampMinder's session name out of the Drive file name, where it would make the
+// find-by-name lookup miss the workbook it just created.
+func TestFormatRosterWorkbookTitleTrimsTheSessionName(t *testing.T) {
+	resetBrandingCache()
+	t.Setenv("IS_DOCKER", "true")
+
+	if title := FormatRosterWorkbookTitle("  Family Camp 6 ", 2026); title != "Family Camp 6 2026 Roster" {
+		t.Errorf("FormatRosterWorkbookTitle = %q, want the name trimmed", title)
+	}
+}

--- a/pocketbase/lodging/api.go
+++ b/pocketbase/lodging/api.go
@@ -1,6 +1,7 @@
 package lodging
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -39,6 +40,29 @@ func RegisterRoutes(e *core.ServeEvent) {
 			}
 			return re.JSON(http.StatusOK, plan)
 		}))
+
+	// The Family Camp roster export (kindred#2433). Synchronous: a handful of
+	// Google calls, not a sync run. It APPENDS a dated tab and never prunes or
+	// overwrites one, because staff hand-edit every tab.
+	e.Router.POST("/api/custom/lodging/roster-export",
+		sync.RequirePermission("bunking.manage", func(re *core.RequestEvent) error {
+			year, sessionCMID, err := rosterExportParams(re)
+			if err != nil {
+				return re.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+			}
+
+			ctx := re.Request.Context()
+			exporter, err := sync.NewRosterExporterForApp(ctx, re.App)
+			if err != nil {
+				return re.JSON(rosterExportStatus(err), map[string]string{"error": err.Error()})
+			}
+
+			result, err := exporter.Export(ctx, year, sessionCMID)
+			if err != nil {
+				return re.JSON(rosterExportStatus(err), map[string]string{"error": err.Error()})
+			}
+			return re.JSON(http.StatusOK, result)
+		}))
 }
 
 // The bounds `year` actually carries (1500000141). Validating against them here
@@ -71,4 +95,44 @@ func seasonYear(re *core.RequestEvent, name string) (int, error) {
 		return 0, fmt.Errorf("%s must be a year between %d and %d", name, minSeasonYear, maxSeasonYear)
 	}
 	return year, nil
+}
+
+// rosterExportParams reads ?year=&session= for the roster export.
+//
+// Validated here rather than left to the builder so a client error stays a 400:
+// a mistyped year otherwise reaches camp_sessions, matches nothing, and comes
+// back as a 404 naming a session id the caller got right.
+func rosterExportParams(re *core.RequestEvent) (year, sessionCMID int, err error) {
+	year, err = seasonYear(re, "year")
+	if err != nil {
+		return 0, 0, err
+	}
+	// A CampMinder session id is always positive, and 0 is what Atoi yields for
+	// a missing parameter -- so the bound catches both.
+	sessionCMID, err = strconv.Atoi(re.Request.URL.Query().Get("session"))
+	if err != nil || sessionCMID <= 0 {
+		return 0, 0, fmt.Errorf("session must be a positive CampMinder session id")
+	}
+	return year, sessionCMID, nil
+}
+
+// rosterExportStatus maps an export failure onto a status code.
+//
+// The refusals are not server faults. A weekend with no enrolled campers, or one
+// that is not a Family Camp weekend, is something staff can legitimately ask for
+// and must be told about plainly -- reporting either as a 500 reads as "the
+// export is broken" and sends them looking in the wrong place. A missing
+// GOOGLE_DRIVE_ROSTER_FOLDER_ID is the opposite: nothing the caller did.
+//
+// errors.Is, not equality: every refusal reaches here wrapped by the builder.
+func rosterExportStatus(err error) int {
+	switch {
+	case errors.Is(err, sync.ErrRosterSessionNotFound):
+		return http.StatusNotFound
+	case errors.Is(err, sync.ErrRosterSessionNotFamily),
+		errors.Is(err, sync.ErrRosterNoEnrolledCampers):
+		return http.StatusBadRequest
+	default:
+		return http.StatusInternalServerError
+	}
 }

--- a/pocketbase/lodging/api_test.go
+++ b/pocketbase/lodging/api_test.go
@@ -67,6 +67,10 @@ func TestYearsFromQueryAcceptsARealSeasonPair(t *testing.T) {
 // off the query string, and how a builder refusal becomes a status code.
 // kindred#2433.
 
+// A synthetic weekend id: these tests parse a query string and never reach the
+// database, so naming a real weekend would imply a specificity they do not have.
+const testWeekendCMID = 1000001
+
 func rosterParamsFor(t *testing.T, query string) (year, sessionCMID int, err error) {
 	t.Helper()
 	re := &core.RequestEvent{}
@@ -76,12 +80,12 @@ func rosterParamsFor(t *testing.T, query string) (year, sessionCMID int, err err
 
 func TestRosterExportParamsAcceptsAWeekend(t *testing.T) {
 	t.Parallel()
-	year, session, err := rosterParamsFor(t, "year=2026&session=1309515")
+	year, session, err := rosterParamsFor(t, "year=2026&session=1000001")
 	if err != nil {
 		t.Fatalf("rosterExportParams: %v", err)
 	}
-	if year != 2026 || session != 1309515 {
-		t.Errorf("year,session = %d,%d; want 2026,1309515", year, session)
+	if year != 2026 || session != testWeekendCMID {
+		t.Errorf("year,session = %d,%d; want 2026,%d", year, session, testWeekendCMID)
 	}
 }
 
@@ -91,10 +95,10 @@ func TestRosterExportParamsAcceptsAWeekend(t *testing.T) {
 func TestRosterExportParamsRejectsBadInput(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct{ name, query, wantIn string }{
-		{"missing year", "session=1309515", "year"},
-		{"unparseable year", "year=abc&session=1309515", "year"},
-		{"year below the field minimum", "year=1999&session=1309515", "year"},
-		{"year above the field maximum", "year=2999&session=1309515", "year"},
+		{"missing year", "session=1000001", "year"},
+		{"unparseable year", "year=abc&session=1000001", "year"},
+		{"year below the field minimum", "year=1999&session=1000001", "year"},
+		{"year above the field maximum", "year=2999&session=1000001", "year"},
 		{"missing session", "year=2026", "session"},
 		{"unparseable session", "year=2026&session=abc", "session"},
 		{"zero session", "year=2026&session=0", "session"},

--- a/pocketbase/lodging/api_test.go
+++ b/pocketbase/lodging/api_test.go
@@ -1,12 +1,16 @@
 package lodging
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/pocketbase/pocketbase/core"
+
+	"github.com/camp/kindred/pocketbase/sync"
 )
 
 // yearsFor builds the minimal RequestEvent yearsFromQuery reads: a request
@@ -56,5 +60,89 @@ func TestYearsFromQueryAcceptsARealSeasonPair(t *testing.T) {
 	}
 	if from != 2026 || to != 2027 {
 		t.Errorf("from,to = %d,%d; want 2026,2027", from, to)
+	}
+}
+
+// The Family Camp roster export endpoint's two testable halves: what it accepts
+// off the query string, and how a builder refusal becomes a status code.
+// kindred#2433.
+
+func rosterParamsFor(t *testing.T, query string) (year, sessionCMID int, err error) {
+	t.Helper()
+	re := &core.RequestEvent{}
+	re.Request = httptest.NewRequest("POST", "/?"+query, http.NoBody)
+	return rosterExportParams(re)
+}
+
+func TestRosterExportParamsAcceptsAWeekend(t *testing.T) {
+	t.Parallel()
+	year, session, err := rosterParamsFor(t, "year=2026&session=1309515")
+	if err != nil {
+		t.Fatalf("rosterExportParams: %v", err)
+	}
+	if year != 2026 || session != 1309515 {
+		t.Errorf("year,session = %d,%d; want 2026,1309515", year, session)
+	}
+}
+
+// TestRosterExportParamsRejectsBadInput keeps a client error a 400. Without the
+// range check a typed year reaches the builder, finds no session, and surfaces
+// as a 404 naming a session id the caller never got wrong.
+func TestRosterExportParamsRejectsBadInput(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct{ name, query, wantIn string }{
+		{"missing year", "session=1309515", "year"},
+		{"unparseable year", "year=abc&session=1309515", "year"},
+		{"year below the field minimum", "year=1999&session=1309515", "year"},
+		{"year above the field maximum", "year=2999&session=1309515", "year"},
+		{"missing session", "year=2026", "session"},
+		{"unparseable session", "year=2026&session=abc", "session"},
+		{"zero session", "year=2026&session=0", "session"},
+		{"negative session", "year=2026&session=-3", "session"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, _, err := rosterParamsFor(t, tc.query); err == nil {
+				t.Fatalf("rosterExportParams(%q) succeeded; want a client error", tc.query)
+			} else if !strings.Contains(err.Error(), tc.wantIn) {
+				t.Errorf("error = %q, want it to name %q", err, tc.wantIn)
+			}
+		})
+	}
+}
+
+// TestRosterExportStatusForRefusals pins the mapping. A refusal is not a server
+// fault: a weekend with no enrolled campers is a thing staff can ask for and
+// must be told about, not a 500 that reads as "the export is broken".
+func TestRosterExportStatusForRefusals(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"unknown session", sync.ErrRosterSessionNotFound, http.StatusNotFound},
+		{"not a family weekend", sync.ErrRosterSessionNotFamily, http.StatusBadRequest},
+		{"no enrolled campers", sync.ErrRosterNoEnrolledCampers, http.StatusBadRequest},
+		// A misconfigured server, not a bad request.
+		{"roster folder unset", sync.ErrRosterFolderNotConfigured, http.StatusInternalServerError},
+		{"anything else", errors.New("drive exploded"), http.StatusInternalServerError},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := rosterExportStatus(tc.err); got != tc.want {
+				t.Errorf("rosterExportStatus(%v) = %d, want %d", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRosterExportStatusUnwrapsWrappedRefusals guards the mapping against the
+// builder's fmt.Errorf("%w: ...") wrapping, which is what actually reaches here.
+func TestRosterExportStatusUnwrapsWrappedRefusals(t *testing.T) {
+	t.Parallel()
+	wrapped := fmt.Errorf("building roster: %w", sync.ErrRosterNoEnrolledCampers)
+	if got := rosterExportStatus(wrapped); got != http.StatusBadRequest {
+		t.Errorf("rosterExportStatus(wrapped) = %d, want %d", got, http.StatusBadRequest)
 	}
 }

--- a/pocketbase/main_test_parallelism_test.go
+++ b/pocketbase/main_test_parallelism_test.go
@@ -216,7 +216,7 @@ var serialGroups = []struct {
 	{
 		// The Family Camp roster stamps its tab name -- and computes ages -- in
 		// camp-local time, defaulting to Pacific when TZ is unset (kindred#2433).
-		// TZ is process-global and read through time.LoadLocation, so these five
+		// TZ is process-global and read through time.LoadLocation, so these four
 		// have to set it for real; there is no injection seam that would still be
 		// testing the fallback. The export path takes an injected clock precisely
 		// so that only the timezone tests need this, not the other twelve.

--- a/pocketbase/main_test_parallelism_test.go
+++ b/pocketbase/main_test_parallelism_test.go
@@ -214,6 +214,34 @@ var serialGroups = []struct {
 		},
 	},
 	{
+		// The Family Camp roster stamps its tab name -- and computes ages -- in
+		// camp-local time, defaulting to Pacific when TZ is unset (kindred#2433).
+		// TZ is process-global and read through time.LoadLocation, so these five
+		// have to set it for real; there is no injection seam that would still be
+		// testing the fallback. The export path takes an injected clock precisely
+		// so that only the timezone tests need this, not the other twelve.
+		pkg:    "sync",
+		reason: "t.Setenv: TZ drives the camp-local timezone fallback itself",
+		tests: []string{
+			"TestCampLocationDefaultsToPacific",
+			"TestCampLocationFallsBackOnAnUnknownZone",
+			"TestCampLocationHonoursTZ",
+			"TestRosterExportStampsAgesInCampLocalTime",
+		},
+	},
+	{
+		// google.IsEnabled() reads GOOGLE_SHEETS_ENABLED from the process
+		// environment, and this test asserts that a staff-triggered export
+		// REFUSES when it is off rather than degrading silently as the sync path
+		// does. There is no seam short of the env var: IsEnabled is what the
+		// production constructor calls.
+		pkg:    "sync",
+		reason: "t.Setenv: GOOGLE_SHEETS_ENABLED drives the export's refusal itself",
+		tests: []string{
+			"TestNewRosterExporterForAppRefusesWhenSheetsIsDisabled",
+		},
+	},
+	{
 		// captureStdout redirects the process's os.Stdout; captureLogs swaps
 		// slog's default handler. Both are process-global, so a parallel test
 		// would capture some other test's output instead of its own.

--- a/pocketbase/sync/family_camp_roster.go
+++ b/pocketbase/sync/family_camp_roster.go
@@ -1,0 +1,304 @@
+package sync
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+)
+
+// The Family Camp family-facing roster: one row per person, campers and adults,
+// grouped into banded blocks per household. kindred#2433.
+//
+// This file is the unit-testable core -- it reads PocketBase and returns an
+// ordered Roster, and makes no Google calls. Rendering lives in
+// family_camp_roster_sheet.go and the Drive/Sheets orchestration in
+// family_camp_roster_export.go.
+
+// rosterAdultPlaceholders are the values registrants type into an adult-name
+// field to mean "there is no second adult". Rendering one puts a row called
+// "N/A" in the middle of a family's block.
+var rosterAdultPlaceholders = map[string]bool{
+	"na": true, "n/a": true, "none": true, "-": true, "0": true, "no": true,
+}
+
+// rosterStateSuffix matches the trailing ", CA" that normalized_city carries.
+// It is dropped because it is redundant on a roster whose families are almost
+// all in one state, and because today's hand-made sheet omits it. Two UPPERCASE
+// letters only: "Washington, District" is a city, not a state suffix.
+var rosterStateSuffix = regexp.MustCompile(`,\s*[A-Z]{2}$`)
+
+// rosterCamper is one enrolled child, before rendering.
+type rosterCamper struct {
+	Name      string
+	Last      string
+	Birthdate string // "YYYY-MM-DD", or "" when unknown
+}
+
+// rosterAdult is one accompanying adult, before rendering. Adults are not
+// enrolled: they come from family_camp_adults, scraped from the registration
+// form.
+type rosterAdult struct {
+	Number int
+	Name   string
+	Email  string
+}
+
+// rosterHousehold is one family's people, before ordering and rendering.
+type rosterHousehold struct {
+	ID      string // households PB record id
+	City    string
+	Campers []rosterCamper
+	Adults  []rosterAdult
+}
+
+// rosterAgeLabel renders a birthdate as an age AT EXPORT TIME (design §Age):
+// whole years from twelve months up, whole months below that, and nothing at all
+// for a blank or unparseable birthdate.
+//
+// Sorting never goes through this -- two campers both displaying "8" must stay
+// in real age order, so the sort reads the birthdate itself.
+func rosterAgeLabel(birthdate string, on time.Time) string {
+	born, ok := parseRosterBirthdate(birthdate)
+	if !ok {
+		return ""
+	}
+
+	months := (on.Year()-born.Year())*12 + int(on.Month()) - int(born.Month())
+	if on.Day() < born.Day() {
+		months--
+	}
+	// A birthdate in the future is bad data. It is never a negative age.
+	months = max(months, 0)
+
+	if months >= 12 {
+		return fmt.Sprintf("%d", months/12)
+	}
+	if months == 1 {
+		return "1 mo"
+	}
+	return fmt.Sprintf("%d mos", months)
+}
+
+// parseRosterBirthdate reads persons.birthdate, which is TEXT holding
+// "YYYY-MM-DD" (2593 of 2598 rows for 2026; the rest are blank). The prefix
+// slice is defensive against a value that ever gains a time component.
+func parseRosterBirthdate(birthdate string) (time.Time, bool) {
+	trimmed := strings.TrimSpace(birthdate)
+	if len(trimmed) < len(time.DateOnly) {
+		return time.Time{}, false
+	}
+	born, err := time.Parse(time.DateOnly, trimmed[:len(time.DateOnly)])
+	if err != nil {
+		return time.Time{}, false
+	}
+	return born, true
+}
+
+// rosterCleanCity prefers normalized_city, which fixes casing ("berkeley" ->
+// "Berkeley, CA"), and falls back to the raw address_city.
+func rosterCleanCity(normalized, raw string) string {
+	value := strings.TrimSpace(normalized)
+	if value == "" {
+		value = strings.TrimSpace(raw)
+	}
+	return strings.TrimSpace(rosterStateSuffix.ReplaceAllString(value, ""))
+}
+
+// isRosterAdultName reports whether a coalesced adult name names a real person.
+func isRosterAdultName(name string) bool {
+	trimmed := strings.TrimSpace(name)
+	return trimmed != "" && !rosterAdultPlaceholders[strings.ToLower(trimmed)]
+}
+
+// rosterAdultName coalesces family_camp_adults' name columns.
+//
+// `name` is the column of record and the split columns are the fallback, never
+// the other way round: last_name is blank on every 2026 row, so reading the
+// split pair first yields a first name with a trailing space.
+func rosterAdultName(name, first, last string) string {
+	if trimmed := strings.TrimSpace(name); trimmed != "" {
+		return trimmed
+	}
+	return strings.TrimSpace(strings.TrimSpace(first) + " " + strings.TrimSpace(last))
+}
+
+// rosterCamperName renders a camper as the family would say it.
+func rosterCamperName(preferred, first, last string) string {
+	given := strings.TrimSpace(preferred)
+	if given == "" {
+		given = strings.TrimSpace(first)
+	}
+	return strings.TrimSpace(given + " " + strings.TrimSpace(last))
+}
+
+// rosterMonths names the months in full, matching the hand-made sheet.
+var rosterMonths = [...]string{
+	"January", "February", "March", "April", "May", "June",
+	"July", "August", "September", "October", "November", "December",
+}
+
+// formatRosterDateRange renders the subtitle under the roster's title.
+func formatRosterDateRange(start, end time.Time) string {
+	startMonth := rosterMonths[start.Month()-1]
+	endMonth := rosterMonths[end.Month()-1]
+
+	if start.Year() != end.Year() {
+		return fmt.Sprintf("%s %d, %d – %s %d, %d",
+			startMonth, start.Day(), start.Year(), endMonth, end.Day(), end.Year())
+	}
+	if start.Month() == end.Month() {
+		return fmt.Sprintf("%s %d–%d, %d", startMonth, start.Day(), end.Day(), end.Year())
+	}
+	return fmt.Sprintf("%s %d – %s %d, %d",
+		startMonth, start.Day(), endMonth, end.Day(), end.Year())
+}
+
+// sortRosterCampers orders one household's campers youngest to oldest, with a
+// missing birthdate filing last and the display name breaking ties so twins do
+// not swap between two exports of unchanged data.
+func sortRosterCampers(campers []rosterCamper) {
+	slices.SortFunc(campers, func(a, b rosterCamper) int {
+		aBorn, aOK := parseRosterBirthdate(a.Birthdate)
+		bBorn, bOK := parseRosterBirthdate(b.Birthdate)
+		switch {
+		case aOK && !bOK:
+			return -1
+		case !aOK && bOK:
+			return 1
+		case aOK && bOK && !aBorn.Equal(bBorn):
+			// Later birthdate = younger = first.
+			return bBorn.Compare(aBorn)
+		}
+		return strings.Compare(strings.ToLower(a.Name), strings.ToLower(b.Name))
+	})
+}
+
+// orderRosterHouseholds sorts blocks A->Z on the case-folded surname of the
+// block's FIRST camper, which is what today's hand-made sheet already does.
+//
+// Call it only after sortRosterCampers, since "first camper" means the youngest.
+// Both tiebreakers matter: two unrelated families sharing a surname is common,
+// and without a total order two exports of unchanged data differ.
+func orderRosterHouseholds(households []rosterHousehold) {
+	slices.SortFunc(households, func(a, b rosterHousehold) int {
+		if c := strings.Compare(rosterSortSurname(&a), rosterSortSurname(&b)); c != 0 {
+			return c
+		}
+		if c := strings.Compare(rosterSortName(&a), rosterSortName(&b)); c != 0 {
+			return c
+		}
+		return strings.Compare(a.ID, b.ID)
+	})
+}
+
+// rosterSortSurname and rosterSortName read the first camper's keys. A household
+// reaches the roster only by having an enrolled camper, so the guard is
+// defensive rather than a real case.
+func rosterSortSurname(h *rosterHousehold) string {
+	if len(h.Campers) == 0 {
+		return ""
+	}
+	return strings.ToLower(h.Campers[0].Last)
+}
+
+func rosterSortName(h *rosterHousehold) string {
+	if len(h.Campers) == 0 {
+		return ""
+	}
+	return strings.ToLower(h.Campers[0].Name)
+}
+
+// linkedHouseholdGroups returns householdID -> 1-based group number for
+// households that SHARE an adult; households in no group are absent from the
+// result (design §5).
+//
+// Two households in one weekend may share an adult -- a friend attending with
+// another family, or co-parents keeping two homes. They are never merged:
+// merging would fix the first case and force a single wrong city onto the
+// second. The color means "these are linked, look here", never "these should
+// be merged".
+//
+// Grouping is TRANSITIVE. If A shares an adult with B and B with C, all three
+// are one group and get one color -- a household in two groups would need two
+// fills and would read as two separate pairings.
+//
+// Group numbers follow `order`, the roster's own household order, so
+// re-exporting unchanged data paints the same households the same color.
+func linkedHouseholdGroups(order []string, adults map[string][]string) map[string]int {
+	// A name repeated within ONE household is kindred#2483's duplicate-adult
+	// defect, not a link, so each household contributes a name at most once.
+	byName := make(map[string][]string)
+	for _, household := range order {
+		seen := make(map[string]bool)
+		for _, name := range adults[household] {
+			key := strings.ToLower(strings.TrimSpace(name))
+			if key == "" || seen[key] {
+				continue
+			}
+			seen[key] = true
+			byName[key] = append(byName[key], household)
+		}
+	}
+
+	find := newRosterUnionFind()
+	for _, sharing := range byName {
+		for _, household := range sharing[1:] {
+			find.union(sharing[0], household)
+		}
+	}
+
+	members := make(map[string]int)
+	for _, household := range order {
+		members[find.root(household)]++
+	}
+
+	groups := make(map[string]int)
+	numbers := make(map[string]int)
+	for _, household := range order {
+		root := find.root(household)
+		if members[root] < 2 {
+			continue
+		}
+		if numbers[root] == 0 {
+			numbers[root] = len(numbers) + 1
+		}
+		groups[household] = numbers[root]
+	}
+	return groups
+}
+
+// rosterUnionFind is a disjoint-set over household ids. Unseen ids are their own
+// root, so a household naming no adult needs no initialisation.
+type rosterUnionFind struct{ parent map[string]string }
+
+func newRosterUnionFind() *rosterUnionFind {
+	return &rosterUnionFind{parent: make(map[string]string)}
+}
+
+func (u *rosterUnionFind) root(id string) string {
+	root := id
+	for {
+		parent, ok := u.parent[root]
+		if !ok || parent == root {
+			break
+		}
+		root = parent
+	}
+	// Compress in a second pass. Compressing during the walk would need the
+	// grandparent, which is absent for a root and would store "" as a parent.
+	for id != root {
+		next := u.parent[id]
+		u.parent[id] = root
+		id = next
+	}
+	return root
+}
+
+func (u *rosterUnionFind) union(a, b string) {
+	rootA, rootB := u.root(a), u.root(b)
+	if rootA != rootB {
+		u.parent[rootB] = rootA
+	}
+}

--- a/pocketbase/sync/family_camp_roster_build.go
+++ b/pocketbase/sync/family_camp_roster_build.go
@@ -133,7 +133,7 @@ func BuildFamilyCampRoster(app core.App, year, sessionCMID int, on time.Time) (*
 	}
 	orderRosterHouseholds(ordered)
 
-	if err := attachRosterCityFallback(app, ordered); err != nil {
+	if err := attachRosterCityFallback(app, year, ordered); err != nil {
 		return nil, err
 	}
 	if err := attachRosterAdults(app, year, ordered); err != nil {
@@ -276,7 +276,15 @@ func loadRosterHouseholds(app core.App, year int, sessionID string) (map[string]
 //
 // Scoped to the household, never widened: a wrong city on a family's block is
 // worse than a blank one. Households that already have a city are not queried.
-func attachRosterCityFallback(app core.App, households []rosterHousehold) error {
+//
+// The year filter is belt-and-braces and kept deliberately. `households` is
+// itself year-scoped -- unique on (cm_id, year), one record per household per
+// season -- so a 2026 household record is unreachable from a 2025 person, and
+// production carries zero households whose persons span years. Filtering anyway
+// states the scoping at the query instead of leaving it to a reader who has to
+// know that invariant, and matches attachRosterAdults, which filters the same
+// way for the same reason.
+func attachRosterCityFallback(app core.App, year int, households []rosterHousehold) error {
 	missing := make([]string, 0)
 	for _, household := range households {
 		if household.City == "" {
@@ -289,7 +297,8 @@ func attachRosterCityFallback(app core.App, households []rosterHousehold) error 
 
 	found := make(map[string]string, len(missing))
 	err := forEachRosterIDChunk(missing, func(filter string, params dbx.Params) error {
-		records, chunkErr := findAllRecords(app, "persons", filter, params)
+		records, chunkErr := findAllRecords(app, "persons",
+			fmt.Sprintf("year = %d && (%s)", year, filter), params)
 		if chunkErr != nil {
 			return chunkErr
 		}

--- a/pocketbase/sync/family_camp_roster_build.go
+++ b/pocketbase/sync/family_camp_roster_build.go
@@ -1,0 +1,428 @@
+package sync
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// The roster builder's database half. kindred#2433.
+//
+// Everything comes from four tables -- attendees, persons, family_camp_adults
+// and camp_sessions. No lodging, no scenario, no solver, no placement: the
+// roster describes who is coming, not where they sleep.
+
+// A roster can be built only for sessionTypeFamily (sessions.go).
+//
+// rosterFilterChunk bounds how many ids go into one `a = x || a = y || ...`
+// filter. A representative weekend is 63 households and 98 campers, so this
+// keeps the whole build to one query per table while staying far short of any
+// filter-length limit.
+const rosterFilterChunk = 100
+
+// Refusals. Each names a state where producing an artifact would be worse than
+// producing an error, so they are sentinels the HTTP layer maps to a status
+// rather than free-form strings.
+var (
+	// ErrRosterSessionNotFound means no camp_sessions row matched (cm_id, year).
+	ErrRosterSessionNotFound = errors.New("no session found for that CampMinder id and year")
+	// ErrRosterSessionNotFamily guards the adult weekends, which enroll
+	// individuals rather than households and have no family_camp_adults rows at
+	// all -- a roster built for one would be a camper-only sheet that looks
+	// plausible and is wrong.
+	ErrRosterSessionNotFamily = errors.New("session is not a Family Camp weekend")
+	// ErrRosterNoEnrolledCampers guards the two of 2026's ten family weekends
+	// that are later in the season. An empty tab appended to a workbook staff
+	// hand-edit is worse than a clear error.
+	ErrRosterNoEnrolledCampers = errors.New("session has no enrolled campers")
+)
+
+// RosterPerson is one rendered row: a camper or one accompanying adult.
+type RosterPerson struct {
+	Name  string
+	Role  string // "Camper", or "Adult 1", "Adult 2", ...
+	Age   string // campers only; adults carry no birthdate on the later slots
+	Email string // adults only
+}
+
+// HouseholdBlock is one family's contiguous run of rows. The block, not the row,
+// is the unit the sheet bands and borders -- that is what makes a family read as
+// one unit.
+type HouseholdBlock struct {
+	HouseholdID string // households PB record id
+	City        string
+	People      []RosterPerson
+	// LinkGroup is 0 for an ordinary household, or a 1-based group number when
+	// this household SHARES an adult with another in the same weekend (§5).
+	LinkGroup int
+	// campers is how many of People are campers. They always lead the block, so
+	// this doubles as the index adults start at.
+	campers int
+}
+
+// Roster is one weekend's whole artifact, ordered and ready to render.
+type Roster struct {
+	SessionID   string // camp_sessions PB record id
+	SessionCMID int
+	SessionName string
+	Year        int
+	Start       time.Time
+	End         time.Time
+	Blocks      []HouseholdBlock
+}
+
+// HouseholdCount returns the number of blocks.
+func (r *Roster) HouseholdCount() int { return len(r.Blocks) }
+
+// CamperCount returns the number of enrolled campers across every block.
+func (r *Roster) CamperCount() int {
+	total := 0
+	for _, block := range r.Blocks {
+		total += block.campers
+	}
+	return total
+}
+
+// AdultCount returns the number of rendered adults across every block.
+func (r *Roster) AdultCount() int { return r.PersonCount() - r.CamperCount() }
+
+// PersonCount returns the number of person rows the sheet will carry.
+func (r *Roster) PersonCount() int {
+	total := 0
+	for _, block := range r.Blocks {
+		total += len(block.People)
+	}
+	return total
+}
+
+// BuildFamilyCampRoster assembles one weekend's roster, ordered and rendered but
+// not yet written anywhere. It makes no Google calls.
+//
+// `on` is the instant ages are measured against. It is a parameter rather than
+// time.Now() because ages are computed AT EXPORT TIME (design §Age) and a
+// hard-coded clock is untestable -- the reference implementation measured ages
+// at session start, and only a caller-supplied instant can tell the two apart.
+func BuildFamilyCampRoster(app core.App, year, sessionCMID int, on time.Time) (*Roster, error) {
+	session, err := findRosterSession(app, year, sessionCMID)
+	if err != nil {
+		return nil, err
+	}
+
+	households, err := loadRosterHouseholds(app, year, session.Id)
+	if err != nil {
+		return nil, err
+	}
+	if len(households) == 0 {
+		return nil, fmt.Errorf("%w: %s (cm_id %d, year %d)",
+			ErrRosterNoEnrolledCampers, session.GetString("name"), sessionCMID, year)
+	}
+
+	ordered := make([]rosterHousehold, 0, len(households))
+	for _, household := range households {
+		ordered = append(ordered, *household)
+	}
+	// Sorted before either attach so both walk households in one stable order,
+	// which is what makes a re-export of unchanged data byte-identical.
+	for i := range ordered {
+		sortRosterCampers(ordered[i].Campers)
+	}
+	orderRosterHouseholds(ordered)
+
+	if err := attachRosterCityFallback(app, ordered); err != nil {
+		return nil, err
+	}
+	if err := attachRosterAdults(app, year, ordered); err != nil {
+		return nil, err
+	}
+
+	return &Roster{
+		SessionID:   session.Id,
+		SessionCMID: sessionCMID,
+		SessionName: session.GetString("name"),
+		Year:        year,
+		// start_date and end_date are PocketBase DATE fields stored as
+		// "2026-08-20 07:00:00.000Z", a layout date_utils.go's parser does not
+		// carry, so GetDateTime is the only correct read.
+		Start:  session.GetDateTime("start_date").Time(),
+		End:    session.GetDateTime("end_date").Time(),
+		Blocks: buildRosterBlocks(ordered, on),
+	}, nil
+}
+
+// buildRosterBlocks renders the ordered households into sheet rows and paints
+// the linked-household groups on.
+func buildRosterBlocks(households []rosterHousehold, on time.Time) []HouseholdBlock {
+	order := make([]string, 0, len(households))
+	adultNames := make(map[string][]string, len(households))
+	for _, household := range households {
+		order = append(order, household.ID)
+		names := make([]string, 0, len(household.Adults))
+		for _, adult := range household.Adults {
+			names = append(names, adult.Name)
+		}
+		adultNames[household.ID] = names
+	}
+	linked := linkedHouseholdGroups(order, adultNames)
+
+	blocks := make([]HouseholdBlock, 0, len(households))
+	for _, household := range households {
+		people := make([]RosterPerson, 0, len(household.Campers)+len(household.Adults))
+		for _, camper := range household.Campers {
+			people = append(people, RosterPerson{
+				Name: camper.Name,
+				Role: "Camper",
+				Age:  rosterAgeLabel(camper.Birthdate, on),
+			})
+		}
+		for _, adult := range household.Adults {
+			people = append(people, RosterPerson{
+				Name:  adult.Name,
+				Role:  fmt.Sprintf("Adult %d", adult.Number),
+				Email: adult.Email,
+			})
+		}
+		blocks = append(blocks, HouseholdBlock{
+			HouseholdID: household.ID,
+			City:        household.City,
+			People:      people,
+			LinkGroup:   linked[household.ID],
+			campers:     len(household.Campers),
+		})
+	}
+	return blocks
+}
+
+// findRosterSession resolves (cm_id, year) to a camp_sessions record and refuses
+// anything that is not a Family Camp weekend.
+func findRosterSession(app core.App, year, sessionCMID int) (*core.Record, error) {
+	// Spaces around every operator: PocketBase's filter parser silently returns
+	// wrong results without them.
+	filter := fmt.Sprintf("cm_id = %d && year = %d", sessionCMID, year)
+	records, err := app.FindRecordsByFilter("camp_sessions", filter, "", 1, 0)
+	if err != nil {
+		return nil, fmt.Errorf("finding session %d for %d: %w", sessionCMID, year, err)
+	}
+	if len(records) == 0 {
+		return nil, fmt.Errorf("%w: cm_id %d, year %d", ErrRosterSessionNotFound, sessionCMID, year)
+	}
+
+	session := records[0]
+	if sessionType := session.GetString("session_type"); sessionType != sessionTypeFamily {
+		return nil, fmt.Errorf("%w: %q is a %q session",
+			ErrRosterSessionNotFamily, session.GetString("name"), sessionType)
+	}
+	return session, nil
+}
+
+// loadRosterHouseholds groups this weekend's actively-enrolled campers by
+// household, keyed on the household RECORD id -- what persons and
+// family_camp_adults both carry.
+func loadRosterHouseholds(app core.App, year int, sessionID string) (map[string]*rosterHousehold, error) {
+	filter := fmt.Sprintf("year = %d && status_id = %d && session = {:session}", year, statusIDActiveEnrolled)
+	attendees, err := findAllRecords(app, "attendees", filter, dbx.Params{"session": sessionID})
+	if err != nil {
+		return nil, err
+	}
+
+	personIDs := make([]string, 0, len(attendees))
+	for _, attendee := range attendees {
+		if personID := attendee.GetString("person"); personID != "" {
+			personIDs = append(personIDs, personID)
+		}
+	}
+
+	persons, err := findRosterRecordsByID(app, "persons", personIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	households := make(map[string]*rosterHousehold)
+	for _, person := range persons {
+		householdID := person.GetString("household")
+		if householdID == "" {
+			// A camper with no household cannot be grouped into a block, and a
+			// block of one orphan would read as a family. Sync repairs the link.
+			continue
+		}
+		household, ok := households[householdID]
+		if !ok {
+			household = &rosterHousehold{ID: householdID}
+			households[householdID] = household
+		}
+		household.Campers = append(household.Campers, rosterCamper{
+			Name: rosterCamperName(
+				person.GetString("preferred_name"),
+				person.GetString("first_name"),
+				person.GetString("last_name"),
+			),
+			Last:      strings.TrimSpace(person.GetString("last_name")),
+			Birthdate: strings.TrimSpace(person.GetString("birthdate")),
+		})
+		if household.City == "" {
+			household.City = rosterCleanCity(
+				person.GetString("normalized_city"), person.GetString("address_city"))
+		}
+	}
+	return households, nil
+}
+
+// attachRosterCityFallback fills the city for households where no enrolled
+// camper carries one, from any other member of the same household (design §3).
+//
+// Scoped to the household, never widened: a wrong city on a family's block is
+// worse than a blank one. Households that already have a city are not queried.
+func attachRosterCityFallback(app core.App, households []rosterHousehold) error {
+	missing := make([]string, 0)
+	for _, household := range households {
+		if household.City == "" {
+			missing = append(missing, household.ID)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+
+	found := make(map[string]string, len(missing))
+	err := forEachRosterIDChunk(missing, func(filter string, params dbx.Params) error {
+		records, chunkErr := findAllRecords(app, "persons", filter, params)
+		if chunkErr != nil {
+			return chunkErr
+		}
+		// findAllRecords sorts by id, so the first non-empty city for a
+		// household is a stable choice rather than whatever the page returned.
+		for _, person := range records {
+			householdID := person.GetString("household")
+			if found[householdID] != "" {
+				continue
+			}
+			if city := rosterCleanCity(
+				person.GetString("normalized_city"), person.GetString("address_city"),
+			); city != "" {
+				found[householdID] = city
+			}
+		}
+		return nil
+	}, "household")
+	if err != nil {
+		return fmt.Errorf("loading household cities: %w", err)
+	}
+
+	for i := range households {
+		if households[i].City == "" {
+			households[i].City = found[households[i].ID]
+		}
+	}
+	return nil
+}
+
+// attachRosterAdults loads each household's accompanying adults for the year.
+//
+// Adults are not enrolled -- they are scraped from the registration form into
+// family_camp_adults, which is keyed (household, year, adult_number). The year
+// filter is what keeps last season's adults off this season's roster.
+func attachRosterAdults(app core.App, year int, households []rosterHousehold) error {
+	ids := make([]string, 0, len(households))
+	for _, household := range households {
+		ids = append(ids, household.ID)
+	}
+
+	byHousehold := make(map[string][]rosterAdult, len(ids))
+	err := forEachRosterIDChunk(ids, func(filter string, params dbx.Params) error {
+		records, chunkErr := findAllRecords(app,
+			"family_camp_adults", fmt.Sprintf("year = %d && (%s)", year, filter), params)
+		if chunkErr != nil {
+			return chunkErr
+		}
+		for _, record := range records {
+			name := rosterAdultName(
+				record.GetString("name"),
+				record.GetString("first_name"),
+				record.GetString("last_name"),
+			)
+			// Placeholders ("N/A", "none", "-") mean "there is no second adult".
+			// Duplicates are NOT filtered: the same person in two slots is
+			// kindred#2483, and deduping here would hide it behind a clean sheet.
+			if !isRosterAdultName(name) {
+				continue
+			}
+			householdID := record.GetString("household")
+			byHousehold[householdID] = append(byHousehold[householdID], rosterAdult{
+				Number: record.GetInt("adult_number"),
+				Name:   name,
+				Email:  strings.TrimSpace(record.GetString("email")),
+			})
+		}
+		return nil
+	}, "household")
+	if err != nil {
+		return fmt.Errorf("loading family camp adults for %d: %w", year, err)
+	}
+
+	for i := range households {
+		adults := byHousehold[households[i].ID]
+		// Sorted in Go rather than by the query: chunking means the concatenated
+		// pages are not globally ordered, and two adults can share a number only
+		// across households, so (number, name) is a total order within one.
+		slices.SortFunc(adults, func(a, b rosterAdult) int {
+			if a.Number != b.Number {
+				return a.Number - b.Number
+			}
+			return strings.Compare(a.Name, b.Name)
+		})
+		households[i].Adults = adults
+	}
+	return nil
+}
+
+// findRosterRecordsByID fetches records by PB record id, chunked, and returns
+// them sorted by id across every chunk. The global sort is what makes
+// "the first camper carrying a city" a stable choice.
+func findRosterRecordsByID(app core.App, collection string, ids []string) ([]*core.Record, error) {
+	unique := slices.Clone(ids)
+	slices.Sort(unique)
+	unique = slices.Compact(unique)
+
+	all := make([]*core.Record, 0, len(unique))
+	err := forEachRosterIDChunk(unique, func(filter string, params dbx.Params) error {
+		records, chunkErr := findAllRecords(app, collection, filter, params)
+		if chunkErr != nil {
+			return chunkErr
+		}
+		all = append(all, records...)
+		return nil
+	}, "id")
+	if err != nil {
+		return nil, fmt.Errorf("loading %s by id: %w", collection, err)
+	}
+	return all, nil
+}
+
+// forEachRosterIDChunk calls fn with an `field = {:p0} || field = {:p1} ...`
+// filter for each chunk of ids, so a whole weekend costs one query per table
+// rather than one per household. Ids are bound as parameters rather than
+// interpolated.
+func forEachRosterIDChunk(ids []string, fn func(filter string, params dbx.Params) error, field string) error {
+	for start := 0; start < len(ids); start += rosterFilterChunk {
+		chunk := ids[start:min(start+rosterFilterChunk, len(ids))]
+
+		clauses := make([]string, 0, len(chunk))
+		params := make(dbx.Params, len(chunk))
+		for i, id := range chunk {
+			key := fmt.Sprintf("p%d", i)
+			// Spaces around the operator: PocketBase's filter parser silently
+			// returns wrong results without them.
+			clauses = append(clauses, fmt.Sprintf("%s = {:%s}", field, key))
+			params[key] = id
+		}
+
+		if err := fn(strings.Join(clauses, " || "), params); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pocketbase/sync/family_camp_roster_build_test.go
+++ b/pocketbase/sync/family_camp_roster_build_test.go
@@ -565,3 +565,30 @@ func TestBuildFamilyCampRosterUsesTheGivenInstantForAges(t *testing.T) {
 		t.Errorf("age two days earlier = %q, want %q -- ages must follow the export instant", got, "7")
 	}
 }
+
+// TestBuildFamilyCampRosterCityFallbackIsYearScoped pins the year filter on the
+// fallback query.
+//
+// Belt-and-braces today, deliberately. `households` is itself year-scoped --
+// unique on (cm_id, year), one record per household per season -- so a 2026
+// household record cannot be reached by a 2025 person, and production carries
+// zero households whose persons span years. The filter costs nothing, states the
+// scoping at the query rather than leaving it to a reader who has to know the
+// households invariant, and matches attachRosterAdults, which filters the same
+// way. This test seeds the shape the invariant forbids so that the filter is
+// pinned rather than merely present.
+func TestBuildFamilyCampRosterCityFallbackIsYearScoped(t *testing.T) {
+	t.Parallel()
+	f := newRosterFixture(t)
+	household := f.addHousehold(9001)
+	f.addCamper(household, &rosterTestPerson{CMID: 1, First: "Emma", Last: "Johnson", Birthdate: "2014-03-02"})
+	// A prior season's member of the same household record, carrying a city.
+	f.addPerson(household, &rosterTestPerson{
+		CMID: 2, First: "Sarah", Last: "Johnson", AddressCity: "Fresno, CA", Year: 2025,
+	})
+
+	roster := f.mustBuild()
+	if got := roster.Blocks[0].City; got != "" {
+		t.Errorf("city = %q, want empty -- a prior season's row must not supply this year's city", got)
+	}
+}

--- a/pocketbase/sync/family_camp_roster_build_test.go
+++ b/pocketbase/sync/family_camp_roster_build_test.go
@@ -1,0 +1,567 @@
+package sync
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// The roster builder's database half: what it reads, what it refuses, and the
+// data traps it must respect (design §7). kindred#2433.
+
+const rosterYear = 2026
+
+// rosterFixture is a weekend under construction, so a test can say what it needs
+// and nothing else.
+type rosterFixture struct {
+	t         *testing.T
+	app       core.App
+	sessionID string
+}
+
+func newRosterFixture(t *testing.T) *rosterFixture {
+	t.Helper()
+	app := newSyncTestApp(t)
+	f := &rosterFixture{t: t, app: app}
+	f.sessionID = f.addSession(cmIDFamilyCamp1, "Family Camp 2: Keshet LGBTQ Weekend", "family",
+		"2026-08-20 07:00:00.000Z", "2026-08-23 07:00:00.000Z")
+	return f
+}
+
+func (f *rosterFixture) addSession(cmID int, name, sessionType, start, end string) string {
+	f.t.Helper()
+	collection, err := f.app.FindCollectionByNameOrId("camp_sessions")
+	if err != nil {
+		f.t.Fatalf("camp_sessions: %v", err)
+	}
+	record := core.NewRecord(collection)
+	record.Set("cm_id", cmID)
+	record.Set("name", name)
+	record.Set("session_type", sessionType)
+	record.Set("start_date", start)
+	record.Set("end_date", end)
+	record.Set("year", rosterYear)
+	if err := f.app.Save(record); err != nil {
+		f.t.Fatalf("save session %q: %v", name, err)
+	}
+	return record.Id
+}
+
+// addHousehold creates a households row and returns its record id.
+func (f *rosterFixture) addHousehold(cmID int) string {
+	f.t.Helper()
+	collection, err := f.app.FindCollectionByNameOrId("households")
+	if err != nil {
+		f.t.Fatalf("households: %v", err)
+	}
+	record := core.NewRecord(collection)
+	record.Set("cm_id", cmID)
+	record.Set("year", rosterYear)
+	if err := f.app.Save(record); err != nil {
+		f.t.Fatalf("save household %d: %v", cmID, err)
+	}
+	return record.Id
+}
+
+type rosterTestPerson struct {
+	CMID           int
+	First          string
+	Last           string
+	Preferred      string
+	Birthdate      string
+	NormalizedCity string
+	AddressCity    string
+	Year           int // 0 means rosterYear
+}
+
+// addPerson creates a persons row WITHOUT enrolling them, which is how a
+// household member who is not an enrolled camper reaches the fixture.
+func (f *rosterFixture) addPerson(householdID string, p *rosterTestPerson) string {
+	f.t.Helper()
+	collection, err := f.app.FindCollectionByNameOrId("persons")
+	if err != nil {
+		f.t.Fatalf("persons: %v", err)
+	}
+	year := p.Year
+	if year == 0 {
+		year = rosterYear
+	}
+	record := core.NewRecord(collection)
+	record.Set("cm_id", p.CMID)
+	record.Set("household", householdID)
+	record.Set("year", year)
+	record.Set("first_name", p.First)
+	record.Set("last_name", p.Last)
+	record.Set("preferred_name", p.Preferred)
+	record.Set("birthdate", p.Birthdate)
+	record.Set("normalized_city", p.NormalizedCity)
+	record.Set("address_city", p.AddressCity)
+	if err := f.app.Save(record); err != nil {
+		f.t.Fatalf("save person %d: %v", p.CMID, err)
+	}
+	return record.Id
+}
+
+// enroll attaches an attendees row. statusID 2 is active-enrolled.
+func (f *rosterFixture) enroll(personID, sessionID string, statusID, year int) {
+	f.t.Helper()
+	collection, err := f.app.FindCollectionByNameOrId("attendees")
+	if err != nil {
+		f.t.Fatalf("attendees: %v", err)
+	}
+	record := core.NewRecord(collection)
+	record.Set("person", personID)
+	record.Set("session", sessionID)
+	record.Set("status_id", statusID)
+	record.Set("year", year)
+	if err := f.app.Save(record); err != nil {
+		f.t.Fatalf("enroll %s: %v", personID, err)
+	}
+}
+
+// addCamper is the common case: a person in a household, actively enrolled in
+// the fixture's session for the roster year.
+func (f *rosterFixture) addCamper(householdID string, p *rosterTestPerson) string {
+	f.t.Helper()
+	personID := f.addPerson(householdID, p)
+	f.enroll(personID, f.sessionID, 2, rosterYear)
+	return personID
+}
+
+type rosterTestAdult struct {
+	Number int
+	Name   string
+	First  string
+	Last   string
+	Email  string
+	Year   int // 0 means rosterYear
+}
+
+func (f *rosterFixture) addAdult(householdID string, a *rosterTestAdult) {
+	f.t.Helper()
+	collection, err := f.app.FindCollectionByNameOrId("family_camp_adults")
+	if err != nil {
+		f.t.Fatalf("family_camp_adults: %v", err)
+	}
+	year := a.Year
+	if year == 0 {
+		year = rosterYear
+	}
+	record := core.NewRecord(collection)
+	record.Set("household", householdID)
+	record.Set("year", year)
+	record.Set("adult_number", a.Number)
+	record.Set("name", a.Name)
+	record.Set("first_name", a.First)
+	record.Set("last_name", a.Last)
+	record.Set("email", a.Email)
+	if err := f.app.Save(record); err != nil {
+		f.t.Fatalf("save adult %d: %v", a.Number, err)
+	}
+}
+
+func (f *rosterFixture) build() (*Roster, error) {
+	f.t.Helper()
+	return BuildFamilyCampRoster(f.app, rosterYear, cmIDFamilyCamp1, exportedAt)
+}
+
+func (f *rosterFixture) mustBuild() *Roster {
+	f.t.Helper()
+	roster, err := f.build()
+	if err != nil {
+		f.t.Fatalf("BuildFamilyCampRoster: %v", err)
+	}
+	return roster
+}
+
+// blockNames renders one block as "Name|Role|Age|Email" rows, which is what the
+// assertions compare -- naming the whole row makes a failure legible.
+func blockRows(block HouseholdBlock) []string {
+	out := make([]string, len(block.People))
+	for i, p := range block.People {
+		out[i] = strings.Join([]string{p.Name, p.Role, p.Age, p.Email}, "|")
+	}
+	return out
+}
+
+func assertRows(t *testing.T, block HouseholdBlock, want []string) {
+	t.Helper()
+	got := blockRows(block)
+	if len(got) != len(want) {
+		t.Fatalf("block has %d rows, want %d:\n got %v\nwant %v", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("row %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestBuildFamilyCampRosterOrdersOneHousehold pins the whole block shape:
+// campers youngest first, then adults by adult_number, ages at export time, the
+// email only on adults, and the city on the household rather than the row.
+func TestBuildFamilyCampRosterOrdersOneHousehold(t *testing.T) {
+	t.Parallel()
+	f := newRosterFixture(t)
+	household := f.addHousehold(9001)
+	f.addCamper(household, &rosterTestPerson{
+		CMID: 1, First: "Emma", Last: "Johnson", Birthdate: "2014-03-02", NormalizedCity: "Berkeley, CA",
+	})
+	f.addCamper(household, &rosterTestPerson{
+		CMID: 2, First: "Avigail", Preferred: "Ava", Last: "Johnson", Birthdate: "2019-11-30",
+	})
+	f.addAdult(household, &rosterTestAdult{Number: 2, Name: "Liam Johnson", Email: "liam@example.com"})
+	f.addAdult(household, &rosterTestAdult{Number: 1, Name: "Sarah Johnson", Email: "sarah@example.com"})
+
+	roster := f.mustBuild()
+
+	if len(roster.Blocks) != 1 {
+		t.Fatalf("blocks = %d, want 1", len(roster.Blocks))
+	}
+	block := roster.Blocks[0]
+	assertRows(t, block, []string{
+		"Ava Johnson|Camper|6|",
+		"Emma Johnson|Camper|12|",
+		"Sarah Johnson|Adult 1||sarah@example.com",
+		"Liam Johnson|Adult 2||liam@example.com",
+	})
+	if block.City != "Berkeley" {
+		t.Errorf("city = %q, want %q", block.City, "Berkeley")
+	}
+	if roster.SessionName != "Family Camp 2: Keshet LGBTQ Weekend" {
+		t.Errorf("session name = %q", roster.SessionName)
+	}
+	if roster.CamperCount() != 2 || roster.AdultCount() != 2 || roster.HouseholdCount() != 1 {
+		t.Errorf("counts = %d campers, %d adults, %d households; want 2, 2, 1",
+			roster.CamperCount(), roster.AdultCount(), roster.HouseholdCount())
+	}
+}
+
+// TestBuildFamilyCampRosterExcludesNonEnrolledAttendees pins the attendee
+// filter. status_id 32 is cancelled and 512 is incomplete; treating either as
+// attending puts a family on the roster who is not coming.
+func TestBuildFamilyCampRosterExcludesNonEnrolledAttendees(t *testing.T) {
+	t.Parallel()
+	f := newRosterFixture(t)
+	household := f.addHousehold(9001)
+	f.addCamper(household, &rosterTestPerson{CMID: 1, First: "Emma", Last: "Johnson", Birthdate: "2014-03-02"})
+
+	for _, status := range []int{32, 512} {
+		cancelled := f.addPerson(household, &rosterTestPerson{CMID: 100 + status, First: "Ghost", Last: "Johnson"})
+		f.enroll(cancelled, f.sessionID, status, rosterYear)
+	}
+
+	roster := f.mustBuild()
+	if roster.CamperCount() != 1 {
+		t.Fatalf("campers = %d, want 1 (rows: %v)", roster.CamperCount(), blockRows(roster.Blocks[0]))
+	}
+}
+
+// TestBuildFamilyCampRosterExcludesOtherSessionsAndYears keeps one weekend's
+// roster to that weekend. CampMinder reuses session ids across years, so the
+// year filter is load-bearing, not belt-and-braces.
+func TestBuildFamilyCampRosterExcludesOtherSessionsAndYears(t *testing.T) {
+	t.Parallel()
+	f := newRosterFixture(t)
+	other := f.addSession(cmIDFamilyCamp6, "Family Camp 6", "family",
+		"2026-09-24 07:00:00.000Z", "2026-09-27 07:00:00.000Z")
+
+	household := f.addHousehold(9001)
+	f.addCamper(household, &rosterTestPerson{CMID: 1, First: "Emma", Last: "Johnson", Birthdate: "2014-03-02"})
+
+	elsewhere := f.addPerson(household, &rosterTestPerson{CMID: 2, First: "Other", Last: "Weekend"})
+	f.enroll(elsewhere, other, 2, rosterYear)
+
+	lastYear := f.addPerson(household, &rosterTestPerson{CMID: 3, First: "Last", Last: "Year", Year: 2025})
+	f.enroll(lastYear, f.sessionID, 2, 2025)
+
+	roster := f.mustBuild()
+	if roster.CamperCount() != 1 {
+		t.Fatalf("campers = %d, want 1 (rows: %v)", roster.CamperCount(), blockRows(roster.Blocks[0]))
+	}
+}
+
+// TestBuildFamilyCampRosterFiltersPlaceholderAdults keeps "N/A" off a family's
+// block while keeping the real adult beside it.
+func TestBuildFamilyCampRosterFiltersPlaceholderAdults(t *testing.T) {
+	t.Parallel()
+	f := newRosterFixture(t)
+	household := f.addHousehold(9001)
+	f.addCamper(household, &rosterTestPerson{CMID: 1, First: "Emma", Last: "Johnson", Birthdate: "2014-03-02"})
+	f.addAdult(household, &rosterTestAdult{Number: 1, Name: "Sarah Johnson", Email: "sarah@example.com"})
+	f.addAdult(household, &rosterTestAdult{Number: 2, Name: "N/A"})
+	f.addAdult(household, &rosterTestAdult{Number: 3, Name: "  "})
+
+	roster := f.mustBuild()
+	assertRows(t, roster.Blocks[0], []string{
+		"Emma Johnson|Camper|12|",
+		"Sarah Johnson|Adult 1||sarah@example.com",
+	})
+}
+
+// TestBuildFamilyCampRosterKeepsNamelessEmailOnLaterAdults pins design §7: an
+// adult_number >= 3 row carries a name and nothing else on 27 of 27 such 2026
+// rows. A blank email there is CORRECT and permanent, not missing data, so the
+// row must render rather than be filtered as incomplete.
+func TestBuildFamilyCampRosterKeepsNamelessEmailOnLaterAdults(t *testing.T) {
+	t.Parallel()
+	f := newRosterFixture(t)
+	household := f.addHousehold(9001)
+	f.addCamper(household, &rosterTestPerson{CMID: 1, First: "Emma", Last: "Johnson", Birthdate: "2014-03-02"})
+	f.addAdult(household, &rosterTestAdult{Number: 1, Name: "Sarah Johnson", Email: "sarah@example.com"})
+	f.addAdult(household, &rosterTestAdult{Number: 3, Name: "Ruth Okafor"})
+
+	roster := f.mustBuild()
+	assertRows(t, roster.Blocks[0], []string{
+		"Emma Johnson|Camper|12|",
+		"Sarah Johnson|Adult 1||sarah@example.com",
+		"Ruth Okafor|Adult 3||",
+	})
+}
+
+// TestBuildFamilyCampRosterCoalescesAdultNames pins that the split columns are
+// the FALLBACK. last_name is blank on every 2026 row, so a builder reading the
+// pair first renders a first name and a trailing space.
+func TestBuildFamilyCampRosterCoalescesAdultNames(t *testing.T) {
+	t.Parallel()
+	f := newRosterFixture(t)
+	household := f.addHousehold(9001)
+	f.addCamper(household, &rosterTestPerson{CMID: 1, First: "Emma", Last: "Johnson", Birthdate: "2014-03-02"})
+	f.addAdult(household, &rosterTestAdult{Number: 1, First: "Sarah", Last: "Johnson"})
+
+	roster := f.mustBuild()
+	assertRows(t, roster.Blocks[0], []string{
+		"Emma Johnson|Camper|12|",
+		"Sarah Johnson|Adult 1||",
+	})
+}
+
+// TestBuildFamilyCampRosterRendersDuplicateAdultsRaw pins design §7 and
+// kindred#2483: the same person in two adult slots, both coalescing to one name,
+// exists in 2 households in 2026. The export renders them RAW -- deduping here
+// would hide the underlying sync defect behind a clean-looking roster.
+func TestBuildFamilyCampRosterRendersDuplicateAdultsRaw(t *testing.T) {
+	t.Parallel()
+	f := newRosterFixture(t)
+	household := f.addHousehold(9001)
+	f.addCamper(household, &rosterTestPerson{CMID: 1, First: "Emma", Last: "Johnson", Birthdate: "2014-03-02"})
+	f.addAdult(household, &rosterTestAdult{Number: 1, Name: "Sarah Johnson", Email: "sarah@example.com"})
+	f.addAdult(household, &rosterTestAdult{Number: 2, Name: "Sarah Johnson", Email: "sarah@example.com"})
+
+	roster := f.mustBuild()
+	assertRows(t, roster.Blocks[0], []string{
+		"Emma Johnson|Camper|12|",
+		"Sarah Johnson|Adult 1||sarah@example.com",
+		"Sarah Johnson|Adult 2||sarah@example.com",
+	})
+}
+
+// TestBuildFamilyCampRosterFallsBackToAnyHouseholdMemberForCity pins design §3:
+// the city can sit on a household member who is not an enrolled camper.
+func TestBuildFamilyCampRosterFallsBackToAnyHouseholdMemberForCity(t *testing.T) {
+	t.Parallel()
+	f := newRosterFixture(t)
+	household := f.addHousehold(9001)
+	f.addCamper(household, &rosterTestPerson{CMID: 1, First: "Emma", Last: "Johnson", Birthdate: "2014-03-02"})
+	f.addPerson(household, &rosterTestPerson{
+		CMID: 2, First: "Sarah", Last: "Johnson", AddressCity: testCityOakland + ", CA",
+	})
+
+	roster := f.mustBuild()
+	if roster.Blocks[0].City != testCityOakland {
+		t.Errorf("city = %q, want %q", roster.Blocks[0].City, testCityOakland)
+	}
+}
+
+// TestBuildFamilyCampRosterCityFallbackStaysWithinTheHousehold guards the
+// fallback against reaching across families -- a wrong city on a family's block
+// is worse than a blank one.
+//
+// Both households here are city-less at camper level, so BOTH go through the
+// fallback query together; only one has a non-camper member carrying a city.
+// That is what makes the test able to fail: with one household in the batch, a
+// fallback that assigned its find to every household in the batch would be
+// indistinguishable from a correct one.
+func TestBuildFamilyCampRosterCityFallbackStaysWithinTheHousehold(t *testing.T) {
+	t.Parallel()
+	f := newRosterFixture(t)
+
+	knows := f.addHousehold(9001)
+	f.addCamper(knows, &rosterTestPerson{CMID: 1, First: "Emma", Last: "Johnson", Birthdate: "2014-03-02"})
+	f.addPerson(knows, &rosterTestPerson{CMID: 2, First: "Sarah", Last: "Johnson", AddressCity: "Fresno, CA"})
+
+	blank := f.addHousehold(9002)
+	f.addCamper(blank, &rosterTestPerson{CMID: 3, First: "Ben", Last: "Garcia", Birthdate: "2015-01-01"})
+	f.addPerson(blank, &rosterTestPerson{CMID: 4, First: "Rosa", Last: "Garcia"})
+
+	cities := map[string]string{}
+	for _, block := range f.mustBuild().Blocks {
+		cities[block.HouseholdID] = block.City
+	}
+	if cities[knows] != "Fresno" {
+		t.Errorf("city = %q on the household that has one, want %q", cities[knows], "Fresno")
+	}
+	if cities[blank] != "" {
+		t.Errorf("city = %q on the household with none, want empty -- the fallback leaked", cities[blank])
+	}
+}
+
+// TestBuildFamilyCampRosterKeepsHouseholdsWithNoAdults pins design §7 and §8: a
+// household with enrolled campers and no Family Camp registration is legitimate
+// (4 of 391 in 2026) and renders as-is, with no cue in v1.
+func TestBuildFamilyCampRosterKeepsHouseholdsWithNoAdults(t *testing.T) {
+	t.Parallel()
+	f := newRosterFixture(t)
+	household := f.addHousehold(9001)
+	f.addCamper(household, &rosterTestPerson{CMID: 1, First: "Emma", Last: "Johnson", Birthdate: "2014-03-02"})
+
+	roster := f.mustBuild()
+	assertRows(t, roster.Blocks[0], []string{"Emma Johnson|Camper|12|"})
+}
+
+// TestBuildFamilyCampRosterIgnoresOtherYearsAdults keeps last season's adults off
+// this season's roster. family_camp_adults is keyed (household, year,
+// adult_number), so the year filter is what separates them.
+func TestBuildFamilyCampRosterIgnoresOtherYearsAdults(t *testing.T) {
+	t.Parallel()
+	f := newRosterFixture(t)
+	household := f.addHousehold(9001)
+	f.addCamper(household, &rosterTestPerson{CMID: 1, First: "Emma", Last: "Johnson", Birthdate: "2014-03-02"})
+	f.addAdult(household, &rosterTestAdult{Number: 1, Name: "Sarah Johnson"})
+	f.addAdult(household, &rosterTestAdult{Number: 2, Name: "Last Season", Year: 2025})
+
+	roster := f.mustBuild()
+	assertRows(t, roster.Blocks[0], []string{
+		"Emma Johnson|Camper|12|",
+		"Sarah Johnson|Adult 1||",
+	})
+}
+
+// TestBuildFamilyCampRosterOrdersHouseholds pins the sheet-level order:
+// ascending on the first (youngest) camper's surname.
+func TestBuildFamilyCampRosterOrdersHouseholds(t *testing.T) {
+	t.Parallel()
+	f := newRosterFixture(t)
+	for cmID, surname := range map[int]string{9001: "Ortiz", 9002: "Garcia", 9003: "Johnson"} {
+		household := f.addHousehold(cmID)
+		f.addCamper(household, &rosterTestPerson{
+			CMID: cmID, First: "Kid", Last: surname, Birthdate: "2014-03-02",
+		})
+	}
+
+	roster := f.mustBuild()
+	want := []string{"Kid Garcia", "Kid Johnson", "Kid Ortiz"}
+	for i, name := range want {
+		if got := roster.Blocks[i].People[0].Name; got != name {
+			t.Errorf("block %d first person = %q, want %q", i, got, name)
+		}
+	}
+}
+
+// TestBuildFamilyCampRosterMarksLinkedHouseholds pins design §5 end to end: two
+// households sharing an adult are colored, never merged.
+func TestBuildFamilyCampRosterMarksLinkedHouseholds(t *testing.T) {
+	t.Parallel()
+	f := newRosterFixture(t)
+	first := f.addHousehold(9001)
+	f.addCamper(first, &rosterTestPerson{CMID: 1, First: "Ana", Last: "Garcia", Birthdate: "2014-03-02"})
+	f.addAdult(first, &rosterTestAdult{Number: 1, Name: "Sarah Johnson"})
+
+	second := f.addHousehold(9002)
+	f.addCamper(second, &rosterTestPerson{CMID: 2, First: "Ben", Last: "Johnson", Birthdate: "2014-03-02"})
+	f.addAdult(second, &rosterTestAdult{Number: 1, Name: "Sarah Johnson"})
+
+	alone := f.addHousehold(9003)
+	f.addCamper(alone, &rosterTestPerson{CMID: 3, First: "Cara", Last: "Ortiz", Birthdate: "2014-03-02"})
+	f.addAdult(alone, &rosterTestAdult{Number: 1, Name: "Ruth Okafor"})
+
+	roster := f.mustBuild()
+	if len(roster.Blocks) != 3 {
+		t.Fatalf("blocks = %d, want 3", len(roster.Blocks))
+	}
+	byHousehold := map[string]HouseholdBlock{}
+	for _, block := range roster.Blocks {
+		byHousehold[block.HouseholdID] = block
+	}
+	if g := byHousehold[first].LinkGroup; g == 0 || g != byHousehold[second].LinkGroup {
+		t.Errorf("link groups = %d and %d, want equal and non-zero",
+			byHousehold[first].LinkGroup, byHousehold[second].LinkGroup)
+	}
+	if g := byHousehold[alone].LinkGroup; g != 0 {
+		t.Errorf("unlinked household has group %d, want 0", g)
+	}
+}
+
+func TestBuildFamilyCampRosterRefusals(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unknown session", func(t *testing.T) {
+		t.Parallel()
+		app := newSyncTestApp(t)
+		_, err := BuildFamilyCampRoster(app, rosterYear, 1234567, exportedAt)
+		if !errors.Is(err, ErrRosterSessionNotFound) {
+			t.Fatalf("err = %v, want ErrRosterSessionNotFound", err)
+		}
+	})
+
+	// A summer session has no family_camp_adults rows at all, so building one
+	// would emit a camper-only roster that looks plausible and is wrong.
+	t.Run("not a family session", func(t *testing.T) {
+		t.Parallel()
+		f := newRosterFixture(t)
+		summer := f.addSession(1309600, "Session 1", "summer",
+			"2026-06-20 07:00:00.000Z", "2026-07-04 07:00:00.000Z")
+		household := f.addHousehold(9001)
+		person := f.addPerson(household, &rosterTestPerson{CMID: 1, First: "Emma", Last: "Johnson"})
+		f.enroll(person, summer, 2, rosterYear)
+
+		_, err := BuildFamilyCampRoster(f.app, rosterYear, 1309600, exportedAt)
+		if !errors.Is(err, ErrRosterSessionNotFamily) {
+			t.Fatalf("err = %v, want ErrRosterSessionNotFamily", err)
+		}
+	})
+
+	// Two of 2026's ten family weekends have no enrolled campers. An empty tab
+	// appended to a workbook is worse than a clear error.
+	t.Run("no enrolled campers", func(t *testing.T) {
+		t.Parallel()
+		f := newRosterFixture(t)
+		_, err := f.build()
+		if !errors.Is(err, ErrRosterNoEnrolledCampers) {
+			t.Fatalf("err = %v, want ErrRosterNoEnrolledCampers", err)
+		}
+	})
+}
+
+// TestBuildFamilyCampRosterUsesTheGivenInstantForAges pins that ages come from
+// the caller's clock rather than the session start (design §Age). The reference
+// implementation passed session start; the design supersedes it, and only a test
+// separating the two can tell them apart.
+func TestBuildFamilyCampRosterUsesTheGivenInstantForAges(t *testing.T) {
+	t.Parallel()
+	f := newRosterFixture(t)
+	household := f.addHousehold(9001)
+	// Birthday falls between the session start (2026-08-20) and the export.
+	f.addCamper(household, &rosterTestPerson{CMID: 1, First: "Emma", Last: "Johnson", Birthdate: "2018-08-19"})
+
+	sessionStart := time.Date(2026, time.August, 20, 0, 0, 0, 0, time.UTC)
+	atStart, err := BuildFamilyCampRoster(f.app, rosterYear, cmIDFamilyCamp1, sessionStart)
+	if err != nil {
+		t.Fatalf("build at session start: %v", err)
+	}
+	if got := atStart.Blocks[0].People[0].Age; got != "8" {
+		t.Fatalf("age at session start = %q, want %q", got, "8")
+	}
+
+	dayBefore := time.Date(2026, time.August, 18, 0, 0, 0, 0, time.UTC)
+	earlier, err := BuildFamilyCampRoster(f.app, rosterYear, cmIDFamilyCamp1, dayBefore)
+	if err != nil {
+		t.Fatalf("build before the birthday: %v", err)
+	}
+	if got := earlier.Blocks[0].People[0].Age; got != "7" {
+		t.Errorf("age two days earlier = %q, want %q -- ages must follow the export instant", got, "7")
+	}
+}

--- a/pocketbase/sync/family_camp_roster_export.go
+++ b/pocketbase/sync/family_camp_roster_export.go
@@ -1,0 +1,315 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"time"
+
+	"github.com/camp/kindred/pocketbase/google"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// Exporting one weekend's roster to Google Sheets. kindred#2433.
+//
+// The export APPENDS a dated tab and never prunes or overwrites one. Staff
+// hand-edit every tab -- paper registrations exist only as lodging-board
+// write-ins and never reach CampMinder -- so the previous tab is where they copy
+// their work from. That is also why there is no scheduled run.
+
+// defaultSheetTabName is the empty tab Google puts in every new spreadsheet.
+const defaultSheetTabName = "Sheet1"
+
+// ErrRosterFolderNotConfigured means GOOGLE_DRIVE_ROSTER_FOLDER_ID is unset.
+//
+// This REFUSES rather than falling back to GOOGLE_DRIVE_FOLDER_ID. Drive folder
+// sharing is the privacy control for these workbooks and it is per-folder: the
+// Exports folder's audience is wider, and a roster landing there would publish
+// family contact details to it. A silent no-op is not an option either -- it is
+// indistinguishable from a weekend with no enrolled campers.
+var ErrRosterFolderNotConfigured = errors.New(
+	"GOOGLE_DRIVE_ROSTER_FOLDER_ID is not set; it is required for Family Camp roster exports " +
+		"and is deliberately a different folder from GOOGLE_DRIVE_FOLDER_ID")
+
+// RosterDriveClient is the Drive surface the export needs, behind an interface
+// so the whole orchestration is testable without a network call.
+type RosterDriveClient interface {
+	// RosterFolderID returns the configured roster folder, or "" when unset.
+	RosterFolderID() string
+	FindOrCreateFolder(ctx context.Context, parentID, name string) (string, error)
+	FindSpreadsheetInFolder(ctx context.Context, folderID, name string) (string, error)
+	CreateSpreadsheetInFolder(ctx context.Context, folderID, title string) (string, error)
+}
+
+// DefaultRosterDriveClient delegates to the google package.
+type DefaultRosterDriveClient struct{}
+
+// RosterFolderID returns GOOGLE_DRIVE_ROSTER_FOLDER_ID.
+func (DefaultRosterDriveClient) RosterFolderID() string { return google.GetRosterFolderID() }
+
+// FindOrCreateFolder returns the id of `name` beneath parentID, creating it if
+// needed. Only the {year} folder goes through this: code owns that name and it
+// is deterministic, whereas a CONFIGURED folder is addressed by id so that
+// renaming it in Drive surfaces as an error rather than a silent duplicate.
+func (DefaultRosterDriveClient) FindOrCreateFolder(
+	ctx context.Context, parentID, name string,
+) (string, error) {
+	return google.FindOrCreateFolder(ctx, parentID, name)
+}
+
+// FindSpreadsheetInFolder searches one folder for a spreadsheet by exact name.
+func (DefaultRosterDriveClient) FindSpreadsheetInFolder(
+	ctx context.Context, folderID, name string,
+) (string, error) {
+	return google.FindSpreadsheetInFolder(ctx, folderID, name)
+}
+
+// CreateSpreadsheetInFolder creates a spreadsheet in an explicit folder.
+func (DefaultRosterDriveClient) CreateSpreadsheetInFolder(
+	ctx context.Context, folderID, title string,
+) (string, error) {
+	return google.CreateSpreadsheetInFolder(ctx, folderID, title)
+}
+
+// RosterExportResult is what one export produced, and the endpoint's response.
+type RosterExportResult struct {
+	SpreadsheetID  string `json:"spreadsheet_id"`
+	URL            string `json:"url"`
+	Title          string `json:"title"`
+	TabName        string `json:"tab_name"`
+	SessionCMID    int    `json:"session_cm_id"`
+	SessionName    string `json:"session_name"`
+	Year           int    `json:"year"`
+	HouseholdCount int    `json:"household_count"`
+	CamperCount    int    `json:"camper_count"`
+	AdultCount     int    `json:"adult_count"`
+	PersonCount    int    `json:"person_count"`
+}
+
+// RosterExporter builds a weekend's roster and appends it to that weekend's
+// workbook.
+type RosterExporter struct {
+	app       core.App
+	writer    SheetsWriter
+	drive     RosterDriveClient
+	workbooks *WorkbookManager
+	now       func() time.Time
+}
+
+// NewRosterExporter wires an exporter. `now` is injected so the dated tab name
+// and the export-time ages are testable.
+func NewRosterExporter(
+	app core.App, writer SheetsWriter, drive RosterDriveClient, now func() time.Time,
+) *RosterExporter {
+	return &RosterExporter{
+		app:       app,
+		writer:    writer,
+		drive:     drive,
+		workbooks: NewWorkbookManager(app, writer),
+		now:       now,
+	}
+}
+
+// Export builds the roster and appends it as a new dated tab, creating the
+// weekend's workbook on the first run.
+//
+// It is synchronous: a handful of Google calls, not a sync run.
+func (e *RosterExporter) Export(ctx context.Context, year, sessionCMID int) (*RosterExportResult, error) {
+	// Built FIRST, so a weekend that refuses (not a family session, no enrolled
+	// campers) never reaches Drive -- no empty workbook, no empty tab.
+	at := e.now().In(campLocation())
+	roster, err := BuildFamilyCampRoster(e.app, year, sessionCMID, at)
+	if err != nil {
+		return nil, err
+	}
+
+	title := google.FormatRosterWorkbookTitle(roster.SessionName, year)
+	spreadsheetID, err := e.resolveWorkbook(ctx, roster, title)
+	if err != nil {
+		return nil, err
+	}
+
+	tabName, sheetID, err := e.appendTab(ctx, spreadsheetID, at)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := e.writer.WriteToSheet(ctx, spreadsheetID, tabName, RosterSheetValues(roster)); err != nil {
+		return nil, fmt.Errorf("writing roster tab %q: %w", tabName, err)
+	}
+	if err := e.writer.ApplyFormatting(ctx, spreadsheetID, RosterSheetFormat(sheetID, roster)); err != nil {
+		return nil, fmt.Errorf("formatting roster tab %q: %w", tabName, err)
+	}
+
+	// Google puts an empty "Sheet1" in every new spreadsheet. Removed only after
+	// the real tab exists, since a spreadsheet cannot have zero sheets.
+	// Best-effort: an orphan default tab is untidy, not a failed export.
+	if err := e.writer.DeleteSheet(ctx, spreadsheetID, defaultSheetTabName); err != nil {
+		slog.Warn("Could not remove the default sheet from a roster workbook",
+			"error", err, "spreadsheet_id", spreadsheetID)
+	}
+
+	result := &RosterExportResult{
+		SpreadsheetID:  spreadsheetID,
+		URL:            google.FormatSpreadsheetURL(spreadsheetID),
+		Title:          title,
+		TabName:        tabName,
+		SessionCMID:    sessionCMID,
+		SessionName:    roster.SessionName,
+		Year:           year,
+		HouseholdCount: roster.HouseholdCount(),
+		CamperCount:    roster.CamperCount(),
+		AdultCount:     roster.AdultCount(),
+		PersonCount:    roster.PersonCount(),
+	}
+
+	if err := e.recordWorkbook(ctx, result); err != nil {
+		return nil, err
+	}
+
+	slog.Info("Exported Family Camp roster",
+		"session", roster.SessionName, "session_cm_id", sessionCMID, "year", year,
+		"tab", tabName, "households", result.HouseholdCount, "people", result.PersonCount,
+		"spreadsheet_id", spreadsheetID)
+	return result, nil
+}
+
+// resolveWorkbook returns this weekend's spreadsheet id, creating the workbook
+// on the first export.
+//
+// Three steps, in order of authority: the registry row, then a Drive search by
+// name, then create. The middle one matters when the database has been cleared
+// but the workbook is still in Drive -- creating a second one under the same
+// name would leave staff with two and no way to tell which carries their edits.
+func (e *RosterExporter) resolveWorkbook(ctx context.Context, roster *Roster, title string) (string, error) {
+	existing, err := e.workbooks.GetWorkbookForSession(
+		ctx, workbookTypeFCRoster, roster.Year, roster.SessionCMID)
+	if err != nil {
+		return "", fmt.Errorf("checking for an existing roster workbook: %w", err)
+	}
+	if existing != nil && existing.SpreadsheetID != "" {
+		return existing.SpreadsheetID, nil
+	}
+
+	// Resolved only now, so a refused weekend never reaches Drive.
+	rosterFolder := e.drive.RosterFolderID()
+	if rosterFolder == "" {
+		return "", ErrRosterFolderNotConfigured
+	}
+
+	// The {year} folder is created BENEATH whatever the env var resolves to, so
+	// prod and dev each get their own without anything special-casing which is
+	// which.
+	yearFolder, err := e.drive.FindOrCreateFolder(ctx, rosterFolder, strconv.Itoa(roster.Year))
+	if err != nil {
+		return "", fmt.Errorf("resolving the %d roster folder: %w", roster.Year, err)
+	}
+
+	found, err := e.drive.FindSpreadsheetInFolder(ctx, yearFolder, title)
+	if err != nil {
+		return "", fmt.Errorf("searching for roster workbook %q: %w", title, err)
+	}
+	if found != "" {
+		slog.Info("Re-linking a roster workbook already in Drive", "title", title, "spreadsheet_id", found)
+		return found, nil
+	}
+
+	created, err := e.drive.CreateSpreadsheetInFolder(ctx, yearFolder, title)
+	if err != nil {
+		return "", fmt.Errorf("creating roster workbook %q: %w", title, err)
+	}
+	slog.Info("Created a roster workbook", "title", title, "spreadsheet_id", created)
+	return created, nil
+}
+
+// appendTab adds a new dated tab and returns its name and sheet id.
+//
+// The sheet id is read back rather than assumed: ApplyFormatting aims every
+// GridRange at it, and the wrong id would silently reformat another tab -- each
+// of which is hand-edited staff work.
+func (e *RosterExporter) appendTab(
+	ctx context.Context, spreadsheetID string, at time.Time,
+) (tabName string, sheetID int64, err error) {
+	before, err := e.writer.GetSheetMetadata(ctx, spreadsheetID)
+	if err != nil {
+		return "", 0, fmt.Errorf("reading roster workbook tabs: %w", err)
+	}
+	existing := make([]string, 0, len(before))
+	for _, sheet := range before {
+		existing = append(existing, sheet.Title)
+	}
+
+	tabName = rosterTabName(at, existing)
+	if ensureErr := e.writer.EnsureSheet(ctx, spreadsheetID, tabName); ensureErr != nil {
+		return "", 0, fmt.Errorf("creating roster tab %q: %w", tabName, ensureErr)
+	}
+
+	after, err := e.writer.GetSheetMetadata(ctx, spreadsheetID)
+	if err != nil {
+		return "", 0, fmt.Errorf("reading back roster tab %q: %w", tabName, err)
+	}
+
+	for _, sheet := range after {
+		if sheet.Title == tabName {
+			return tabName, sheet.SheetID, nil
+		}
+	}
+	return "", 0, fmt.Errorf("roster tab %q was created but is not in the workbook's metadata", tabName)
+}
+
+// recordWorkbook upserts the registry row, keyed on (type, year, session).
+func (e *RosterExporter) recordWorkbook(ctx context.Context, result *RosterExportResult) error {
+	tabs, err := e.writer.GetSheetMetadata(ctx, result.SpreadsheetID)
+	if err != nil {
+		return fmt.Errorf("counting roster workbook tabs: %w", err)
+	}
+
+	if _, err := e.workbooks.SaveWorkbookRecord(ctx, &WorkbookRecord{
+		SpreadsheetID: result.SpreadsheetID,
+		WorkbookType:  workbookTypeFCRoster,
+		Year:          result.Year,
+		SessionCMID:   result.SessionCMID,
+		Title:         result.Title,
+		URL:           result.URL,
+		TabCount:      len(tabs),
+		TotalRecords:  result.PersonCount,
+		Status:        "ok",
+	}); err != nil {
+		return fmt.Errorf("recording roster workbook: %w", err)
+	}
+	return nil
+}
+
+// ErrRosterSheetsDisabled means GOOGLE_SHEETS_ENABLED is not true.
+//
+// The sync path degrades gracefully when Sheets is off, because a nightly export
+// that quietly skips is better than one that fails the run. A staff-triggered
+// export is the opposite: someone is waiting for a link, and a nil writer would
+// panic on the first call rather than name what is switched off.
+var ErrRosterSheetsDisabled = errors.New(
+	"GOOGLE_SHEETS_ENABLED is not true; Family Camp roster export needs Google Sheets")
+
+// NewRosterExporterForApp wires an exporter against the real Google clients.
+//
+// The writer is rate-limited, matching the data export: both surfaces share one
+// Sheets quota, and the roster's formatting call is a write like any other.
+func NewRosterExporterForApp(ctx context.Context, app core.App) (*RosterExporter, error) {
+	if !google.IsEnabled() {
+		return nil, ErrRosterSheetsDisabled
+	}
+
+	client, err := google.NewSheetsClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("creating the Google Sheets client: %w", err)
+	}
+	if client == nil {
+		// IsEnabled said yes, so this is unreachable -- and is checked anyway
+		// because the alternative is a nil-pointer panic inside a request.
+		return nil, ErrRosterSheetsDisabled
+	}
+
+	writer := NewRateLimitedSheetsWriter(NewRealSheetsWriter(client), nil)
+	return NewRosterExporter(app, writer, DefaultRosterDriveClient{}, time.Now), nil
+}

--- a/pocketbase/sync/family_camp_roster_export_test.go
+++ b/pocketbase/sync/family_camp_roster_export_test.go
@@ -1,0 +1,386 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// The export orchestration: resolving the weekend's workbook in Drive, appending
+// a dated tab, and recording the result. kindred#2433.
+//
+// Google is behind two seams -- MockSheetsWriter for Sheets and mockRosterDrive
+// for Drive -- so every path here is asserted without a network call.
+
+// mockRosterDrive records what the exporter asked Drive to do.
+type mockRosterDrive struct {
+	folderID string
+
+	folders     map[string]string // "parent/name" -> folder id
+	spreadsheet map[string]string // "folder/title" -> spreadsheet id
+
+	CreatedFolders     []string
+	CreatedSpreadsheet []string
+	Searched           []string
+	nextID             int
+
+	CreateErr error
+}
+
+func newMockRosterDrive() *mockRosterDrive {
+	return &mockRosterDrive{
+		folderID:    "roster-folder",
+		folders:     map[string]string{},
+		spreadsheet: map[string]string{},
+	}
+}
+
+func (d *mockRosterDrive) RosterFolderID() string { return d.folderID }
+
+func (d *mockRosterDrive) FindOrCreateFolder(_ context.Context, parentID, name string) (string, error) {
+	key := parentID + "/" + name
+	if id, ok := d.folders[key]; ok {
+		return id, nil
+	}
+	d.nextID++
+	id := fmt.Sprintf("folder-%d", d.nextID)
+	d.folders[key] = id
+	d.CreatedFolders = append(d.CreatedFolders, key)
+	return id, nil
+}
+
+func (d *mockRosterDrive) FindSpreadsheetInFolder(_ context.Context, folderID, name string) (string, error) {
+	key := folderID + "/" + name
+	d.Searched = append(d.Searched, key)
+	return d.spreadsheet[key], nil
+}
+
+func (d *mockRosterDrive) CreateSpreadsheetInFolder(_ context.Context, folderID, title string) (string, error) {
+	if d.CreateErr != nil {
+		return "", d.CreateErr
+	}
+	d.nextID++
+	id := fmt.Sprintf("sheet-%d", d.nextID)
+	d.spreadsheet[folderID+"/"+title] = id
+	d.CreatedSpreadsheet = append(d.CreatedSpreadsheet, title)
+	return id, nil
+}
+
+// testRosterTab is the tab name the harness's fixed instant renders to.
+const testRosterTab = "Aug 19, 2026 3:04 PM"
+
+// exportHarness wires a roster fixture to the two mocked Google seams.
+type exportHarness struct {
+	t      *testing.T
+	app    core.App
+	writer *MockSheetsWriter
+	drive  *mockRosterDrive
+	at     time.Time
+}
+
+func newExportHarness(t *testing.T) *exportHarness {
+	t.Helper()
+	f := newRosterFixture(t)
+	household := f.addHousehold(9001)
+	f.addCamper(household, &rosterTestPerson{
+		CMID: 1, First: "Emma", Last: "Johnson", Birthdate: "2014-03-02", NormalizedCity: "Berkeley, CA",
+	})
+	f.addAdult(household, &rosterTestAdult{Number: 1, Name: "Sarah Johnson", Email: "sarah@example.com"})
+
+	// sheets_workbooks does not exist on the sync fixture app, so the harness
+	// adds it here, mirroring migration 1500000165.
+	workbooks := core.NewBaseCollection("sheets_workbooks")
+	workbooks.Fields.Add(&core.TextField{Name: "spreadsheet_id"})
+	workbooks.Fields.Add(&core.SelectField{
+		Name: "workbook_type", MaxSelect: 1, Values: []string{"globals", "year", "fc_roster"},
+	})
+	workbooks.Fields.Add(&core.NumberField{Name: "year", OnlyInt: true})
+	workbooks.Fields.Add(&core.NumberField{Name: "session_cm_id", OnlyInt: true})
+	workbooks.Fields.Add(&core.TextField{Name: "title"})
+	workbooks.Fields.Add(&core.TextField{Name: "url"})
+	workbooks.Fields.Add(&core.NumberField{Name: "tab_count", OnlyInt: true})
+	workbooks.Fields.Add(&core.NumberField{Name: "total_records", OnlyInt: true})
+	workbooks.Fields.Add(&core.SelectField{
+		Name: "status", MaxSelect: 1, Values: []string{"ok", "error", "syncing"},
+	})
+	workbooks.Fields.Add(&core.TextField{Name: "error_message"})
+	workbooks.Fields.Add(&core.TextField{Name: "last_sync"})
+	workbooks.AddIndex("idx_sheets_workbooks_type_year", true,
+		"workbook_type, year, session_cm_id", "")
+	if err := f.app.Save(workbooks); err != nil {
+		t.Fatalf("save sheets_workbooks: %v", err)
+	}
+
+	return &exportHarness{
+		t: t, app: f.app,
+		writer: NewMockSheetsWriter(),
+		drive:  newMockRosterDrive(),
+		// Stated in CAMP-LOCAL time, because that is what the tab name renders
+		// in. Writing this as a UTC wall clock would make every tab-name
+		// assertion below depend on the offset, which is the bug the export's
+		// campLocation() conversion exists to prevent.
+		at: time.Date(2026, time.August, 19, 15, 4, 0, 0, testCampLocation(t)),
+	}
+}
+
+// testCampLocation is Pacific, loaded explicitly rather than through
+// campLocation(), so these tests do not depend on the machine's TZ.
+func testCampLocation(t *testing.T) *time.Location {
+	t.Helper()
+	loc, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		t.Fatalf("load America/Los_Angeles: %v", err)
+	}
+	return loc
+}
+
+func (h *exportHarness) exporter() *RosterExporter {
+	return NewRosterExporter(h.app, h.writer, h.drive, func() time.Time { return h.at })
+}
+
+func (h *exportHarness) export() (*RosterExportResult, error) {
+	h.t.Helper()
+	return h.exporter().Export(context.Background(), rosterYear, cmIDFamilyCamp1)
+}
+
+func (h *exportHarness) mustExport() *RosterExportResult {
+	h.t.Helper()
+	result, err := h.export()
+	if err != nil {
+		h.t.Fatalf("Export: %v", err)
+	}
+	return result
+}
+
+// TestRosterExportCreatesTheWorkbookOnFirstRun pins the whole first-export path:
+// the {year} folder beneath the configured roster folder, a workbook named for
+// the weekend, one dated tab, values, formatting, and a registry row.
+func TestRosterExportCreatesTheWorkbookOnFirstRun(t *testing.T) {
+	t.Parallel()
+	h := newExportHarness(t)
+	result := h.mustExport()
+
+	if got := h.drive.CreatedFolders; len(got) != 1 || got[0] != "roster-folder/2026" {
+		t.Errorf("created folders = %v, want exactly [roster-folder/2026]", got)
+	}
+	wantTitle := "(DEV) Family Camp 2: Keshet LGBTQ Weekend 2026 Roster"
+	if got := h.drive.CreatedSpreadsheet; len(got) != 1 || got[0] != wantTitle {
+		t.Errorf("created spreadsheets = %v, want exactly [%q]", got, wantTitle)
+	}
+
+	if result.TabName != testRosterTab {
+		t.Errorf("tab name = %q", result.TabName)
+	}
+	if result.SpreadsheetID == "" || result.URL == "" {
+		t.Errorf("result = %+v, want a spreadsheet id and url", result)
+	}
+	if result.HouseholdCount != 1 || result.CamperCount != 1 || result.AdultCount != 1 {
+		t.Errorf("counts = %+v, want 1 household, 1 camper, 1 adult", result)
+	}
+
+	rows := h.writer.WrittenData[result.TabName]
+	if len(rows) != rosterFirstDataRow+2 {
+		t.Fatalf("wrote %d rows, want %d", len(rows), rosterFirstDataRow+2)
+	}
+	if h.writer.ApplyFormattingCalls != 1 {
+		t.Errorf("ApplyFormatting called %d times, want exactly 1 -- one batch per tab",
+			h.writer.ApplyFormattingCalls)
+	}
+
+	// The registry row is what stops the next export creating a second workbook.
+	manager := NewWorkbookManager(h.app, h.writer)
+	stored, err := manager.GetWorkbookForSession(
+		context.Background(), workbookTypeFCRoster, rosterYear, cmIDFamilyCamp1)
+	if err != nil {
+		t.Fatalf("GetWorkbookForSession: %v", err)
+	}
+	if stored == nil || stored.SpreadsheetID != result.SpreadsheetID {
+		t.Fatalf("stored workbook = %+v, want spreadsheet %s", stored, result.SpreadsheetID)
+	}
+}
+
+// TestRosterExportAppendsToTheSameWorkbook pins the append contract: a second
+// export reuses the weekend's workbook, adds a tab, and NEVER prunes or
+// overwrites the earlier one -- staff hand-edit every tab.
+func TestRosterExportAppendsToTheSameWorkbook(t *testing.T) {
+	t.Parallel()
+	h := newExportHarness(t)
+	first := h.mustExport()
+
+	h.at = h.at.Add(24 * time.Hour)
+	second := h.mustExport()
+
+	if first.SpreadsheetID != second.SpreadsheetID {
+		t.Errorf("second export used workbook %s, want %s", second.SpreadsheetID, first.SpreadsheetID)
+	}
+	if len(h.drive.CreatedSpreadsheet) != 1 {
+		t.Errorf("created %d workbooks, want 1", len(h.drive.CreatedSpreadsheet))
+	}
+	if first.TabName == second.TabName {
+		t.Fatalf("both exports wrote tab %q", first.TabName)
+	}
+	if !h.writer.ExistingTabs[first.TabName] {
+		t.Errorf("first tab %q no longer exists -- tabs are never pruned", first.TabName)
+	}
+	if len(h.writer.ClearedTabs) != 0 {
+		t.Errorf("cleared %v -- an appended tab is new, and clearing would erase hand edits",
+			h.writer.ClearedTabs)
+	}
+	if len(h.writer.DeletedSheets) > 0 && slices.Contains(h.writer.DeletedSheets, first.TabName) {
+		t.Errorf("deleted the earlier tab %q", first.TabName)
+	}
+}
+
+// TestRosterExportSuffixesATabNameCollision covers two exports inside one minute.
+func TestRosterExportSuffixesATabNameCollision(t *testing.T) {
+	t.Parallel()
+	h := newExportHarness(t)
+	first := h.mustExport()
+	second := h.mustExport()
+
+	if second.TabName != first.TabName+" (2)" {
+		t.Errorf("second tab = %q, want %q", second.TabName, first.TabName+" (2)")
+	}
+	if len(h.writer.WrittenData[second.TabName]) == 0 {
+		t.Errorf("nothing written to %q", second.TabName)
+	}
+}
+
+// TestRosterExportRefusesWithoutTheRosterFolder pins the loudest rule in the
+// design: a blank GOOGLE_DRIVE_ROSTER_FOLDER_ID REFUSES, naming the variable.
+//
+// It must never fall back to GOOGLE_DRIVE_FOLDER_ID -- that folder's audience is
+// the data export's, and these workbooks carry family contact details. Nor may
+// it degrade to a silent no-op, which is indistinguishable from a weekend with
+// no enrolled campers.
+func TestRosterExportRefusesWithoutTheRosterFolder(t *testing.T) {
+	t.Parallel()
+	h := newExportHarness(t)
+	h.drive.folderID = ""
+
+	_, err := h.export()
+	if !errors.Is(err, ErrRosterFolderNotConfigured) {
+		t.Fatalf("err = %v, want ErrRosterFolderNotConfigured", err)
+	}
+	if !strings.Contains(err.Error(), "GOOGLE_DRIVE_ROSTER_FOLDER_ID") {
+		t.Errorf("err = %q, want it to name the environment variable", err)
+	}
+	if len(h.drive.CreatedFolders) != 0 || len(h.drive.CreatedSpreadsheet) != 0 {
+		t.Errorf("created %v / %v in Drive, want nothing",
+			h.drive.CreatedFolders, h.drive.CreatedSpreadsheet)
+	}
+	if len(h.writer.EnsuredTabs) != 0 {
+		t.Errorf("ensured %v, want no tab written", h.writer.EnsuredTabs)
+	}
+}
+
+// TestRosterExportRelinksAWorkbookFoundInDrive covers a cleared database: the
+// workbook is still in Drive, so a second one under the same name would leave
+// staff with two and no way to tell which carries their edits.
+func TestRosterExportRelinksAWorkbookFoundInDrive(t *testing.T) {
+	t.Parallel()
+	h := newExportHarness(t)
+	title := "(DEV) Family Camp 2: Keshet LGBTQ Weekend 2026 Roster"
+	h.drive.folders["roster-folder/2026"] = "existing-year-folder"
+	h.drive.spreadsheet["existing-year-folder/"+title] = "already-there"
+
+	result := h.mustExport()
+
+	if result.SpreadsheetID != "already-there" {
+		t.Errorf("spreadsheet = %q, want the one already in Drive", result.SpreadsheetID)
+	}
+	if len(h.drive.CreatedSpreadsheet) != 0 {
+		t.Errorf("created %v, want none -- the workbook was already there", h.drive.CreatedSpreadsheet)
+	}
+}
+
+// TestRosterExportRemovesTheDefaultSheet1 keeps Google's empty default tab out
+// of a workbook whose tabs are the audit trail.
+func TestRosterExportRemovesTheDefaultSheet1(t *testing.T) {
+	t.Parallel()
+	h := newExportHarness(t)
+	h.writer.ExistingTabs["Sheet1"] = true
+
+	h.mustExport()
+
+	if !slices.Contains(h.writer.DeletedSheets, "Sheet1") {
+		t.Errorf("deleted %v, want Sheet1 removed", h.writer.DeletedSheets)
+	}
+}
+
+// TestRosterExportFormatsTheTabItJustCreated guards the id the formatting is
+// aimed at. A GridRange with the wrong sheet id silently formats another tab --
+// and every earlier tab in this workbook is hand-edited staff work.
+func TestRosterExportFormatsTheTabItJustCreated(t *testing.T) {
+	t.Parallel()
+	h := newExportHarness(t)
+	h.writer.SheetIDsByName[testRosterTab] = 987
+
+	result := h.mustExport()
+
+	if len(h.writer.AppliedFormats) != 1 {
+		t.Fatalf("applied %d formats, want 1", len(h.writer.AppliedFormats))
+	}
+	if got := h.writer.AppliedFormats[0].SheetID; got != 987 {
+		t.Errorf("formatted sheet id %d, want 987 (the tab %q)", got, result.TabName)
+	}
+}
+
+// TestRosterExportPropagatesBuilderRefusals keeps a refused weekend from
+// touching Drive at all -- no empty workbook, no empty tab.
+func TestRosterExportPropagatesBuilderRefusals(t *testing.T) {
+	t.Parallel()
+	f := newRosterFixture(t) // a family session with no enrolled campers
+	writer := NewMockSheetsWriter()
+	drive := newMockRosterDrive()
+	exporter := NewRosterExporter(f.app, writer, drive, time.Now)
+
+	_, err := exporter.Export(context.Background(), rosterYear, cmIDFamilyCamp1)
+	if !errors.Is(err, ErrRosterNoEnrolledCampers) {
+		t.Fatalf("err = %v, want ErrRosterNoEnrolledCampers", err)
+	}
+	if len(drive.CreatedFolders) != 0 || len(drive.CreatedSpreadsheet) != 0 {
+		t.Errorf("touched Drive: %v / %v", drive.CreatedFolders, drive.CreatedSpreadsheet)
+	}
+	if len(writer.EnsuredTabs) != 0 {
+		t.Errorf("ensured %v, want no tab", writer.EnsuredTabs)
+	}
+}
+
+// TestRosterExportStampsAgesInCampLocalTime pins the clock the export reads.
+// PocketBase's container leaves time.Local at UTC unless TZ is set, so an export
+// made at 5pm Pacific would otherwise be stamped with the next day's date.
+func TestRosterExportStampsAgesInCampLocalTime(t *testing.T) {
+	t.Setenv("TZ", "America/Los_Angeles")
+	h := newExportHarness(t)
+	// 2026-08-20 05:04 UTC is 2026-08-19 22:04 Pacific.
+	h.at = time.Date(2026, time.August, 20, 5, 4, 0, 0, time.UTC)
+
+	result := h.mustExport()
+	if !strings.HasPrefix(result.TabName, "Aug 19, 2026") {
+		t.Errorf("tab name = %q, want it stamped Aug 19 in camp-local time", result.TabName)
+	}
+}
+
+// TestNewRosterExporterForAppRefusesWhenSheetsIsDisabled pins the other
+// misconfiguration. With GOOGLE_SHEETS_ENABLED unset, NewSheetsClient returns
+// nil, nil -- the graceful degradation the sync path wants, and exactly wrong
+// for a staff-triggered export, where a nil writer would panic on the first
+// call instead of telling anyone what is switched off.
+func TestNewRosterExporterForAppRefusesWhenSheetsIsDisabled(t *testing.T) {
+	t.Setenv("GOOGLE_SHEETS_ENABLED", "false")
+
+	_, err := NewRosterExporterForApp(context.Background(), newSyncTestApp(t))
+	if !errors.Is(err, ErrRosterSheetsDisabled) {
+		t.Fatalf("err = %v, want ErrRosterSheetsDisabled", err)
+	}
+	if !strings.Contains(err.Error(), "GOOGLE_SHEETS_ENABLED") {
+		t.Errorf("err = %q, want it to name the environment variable", err)
+	}
+}

--- a/pocketbase/sync/family_camp_roster_sheet.go
+++ b/pocketbase/sync/family_camp_roster_sheet.go
@@ -1,0 +1,318 @@
+package sync
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"slices"
+	"strings"
+	"time"
+
+	// The roster stamps its tab name in camp-local time, so time.LoadLocation
+	// must work. PocketBase ships on chainguard/static, which carries no
+	// guarantee of /usr/share/zoneinfo, and a LoadLocation that silently failed
+	// would date an evening export to the next day. Embedding the database costs
+	// ~450KB and removes the dependency on the base image entirely.
+	_ "time/tzdata"
+
+	"github.com/pocketbase/pocketbase/tools/types"
+)
+
+// Rendering one Roster into the values and formatting directives for one tab.
+// No Google calls: the SheetFormat is a value, asserted as a value in tests.
+// kindred#2433.
+
+// The sheet's shape. Row and column indices are 0-based, matching GridRange.
+const (
+	rosterTitleRow     = 0
+	rosterSubtitleRow  = 1
+	rosterHeaderRow    = 2
+	rosterFirstDataRow = 3
+
+	rosterNameColumn  = 0
+	rosterRoleColumn  = 1
+	rosterAgeColumn   = 2
+	rosterEmailColumn = 3
+	rosterCityColumn  = 4
+
+	rosterColumnCount = 5
+)
+
+// rosterHeaders are upper-cased on the way out, matching the hand-made sheet.
+var rosterHeaders = [rosterColumnCount]string{"Name", "Adult / Camper", "Age", "Email", "City"}
+
+// rosterColumnPixels are the widths from the design, in the header order above.
+var rosterColumnPixels = [rosterColumnCount]int{200, 115, 75, 245, 130}
+
+// The palette. Every color here is stated once and read from both the fills and
+// the borders, so a change lands in one place.
+const (
+	rosterBandHex     = "#ECEFF1" // alternating household banding
+	rosterHeaderBgHex = "#37474F"
+	rosterHeaderFgHex = "#FFFFFF"
+	rosterSubtitleHex = "#5F6368"
+	rosterRoleHex     = "#455A64"
+	rosterBlockEdge   = "#78909C" // medium, the block's top and bottom
+	rosterCellEdge    = "#DADDE1" // thin, everywhere else
+)
+
+// rosterLinkTints are the six pale fills a linked-household group can take
+// (design §5). They REPLACE the banding rather than sitting alongside it, so a
+// linked pair is visible whichever parity it lands on.
+//
+// Only three of 2026's ten family weekends contain any linked households at all,
+// and the most in one weekend is two groups -- six is already generous, and
+// group numbers wrap rather than run out.
+var rosterLinkTints = [...]string{
+	"#FFF8E1", // amber
+	"#E8F5E9", // green
+	"#E3F2FD", // blue
+	"#FCE4EC", // pink
+	"#F3E5F5", // purple
+	"#FFF3E0", // orange
+}
+
+// rosterTabLayout is the tab name's timestamp format, e.g. "Aug 19, 2026 3:04 PM".
+const rosterTabLayout = "Jan 2, 2006 3:04 PM"
+
+// defaultCampTimezone is the fallback when TZ is unset, matching
+// docker-compose.yml's `TZ=${TZ:-America/Los_Angeles}`.
+const defaultCampTimezone = "America/Los_Angeles"
+
+// RosterSheetValues renders the roster's cell values, ready for WriteToSheet.
+//
+// The City is written only on a block's FIRST row: it describes the household,
+// and repeating it down every row is what makes the hand-made sheet read as a
+// list of people rather than a list of families.
+func RosterSheetValues(roster *Roster) [][]any {
+	rows := make([][]any, 0, rosterFirstDataRow+roster.PersonCount())
+
+	title := blankRosterRow()
+	title[rosterNameColumn] = fmt.Sprintf("%s %d Roster", roster.SessionName, roster.Year)
+	rows = append(rows, title)
+
+	subtitle := blankRosterRow()
+	subtitle[rosterNameColumn] = formatRosterDateRange(roster.Start, roster.End)
+	rows = append(rows, subtitle)
+
+	header := blankRosterRow()
+	for col, name := range rosterHeaders {
+		header[col] = strings.ToUpper(name)
+	}
+	rows = append(rows, header)
+
+	for _, block := range roster.Blocks {
+		for i, person := range block.People {
+			row := blankRosterRow()
+			row[rosterNameColumn] = person.Name
+			row[rosterRoleColumn] = person.Role
+			row[rosterAgeColumn] = person.Age
+			row[rosterEmailColumn] = person.Email
+			if i == 0 {
+				row[rosterCityColumn] = block.City
+			}
+			rows = append(rows, row)
+		}
+	}
+	return rows
+}
+
+// blankRosterRow returns a full-width row of empty strings. Every row is the
+// same width so a short row cannot leave a previous tab's cell showing through
+// -- and so the merged title row actually spans the columns it claims to.
+func blankRosterRow() []any {
+	row := make([]any, rosterColumnCount)
+	for i := range row {
+		row[i] = ""
+	}
+	return row
+}
+
+// RosterSheetFormat describes the whole tab's appearance for ONE batchUpdate.
+// Per-block work is per-block RULES inside one call, never one call per block:
+// a 63-household roster must not become 63 round trips.
+func RosterSheetFormat(sheetID int64, roster *Roster) *SheetFormat {
+	lastRow := rosterFirstDataRow + roster.PersonCount()
+
+	format := &SheetFormat{
+		SheetID: sheetID,
+		Merges: []GridRange{
+			fullWidthRosterRange(rosterTitleRow, rosterTitleRow+1),
+			fullWidthRosterRange(rosterSubtitleRow, rosterSubtitleRow+1),
+		},
+		// Rows 1-3 frozen, so the first person is the first row to scroll.
+		FrozenRows: rosterFirstDataRow,
+	}
+
+	for col, pixels := range rosterColumnPixels {
+		format.ColumnWidths = append(format.ColumnWidths, ColumnWidth{
+			StartCol: col, EndCol: col + 1, Pixels: pixels,
+		})
+	}
+
+	format.Styles = append(format.Styles,
+		StyleRule{
+			Range: fullWidthRosterRange(rosterTitleRow, rosterTitleRow+1),
+			Style: CellStyle{
+				Bold: types.Pointer(true), FontSize: 14,
+				HorizontalAlignment: "CENTER", VerticalAlignment: "MIDDLE",
+			},
+		},
+		StyleRule{
+			Range: fullWidthRosterRange(rosterSubtitleRow, rosterSubtitleRow+1),
+			Style: CellStyle{
+				FontSize: 10, FontHex: rosterSubtitleHex,
+				HorizontalAlignment: "CENTER", VerticalAlignment: "MIDDLE",
+			},
+		},
+		StyleRule{
+			Range: fullWidthRosterRange(rosterHeaderRow, rosterHeaderRow+1),
+			Style: CellStyle{
+				BackgroundHex: rosterHeaderBgHex, FontHex: rosterHeaderFgHex,
+				Bold: types.Pointer(true), FontSize: 9, VerticalAlignment: "MIDDLE",
+			},
+		},
+	)
+
+	// Nothing below this point has any rows to describe when the roster is empty,
+	// and a zero-height GridRange is refused by buildFormatRequests rather than
+	// silently widened to the whole tab. BuildFamilyCampRoster already refuses an
+	// empty weekend; this keeps the renderer safe on its own terms.
+	if roster.PersonCount() == 0 {
+		return format
+	}
+
+	format.Styles = append(format.Styles,
+		// Left first, then the age column's CENTER on top of it. The Sheets API
+		// applies requests IN ORDER, so the reverse would left-align the ages.
+		StyleRule{
+			Range: fullWidthRosterRange(rosterFirstDataRow, lastRow),
+			Style: CellStyle{HorizontalAlignment: "LEFT", VerticalAlignment: "MIDDLE"},
+		},
+		StyleRule{
+			Range: GridRange{
+				StartRow: rosterFirstDataRow, EndRow: lastRow,
+				StartCol: rosterAgeColumn, EndCol: rosterAgeColumn + 1,
+			},
+			Style: CellStyle{HorizontalAlignment: "CENTER"},
+		},
+		StyleRule{
+			Range: GridRange{
+				StartRow: rosterFirstDataRow, EndRow: lastRow,
+				StartCol: rosterRoleColumn, EndCol: rosterRoleColumn + 1,
+			},
+			Style: CellStyle{FontHex: rosterRoleHex},
+		},
+		// The whole city column, not one rule per block. Only a block's first row
+		// carries a city, and bold on an empty cell is invisible -- so this is one
+		// request where the per-block form would be one per household.
+		StyleRule{
+			Range: GridRange{
+				StartRow: rosterFirstDataRow, EndRow: lastRow,
+				StartCol: rosterCityColumn, EndCol: rosterCityColumn + 1,
+			},
+			Style: CellStyle{Bold: types.Pointer(true)},
+		},
+	)
+
+	appendRosterBlockFormatting(format, roster)
+	return format
+}
+
+// appendRosterBlockFormatting paints each household block: its fill, and the
+// borders that make it read as one unit.
+func appendRosterBlockFormatting(format *SheetFormat, roster *Roster) {
+	blockEdge := &BorderEdge{Style: "SOLID_MEDIUM", Hex: rosterBlockEdge}
+	cellEdge := &BorderEdge{Style: "SOLID", Hex: rosterCellEdge}
+
+	row := rosterFirstDataRow
+	for i, block := range roster.Blocks {
+		if len(block.People) == 0 {
+			continue
+		}
+		span := fullWidthRosterRange(row, row+len(block.People))
+
+		// A linked group's tint REPLACES the banding; an ordinary block is
+		// banded on odd indices and left white on even ones. White needs no
+		// request: every export appends a brand-new tab, so there is no earlier
+		// fill to clear.
+		if fill := rosterBlockFill(block, i); fill != "" {
+			format.Styles = append(format.Styles, StyleRule{
+				Range: span, Style: CellStyle{BackgroundHex: fill},
+			})
+		}
+
+		format.Borders = append(format.Borders, BorderRule{
+			Range: span,
+			Top:   blockEdge, Bottom: blockEdge,
+			Left: cellEdge, Right: cellEdge,
+			InnerHorizontal: cellEdge, InnerVertical: cellEdge,
+		})
+
+		row += len(block.People)
+	}
+}
+
+// rosterBlockFill returns the background for one block, or "" for plain white.
+func rosterBlockFill(block HouseholdBlock, index int) string {
+	if block.LinkGroup > 0 {
+		// Group numbers are 1-based and wrap rather than run out.
+		return rosterLinkTints[(block.LinkGroup-1)%len(rosterLinkTints)]
+	}
+	if index%2 == 1 {
+		return rosterBandHex
+	}
+	return ""
+}
+
+// fullWidthRosterRange is the half-open row span across every column.
+func fullWidthRosterRange(startRow, endRow int) GridRange {
+	return GridRange{
+		StartRow: startRow, EndRow: endRow,
+		StartCol: 0, EndCol: rosterColumnCount,
+	}
+}
+
+// rosterTabName returns the date-stamped tab name for `at`, suffixed " (2)",
+// " (3)", ... when a tab of that exact name already exists.
+//
+// Tabs are NEVER pruned and NEVER overwritten: staff hand-edit every one, and
+// re-applying that work means copying from the previous tab. A collision means
+// two exports inside one minute, which is a real thing staff do when the first
+// one surprised them.
+func rosterTabName(at time.Time, existing []string) string {
+	base := at.Format(rosterTabLayout)
+	if !slices.Contains(existing, base) {
+		return base
+	}
+	for suffix := 2; ; suffix++ {
+		candidate := fmt.Sprintf("%s (%d)", base, suffix)
+		if !slices.Contains(existing, candidate) {
+			return candidate
+		}
+	}
+}
+
+// campLocation returns the timezone tab names and export-time ages are rendered
+// in: TZ when it names a zone Go can load, otherwise Pacific.
+//
+// The fallback is not cosmetic. PocketBase's container leaves time.Local at UTC
+// unless TZ is set, and an export made at 5pm Pacific would then be stamped with
+// the NEXT day's date -- on an artifact whose whole point is a dated audit trail
+// of what staff pulled and when.
+func campLocation() *time.Location {
+	if name := strings.TrimSpace(os.Getenv("TZ")); name != "" {
+		if loc, err := time.LoadLocation(name); err == nil {
+			return loc
+		}
+		slog.Warn("TZ does not name a known timezone, falling back",
+			"tz", name, "fallback", defaultCampTimezone)
+	}
+	if loc, err := time.LoadLocation(defaultCampTimezone); err == nil {
+		return loc
+	}
+	// Unreachable with time/tzdata embedded, and deliberately not fatal: a
+	// roster stamped in UTC is worth more than no roster.
+	slog.Error("could not load any camp timezone, stamping in UTC")
+	return time.UTC
+}

--- a/pocketbase/sync/family_camp_roster_sheet_test.go
+++ b/pocketbase/sync/family_camp_roster_sheet_test.go
@@ -1,0 +1,430 @@
+package sync
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Rendering one Roster into the values and formatting directives for one tab.
+// Nothing here calls Google: the SheetFormat is asserted as a value, which is
+// the whole reason it is a value. kindred#2433.
+
+// alignCenter is the Sheets horizontal-alignment value the age column takes.
+const alignCenter = "CENTER"
+
+// sampleRoster is two households -- one banded, one not -- with a camper of each
+// age shape and an adult carrying no email.
+func sampleRoster() *Roster {
+	return &Roster{
+		SessionName: "Family Camp 2: Keshet LGBTQ Weekend",
+		SessionCMID: 1309515,
+		Year:        2026,
+		Start:       time.Date(2026, time.August, 20, 7, 0, 0, 0, time.UTC),
+		End:         time.Date(2026, time.August, 23, 7, 0, 0, 0, time.UTC),
+		Blocks: []HouseholdBlock{
+			{
+				HouseholdID: "hh1",
+				City:        "Berkeley",
+				campers:     2,
+				People: []RosterPerson{
+					{Name: "Ava Johnson", Role: "Camper", Age: "6"},
+					{Name: "Emma Johnson", Role: "Camper", Age: "12"},
+					{Name: "Sarah Johnson", Role: "Adult 1", Email: "sarah@example.com"},
+				},
+			},
+			{
+				HouseholdID: "hh2",
+				City:        "Oakland",
+				campers:     1,
+				People: []RosterPerson{
+					{Name: "Ben Garcia", Role: "Camper", Age: "11 mos"},
+					{Name: "Rosa Garcia", Role: "Adult 3"},
+				},
+			},
+		},
+	}
+}
+
+func TestRosterSheetValues(t *testing.T) {
+	t.Parallel()
+	values := RosterSheetValues(sampleRoster())
+
+	want := [][]string{
+		{"Family Camp 2: Keshet LGBTQ Weekend 2026 Roster", "", "", "", ""},
+		{"August 20–23, 2026", "", "", "", ""},
+		{"NAME", "ADULT / CAMPER", "AGE", "EMAIL", "CITY"},
+		// City appears only on the block's first row.
+		{"Ava Johnson", "Camper", "6", "", "Berkeley"},
+		{"Emma Johnson", "Camper", "12", "", ""},
+		{"Sarah Johnson", "Adult 1", "", "sarah@example.com", ""},
+		{"Ben Garcia", "Camper", "11 mos", "", "Oakland"},
+		{"Rosa Garcia", "Adult 3", "", "", ""},
+	}
+
+	if len(values) != len(want) {
+		t.Fatalf("values has %d rows, want %d:\n%v", len(values), len(want), values)
+	}
+	for row := range want {
+		if len(values[row]) != rosterColumnCount {
+			t.Fatalf("row %d has %d cells, want %d: %v", row, len(values[row]), rosterColumnCount, values[row])
+		}
+		for col := range want[row] {
+			if got := fmt.Sprintf("%v", values[row][col]); got != want[row][col] {
+				t.Errorf("values[%d][%d] = %q, want %q", row, col, got, want[row][col])
+			}
+		}
+	}
+}
+
+// findStyle returns the first style rule covering exactly the given range.
+func findStyle(t *testing.T, format *SheetFormat, r GridRange) CellStyle {
+	t.Helper()
+	for _, rule := range format.Styles {
+		if rule.Range == r {
+			return rule.Style
+		}
+	}
+	t.Fatalf("no style rule for range %+v; have %d rules", r, len(format.Styles))
+	return CellStyle{}
+}
+
+func TestRosterSheetFormatStructure(t *testing.T) {
+	t.Parallel()
+	format := RosterSheetFormat(42, sampleRoster())
+
+	if format.SheetID != 42 {
+		t.Errorf("SheetID = %d, want 42", format.SheetID)
+	}
+	// Rows 1-3 frozen, so row 4 -- the first person -- is the first to scroll.
+	if format.FrozenRows != 3 {
+		t.Errorf("FrozenRows = %d, want 3", format.FrozenRows)
+	}
+
+	wantMerges := []GridRange{
+		{StartRow: 0, EndRow: 1, StartCol: 0, EndCol: 5},
+		{StartRow: 1, EndRow: 2, StartCol: 0, EndCol: 5},
+	}
+	if len(format.Merges) != len(wantMerges) {
+		t.Fatalf("merges = %+v, want %+v", format.Merges, wantMerges)
+	}
+	for i, want := range wantMerges {
+		if format.Merges[i] != want {
+			t.Errorf("merge %d = %+v, want %+v", i, format.Merges[i], want)
+		}
+	}
+
+	wantWidths := []ColumnWidth{
+		{StartCol: 0, EndCol: 1, Pixels: 200},
+		{StartCol: 1, EndCol: 2, Pixels: 115},
+		{StartCol: 2, EndCol: 3, Pixels: 75},
+		{StartCol: 3, EndCol: 4, Pixels: 245},
+		{StartCol: 4, EndCol: 5, Pixels: 130},
+	}
+	if len(format.ColumnWidths) != len(wantWidths) {
+		t.Fatalf("widths = %+v, want %+v", format.ColumnWidths, wantWidths)
+	}
+	for i, want := range wantWidths {
+		if format.ColumnWidths[i] != want {
+			t.Errorf("width %d = %+v, want %+v", i, format.ColumnWidths[i], want)
+		}
+	}
+}
+
+func TestRosterSheetFormatHeaderAndTitle(t *testing.T) {
+	t.Parallel()
+	format := RosterSheetFormat(42, sampleRoster())
+
+	title := findStyle(t, format, GridRange{StartRow: 0, EndRow: 1, StartCol: 0, EndCol: 5})
+	if title.FontSize != 14 || title.Bold == nil || !*title.Bold || title.HorizontalAlignment != alignCenter {
+		t.Errorf("title style = %+v, want bold 14pt centered", title)
+	}
+
+	subtitle := findStyle(t, format, GridRange{StartRow: 1, EndRow: 2, StartCol: 0, EndCol: 5})
+	if subtitle.FontSize != 10 || subtitle.FontHex != "#5F6368" || subtitle.HorizontalAlignment != alignCenter {
+		t.Errorf("subtitle style = %+v, want 10pt #5F6368 centered", subtitle)
+	}
+
+	header := findStyle(t, format, GridRange{StartRow: 2, EndRow: 3, StartCol: 0, EndCol: 5})
+	if header.BackgroundHex != "#37474F" || header.FontHex != "#FFFFFF" ||
+		header.FontSize != 9 || header.Bold == nil || !*header.Bold {
+		t.Errorf("header style = %+v, want bold 9pt white on #37474F", header)
+	}
+}
+
+// TestRosterSheetFormatBandsPerHousehold pins the rule that makes a family read
+// as one unit: the fill alternates per BLOCK, not per row.
+func TestRosterSheetFormatBandsPerHousehold(t *testing.T) {
+	t.Parallel()
+	roster := sampleRoster()
+	format := RosterSheetFormat(42, roster)
+
+	// Block 0 is rows 3-5 and unbanded; block 1 is rows 6-7 and banded.
+	banded := GridRange{StartRow: 6, EndRow: 8, StartCol: 0, EndCol: 5}
+	if got := findStyle(t, format, banded).BackgroundHex; got != "#ECEFF1" {
+		t.Errorf("second block fill = %q, want %q", got, "#ECEFF1")
+	}
+
+	unbanded := GridRange{StartRow: 3, EndRow: 6, StartCol: 0, EndCol: 5}
+	for _, rule := range format.Styles {
+		if rule.Range == unbanded && rule.Style.BackgroundHex != "" {
+			t.Errorf("first block has fill %q, want none -- banding starts white", rule.Style.BackgroundHex)
+		}
+	}
+}
+
+// TestRosterSheetFormatTintsLinkedHouseholds pins §5: a linked household's tint
+// REPLACES its banding, so the pair is visible whichever parity it lands on.
+func TestRosterSheetFormatTintsLinkedHouseholds(t *testing.T) {
+	t.Parallel()
+	roster := sampleRoster()
+	roster.Blocks[0].LinkGroup = 1
+	roster.Blocks[1].LinkGroup = 1
+	format := RosterSheetFormat(42, roster)
+
+	first := findStyle(t, format, GridRange{StartRow: 3, EndRow: 6, StartCol: 0, EndCol: 5}).BackgroundHex
+	second := findStyle(t, format, GridRange{StartRow: 6, EndRow: 8, StartCol: 0, EndCol: 5}).BackgroundHex
+
+	if first != second {
+		t.Errorf("linked blocks have fills %q and %q, want one color for the group", first, second)
+	}
+	if first == "" || first == "#ECEFF1" {
+		t.Errorf("linked fill = %q, want a tint that is neither empty nor the banding grey", first)
+	}
+}
+
+// TestRosterSheetFormatGivesEachLinkGroupItsOwnColour keeps two pairings apart.
+func TestRosterSheetFormatGivesEachLinkGroupItsOwnColour(t *testing.T) {
+	t.Parallel()
+	roster := sampleRoster()
+	roster.Blocks[0].LinkGroup = 1
+	roster.Blocks[1].LinkGroup = 2
+	format := RosterSheetFormat(42, roster)
+
+	first := findStyle(t, format, GridRange{StartRow: 3, EndRow: 6, StartCol: 0, EndCol: 5}).BackgroundHex
+	second := findStyle(t, format, GridRange{StartRow: 6, EndRow: 8, StartCol: 0, EndCol: 5}).BackgroundHex
+	if first == second {
+		t.Errorf("both link groups painted %q, want distinct colors", first)
+	}
+}
+
+// TestRosterSheetFormatLinkPaletteWrapsSafely guards the modulo: a group number
+// beyond the palette must still yield a color rather than panic or go blank.
+func TestRosterSheetFormatLinkPaletteWrapsSafely(t *testing.T) {
+	t.Parallel()
+	for _, group := range []int{1, 6, 7, 13, 99} {
+		roster := sampleRoster()
+		roster.Blocks[0].LinkGroup = group
+		format := RosterSheetFormat(42, roster)
+		got := findStyle(t, format, GridRange{StartRow: 3, EndRow: 6, StartCol: 0, EndCol: 5}).BackgroundHex
+		if got == "" {
+			t.Errorf("link group %d painted nothing", group)
+		}
+	}
+}
+
+// TestRosterSheetFormatBordersEachBlock pins the block borders: medium on the
+// first row's top edge and the last row's bottom edge, thin everywhere else.
+func TestRosterSheetFormatBordersEachBlock(t *testing.T) {
+	t.Parallel()
+	format := RosterSheetFormat(42, sampleRoster())
+
+	wantRanges := []GridRange{
+		{StartRow: 3, EndRow: 6, StartCol: 0, EndCol: 5},
+		{StartRow: 6, EndRow: 8, StartCol: 0, EndCol: 5},
+	}
+	if len(format.Borders) != len(wantRanges) {
+		t.Fatalf("borders = %d rules, want %d (one per block)", len(format.Borders), len(wantRanges))
+	}
+	for i, want := range wantRanges {
+		rule := format.Borders[i]
+		if rule.Range != want {
+			t.Errorf("border %d range = %+v, want %+v", i, rule.Range, want)
+		}
+		if rule.Top == nil || rule.Top.Style != "SOLID_MEDIUM" || rule.Top.Hex != "#78909C" {
+			t.Errorf("border %d top = %+v, want medium #78909C", i, rule.Top)
+		}
+		if rule.Bottom == nil || rule.Bottom.Style != "SOLID_MEDIUM" || rule.Bottom.Hex != "#78909C" {
+			t.Errorf("border %d bottom = %+v, want medium #78909C", i, rule.Bottom)
+		}
+		for name, edge := range map[string]*BorderEdge{
+			"left": rule.Left, "right": rule.Right,
+			"innerHorizontal": rule.InnerHorizontal, "innerVertical": rule.InnerVertical,
+		} {
+			if edge == nil || edge.Style != "SOLID" || edge.Hex != "#DADDE1" {
+				t.Errorf("border %d %s = %+v, want thin #DADDE1", i, name, edge)
+			}
+		}
+	}
+}
+
+// TestRosterSheetFormatCentresOnlyTheAgeColumn pins the alignment, and pins that
+// the CENTER rule is emitted AFTER the LEFT rule -- the Sheets API applies
+// requests in order, so the reverse would left-align the age column.
+func TestRosterSheetFormatCentresOnlyTheAgeColumn(t *testing.T) {
+	t.Parallel()
+	format := RosterSheetFormat(42, sampleRoster())
+
+	leftAt, centreAt := -1, -1
+	for i, rule := range format.Styles {
+		switch rule.Style.HorizontalAlignment {
+		case "LEFT":
+			if rule.Range.StartCol == 0 && rule.Range.EndCol == rosterColumnCount {
+				leftAt = i
+			}
+		case alignCenter:
+			if rule.Range.StartCol == rosterAgeColumn && rule.Range.EndCol == rosterAgeColumn+1 {
+				centreAt = i
+			}
+		}
+	}
+	if leftAt < 0 {
+		t.Fatal("no LEFT alignment rule spanning every column")
+	}
+	if centreAt < 0 {
+		t.Fatal("no CENTER alignment rule for the age column alone")
+	}
+	if centreAt < leftAt {
+		t.Errorf("CENTER rule at %d precedes LEFT rule at %d -- the later request wins, "+
+			"so the age column would end up left-aligned", centreAt, leftAt)
+	}
+}
+
+// TestRosterSheetFormatIsOneBatch pins the design's round-trip budget: a
+// 63-household roster is ONE ApplyFormatting call, so the request count must
+// grow with households rather than the call count.
+func TestRosterSheetFormatIsOneBatch(t *testing.T) {
+	t.Parallel()
+	roster := sampleRoster()
+	format := RosterSheetFormat(42, roster)
+	if format.isEmpty() {
+		t.Fatal("format is empty")
+	}
+	if _, err := buildFormatRequests(format); err != nil {
+		t.Fatalf("buildFormatRequests rejected the roster format: %v", err)
+	}
+}
+
+// TestRosterSheetFormatRejectsNothing runs the real request builder over a
+// roster big enough to exercise every branch, because an invalid range is a 400
+// that takes the whole tab's single batchUpdate down with it.
+func TestRosterSheetFormatSurvivesAManyHouseholdRoster(t *testing.T) {
+	t.Parallel()
+	roster := &Roster{
+		SessionName: "Family Camp 6",
+		Year:        2026,
+		Start:       time.Date(2026, time.September, 24, 7, 0, 0, 0, time.UTC),
+		End:         time.Date(2026, time.September, 27, 7, 0, 0, 0, time.UTC),
+	}
+	for i := range 63 {
+		roster.Blocks = append(roster.Blocks, HouseholdBlock{
+			HouseholdID: fmt.Sprintf("hh%d", i),
+			City:        "Berkeley",
+			campers:     1,
+			LinkGroup:   i % 3, // exercises ungrouped and several palette entries
+			People: []RosterPerson{
+				{Name: "Camper", Role: "Camper", Age: "8"},
+				{Name: "Adult", Role: "Adult 1", Email: "a@example.com"},
+			},
+		})
+	}
+
+	format := RosterSheetFormat(7, roster)
+	requests, err := buildFormatRequests(format)
+	if err != nil {
+		t.Fatalf("buildFormatRequests: %v", err)
+	}
+	if len(requests) == 0 {
+		t.Fatal("no requests emitted")
+	}
+	values := RosterSheetValues(roster)
+	if len(values) != rosterFirstDataRow+126 {
+		t.Errorf("values = %d rows, want %d", len(values), rosterFirstDataRow+126)
+	}
+}
+
+func TestRosterTabName(t *testing.T) {
+	t.Parallel()
+	at := time.Date(2026, time.August, 19, 15, 4, 0, 0, time.UTC)
+
+	if got := rosterTabName(at, nil); got != testRosterTab {
+		t.Errorf("rosterTabName = %q, want %q", got, testRosterTab)
+	}
+}
+
+// TestRosterTabNameSuffixesOnCollision pins the two-exports-inside-one-minute
+// case. Tabs are NEVER pruned and NEVER overwritten -- staff hand-edit each one.
+func TestRosterTabNameSuffixesOnCollision(t *testing.T) {
+	t.Parallel()
+	at := time.Date(2026, time.August, 19, 15, 4, 0, 0, time.UTC)
+	base := testRosterTab
+
+	if got := rosterTabName(at, []string{base}); got != base+" (2)" {
+		t.Errorf("rosterTabName = %q, want %q", got, base+" (2)")
+	}
+	if got := rosterTabName(at, []string{base, base + " (2)"}); got != base+" (3)" {
+		t.Errorf("rosterTabName = %q, want %q", got, base+" (3)")
+	}
+	// An unrelated tab must not push the suffix.
+	if got := rosterTabName(at, []string{"Aug 18, 2026 9:00 AM"}); got != base {
+		t.Errorf("rosterTabName = %q, want %q", got, base)
+	}
+}
+
+// TestRosterTabNameFitsSheetsLimits keeps the generated name inside the 31-char
+// cap and clear of the characters Sheets rejects.
+//
+// The colon is NOT in that set, despite the design's §Tab naming sentence saying
+// it is -- which would have made the design's own "3:04 PM" format illegal.
+// Probed against the real API on 2026-08-19: addSheet accepted
+// "Aug 19, 2026 3:04 PM", and a Values.Update reached it through BOTH
+// "'Aug 19, 2026 3:04 PM'!A1" and the bare "Aug 19, 2026 3:04 PM!A1" that
+// WriteToSheet builds. That last part is why WriteToSheet needs no change to
+// carry a tab name containing spaces and commas.
+func TestRosterTabNameFitsSheetsLimits(t *testing.T) {
+	t.Parallel()
+	// December at 12:59 gives the longest shape this layout can produce.
+	at := time.Date(2026, time.December, 31, 12, 59, 0, 0, time.UTC)
+	existing := make([]string, 0, 12)
+	for range 12 {
+		name := rosterTabName(at, existing)
+		if len(name) > 31 {
+			t.Errorf("tab name %q is %d chars, over the 31-char cap", name, len(name))
+		}
+		if strings.ContainsAny(name, `\/?*[]`) {
+			t.Errorf("tab name %q contains a character Sheets rejects", name)
+		}
+		if slices.Contains(existing, name) {
+			t.Fatalf("tab name %q collides with one already taken: %v", name, existing)
+		}
+		existing = append(existing, name)
+	}
+}
+
+// TestCampLocationDefaultsToPacific pins the design's default. PocketBase runs in
+// a container whose Go time.Local is UTC unless TZ is set, and a roster stamped
+// "Aug 20, 2026 12:15 AM" for an export made on the 19th reads as the wrong day.
+func TestCampLocationDefaultsToPacific(t *testing.T) {
+	t.Setenv("TZ", "")
+	if got := campLocation().String(); got != "America/Los_Angeles" {
+		t.Errorf("campLocation = %q, want America/Los_Angeles", got)
+	}
+}
+
+func TestCampLocationHonoursTZ(t *testing.T) {
+	t.Setenv("TZ", "America/New_York")
+	if got := campLocation().String(); got != "America/New_York" {
+		t.Errorf("campLocation = %q, want America/New_York", got)
+	}
+}
+
+// TestCampLocationFallsBackOnAnUnknownZone keeps a typo in TZ from taking the
+// export down.
+func TestCampLocationFallsBackOnAnUnknownZone(t *testing.T) {
+	t.Setenv("TZ", "Mars/Olympus_Mons")
+	if got := campLocation().String(); got != "America/Los_Angeles" {
+		t.Errorf("campLocation = %q, want the Pacific default", got)
+	}
+}

--- a/pocketbase/sync/family_camp_roster_test.go
+++ b/pocketbase/sync/family_camp_roster_test.go
@@ -1,0 +1,399 @@
+package sync
+
+import (
+	"testing"
+	"time"
+)
+
+// exportedAt is the "now" every age test is measured against. Ages are computed
+// AT EXPORT TIME rather than at session start (kindred#2433 design §Age), so the
+// reference value is a wall-clock instant, not a session property.
+var exportedAt = time.Date(2026, time.August, 19, 15, 4, 0, 0, time.UTC)
+
+func TestRosterAgeLabel(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name      string
+		birthdate string
+		want      string
+	}{
+		{"blank birthdate renders nothing", "", ""},
+		{"unparseable birthdate renders nothing", "not-a-date", ""},
+		// The whole-years / whole-months boundary, from both sides. A camper one
+		// day short of their first birthday is "11 mos", not "0".
+		{"eleven months", "2025-09-19", "11 mos"},
+		{"exactly twelve months", "2025-08-19", "1"},
+		{"thirteen months", "2025-07-19", "1"},
+		// The singular. "1 mos" is the tell that the branch is missing.
+		{"one month", "2026-07-19", "1 mo"},
+		{"zero months", "2026-08-19", "0 mos"},
+		// Day-of-month borrow: born on the 20th, exported on the 19th, so the
+		// current month has not completed.
+		{"borrows when the day has not come round", "2026-07-20", "0 mos"},
+		{"borrows across a year boundary", "2018-08-20", "7"},
+		{"does not borrow on the birthday itself", "2018-08-19", "8"},
+		// A birthdate in the future is bad data, never a negative age.
+		{"future birthdate clamps to zero", "2027-01-01", "0 mos"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := rosterAgeLabel(tc.birthdate, exportedAt); got != tc.want {
+				t.Errorf("rosterAgeLabel(%q) = %q, want %q", tc.birthdate, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRosterAgeLabelAcrossALeapDayBirthday pins the two days that straddle a
+// 29 February birthday in a non-leap year, where "the same day of the month"
+// does not exist. 28 February must still be the last day of the ninth year.
+func TestRosterAgeLabelAcrossALeapDayBirthday(t *testing.T) {
+	t.Parallel()
+	const leapling = "2016-02-29"
+	for _, tc := range []struct {
+		name string
+		on   time.Time
+		want string
+	}{
+		{"the day before", time.Date(2026, time.February, 28, 12, 0, 0, 0, time.UTC), "9"},
+		{"the day after", time.Date(2026, time.March, 1, 12, 0, 0, 0, time.UTC), "10"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := rosterAgeLabel(leapling, tc.on); got != tc.want {
+				t.Errorf("rosterAgeLabel(%q, %s) = %q, want %q", leapling, tc.on.Format(time.DateOnly), got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRosterCleanCity(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, normalized, raw, want string
+	}{
+		// normalized_city is preferred because it fixes casing.
+		{"prefers the normalized value", "Berkeley, CA", "berkeley", "Berkeley"},
+		{"falls back to the raw value", "", "Oakland", "Oakland"},
+		{"falls back when normalized is whitespace", "   ", "Oakland", "Oakland"},
+		{"strips the state suffix", "San Francisco, CA", "", "San Francisco"},
+		{"strips a suffix with no space", "Portland,OR", "", "Portland"},
+		{"keeps a comma that is not a state", "Washington, District", "", "Washington, District"},
+		{"keeps a lowercase two-letter tail", "Something, ca", "", "Something, ca"},
+		{"both blank", "", "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := rosterCleanCity(tc.normalized, tc.raw); got != tc.want {
+				t.Errorf("rosterCleanCity(%q, %q) = %q, want %q", tc.normalized, tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsRosterAdultName pins the placeholder filter. Registrants type these into
+// the adult-name field to mean "no second adult"; rendering them puts a row
+// called "N/A" on a family's roster block.
+func TestIsRosterAdultName(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		want bool
+	}{
+		{"Emma Johnson", true},
+		{"", false},
+		{"   ", false},
+		{"na", false},
+		{"NA", false},
+		{"N/A", false},
+		{"n/a", false},
+		{"none", false},
+		{"None", false},
+		{"-", false},
+		{"0", false},
+		{"no", false},
+		{" No ", false},
+		// Real names that merely start with a placeholder token stay.
+		{"Nathan Okafor", true},
+		{"Noor Haddad", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isRosterAdultName(tc.name); got != tc.want {
+				t.Errorf("isRosterAdultName(%q) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRosterAdultName pins the coalesce. family_camp_adults.last_name is blank
+// for every 2026 row, so reading the split columns alone yields a first name and
+// a trailing space -- `name` is the column of record.
+func TestRosterAdultName(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, nameCol, first, last, want string
+	}{
+		{"name column wins", "Emma Johnson", "Emma", "Johnson", "Emma Johnson"},
+		{"falls back to the split columns", "", "Liam", "Garcia", "Liam Garcia"},
+		{"falls back when name is whitespace", "  ", "Liam", "Garcia", "Liam Garcia"},
+		{"first name only", "", "Liam", "", "Liam"},
+		{"last name only", "", "", "Garcia", "Garcia"},
+		{"all blank", "", "", "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := rosterAdultName(tc.nameCol, tc.first, tc.last)
+			if got != tc.want {
+				t.Errorf("rosterAdultName(%q, %q, %q) = %q, want %q",
+					tc.nameCol, tc.first, tc.last, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRosterCamperName(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, preferred, first, last, want string
+	}{
+		{"preferred name wins", "Ollie", "Oliver", "Chen", "Ollie Chen"},
+		{"falls back to first name", "", "Oliver", "Chen", "Oliver Chen"},
+		{"falls back when preferred is whitespace", " ", "Oliver", "Chen", "Oliver Chen"},
+		{"no surname", "", "Oliver", "", "Oliver"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := rosterCamperName(tc.preferred, tc.first, tc.last)
+			if got != tc.want {
+				t.Errorf("rosterCamperName(%q, %q, %q) = %q, want %q",
+					tc.preferred, tc.first, tc.last, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatRosterDateRange(t *testing.T) {
+	t.Parallel()
+	day := func(y int, m time.Month, d int) time.Time {
+		return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+	}
+	for _, tc := range []struct {
+		name       string
+		start, end time.Time
+		want       string
+	}{
+		{
+			"within one month",
+			day(2026, time.August, 20), day(2026, time.August, 23),
+			"August 20–23, 2026",
+		},
+		{
+			"straddling a month boundary",
+			day(2026, time.August, 30), day(2026, time.September, 2),
+			"August 30 – September 2, 2026",
+		},
+		{
+			"a single day",
+			day(2026, time.July, 4), day(2026, time.July, 4),
+			"July 4–4, 2026",
+		},
+		{
+			// The design names only the same-month and same-year-different-month
+			// forms, both of which print one year -- the end's. Winter Family Camp
+			// runs in late December (27-29 in 2026, 21-23 in 2025), so a New Year
+			// weekend is a shape this will meet, and printing only the end year
+			// would date the whole weekend to January.
+			"straddling a year boundary",
+			day(2026, time.December, 30), day(2027, time.January, 2),
+			"December 30, 2026 – January 2, 2027",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := formatRosterDateRange(tc.start, tc.end); got != tc.want {
+				t.Errorf("formatRosterDateRange = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSortRosterCampers pins youngest-first, with a missing birthdate filing
+// last. The order matters beyond the block itself: households are sorted on the
+// FIRST camper's surname, so a wrong camper order silently reorders the sheet.
+func TestSortRosterCampers(t *testing.T) {
+	t.Parallel()
+	campers := []rosterCamper{
+		{Name: "Emma Johnson", Last: "Johnson", Birthdate: "2014-03-02"},
+		{Name: "Noah Johnson", Last: "Johnson", Birthdate: ""},
+		{Name: "Ava Johnson", Last: "Johnson", Birthdate: "2019-11-30"},
+		{Name: "Liam Johnson", Last: "Johnson", Birthdate: "2017-06-01"},
+	}
+	sortRosterCampers(campers)
+
+	want := []string{"Ava Johnson", "Liam Johnson", "Emma Johnson", "Noah Johnson"}
+	for i, name := range want {
+		if campers[i].Name != name {
+			t.Errorf("campers[%d] = %q, want %q (full order: %v)", i, campers[i].Name, name, names(campers))
+		}
+	}
+}
+
+// TestSortRosterCampersBreaksTiesByName keeps the output stable for twins, whose
+// birthdates are identical.
+func TestSortRosterCampersBreaksTiesByName(t *testing.T) {
+	t.Parallel()
+	campers := []rosterCamper{
+		{Name: "Zoe Garcia", Last: "Garcia", Birthdate: "2015-04-04"},
+		{Name: "Ana Garcia", Last: "Garcia", Birthdate: "2015-04-04"},
+	}
+	sortRosterCampers(campers)
+	if campers[0].Name != "Ana Garcia" {
+		t.Errorf("campers = %v, want Ana Garcia first", names(campers))
+	}
+}
+
+func names(campers []rosterCamper) []string {
+	out := make([]string, len(campers))
+	for i, c := range campers {
+		out[i] = c.Name
+	}
+	return out
+}
+
+// TestOrderRosterHouseholds pins the household ordering: case-folded surname of
+// the block's first camper, then that camper's display name, then the record id.
+func TestOrderRosterHouseholds(t *testing.T) {
+	t.Parallel()
+	households := []rosterHousehold{
+		{ID: "hh3", Campers: []rosterCamper{{Name: "Ana Ortiz", Last: "ortiz"}}},
+		{ID: "hh1", Campers: []rosterCamper{{Name: "Emma Johnson", Last: "Johnson"}}},
+		{ID: "hh2", Campers: []rosterCamper{{Name: "Ben Garcia", Last: "Garcia"}}},
+	}
+	orderRosterHouseholds(households)
+
+	want := []string{"hh2", "hh1", "hh3"}
+	for i, id := range want {
+		if households[i].ID != id {
+			t.Fatalf("order = %v, want %v", householdIDs(households), want)
+		}
+	}
+}
+
+// TestOrderRosterHouseholdsBreaksTies pins both tiebreakers, because two
+// unrelated families sharing a surname is common and a nondeterministic order
+// makes two exports of unchanged data differ.
+func TestOrderRosterHouseholdsBreaksTies(t *testing.T) {
+	t.Parallel()
+	households := []rosterHousehold{
+		{ID: "hhZ", Campers: []rosterCamper{{Name: "Zoe Garcia", Last: "Garcia"}}},
+		{ID: "hhB", Campers: []rosterCamper{{Name: "Ana Garcia", Last: "Garcia"}}},
+		{ID: "hhA", Campers: []rosterCamper{{Name: "Ana Garcia", Last: "Garcia"}}},
+	}
+	orderRosterHouseholds(households)
+
+	want := []string{"hhA", "hhB", "hhZ"}
+	for i, id := range want {
+		if households[i].ID != id {
+			t.Fatalf("order = %v, want %v", householdIDs(households), want)
+		}
+	}
+}
+
+func householdIDs(households []rosterHousehold) []string {
+	out := make([]string, len(households))
+	for i, h := range households {
+		out[i] = h.ID
+	}
+	return out
+}
+
+// TestLinkedHouseholdGroups pins §5: two households sharing an adult are LINKED,
+// never merged. Merging would fix the friend-attending-with-another-family case
+// and force a single wrong city onto co-parents keeping two homes.
+func TestLinkedHouseholdGroups(t *testing.T) {
+	t.Parallel()
+	order := []string{"hh1", "hh2", "hh3", "hh4"}
+	adults := map[string][]string{
+		"hh1": {"Emma Johnson", "Liam Johnson"},
+		"hh2": {"Liam Johnson"}, // shares an adult with hh1
+		"hh3": {"Ana Ortiz"},
+		"hh4": {"Ben Garcia"},
+	}
+
+	groups := linkedHouseholdGroups(order, adults)
+
+	if groups["hh1"] == 0 || groups["hh1"] != groups["hh2"] {
+		t.Errorf("hh1=%d hh2=%d, want both in the same non-zero group", groups["hh1"], groups["hh2"])
+	}
+	if groups["hh3"] != 0 || groups["hh4"] != 0 {
+		t.Errorf("hh3=%d hh4=%d, want both ungrouped", groups["hh3"], groups["hh4"])
+	}
+}
+
+// TestLinkedHouseholdGroupsAreTransitive keeps one household out of two groups:
+// A shares an adult with B and B with C, so all three are one group and get one
+// color. Two colors on B would read as two separate pairings.
+func TestLinkedHouseholdGroupsAreTransitive(t *testing.T) {
+	t.Parallel()
+	order := []string{"hhA", "hhB", "hhC"}
+	adults := map[string][]string{
+		"hhA": {"Emma Johnson"},
+		"hhB": {"Emma Johnson", "Liam Garcia"},
+		"hhC": {"Liam Garcia"},
+	}
+
+	groups := linkedHouseholdGroups(order, adults)
+	if groups["hhA"] == 0 || groups["hhA"] != groups["hhB"] || groups["hhB"] != groups["hhC"] {
+		t.Errorf("groups = %v, want all three in one non-zero group", groups)
+	}
+}
+
+// TestLinkedHouseholdGroupsMatchCaseInsensitively: the same adult is typed into
+// two households' registration forms by two different people.
+func TestLinkedHouseholdGroupsMatchCaseInsensitively(t *testing.T) {
+	t.Parallel()
+	groups := linkedHouseholdGroups(
+		[]string{"hh1", "hh2"},
+		map[string][]string{"hh1": {"emma johnson"}, "hh2": {"  Emma Johnson "}},
+	)
+	if groups["hh1"] == 0 || groups["hh1"] != groups["hh2"] {
+		t.Errorf("groups = %v, want one shared group", groups)
+	}
+}
+
+// TestLinkedHouseholdGroupsIgnoreDuplicatesWithinOneHousehold guards the
+// interaction with kindred#2483: the same person in two adult slots of ONE
+// household is a duplicate, not a link, and must not color that household.
+func TestLinkedHouseholdGroupsIgnoreDuplicatesWithinOneHousehold(t *testing.T) {
+	t.Parallel()
+	groups := linkedHouseholdGroups(
+		[]string{"hh1"},
+		map[string][]string{"hh1": {"Emma Johnson", "Emma Johnson"}},
+	)
+	if len(groups) != 0 {
+		t.Errorf("groups = %v, want no household grouped", groups)
+	}
+}
+
+// TestLinkedHouseholdGroupsNumberByFirstAppearance keeps colors stable: the
+// group numbering follows the roster's own household order, so re-exporting
+// unchanged data paints the same households the same color.
+func TestLinkedHouseholdGroupsNumberByFirstAppearance(t *testing.T) {
+	t.Parallel()
+	order := []string{"hh1", "hh2", "hh3", "hh4"}
+	adults := map[string][]string{
+		"hh1": {"Ana Ortiz"},
+		"hh2": {"Emma Johnson"},
+		"hh3": {"Ana Ortiz"},
+		"hh4": {"Emma Johnson"},
+	}
+
+	groups := linkedHouseholdGroups(order, adults)
+	if groups["hh1"] != 1 || groups["hh3"] != 1 {
+		t.Errorf("hh1=%d hh3=%d, want group 1 (first to appear)", groups["hh1"], groups["hh3"])
+	}
+	if groups["hh2"] != 2 || groups["hh4"] != 2 {
+		t.Errorf("hh2=%d hh4=%d, want group 2", groups["hh2"], groups["hh4"])
+	}
+}

--- a/pocketbase/sync/sync_testsupport_test.go
+++ b/pocketbase/sync/sync_testsupport_test.go
@@ -69,6 +69,16 @@ func newSyncTestApp(t *testing.T) core.App {
 	persons.Fields.Add(&core.NumberField{Name: "household_id"})
 	persons.Fields.Add(&core.RelationField{Name: "household", CollectionId: households.Id, MaxSelect: 1})
 	persons.Fields.Add(&core.NumberField{Name: "year"})
+	// Identity, age and city, for the Family Camp roster export (kindred#2433).
+	// birthdate is TEXT holding "YYYY-MM-DD", not a PocketBase date -- a DateField
+	// here would round-trip through PB's own layout and hide the parse the
+	// exporter actually performs.
+	persons.Fields.Add(&core.TextField{Name: "first_name"})
+	persons.Fields.Add(&core.TextField{Name: "last_name"})
+	persons.Fields.Add(&core.TextField{Name: "preferred_name"})
+	persons.Fields.Add(&core.TextField{Name: "birthdate"})
+	persons.Fields.Add(&core.TextField{Name: "address_city"})
+	persons.Fields.Add(&core.TextField{Name: "normalized_city"})
 	saveCollection(t, app, persons)
 
 	attendees := core.NewBaseCollection("attendees")
@@ -87,6 +97,13 @@ func newSyncTestApp(t *testing.T) core.App {
 	adults.Fields.Add(&core.NumberField{Name: "year"})
 	adults.Fields.Add(&core.NumberField{Name: "adult_number"})
 	adults.Fields.Add(&core.TextField{Name: "name"})
+	// The roster coalesces `name` over the split pair and renders the email
+	// (kindred#2433). last_name is blank on every 2026 row, which is exactly why
+	// the fixture carries all three: a test that seeded only `name` could not
+	// tell a correct coalesce from one that never reads the fallback.
+	adults.Fields.Add(&core.TextField{Name: "first_name"})
+	adults.Fields.Add(&core.TextField{Name: "last_name"})
+	adults.Fields.Add(&core.TextField{Name: "email"})
 	saveCollection(t, app, adults)
 
 	hcv := core.NewBaseCollection("household_custom_values")

--- a/pocketbase/sync/workbook_manager.go
+++ b/pocketbase/sync/workbook_manager.go
@@ -20,21 +20,38 @@ const (
 
 	// workbookTypeGlobals is the type identifier for the globals workbook
 	workbookTypeGlobals = "globals"
+
+	// workbookTypeFCRoster is the type identifier for a Family Camp weekend's
+	// roster workbook (kindred#2433). Unlike globals and year, several rows share
+	// a year -- one per weekend -- so these are the only rows whose key needs the
+	// session dimension. workbook_type stays a CLOSED vocabulary: one type per
+	// session would turn GetWorkbookByType's filter into id string-matching and
+	// the admin Sheets tab's grouping into noise.
+	workbookTypeFCRoster = "fc_roster"
+
+	// notSessionScoped is the session_cm_id a globals or per-year workbook
+	// carries. A real CampMinder id is never 0, and PocketBase declares number
+	// columns NUMERIC DEFAULT 0 NOT NULL, so the rows that predate migration
+	// 1500000165 already read as this.
+	notSessionScoped = 0
 )
 
 // WorkbookRecord represents a workbook stored in the database.
 type WorkbookRecord struct {
 	ID            string
 	SpreadsheetID string
-	WorkbookType  string // "globals" or "year"
+	WorkbookType  string // "globals", "year" or "fc_roster"
 	Year          int    // 0 for globals
-	Title         string
-	URL           string
-	TabCount      int
-	TotalRecords  int
-	Status        string // "ok", "error", "syncing"
-	ErrorMessage  string
-	LastSync      string
+	// SessionCMID scopes a roster workbook to one Family Camp weekend, and is
+	// notSessionScoped for globals and per-year workbooks.
+	SessionCMID  int
+	Title        string
+	URL          string
+	TabCount     int
+	TotalRecords int
+	Status       string // "ok", "error", "syncing"
+	ErrorMessage string
+	LastSync     string
 }
 
 // DriveSearcher allows searching Drive for existing spreadsheets (enables mocking)
@@ -91,18 +108,35 @@ func NewWorkbookManagerWithSearcher(
 // GetWorkbookByType retrieves a workbook record by type and year.
 // For globals workbook, pass year=0.
 // Returns nil if no workbook exists.
-func (m *WorkbookManager) GetWorkbookByType(_ context.Context, workbookType string, year int) (*WorkbookRecord, error) {
-	var filter string
-	if workbookType == workbookTypeGlobals {
-		filter = fmt.Sprintf("workbook_type = '%s'", workbookType)
-	} else {
-		filter = fmt.Sprintf("workbook_type = '%s' && year = %d", workbookType, year)
+//
+// This is the NON-session-scoped lookup: it matches only rows carrying
+// session_cm_id = notSessionScoped, which is every globals and per-year row.
+// Roster workbooks share a year with the per-year workbook, so without that
+// clause this would start returning an arbitrary weekend's roster to the data
+// export. Use GetWorkbookForSession for those.
+func (m *WorkbookManager) GetWorkbookByType(
+	ctx context.Context, workbookType string, year int,
+) (*WorkbookRecord, error) {
+	return m.GetWorkbookForSession(ctx, workbookType, year, notSessionScoped)
+}
+
+// GetWorkbookForSession retrieves a workbook record by type, year and session.
+// Returns nil if no workbook exists.
+func (m *WorkbookManager) GetWorkbookForSession(
+	_ context.Context, workbookType string, year, sessionCMID int,
+) (*WorkbookRecord, error) {
+	// Note the spaces around every operator -- PocketBase's filter parser
+	// silently returns wrong results without them.
+	filter := fmt.Sprintf("workbook_type = '%s' && session_cm_id = %d", workbookType, sessionCMID)
+	if workbookType != workbookTypeGlobals {
+		filter = fmt.Sprintf("%s && year = %d", filter, year)
 	}
 
 	records, err := m.app.FindRecordsByFilter(sheetsWorkbooksCollection, filter, "", 1, 0)
 	if err != nil {
 		// Collection might not exist yet (before migration runs)
-		slog.Debug("Error finding workbook", "error", err, "type", workbookType, "year", year)
+		slog.Debug("Error finding workbook",
+			"error", err, "type", workbookType, "year", year, "session_cm_id", sessionCMID)
 		return nil, nil
 	}
 
@@ -116,6 +150,7 @@ func (m *WorkbookManager) GetWorkbookByType(_ context.Context, workbookType stri
 		SpreadsheetID: safeString(record.Get("spreadsheet_id")),
 		WorkbookType:  safeString(record.Get("workbook_type")),
 		Year:          safeInt(record.Get("year")),
+		SessionCMID:   safeInt(record.Get("session_cm_id")),
 		Title:         safeString(record.Get("title")),
 		URL:           safeString(record.Get("url")),
 		TabCount:      safeInt(record.Get("tab_count")),
@@ -133,8 +168,11 @@ func (m *WorkbookManager) SaveWorkbookRecord(ctx context.Context, wb *WorkbookRe
 		return nil, fmt.Errorf("collection %s not found: %w", sheetsWorkbooksCollection, err)
 	}
 
-	// Check if record already exists
-	existing, err := m.GetWorkbookByType(ctx, wb.WorkbookType, wb.Year)
+	// Check if record already exists. Keyed on the SESSION too: without it the
+	// second Family Camp weekend of a season matches the first weekend's row,
+	// takes the update branch below, and silently overwrites its spreadsheet_id.
+	// The unique index cannot catch that -- this check short-circuits ahead of it.
+	existing, err := m.GetWorkbookForSession(ctx, wb.WorkbookType, wb.Year, wb.SessionCMID)
 	if err != nil {
 		return nil, fmt.Errorf("checking existing workbook: %w", err)
 	}
@@ -157,6 +195,9 @@ func (m *WorkbookManager) SaveWorkbookRecord(ctx context.Context, wb *WorkbookRe
 	if wb.Year > 0 {
 		record.Set("year", wb.Year)
 	}
+	// Always set, unlike year: 0 is a meaningful value here (notSessionScoped),
+	// and it must match what GetWorkbookForSession filters on.
+	record.Set("session_cm_id", wb.SessionCMID)
 	record.Set("title", wb.Title)
 	record.Set("url", wb.URL)
 	record.Set("tab_count", wb.TabCount)
@@ -215,6 +256,7 @@ func (m *WorkbookManager) ListAllWorkbooks(_ context.Context) ([]WorkbookRecord,
 			SpreadsheetID: safeString(record.Get("spreadsheet_id")),
 			WorkbookType:  safeString(record.Get("workbook_type")),
 			Year:          safeInt(record.Get("year")),
+			SessionCMID:   safeInt(record.Get("session_cm_id")),
 			Title:         safeString(record.Get("title")),
 			URL:           safeString(record.Get("url")),
 			TabCount:      safeInt(record.Get("tab_count")),
@@ -413,10 +455,24 @@ func (m *WorkbookManager) UpdateMasterIndex(ctx context.Context) error {
 
 // BuildIndexSheetData builds the data matrix for the master index sheet.
 // Rows are sorted: globals first, then years in descending order.
+//
+// Family Camp roster workbooks are EXCLUDED. The Index sheet lives in the
+// globals workbook, in the Exports folder, whose audience is deliberately wider
+// than the roster folder's -- that per-folder split is the privacy control for
+// workbooks carrying family contact details (kindred#2433 design §2). Listing
+// one here would publish its weekend name and a clickable link to that wider
+// audience. They would also all render as their year, since the index has no
+// session column, so eight 2026 weekends would arrive as eight rows labeled
+// 2026. Staff reach a roster through the roster folder or the export's own
+// response, never through this index.
 func BuildIndexSheetData(workbooks []WorkbookRecord) [][]any {
 	// Sort workbooks: globals first, then years descending
-	sorted := make([]WorkbookRecord, len(workbooks))
-	copy(sorted, workbooks)
+	sorted := make([]WorkbookRecord, 0, len(workbooks))
+	for i := range workbooks {
+		if workbooks[i].WorkbookType != workbookTypeFCRoster {
+			sorted = append(sorted, workbooks[i])
+		}
+	}
 	slices.SortFunc(sorted, func(a, b WorkbookRecord) int {
 		// Globals always first
 		aGlobal := a.WorkbookType == workbookTypeGlobals

--- a/pocketbase/sync/workbook_manager_session_test.go
+++ b/pocketbase/sync/workbook_manager_session_test.go
@@ -1,0 +1,228 @@
+package sync
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+)
+
+// The workbook registry's SESSION dimension. kindred#2433.
+//
+// Every other test in workbook_manager_test.go skips, because tests.NewTestApp()
+// carries no sheets_workbooks collection -- which is why the collapse this file
+// pins was reachable in the first place. The fixture below mirrors migration
+// 1500000165, unique index included, so a save that the database would reject
+// fails here rather than in production.
+
+// newWorkbookTestApp returns an app carrying sheets_workbooks as
+// 1500000165 leaves it.
+func newWorkbookTestApp(t *testing.T) core.App {
+	t.Helper()
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	workbooks := core.NewBaseCollection("sheets_workbooks")
+	workbooks.Fields.Add(&core.TextField{Name: "spreadsheet_id"})
+	workbooks.Fields.Add(&core.SelectField{
+		Name: "workbook_type", MaxSelect: 1,
+		Values: []string{"globals", "year", "fc_roster"},
+	})
+	workbooks.Fields.Add(&core.NumberField{Name: "year", OnlyInt: true})
+	// Optional and defaulting to 0, which reads as "not session-scoped" -- the
+	// same convention year = 0 already uses for the globals workbook.
+	workbooks.Fields.Add(&core.NumberField{Name: "session_cm_id", OnlyInt: true})
+	workbooks.Fields.Add(&core.TextField{Name: "title"})
+	workbooks.Fields.Add(&core.TextField{Name: "url"})
+	workbooks.Fields.Add(&core.NumberField{Name: "tab_count", OnlyInt: true})
+	workbooks.Fields.Add(&core.NumberField{Name: "total_records", OnlyInt: true})
+	workbooks.Fields.Add(&core.SelectField{
+		Name: "status", MaxSelect: 1, Values: []string{"ok", "error", "syncing"},
+	})
+	workbooks.Fields.Add(&core.TextField{Name: "error_message"})
+	workbooks.Fields.Add(&core.TextField{Name: "last_sync"})
+	// The re-keyed index from 1500000165. Without it this file would only prove
+	// the ORM lookup agrees with itself, and a divergence between the existence
+	// check and the real constraint would pass here and fail in production.
+	workbooks.AddIndex("idx_sheets_workbooks_type_year", true,
+		"workbook_type, year, session_cm_id", "")
+	if err := app.Save(workbooks); err != nil {
+		t.Fatalf("save sheets_workbooks: %v", err)
+	}
+	return app
+}
+
+func rosterWorkbook(sessionCMID int, spreadsheetID string) *WorkbookRecord {
+	return &WorkbookRecord{
+		SpreadsheetID: spreadsheetID,
+		WorkbookType:  workbookTypeFCRoster,
+		Year:          2026,
+		SessionCMID:   sessionCMID,
+		Title:         "Weekend Roster",
+		URL:           "https://docs.google.com/spreadsheets/d/" + spreadsheetID + "/edit",
+		Status:        "ok",
+	}
+}
+
+// TestSaveWorkbookRecordKeepsRosterWorkbooksApartBySession is the trap this
+// dimension exists for.
+//
+// GetWorkbookByType filters (workbook_type, year) with limit 1, and
+// SaveWorkbookRecord uses it as its existence check. Copying that for
+// fc_roster makes the SECOND weekend of a season match the FIRST weekend's row,
+// take the UPDATE branch, and silently overwrite its spreadsheet_id -- collapsing
+// all eight of 2026's enrolled weekends into one workbook. The unique index does
+// NOT save you: the ORM check short-circuits ahead of it.
+func TestSaveWorkbookRecordKeepsRosterWorkbooksApartBySession(t *testing.T) {
+	t.Parallel()
+	app := newWorkbookTestApp(t)
+	manager := NewWorkbookManager(app, NewMockSheetsWriter())
+	ctx := context.Background()
+
+	first, err := manager.SaveWorkbookRecord(ctx, rosterWorkbook(1309515, "sheet-fc2"))
+	if err != nil {
+		t.Fatalf("save first roster workbook: %v", err)
+	}
+	second, err := manager.SaveWorkbookRecord(ctx, rosterWorkbook(1309519, "sheet-fc6"))
+	if err != nil {
+		t.Fatalf("save second roster workbook: %v", err)
+	}
+
+	if first.ID == second.ID {
+		t.Fatalf("both weekends saved onto record %s -- the session dimension is not in the key", first.ID)
+	}
+
+	all, err := manager.ListAllWorkbooks(ctx)
+	if err != nil {
+		t.Fatalf("ListAllWorkbooks: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("stored %d workbooks, want 2: %+v", len(all), all)
+	}
+
+	got, err := manager.GetWorkbookForSession(ctx, workbookTypeFCRoster, 2026, 1309519)
+	if err != nil {
+		t.Fatalf("GetWorkbookForSession: %v", err)
+	}
+	if got == nil || got.SpreadsheetID != "sheet-fc6" {
+		t.Fatalf("lookup for weekend 1309519 returned %+v, want sheet-fc6", got)
+	}
+	if got.SessionCMID != 1309519 {
+		t.Errorf("SessionCMID = %d, want 1309519 -- the column is not round-tripping", got.SessionCMID)
+	}
+}
+
+// TestSaveWorkbookRecordUpdatesTheSameSessionInPlace keeps the second export of
+// ONE weekend on the row the first export created, rather than colliding with
+// the unique index.
+func TestSaveWorkbookRecordUpdatesTheSameSessionInPlace(t *testing.T) {
+	t.Parallel()
+	app := newWorkbookTestApp(t)
+	manager := NewWorkbookManager(app, NewMockSheetsWriter())
+	ctx := context.Background()
+
+	first, err := manager.SaveWorkbookRecord(ctx, rosterWorkbook(1309515, "sheet-fc2"))
+	if err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+
+	again := rosterWorkbook(1309515, "sheet-fc2")
+	again.TabCount = 3
+	second, err := manager.SaveWorkbookRecord(ctx, again)
+	if err != nil {
+		t.Fatalf("second save: %v", err)
+	}
+	if first.ID != second.ID {
+		t.Errorf("second export created record %s, want an update of %s", second.ID, first.ID)
+	}
+
+	all, err := manager.ListAllWorkbooks(ctx)
+	if err != nil {
+		t.Fatalf("ListAllWorkbooks: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("stored %d workbooks, want 1", len(all))
+	}
+	if all[0].TabCount != 3 {
+		t.Errorf("TabCount = %d, want 3", all[0].TabCount)
+	}
+}
+
+// TestGetWorkbookByTypeIgnoresSessionScopedRows keeps the data export's own
+// lookups working unchanged once roster rows share their year. Both existing
+// callers pass globals/year, whose rows carry session_cm_id 0.
+func TestGetWorkbookByTypeIgnoresSessionScopedRows(t *testing.T) {
+	t.Parallel()
+	app := newWorkbookTestApp(t)
+	manager := NewWorkbookManager(app, NewMockSheetsWriter())
+	ctx := context.Background()
+
+	if _, err := manager.SaveWorkbookRecord(ctx, rosterWorkbook(1309515, "sheet-fc2")); err != nil {
+		t.Fatalf("save roster workbook: %v", err)
+	}
+	if _, err := manager.SaveWorkbookRecord(ctx, &WorkbookRecord{
+		SpreadsheetID: "sheet-year", WorkbookType: "year", Year: 2026,
+		Title: "CM Data - 2026", Status: "ok",
+	}); err != nil {
+		t.Fatalf("save year workbook: %v", err)
+	}
+
+	got, err := manager.GetWorkbookByType(ctx, "year", 2026)
+	if err != nil {
+		t.Fatalf("GetWorkbookByType: %v", err)
+	}
+	if got == nil || got.SpreadsheetID != "sheet-year" {
+		t.Fatalf("GetWorkbookByType returned %+v, want sheet-year", got)
+	}
+}
+
+// TestGetWorkbookForSessionReturnsNilWhenAbsent pins the not-found contract the
+// export's find-or-create branch depends on.
+func TestGetWorkbookForSessionReturnsNilWhenAbsent(t *testing.T) {
+	t.Parallel()
+	manager := NewWorkbookManager(newWorkbookTestApp(t), NewMockSheetsWriter())
+
+	got, err := manager.GetWorkbookForSession(context.Background(), workbookTypeFCRoster, 2026, 1309515)
+	if err != nil {
+		t.Fatalf("GetWorkbookForSession: %v", err)
+	}
+	if got != nil {
+		t.Errorf("got %+v, want nil for a session with no workbook", got)
+	}
+}
+
+// TestBuildIndexSheetDataOmitsRosterWorkbooks keeps family contact workbooks out
+// of the Exports folder's index.
+//
+// The Index sheet lives in the GLOBALS workbook, in the Exports folder, whose
+// audience is deliberately wider than the roster folder's -- that per-folder
+// split IS the privacy control (design §2). Listing a roster workbook's title
+// and a clickable link there would publish the existence, the weekend name and
+// the URL of a workbook full of family contact details to that wider audience.
+// Every roster row also renders as its year, so eight 2026 weekends would arrive
+// as eight rows all labeled 2026.
+func TestBuildIndexSheetDataOmitsRosterWorkbooks(t *testing.T) {
+	t.Parallel()
+	data := BuildIndexSheetData([]WorkbookRecord{
+		{WorkbookType: workbookTypeGlobals, Title: "CM Data - Globals", URL: "u1"},
+		{WorkbookType: "year", Year: 2026, Title: "CM Data - 2026", URL: "u2"},
+		{WorkbookType: workbookTypeFCRoster, Year: 2026, SessionCMID: 1309515,
+			Title: "Weekend Roster", URL: "u3"},
+	})
+
+	// One header row plus the two data workbooks.
+	if len(data) != 3 {
+		t.Fatalf("index has %d rows, want 3 (header + globals + year): %v", len(data), data)
+	}
+	for _, row := range data {
+		for _, cell := range row {
+			if s, ok := cell.(string); ok && (s == "Weekend Roster" || s == `=HYPERLINK("u3","Open")`) {
+				t.Errorf("index carries a roster workbook: %v", row)
+			}
+		}
+	}
+}

--- a/pocketbase/sync/workbook_manager_session_test.go
+++ b/pocketbase/sync/workbook_manager_session_test.go
@@ -56,6 +56,16 @@ func newWorkbookTestApp(t *testing.T) core.App {
 	return app
 }
 
+// Two synthetic weekend ids. The registry key is what these tests are about, so
+// they deliberately name no real weekend -- a reader should not have to wonder
+// which season's data a key-collision test is describing. The roster BUILDER
+// tests use sync_testsupport_test.go's shared cmIDFamilyCamp* constants, because
+// those fixtures do stand in for real weekends.
+const (
+	cmIDTestWeekendA = 1000001
+	cmIDTestWeekendB = 1000002
+)
+
 func rosterWorkbook(sessionCMID int, spreadsheetID string) *WorkbookRecord {
 	return &WorkbookRecord{
 		SpreadsheetID: spreadsheetID,
@@ -83,11 +93,11 @@ func TestSaveWorkbookRecordKeepsRosterWorkbooksApartBySession(t *testing.T) {
 	manager := NewWorkbookManager(app, NewMockSheetsWriter())
 	ctx := context.Background()
 
-	first, err := manager.SaveWorkbookRecord(ctx, rosterWorkbook(1309515, "sheet-fc2"))
+	first, err := manager.SaveWorkbookRecord(ctx, rosterWorkbook(cmIDTestWeekendA, "sheet-weekend-a"))
 	if err != nil {
 		t.Fatalf("save first roster workbook: %v", err)
 	}
-	second, err := manager.SaveWorkbookRecord(ctx, rosterWorkbook(1309519, "sheet-fc6"))
+	second, err := manager.SaveWorkbookRecord(ctx, rosterWorkbook(cmIDTestWeekendB, "sheet-weekend-b"))
 	if err != nil {
 		t.Fatalf("save second roster workbook: %v", err)
 	}
@@ -104,15 +114,15 @@ func TestSaveWorkbookRecordKeepsRosterWorkbooksApartBySession(t *testing.T) {
 		t.Fatalf("stored %d workbooks, want 2: %+v", len(all), all)
 	}
 
-	got, err := manager.GetWorkbookForSession(ctx, workbookTypeFCRoster, 2026, 1309519)
+	got, err := manager.GetWorkbookForSession(ctx, workbookTypeFCRoster, 2026, cmIDTestWeekendB)
 	if err != nil {
 		t.Fatalf("GetWorkbookForSession: %v", err)
 	}
-	if got == nil || got.SpreadsheetID != "sheet-fc6" {
-		t.Fatalf("lookup for weekend 1309519 returned %+v, want sheet-fc6", got)
+	if got == nil || got.SpreadsheetID != "sheet-weekend-b" {
+		t.Fatalf("lookup for weekend %d returned %+v, want the second weekend's sheet", cmIDTestWeekendB, got)
 	}
-	if got.SessionCMID != 1309519 {
-		t.Errorf("SessionCMID = %d, want 1309519 -- the column is not round-tripping", got.SessionCMID)
+	if got.SessionCMID != cmIDTestWeekendB {
+		t.Errorf("SessionCMID = %d, want %d -- the column is not round-tripping", got.SessionCMID, cmIDTestWeekendB)
 	}
 }
 
@@ -125,12 +135,12 @@ func TestSaveWorkbookRecordUpdatesTheSameSessionInPlace(t *testing.T) {
 	manager := NewWorkbookManager(app, NewMockSheetsWriter())
 	ctx := context.Background()
 
-	first, err := manager.SaveWorkbookRecord(ctx, rosterWorkbook(1309515, "sheet-fc2"))
+	first, err := manager.SaveWorkbookRecord(ctx, rosterWorkbook(cmIDTestWeekendA, "sheet-weekend-a"))
 	if err != nil {
 		t.Fatalf("first save: %v", err)
 	}
 
-	again := rosterWorkbook(1309515, "sheet-fc2")
+	again := rosterWorkbook(cmIDTestWeekendA, "sheet-weekend-a")
 	again.TabCount = 3
 	second, err := manager.SaveWorkbookRecord(ctx, again)
 	if err != nil {
@@ -161,7 +171,7 @@ func TestGetWorkbookByTypeIgnoresSessionScopedRows(t *testing.T) {
 	manager := NewWorkbookManager(app, NewMockSheetsWriter())
 	ctx := context.Background()
 
-	if _, err := manager.SaveWorkbookRecord(ctx, rosterWorkbook(1309515, "sheet-fc2")); err != nil {
+	if _, err := manager.SaveWorkbookRecord(ctx, rosterWorkbook(cmIDTestWeekendA, "sheet-weekend-a")); err != nil {
 		t.Fatalf("save roster workbook: %v", err)
 	}
 	if _, err := manager.SaveWorkbookRecord(ctx, &WorkbookRecord{
@@ -186,7 +196,7 @@ func TestGetWorkbookForSessionReturnsNilWhenAbsent(t *testing.T) {
 	t.Parallel()
 	manager := NewWorkbookManager(newWorkbookTestApp(t), NewMockSheetsWriter())
 
-	got, err := manager.GetWorkbookForSession(context.Background(), workbookTypeFCRoster, 2026, 1309515)
+	got, err := manager.GetWorkbookForSession(context.Background(), workbookTypeFCRoster, 2026, cmIDTestWeekendA)
 	if err != nil {
 		t.Fatalf("GetWorkbookForSession: %v", err)
 	}
@@ -210,7 +220,7 @@ func TestBuildIndexSheetDataOmitsRosterWorkbooks(t *testing.T) {
 	data := BuildIndexSheetData([]WorkbookRecord{
 		{WorkbookType: workbookTypeGlobals, Title: "CM Data - Globals", URL: "u1"},
 		{WorkbookType: "year", Year: 2026, Title: "CM Data - 2026", URL: "u2"},
-		{WorkbookType: workbookTypeFCRoster, Year: 2026, SessionCMID: 1309515,
+		{WorkbookType: workbookTypeFCRoster, Year: 2026, SessionCMID: cmIDTestWeekendA,
 			Title: "Weekend Roster", URL: "u3"},
 	})
 


### PR DESCRIPTION
feat(sync): Family Camp roster builder and export endpoint

Second of three PRs for the family-facing Family Camp roster (Refs #2433).
PR 1 (#2495) shipped the plumbing; this builds the artifact and exposes it at
`POST /api/custom/lodging/roster-export?year=&session=`, gated on
`bunking.manage`. PR 3 adds the toolbar button.

One row per person, campers and adults, grouped into banded blocks per
household, appended as a new date-stamped tab. It never overwrites or prunes a
tab: staff hand-edit every one, because paper registrations exist only as
lodging-board write-ins and never reach CampMinder, so the previous tab is where
they copy their work from. That is also why there is no scheduled run.

## The trap this PR had to avoid

`GetWorkbookByType` filtered `(workbook_type, year)` with `limit 1`, and
`SaveWorkbookRecord` used it as its existence check. Reusing that for
`fc_roster` would make the SECOND weekend of a season match the FIRST weekend's
row, take the UPDATE branch, and silently overwrite its `spreadsheet_id` --
collapsing all eight of 2026's enrolled weekends into one workbook. The new
unique index does not catch it, because the ORM check short-circuits ahead of
it. `WorkbookRecord` now carries `SessionCMID`, `GetWorkbookForSession` is the
session-aware lookup, and `GetWorkbookByType` delegates to it with
`session_cm_id = 0` so the data export's own lookups are unchanged. Verified
against dev: three weekends exported, three rows, three distinct spreadsheets.

## Two things found while building it

**The admin Sheets tab would have regressed with no frontend file in the diff.**
`useSheetsWorkbooks` reads `sheets_workbooks` directly and `SheetsTab` labels
every non-globals row `String(workbook.year)`, so eight roster workbooks would
have rendered as eight rows all reading "2026", sorted above the real 2026 data
workbook and each opening somewhere else. The hook now filters `fc_roster` out.
Roster workbooks are also excluded from `BuildIndexSheetData`: that index lives
in the globals workbook in the Exports folder, whose audience is deliberately
wider than the roster folder's, and listing one there would publish a
family-contact workbook's name and link to that audience.

**The design's tab-naming paragraph contradicted itself** -- it said tab names
reject `: \ / ? * [ ]` while specifying a `3:04 PM` format. Probed against the
live Sheets API: the colon is accepted, and a `Values.Update` reaches the tab
through both quoted and bare A1 notation, so `WriteToSheet` needs no change to
carry a name with spaces and commas. That rejected set is Excel's rule, not
Sheets'. The 31-character cap is real and is tested.

## Data traps respected

- Duplicate adults render RAW -- deduping here would hide #2483.
- Households sharing an adult are colour-linked, NEVER merged; merging would
  force one wrong city onto co-parents keeping two homes.
- `adult_number >= 3` rows carry a name and no email on 27 of 27 such 2026 rows;
  that blank is correct and permanent, not missing data.
- `family_camp_adults.last_name` is blank for all of 2026, so `name` is the
  column of record and the split pair is only the fallback.
- Households with campers and no adults render as-is.
- Ages are computed AT EXPORT TIME, not at session start -- the reference
  implementation did the latter and the design supersedes it.

## Verification

Unit tests cover the age boundaries (0/1/11/12/13 months and a leap-day
birthday), ordering, the placeholder filter, the name coalesce, city cleaning
and the household fallback, linked-household grouping, tab-name collisions, and
the emitted `batchUpdate` shape against a mock writer. Two of them were
mutation-checked: reinstating the session-blind lookup fails the collapse test,
and adding adult dedup fails the #2483 test. A third was rewritten after a
mutation survived it.

End to end against dev, hitting the real Google API: Family Camp 2 exported 63
households, 98 campers, 120 adults, 218 person rows -- the design's stated
figures for that weekend. Reading the sheet back confirmed 221 rows, both
merges, `frozenRows=3`, the five column widths, the header fill, 63 medium top
and 63 medium bottom borders (one per household), a centred age column, and two
linked-household groups. Every refusal path returns its intended status: 401
unauthenticated, 400 bad params / not a family weekend / no enrolled campers,
404 unknown session.

`scripts/pre-push-verify.sh` passes, `golangci-lint` clean.

Refs #2433

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Family Camp roster exports to Google Sheets, including camper, household, adult, age, city, and linked-household details.
  * Exports create or reuse year- and session-specific workbooks, add dated tabs, and apply consistent formatting.
  * Added clear validation and error handling for invalid or unavailable sessions.
* **Bug Fixes**
  * Family Camp roster workbooks are excluded from general workbook listings and indexes.
  * Improved workbook tracking across separate camp sessions.
* **Tests**
  * Added comprehensive coverage for roster generation, formatting, exports, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->