### PR TITLE
fix(ci): authenticate git-cliff's GitHub API calls in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ permissions:
   checks: read
   actions: write
   packages: write
+  pull-requests: read  # git-cliff reads /pulls for changelog author attribution
 
 jobs:
   release:
@@ -106,6 +107,10 @@ jobs:
       id: version
       env:
         INPUT_VERSION: ${{ inputs.version }}
+        # cliff.toml has [remote.github], so git-cliff calls the GitHub API (~40
+        # requests) even for --bumped-version. Unauthenticated that is 60/hr shared
+        # across the runner's IP; a 403 makes git-cliff panic, not degrade.
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
         # Get last tag
         LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
@@ -116,7 +121,7 @@ jobs:
           [[ "$VER" != v* ]] && VER="v$VER"
         else
           # Auto-bump via git-cliff
-          VER=$(git cliff --bumped-version 2>/dev/null | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          VER=$(git cliff --bumped-version | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+' | head -1)
           [[ -z "$VER" ]] && { echo "::error::git-cliff could not determine version"; exit 1; }
           [[ "$VER" != v* ]] && VER="v$VER"
         fi
@@ -132,6 +137,8 @@ jobs:
 
     - name: Generate changelog
       id: changelog
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
         git cliff --unreleased --strip header > RELEASE_NOTES.md
         echo "### Release Notes" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## The failure

`Release` run [32418804935](https://github.com/adamflagg/kindred/actions/runs/32418804935) died at **Calculate version** with:

```
::error::git-cliff could not determine version
```

That message is a red herring — it is what the workflow prints when `$VER` comes back empty, and `$VER` came back empty because git-cliff had **panicked** and its stderr was discarded by `2>/dev/null`.

## Root cause

`cliff.toml` declares `[remote.github]`, and the changelog body template uses `{{ commit.remote.username }}`. That makes git-cliff fetch the repo's commits *and* pull requests from `api.github.com` before it computes anything — currently ~19 pages of commits plus ~23 pages of PRs, about 40 requests — and it does this **even for `--bumped-version`**, which needs none of it.

Neither git-cliff step passed a token, so all ~40 requests were unauthenticated: a 60/hour budget shared across whatever else happens to be on that runner's IP. When the budget is gone GitHub returns 403, and git-cliff does not degrade — it panics:

```
thread 'main' panicked at git-cliff-core/src/changelog.rs:493:18:
Could not get github metadata: HttpClientError(reqwest::Error { kind: Status(403, None),
  url: "https://api.github.com/repos/<owner>/<repo>/commits?per_page=100&page=0" })
exit=101
```

Piped through `2>/dev/null | grep … | head -1`, that becomes `VER=''`.

### Why it took some digging to reproduce

git-cliff caches remote responses in `~/.cache/git-cliff-core` (160 MB locally). Every local run after the first is served from that cache and succeeds regardless of network or quota — the failure only reproduces on a **cold** cache, which is what a fresh runner always has. Verified locally on git-cliff 2.13.1, the same build CI installs:

| cache | auth | result |
|---|---|---|
| warm | none | `v6.0.0`, exit 0 |
| cold | none, quota 0/60 | panic, exit 101, empty stdout — matches CI |
| cold | `GITHUB_TOKEN` set | `v6.0.0`, exit 0 |

### Why 2026-07-31 passed and this one did not

Nothing changed. Same git-cliff (2.13.1 both runs), same `cliff.toml` (untouched since #300). It is a shared-IP quota lottery, and the repo has grown enough that a single run now wants ~40 of those 60 requests.

## The fix

- Pass `GITHUB_TOKEN: ${{ github.token }}` to both git-cliff steps — **Calculate version** and **Generate changelog**. Authenticated, the budget is 1000/hour per repository, so ~40 requests is not close to the edge.
- Add `pull-requests: read` to the job's `permissions:`. This repo is public so public data reads work regardless, but git-cliff explicitly calls `/pulls` and the scope should say so; it also keeps this working if the repo ever goes private.
- Drop `2>/dev/null` on the `--bumped-version` call. On success git-cliff writes only the version to stdout, so suppressing stderr buys nothing and cost us the actual diagnostic. The `[[ -z "$VER" ]]` guard stays as the backstop.

**Generate changelog** had the same exposure and would have panicked at the next step for the same reason — it was just never reached.

## Verification

Config-only change to `.github/workflows/release.yml`; there is no test surface. Evidence is the local reproduction table above: cold cache + no auth panics exactly as CI did, cold cache + token returns `v6.0.0` and exits 0. The real proof is the next `Release` dispatch, which is manual.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release automation so changelogs can reliably include GitHub metadata.
  * Enhanced version calculation diagnostics by preserving relevant error output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->