### PR TITLE
feat(frontend): Family Camp roster export button

### DIFF
--- a/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
@@ -1167,3 +1167,63 @@ describe('HouseholdRosterTable — filters by housing need (kindred#2251)', () =
     expect(visibleRowNames().sort()).toEqual(['No Needs Parent', 'Power Parent'])
   })
 })
+
+// The roster export affordance's placement and gating (kindred#2433 §4.6).
+// The button's own behaviour is covered in RosterExportButton.test.tsx; what
+// this block pins is that the table only offers it where it can succeed.
+describe('roster export button', () => {
+  const exportParties = [party({ display_name: 'Settled Family', unit_name: 'Ridge A' })]
+
+  it('offers the export on a family weekend to someone who can manage lodging', () => {
+    render(
+      <HouseholdRosterTable
+        year={2026}
+        parties={exportParties}
+        sessionCmId={1000001}
+        sessionType="family"
+        canManage
+      />,
+      { wrapper }
+    )
+    expect(screen.getByRole('button', { name: /export roster/i })).toBeInTheDocument()
+  })
+
+  // Gated in the UI as well as at the API: the endpoint requires
+  // bunking.manage, so showing the button to a read-only viewer offers an
+  // action whose only outcome is a 403.
+  it('hides the export from a viewer without bunking.manage', () => {
+    render(
+      <HouseholdRosterTable
+        year={2026}
+        parties={exportParties}
+        sessionCmId={1000001}
+        sessionType="family"
+        canManage={false}
+      />,
+      { wrapper }
+    )
+    expect(screen.queryByRole('button', { name: /export roster/i })).not.toBeInTheDocument()
+  })
+
+  it('hides the export on an adult weekend', () => {
+    render(
+      <HouseholdRosterTable
+        year={2026}
+        parties={exportParties}
+        sessionCmId={1000001}
+        sessionType="adult"
+        canManage
+      />,
+      { wrapper }
+    )
+    expect(screen.queryByRole('button', { name: /export roster/i })).not.toBeInTheDocument()
+  })
+
+  // The props are optional and default to "no export", matching sessionCmId's
+  // own default — most tests in this file render one weekend and never pass
+  // them, and none of them should sprout a button.
+  it('hides the export when the new props are not supplied at all', () => {
+    render(<HouseholdRosterTable year={2026} parties={exportParties} />, { wrapper })
+    expect(screen.queryByRole('button', { name: /export roster/i })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/weekend/HouseholdRosterTable.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.tsx
@@ -19,6 +19,7 @@ import { FamilyDetailsPanel } from './FamilyDetailsPanel'
 import { HouseholdRosterRow } from './HouseholdRosterRow'
 import { partyKey } from './partyKey'
 import { attentionSections, indexUnitsByCode, resolvePartyUnit } from './rosterAttention'
+import { RosterExportButton } from './RosterExportButton'
 
 /**
  * First season `needs_private_bathroom`/`needs_power` carry real signal.
@@ -67,6 +68,21 @@ export interface HouseholdRosterTableProps {
    * exercise a session change.
    */
   sessionCmId?: number
+  /**
+   * The weekend's `camp_sessions.session_type`. Only `family` weekends have a
+   * roster to export (kindred#2433) — adult weekends enrol individuals rather
+   * than households. Optional and defaulting to "" for the same reason
+   * `sessionCmId` defaults to 0: most tests in this file render one weekend's
+   * roster and never exercise the export.
+   */
+  sessionType?: string
+  /**
+   * Whether the viewer holds `bunking.manage`. Gates the roster export in the
+   * UI as well as at the API, so a read-only viewer is not offered an action
+   * whose only outcome is a 403. Named to match `WeekendFriendGroups`, the
+   * sibling on this page that already takes the same pair.
+   */
+  canManage?: boolean
 }
 
 const HEAD_CELL = 'text-muted-foreground pb-2 text-xs font-bold tracking-wider uppercase'
@@ -92,6 +108,8 @@ export function HouseholdRosterTable({
   units = [],
   year,
   sessionCmId = 0,
+  sessionType = '',
+  canManage = false,
 }: HouseholdRosterTableProps) {
   // A third `FamilyDetailsPanel` callsite (kindred#1996), wired exactly as
   // `LodgingBoard` and `LodgingMap` wire the other two — same `usePanelParty`
@@ -229,11 +247,16 @@ export function HouseholdRosterTable({
             )
           })}
         </div>
-        {activeNeeds.length > 0 && (
-          <span className="text-muted-foreground text-sm tabular-nums">
-            {filteredParties.length} of {parties.length}
-          </span>
-        )}
+        <div className="ml-auto flex items-center gap-3">
+          {activeNeeds.length > 0 && (
+            <span className="text-muted-foreground text-sm tabular-nums">
+              {filteredParties.length} of {parties.length}
+            </span>
+          )}
+          {canManage && (
+            <RosterExportButton year={year} sessionCmId={sessionCmId} sessionType={sessionType} />
+          )}
+        </div>
       </div>
 
       {showHistoricalGapWarning && (

--- a/frontend/src/components/weekend/RosterExportButton.test.tsx
+++ b/frontend/src/components/weekend/RosterExportButton.test.tsx
@@ -1,0 +1,300 @@
+/**
+ * The Family Camp roster export affordance (kindred#2433, design §4.6).
+ *
+ * Modelled on SeasonRollForwardPanel's tests, which cover the only other
+ * `/api/custom/lodging` POST: the same `fetchWithAuth` mocking, and the same
+ * "never a bare fetch" assertion, because that endpoint family carries the
+ * PocketBase JWT from localStorage rather than a cookie.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { RosterExportButton } from './RosterExportButton'
+
+const mockFetchWithAuth = vi.fn()
+vi.mock('../../hooks/useApiWithAuth', () => ({
+  useApiWithAuth: () => ({
+    fetchWithAuth: mockFetchWithAuth,
+    isAuthenticated: true,
+    isAuthLoading: false,
+  }),
+}))
+
+const RESULT = {
+  spreadsheet_id: 'sheet-abc',
+  url: 'https://docs.google.com/spreadsheets/d/sheet-abc/edit',
+  title: 'Family Camp 2 2026 Roster',
+  tab_name: 'Aug 19, 2026 3:04 PM',
+  session_cm_id: 1000001,
+  session_name: 'Family Camp 2',
+  year: 2026,
+  household_count: 63,
+  camper_count: 98,
+  adult_count: 120,
+  person_count: 218,
+}
+
+function ok(body: unknown = RESULT) {
+  return { ok: true, status: 200, json: () => Promise.resolve(body) }
+}
+
+function fail(status: number, error: string) {
+  return { ok: false, status, json: () => Promise.resolve({ error }) }
+}
+
+// A client shared across renders inside one test, so a remount reads the cache
+// the previous mount wrote — which is the whole point of the persistence tests.
+function newClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
+function renderButton(
+  overrides: Partial<Parameters<typeof RosterExportButton>[0]> = {},
+  client: QueryClient = newClient()
+) {
+  const ui = (
+    <QueryClientProvider client={client}>
+      <RosterExportButton year={2026} sessionCmId={1000001} sessionType="family" {...overrides} />
+    </QueryClientProvider>
+  )
+  return { ...render(ui), client, ui }
+}
+
+const clickExport = async () => {
+  const user = userEvent.setup()
+  await user.click(screen.getByRole('button', { name: /export roster/i }))
+}
+
+beforeEach(() => {
+  mockFetchWithAuth.mockReset()
+  mockFetchWithAuth.mockResolvedValue(ok())
+})
+
+describe('RosterExportButton', () => {
+  it('renders for a family weekend', () => {
+    renderButton()
+    expect(screen.getByRole('button', { name: /export roster/i })).toBeInTheDocument()
+  })
+
+  // Adult weekends enrol individuals rather than households and carry no
+  // family_camp_adults rows at all, so the endpoint refuses them. Offering the
+  // button would be an affordance whose only outcome is an error.
+  it('renders nothing for an adult weekend', () => {
+    const { container } = renderButton({ sessionType: 'adult' })
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when the session type is not yet known', () => {
+    const { container } = renderButton({ sessionType: '' })
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  // A weekend with no enrolled campers is refused server-side. Without a
+  // session there is nothing to export at all.
+  it('renders nothing without a session', () => {
+    const { container } = renderButton({ sessionCmId: 0 })
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('routes the export through fetchWithAuth, never a bare fetch', async () => {
+    // Asserting only that a header reached an already-cooperating mock proves
+    // nothing. The property worth pinning is that the raw network layer is
+    // never touched: the PocketBase JWT lives in localStorage, so a bare fetch
+    // would carry no Authorization header and 401 silently.
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}'))
+    renderButton()
+
+    await clickExport()
+
+    await waitFor(() => {
+      expect(mockFetchWithAuth).toHaveBeenCalledTimes(1)
+    })
+    expect(fetchSpy).not.toHaveBeenCalled()
+
+    const [url, options] = mockFetchWithAuth.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('/api/custom/lodging/roster-export')
+    expect(url).toContain('year=2026')
+    expect(url).toContain('session=1000001')
+    expect(options.method).toBe('POST')
+    fetchSpy.mockRestore()
+  })
+
+  it('disables the button while the export is in flight', async () => {
+    let release: (value: unknown) => void = () => undefined
+    mockFetchWithAuth.mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve
+      })
+    )
+    renderButton()
+
+    await clickExport()
+
+    const button = screen.getByRole('button', { name: /exporting/i })
+    await waitFor(() => {
+      expect(button).toBeDisabled()
+    })
+
+    release(ok())
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: /open/i })).toBeInTheDocument()
+    })
+  })
+
+  // The link IS the deliverable: the workbook lands in Drive, not in the app,
+  // so an export that does not surface where it went has not finished.
+  it('surfaces the workbook link and the counts on success', async () => {
+    renderButton()
+
+    await clickExport()
+
+    const link = await screen.findByRole('link', { name: /open/i })
+    expect(link).toHaveAttribute('href', RESULT.url)
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'))
+    expect(screen.getByText(/Aug 19, 2026 3:04 PM/)).toBeInTheDocument()
+    expect(screen.getByText(/63 households/)).toBeInTheDocument()
+    expect(screen.getByText(/218 people/)).toBeInTheDocument()
+  })
+
+  // The endpoint's refusals are prose staff can act on -- "no enrolled
+  // campers" tells them the weekend is empty, which a bare status code does
+  // not. This route is PocketBase, so the body carries `error`, not `detail`.
+  it('surfaces the server error message', async () => {
+    mockFetchWithAuth.mockResolvedValue(
+      fail(400, 'session has no enrolled campers: Family Camp 8 (cm_id 1000009, year 2026)')
+    )
+    renderButton()
+
+    await clickExport()
+
+    expect(await screen.findByText(/no enrolled campers/i)).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /open/i })).not.toBeInTheDocument()
+  })
+
+  it('falls back to the status code when the body carries no message', async () => {
+    mockFetchWithAuth.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.reject(new Error('not json')),
+    })
+    renderButton()
+
+    await clickExport()
+
+    expect(await screen.findByText(/500/)).toBeInTheDocument()
+  })
+
+  // Re-exporting is normal: staff pull a fresh tab after a sync. The previous
+  // run's link must not linger beside a new failure.
+  it('clears a previous result when a later export fails', async () => {
+    renderButton()
+    await clickExport()
+    expect(await screen.findByRole('link', { name: /open/i })).toBeInTheDocument()
+
+    mockFetchWithAuth.mockResolvedValue(fail(500, 'Drive is unreachable'))
+    await clickExport()
+
+    expect(await screen.findByText(/Drive is unreachable/)).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /open/i })).not.toBeInTheDocument()
+  })
+})
+
+describe('RosterExportButton persistence and layout', () => {
+  // Staff export, wander off to the Housing tab or another weekend, and come
+  // back. Losing the link means the only record of where the workbook went is
+  // gone, and the obvious recovery -- press it again -- appends a redundant tab
+  // to a workbook whose tabs are hand-edited.
+  it('keeps the link when the roster is unmounted and mounted again', async () => {
+    const client = newClient()
+    const first = renderButton({}, client)
+    await clickExport()
+    expect(await screen.findByRole('link', { name: /open/i })).toBeInTheDocument()
+
+    first.unmount()
+    render(
+      <QueryClientProvider client={client}>
+        <RosterExportButton year={2026} sessionCmId={1000001} sessionType="family" />
+      </QueryClientProvider>
+    )
+
+    expect(screen.getByRole('link', { name: /open/i })).toHaveAttribute('href', RESULT.url)
+    // Restoring from cache must not re-run the export: a second POST would
+    // append a second tab to the workbook.
+    expect(mockFetchWithAuth).toHaveBeenCalledTimes(1)
+  })
+
+  // Each weekend owns its own workbook, so one weekend's link must never show
+  // on another's roster — that link opens the wrong families' contact details.
+  it('scopes the remembered link to its own weekend', async () => {
+    const client = newClient()
+    const first = renderButton({}, client)
+    await clickExport()
+    expect(await screen.findByRole('link', { name: /open/i })).toBeInTheDocument()
+
+    first.unmount()
+    render(
+      <QueryClientProvider client={client}>
+        <RosterExportButton year={2026} sessionCmId={1000002} sessionType="family" />
+      </QueryClientProvider>
+    )
+
+    expect(screen.queryByRole('link', { name: /open/i })).not.toBeInTheDocument()
+  })
+
+  // The error describes the LAST ATTEMPT, not a durable fact about the weekend.
+  // Re-showing it on return would report a failure that is not happening now.
+  it('does not carry an error across a remount', async () => {
+    const client = newClient()
+    mockFetchWithAuth.mockResolvedValue(fail(500, 'Drive is unreachable'))
+    const first = renderButton({}, client)
+    await clickExport()
+    expect(await screen.findByText(/Drive is unreachable/)).toBeInTheDocument()
+
+    first.unmount()
+    render(
+      <QueryClientProvider client={client}>
+        <RosterExportButton year={2026} sessionCmId={1000001} sessionType="family" />
+      </QueryClientProvider>
+    )
+
+    expect(screen.queryByText(/Drive is unreachable/)).not.toBeInTheDocument()
+  })
+
+  // The result sits BESIDE the button, not under it. Stacking grew the toolbar
+  // the moment a result appeared and shoved the whole roster table down the
+  // page. jsdom does no layout, so this pins the mechanism -- one row, not a
+  // column -- and the rendered result is confirmed by eye.
+  it('renders the result beside the button rather than stacked under it', async () => {
+    renderButton()
+    const button = screen.getByRole('button', { name: /export roster/i })
+    const row = button.parentElement
+    expect(row?.className).toContain('items-center')
+    expect(row?.className).not.toContain('flex-col')
+
+    await clickExport()
+
+    const link = await screen.findByRole('link', { name: /open/i })
+    // Same row as the button: a shared parent is what keeps the toolbar one
+    // line tall whether or not a result is showing.
+    expect(row).toContainElement(link)
+  })
+})
+
+// Caught in the browser, not by the suite above: React Query logs
+//   "No queryFn was passed as an option, and no default queryFn was found"
+// for a query declared without one, EVEN when `enabled: false` means it can
+// never run. This slot is deliberately never fetched -- refetching would POST
+// again and append a second tab -- so the queryFn has to exist and refuse.
+it('declares the export cache slot without logging a React Query error', async () => {
+  const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+  renderButton()
+
+  await clickExport()
+  await screen.findByRole('link', { name: /open/i })
+
+  expect(consoleError).not.toHaveBeenCalled()
+  consoleError.mockRestore()
+})

--- a/frontend/src/components/weekend/RosterExportButton.tsx
+++ b/frontend/src/components/weekend/RosterExportButton.tsx
@@ -1,0 +1,185 @@
+/**
+ * Export a Family Camp weekend's family-facing roster to Google Sheets.
+ * kindred#2433, design §4.6.
+ *
+ * The export APPENDS a new date-stamped tab to that weekend's workbook and never
+ * overwrites one, so pressing this twice is safe and is a thing staff do —
+ * they hand-edit every tab and copy their work forward from the previous one.
+ *
+ * The workbook lands in Drive, not in the app, so surfacing the link IS the
+ * completion of the action rather than a nicety.
+ */
+import { useState } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { ExternalLink, Loader2, TableProperties } from 'lucide-react'
+
+import { useApiWithAuth } from '../../hooks/useApiWithAuth'
+import { queryKeys } from '../../utils/queryKeys'
+
+const ENDPOINT = '/api/custom/lodging/roster-export'
+
+/** What the export endpoint returns (pocketbase/sync/family_camp_roster_export.go). */
+export interface RosterExportResult {
+  spreadsheet_id: string
+  url: string
+  title: string
+  tab_name: string
+  session_cm_id: number
+  session_name: string
+  year: number
+  household_count: number
+  camper_count: number
+  adult_count: number
+  person_count: number
+}
+
+export interface RosterExportButtonProps {
+  year: number
+  /** 0 means no weekend is selected, and there is nothing to export. */
+  sessionCmId: number
+  /**
+   * The weekend's `camp_sessions.session_type`. Only `family` weekends have a
+   * roster: adult weekends enrol individuals rather than households and carry
+   * no `family_camp_adults` rows, so the endpoint refuses them.
+   */
+  sessionType: string
+}
+
+/**
+ * This is a PocketBase custom route, not FastAPI — its errors carry `error`,
+ * not `detail`. Same shape as SeasonRollForwardPanel's reader, which covers the
+ * only other `/api/custom/lodging` endpoint.
+ *
+ * The message is worth surfacing rather than flattening to a status: the
+ * endpoint's refusals are prose staff can act on ("session has no enrolled
+ * campers" tells them the weekend is empty), which a bare 400 does not.
+ */
+async function toError(response: Response, fallback: string): Promise<Error> {
+  let message: unknown
+  try {
+    const body: unknown = await response.json()
+    if (body && typeof body === 'object' && 'error' in body) {
+      message = (body as { error?: unknown }).error
+    }
+  } catch {
+    message = undefined
+  }
+  if (typeof message === 'string' && message.length > 0) return new Error(message)
+  return new Error(`${fallback} (HTTP ${String(response.status)})`)
+}
+
+export function RosterExportButton({ year, sessionCmId, sessionType }: RosterExportButtonProps) {
+  const { fetchWithAuth } = useApiWithAuth()
+  const queryClient = useQueryClient()
+  const [isExporting, setIsExporting] = useState(false)
+  // Local, unlike the result: an error describes the LAST ATTEMPT, not a
+  // durable fact about the weekend. Persisting it would re-report a failure
+  // that is not happening now every time staff returned to the tab.
+  const [error, setError] = useState<string | null>(null)
+
+  const exportKey = queryKeys.rosterExport(year, sessionCmId)
+
+  // The cache as a store, not a fetch. `enabled: false` means React Query never
+  // calls a queryFn — which is the point, because "refetching" here would POST
+  // again and append a second tab to a workbook full of hand edits. The slot is
+  // written by handleExport below, and read here so the link survives leaving
+  // the roster tab and coming back.
+  const { data: result } = useQuery<RosterExportResult | null>({
+    queryKey: exportKey,
+    // Declared and never callable. `enabled: false` already stops React Query
+    // running it, but the option is not optional: without it React Query logs
+    // "No queryFn was passed as an option" on every render. Throwing is the
+    // right body -- if anything ever does reach it (a stray `refetch`, a
+    // default queryFn added later), failing loudly beats the alternative,
+    // which is a second POST appending another tab to a workbook of hand edits.
+    queryFn: () => {
+      throw new Error(
+        'The roster export cache slot is written by the export itself and must never be fetched'
+      )
+    },
+    enabled: false,
+    initialData: null,
+    staleTime: Infinity,
+  })
+
+  // Rendered only where an export can succeed. The API refuses both of these
+  // too — this keeps the UI from offering an affordance whose only outcome is
+  // an error message.
+  if (sessionType !== 'family' || sessionCmId <= 0) return null
+
+  const handleExport = async () => {
+    setIsExporting(true)
+    // Both cleared up front: re-exporting is normal, and a stale link sitting
+    // beside a fresh failure would read as a success.
+    setError(null)
+    queryClient.setQueryData<RosterExportResult | null>(exportKey, null)
+    try {
+      const response = await fetchWithAuth(
+        `${ENDPOINT}?year=${String(year)}&session=${String(sessionCmId)}`,
+        { method: 'POST' }
+      )
+      if (!response.ok) throw await toError(response, 'Failed to export the roster')
+      queryClient.setQueryData<RosterExportResult>(
+        exportKey,
+        (await response.json()) as RosterExportResult
+      )
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Failed to export the roster')
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
+  return (
+    // ONE ROW, deliberately. Stacking the result under the button grew the
+    // toolbar the moment an export finished and shoved the whole roster table
+    // down the page. Everything here stays on the button's line, and the
+    // message truncates rather than wrapping, so the table never moves.
+    <div className="flex min-w-0 items-center justify-end gap-2">
+      {result && (
+        <span className="text-muted-foreground flex min-w-0 items-center gap-2 text-xs">
+          <a
+            href={result.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary inline-flex flex-shrink-0 items-center gap-1 font-medium hover:underline"
+          >
+            Open
+            <ExternalLink className="h-3 w-3" />
+          </a>
+          <span className="hidden truncate tabular-nums lg:inline">{result.tab_name}</span>
+          <span className="hidden truncate tabular-nums xl:inline">
+            {result.household_count} households · {result.person_count} people
+          </span>
+        </span>
+      )}
+
+      {error && (
+        // `title` carries the untruncated text: the endpoint's refusals name the
+        // weekend and its ids, which is longer than one toolbar line.
+        <span
+          title={error}
+          className="max-w-56 truncate text-xs text-red-700 lg:max-w-md dark:text-red-400"
+        >
+          {error}
+        </span>
+      )}
+
+      <button
+        type="button"
+        onClick={() => {
+          void handleExport()
+        }}
+        disabled={isExporting}
+        className="btn-secondary flex flex-shrink-0 items-center gap-1.5 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {isExporting ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <TableProperties className="h-4 w-4" />
+        )}
+        {isExporting ? 'Exporting…' : 'Export Roster'}
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/pages/WeekendRosterPage.tsx
+++ b/frontend/src/pages/WeekendRosterPage.tsx
@@ -481,6 +481,11 @@ export default function WeekendRosterPage() {
                         units={units}
                         year={currentYear}
                         sessionCmId={selectedCmId ?? 0}
+                        /* The roster export (kindred#2433) is family-only and
+                           gated on bunking.manage, same pair `WeekendFriendGroups`
+                           below already takes. */
+                        sessionType={selectedSession?.session_type ?? ''}
+                        canManage={canManageLodging}
                       />
                     </ErrorBoundary>
                   </Activity>

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -556,6 +556,20 @@ export const queryKeys = {
    * are filtered out of it at the query — see `useSheetsWorkbooks`.
    */
   sheetsWorkbooks: () => ['sheets-workbooks'] as const,
+  /**
+   * The last roster export for one weekend (kindred#2433).
+   *
+   * A CACHE SLOT, not a fetch. The export is a POST that appends a tab to a
+   * Google Sheet, so this key is never fetched and never invalidated — it is
+   * written with `setQueryData` and read back through a disabled query.
+   * Refetching it would mean exporting again, and every tab in that workbook is
+   * hand-edited staff work.
+   *
+   * Keyed per weekend because each owns its own workbook: one weekend's link
+   * shown on another's roster opens the wrong families' contact details.
+   */
+  rosterExport: (year: number, sessionCmId: number) =>
+    ['roster-export', year, sessionCmId] as const,
 }
 
 /**


### PR DESCRIPTION
feat(frontend): Family Camp roster export button

Last of three PRs for the family-facing Family Camp roster. PR 1 (#2495)
shipped the Drive and Sheets plumbing, PR 2 (#2497) the builder and the
`POST /api/custom/lodging/roster-export` endpoint; this is the affordance that
reaches it.

A single `Export Roster` button at the right-hand end of the roster toolbar,
opposite the housing-need filter chips. It appends a new date-stamped tab to
that weekend's workbook — it never overwrites one, so pressing it twice is safe
and is a thing staff do, because they hand-edit every tab and copy their work
forward from the previous one.

## Rendered only where it can succeed

Family weekends only, and only with `bunking.manage`. Adult weekends enrol
individuals rather than households and carry no `family_camp_adults` rows at
all, so the endpoint refuses them; the permission gate matches the API's.
Offering the button in either case would be an affordance whose only outcome is
an error. `HouseholdRosterTable` takes `sessionType` and `canManage` for this —
the same pair `WeekendFriendGroups` already takes on the same page — both
optional and defaulting to "no export", so the fifty-odd existing tests that
render a roster grow no button.

## Two things owner review caught, and one of them the suite had missed

**The toolbar grew when a result appeared.** The result was stacked under the
button in a `flex-col`, so finishing an export shoved the whole roster table
down the page. It is now one row, with the result to the left of the button on
the button's own line. Long text cannot reintroduce it: the error truncates to
a single line carrying the full message on `title`, and the two stat spans drop
out below `xl`/`lg` rather than wrapping.

**The link now persists**, in the React Query cache keyed per weekend, so it
survives leaving the roster tab and coming back. Per-weekend keying is not
incidental — each weekend owns its own workbook, so a shared slot would show
one weekend's link on another's roster and open the wrong families' contact
details. The error deliberately does NOT persist: it describes the last
attempt, not a durable fact about the weekend, and re-showing it on return
would report a failure that is not happening.

**The cache slot logged a React Query error on every render** — "No queryFn was
passed as an option" — which fires even under `enabled: false`. Spotted in the
browser console during review, not by the tests, so the fix starts with a test
that reproduces it. The slot must never be fetched: refetching here means
POSTing again and appending a second tab to a workbook full of hand edits. So
the `queryFn` now exists and THROWS, because failing loudly beats a silent
duplicate export if anything ever reaches it.

## Verification

Fifteen tests on the button — the gating cases, that the call goes through
`fetchWithAuth` and never a bare `fetch` (the PocketBase JWT lives in
localStorage, so a bare fetch 401s silently), the pending/success/error states,
the link and counts, persistence across a remount, per-weekend scoping, and no
console error. Four more on `HouseholdRosterTable` for the placement and the
two gates. The layout and persistence tests were mutation-checked: restoring
`flex-col` fails the first, reverting to `useState` fails the second.

Driven against a real dev stack, where the button reaches PR 2's live endpoint
and produces an actual workbook. `scripts/pre-push-verify.sh` passes.

Closes #2433.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
