### PR TITLE
fix(api): a container reports the amenities its rooms actually have

### DIFF
--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -238,6 +238,16 @@ class LodgingUnitSummary(BaseModel):
     # built without the resolution pass must not claim an unmet need.
     power_coverage: AmenityCoverage = "unknown"
     has_ac: bool = False
+    # The AC twin of `power_coverage`, resolved over the same leaf walk and
+    # defaulting to "unknown" for the same reason: a payload built without
+    # the resolution pass must not claim an absent amenity. Seven of the 15
+    # production containers record `has_ac = 0` with AC-bearing rooms, so
+    # merging a house hid a mark both its rooms carry.
+    #
+    # DISPLAY ONLY. Air conditioning has no demand glyph -- ruled on 0 of 184
+    # housing narratives mentioning it, against 54 for a bathroom -- so this
+    # exists to keep the amenity strip honest, not to grade a need.
+    ac_coverage: AmenityCoverage = "unknown"
     has_fridge: bool = False
     # NARROWS `has_fridge` -- it can never contradict its parent, so a consumer
     # reading only `has_fridge` stays correct (the registry's own contract,

--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -106,9 +106,11 @@ Shareability = Literal["unknown", "shareable", "single_party"]
 # How much of a slot carries one amenity, resolved over its LEAF descendants
 # (kindred#1912). Three grains rather than a bool because both boolean
 # policies fall out of it for free -- `OR == != "none"`, `AND == == "all"` --
-# and because what SOME means differs per criterion: for `is_accessible`, some
-# is worse than none, since a building advertising two step-free rooms out of
-# ten invites the placement that lands in one of the other eight.
+# and because what SOME means differs per criterion: for step-free, some is
+# worse than none, since a building advertising two step-free rooms out of ten
+# invites the placement that lands in one of the other eight. (That grain is
+# graded from `has_ramp`, NOT `is_accessible` -- this named the wrong column
+# until kindred#2502; the two are independent and disagree on five rows.)
 #
 # "unknown" is the absence of evidence, exactly as EffectiveBathroom and
 # Shareability spell their own. `has_power = False` on an unconfirmed row

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -1209,10 +1209,12 @@ def _resolve_bathroom(units: list[LodgingUnitSummary], index: _BathroomIndex) ->
     four-value enum every surface already reads and giving it a parallel
     `bathroom_coverage` would have left two fields to keep in step. So it is
     the twin of those four in its walk and its `is_active` filter, and the
-    last amenity that was still answered from the unit's own row. All 15 production containers
-    store `bathroom = "none"` (a building is not a room) while 13 of them
-    have at least one room that records one, so every whole-house card drew
-    no bathroom while both its rooms drew one the moment staff split it.
+    last amenity that was still answered from the unit's own row.
+
+    All 15 production containers store `bathroom = "none"` (a building is not
+    a room) while 13 of them have at least one room that records one, so every
+    whole-house card drew no bathroom while both its rooms drew one the moment
+    staff split it.
 
     ⚠️ CONTAINERS ONLY, unlike the three above. A leaf's own row is already
     the right answer and `_build_units` already computes it correctly --

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -1713,9 +1713,21 @@ class LodgingRosterService:
             # Same one-index-per-call rule `build_roster` follows -- see the
             # comment there and `_BathroomIndex`'s own docstring.
             unit_index = _BathroomIndex.build(unit_summaries)
-            # `build_roster` runs the amenity resolvers right here; this path
-            # ran none of them, so a container's bathroom stayed at its own
-            # blank row on the summary while the board resolved it.
+            # ⚠️ THIS PATH RAN NONE OF THE AMENITY RESOLVERS UNTIL kindred#2502.
+            # `build_roster` runs all five right after building its index; this
+            # one built the index and went straight to `_build_counts`, so every
+            # coverage field stayed at its `"unknown"` default and a container's
+            # bathroom stayed at its own blank row while the board resolved it.
+            #
+            # Nothing `_build_counts` reads today is a coverage field, so four of
+            # these five change no number on this path right now. They are wired
+            # anyway, because the ASYMMETRY is the defect: one path resolving and
+            # the other not is exactly how the bathroom gap survived unnoticed,
+            # and the next reader of a coverage field here would inherit it.
+            _resolve_power_coverage(unit_summaries, unit_index)
+            _resolve_fridge_coverage(unit_summaries, unit_index)
+            _resolve_ramp_coverage(unit_summaries, unit_index)
+            _resolve_ac_coverage(unit_summaries, unit_index)
             _resolve_bathroom(unit_summaries, unit_index)
             parties = self._build_parties(
                 session_type=_s(session, "session_type"),

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -925,7 +925,7 @@ class _BathroomIndex(NamedTuple):
 
     units_by_code: dict[str, LodgingUnitSummary]
     # Immediate children only, keyed by the PARENT's code. Nesting (a
-    # container inside a container, e.g. Doctor's House under a larger
+    # container inside a container, e.g. an apartment under a larger
     # block) is walked at read time in `leaf_codes_under`, mirroring
     # `drawn_units`' own upward walk of the same `parent_code` relation.
     children_by_parent: dict[str, tuple[LodgingUnitSummary, ...]]
@@ -1015,8 +1015,10 @@ def _resolve_party_bathroom(unit_codes: list[str], index: _BathroomIndex) -> str
         if unit.is_container:
             leaves = index.leaf_codes_under(code)
             occupied |= leaves
-            leaf_groups = frozenset(index.units_by_code[leaf].bathroom_group for leaf in leaves)
-            inherited_bathroom, inherited_group = container_bathroom(leaf_groups)
+            leaf_bathrooms = frozenset(
+                (index.units_by_code[leaf].bathroom, index.units_by_code[leaf].bathroom_group) for leaf in leaves
+            )
+            inherited_bathroom, inherited_group = container_bathroom(leaf_bathrooms)
             if not bathroom:
                 bathroom, group = inherited_bathroom, inherited_group
         else:
@@ -1159,6 +1161,59 @@ def _resolve_ramp_coverage(units: list[LodgingUnitSummary], index: _BathroomInde
         grade=ramp_coverage,
         target="ramp_coverage",
     )
+
+
+def _resolve_bathroom(units: list[LodgingUnitSummary], index: _BathroomIndex) -> None:
+    """Fill in every CONTAINER's `bathroom` from its leaves -- kindred#2502.
+
+    The fourth twin of the three resolvers above, and the last amenity that
+    was still answered from the unit's own row. All 15 production containers
+    store `bathroom = "none"` (a building is not a room) while 13 of them
+    have at least one room that records one, so every whole-house card drew
+    no bathroom while both its rooms drew one the moment staff split it.
+
+    ⚠️ CONTAINERS ONLY, unlike the three above. A leaf's own row is already
+    the right answer and `_build_units` already computes it correctly --
+    `effective_bathroom` against a one-element slot leaves a `shared` leaf
+    `shared`. Overwriting leaves here would be a no-op at best and would
+    duplicate the one place that logic lives.
+
+    ⚠️ WHY A RESOLVER AND NOT SLOT-CODE THREADING. The party path answers
+    this correctly already (`_resolve_party_bathroom`), but only once a
+    placement exists -- so the same building graded unmet in the picker and
+    met once the family landed in it. Most containers are never placed into.
+    A resolver has no placement to read, which is the whole point: it answers
+    for an EMPTY building, which is when staff are choosing one.
+
+    The exclusivity upgrade is honest here rather than generous: booking a
+    whole container covers every room under it by construction, so if the
+    rooms' shared group has no members outside the container,
+    `effective_bathroom` is being handed a genuinely complete slot.
+    """
+    for unit in units:
+        if not unit.is_container:
+            continue
+        leaves = [
+            leaf
+            for code in sorted(index.leaf_codes_under(unit.code))
+            if (leaf := index.units_by_code.get(code)) is not None and leaf.is_active
+        ]
+        inherited, group = container_bathroom(frozenset((leaf.bathroom, leaf.bathroom_group) for leaf in leaves))
+        if inherited == "none":
+            # Nothing to inherit -- the container keeps exactly what its own
+            # registry row says, which is what it already holds. This is also
+            # the bathhouse case: rooms sharing a group that names somewhere
+            # they WALK to, with no bathroom in any of them.
+            continue
+        unit.bathroom = cast(
+            Any,
+            effective_bathroom(
+                inherited,
+                group,
+                index.group_members.get(group, frozenset()),
+                frozenset(leaf.code for leaf in leaves),
+            ),
+        )
 
 
 def _resolve_amenity_coverage[Answer](
@@ -1450,6 +1505,7 @@ class LodgingRosterService:
         # The same walk, one dimension over (kindred#2438), and the third and
         # last read of it. Same path-only reasoning as above.
         _resolve_ramp_coverage(unit_summaries, unit_index)
+        _resolve_bathroom(unit_summaries, unit_index)
         # A SECOND PASS, and it has to be: a unit's cover can come from a row
         # on a unit built after it, so there is no order in which one pass over
         # `_build_units` would see every own-row it needs.
@@ -1640,6 +1696,10 @@ class LodgingRosterService:
             # Same one-index-per-call rule `build_roster` follows -- see the
             # comment there and `_BathroomIndex`'s own docstring.
             unit_index = _BathroomIndex.build(unit_summaries)
+            # `build_roster` runs the amenity resolvers right here; this path
+            # ran none of them, so a container's bathroom stayed at its own
+            # blank row on the summary while the board resolved it.
+            _resolve_bathroom(unit_summaries, unit_index)
             parties = self._build_parties(
                 session_type=_s(session, "session_type"),
                 # THIS weekend's start. The six year-scoped fetches above are

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -1163,6 +1163,22 @@ def _resolve_ramp_coverage(units: list[LodgingUnitSummary], index: _BathroomInde
     )
 
 
+def _resolve_ac_coverage(units: list[LodgingUnitSummary], index: _BathroomIndex) -> None:
+    """Fill in every unit's `ac_coverage` in place -- kindred#2502.
+
+    The fourth caller of `_resolve_amenity_coverage`, and the last amenity on
+    the card that had no resolver at all: `has_ac` sat in the schema between
+    two fields that both have twins, and three surfaces read it raw. Seven of
+    the 15 production containers record `has_ac = 0` with AC-bearing rooms.
+
+    Display only -- see the schema field. Every rule this walk applies is
+    `_resolve_power_coverage`'s, unchanged.
+    """
+    _resolve_amenity_coverage(
+        units, index, answer=lambda room: room.has_ac, grade=amenity_coverage, target="ac_coverage"
+    )
+
+
 def _resolve_bathroom(units: list[LodgingUnitSummary], index: _BathroomIndex) -> None:
     """Fill in every CONTAINER's `bathroom` from its leaves -- kindred#2502.
 
@@ -1505,6 +1521,7 @@ class LodgingRosterService:
         # The same walk, one dimension over (kindred#2438), and the third and
         # last read of it. Same path-only reasoning as above.
         _resolve_ramp_coverage(unit_summaries, unit_index)
+        _resolve_ac_coverage(unit_summaries, unit_index)
         _resolve_bathroom(unit_summaries, unit_index)
         # A SECOND PASS, and it has to be: a unit's cover can come from a row
         # on a unit built after it, so there is no order in which one pass over

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -1013,7 +1013,27 @@ def _resolve_party_bathroom(unit_codes: list[str], index: _BathroomIndex) -> str
             # empty-`unit_codes` guard above already refuses to make.
             return "unknown"
         if unit.is_container:
-            leaves = index.leaf_codes_under(code)
+            # ACTIVE leaves only, exactly as `_resolve_bathroom` filters the
+            # same walk. THE TWO LANES MUST AGREE: this one answers for a
+            # container once a family is IN it, that one answers for the
+            # empty card staff are choosing from, and one field cannot mean
+            # two things across a single click. A retired room otherwise
+            # counted twice over here -- once to supply a bathroom nobody can
+            # be placed in, and again to complete the group
+            # `effective_bathroom`'s exclusivity branch checks, which is what
+            # turned a live room with no bathroom into a `private` verdict on
+            # a medical request.
+            #
+            # `index.group_members` stays UNFILTERED on both paths, and that
+            # is deliberate rather than an oversight: a group with a retired
+            # member is not fully covered by a whole-let of the live ones, so
+            # both lanes hold at "shared" rather than upgrading. Filter it in
+            # one place and they diverge again.
+            leaves = frozenset(
+                leaf_code
+                for leaf_code in index.leaf_codes_under(code)
+                if (leaf := index.units_by_code.get(leaf_code)) is not None and leaf.is_active
+            )
             occupied |= leaves
             leaf_bathrooms = frozenset(
                 (index.units_by_code[leaf].bathroom, index.units_by_code[leaf].bathroom_group) for leaf in leaves
@@ -1182,8 +1202,14 @@ def _resolve_ac_coverage(units: list[LodgingUnitSummary], index: _BathroomIndex)
 def _resolve_bathroom(units: list[LodgingUnitSummary], index: _BathroomIndex) -> None:
     """Fill in every CONTAINER's `bathroom` from its leaves -- kindred#2502.
 
-    The fourth twin of the three resolvers above, and the last amenity that
-    was still answered from the unit's own row. All 15 production containers
+    THE FIFTH IN-PLACE RESOLVER AND THE ONLY ONE THAT IS NOT A COVERAGE
+    GRADE. Power, fridge, step-free and AC all funnel through
+    `_resolve_amenity_coverage` and write a `*_coverage` field beside the raw
+    column; this one overwrites the column itself, because `bathroom` is a
+    four-value enum every surface already reads and giving it a parallel
+    `bathroom_coverage` would have left two fields to keep in step. So it is
+    the twin of those four in its walk and its `is_active` filter, and the
+    last amenity that was still answered from the unit's own row. All 15 production containers
     store `bathroom = "none"` (a building is not a room) while 13 of them
     have at least one room that records one, so every whole-house card drew
     no bathroom while both its rooms drew one the moment staff split it.
@@ -1240,7 +1266,15 @@ def _resolve_amenity_coverage[Answer](
     grade: Callable[[Sequence[Answer | None]], str],
     target: str,
 ) -> None:
-    """The one leaf walk all three resolvers above run.
+    """The one leaf walk all FOUR coverage resolvers above run.
+
+    Four, not three: `_resolve_ac_coverage` (kindred#2502) joined power,
+    fridge and step-free, and its own docstring already called itself the
+    fourth caller while this line still said three. `_resolve_bathroom` sits
+    above too and deliberately does NOT come through here -- it writes a
+    container's own `bathroom` rather than a coverage grade, and needs
+    `container_bathroom`'s group reasoning, which has no place in a walk
+    parameterised on one flag per room.
 
     Parameterised on WHICH flag a room answers with and WHICH field receives
     the verdict, so a second amenity is a call site rather than a second
@@ -1510,16 +1544,28 @@ class LodgingRosterService:
         # same `unit_summaries` for `_build_counts` was caught in review on
         # kindred#2041's PR.
         unit_index = _BathroomIndex.build(unit_summaries)
-        # Only on THIS path. `build_summary` builds its own units and index to
-        # get at the counts, but its `WeekendSummaryEntry` carries no `units`
-        # -- so resolving coverage there would be work no response can read.
+        # FIVE IN-PLACE RESOLVERS, AND `build_summary._entry` RUNS THE SAME
+        # FIVE.
+        #
+        # This comment said "only on THIS path" until kindred#2502, on the
+        # reasoning that `WeekendSummaryEntry` carries no `units` so resolving
+        # there would be work no response can read. That is no longer true of
+        # any of them: the identical five are wired into `_entry` now, because
+        # ONE orchestrator resolving and the other not is precisely how the
+        # bathroom gap survived unnoticed. See the note there for what they do
+        # and do not move on that path.
+        #
+        # Four of them walk the leaves and write a `*_coverage` grade
+        # (kindred#1912, #2224, #2438, #2502). The fifth is not a coverage
+        # grade at all: it overwrites a CONTAINER's own `bathroom` from its
+        # rooms. It repeats their leaf comprehension and their `is_active`
+        # filter rather than calling `_resolve_amenity_coverage`, because it
+        # needs `container_bathroom`'s group reasoning and that walk is
+        # parameterised on one flag per room. Nothing here depends on the
+        # ORDER of the five -- they are independent, and grouped because they
+        # are one thought.
         _resolve_power_coverage(unit_summaries, unit_index)
-        # The same walk, one amenity over (kindred#2224). Same path-only
-        # reasoning as above: `build_summary` carries no `units`, so resolving
-        # coverage there would be work no response can read.
         _resolve_fridge_coverage(unit_summaries, unit_index)
-        # The same walk, one dimension over (kindred#2438), and the third and
-        # last read of it. Same path-only reasoning as above.
         _resolve_ramp_coverage(unit_summaries, unit_index)
         _resolve_ac_coverage(unit_summaries, unit_index)
         _resolve_bathroom(unit_summaries, unit_index)
@@ -1527,11 +1573,20 @@ class LodgingRosterService:
         # on a unit built after it, so there is no order in which one pass over
         # `_build_units` would see every own-row it needs.
         #
-        # Only on THIS path, for the identical reason `_resolve_power_coverage`
-        # above is: `build_summary` builds its own units to get at the counts,
-        # but its `WeekendSummaryEntry` carries no `units`, so resolving covers
-        # there would be work no response can read -- once per weekend, across
-        # every weekend of the year, on every lander request.
+        # Only on THIS path, and since kindred#2502 it is the ONLY resolver
+        # here that is. `build_summary` builds its own units to get at the
+        # counts, but its `WeekendSummaryEntry` carries no `units`, so
+        # resolving covers there would be work no response can read -- once per
+        # weekend, across every weekend of the year, on every lander request.
+        # That argument survived for THIS function and not for the five above
+        # because a cover is read off `units` and nothing else; no count reads
+        # one.
+        #
+        # kindred#2503 is where that changes. If `is_family_available` ever
+        # reads the RESOLVED cover rather than the unit's own write-in row,
+        # `_build_counts` reads availability, and this call has to run on both
+        # paths or the lander and the board will disagree about which houses
+        # are free.
         _resolve_write_in_covers(unit_summaries, written_in_unit_ids(write_ins))
         housing_names = housing_names_task.result()
         parties = self._build_parties(
@@ -1719,11 +1774,33 @@ class LodgingRosterService:
             # coverage field stayed at its `"unknown"` default and a container's
             # bathroom stayed at its own blank row while the board resolved it.
             #
-            # Nothing `_build_counts` reads today is a coverage field, so four of
-            # these five change no number on this path right now. They are wired
-            # anyway, because the ASYMMETRY is the defect: one path resolving and
-            # the other not is exactly how the bathroom gap survived unnoticed,
-            # and the next reader of a coverage field here would inherit it.
+            # ALL FIVE MOVE NO NUMBER ON THIS PATH TODAY -- not four of them.
+            # An earlier draft of this comment left the fifth unexplained, and
+            # CodeRabbit read the gap the obvious way and asked for
+            # `_resolve_bathroom`'s call to be deleted as having no observable
+            # effect. The premise is right; the repair is not. Both halves,
+            # verified rather than asserted:
+            #
+            #   * `_build_counts` reads `is_active`, `inventory_class`,
+            #     `is_family_available`, `sleeps` and `is_confirmed`. It reads
+            #     no `*_coverage` field and no `bathroom`, and
+            #     `WeekendSummaryEntry` exposes nothing but `session` and
+            #     `counts`.
+            #   * `_resolve_bathroom` writes a CONTAINER's `bathroom`, and the
+            #     one function on this path that could read it back --
+            #     `_resolve_party_bathroom`, via `_build_parties` -- recomputes
+            #     a container's answer from its leaves instead of reading the
+            #     container's own field. So the overwrite is invisible there
+            #     too.
+            #
+            # They are wired anyway, and deleting the call is the wrong repair,
+            # because the ASYMMETRY is the defect rather than a consequence of
+            # it. One orchestrator resolving and the other not is exactly how
+            # the bathroom gap survived unnoticed, and the next reader of a
+            # coverage field here -- a count over `power_coverage`, a
+            # `WeekendSummaryEntry` that grows a units field -- would inherit
+            # the gap silently, holding a plausible-looking `"unknown"` rather
+            # than failing.
             _resolve_power_coverage(unit_summaries, unit_index)
             _resolve_fridge_coverage(unit_summaries, unit_index)
             _resolve_ramp_coverage(unit_summaries, unit_index)

--- a/api/services/lodging_rules.py
+++ b/api/services/lodging_rules.py
@@ -189,9 +189,17 @@ def amenity_coverage(values: Sequence[bool | None]) -> str:
     for free -- `OR == result != "none"`, `AND == result == "all"` -- so a
     per-criterion OR/AND policy map would be a strict subset of this that
     costs more to build. What the three grains MEAN differs per criterion
-    (for `is_accessible`, SOME is worse than NONE: a building advertising two
+    (for step-free, SOME is worse than NONE: a building advertising two
     step-free rooms out of ten invites the placement that lands in one of the
     other eight), and that nuance belongs to the renderer, not here.
+
+    ⚠️ THE STEP-FREE GRAIN IS GRADED FROM `has_ramp`, NOT `is_accessible`.
+    This paragraph named the wrong column until kindred#2502. They are
+    INDEPENDENT and they disagree: of the five rows with `has_ramp = 'yes'`,
+    two are `is_accessible` true and three are false, and the four explicit
+    `no`s plus five `partial`s are invisible to that flag entirely. Which of
+    the two a surface should show is an open product question (kindred#2327);
+    which one this machinery grades is not.
 
     This function does not walk anything. Resolving which rooms answer for a
     slot is the caller's job -- `_BathroomIndex.leaf_codes_under` in

--- a/api/services/lodging_rules.py
+++ b/api/services/lodging_rules.py
@@ -282,18 +282,17 @@ def ramp_coverage(values: Sequence[str | None]) -> str:
     return "none"
 
 
-def container_bathroom(leaf_bathroom_groups: frozenset[str]) -> tuple[str, str]:
+def container_bathroom(leaves: frozenset[tuple[str, str]]) -> tuple[str, str]:
     """A container's bathroom, inherited from its leaf descendants.
 
     Containers (buildings, apartments) store `bathroom = "none"` on the
     registry row itself -- the field describes a ROOM, and a building is
     not one. That is correct for the units inventory, which has no
     occupant to resolve the ambiguity for. It is wrong for a party that has
-    booked the WHOLE container: the health-center apartments are two
-    bedrooms over one shared bath, normally let whole, which is exactly the
-    case `effective_bathroom`'s exclusivity branch exists for -- except the
-    container's own "none" short-circuits that branch (line 108-109) before
-    it ever runs.
+    booked the WHOLE container: two bedrooms over one shared bath, normally
+    let whole, is exactly the case `effective_bathroom`'s exclusivity
+    branch exists for -- except the container's own "none" short-circuits
+    that branch before it ever runs.
 
     This resolves what "bathroom" and "bathroom_group" to FEED
     `effective_bathroom` on the container's behalf, rather than widening
@@ -302,24 +301,46 @@ def container_bathroom(leaf_bathroom_groups: frozenset[str]) -> tuple[str, str]:
     the inheritance a container needs is a fact about its children, computed
     here and handed in as an ordinary "shared" input.
 
+    ⚠️ THIS TAKES (bathroom, group) PAIRS. It took bare group ids until
+    kindred#2502, and identity alone is not enough to answer the question:
+    a group says which rooms share ONE bathroom, never that the bathroom is
+    inside any of them. One registry group names a BATHHOUSE its two rooms
+    walk to -- both record `bathroom = "none"` -- and on identity alone this
+    returned ("shared", group), which `effective_bathroom` then upgraded to
+    "private" for a whole-let. That is a satisfied verdict on an in-cabin
+    bathroom request that is asked for medical reasons, about two rooms with
+    no bathroom in them. A group is inheritable only when some leaf behind
+    it actually records one.
+
     Args:
-        leaf_bathroom_groups: the `bathroom_group` of every LEAF unit
-            directly or indirectly under the container ("" for a leaf with
-            no group).
+        leaves: the `(bathroom, bathroom_group)` pair of every LEAF unit
+            directly or indirectly under the container. `bathroom` is the
+            registry's own value ("", "none", "private", "shared") and
+            `bathroom_group` is "" for a leaf with no group.
 
     Returns:
         ("shared", group) when every leaf agrees on the same non-empty
-        group -- the children physically share one bathroom, so booking the
-        whole container definitionally covers that group. ("none", "")
-        when the leaves disagree, carry no group, or there are none at all:
-        nothing to inherit, so the container reports exactly what its own
-        registry row already says.
+        group AND at least one of them records a bathroom -- the children
+        physically share one bathroom, so booking the whole container
+        definitionally covers that group. ("none", "") otherwise: nothing
+        to inherit, so the container reports exactly what its own registry
+        row already says.
+
+        ⚠️ Leaves spanning two groups return ("none", "") even when every
+        one of them has a bathroom. That is a FALSE NEGATIVE and it is
+        deliberate: widening it redefines what "this building has a
+        bathroom" means, which is an owner ruling rather than a bug fix.
+        `test_leaves_split_across_groups_inherit_nothing` pins it.
     """
-    if len(leaf_bathroom_groups) == 1:
-        (group,) = leaf_bathroom_groups
-        if group:
-            return "shared", group
-    return "none", ""
+    groups = {group for _, group in leaves}
+    if len(groups) != 1:
+        return "none", ""
+    (group,) = groups
+    if not group:
+        return "none", ""
+    if not any(bathroom in ("private", "shared") for bathroom, _ in leaves):
+        return "none", ""
+    return "shared", group
 
 
 # ── Free-text bunk-request provenance (kindred#2330) ─────────────────────────

--- a/docs/reference/lodging-board-vs-summer.md
+++ b/docs/reference/lodging-board-vs-summer.md
@@ -194,14 +194,17 @@ fit verdict. So the two boards now agree on the shape.
 
 They still disagree on FILTERING, deliberately: `BunkSwapModal` hides
 ineligible bunks via `isEligibleSwapTarget`, and this list hides nothing.
-`placementCandidates.ts` carries the arithmetic — 6 of 118 units have a private
-bathroom against **63 of 459 registrations** asking for one, so a list narrowed
-to "what fits" would be empty most of the time and staff would go back to
-dragging. (An earlier draft of this paragraph said "45 parties". That figure is
-real but belongs to `needsFit.ts`, which counts ROSTERED parties for the
+`placementCandidates.ts` carries the arithmetic — **36 of 118 units** answer the
+bathroom need against **66 of 479 registrations** asking for one, so a list
+narrowed to "what fits" would be empty most of the time and staff would go back
+to dragging. (An earlier draft of this paragraph said "45 parties". That figure
+is real but belongs to `needsFit.ts`, which counts ROSTERED parties for the
 drag-time hatch rather than raw registrations — a different population, and the
-mis-attribution is the defect rather than the number.) Summer's
-gender rule is a hard constraint; amenity fit here is explicitly advisory.
+mis-attribution is the defect rather than the number. It is **41** on the
+2026-08-20 snapshot.) The supply figure read **6 of 118** until that same day:
+kindred#2501 moved the need from exclusivity to presence and kindred#2502
+resolved 8 of the 15 containers over their rooms. Summer's gender rule is a hard
+constraint; amenity fit here is explicitly advisory.
 
 ⚠️ **`UnitAvailabilityControl` IS GONE, and this paragraph used to say it stays.**
 It read: _"`UnitAvailabilityControl` and the merge/split pills stay INLINE.

--- a/docs/reference/weekend-card-vocabulary.md
+++ b/docs/reference/weekend-card-vocabulary.md
@@ -276,7 +276,21 @@ The roster therefore called twelve entirely-powered buildings unpowered while
 the board's own hatch called them fine. All three call the resolver now.
 
 WHICH needs a surface reports is still per-surface, and each scope is written
-down where it lives rather than implied: the drag hatch grades three (bathroom
-would hatch 112 of 118 cards, and still 90 under #2501's presence rule), the roster grades two
-(adding fridge and step-free moves parties between staff-facing section counts
-and needs its own ruling), and the card draws all four.
+down where it lives rather than implied: the drag hatch grades three, the roster
+grades two (adding fridge and step-free moves parties between staff-facing
+section counts and needs its own ruling), and the card draws all four.
+
+**Bathroom is the one excluded from the hatch on arithmetic, and the arithmetic
+moved twice on 2026-08-20** — re-derived against the production snapshot by
+running the shipped functions over all 118 units, not carried forward:
+
+| Rule the hatch would grade on                             | Units answering the need | Cards hatched |
+| --------------------------------------------------------- | ------------------------ | ------------- |
+| exclusivity, before container resolution _(pre-#2501)_    | 6                        | 112           |
+| presence, before container resolution                     | 28                       | 90            |
+| **presence, after `_resolve_bathroom` _(shipped today)_** | **36**                   | **82**        |
+
+#2502's `_resolve_bathroom` moves 8 of the 15 containers from `none` to a
+bathroom their rooms actually have, which is why the presence figure improved
+again after #2501 landed. 82 of 118 is still a wash, so the exclusion stands —
+but quote 82, not 90.

--- a/docs/reference/weekend-card-vocabulary.md
+++ b/docs/reference/weekend-card-vocabulary.md
@@ -50,7 +50,7 @@ the home for _divergences_; this file is the home for _vocabulary_.
 | Mark                                                                                      | Where                             | Means                          | Why it is there                                                                                                                                                                                                                                                                                                                                                                                  | Ruled           |
 | ----------------------------------------------------------------------------------------- | --------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------- |
 | Need glyphs — bathroom · power · fridge · step-free                                       | chip row, **icon-only**           | what the household asked for   | the whole point of #2072. One grading for all four, in `needGlyphs.ts` — the three tables that used to grade them separately now call it                                                                                                                                                                                                                                                         | A3              |
-| — the bathroom glyph's label                                                              |                                   | `Bathroom in unit`             | not `Private bathroom`: the column's word, never the question's (§4). ⚠️ The **rule** still grades exclusivity until #2501, so for one release a room can show a bathroom while the family shows red                                                                                                                                                                                             | 2026-08-19      |
+| — the bathroom glyph's label                                                              |                                   | `Bathroom in unit`             | not `Private bathroom`: the column's word, never the question's (§4). ✅ **The rule now matches the word** — kindred#2501 landed 2026-08-20, so `bathroomCoverage` grades presence in both readings and the one-release contradiction this cell used to warn about is closed. Only the COLUMN name still lags                                                                                    | 2026-08-19      |
 | — hues                                                                                    |                                   | sky · purple · teal · orange   | **`text-sky-500 dark:text-sky-400`** and the same 500/400 step for purple, teal, orange. The artifact's hex values _stand in for_ those Tailwind steps — they are v3's, and this project ships v4, whose OKLCH ramps render `#00a6f4` / `#ad46ff` / `#00bba7` / `#ff6900`. The tokens are the definition (§6); do not hand-write hex                                                             | A3              |
 | — unmet state                                                                             |                                   | the placed room has not got it | the glyph takes the **warn** fill, border and icon colour. The shape still says which need it is, which is what makes losing the hue affordable                                                                                                                                                                                                                                                  | N2              |
 | — absent state                                                                            |                                   | not asked for                  | **omitted entirely, never dimmed**                                                                                                                                                                                                                                                                                                                                                               | absence rule    |
@@ -111,9 +111,28 @@ The word _private_ entered at the column name and propagated to the label.
 Private-vs-shared is an artefact of how containers and `bathroom_group`s were
 modelled, not a question anyone asked a family.
 
-Fixing the rule is **kindred#2501** (`satisfiedBy` → `effective_bathroom !==
-'none'`), gated on reading the Adult form's wording, which supplies 19 of 66
-flagged households and has never been audited.
+**Fixed 2026-08-20 by kindred#2501**, and the shipped rule is slightly
+narrower than the one planned here. This paragraph proposed `effective_bathroom
+!== 'none'`; what landed also excludes `'unknown'`, because the same day's glyph
+ruling settled that an unmeasured space must not read as met — _"unknown values
+should not equal fits, across all surfaces on the glyphs, its unconfirmed
+information."_ So the met arm is `'private' || 'shared'`, stated positively in
+`needGlyphs.bathroomCoverage`, and it applies to BOTH readings: the placed lane
+off `party.effective_bathroom` and the prospective lane off `unit.bathroom`.
+Flipping only the placed one — which is what #2501's body asked for — would have
+moved the contradiction into the Assign modal instead of closing it.
+
+What `'shared'` means is worth restating, because the word invites the wrong
+reading: a bathroom INSIDE the cabin that two parties split. Walking to a
+bathhouse is not `'shared'`; it records as `'none'` and is still unmet.
+
+The cost was accepted on the record rather than discovered: the ~3–5 households
+a year who need a bathroom nobody else uses lose an automatic red mark and are
+found by reading the request instead. The Adult form audit this was once gated
+on did not block the ruling.
+
+**Renaming `needs_private_bathroom` is the remaining follow-up.** The column is
+now the only place the word _private_ survives.
 
 ## 5. Open — silence here is not consent
 
@@ -127,11 +146,14 @@ Accommodation` label, the four sharing-intent chips (including whether the
   half of a pair breaks it. The card and that list therefore word one fact two
   ways today. **Put both in front of staff together**, since the label is
   explicitly not locked.
-- **The roster's own wording did not move either**, for a sharper reason: the
-  glyph is called _Bathroom in unit_ because that is the axis the form asks
-  about, but `rosterAttention` still grades exclusivity until #2501, and
-  "No bathroom in unit" would be a false sentence about a cabin with a shared
-  bathroom in it. Both halves move together when #2501 lands.
+- **The roster's wording moved with the rule, 2026-08-20 — CLOSED.** It was
+  held back for a sharper reason than the item above: the glyph is called
+  _Bathroom in unit_ because that is the axis the form asks about, but while
+  `rosterAttention` still graded exclusivity, "No bathroom in unit" would have
+  been a false sentence about a cabin with a shared bathroom in it. #2501 moved
+  the rule, so both halves of `ROSTER_NEED_WORDING` moved with it — `asked` to
+  `Bathroom in unit` and `unmet` to `No bathroom in unit`. Changing only
+  `unmet` would have left the exclusivity claim standing on the asked side.
 
 ## 5a. Answered 2026-08-19 — the four rulings the implementation needed
 
@@ -143,7 +165,7 @@ resolved by an implementer without guessing.
 | **The meta row is not empty.** Ruling 12 deletes it, but `Inactive`, `Building` and `Reconfirm space` survive T2 and the footer move | `Building` is **cut** (§3). The row **stays, rendering only when `Inactive` or `Reconfirm space` is present** — never, on today's data, so ruling 12's outcome holds on every live card while both marks keep a home for when #2500 makes `Reconfirm space` fire on all 118 units at season start. **Lands in stage 3** (§9) |
 | **The Assign modal's `People` field has no column.** `lodging_write_ins` holds `occupant_name` and `note` only                       | Land the modal **without the people count**, and scope kindred#2503 to add it — that issue body now owns the field explicitly                                                                                                                                                                                                |
 | **"Party size vs REMAINING beds" redefines a staff-facing number**                                                                   | Owner, verbatim: _"The modal states beds FREE because that is the question being asked at the point of placement — will this party fit in what is left. The card's N/M is unchanged and over-capacity still means placed exceeds capacity everywhere on the board."_                                                         |
-| **Rulings 2 and 4 contradict until #2501** — presence on the room, exclusivity on the family                                         | **Accept for one release**, named in the PR body with a comment at both sites. `needGlyphs.test.ts` carries the assertion that flips when #2501 lands                                                                                                                                                                        |
+| **Rulings 2 and 4 contradict until #2501** — presence on the room, exclusivity on the family                                         | **Accepted for one release**, named in the PR body with a comment at both sites. `needGlyphs.test.ts` carried the assertion that flips when #2501 lands. ✅ **Spent 2026-08-20**: #2501 landed, both rulings read presence, and that assertion has flipped. The release the contradiction was borrowed against is this one   |
 
 ## 5b. Answered 2026-08-20 — the glyph rulings the review produced
 
@@ -194,13 +216,13 @@ resolved by an implementer without guessing.
 
 ## 7. Deferred, with issues
 
-| Issue        | What                                                                                                                                                   |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| kindred#2499 | evaluate removing the `Write-in` badge from the map surfaces                                                                                           |
-| kindred#2500 | year roll-forward should create units **unconfirmed** — this is what makes _Reconfirm space_ fire at all                                               |
-| kindred#2501 | the bathroom fit rule, above                                                                                                                           |
-| kindred#2502 | `_build_units` scores a container's bathroom on its own blank row                                                                                      |
-| kindred#2503 | optional party size on a write-in, its effect on the occupancy numerator, **and the Assign modal's `People` field** — the modal ships without it (§5a) |
+| Issue            | What                                                                                                                                                                                                    |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| kindred#2499     | evaluate removing the `Write-in` badge from the map surfaces                                                                                                                                            |
+| kindred#2500     | year roll-forward should create units **unconfirmed** — this is what makes _Reconfirm space_ fire at all                                                                                                |
+| ~~kindred#2501~~ | **Landed 2026-08-20** — the bathroom fit rule, above. Presence in both readings                                                                                                                         |
+| ~~kindred#2502~~ | **Landed 2026-08-20** — a container now resolves `bathroom` from its leaves, and `ac_coverage` joins the three coverage twins. The card, the map peek and the Assign modal all read the resolved fields |
+| kindred#2503     | optional party size on a write-in, its effect on the occupancy numerator, **and the Assign modal's `People` field** — the modal ships without it (§5a)                                                  |
 
 ## 8. Where the deliberation lives, and which source wins
 
@@ -255,6 +277,6 @@ the board's own hatch called them fine. All three call the resolver now.
 
 WHICH needs a surface reports is still per-surface, and each scope is written
 down where it lives rather than implied: the drag hatch grades three (bathroom
-would hatch 112 of 118 cards and 90 even after #2501), the roster grades two
+would hatch 112 of 118 cards, and still 90 under #2501's presence rule), the roster grades two
 (adding fridge and step-free moves parties between staff-facing section counts
 and needs its own ruling), and the card draws all four.

--- a/frontend/src/components/weekend/AccessibilityFlagList.test.tsx
+++ b/frontend/src/components/weekend/AccessibilityFlagList.test.tsx
@@ -13,12 +13,56 @@
  *
  * What this file pins is the ABSENCE: no permission check, no fetch, no
  * state. A chips list that reaches for the narrative is what was wrong.
+ *
+ * ⚠️ AND IT PINS ONE MORE ABSENCE NOW: no second list of needs. The rows and
+ * the roster's filter chips are DERIVED from `NEED_GLYPHS` (kindred#2072's
+ * "one place a need is graded"), so the `needGlyphs` mock below appends a
+ * synthetic fifth need that this file never names anywhere else. A component
+ * that hardcodes its four branches back cannot render it, which is the whole
+ * point of the mock.
  */
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { AccessibilityFlags } from '../../types/lodging'
-import { AccessibilityFlagList } from './AccessibilityFlagList'
+import { AccessibilityFlagList, NEED_FILTER_OPTIONS } from './AccessibilityFlagList'
+import { NEED_GLYPHS } from './needGlyphs'
+
+/**
+ * A need that exists only inside this file's module mock.
+ *
+ * Its `flag` is `accommodation_is_mandatory` because every other key on
+ * `AccessibilityFlags` is already a real need's flag, and a synthetic key
+ * would not typecheck. Setting it alone renders no accommodation row — that
+ * row is gated on `needs_accommodation` — so the probe is unambiguous.
+ */
+const { SYNTHETIC_KEY, SYNTHETIC_LABEL, SYNTHETIC_FLAG } = vi.hoisted(() => ({
+  SYNTHETIC_KEY: 'synthetic_probe',
+  SYNTHETIC_LABEL: 'Synthetic probe need',
+  SYNTHETIC_FLAG: 'accommodation_is_mandatory',
+}))
+
+vi.mock('./needGlyphs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./needGlyphs')>()
+  // Imported INSIDE the factory: `vi.mock` is hoisted above this file's own
+  // imports, so a top-level lucide binding would not be initialized yet.
+  const { CircleHelp } = await import('lucide-react')
+  return {
+    ...actual,
+    NEED_GLYPHS: [
+      ...actual.NEED_GLYPHS,
+      {
+        key: SYNTHETIC_KEY,
+        flag: SYNTHETIC_FLAG,
+        label: SYNTHETIC_LABEL,
+        Icon: CircleHelp,
+        hueClassName: 'text-sky-500 dark:text-sky-400',
+        someIs: 'unmet',
+        coverage: () => 'unknown',
+      },
+    ] as unknown as typeof actual.NEED_GLYPHS,
+  }
+})
 
 const useHouseholdMedical = vi.fn(() => ({ data: undefined, isLoading: false, error: null }))
 
@@ -30,6 +74,8 @@ function flags(overrides: Partial<AccessibilityFlags> = {}): AccessibilityFlags 
   return {
     needs_private_bathroom: false,
     needs_power: false,
+    needs_fridge: false,
+    needs_step_free: false,
     needs_accommodation: false,
     accommodation_is_mandatory: false,
     has_infant: false,
@@ -38,9 +84,13 @@ function flags(overrides: Partial<AccessibilityFlags> = {}): AccessibilityFlags 
 }
 
 describe('derived flags', () => {
-  it('renders the private-bathroom need', () => {
+  it('renders the bathroom need', () => {
+    // "Bathroom in unit", not "Private bathroom". The label comes from
+    // `NEED_GLYPHS` now, and kindred#2501 moved the RULE to presence — a
+    // household reported here has no bathroom in the unit at all, shared or
+    // otherwise, so the ask and the verdict name the same axis.
     render(<AccessibilityFlagList flags={flags({ needs_private_bathroom: true })} />)
-    expect(screen.getByText('Private bathroom')).toBeInTheDocument()
+    expect(screen.getByText('Bathroom in unit')).toBeInTheDocument()
   })
 
   it('renders the power need (CPAP)', () => {
@@ -48,15 +98,28 @@ describe('derived flags', () => {
     expect(screen.getByText('Power')).toBeInTheDocument()
   })
 
-  it('treats power and private bathroom as INDEPENDENT needs', () => {
+  it('renders the fridge need (kindred#2224)', () => {
+    // Six 2026 households ask for a fridge and no roster surface said so —
+    // one of them sits on a card whose `fridge_coverage` is `none`, drawing a
+    // red glyph on the board while this panel did not mention a fridge at all.
+    render(<AccessibilityFlagList flags={flags({ needs_fridge: true })} />)
+    expect(screen.getByText('Fridge')).toBeInTheDocument()
+  })
+
+  it('renders the step-free need (kindred#2438)', () => {
+    render(<AccessibilityFlagList flags={flags({ needs_step_free: true })} />)
+    expect(screen.getByText('Step-free')).toBeInTheDocument()
+  })
+
+  it('treats power and bathroom as INDEPENDENT needs', () => {
     // The CPAP / adult-infant source fields are multi-option, not boolean, and
     // one option carries both needs. A household can need power without a
-    // private bathroom and vice versa; neither implies the other.
+    // bathroom in the unit and vice versa; neither implies the other.
     render(
       <AccessibilityFlagList flags={flags({ needs_power: true, needs_private_bathroom: false })} />
     )
     expect(screen.getByText('Power')).toBeInTheDocument()
-    expect(screen.queryByText('Private bathroom')).not.toBeInTheDocument()
+    expect(screen.queryByText('Bathroom in unit')).not.toBeInTheDocument()
   })
 
   it('renders the infant flag', () => {
@@ -83,6 +146,55 @@ describe('derived flags', () => {
   it('renders nothing when no flag is set', () => {
     const { container } = render(<AccessibilityFlagList flags={flags()} />)
     expect(container.textContent).toBe('')
+  })
+})
+
+describe('one place a need is named — derived from NEED_GLYPHS', () => {
+  it('renders a row for EVERY graded need, not the two it used to hardcode', () => {
+    const everyGradedFlag = Object.fromEntries(
+      NEED_GLYPHS.map((glyph) => [glyph.flag, true])
+    ) as Partial<AccessibilityFlags>
+    render(<AccessibilityFlagList flags={flags(everyGradedFlag)} />)
+    for (const glyph of NEED_GLYPHS) {
+      expect(screen.getByText(glyph.label)).toBeInTheDocument()
+    }
+  })
+
+  it('renders a row for a need added to NEED_GLYPHS with no second edit here', () => {
+    // The mock above appends a fifth spec. A four-branch `if` chain cannot
+    // render it — this is the test that fails if somebody re-hardcodes.
+    render(<AccessibilityFlagList flags={flags({ accommodation_is_mandatory: true })} />)
+    expect(screen.getByText(SYNTHETIC_LABEL)).toBeInTheDocument()
+    // ...and NOT the accommodation row, which is gated on a different flag.
+    expect(screen.queryByText(/^Accommodation/)).not.toBeInTheDocument()
+  })
+
+  it('offers exactly one filter option per graded need, in the glyph order, plus the two ungraded extras', () => {
+    // `accommodation` names no amenity (no cabin field answers it) and
+    // `infant` is derived from ages rather than asked for, so neither is a
+    // graded need and neither can be derived from NEED_GLYPHS. They are the
+    // ONLY two allowed to be spelled out here.
+    expect(NEED_FILTER_OPTIONS.map((option) => option.key)).toEqual([
+      'accommodation',
+      ...NEED_GLYPHS.map((glyph) => glyph.key),
+      'infant',
+    ])
+  })
+
+  it('takes each graded option label and icon from the glyph itself, never a second copy', () => {
+    for (const glyph of NEED_GLYPHS) {
+      const option = NEED_FILTER_OPTIONS.find((candidate) => candidate.key === glyph.key)
+      expect(option?.label).toBe(glyph.label)
+      expect(option?.icon).toBe(glyph.Icon)
+    }
+  })
+
+  it('matches each graded option on the glyph OWN flag', () => {
+    for (const glyph of NEED_GLYPHS) {
+      const option = NEED_FILTER_OPTIONS.find((candidate) => candidate.key === glyph.key)
+      expect(option?.matches({ [glyph.flag]: true })).toBe(true)
+      expect(option?.matches({})).toBe(false)
+    }
   })
 })
 

--- a/frontend/src/components/weekend/AccessibilityFlagList.tsx
+++ b/frontend/src/components/weekend/AccessibilityFlagList.tsx
@@ -11,32 +11,78 @@
  * component appears once per roster row, 62 to a page, so keeping it free of
  * the medical hook is what stops a later change from making 62 gated
  * requests.
+ *
+ * ## It no longer keeps its own list of needs
+ *
+ * This file used to hold a four-branch `if` chain and a four-entry filter
+ * array — a SECOND needs table beside `NEED_GLYPHS`, which kindred#2072 had
+ * already made "the one place a need is graded". The two disagreed, silently
+ * and in the direction that costs the most: `needs_fridge` (kindred#2224) and
+ * `needs_step_free` (kindred#2438) drew a per-family glyph on the board and
+ * appeared on NO roster surface at all. Six 2026 households ask for a fridge,
+ * and one of them sits on a card whose `fridge_coverage` is `none` — a red
+ * glyph on the board, while the details panel's "Housing needs" section did
+ * not mention a fridge.
+ *
+ * So the graded needs, their words and their icons all come from `NEED_GLYPHS`
+ * now, in its order. Adding a fifth entry there surfaces it here — as a row,
+ * and as a roster filter chip — with no edit to this file, and
+ * `AccessibilityFlagList.test.tsx` mocks in a synthetic fifth need to prove
+ * that rather than trusting it.
  */
-import { Accessibility, Baby, Bath, Plug, ShieldAlert } from 'lucide-react'
+import { Accessibility, Baby, ShieldAlert, type LucideIcon } from 'lucide-react'
 
 import type { AccessibilityFlags } from '../../types/lodging'
+import type { NeedKey } from './needGlyphs'
+import { NEED_GLYPHS } from './needGlyphs'
 
 export interface AccessibilityFlagListProps {
   flags: AccessibilityFlags
 }
 
 /**
- * The four flags this file renders, as a filter vocabulary (kindred#2251).
- * One definition feeding both the per-row chips below and
- * `HouseholdRosterTable`'s roster-level filter, so a fifth need can never
- * exist in one without the other. `accommodation_is_mandatory` only changes
- * a CHIP's label/tone below — it plays no part in whether the accommodation
- * need matches, since the filter asks "does this household need one" and a
- * staff member can already see mandatory-vs-preferred once they open a row.
+ * The needs this file renders, as a filter vocabulary (kindred#2251).
+ *
+ * `NeedKey` is spliced in rather than restated, so the union cannot fall
+ * behind `NEED_GLYPHS` without a type error. The two literals either side of
+ * it are the only needs that are NOT graded against a cabin, and each is a
+ * genuinely different kind of thing rather than a fifth glyph waiting to be
+ * written:
+ *
+ *   `accommodation` — names no specific amenity, so no cabin field answers
+ *                     it. `accommodation_is_mandatory` only changes a ROW's
+ *                     label and tone below; it plays no part in whether the
+ *                     need MATCHES, since the filter asks "does this
+ *                     household need one" and a staff member can already see
+ *                     mandatory-vs-preferred once they open a row.
+ *   `infant`        — derived from the household's ages rather than asked
+ *                     for, so it informs which cabin suits them without being
+ *                     an unfulfilled request.
  */
-export type NeedFilterKey = 'accommodation' | 'bathroom' | 'power' | 'infant'
+export type NeedFilterKey = 'accommodation' | NeedKey | 'infant'
 
 export interface NeedFilterOption {
   key: NeedFilterKey
   label: string
-  icon: typeof Bath
+  icon: LucideIcon
   matches: (flags: AccessibilityFlags) => boolean
 }
+
+/**
+ * The graded needs, DERIVED — one entry per `NEED_GLYPHS` spec, in its order.
+ *
+ * Order is part of the vocabulary on the card (see `NEED_GLYPHS`' own note),
+ * and staff meet the same four needs here, so it is inherited rather than
+ * re-chosen. The row list and the filter chips both read this, which is what
+ * stops the panel and the toolbar from drifting apart the way the panel and
+ * the card just did.
+ */
+const GRADED_NEED_OPTIONS: NeedFilterOption[] = NEED_GLYPHS.map((glyph) => ({
+  key: glyph.key,
+  label: glyph.label,
+  icon: glyph.Icon,
+  matches: (flags: AccessibilityFlags) => flags[glyph.flag] === true,
+}))
 
 // eslint-disable-next-line react-refresh/only-export-components -- Shared filter vocabulary, not a component
 export const NEED_FILTER_OPTIONS: NeedFilterOption[] = [
@@ -46,18 +92,7 @@ export const NEED_FILTER_OPTIONS: NeedFilterOption[] = [
     icon: Accessibility,
     matches: (flags) => flags.needs_accommodation === true,
   },
-  {
-    key: 'bathroom',
-    label: 'Private bathroom',
-    icon: Bath,
-    matches: (flags) => flags.needs_private_bathroom === true,
-  },
-  {
-    key: 'power',
-    label: 'Power',
-    icon: Plug,
-    matches: (flags) => flags.needs_power === true,
-  },
+  ...GRADED_NEED_OPTIONS,
   {
     key: 'infant',
     label: 'Infant in party',
@@ -80,7 +115,7 @@ const TONE_ICON: Record<Tone, string> = {
   neutral: 'text-muted-foreground',
 }
 
-function NeedRow({ label, icon: Icon, tone }: { label: string; icon: typeof Bath; tone: Tone }) {
+function NeedRow({ label, icon: Icon, tone }: { label: string; icon: LucideIcon; tone: Tone }) {
   return (
     <li className={`flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm ${TONE_ROW[tone]}`}>
       <Icon className={`h-4 w-4 flex-shrink-0 ${TONE_ICON[tone]}`} aria-hidden="true" />
@@ -92,7 +127,7 @@ function NeedRow({ label, icon: Icon, tone }: { label: string; icon: typeof Bath
 export function AccessibilityFlagList({ flags }: AccessibilityFlagListProps) {
   const mandatory = flags.accommodation_is_mandatory === true
 
-  const needs: Array<{ key: string; label: string; icon: typeof Bath; tone: Tone }> = []
+  const needs: Array<{ key: string; label: string; icon: LucideIcon; tone: Tone }> = []
   if (flags.needs_accommodation === true) {
     needs.push({
       key: 'accommodation',
@@ -101,13 +136,21 @@ export function AccessibilityFlagList({ flags }: AccessibilityFlagListProps) {
       tone: mandatory ? 'red' : 'neutral',
     })
   }
-  // Power and private bathroom are INDEPENDENT needs. The source fields are
-  // multi-option and one option carries both — neither implies the other.
-  if (flags.needs_private_bathroom === true) {
-    needs.push({ key: 'bathroom', label: 'Private bathroom', icon: Bath, tone: 'amber' })
-  }
-  if (flags.needs_power === true) {
-    needs.push({ key: 'power', label: 'Power', icon: Plug, tone: 'amber' })
+  // Every graded need the household ASKED for, ungraded here.
+  //
+  // This row says what was requested; it deliberately does not say whether the
+  // cabin answers it. That verdict is the glyph's job on the card and
+  // `rosterAttention`'s on the roster row, and stating it in a third place is
+  // how the three tables kindred#2072 collapsed came to disagree.
+  //
+  // They are INDEPENDENT needs, all of them. The CPAP and adult-infant source
+  // fields are multi-option and one option carries both power and bathroom, so
+  // neither implies the other; fridge and step-free are parsed out of the
+  // accommodation narrative separately again.
+  for (const option of GRADED_NEED_OPTIONS) {
+    if (option.matches(flags)) {
+      needs.push({ key: option.key, label: option.label, icon: option.icon, tone: 'amber' })
+    }
   }
   // Housing suitability, not a request: it informs which cabin suits them
   // (crib space, bathroom proximity, who shares a wall) rather than gating it.

--- a/frontend/src/components/weekend/AssignFamilyModal.test.tsx
+++ b/frontend/src/components/weekend/AssignFamilyModal.test.tsx
@@ -142,11 +142,143 @@ describe('AssignFamilyModal — the header states beds FREE (owner ruling 2026-0
   })
 
   it('names what the room offers, in words — there is width for them here', () => {
-    renderModal({ unit: unit({ bathroom: 'shared', has_power: true, has_ac: true }) })
+    /*
+     * ⚠️ THE FIXTURE FLIPPED FROM `has_power: true` TO `power_coverage: 'all'`,
+     * AND THAT FLIP IS THE WHOLE POINT OF THIS CHANGE.
+     *
+     * As written, this test set `power_coverage: 'none'` (the base fixture)
+     * AND `has_power: true`, then asserted the header printed "power" — so it
+     * ruled FOR the raw flag on the one pair the resolved field exists to
+     * arbitrate. That is not a stale string; it is the bug, pinned. The header
+     * read raw `has_power` / `has_ac` while the candidate rows twelve lines
+     * below graded `power_coverage`, so on a container the header omitted
+     * "power" while every row under it drew a met plug.
+     *
+     * THE SPECIFICATION IS THE RESOLVED FIELD, not this test's old fixture:
+     * `needGlyphs.ts` and `LodgingUnitCard.tsx` both already read the resolved
+     * coverage, and the reason is measured — twelve of the fourteen 2026
+     * family-pool containers record `has_power = 0` while every leaf beneath
+     * them has power. The raw flag is the wrong answer on twelve buildings.
+     *
+     * The fridge word is NEW. It is one of the four ruled need dimensions, the
+     * rows below draw a fridge glyph, and a header silent about it was silent
+     * about something the rows were speaking on.
+     */
+    renderModal({
+      unit: unit({
+        bathroom: 'shared',
+        power_coverage: 'all',
+        fridge_coverage: 'all',
+        ac_coverage: 'all',
+        // The raw twins say the opposite, and none of them is read.
+        has_power: false,
+        has_fridge: false,
+        has_ac: false,
+      }),
+    })
     const capacity = screen.getByTestId('assign-capacity')
     expect(capacity).toHaveTextContent('bathroom')
     expect(capacity).toHaveTextContent('power')
+    expect(capacity).toHaveTextContent('fridge')
     expect(capacity).toHaveTextContent('air conditioning')
+  })
+
+  it('never claims an amenity from the raw flag the resolved field arbitrates', () => {
+    // The exact pair the old fixture ruled the wrong way round. A row that
+    // records `has_power` on a container whose rooms have none is what
+    // `power_coverage` was added to overrule.
+    renderModal({ unit: unit({ has_power: true, has_ac: true, has_fridge: true }) })
+    const capacity = screen.getByTestId('assign-capacity').textContent
+    expect(capacity).not.toContain('power')
+    expect(capacity).not.toContain('fridge')
+    expect(capacity).not.toContain('air conditioning')
+  })
+
+  it('states a CONTAINER’s amenities, so the header cannot contradict its own rows', () => {
+    /*
+     * ⚠️ THE MEASURED DEFECT. The modal is mounted from `LodgingUnitCard` with
+     * the DRAWN unit, so on a combined house the header said nothing about
+     * power — the container's own `has_power` is 0 — while every candidate row
+     * below it drew a met plug off `power_coverage`. One dialog, two answers,
+     * twelve lines apart.
+     *
+     * Both halves are asserted together on purpose: this test fails if either
+     * surface moves away from the other.
+     */
+    const house = unit({
+      code: 'house',
+      is_container: true,
+      is_combined: true,
+      // The container row's OWN fields, exactly as production records them.
+      has_power: false,
+      has_ac: false,
+      // What the server resolved from the rooms beneath it.
+      power_coverage: 'all',
+      ac_coverage: 'all',
+      bathroom: 'private',
+    })
+    renderModal({
+      unit: house,
+      units: [house],
+      parties: [party({ household_cm_id: 107, flags: { needs_power: true } })],
+    })
+    const capacity = screen.getByTestId('assign-capacity')
+    expect(capacity).toHaveTextContent('power')
+    expect(capacity).toHaveTextContent('air conditioning')
+    expect(capacity).toHaveTextContent('bathroom')
+
+    const glyph = within(screen.getByTestId('candidate-household-107')).getByTestId(
+      'need-glyph-power'
+    )
+    expect(glyph.className).not.toContain('bg-red-100')
+  })
+
+  it('says a building offers power when only SOME of its rooms do', () => {
+    // The unit card's own predicate — presence, so `some` draws the plug: the
+    // mark says the building offers power somewhere. Whether it reaches a
+    // particular family is the need glyph's question, and that one grades
+    // `some` separately (`someIs`).
+    renderModal({ unit: unit({ power_coverage: 'some', fridge_coverage: 'some' }) })
+    const capacity = screen.getByTestId('assign-capacity')
+    expect(capacity).toHaveTextContent('power')
+    expect(capacity).toHaveTextContent('fridge')
+  })
+
+  it('claims nothing on absent evidence — `unknown` is not a yes', () => {
+    // Owner ruling 2026-08-20, on the glyphs: *"unknown values should not
+    // equal fits… its unconfirmed information."* The same reading here, for
+    // the same reason — a word in the header is a CLAIM about the room, and
+    // there is no third state to fall back on. 102 of 118 cabins carry an
+    // unassessed grade on at least one dimension.
+    renderModal({
+      unit: unit({
+        bathroom: 'unknown',
+        power_coverage: 'unknown',
+        fridge_coverage: 'unknown',
+        ac_coverage: 'unknown',
+      }),
+    })
+    // The capacity sentence and NOTHING else — no separator, no word.
+    expect(screen.getByTestId('assign-capacity').textContent).toBe('2 of 4 beds free')
+  })
+
+  it('claims nothing when the server sent no coverage at all', () => {
+    /*
+     * The Pydantic-default gotcha: a field with a default renders OPTIONAL in
+     * the generated types, so every coverage can arrive absent. Absent is
+     * unknown, and unknown is not a yes.
+     *
+     * The keys are DELETED rather than set to `undefined`, because
+     * `exactOptionalPropertyTypes` makes those two different things and only
+     * this one is what the wire produces. `ac_coverage` is never in the base
+     * fixture, so it is already absent here.
+     */
+    const noCoverage = unit()
+    delete noCoverage.bathroom
+    delete noCoverage.power_coverage
+    delete noCoverage.fridge_coverage
+    renderModal({ unit: noCoverage })
+    expect(screen.getByTestId('assign-capacity').textContent).toBe('2 of 4 beds free')
   })
 })
 
@@ -566,8 +698,14 @@ describe('AssignFamilyModal — the candidate rows', () => {
   })
 
   it('reddens a glyph the room cannot answer', () => {
+    // ⚠️ `'none'`, AND IT USED TO BE `'shared'`. The fixture was only ever a
+    // VEHICLE for "this room does not meet the need"; kindred#2501 made
+    // `'shared'` meet it (presence, not exclusivity), so the vehicle had to
+    // change or the test would be pinning the opposite of what it says. The
+    // room with no bathroom at all is the honest stand-in — a walk to a
+    // bathhouse records as `'none'`. The test's intent is unchanged.
     renderModal({
-      unit: unit({ bathroom: 'shared' }),
+      unit: unit({ bathroom: 'none' }),
       parties: [party({ household_cm_id: 103, flags: { needs_private_bathroom: true } })],
     })
     const glyph = within(screen.getByTestId('candidate-household-103')).getByTestId(
@@ -667,8 +805,10 @@ describe('AssignFamilyModal — the candidate rows', () => {
     // household no longer fits it — so the row would carry the CAPACITY note,
     // which is a different sentence in the same red and would leave this test
     // passing for the wrong reason.
+    // `bathroom: 'none'` — see the fixture note on "reddens a glyph the room
+    // cannot answer". `'shared'` stopped being an unmet room at kindred#2501.
     renderModal({
-      unit: unit({ bathroom: 'shared' }),
+      unit: unit({ bathroom: 'none' }),
       occupants: 0,
       parties: [party({ household_cm_id: 105, flags: { needs_private_bathroom: true } })],
     })
@@ -767,8 +907,10 @@ describe('AssignFamilyModal — the candidate rows', () => {
      * invalid HTML, its own focus stop, and a click that both pinned a tooltip
      * and wrote a placement.
      */
+    // `bathroom: 'none'` — see the fixture note on "reddens a glyph the room
+    // cannot answer". `'shared'` stopped being an unmet room at kindred#2501.
     const { props } = renderModal({
-      unit: unit({ bathroom: 'shared' }),
+      unit: unit({ bathroom: 'none' }),
       parties: [party({ household_cm_id: 103, flags: { needs_private_bathroom: true } })],
     })
     const row = screen.getByTestId('candidate-household-103')
@@ -780,8 +922,8 @@ describe('AssignFamilyModal — the candidate rows', () => {
     expect(glyph.tagName).not.toBe('BUTTON')
     // It still says what it is, to a pointer — which is the audience.
     expect(glyph).toHaveAttribute('title', 'Bathroom in unit — the cabin does not meet it')
-    // And it is still the graded mark, not a decoration: this cabin is shared,
-    // the household asked for a bathroom, so the glyph is in the warn state.
+    // And it is still the graded mark, not a decoration: this cabin has no
+    // bathroom, the household asked for one, so the glyph is in the warn state.
     expect(glyph.className).toContain('bg-red-100')
     expect(props.onSelect).not.toHaveBeenCalled()
   })

--- a/frontend/src/components/weekend/AssignFamilyModal.test.tsx
+++ b/frontend/src/components/weekend/AssignFamilyModal.test.tsx
@@ -844,10 +844,10 @@ describe('AssignFamilyModal — the candidate rows', () => {
   })
 
   it('NEVER hides a family, however badly it fits', () => {
-    // The ruling `placementCandidates` exists to carry: 6 of 118 units have a
-    // private bathroom against 45 parties asking for one, so a list narrowed
-    // to "what fits" would be empty most of the time and staff would go back
-    // to dragging.
+    // The ruling `placementCandidates` exists to carry: 36 of 118 units answer
+    // the bathroom need against 41 bathroom-asking households rostered across
+    // 2026's family weekends, so a list narrowed to "what fits" would be empty
+    // most of the time and staff would go back to dragging.
     renderModal({
       unit: unit({ bathroom: 'shared', power_coverage: 'none', sleeps: 1 }),
       parties: [party({ flags: { needs_private_bathroom: true, needs_power: true } }), NGUYEN],

--- a/frontend/src/components/weekend/AssignFamilyModal.tsx
+++ b/frontend/src/components/weekend/AssignFamilyModal.tsx
@@ -119,25 +119,93 @@ export interface AssignFamilyModalProps {
 }
 
 /**
+ * Does the room OFFER this, on the evidence the server resolved?
+ *
+ * ONE PREDICATE FOR ALL FOUR AMENITIES, and it is `LodgingUnitCard`'s own:
+ * anything but `none` and `unknown` is a yes. Written once here so the header
+ * cannot answer one dimension differently from another — the four used to be
+ * four hand-written conditions over four differently-shaped raw fields, which
+ * is how one of them (`has_ramp`, a three-value select where `'no'` is TRUTHY)
+ * inverts under a boolean read.
+ *
+ * ⚠️ `unknown` IS ABSENT, AND THAT IS A CLAIM ABOUT CLAIMS. A word in this
+ * header asserts the room HAS the thing; there is no third, neutral state to
+ * fall back on, so the only question is which assertion is safer about a space
+ * nobody has measured. The owner ruled it for the glyphs on 2026-08-20 —
+ * *"unknown values should not equal fits, across all surfaces on the glyphs,
+ * its unconfirmed information"* — and this header is read in the same glance
+ * as those glyphs, against the same rooms. It takes the same reading.
+ *
+ * `undefined` is the Pydantic-default gotcha rather than a separate case: a
+ * field with a default renders optional in the generated types, so an absent
+ * coverage is simply an unstated one.
+ *
+ * `some` IS a yes, deliberately, and it is again the card's rule: the word
+ * says the building offers the thing SOMEWHERE. Whether it reaches a
+ * particular family is the need glyph's question, and `needGlyphs.someIs`
+ * grades that separately per need.
+ */
+function offers(value: string | undefined): boolean {
+  return value !== undefined && value !== 'none' && value !== 'unknown'
+}
+
+/**
  * What the room offers, in WORDS.
  *
  * The unit card spends its title row on icons because it has 280px; this has
  * the width to say them, and a staff member reading a candidate's glyphs
  * against the room should not have to decode two icon sets at once.
  *
+ * ⚠️ EVERY FIELD HERE IS THE SERVER-RESOLVED ONE, NEVER ITS RAW TWIN, AND THE
+ * RAW READ WAS A MEASURED DEFECT.
+ *
+ * This function read `unit.has_power` and `unit.has_ac` — the DRAWN row's own
+ * columns — while `resolveNeedGlyphs` twelve lines below graded the candidate
+ * rows off `power_coverage`. The modal is mounted from `LodgingUnitCard` with
+ * the drawn unit, so on a container the header omitted "power" while every
+ * candidate row under it drew a met plug: one dialog, two answers, and nothing
+ * anywhere saying which was meant.
+ *
+ * The raw flag is not merely a second opinion, it is the WRONG one on a
+ * container. Twelve of the fourteen 2026 family-pool containers record
+ * `has_power = 0` while every leaf beneath them has power, and 8 of the 15
+ * containers resolve a bathroom their own row calls `none`. `power_coverage`,
+ * `fridge_coverage`, `ac_coverage` and the in-place-resolved `bathroom` are
+ * the server's answers over the leaves (`amenity_coverage` /
+ * `container_bathroom` in `api/services/lodging_rules.py`). Do not "simplify"
+ * any of these back to the row's own column.
+ *
  * PRESENCE for the bathroom, matching the card's own mark (ruling 2): the
  * CampMinder question asks whether a bathroom can be reached without leaving
- * the cabin, never whether it is exclusive (vocabulary §4).
+ * the cabin, never whether it is exclusive (vocabulary §4). `shared` is
+ * therefore a yes, on the same axis kindred#2501 moved the glyph's rule onto.
+ *
+ * FRIDGE IS A WORD HERE AND HAS NO ICON ON THE CARD. It is one of the four
+ * ruled need dimensions, the candidate rows below draw a fridge glyph, and a
+ * header silent about it was silent about something the rows were speaking on
+ * — the same disagreement power had, one dimension over. `fridge_coverage`
+ * also carries the owner's 2026-08-15 ruling that a SHARED fridge IS a fridge,
+ * which no client-side read of `has_fridge` would reproduce.
+ *
+ * STEP-FREE IS DELIBERATELY ABSENT. `ramp_coverage` is the fourth need glyph,
+ * but 102 of 118 cabins have never been assessed, so the word would be missing
+ * from nine headers in ten and read as "no ramp" rather than as "nobody
+ * looked". The glyph can say that — it is only drawn for a household that
+ * ASKED — and this unconditional line cannot.
  */
 function amenityWords(unit: LodgingUnitRow): string[] {
-  const bathroom = unit.bathroom ?? 'unknown'
   // Power first, then bathroom — the review artifact's order
   // (`2 of 4 beds free · power · bathroom`). Arbitrary in isolation, so it
-  // follows the artifact rather than inventing a second convention.
+  // follows the artifact rather than inventing a second convention. The two
+  // the artifact does not name follow it, fridge before air conditioning:
+  // fridge is a need a family can ASK for, and air conditioning is the one
+  // amenity on this board with no demand counterpart at all (0 of 184 housing
+  // narratives mention it, against 11 for a fridge).
   return [
-    unit.has_power === true ? 'power' : null,
-    bathroom !== 'none' && bathroom !== 'unknown' ? 'bathroom' : null,
-    unit.has_ac === true ? 'air conditioning' : null,
+    offers(unit.power_coverage) ? 'power' : null,
+    offers(unit.bathroom) ? 'bathroom' : null,
+    offers(unit.fridge_coverage) ? 'fridge' : null,
+    offers(unit.ac_coverage) ? 'air conditioning' : null,
   ].filter((word): word is string => word !== null)
 }
 

--- a/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.test.tsx
@@ -10,7 +10,9 @@ import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { RosterPartyRow } from '../../types/lodging'
+import { NEED_FILTER_OPTIONS } from './AccessibilityFlagList'
 import { HouseholdRosterTable } from './HouseholdRosterTable'
+import { NEED_GLYPHS } from './needGlyphs'
 
 vi.mock('../../hooks/usePermissions', () => ({
   usePermissions: () => ({
@@ -1014,6 +1016,34 @@ describe('HouseholdRosterTable — filters by housing need (kindred#2251)', () =
       has_infant: true,
     },
   })
+  const fridgeFamily = party({
+    display_name: 'Fridge Family',
+    household_cm_id: 2000014,
+    adults: [{ adult_number: 1, display_name: 'Fridge Parent', relationship: 'Parent' }],
+    flags: {
+      needs_private_bathroom: false,
+      needs_power: false,
+      needs_fridge: true,
+      needs_step_free: false,
+      needs_accommodation: false,
+      accommodation_is_mandatory: false,
+      has_infant: false,
+    },
+  })
+  const stepFreeFamily = party({
+    display_name: 'Step Free Family',
+    household_cm_id: 2000015,
+    adults: [{ adult_number: 1, display_name: 'Step Free Parent', relationship: 'Parent' }],
+    flags: {
+      needs_private_bathroom: false,
+      needs_power: false,
+      needs_fridge: false,
+      needs_step_free: true,
+      needs_accommodation: false,
+      accommodation_is_mandatory: false,
+      has_infant: false,
+    },
+  })
   const noNeedsFamily = party({
     display_name: 'No Needs Family',
     household_cm_id: 2000013,
@@ -1025,9 +1055,48 @@ describe('HouseholdRosterTable — filters by housing need (kindred#2251)', () =
       wrapper,
     })
     expect(screen.getByRole('button', { name: 'Accommodation' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Private bathroom' })).toBeInTheDocument()
+    // "Bathroom in unit", not "Private bathroom" -- the chip's word now comes
+    // from `NEED_GLYPHS`, and kindred#2501 moved the rule to presence.
+    expect(screen.getByRole('button', { name: 'Bathroom in unit' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Power' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Fridge' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Step-free' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Infant in party' })).toBeInTheDocument()
+  })
+
+  it('renders a chip for every NEED_FILTER_OPTIONS entry, so a fifth need needs no edit here', () => {
+    // The list is DERIVED from `NEED_GLYPHS` (see AccessibilityFlagList).
+    // Asserting against the constant rather than six literals is what makes a
+    // future fifth graded need surface on this toolbar automatically.
+    render(<HouseholdRosterTable year={2026} parties={[bathroomFamily, powerFamily]} />, {
+      wrapper,
+    })
+    for (const option of NEED_FILTER_OPTIONS) {
+      expect(screen.getByRole('button', { name: option.label })).toBeInTheDocument()
+    }
+    for (const glyph of NEED_GLYPHS) {
+      expect(screen.getByRole('button', { name: glyph.label })).toBeInTheDocument()
+    }
+  })
+
+  it('narrows the roster to the fridge need (kindred#2224)', async () => {
+    // Six 2026 households ask for a fridge; before this the roster had no way
+    // to find them at all.
+    render(
+      <HouseholdRosterTable year={2026} parties={[fridgeFamily, powerFamily, noNeedsFamily]} />,
+      { wrapper }
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Fridge' }))
+    expect(visibleRowNames()).toEqual(['Fridge Parent'])
+  })
+
+  it('narrows the roster to the step-free need (kindred#2438)', async () => {
+    render(
+      <HouseholdRosterTable year={2026} parties={[stepFreeFamily, powerFamily, noNeedsFamily]} />,
+      { wrapper }
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Step-free' }))
+    expect(visibleRowNames()).toEqual(['Step Free Parent'])
   })
 
   it('narrows the roster to parties matching the selected need', async () => {
@@ -1084,6 +1153,20 @@ describe('HouseholdRosterTable — filters by housing need (kindred#2251)', () =
     render(<HouseholdRosterTable year={2024} parties={[noNeedsFamily]} />, { wrapper })
     await userEvent.click(screen.getByRole('button', { name: 'Accommodation' }))
     expect(screen.queryByText(/2026 season/)).not.toBeInTheDocument()
+  })
+
+  it('does not warn for fridge or step-free either — they share accommodation\u2019s provenance', async () => {
+    // NOT a 2026-only column, unlike bathroom/power. Both are derived in the
+    // Go sync from the accommodation NARRATIVE (`accommodationExplainFieldNames`
+    // in `pocketbase/sync/family_camp_derived.go`), whose source fields existed
+    // in earlier seasons — which is the same reason `needs_accommodation` is
+    // excluded from `HISTORICAL_GAP_KEYS`. Adding the two new chips to the gap
+    // set would show a caveat that is false about them.
+    render(<HouseholdRosterTable year={2024} parties={[noNeedsFamily]} />, { wrapper })
+    await userEvent.click(screen.getByRole('button', { name: 'Fridge' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Step-free' }))
+    expect(screen.queryByText(/2026 season/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/missing data/i)).not.toBeInTheDocument()
   })
 
   it('warns that private-bathroom/power data does not exist before the 2026 season (kindred#2251 caveat)', async () => {

--- a/frontend/src/components/weekend/HouseholdRosterTable.tsx
+++ b/frontend/src/components/weekend/HouseholdRosterTable.tsx
@@ -46,6 +46,14 @@ import { RosterExportButton } from './RosterExportButton'
  * databases carry one, so the banner copy below is scoped to the pre-2026
  * seasons this set already gates on rather than claiming the filter can
  * never match anything.
+ *
+ * ⚠️ `fridge` and `step_free` are OUT for `needs_accommodation`'s reason, not
+ * as an oversight. Both are derived in the Go sync from the accommodation
+ * NARRATIVE (`accommodationExplainFieldNames`, `family_camp_derived.go`),
+ * whose source fields existed in earlier seasons too — so they carry real, if
+ * sparse, historical signal and the caveat below would be false about them.
+ * They joined this toolbar when the chips started deriving from `NEED_GLYPHS`;
+ * the gap set did not grow with them.
  */
 const NEEDS_DATA_FIRST_YEAR = 2026
 const HISTORICAL_GAP_KEYS: ReadonlySet<NeedFilterKey> = new Set(['bathroom', 'power', 'infant'])
@@ -268,8 +276,8 @@ export function HouseholdRosterTable({
             </>
           ) : (
             <>
-              Private bathroom and power needs are only recorded starting the 2026 season. A result
-              for {year} reflects missing data, not that nobody needed one.
+              Bathroom and power needs are only recorded starting the 2026 season. A result for{' '}
+              {year} reflects missing data, not that nobody needed one.
             </>
           )}
         </p>

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -1365,6 +1365,9 @@ describe('LodgingUnitCard — summer’s type scale', () => {
             bathroom: 'private',
             has_power: true,
             has_ac: true,
+            // The sweep is only as good as the DOM it renders; `ac_coverage`
+            // is what mounts the snowflake now (kindred#2502).
+            ac_coverage: 'all',
             parent_code: 'cedar-house',
             is_container: true,
             is_combined: true,
@@ -2271,12 +2274,69 @@ describe('LodgingUnitCard — T2: the amenities ride the TITLE row', () => {
     expect(container.querySelectorAll('[data-testid^="amenity-"]')).toHaveLength(0)
   })
 
+  /*
+   * ⚠️ THE AC MARK READS `ac_coverage`, NOT THE RAW `has_ac` — kindred#2502.
+   *
+   * The plug two lines above it moved to a resolved coverage field at
+   * kindred#2072, for a reason stated in the card itself: the raw flag drew no
+   * plug on twelve entirely-powered buildings. AC had no resolver at all until
+   * this branch added one, so it kept the raw read and kept the bug — and the
+   * server's own count is the measurement, not an analogy:
+   * `_resolve_ac_coverage` records that SEVEN of the 15 production containers
+   * carry `has_ac = 0` with AC-bearing rooms.
+   *
+   * kindred#2502 named THREE surfaces reading it raw. `MapUnitPopover` and
+   * `AssignFamilyModal` both moved to `ac_coverage`; this card is the third
+   * and was the one left behind, so the modal a staff member opens FROM this
+   * card printed "air conditioning" while the card itself drew no snowflake.
+   * That is the same contradiction kindred#2501 closed on the bathroom axis,
+   * one dimension over.
+   *
+   * `some` DRAWS THE MARK, which is the plug's rule and not a new one: the
+   * amenity mark says the building offers it somewhere, and whether it reaches
+   * a particular family is the need glyph's question. AC has no need glyph —
+   * 0 of 184 housing narratives mention it — so there is no demand side to
+   * contradict.
+   */
+  it('draws the snowflake for a BUILDING whose rooms have AC but whose own row does not', () => {
+    const { container } = renderUnit({
+      has_ac: false,
+      ac_coverage: 'all',
+      is_container: true,
+      is_combined: true,
+    })
+    expect(container.querySelector('[data-testid="amenity-ac"]')).not.toBeNull()
+  })
+
+  it('draws it when only SOME rooms have AC, as the plug does for power', () => {
+    const { container } = renderUnit({ has_ac: false, ac_coverage: 'some' })
+    expect(container.querySelector('[data-testid="amenity-ac"]')).not.toBeNull()
+  })
+
+  it('never claims AC from the raw flag the resolved field arbitrates', () => {
+    // The raw twin set to the OPPOSITE of the resolved answer, so the test
+    // proves which one is read rather than merely agreeing with both.
+    const { container } = renderUnit({ has_ac: true, ac_coverage: 'none' })
+    expect(container.querySelector('[data-testid="amenity-ac"]')).toBeNull()
+  })
+
+  it('says nothing about AC nobody has recorded', () => {
+    // `unknown` is "nobody has said", and the mark asserts presence — the same
+    // reading the bathroom and power marks beside it take.
+    const { container } = renderUnit({ has_ac: true, ac_coverage: 'unknown' })
+    expect(container.querySelector('[data-testid="amenity-ac"]')).toBeNull()
+  })
+
   it('keeps the title, the amenities and the occupancy figure on ONE row', () => {
     const { container } = renderUnit({
       bathroom: 'shared',
       has_power: true,
       power_coverage: 'all',
+      // `ac_coverage`, not the raw `has_ac`, since kindred#2502 — this was
+      // `has_ac: true` alone, which no longer draws the third icon this test
+      // counts. The VEHICLE changed; the one-row layout under test did not.
       has_ac: true,
+      ac_coverage: 'all',
     })
     const title = container.querySelector('[data-testid="unit-title-row"]')
     expect(title?.querySelector('h3')).not.toBeNull()

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -223,10 +223,11 @@ export interface LodgingUnitCardProps {
   /**
    * Every UNPLACED party on the weekend — the picker's list (kindred#2080).
    *
-   * NEVER pre-filtered by fit, on the owner's ruling: 6 of 118 units carry a
-   * private bathroom against 63 parties asking for one, so a list narrowed to
-   * "what fits" would be empty most of the time. `placementCandidates`
-   * annotates and orders them instead.
+   * NEVER pre-filtered by fit, on the owner's ruling: 36 of 118 units answer
+   * the bathroom need against 66 of 479 registrations asking for one, so a
+   * list narrowed to "what fits" would be empty most of the time.
+   * `placementCandidates` annotates and orders them instead, and carries the
+   * arithmetic — including why the supply figure read 6 until 2026-08-20.
    */
   unplacedParties?: RosterPartyRow[]
   /**

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -920,9 +920,15 @@ export function LodgingUnitCard({
             shared unit satisfies it as fully as a private one. Of the 6
             private units, 5 are staff housing no weekend has ever released —
             so the distinction is one no staff member on this board can act on.
-            Vocabulary §4 carries the full correction; kindred#2501 is the
-            matching fix to the family-side RULE, which still grades
-            exclusivity for one more release. */}
+            Vocabulary §4 carries the full correction.
+
+            ⚠️ THE ONE-RELEASE GAP THIS USED TO NAME IS CLOSED. It said
+            kindred#2501 was "the matching fix to the family-side RULE, which
+            still grades exclusivity for one more release" — #2501 has landed,
+            and `needGlyphs.bathroomCoverage` now maps `'shared'` and
+            `'private'` alike onto the met arm. This mark and the family glyph
+            read one axis. Only the COLUMN name (`needs_private_bathroom`)
+            still lags, which is a named follow-up. */}
         {unit.bathroom !== undefined && unit.bathroom !== 'none' && unit.bathroom !== 'unknown' && (
           <Bath
             data-testid="amenity-bathroom"
@@ -953,14 +959,34 @@ export function LodgingUnitCard({
             staff place against it; what it gets no glyph for is family DEMAND.
             The `Snowflake` below is the UNIT's own amenity mark and still
             draws on the title row — it is the paired demand glyph, the one
-            that would say a family asked for this, that nothing mints. */}
-        {unit.has_ac === true && (
-          <Snowflake
-            data-testid="amenity-ac"
-            aria-label="Air conditioning"
-            className="text-muted-foreground h-3.5 w-3.5 flex-shrink-0"
-          />
-        )}
+            that would say a family asked for this, that nothing mints.
+
+            ⚠️ `ac_coverage`, NEVER THE RAW `has_ac` — kindred#2502, and the
+            LAST of this row's three marks to move. The plug above it made the
+            same move at kindred#2072 for the same reason, and the server's own
+            count is the measurement: `_resolve_ac_coverage` records that SEVEN
+            of the 15 production containers carry `has_ac = 0` with AC-bearing
+            rooms, so the raw read drew no snowflake on seven buildings that
+            are air-conditioned throughout.
+
+            It was also a CONTRADICTION rather than only an omission. #2502
+            named three surfaces reading this field raw; `MapUnitPopover` and
+            `AssignFamilyModal` both moved, so the modal a staff member opens
+            FROM this card listed "air conditioning" while the card behind it
+            drew nothing — the same disagreement kindred#2501 closed on the
+            bathroom axis, one dimension over.
+
+            PRESENCE, so `some` draws it, exactly as the plug does: the mark
+            says the building offers AC somewhere. There is no need glyph to
+            disagree with that here, because AC has no demand side at all. */}
+        {(unit.ac_coverage ?? 'unknown') !== 'none' &&
+          (unit.ac_coverage ?? 'unknown') !== 'unknown' && (
+            <Snowflake
+              data-testid="amenity-ac"
+              aria-label="Air conditioning"
+              className="text-muted-foreground h-3.5 w-3.5 flex-shrink-0"
+            />
+          )}
         {/* The tooltip hangs on THIS figure, never on the `<h3>` above it
             (kindred#2177). It is also the smallest trigger on the board, which
             is why `ui/Tooltip` grows a transparent 24px hit target around

--- a/frontend/src/components/weekend/MapUnitPopover.test.tsx
+++ b/frontend/src/components/weekend/MapUnitPopover.test.tsx
@@ -41,6 +41,24 @@ function row(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
     has_ac: false,
     has_fridge: false,
     is_accessible: false,
+    // ⚠️ THE RESOLVED COVERAGES DEFAULT TO `none`, AND THAT IS THE FIXTURE
+    // CHANGE THAT MATTERS. This helper used to set none of them, so every
+    // amenity assertion in this file was answered by the RAW columns beside
+    // them — which encoded "the map lists what the registry ROW says", the
+    // pre-kindred#1912 rule the unit card abandoned when it moved to
+    // `power_coverage`. A container's own row is `has_power: false` while
+    // every leaf beneath it is powered, so that rule draws no plug on twelve
+    // entirely-powered buildings.
+    //
+    // `none` rather than `unknown` so a test that wants a mark has to SAY so,
+    // matching `AssignFamilyModal.test.tsx`'s and `LodgingUnitCard.test.tsx`'s
+    // own unit helpers — three suites, one default, so a fixture copied
+    // between them keeps meaning the same thing.
+    power_coverage: 'none',
+    ac_coverage: 'none',
+    fridge_coverage: 'none',
+    has_ramp: '',
+    ramp_coverage: 'none',
     is_confirmed: false,
     is_active: true,
     is_container: false,
@@ -97,6 +115,10 @@ function mapUnit(unit: LodgingUnitRow, parties: RosterPartyRow[] = []): MapUnit 
     // container tests at the foot of this file.
     roomCount: 1,
     capacity: unit.sleeps ?? null,
+    // Nothing straddles: the ordinary case, and what `buildMapModel` computes
+    // for a party wholly inside the room it is drawn on. The spanning fixtures
+    // override it — see the over-capacity block below.
+    spanWidth: 0,
     x: 0.4,
     y: 0.5,
   }
@@ -222,20 +244,37 @@ describe('MapUnitPopover — one room', () => {
     expect(screen.getByText('Unconfirmed')).toBeInTheDocument()
   })
 
-  it('lists the amenities the registry records', () => {
+  it('lists the amenities the RESOLVED coverages report', () => {
+    // The five marks, on the fixture that separates them from the raw
+    // columns: every raw flag is false and every resolved coverage is `all`,
+    // which is exactly the shape a combined building takes on the wire.
     render(
       <MapUnitPopover
         units={[
-          mapUnit(row({ bathroom: 'private', has_power: true, has_ac: true, is_accessible: true })),
+          mapUnit(
+            row({
+              bathroom: 'private',
+              has_power: false,
+              power_coverage: 'all',
+              has_ac: false,
+              ac_coverage: 'all',
+              has_fridge: false,
+              fridge_coverage: 'all',
+              is_accessible: false,
+              has_ramp: '',
+              ramp_coverage: 'all',
+            })
+          ),
         ]}
         hue={HUE}
         onOpenParty={vi.fn()}
       />
     )
-    expect(screen.getByLabelText('Private bathroom')).toBeInTheDocument()
+    expect(screen.getByLabelText('Bathroom in unit')).toBeInTheDocument()
     expect(screen.getByLabelText('Power')).toBeInTheDocument()
     expect(screen.getByLabelText('Air conditioning')).toBeInTheDocument()
-    expect(screen.getByLabelText('Accessible')).toBeInTheDocument()
+    expect(screen.getByLabelText('Fridge')).toBeInTheDocument()
+    expect(screen.getByLabelText('Step-free')).toBeInTheDocument()
   })
 
   it('reports beds needed against the capacity', () => {
@@ -362,6 +401,232 @@ describe('MapUnitPopover — one room', () => {
     const messages = warn.mock.calls.map((call) => String(call[0])).join('\n')
     warn.mockRestore()
     expect(messages).not.toMatch(/same key/i)
+  })
+})
+
+/**
+ * THE AMENITY LIST READS WHAT THE SERVER RESOLVED, NEVER THE ROW'S OWN
+ * COLUMNS.
+ *
+ * `mapModel` builds from `buildBoard`, so a COMBINED CONTAINER is a map slot —
+ * and a container's own registry row is the one row whose amenity columns are
+ * meaningless. Measured over the five containers ever drawn combined in 2026:
+ * three report no power against `power_coverage: 'all'`, three report no AC
+ * with AC-bearing rooms, one reports no fridge against `fridge_coverage:
+ * 'all'`, and all five reported no bathroom before the resolver landed.
+ *
+ * The same component already graded NEEDS off the resolved fields, through
+ * `partyAttention`, so this list disagreed with the red line printed two
+ * elements below it in the same card.
+ */
+describe('MapUnitPopover — amenities, off the resolved coverages', () => {
+  it('counts a SHARED bathroom as a bathroom in the unit', () => {
+    // kindred#2501, owner ruling 2026-08-20: the axis is PRESENCE, not
+    // exclusivity — the CampMinder question behind the family's flag asks for
+    // "a bathroom that doesn't require you to leave your cabin". `shared` is a
+    // bathroom INSIDE the cabin that two parties split; walking to a bathhouse
+    // records as `none`. The retired `Private bathroom` / `Shared bathroom`
+    // pair said which kind, which is a distinction no staff member on this
+    // surface can act on.
+    render(
+      <MapUnitPopover
+        units={[mapUnit(row({ bathroom: 'shared' }))]}
+        hue={HUE}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByLabelText('Bathroom in unit')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Shared bathroom')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Private bathroom')).not.toBeInTheDocument()
+  })
+
+  it('reads the bathroom the SERVER resolved onto a container, not the container row', () => {
+    // `_resolve_bathroom` fills a container's own `bathroom` from its leaves,
+    // and 8 of the 15 production containers moved from `none` to `private`
+    // when it landed. Nothing here re-derives it; the field is already right.
+    render(
+      <MapUnitPopover
+        units={[mapUnit(row({ is_container: true, bathroom: 'private' }))]}
+        hue={HUE}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByLabelText('Bathroom in unit')).toBeInTheDocument()
+  })
+
+  it('draws the plug for a building whose rooms are powered but whose own row is not', () => {
+    render(
+      <MapUnitPopover
+        units={[mapUnit(row({ has_power: false, power_coverage: 'all' }))]}
+        hue={HUE}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByLabelText('Power')).toBeInTheDocument()
+  })
+
+  it('draws power and AC for a building where only SOME rooms have them', () => {
+    // PRESENCE, the same reading `LodgingUnitCard`'s title row takes: the mark
+    // says the building offers it somewhere. Whether it reaches a particular
+    // family is the need glyph's question, and that one grades `some` on its
+    // own scale.
+    render(
+      <MapUnitPopover
+        units={[mapUnit(row({ power_coverage: 'some', ac_coverage: 'some' }))]}
+        hue={HUE}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByLabelText('Power')).toBeInTheDocument()
+    expect(screen.getByLabelText('Air conditioning')).toBeInTheDocument()
+  })
+
+  it('counts a shared fridge as a fridge, because the server already did', () => {
+    // Owner ruling 2026-08-15: a SHARED fridge IS a fridge, which is why
+    // `_resolve_fridge_coverage` ORs `has_shared_fridge` in. Read the resolved
+    // field and this surface inherits the ruling instead of holding a second
+    // implementation of it — the fixture's raw `has_fridge` is false.
+    render(
+      <MapUnitPopover
+        units={[
+          mapUnit(row({ has_fridge: false, has_shared_fridge: true, fridge_coverage: 'all' })),
+        ]}
+        hue={HUE}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByLabelText('Fridge')).toBeInTheDocument()
+  })
+
+  it('draws no step-free mark on a cabin staff assessed as having NO ramp', () => {
+    // ⚠️ `has_ramp` IS A THREE-VALUE SELECT, SO `'no'` IS A TRUTHY STRING.
+    // Any consumer testing it for truthiness renders "step-free" on the very
+    // cabins staff assessed as explicitly having none — the exact inversion
+    // the select exists to prevent.
+    render(
+      <MapUnitPopover
+        units={[mapUnit(row({ has_ramp: 'no', ramp_coverage: 'none' }))]}
+        hue={HUE}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.queryByLabelText('Step-free')).not.toBeInTheDocument()
+  })
+
+  it('withholds the step-free mark when only SOME rooms are step-free', () => {
+    // NOT the power/fridge reading, and the asymmetry is already ruled in
+    // `needGlyphs`' `someIs`: a fridge one room over is still a fridge a
+    // family can use, and a ramp one room over is not. A building advertising
+    // two step-free rooms out of ten invites precisely the placement that
+    // lands in one of the other eight.
+    render(
+      <MapUnitPopover
+        units={[mapUnit(row({ ramp_coverage: 'some' }))]}
+        hue={HUE}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.queryByLabelText('Step-free')).not.toBeInTheDocument()
+  })
+
+  it('withholds it for a QUALIFIED ramp too, rather than overclaiming step-free', () => {
+    // `partial` is the fifth grade `ramp_coverage` carries and the other three
+    // dimensions cannot: a ramp with a lip. The list has one binary mark per
+    // dimension and no room for degree, so "Step-free" would state more than
+    // the registry recorded.
+    render(
+      <MapUnitPopover
+        units={[mapUnit(row({ ramp_coverage: 'partial' }))]}
+        hue={HUE}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.queryByLabelText('Step-free')).not.toBeInTheDocument()
+  })
+
+  it('does not take `is_accessible` as the step-free answer', () => {
+    /*
+     * ⚠️ AN OPEN PRODUCT QUESTION, DELIBERATELY NOT SETTLED HERE. `is_accessible`
+     * and `has_ramp` are two independent registry columns and they DISAGREE:
+     * of the production rows recording `has_ramp: 'yes'`, two are
+     * `is_accessible: true` and three are false. Which one staff mean by
+     * "accessible" needs an owner, not a guess from this file.
+     *
+     * What is NOT open is whether this list may keep reading `is_accessible`.
+     * It is a raw boolean on the row, so it carries the container trap every
+     * other raw column here carried, and it has no resolver. `ramp_coverage`
+     * is resolved over the leaves and is the field the step-free NEED GLYPH
+     * already grades against on this same card — so it is the one reading this
+     * surface can defend, and the one it takes until the question is answered.
+     */
+    render(
+      <MapUnitPopover
+        units={[mapUnit(row({ is_accessible: true, has_ramp: '', ramp_coverage: 'none' }))]}
+        hue={HUE}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.queryByLabelText('Step-free')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Accessible')).not.toBeInTheDocument()
+  })
+
+  it('says nothing at all about a space nobody has assessed', () => {
+    // `unknown` is not a soft yes. The list is an inclusion list, so silence
+    // is its way of declining to assert anything.
+    render(
+      <MapUnitPopover
+        units={[
+          mapUnit(
+            row({
+              bathroom: 'unknown',
+              power_coverage: 'unknown',
+              ac_coverage: 'unknown',
+              fridge_coverage: 'unknown',
+              ramp_coverage: 'unknown',
+            })
+          ),
+        ]}
+        hue={HUE}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.queryByLabelText('Bathroom in unit')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Power')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Air conditioning')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Fridge')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Step-free')).not.toBeInTheDocument()
+  })
+})
+
+/**
+ * THE OVER-CAPACITY COLOUR IS A CLAIM, AND A SPANNING PARTY WITHHOLDS IT.
+ *
+ * Since kindred#2010 a party holding several rooms is drawn on EACH of them,
+ * so the same six people appear on two marks and there is no per-room split to
+ * divide them by — `party_size` is one number for the household. Both board
+ * surfaces already gate on it (`LodgingUnitCard`'s `overCapacity`, the Assign
+ * modal's header); this popover asserted it with no gate at all.
+ *
+ * ZERO parties span in 2026's registry, so nothing is on screen today. This is
+ * the latent half, pinned before it is reachable rather than after.
+ */
+describe('MapUnitPopover — the over-capacity mark, gated as the board gates it', () => {
+  const OVERFULL = mapUnit(row({ sleeps: 2 }), [party('Johnson')])
+
+  it('colours a room the party wholly occupies and over-fills', () => {
+    render(<MapUnitPopover units={[OVERFULL]} hue={HUE} onOpenParty={vi.fn()} />)
+    expect(screen.getByText('3 of 2')).toHaveClass('text-amber-700')
+  })
+
+  it('withholds the colour from a party drawn on more rooms than this one', () => {
+    // Three people against this room's two beds is not a verdict anyone can
+    // support when the household also holds the room next door. The FIGURE
+    // still stands — over-stating reads as "look at this", where dropping the
+    // party would read as "room for more" — and only the claim is withheld.
+    render(
+      <MapUnitPopover units={[{ ...OVERFULL, spanWidth: 2 }]} hue={HUE} onOpenParty={vi.fn()} />
+    )
+    expect(screen.getByText('3 of 2')).not.toHaveClass('text-amber-700')
   })
 })
 

--- a/frontend/src/components/weekend/MapUnitPopover.tsx
+++ b/frontend/src/components/weekend/MapUnitPopover.tsx
@@ -23,7 +23,7 @@
 import { Accessibility, Bath, Home, Plug, Refrigerator, Snowflake } from 'lucide-react'
 import { type ReactNode, useState } from 'react'
 
-import type { RosterPartyRow } from '../../types/lodging'
+import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
 import { Tooltip } from '../ui/Tooltip'
 import { namedAdults, partyIdentityLabel } from './householdIdentity'
 import { CONSENT_AMBER } from './mapColors'
@@ -101,21 +101,95 @@ function WholeBuildingBadge() {
 }
 
 /**
- * What the registry records about the room.
+ * Does the space OFFER this amenity anywhere?
+ *
+ * PRESENCE, which is the mark's whole claim — the same reading
+ * `LodgingUnitCard`'s title row takes for its plug. Whether the amenity reaches
+ * a PARTICULAR family is the need glyph's question, and `needGlyphs` grades
+ * `some` on its own per-need scale a few elements below this list.
+ *
+ * `?? 'unknown'` is the Pydantic-default gotcha rather than a guess: a field
+ * carrying a server-side default renders optional in the generated type.
+ */
+function offers(coverage: LodgingUnitRow['power_coverage']): boolean {
+  const value = coverage ?? 'unknown'
+  return value !== 'none' && value !== 'unknown'
+}
+
+/**
+ * What the registry records about the room — READ OFF THE RESOLVED FIELDS,
+ * never off the row's own amenity columns.
+ *
+ * ⚠️ THIS LIST USED TO READ SIX RAW COLUMNS AND ZERO RESOLVED ONES, WHICH IS
+ * WRONG HERE SPECIFICALLY BECAUSE `mapModel` BUILDS FROM `buildBoard`: a
+ * COMBINED CONTAINER is a map slot, and a container's own row is the one row
+ * whose amenity columns mean nothing. Measured over the five containers ever
+ * drawn combined in 2026 — three reported no power against
+ * `power_coverage: 'all'`, three no AC with AC-bearing rooms, one no fridge
+ * against `fridge_coverage: 'all'`, and all five no bathroom.
+ *
+ * The same component grades NEEDS off the resolved coverages, through
+ * `partyAttention`, so this list disagreed with the red unmet line printed two
+ * elements below it in the same card.
  *
  * Icons keep their `aria-label` — not for AT, but because it is the only handle
- * `MapUnitPopover.test.tsx` has to assert an amenity rendered (`getByLabelText`
- * at :219-222); the glyph itself carries no queryable text. Same icon grammar as
- * `LodgingUnitCard`, so an amenity reads the same on both surfaces.
+ * `MapUnitPopover.test.tsx` has to assert an amenity rendered
+ * (`getByLabelText`); the glyph itself carries no queryable text. The labels
+ * are `NEED_GLYPHS`' own words, so the mark and the glyph name one thing once.
  */
 function Amenities({ unit }: { unit: MapUnit['unit'] }): ReactNode {
   const items: Array<{ label: string; icon: typeof Bath }> = []
-  if (unit.bathroom === 'private') items.push({ label: 'Private bathroom', icon: Bath })
-  if (unit.bathroom === 'shared') items.push({ label: 'Shared bathroom', icon: Bath })
-  if (unit.has_power === true) items.push({ label: 'Power', icon: Plug })
-  if (unit.has_ac === true) items.push({ label: 'Air conditioning', icon: Snowflake })
-  if (unit.has_fridge === true) items.push({ label: 'Fridge', icon: Refrigerator })
-  if (unit.is_accessible === true) items.push({ label: 'Accessible', icon: Accessibility })
+  // ONE ITEM, ON THE IN-CABIN AXIS. The `Private bathroom` / `Shared bathroom`
+  // pair is retired (kindred#2501, owner ruling 2026-08-20): the CampMinder
+  // question behind the family's flag asks for *"a bathroom that doesn't
+  // require you to leave your cabin"*, so a shared bathroom answers it as
+  // fully as a private one and the kind is a distinction no staff member on
+  // this surface can act on. `shared` means a bathroom INSIDE the cabin that
+  // two parties split; walking to a bathhouse records as `none`.
+  //
+  // The field itself is now RESOLVED IN PLACE for a container — `_resolve_
+  // bathroom` fills it from the leaves, and 8 of the 15 production containers
+  // moved from `none` to `private` when it landed — so this reads the same
+  // property name it always did and gets a different, correct answer.
+  const bathroom = unit.bathroom ?? 'unknown'
+  if (bathroom !== 'none' && bathroom !== 'unknown')
+    items.push({ label: 'Bathroom in unit', icon: Bath })
+  if (offers(unit.power_coverage)) items.push({ label: 'Power', icon: Plug })
+  if (offers(unit.ac_coverage)) items.push({ label: 'Air conditioning', icon: Snowflake })
+  // `fridge_coverage`, which already carries the owner's 2026-08-15 ruling
+  // that a SHARED fridge IS a fridge (`_resolve_fridge_coverage` ORs
+  // `has_shared_fridge` in). Reading the raw pair here would put a second
+  // implementation of that ruling on the client.
+  if (offers(unit.fridge_coverage)) items.push({ label: 'Fridge', icon: Refrigerator })
+  /*
+   * STEP-FREE, AND IT IS THE ONE DIMENSION THAT NEEDS `all` RATHER THAN
+   * `offers`.
+   *
+   * That asymmetry is already ruled, in `needGlyphs`' `someIs`: a fridge one
+   * room over is still a fridge a family can use, and a ramp one room over is
+   * not. A building advertising two step-free rooms out of ten invites
+   * precisely the placement that lands in one of the other eight. `partial` —
+   * a ramp with a lip, the fifth grade only this dimension carries — is
+   * withheld too, because this list has one binary mark per dimension and no
+   * room for degree, so "Step-free" would state more than was recorded.
+   *
+   * ⚠️ NOT `is_accessible`, AND NOT THE RAW `has_ramp`. `has_ramp` is a
+   * three-value select where `''` means NOT ASSESSED (104 of 118 rows) and
+   * `'no'` is a TRUTHY STRING, so a boolean read renders "step-free" on the
+   * cabins staff assessed as explicitly having none.
+   *
+   * `is_accessible` is a genuine OPEN PRODUCT QUESTION and this change does not
+   * settle it: the two columns disagree — of the rows recording
+   * `has_ramp: 'yes'`, two are `is_accessible: true` and three are false — and
+   * which one staff mean by "accessible" needs an owner. What is not open is
+   * whether this list may keep reading it: it is a raw boolean with no
+   * resolver, so it carries the same container trap as every other raw column
+   * here. `ramp_coverage` is resolved over the leaves and is what the step-free
+   * NEED GLYPH on this same card already grades against, so it is the reading
+   * this surface can defend until the question is answered.
+   */
+  if ((unit.ramp_coverage ?? 'unknown') === 'all')
+    items.push({ label: 'Step-free', icon: Accessibility })
   if (items.length === 0) return null
 
   return (
@@ -178,7 +252,7 @@ interface DetailCardProps {
 }
 
 function DetailCard({ entry, hue, onOpenParty, wholeBuildingKeys }: DetailCardProps) {
-  const { unit, parties, consent, capacity } = entry
+  const { unit, parties, consent, capacity, spanWidth } = entry
   // `capacity`, NOT `unit.sleeps` (kindred#2183). They are the same number for
   // every ordinary room, and different for the one case this card could not
   // previously tell the truth about: a combined house's own `sleeps` is a
@@ -188,6 +262,23 @@ function DetailCard({ entry, hue, onOpenParty, wholeBuildingKeys }: DetailCardPr
   const capacityKnown = capacity !== null
   const badge = reservationBadge(unit)
   const bedsNeeded = parties.reduce((sum, party) => sum + partyBeds(party), 0)
+  /*
+   * THE AMBER IS A CLAIM, AND `spanWidth` IS WHAT WITHHOLDS IT — the same gate
+   * `LodgingUnitCard`'s `overCapacity` and `AssignFamilyModal`'s header take,
+   * mirrored here rather than left off. This card had no gate at all.
+   *
+   * Since kindred#2010 a party holding several rooms is drawn on EACH of them,
+   * so the same people are counted in full against each room's beds and no
+   * per-room split exists to divide them by — `party_size` is one number for
+   * the household. The FIGURE still stands, because over-stating reads as
+   * "look at this" where dropping the party would read as "room for more"; only
+   * the verdict is withheld, and a household legitimately spread across two
+   * rooms it needs is not over anything.
+   *
+   * ZERO parties span the 2026 registry after #2040, so nothing on screen moves
+   * today. This is a guard on a reachable state.
+   */
+  const overCapacity = capacityKnown && spanWidth === 0 && bedsNeeded > capacity
 
   // Only the ACTIONABLE levels. `unverified` is a live fallback for a cabin
   // nobody has confirmed yet, not the state of the whole registry — measured
@@ -244,7 +335,7 @@ function DetailCard({ entry, hue, onOpenParty, wholeBuildingKeys }: DetailCardPr
         {parties.length > 0 && capacityKnown && (
           <div className="flex justify-between gap-3">
             <dt className="text-muted-foreground">Beds</dt>
-            <dd className={bedsNeeded > capacity ? 'font-semibold text-amber-700' : ''}>
+            <dd className={overCapacity ? 'font-semibold text-amber-700' : ''}>
               {`${String(bedsNeeded)} of ${String(capacity)}`}
             </dd>
           </div>

--- a/frontend/src/components/weekend/mapModel.test.ts
+++ b/frontend/src/components/weekend/mapModel.test.ts
@@ -358,6 +358,73 @@ describe('buildMapModel — what a drawn unit stands for (kindred#2183)', () => 
   })
 })
 
+/**
+ * kindred#2010's straddle marker, threaded to the map for the same reason
+ * `roomCount` and `capacity` are: `MapUnitPopover` is handed `MapUnit[]` and
+ * never the registry, so it cannot ask `slotOccupancy` the question itself.
+ *
+ * Without it the peek asserts over-capacity where BOTH board surfaces withhold
+ * it — `LodgingUnitCard`'s `overCapacity` and the Assign modal's header each
+ * gate on `spanWidth === 0`, and this popover had no gate at all.
+ */
+describe('buildMapModel — how wide a straddling party is (kindred#2010)', () => {
+  /** A house drawn SPLIT: the container is not combined, so its rooms are the marks. */
+  const HOUSE = unit({
+    unit_id: 'h0',
+    code: 'aspen-house',
+    name: 'Aspen House',
+    is_container: true,
+    sleeps: 7,
+  })
+  const R1 = unit({
+    unit_id: 'h1',
+    code: 'aspen-1',
+    name: 'Aspen 1',
+    parent_code: 'aspen-house',
+    sleeps: 3,
+  })
+  const R2 = unit({
+    unit_id: 'h2',
+    code: 'aspen-2',
+    name: 'Aspen 2',
+    parent_code: 'aspen-house',
+    sleeps: 3,
+  })
+
+  it('reports nothing spanning for a party wholly inside the room it is drawn on', () => {
+    // `unit_name` is what `indexPayload` reads to decide a party is PLACED at
+    // all — a party with only a `unit_code` lands in the unplaced queue and
+    // would pass this assertion by never reaching a slot.
+    const model = buildMapModel([party({ unit_code: 'cedar-1', unit_name: 'Cedar 1' })], [unit()])
+    expect(model.units[0]?.parties).toHaveLength(1)
+    expect(model.units[0]?.spanWidth).toBe(0)
+  })
+
+  it('reports how many rooms a straddling party holds, on every mark it is drawn on', () => {
+    // The household holds both halves and is drawn on each, so the same six
+    // people are counted twice over three beds apiece.
+    const model = buildMapModel(
+      [
+        party({
+          party_size: 6,
+          unit_code: '',
+          unit_codes: ['aspen-1', 'aspen-2'],
+          unit_name: 'Aspen 1',
+        }),
+      ],
+      [HOUSE, R1, R2]
+    )
+    expect(model.units.map((u) => u.unit.code)).toEqual(['aspen-1', 'aspen-2'])
+    expect(model.units.map((u) => u.parties.length)).toEqual([1, 1])
+    expect(model.units.map((u) => u.spanWidth)).toEqual([2, 2])
+  })
+
+  it('reports nothing spanning on an empty room', () => {
+    const model = buildMapModel([], [HOUSE, R1, R2])
+    expect(model.units.map((u) => u.spanWidth)).toEqual([0, 0])
+  })
+})
+
 describe('countMapUnits', () => {
   it('counts what the map draws, which is not the inventory count', () => {
     const units = [

--- a/frontend/src/components/weekend/mapModel.ts
+++ b/frontend/src/components/weekend/mapModel.ts
@@ -12,7 +12,7 @@
  * queue, because they ARE placed and saying otherwise is a lie about the data.
  */
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
-import { buildBoard, type ConsentFlag } from './boardLayout'
+import { buildBoard, slotOccupancy, type ConsentFlag } from './boardLayout'
 import { effectiveSleeps } from './rosterAttention'
 import { coveredCodes } from './unitLevel'
 
@@ -58,6 +58,25 @@ export interface MapUnit {
    * rather than reimplemented.
    */
   capacity: number | null
+  /**
+   * 0 when every party on this mark is wholly inside it; otherwise how many
+   * rooms the widest straddling party holds. `slotOccupancy`'s own field,
+   * carried through rather than re-derived — that doc is the full account.
+   *
+   * Threaded for the same reason `roomCount` and `capacity` are: the popover
+   * receives `MapUnit[]` and never the registry, so it cannot walk a party's
+   * leaves to ask the question itself. Without it the peek asserts over
+   * capacity where BOTH board surfaces withhold it — `LodgingUnitCard`'s
+   * `overCapacity` and `AssignFamilyModal`'s header each gate on
+   * `spanWidth === 0`, because a party drawn on two rooms is counted in full
+   * on each of them (kindred#2010) and no per-room split exists to divide it
+   * by.
+   *
+   * Measured at ZERO spanning parties on the 2026 registry after #2040, so
+   * this changes nothing on screen today. It is the guard on a reachable state,
+   * pinned before it is reached.
+   */
+  spanWidth: number
   /** Normalized 0-1 map coordinates. Projection to pixels is the viewport's job. */
   x: number
   y: number
@@ -181,6 +200,14 @@ export function buildMapModel(parties: RosterPartyRow[], units: LodgingUnitRow[]
         // would be one with no shape difference to excuse it — that helper
         // takes the same `LodgingUnitRow[]` this file has in hand.
         capacity: effectiveSleeps(slot.unit, units),
+        // `slotOccupancy`, IMPORTED for the same reason `effectiveSleeps` is:
+        // "is this party inside this card" is one predicate, and #2040 records
+        // what a second copy costs — the overlap rule was fixed at the slot
+        // level and came straight back one level down in `FamilyCard`. Only
+        // the `spanWidth` half is taken; the map's peek counts its own beds
+        // with `partyBeds`, which is the roster's number rather than the
+        // board's `partySize`.
+        spanWidth: slotOccupancy(slot, units).spanWidth,
         // Non-null by hasCoordinates above; narrowed for the type checker.
         x: slot.unit.map_x ?? 0,
         y: slot.unit.map_y ?? 0,

--- a/frontend/src/components/weekend/needGlyphs.test.ts
+++ b/frontend/src/components/weekend/needGlyphs.test.ts
@@ -125,22 +125,35 @@ describe('needCoverage — where each need reads its supply', () => {
   })
 
   /**
-   * ⚠️ THE ONE PLACE TWO RULINGS CONTRADICT, ACCEPTED FOR ONE RELEASE.
+   * ⚠️ THIS ASSERTION IS THE REVERSE OF THE ONE IT REPLACES — kindred#2501.
    *
-   * The unit card will draw its bathroom mark as PRESENCE
-   * (`bathroom != 'none'`) once stage 3 lands, because that is the axis the
-   * CampMinder question actually asks. This grading still says a SHARED
-   * bathroom does not satisfy the need, because that is what `rosterAttention`
-   * has always said and changing it is
-   * kindred#2501 — itself gated on reading the Adult form's wording, which
-   * supplies 19 of 66 flagged households and has never been audited.
+   * It used to pin `shared → none`: a shared bathroom did NOT satisfy the
+   * need, because the column is called `needs_private_bathroom` and that is
+   * what the product had always said. The SPECIFICATION changed — this is not
+   * the implementation drifting and the test being bent to follow it. Owner
+   * ruling 2026-08-20: *"the glyph should not grade exclusivity, just 'do they
+   * have a bathroom (shared or private)'"*, and on this case exactly,
+   * *"sharing a bathroom for whatever reason still provides people a
+   * bathroom."*
    *
-   * So a room can show "has a bathroom" while the family on it shows a red
-   * bathroom glyph. Owner ruling 2026-08-19: accept it, name it, and pin it —
-   * this test is the pin. When #2501 lands, THIS is the assertion that flips.
+   * `shared` is a bathroom INSIDE the cabin that two parties split. Walking to
+   * a bathhouse is not `shared`, it is `none`. The CampMinder question behind
+   * the flag asks for *"a bathroom that doesn't require you to leave your
+   * cabin"*, so an in-cabin split bathroom answers the question that was
+   * actually asked.
+   *
+   * WHAT IT COSTS, ACCEPTED ON THE RECORD: the ~3–5 households a year who need
+   * exclusivity rather than proximity lose an automatic red mark, and are
+   * found by reading the request instead. That was the trade the owner took.
+   *
+   * This also ENDS the one-release contradiction the previous comment named:
+   * the unit card draws its bathroom mark for `private` and `shared` alike, so
+   * a room showing "has a bathroom" no longer carries a family with a red
+   * bathroom glyph. Renaming `needs_private_bathroom` is a deliberate
+   * follow-up, not this change.
    */
-  it('still grades a shared bathroom as not satisfying the need — until kindred#2501', () => {
-    expect(needCoverage('bathroom', party({ effective_bathroom: 'shared' }), unit())).toBe('none')
+  it('grades a shared bathroom as MEETING the need — presence, not exclusivity', () => {
+    expect(needCoverage('bathroom', party({ effective_bathroom: 'shared' }), unit())).toBe('all')
   })
 
   it('reports unknown where the server could not resolve the bathroom', () => {
@@ -304,8 +317,13 @@ describe('needCoverage — the PROSPECTIVE reading', () => {
     expect(needCoverage('bathroom', unplaced, unit({ bathroom: 'private' }), 'prospective')).toBe(
       'all'
     )
+    // ⚠️ `shared → all` HERE TOO, and pinning it in both readings is the
+    // point rather than duplication. kindred#2501's body was written against
+    // the placed lane alone; flipping only that one would have left the modal
+    // calling a shared bathroom unmet while the card called it met — moving
+    // the contradiction instead of closing it.
     expect(needCoverage('bathroom', unplaced, unit({ bathroom: 'shared' }), 'prospective')).toBe(
-      'none'
+      'all'
     )
   })
 

--- a/frontend/src/components/weekend/needGlyphs.ts
+++ b/frontend/src/components/weekend/needGlyphs.ts
@@ -128,8 +128,9 @@ export interface NeedGlyphSpec {
    * says "private"; the CampMinder question behind it never asks about
    * exclusivity — *"a bathroom that doesn't require you to leave your
    * cabin"* — so the label says the axis that was actually asked. See §4 of
-   * the vocabulary doc for the full correction, and `bathroomCoverage` below
-   * for why the RULE has not moved with the word yet.
+   * the vocabulary doc for the full correction. The RULE has now moved with
+   * the word (kindred#2501): `bathroomCoverage` grades presence, and only the
+   * column's name still lags, which is a named follow-up.
    */
   readonly label: string
   readonly Icon: LucideIcon
@@ -168,7 +169,7 @@ export interface NeedGlyphSpec {
 }
 
 /**
- * The bathroom need's supply, and the one that reads the PARTY.
+ * The bathroom need's supply, and the one that reads the PARTY when placed.
  *
  * `unit.bathroom` is one room's own field, and a merged slot's `unit_code` is
  * `""` BY DESIGN (kindred#1982) — so there is no single unit to read it off
@@ -177,21 +178,29 @@ export interface NeedGlyphSpec {
  * answer across every code the placement covers (`lodging_rules`,
  * kindred#2022), container inheritance included.
  *
- * ⚠️ THIS IS THE HALF OF THE RULING THAT HAS NOT LANDED, DELIBERATELY.
+ * ⚠️ THIS GRADES PRESENCE, NOT EXCLUSIVITY — kindred#2501, owner ruling
+ * 2026-08-20: *"the glyph should not grade exclusivity, just 'do they have a
+ * bathroom (shared or private)'"* and, on the shared case itself, *"sharing a
+ * bathroom for whatever reason still provides people a bathroom."*
  *
- * The unit card WILL draw its bathroom mark as PRESENCE — `bathroom != 'none'`,
- * the axis the form actually asks about — when kindred#2072's stage 3 lands;
- * today it still spells out `Private` / `Shared`. This grades a SHARED
- * bathroom as not meeting the need either way, because that is what the
- * product has always said
- * and changing it is kindred#2501 — itself gated on reading the Adult form's
- * wording, which supplies 19 of 66 flagged households and has never been
- * audited.
+ * So `'shared'` joins `'private'` in the met arm. It is worth being precise
+ * about what `'shared'` MEANS, because the word invites the wrong reading: it
+ * is a bathroom INSIDE the cabin that two parties split. Walking to a
+ * bathhouse is not `'shared'` — it records as `'none'`, and still reads as
+ * unmet. The CampMinder question behind the flag asks for *"a bathroom that
+ * doesn't require you to leave your cabin"*, so the axis was never
+ * exclusivity, and the column's name (`needs_private_bathroom`) is the thing
+ * that is wrong here. Renaming it is a deliberate follow-up, not this change.
  *
- * So for one release a room can show "has a bathroom" while the family on it
- * shows a red bathroom glyph. Owner ruling 2026-08-19: accept it and name it.
- * When #2501 lands this becomes `'shared'` joining the `'private'` arm, and
- * `needGlyphs.test.ts` carries the assertion that flips.
+ * WHAT IT COSTS, ACCEPTED ON THE RECORD: the ~3–5 households a year who need a
+ * bathroom nobody else uses lose an automatic red mark and are found by
+ * reading the request instead.
+ *
+ * This ENDS a one-release contradiction rather than creating one. The unit
+ * card draws its own bathroom mark for `private` and `shared` alike — its
+ * predicate is presence, neither `none` nor `unknown` — so until now a room
+ * could show "has a bathroom" while the family placed on it showed a red
+ * bathroom glyph, off the same field. One axis now, on both marks.
  */
 function bathroomCoverage(
   party: RosterPartyRow,
@@ -199,10 +208,16 @@ function bathroomCoverage(
   reading: NeedReading
 ): Coverage {
   // The PROSPECTIVE half: the candidate cabin's own field, which is also what
-  // the unit card's amenity mark prints — so a row in the Assign modal can
-  // never contradict the card it was opened from.
+  // the unit card's amenity mark prints.
+  //
+  // ⚠️ BOTH READINGS TAKE THE SAME PREDICATE BELOW, AND THAT IS LOAD-BEARING.
+  // This comment used to claim an Assign-modal row "can never contradict the
+  // card it was opened from" — it could and it did, because the card graded
+  // presence and this graded exclusivity. #2501's body was written against the
+  // placed lane alone for the same reason; flipping only that one would have
+  // moved the contradiction into the modal rather than closing it.
   const value = reading === 'prospective' ? (unit.bathroom ?? 'unknown') : party.effective_bathroom
-  if (value === 'private') return 'all'
+  if (value === 'private' || value === 'shared') return 'all'
   if (value === undefined || value === 'unknown') return 'unknown'
   return 'none'
 }

--- a/frontend/src/components/weekend/needsFit.ts
+++ b/frontend/src/components/weekend/needsFit.ts
@@ -63,10 +63,15 @@ export function worseOf(a: NeedsFit, b: NeedsFit): NeedsFit {
  *
  * `bathroom` is out, and it is the only one that had to be argued.
  *
- * Only 6 of 118 units carry a private bathroom, so a hatch that graded it
- * would fire on 112 cards the moment any of the 45 bathroom-asking parties was
- * picked up. kindred#2501 does not rescue it either: the loosened rule counts
- * 28 of 118, which still hatches 90. "A mark that is always on is chrome staff
+ * Only 36 of 118 units answer the bathroom need, so a hatch that graded it
+ * would fire on 82 cards the moment any of the 41 bathroom-asking households
+ * on 2026's family weekends was picked up — at most 12 of them sit on any one
+ * weekend, but every card is on screen for each. Both rescues are already IN
+ * that figure and neither is enough: kindred#2501 moved the axis from
+ * exclusivity to presence (6 of 118 → 28) and kindred#2502's
+ * `_resolve_bathroom` gave 8 of the 15 containers the bathroom their rooms
+ * record (28 → 36), taking the hatch from 112 cards to 82. "A mark that is
+ * always on is chrome staff
  * learn to read past" (`unitBadges.ts`, on the struck shared-space ring) — a
  * board hatched almost everywhere says nothing at all, which is the same
  * reasoning `resolveNeedsFit` already applies at rest.

--- a/frontend/src/components/weekend/needsFit.ts
+++ b/frontend/src/components/weekend/needsFit.ts
@@ -70,11 +70,12 @@ export function worseOf(a: NeedsFit, b: NeedsFit): NeedsFit {
  * that figure and neither is enough: kindred#2501 moved the axis from
  * exclusivity to presence (6 of 118 → 28) and kindred#2502's
  * `_resolve_bathroom` gave 8 of the 15 containers the bathroom their rooms
- * record (28 → 36), taking the hatch from 112 cards to 82. "A mark that is
- * always on is chrome staff
- * learn to read past" (`unitBadges.ts`, on the struck shared-space ring) — a
- * board hatched almost everywhere says nothing at all, which is the same
- * reasoning `resolveNeedsFit` already applies at rest.
+ * record (28 → 36), taking the hatch from 112 cards to 82.
+ *
+ * "A mark that is always on is chrome staff learn to read past"
+ * (`unitBadges.ts`, on the struck shared-space ring) — a board hatched almost
+ * everywhere says nothing at all, which is the same reasoning
+ * `resolveNeedsFit` already applies at rest.
  *
  * The bathroom need is NOT unreported. It draws a per-family glyph on the card
  * itself (kindred#2072), where it is one household's fact rather than a

--- a/frontend/src/components/weekend/placementCandidates.test.ts
+++ b/frontend/src/components/weekend/placementCandidates.test.ts
@@ -71,14 +71,42 @@ describe('candidateFit', () => {
     expect(result.notes).toEqual([])
   })
 
-  it('marks a private-bathroom need against a shared bathroom', () => {
-    // The NOTE is struck (kindred#2072): the row draws a red bathroom glyph,
-    // and a sentence beside it repeating the fact is the "one fact twice" N2
-    // removed from the family card. The verdict it feeds is unchanged, and
-    // the verdict is what orders the list.
+  it('credits a SHARED bathroom — the row grades presence, not exclusivity', () => {
+    /*
+     * ⚠️ REVERSED 2026-08-20 (kindred#2501). This test used to assert `unmet`
+     * on exactly this fixture, and it was the picker's exclusivity pin. The
+     * SPECIFICATION changed, not the code: owner ruling — *"the glyph should
+     * not grade exclusivity, just 'do they have a bathroom (shared or
+     * private)'"*, and on this case itself *"sharing a bathroom for whatever
+     * reason still provides people a bathroom."*
+     *
+     * `'shared'` means a bathroom INSIDE the cabin that two parties split;
+     * walking to a bathhouse is not `'shared'`, it records as `'none'` and is
+     * pinned unmet by the test below. The picker had no separate rule to
+     * change — it grades through `needGlyphs.bathroomCoverage` since
+     * kindred#2072, so this row moved when that predicate did, which is the
+     * whole point of there being one grading.
+     */
     const result = candidateFit(
       party({ flags: { needs_private_bathroom: true } }),
       unit({ bathroom: 'shared' }),
+      []
+    )
+    expect(result.fit).toBe('fits')
+    expect(result.notes).toEqual([])
+  })
+
+  it('marks a bathroom need against a cabin with NO bathroom', () => {
+    // The negative arm the exclusivity pin above used to carry. A walk to a
+    // bathhouse records as `'none'`, and that is still an unmet need.
+    //
+    // The NOTE is struck (kindred#2072): the row draws a red bathroom glyph,
+    // and a sentence beside it repeating the fact is the "one fact twice" N2
+    // removed from the family card. The verdict it feeds is what orders the
+    // list, and that is what this pins.
+    const result = candidateFit(
+      party({ flags: { needs_private_bathroom: true } }),
+      unit({ bathroom: 'none' }),
       []
     )
     expect(result.fit).toBe('unmet')
@@ -207,9 +235,14 @@ describe('candidateFit', () => {
     // `unmet` (bathroom) beats `partial` (some rooms have power). The notes
     // that used to ride along are struck; what survives is the ordering rule,
     // which is what this test was really protecting.
+    //
+    // The unmet VEHICLE moved from `bathroom: 'shared'` to `'none'`
+    // (kindred#2501 made a shared bathroom meet the need). The intent —
+    // worst-of across dimensions — is untouched; it just needs a dimension
+    // that actually fails.
     const result = candidateFit(
       party({ flags: { needs_private_bathroom: true, needs_power: true } }),
-      unit({ bathroom: 'shared', power_coverage: 'some' }),
+      unit({ bathroom: 'none', power_coverage: 'some' }),
       []
     )
     expect(result.fit).toBe('unmet')
@@ -327,7 +360,9 @@ describe('placementCandidates', () => {
     ]
     const rows = placementCandidates(
       parties,
-      unit({ bathroom: 'shared', power_coverage: 'none' }),
+      // `bathroom: 'none'` — a cabin with no bathroom at all. Was `'shared'`,
+      // which stopped being an unmet vehicle at kindred#2501.
+      unit({ bathroom: 'none', power_coverage: 'none' }),
       []
     )
     expect(rows).toHaveLength(3)
@@ -344,7 +379,9 @@ describe('placementCandidates', () => {
     })
     const rows = placementCandidates(
       [unmet, partial, fitting],
-      unit({ bathroom: 'shared', power_coverage: 'some' }),
+      // `bathroom: 'none'` is what makes the third party unmet; `'shared'` no
+      // longer does (kindred#2501). The ordering rule under test is unchanged.
+      unit({ bathroom: 'none', power_coverage: 'some' }),
       []
     )
     expect(rows.map((row) => row.fit)).toEqual(['fits', 'partial', 'unmet'])
@@ -406,9 +443,20 @@ describe('candidateFit — one grading, and the notes the glyphs now carry (kind
   it('reads a candidate bathroom off the CABIN, never off a placement it does not have', () => {
     // Every party in this list is unplaced, so `effective_bathroom` is the
     // wrong question — it would annotate identically on every cabin.
-    const unplaced = party({ flags: { needs_private_bathroom: true }, effective_bathroom: 'none' })
-    expect(candidateFit(unplaced, unit({ bathroom: 'private' }), []).fit).toBe('fits')
-    expect(candidateFit(unplaced, unit({ bathroom: 'shared' }), []).fit).toBe('unmet')
+    //
+    // BOTH arms now disagree with the party's own field, which is what makes
+    // them discriminating: the old second arm paired `effective_bathroom:
+    // 'none'` with `bathroom: 'shared'` and, once kindred#2501 made `'shared'`
+    // meet the need, the two readings answered differently for the first time
+    // — so it started failing. Fixed by giving it a party whose PLACED reading
+    // would say `fits`, against a cabin that says `none`.
+    const wouldFail = party({ flags: { needs_private_bathroom: true }, effective_bathroom: 'none' })
+    const wouldPass = party({
+      flags: { needs_private_bathroom: true },
+      effective_bathroom: 'private',
+    })
+    expect(candidateFit(wouldFail, unit({ bathroom: 'private' }), []).fit).toBe('fits')
+    expect(candidateFit(wouldPass, unit({ bathroom: 'none' }), []).fit).toBe('unmet')
   })
 
   it('writes NO note for a need — the glyph beside it says the same thing', () => {
@@ -418,7 +466,11 @@ describe('candidateFit — one grading, and the notes the glyphs now carry (kind
     // the same glyphs, so the same rule applies to it.
     const result = candidateFit(
       party({ flags: { needs_private_bathroom: true, needs_power: true } }),
-      unit({ bathroom: 'shared', power_coverage: 'none' }),
+      // Both dimensions genuinely fail. This was passing on the power arm
+      // alone after kindred#2501 made `bathroom: 'shared'` MEET the need,
+      // which left the fixture's bathroom half saying nothing while the
+      // comment above claimed it did.
+      unit({ bathroom: 'none', power_coverage: 'none' }),
       []
     )
     expect(result.fit).toBe('unmet')

--- a/frontend/src/components/weekend/placementCandidates.test.ts
+++ b/frontend/src/components/weekend/placementCandidates.test.ts
@@ -2,9 +2,9 @@
  * The picker's list: every unplaced party, annotated and ordered, never cut.
  *
  * The rule these tests pin is an owner ruling (2026-08-07, restated
- * 2026-08-09) and it is the OPPOSITE of the instinct: 6 of 118 units carry a
- * private bathroom against 63 parties asking for one, so a hide-filter would
- * empty the list. `placementCandidates` must therefore return exactly as many
+ * 2026-08-09) and it is the OPPOSITE of the instinct: 36 of 118 units answer
+ * the bathroom need against 66 of 479 registrations asking for one, so a
+ * hide-filter would empty the list. `placementCandidates` must therefore return exactly as many
  * rows as it was given, every time.
  *
  * Fictional data throughout.

--- a/frontend/src/components/weekend/placementCandidates.test.ts
+++ b/frontend/src/components/weekend/placementCandidates.test.ts
@@ -4,8 +4,8 @@
  * The rule these tests pin is an owner ruling (2026-08-07, restated
  * 2026-08-09) and it is the OPPOSITE of the instinct: 36 of 118 units answer
  * the bathroom need against 66 of 479 registrations asking for one, so a
- * hide-filter would empty the list. `placementCandidates` must therefore return exactly as many
- * rows as it was given, every time.
+ * hide-filter would empty the list. `placementCandidates` must therefore
+ * return exactly as many rows as it was given, every time.
  *
  * Fictional data throughout.
  */

--- a/frontend/src/components/weekend/placementCandidates.ts
+++ b/frontend/src/components/weekend/placementCandidates.ts
@@ -6,11 +6,20 @@
  *
  * Owner ruling 2026-08-07, restated 2026-08-09, and it is the opposite of what
  * a "filtered picker" instinct suggests. The reason is arithmetic rather than
- * taste: of 118 production 2026 units, **6** carry a private bathroom and
- * **49 have no power**, while of 459 2026 registrations **63** ask for a
- * private bathroom and **47** ask for power. A list filtered to "what fits"
- * would be empty most of the time, which would make this new path WEAKER than
- * the drag it exists to shorten — staff would go back to dragging.
+ * taste: of 118 production 2026 units, **36** answer the bathroom need and
+ * **36 have no power at all**, while of 479 2026 registrations **66** ask for
+ * a bathroom in the unit and **48** ask for power. A list filtered to "what
+ * fits" would be empty most of the time, which would make this new path WEAKER
+ * than the drag it exists to shorten — staff would go back to dragging.
+ *
+ * ⚠️ THE SUPPLY FIGURE MOVED TWICE ON 2026-08-20 AND IS EASY TO QUOTE STALE.
+ * It read **6** while the need was graded on exclusivity; kindred#2501 moved
+ * the axis to presence (6 → 28) and kindred#2502's `_resolve_bathroom` then
+ * gave 8 of the 15 containers the bathroom their rooms record (28 → 36). The
+ * ruling survives the improvement — 36 of 118 still empties a filtered list —
+ * but the old number understates the supply by six times. The power figure is
+ * `power_coverage: 'none'`, which is what `needGlyphs` grades; 49 rows carry a
+ * raw `has_power = 0`, and that is the container trap, not the supply.
  *
  * So `placementCandidates` returns exactly as many rows as it is given, always.
  * The fit verdict is an ANNOTATION and a SORT KEY, never a gate. The refusals
@@ -43,7 +52,8 @@
  * drag-time hatch. Since kindred#2072 both read ONE grading, `needGlyphs.ts`,
  * so a (need, party, cabin) triple can no longer get two answers. What still
  * differs is SCOPE, and each scope is written down where it lives: the hatch
- * grades three needs (bathroom would hatch 112 of 118 cards on any pick-up),
+ * grades three needs (bathroom would hatch 82 of 118 cards on any pick-up —
+ * 112 before #2501 and #2502 moved the axis and resolved the containers),
  * this grades all four plus capacity.
  *
  * ⚠️ AND ONE READING, which is this module's own contribution to that

--- a/frontend/src/components/weekend/rosterAttention.test.ts
+++ b/frontend/src/components/weekend/rosterAttention.test.ts
@@ -23,6 +23,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+import { buildBoard } from './boardLayout'
 import { partyHeadcount } from './householdIdentity'
 import {
   attentionSections,
@@ -110,12 +111,18 @@ describe('partyAttention — ranking', () => {
 
 describe('partyAttention — does the cabin provide what was asked for', () => {
   it('reports an unmet need when a CONFIRMED cabin lacks it', () => {
+    // ⚠️ THE FIXTURE MOVED WITH kindred#2501, not just the string. This case
+    // used to demonstrate "lacks it" with `shared`, which now MEETS the need
+    // — a shared bathroom is one two parties split INSIDE the cabin. The only
+    // value that still means "no bathroom in this unit" is `none`, which is
+    // also what a walk to a bathhouse records as, so that is what a test about
+    // lacking a bathroom must use.
     const a = partyAttention(
-      party({ flags: { needs_private_bathroom: true }, effective_bathroom: 'shared' }),
-      unit({ is_confirmed: true, bathroom: 'shared' })
+      party({ flags: { needs_private_bathroom: true }, effective_bathroom: 'none' }),
+      unit({ is_confirmed: true, bathroom: 'none' })
     )
     expect(a.level).toBe('unmet')
-    expect(a.reason).toBe('No private bathroom')
+    expect(a.reason).toBe('No bathroom in unit')
   })
 
   it('settles when a confirmed cabin provides everything asked for', () => {
@@ -138,7 +145,7 @@ describe('partyAttention — does the cabin provide what was asked for', () => {
       unit({ is_confirmed: true, bathroom: 'none', has_power: false })
     )
     expect(a.level).toBe('unmet')
-    expect(a.reason).toBe('No private bathroom · No power')
+    expect(a.reason).toBe('No bathroom in unit · No power')
   })
 
   /*
@@ -215,16 +222,34 @@ describe('partyAttention — does the cabin provide what was asked for', () => {
     expect(partyAttention(p, unit({ is_confirmed: true })).level).toBe('unmet')
   })
 
-  it('still flags a bathroom the server resolved as SHARED — until kindred#2501', () => {
-    // The rule itself has not moved: exclusivity is still what is graded, and
-    // loosening it to `!== 'none'` is kindred#2501, gated on reading the Adult
-    // form's wording. Only the unresolvable case changed.
+  /*
+   * ⚠️ THIS TEST NOW PINS THE OPPOSITE VERDICT — kindred#2501, and the
+   * SPECIFICATION changed rather than the implementation drifting.
+   *
+   * It used to assert that a bathroom the server resolved as SHARED left the
+   * household in the unmet band, because the flag is called
+   * `needs_private_bathroom` and exclusivity was what the roster graded. Owner
+   * ruling 2026-08-20: *"the glyph should not grade exclusivity, just 'do they
+   * have a bathroom (shared or private)'"* — and, on this case exactly,
+   * *"sharing a bathroom for whatever reason still provides people a
+   * bathroom."*
+   *
+   * `shared` is a bathroom INSIDE the cabin that two parties split; walking to
+   * a bathhouse records as `none`, not as `shared`. The CampMinder question
+   * behind the flag asks for *"a bathroom that doesn't require you to leave
+   * your cabin"*, which an in-cabin split bathroom answers.
+   *
+   * WHAT IT COSTS, ACCEPTED ON THE RECORD: the ~3–5 households a year who need
+   * exclusivity rather than proximity lose an automatic red mark and are found
+   * by reading the request instead. The underlying field keeps its name; the
+   * rename is a deliberate follow-up.
+   */
+  it('settles a bathroom the server resolved as SHARED — presence, not exclusivity', () => {
     const a = partyAttention(
       party({ flags: { needs_private_bathroom: true }, effective_bathroom: 'shared' }),
       unit({ is_confirmed: true })
     )
-    expect(a.level).toBe('unmet')
-    expect(a.reason).toBe('No private bathroom')
+    expect(a.level).toBe('settled')
   })
 
   it('flags a CONFIRMED cabin whose power nobody has resolved', () => {
@@ -334,9 +359,25 @@ describe('partyAttention — does the cabin provide what was asked for', () => {
     expect(a.level).toBe('settled')
   })
 
-  it('does not credit a strict subset of a bathroom_group', () => {
-    // Holding only one of the two rooms in the group never clears the
-    // exclusivity bar server-side, so `effective_bathroom` stays 'shared'.
+  it('credits a strict subset of a bathroom_group — the bathroom is still in the cabin', () => {
+    /*
+     * ⚠️ REVERSED BY kindred#2501, and this one is the clearest illustration
+     * of what the ruling actually changed.
+     *
+     * Holding only one of the two rooms in a bathroom group never clears the
+     * EXCLUSIVITY bar server-side, so `effective_bathroom` stays 'shared' —
+     * and this test used to assert that the roster therefore flagged the
+     * household. The server's resolution has not changed and neither has this
+     * fixture; what changed is what the roster ASKS of it. Presence, not
+     * exclusivity: the other room's family shares that bathroom, but it is
+     * still a bathroom this family reaches without leaving the cabin, which is
+     * what the CampMinder question asked about.
+     *
+     * The exclusivity case has not disappeared, it has stopped being
+     * automatic: the ~3–5 households a year who need a bathroom nobody else
+     * uses are found by reading the request. The owner accepted that trade on
+     * 2026-08-20.
+     */
     const a = partyAttention(
       party({
         flags: { needs_private_bathroom: true },
@@ -345,8 +386,7 @@ describe('partyAttention — does the cabin provide what was asked for', () => {
       }),
       unit({ bathroom: 'shared', is_confirmed: true })
     )
-    expect(a.level).toBe('unmet')
-    expect(a.reason).toBe('No private bathroom')
+    expect(a.level).toBe('settled')
   })
 
   it('never infers settled from a missing bathroom_group, even unconfirmed', () => {
@@ -466,6 +506,250 @@ describe('resolvePartyUnit', () => {
 
   it('returns undefined for an unplaced party (neither field set)', () => {
     expect(resolvePartyUnit(party({ unit_code: '', unit_codes: [] }), new Map())).toBeUndefined()
+  })
+
+  /*
+   * ⚠️ WHICH CARD GRADES THE PARTY — and until now the two grading paths
+   * answered differently for the same family.
+   *
+   * `LodgingUnitCard` grades its occupants against the card it DREW. This
+   * function returned `members[0]`: the first id in the `units` relation, i.e.
+   * whatever order the rows were stored in. Seven 2026 placements resolved to
+   * a different unit on the two paths. No verdict differed on that data only
+   * because every container and every leaf resolved `power_coverage: 'all'` —
+   * but two containers have leaves that disagree on `has_fridge`, so the
+   * container resolves `fridge_coverage: 'some'` while one leaf says `all` and
+   * the other says `none`. Which answer a family got depended on which room
+   * happened to be stored first. The tests below pin the rule instead: the
+   * card the board draws, and where a placement spans several cards, the WORST
+   * grade rather than an arbitrary member's.
+   */
+
+  it('resolves a merged placement to the CARD the board draws, not a member room', () => {
+    const combined = unit({
+      unit_id: 'c1',
+      code: 'block',
+      name: 'Block',
+      is_container: true,
+      is_combined: true,
+      // The server's roll-up over the two rooms below: they disagree, so the
+      // container reports `some`. A member room reports `all` or `none` and
+      // neither is the whole let's answer.
+      fridge_coverage: 'some',
+      power_coverage: 'all',
+    })
+    const roomOne = unit({
+      unit_id: 'c2',
+      code: 'block-1',
+      name: 'Block 1',
+      parent_code: 'block',
+      fridge_coverage: 'all',
+      power_coverage: 'all',
+    })
+    const roomTwo = unit({
+      unit_id: 'c3',
+      code: 'block-2',
+      name: 'Block 2',
+      parent_code: 'block',
+      fridge_coverage: 'none',
+      power_coverage: 'all',
+    })
+    const units = [combined, roomOne, roomTwo]
+    const resolved = resolvePartyUnit(
+      party({ unit_code: '', unit_codes: ['block-1', 'block-2'], is_merged_slot: true }),
+      new Map(units.map((row) => [row.code, row]))
+    )
+    expect(resolved).toBe(combined)
+    expect(resolved?.fridge_coverage).toBe('some')
+  })
+
+  it('agrees with the board about which card a merged placement is graded on', () => {
+    // The parity assertion, against the board's OWN model rather than a
+    // restatement of the rule: `buildBoard` decides which card a placement
+    // lands on, and this function must land on the same one. Two
+    // implementations of "which card represents this placement" is exactly
+    // how the two paths drifted apart in the first place.
+    const combined = unit({
+      unit_id: 'c1',
+      code: 'block',
+      name: 'Block',
+      is_container: true,
+      is_combined: true,
+      fridge_coverage: 'some',
+    })
+    const roomOne = unit({ unit_id: 'c2', code: 'block-1', name: 'Block 1', parent_code: 'block' })
+    const roomTwo = unit({ unit_id: 'c3', code: 'block-2', name: 'Block 2', parent_code: 'block' })
+    const units = [combined, roomOne, roomTwo]
+    const merged = party({
+      unit_code: '',
+      unit_codes: ['block-1', 'block-2'],
+      unit_name: 'Block 1 + Block 2',
+      is_merged_slot: true,
+    })
+
+    const slots = buildBoard([merged], units).areas.flatMap((area) =>
+      area.slots.filter((slot) => slot.parties.length > 0)
+    )
+    expect(slots).toHaveLength(1)
+    expect(resolvePartyUnit(merged, new Map(units.map((row) => [row.code, row])))).toBe(
+      slots[0]?.unit
+    )
+  })
+
+  it('rolls a room named on its own up to the combined card representing it', () => {
+    // Not merge-only. A placement can name ONE room while an ancestor is
+    // combined — the board draws the house, so the house is what grades the
+    // family, and returning the room grades them against a card nobody is
+    // looking at.
+    const combined = unit({
+      unit_id: 'c1',
+      code: 'block',
+      name: 'Block',
+      is_container: true,
+      is_combined: true,
+      power_coverage: 'some',
+    })
+    const roomOne = unit({
+      unit_id: 'c2',
+      code: 'block-1',
+      name: 'Block 1',
+      parent_code: 'block',
+      power_coverage: 'all',
+    })
+    const units = [combined, roomOne]
+    const resolved = resolvePartyUnit(
+      party({ unit_code: 'block-1' }),
+      new Map(units.map((row) => [row.code, row]))
+    )
+    expect(resolved).toBe(combined)
+  })
+
+  it('takes the WORST grade when a placement spans several cards', () => {
+    // Two freestanding cabins, no container above them, so the board draws
+    // two cards and there is no server-side roll-up to read. A family whose
+    // need fails in one of its rooms has a problem; surfacing the better room
+    // hides it.
+    const powered = unit({ unit_id: 'c1', code: 'cabin-1', name: 'Cabin 1', power_coverage: 'all' })
+    const dark = unit({ unit_id: 'c2', code: 'cabin-2', name: 'Cabin 2', power_coverage: 'none' })
+    const units = [powered, dark]
+    const spanning = party({
+      flags: { needs_power: true },
+      unit_code: '',
+      unit_codes: ['cabin-1', 'cabin-2'],
+      unit_name: 'Cabin 1 + Cabin 2',
+      is_merged_slot: true,
+    })
+    const resolved = resolvePartyUnit(spanning, new Map(units.map((row) => [row.code, row])))
+    expect(resolved?.power_coverage).toBe('none')
+    expect(partyAttention(spanning, resolved)).toEqual({ level: 'unmet', reason: 'No power' })
+  })
+
+  it('does not change its answer with the storage order of the units relation', () => {
+    // The coin-flip this replaces: `members[0]` read the order the `units`
+    // relation happened to be stored in, so swapping two ids flipped the
+    // verdict. Reversing the codes must be invisible.
+    const powered = unit({ unit_id: 'c1', code: 'cabin-1', name: 'Cabin 1', power_coverage: 'all' })
+    const dark = unit({ unit_id: 'c2', code: 'cabin-2', name: 'Cabin 2', power_coverage: 'none' })
+    const unitsByCode = new Map([powered, dark].map((row) => [row.code, row]))
+    const forwards = resolvePartyUnit(
+      party({ unit_code: '', unit_codes: ['cabin-1', 'cabin-2'], is_merged_slot: true }),
+      unitsByCode
+    )
+    const backwards = resolvePartyUnit(
+      party({ unit_code: '', unit_codes: ['cabin-2', 'cabin-1'], is_merged_slot: true }),
+      unitsByCode
+    )
+    expect(forwards?.power_coverage).toBe(backwards?.power_coverage)
+    expect(forwards?.power_coverage).toBe('none')
+  })
+
+  it('folds every resolved amenity, not only the two the roster grades', () => {
+    // The row is handed to `FamilyCard` and `FamilyDetailsPanel`, which draw
+    // all four need glyphs off it. Folding only `power_coverage` would leave
+    // the fridge and step-free glyphs reading the first card again.
+    const better = unit({
+      unit_id: 'c1',
+      code: 'cabin-1',
+      name: 'Cabin 1',
+      bathroom: 'private',
+      power_coverage: 'all',
+      fridge_coverage: 'all',
+      ramp_coverage: 'all',
+      ac_coverage: 'all',
+    })
+    const worse = unit({
+      unit_id: 'c2',
+      code: 'cabin-2',
+      name: 'Cabin 2',
+      bathroom: 'none',
+      power_coverage: 'some',
+      fridge_coverage: 'unknown',
+      ramp_coverage: 'partial',
+      ac_coverage: 'none',
+    })
+    const resolved = resolvePartyUnit(
+      party({ unit_code: '', unit_codes: ['cabin-1', 'cabin-2'], is_merged_slot: true }),
+      new Map([better, worse].map((row) => [row.code, row]))
+    )
+    expect(resolved?.bathroom).toBe('none')
+    expect(resolved?.power_coverage).toBe('some')
+    // `unknown` outranks `some`: nobody has measured the second cabin, and an
+    // unmeasured room a family sleeps in is the louder mark on the glyph.
+    expect(resolved?.fridge_coverage).toBe('unknown')
+    expect(resolved?.ramp_coverage).toBe('partial')
+    expect(resolved?.ac_coverage).toBe('none')
+  })
+
+  it('ranks the grades nothing < unmeasured < some rooms < qualified < all of it', () => {
+    // The ladder, pinned rung by rung, because the two non-obvious ones are
+    // exactly what a later reader would "simplify" away: `unknown` is WORSE
+    // than `some` AND worse than `partial`, since an unmeasured room grades
+    // `unmet` on the glyph while both of the others can grade `partial`.
+    // Without these three assertions the ordering can be permuted freely and
+    // every other test in this file still passes.
+    const fold = (
+      left: Partial<LodgingUnitRow>,
+      right: Partial<LodgingUnitRow>
+    ): LodgingUnitRow | undefined =>
+      resolvePartyUnit(
+        party({ unit_code: '', unit_codes: ['cabin-1', 'cabin-2'], is_merged_slot: true }),
+        new Map([
+          ['cabin-1', unit({ unit_id: 'c1', code: 'cabin-1', name: 'Cabin 1', ...left })],
+          ['cabin-2', unit({ unit_id: 'c2', code: 'cabin-2', name: 'Cabin 2', ...right })],
+        ])
+      )
+
+    expect(fold({ power_coverage: 'none' }, { power_coverage: 'unknown' })?.power_coverage).toBe(
+      'none'
+    )
+    expect(fold({ power_coverage: 'unknown' }, { power_coverage: 'some' })?.power_coverage).toBe(
+      'unknown'
+    )
+    expect(fold({ power_coverage: 'some' }, { power_coverage: 'all' })?.power_coverage).toBe('some')
+    expect(fold({ ramp_coverage: 'unknown' }, { ramp_coverage: 'partial' })?.ramp_coverage).toBe(
+      'unknown'
+    )
+    expect(fold({ ramp_coverage: 'partial' }, { ramp_coverage: 'all' })?.ramp_coverage).toBe(
+      'partial'
+    )
+    expect(fold({ bathroom: 'shared' }, { bathroom: 'private' })?.bathroom).toBe('shared')
+  })
+
+  it('still grades against a named container the board draws no card for', () => {
+    // A childless container: `drawnUnits` gives it no card and the board
+    // routes the party to `offBoard`, which then calls this function to grade
+    // its glyphs. The registry row is real evidence even when no card is
+    // drawn, so it stands in for itself rather than reporting no evidence at
+    // all — undefined would make every glyph read as MET.
+    const empty = unit({
+      unit_id: 'c1',
+      code: 'block',
+      name: 'Block',
+      is_container: true,
+      power_coverage: 'none',
+    })
+    const resolved = resolvePartyUnit(party({ unit_code: 'block' }), new Map([['block', empty]]))
+    expect(resolved).toBe(empty)
   })
 })
 

--- a/frontend/src/components/weekend/rosterAttention.ts
+++ b/frontend/src/components/weekend/rosterAttention.ts
@@ -28,7 +28,7 @@
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
 import { partyHeadcount } from './householdIdentity'
 import { needCoverage, needGlyph, needVerdict } from './needGlyphs'
-import { coveredCodes, drawnUnits } from './unitLevel'
+import { coveredCodes, drawnUnits, representingCodes } from './unitLevel'
 
 /** Ordered most urgent first. The order of this array IS the section order. */
 export const ATTENTION_ORDER = ['required', 'unmet', 'unplaced', 'unverified', 'settled'] as const
@@ -84,23 +84,28 @@ export const ATTENTION_LABEL: Record<AttentionLevel, string> = {
 const ROSTER_NEEDS = ['bathroom', 'power'] as const
 
 /**
- * The roster's own wording for those two, which is NOT the glyph's label.
+ * The roster's own wording for those two, and it now MATCHES the glyph's
+ * label — kindred#2501.
  *
- * The glyph is called "Bathroom in unit", because that is the axis the
- * CampMinder question asks about (`weekend-card-vocabulary.md` §4). The RULE
- * still grades exclusivity until kindred#2501 lands, and these strings are
- * read on the roster row, the details panel and the map peek — surfaces that
- * report the verdict, not the ask. Saying "No bathroom in unit" about a cabin
- * with a shared bathroom in it would be false; saying "No private bathroom"
- * is exactly what was checked.
+ * These strings are read on the roster row, the details panel and the map peek
+ * — surfaces that report the verdict, not the ask — so they have to say what
+ * was actually checked. Until #2501 that was exclusivity, and "No private
+ * bathroom" was the honest word for it: saying "No bathroom in unit" about a
+ * cabin with a shared bathroom inside it would have been false.
  *
- * Both halves move to the glyph's vocabulary when #2501 flips the rule, and
- * not before. That is the same one-release contradiction the card accepts and
- * `needGlyphs.bathroomCoverage` documents.
+ * The rule moved (owner ruling 2026-08-20 — the glyph grades presence, not
+ * exclusivity), so the wording moves with it, and now saying "private" would
+ * be the false half: a household reported here has NO bathroom in the unit at
+ * all, shared or otherwise. Both halves move together, because the ask and the
+ * verdict have to name the same axis or the roster reads as two products.
+ *
+ * The underlying `needs_private_bathroom` field keeps its name; renaming it is
+ * a deliberate follow-up. `needGlyphs.bathroomCoverage` carries the ruling and
+ * what it costs.
  */
 const ROSTER_NEED_WORDING: Record<(typeof ROSTER_NEEDS)[number], { asked: string; unmet: string }> =
   {
-    bathroom: { asked: 'Private bathroom', unmet: 'No private bathroom' },
+    bathroom: { asked: 'Bathroom in unit', unmet: 'No bathroom in unit' },
     power: { asked: 'Power', unmet: 'No power' },
   }
 
@@ -125,44 +130,217 @@ export function partyBeds(party: RosterPartyRow): number {
 }
 
 /**
+ * The board's rule for which DRAWN card represents a named code: itself if it
+ * is drawn, else the nearest drawn ancestor (rolled up), else every drawn node
+ * beneath it (fanned down). `[]` when the board draws nothing for it at all.
+ *
+ * ⚠️ A SECOND COPY of `cardCodesFor`, the closure inside
+ * `boardLayout.indexPayload`, and the duplication is knowing rather than
+ * accidental: that one is not exported, and two implementations of "which card
+ * represents this placement" is the exact drift this function exists to close.
+ * So the pair is pinned against the board's OWN model rather than against a
+ * restatement of the rule — `rosterAttention.test.ts` builds a board from the
+ * same payload and asserts both land on the same card. Lifting the shared rule
+ * into `unitLevel.ts`, where `representingCodes` (the fan-down half) already
+ * lives, is the follow-up.
+ *
+ * The roll-up walk is deliberately NOT the "whole building" grain — see
+ * `cardCodesFor`'s own note and `unitLevel.buildingKey`. It stops at the
+ * nearest DRAWN ancestor, which flips with `is_combined`, and that is right
+ * here precisely because the question IS "which card is on screen".
+ */
+function representingCards(
+  named: LodgingUnitRow,
+  units: LodgingUnitRow[],
+  unitsByCode: ReadonlyMap<string, LodgingUnitRow>,
+  drawnByCode: ReadonlyMap<string, LodgingUnitRow>
+): LodgingUnitRow[] {
+  const own = drawnByCode.get(named.code)
+  if (own !== undefined) return [own]
+
+  let cursor = named
+  const seen = new Set<string>()
+  while ((cursor.parent_code ?? '') !== '' && !seen.has(cursor.code)) {
+    seen.add(cursor.code)
+    const parent = unitsByCode.get(cursor.parent_code ?? '')
+    if (parent === undefined) break
+    const drawnParent = drawnByCode.get(parent.code)
+    if (drawnParent !== undefined) return [drawnParent]
+    cursor = parent
+  }
+
+  return representingCodes(named, units, new Set(drawnByCode.keys()))
+    .map((code) => drawnByCode.get(code))
+    .filter((card): card is LodgingUnitRow => card !== undefined)
+}
+
+/*
+ * THE RESOLVED GRADES, ORDERED WORST FIRST, and the order is the whole content
+ * of the roll-up below — so it is worth saying why it is this one.
+ *
+ * It is a ladder of how much of the space provides the thing: nothing, nobody
+ * has looked, some rooms, a qualified answer, all of it. Ordered that way the
+ * fold is exactly `needVerdict`'s worst case over the cards — checked pair by
+ * pair, the fold's verdict is never softer than the loudest card's, including
+ * the two pairs that are not obvious: `unknown` beats `some` because an
+ * unmeasured room grades `unmet` while `some` may grade `partial`, and
+ * `unknown` beats `partial` for the same reason.
+ *
+ * ⚠️ THAT HOLDS FOR THE GLYPH READING, WHICH IS THE ONLY ONE THIS FEEDS. The
+ * drag-time hatch reads `unknown` as `fits` (`UnknownReading` in
+ * `needGlyphs.ts`), and under that reading a fold of `{unknown, some}` would
+ * be softer than `some` alone. The hatch grades a candidate cabin the party is
+ * not in, never a resolved placement, so it never sees one of these rows — if
+ * that ever changes, this ladder needs a second one beside it.
+ *
+ * `partial` is ramp-only and `shared`/`private` are bathroom-only, so the
+ * three vocabularies get three constants rather than one union that would
+ * type-check against fields it can never hold.
+ */
+const AMENITY_WORST_FIRST = ['none', 'unknown', 'some', 'all'] as const
+const RAMP_WORST_FIRST = ['none', 'unknown', 'some', 'partial', 'all'] as const
+const BATHROOM_WORST_FIRST = ['none', 'unknown', 'shared', 'private'] as const
+
+/** The worst grade present, treating an absent field as `absent`. */
+function worstGrade<T extends string>(
+  order: readonly T[],
+  absent: T,
+  values: ReadonlyArray<T | undefined>
+): T {
+  let rank = order.length - 1
+  for (const value of values) {
+    const index = order.indexOf(value ?? absent)
+    if (index >= 0 && index < rank) rank = index
+  }
+  return order[rank] ?? absent
+}
+
+/**
+ * One row standing for several cards, graded at the WORST of them.
+ *
+ * ⚠️ A GRADING VIEW, NOT A UNIT. Only the five resolved amenity fields are
+ * rolled up; `code`, `name`, `area_name`, `sleeps` and the raw `has_*` twins
+ * are the FIRST card's and describe that card alone. Nothing reads them off a
+ * resolved party unit today — `FamilyDetailsPanel` prints `area_name`, and
+ * every card of a multi-card placement is in one area often enough for that to
+ * be unremarkable — but a future caller wanting the placement's own identity
+ * must not take it from here.
+ *
+ * The alternative was to return the single worst card, and it is wrong for the
+ * case that motivates the whole thing: two rooms where one has power and no
+ * fridge and the other has a fridge and no power have no worse card between
+ * them, and picking either one hides a need the family will actually be short
+ * of.
+ */
+function worstCard(cards: readonly LodgingUnitRow[]): LodgingUnitRow | undefined {
+  const first = cards[0]
+  if (first === undefined || cards.length === 1) return first
+  return {
+    ...first,
+    bathroom: worstGrade(
+      BATHROOM_WORST_FIRST,
+      'unknown',
+      cards.map((card) => card.bathroom)
+    ),
+    power_coverage: worstGrade(
+      AMENITY_WORST_FIRST,
+      'unknown',
+      cards.map((card) => card.power_coverage)
+    ),
+    fridge_coverage: worstGrade(
+      AMENITY_WORST_FIRST,
+      'unknown',
+      cards.map((card) => card.fridge_coverage)
+    ),
+    ac_coverage: worstGrade(
+      AMENITY_WORST_FIRST,
+      'unknown',
+      cards.map((card) => card.ac_coverage)
+    ),
+    ramp_coverage: worstGrade(
+      RAMP_WORST_FIRST,
+      'unknown',
+      cards.map((card) => card.ramp_coverage)
+    ),
+  }
+}
+
+/**
  * The unit whose confirmed data backs this party's fit check, or undefined
  * when there is no confirmed evidence to read.
  *
- * An ordinary placement resolves off `unit_code`, same as always. A merged
- * slot's `unit_code` is "" BY DESIGN (kindred#1982) — `unitsByCode.get('')`
- * finds nothing, which is exactly how the roster row, family card, and
- * detail panel each lost every genuine multi-leaf merge to `unverified`
- * even after `party.effective_bathroom` started reporting `private` for
- * them. `unit_codes` (kindred#1940) carries every leaf the placement
- * covers, and each leaf's OWN `is_confirmed` is real staff signal. Trusting
- * the merge as evidence requires EVERY member to resolve AND be confirmed —
- * one unconfirmed room is still an absence of data, the same principle the
- * single-unit gate already enforces, not a looser one for having more
- * rooms.
+ * ⚠️ THE CARD THE BOARD DRAWS, which is what this used to get wrong. An
+ * ordinary placement resolves off `unit_code`, same as always. A merged slot's
+ * `unit_code` is "" BY DESIGN (kindred#1982) — `unitsByCode.get('')` finds
+ * nothing, which is how the roster row, family card, and detail panel each
+ * lost every genuine multi-leaf merge to `unverified` even after
+ * `party.effective_bathroom` started reporting `private` for them. `unit_codes`
+ * (kindred#1940) carries every leaf the placement covers, and this used to take
+ * `members[0]` off it: the first id in the `units` relation, i.e. whatever
+ * order the rows were stored in.
  *
- * The first resolved member stands in as the representative for the needs that
- * read a UNIT field — since kindred#2072 that is `power_coverage`, resolved by
- * the server over the unit's leaf descendants, rather than the raw `has_power`
- * this used to say. The bathroom need never looks at the unit at all — it
- * reads `party.effective_bathroom` — so which member gets picked never changes
- * that verdict; `is_confirmed` is what has to hold for every one of them.
+ * That made the grade a coin flip AND put it at odds with the other two
+ * surfaces that grade the same family. `LodgingUnitCard` grades its occupants
+ * against the card it drew, and `MapUnitPopover` calls `partyAttention` with
+ * the map's drawn unit — for a combined house, the container. Seven 2026
+ * placements resolved to a different unit here than on those two. No verdict
+ * differed on that data, but only by luck: every container and every leaf
+ * resolves `power_coverage: 'all'`, while two containers have leaves that
+ * disagree on `has_fridge`, so the container resolves `fridge_coverage: 'some'`
+ * where one leaf says `all` and the other `none`. Flipping two ids in the
+ * relation flipped the answer.
  *
- * The map surface (`MapUnitPopover`) does not call this: it already resolves
- * a real, defined per-leaf unit for a merged party (drawing it once per
- * room it occupies), so it never hit this gap.
+ * So the named codes are mapped onto the DRAWN cards representing them, by the
+ * board's own rule (`representingCards`). A merge under a combined house
+ * resolves to the house — one card, the server's roll-up over its leaves, the
+ * same row `LodgingUnitCard` and `MapUnitPopover` grade against. A named code
+ * the board draws no card for at all — a childless container — stands in for
+ * itself rather than reporting no evidence: the registry row is real, and
+ * `undefined` would make every need glyph on that party's off-board card read
+ * as MET.
+ *
+ * Where a placement spans SEVERAL cards, the answer is the worst of them
+ * (`worstCard`), not a member. A family whose need fails in one of its rooms
+ * has a problem, and surfacing the best room hides it.
+ *
+ * Trusting a multi-card placement as evidence still requires EVERY card to
+ * resolve AND be confirmed — one unconfirmed room is an absence of data, the
+ * same principle the single-unit gate enforces, not a looser one for having
+ * more rooms. A code with no row in the payload fails that outright. The
+ * single-card path returns the row as it always has and lets `partyAttention`
+ * apply its own `is_confirmed` gate.
+ *
+ * The bathroom need never looks at the unit in the placed reading — it reads
+ * `party.effective_bathroom` — so which card is picked never changes THAT
+ * verdict. The other three do read the unit, and now read the same one the
+ * board does.
  */
 export function resolvePartyUnit(
   party: RosterPartyRow,
   unitsByCode: Map<string, LodgingUnitRow>
 ): LodgingUnitRow | undefined {
   const singleCode = party.unit_code ?? ''
-  if (singleCode.length > 0) return unitsByCode.get(singleCode)
+  const named = singleCode.length > 0 ? [singleCode] : (party.unit_codes ?? [])
+  if (named.length === 0) return undefined
 
-  const codes = party.unit_codes ?? []
-  if (codes.length === 0) return undefined
-  const members = codes.map((code) => unitsByCode.get(code))
-  const allConfirmed = members.every((member) => member?.is_confirmed === true)
-  return allConfirmed ? members[0] : undefined
+  const units = [...unitsByCode.values()]
+  const drawnByCode = new Map(drawnUnits(units).map((unit) => [unit.code, unit]))
+
+  const cards: LodgingUnitRow[] = []
+  const seen = new Set<string>()
+  for (const code of named) {
+    const unit = unitsByCode.get(code)
+    if (unit === undefined) return undefined
+    const represented = representingCards(unit, units, unitsByCode, drawnByCode)
+    for (const card of represented.length > 0 ? represented : [unit]) {
+      if (seen.has(card.code)) continue
+      seen.add(card.code)
+      cards.push(card)
+    }
+  }
+
+  if (cards.length === 1) return cards[0]
+  return cards.every((card) => card.is_confirmed === true) ? worstCard(cards) : undefined
 }
 
 /**

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -2227,6 +2227,10 @@ export type LodgingUnitSummary = {
    */
   has_ac?: boolean
   /**
+   * Ac Coverage
+   */
+  ac_coverage?: 'all' | 'some' | 'none' | 'unknown'
+  /**
    * Has Fridge
    */
   has_fridge?: boolean

--- a/frontend/src/types/lodging.test.ts
+++ b/frontend/src/types/lodging.test.ts
@@ -273,6 +273,10 @@ const _exhaustiveLodgingUnit: Required<LodgingUnitRow> = {
   // fourteen 2026 family-pool containers disagree with themselves on it.
   power_coverage: 'none',
   has_ac: false,
+  // The AC twin of `power_coverage`, resolved over the same leaf walk.
+  // DISPLAY ONLY -- air conditioning has no demand glyph, so this keeps the
+  // amenity strip honest on a merged house rather than grading a need.
+  ac_coverage: 'none',
   has_fridge: false,
   // NARROWS `has_fridge` and can never contradict it. Published beside its
   // parent (kindred#2224) because A SHARED FRIDGE IS A FRIDGE — the owner's

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -3771,6 +3771,147 @@ class TestPartySizeIsABedCount:
         assert seen == {date(2026, 9, 4), date(2026, 10, 10)}
 
 
+class TestUnitBathroomResolution:
+    """kindred#2502 -- `LodgingUnitSummary.bathroom`, resolved over LEAF
+    descendants rather than read off the container's own row.
+
+    The fourth twin of `power_coverage` / `fridge_coverage` / `ramp_coverage`,
+    and the last amenity that was still answered from the row itself. All 15
+    production containers store `bathroom = "none"` -- a building is not a
+    room -- while 13 of them have at least one room that records one, so the
+    unit card drew no bathroom on every whole-house card while both its
+    leaves drew one the moment staff split it.
+
+    ⚠️ THIS MUST ANSWER FOR AN UNOCCUPIED CONTAINER. The party path already
+    answers correctly via `_resolve_party_bathroom`, but only once something
+    is placed -- so the same building graded UNMET in the picker and MET once
+    the family landed in it. A resolver has no placement to read, which is
+    exactly why the fix is a resolver and not the slot-code threading the
+    issue body originally proposed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_leaf_still_answers_for_itself(self) -> None:
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("u1", "ridge-1", "Ridge 1", sleeps=4, bathroom="private"),
+                _unit("u2", "ridge-2", "Ridge 2", sleeps=4, bathroom="none"),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        by_code = {u.code: u for u in roster.units}
+        assert by_code["ridge-1"].bathroom == "private"
+        assert by_code["ridge-2"].bathroom == "none"
+
+    @pytest.mark.asyncio
+    async def test_a_container_inherits_the_bathroom_its_rooms_share(self) -> None:
+        """The reported symptom: the building says none, both rooms say shared.
+
+        A whole-let covers the whole group by construction, so the container
+        resolves to the exclusive grade its rooms cannot claim alone.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("c1", "lodge", "Lodge", is_container=True, bathroom="none"),
+                _unit(
+                    "u1",
+                    "lodge-1",
+                    "Lodge 1",
+                    sleeps=2,
+                    bathroom="shared",
+                    bathroom_group="lodge-bath",
+                    parent_unit="c1",
+                ),
+                _unit(
+                    "u2",
+                    "lodge-2",
+                    "Lodge 2",
+                    sleeps=3,
+                    bathroom="shared",
+                    bathroom_group="lodge-bath",
+                    parent_unit="c1",
+                ),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        by_code = {u.code: u for u in roster.units}
+        assert by_code["lodge"].bathroom == "private"
+        assert by_code["lodge-1"].bathroom == "shared"
+        assert by_code["lodge-2"].bathroom == "shared"
+
+    @pytest.mark.asyncio
+    async def test_a_container_whose_rooms_walk_to_a_bathhouse_inherits_nothing(self) -> None:
+        """The false positive this resolver must not publish to a second
+        surface. Both rooms record no bathroom while sharing one group -- the
+        group names the bathhouse they walk to, not a bathroom in either
+        room."""
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("c1", "village", "Village", is_container=True, bathroom="none"),
+                _unit(
+                    "u1",
+                    "village-a",
+                    "Village A",
+                    sleeps=2,
+                    bathroom="none",
+                    bathroom_group="village-bathhouse",
+                    parent_unit="c1",
+                ),
+                _unit(
+                    "u2",
+                    "village-b",
+                    "Village B",
+                    sleeps=2,
+                    bathroom="none",
+                    bathroom_group="village-bathhouse",
+                    parent_unit="c1",
+                ),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert {u.code: u.bathroom for u in roster.units}["village"] == "none"
+
+    @pytest.mark.asyncio
+    async def test_it_resolves_through_an_intermediate_container(self) -> None:
+        """18 of 118 units are grandchildren, and some top-level containers
+        have no leaf children at all -- only container children. A one-level
+        walk answers "none" here."""
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("c0", "block", "Block", is_container=True, bathroom="none"),
+                _unit("c1", "block-wing", "Wing", is_container=True, bathroom="none", parent_unit="c0"),
+                _unit(
+                    "u1",
+                    "block-wing-1",
+                    "Wing 1",
+                    sleeps=2,
+                    bathroom="shared",
+                    bathroom_group="wing-bath",
+                    parent_unit="c1",
+                ),
+                _unit(
+                    "u2",
+                    "block-wing-2",
+                    "Wing 2",
+                    sleeps=2,
+                    bathroom="shared",
+                    bathroom_group="wing-bath",
+                    parent_unit="c1",
+                ),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert {u.code: u.bathroom for u in roster.units}["block"] == "private"
+
+
 class TestUnitPowerCoverage:
     """kindred#1912 -- `LodgingUnitSummary.power_coverage`, resolved over LEAF
     descendants rather than read off the row.

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -67,6 +67,7 @@ def _unit(
     parent_unit: str = "",
     shareability: str = "",
     has_power: bool = False,
+    has_ac: bool = False,
     has_fridge: bool = False,
     # NARROWS `has_fridge` and can never contradict it (owner ruling,
     # kindred#2224): a shared fridge IS a fridge. Zero of the 118 production
@@ -97,7 +98,7 @@ def _unit(
         bathroom_group=bathroom_group,
         near_bathhouse=False,
         has_power=has_power,
-        has_ac=False,
+        has_ac=has_ac,
         has_fridge=has_fridge,
         has_shared_fridge=has_shared_fridge,
         has_ramp=has_ramp,
@@ -3769,6 +3770,61 @@ class TestPartySizeIsABedCount:
 
         seen = {call.kwargs["session_start"] for call in build_parties.call_args_list}
         assert seen == {date(2026, 9, 4), date(2026, 10, 10)}
+
+
+class TestUnitAcCoverage:
+    """kindred#2502 -- `LodgingUnitSummary.ac_coverage`.
+
+    `has_ac` was the one amenity on the card with no resolver at all: it sat
+    in the schema between two fields that both have twins, and three surfaces
+    read it raw. Seven of the 15 production containers record `has_ac = 0`
+    with AC-bearing rooms, so merging a house hid an AC mark both its rooms
+    carry and splitting brought it back.
+
+    Display-only -- AC has no demand glyph, ruled deliberately on 0 of 184
+    housing narratives mentioning it. This is about the amenity strip telling
+    the truth, not about grading a need.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_container_inherits_ac_from_its_rooms(self) -> None:
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("c1", "lodge", "Lodge", is_container=True, has_ac=False),
+                _unit("u1", "lodge-1", "Lodge 1", sleeps=2, has_ac=True, parent_unit="c1"),
+                _unit("u2", "lodge-2", "Lodge 2", sleeps=2, has_ac=True, parent_unit="c1"),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        by_code = {u.code: u for u in roster.units}
+        assert by_code["lodge"].ac_coverage == "all"
+        assert by_code["lodge"].has_ac is False
+
+    @pytest.mark.asyncio
+    async def test_a_partly_cooled_container_reports_some(self) -> None:
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("c1", "lodge", "Lodge", is_container=True, has_ac=False),
+                _unit("u1", "lodge-1", "Lodge 1", sleeps=2, has_ac=True, parent_unit="c1"),
+                _unit("u2", "lodge-2", "Lodge 2", sleeps=2, has_ac=False, parent_unit="c1"),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert {u.code: u.ac_coverage for u in roster.units}["lodge"] == "some"
+
+    @pytest.mark.asyncio
+    async def test_a_leaf_answers_for_itself(self) -> None:
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[_unit("u1", "ridge-1", "Ridge 1", sleeps=4, has_ac=True)],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert roster.units[0].ac_coverage == "all"
 
 
 class TestUnitBathroomResolution:

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -2116,6 +2116,65 @@ class TestPartyEffectiveBathroom:
         assert roster.parties[0].effective_bathroom == "none"
 
     @pytest.mark.asyncio
+    async def test_a_retired_room_does_not_supply_the_placement_its_bathroom(self) -> None:
+        """THE TWO LANES MUST AGREE, and this is the shape that split them.
+
+        `_resolve_bathroom` (the empty-card lane) filters its leaf walk to
+        `is_active`, on `_resolve_power_coverage`'s rule -- nobody can be
+        placed in a retired room, so it does not answer for its building.
+        This lane walked the same tree UNFILTERED, so a decommissioned room
+        still spoke.
+
+        The container below has one live room with no bathroom and one
+        retired room that records a shared one, both in the same group. The
+        card therefore says "no bathroom", correctly. Without the filter the
+        placed party read `private` -- upgraded, because the retired room
+        counted twice over: once to supply a bathroom nobody can use, and
+        again to complete the group the exclusivity branch checks. Picker and
+        placement disagreeing on one field is the defect class this whole
+        change exists to close, so the two walks take the same filter.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_households={"hh_1": _household()},
+            fetch_attendees_for_session=[_child()],
+            fetch_units=[
+                _unit("u1", "annex", "The Annex", sleeps=4, is_container=True, default_combined=True),
+                _unit(
+                    "u2",
+                    "annex-1",
+                    "Annex 1",
+                    sleeps=2,
+                    bathroom="none",
+                    bathroom_group="annex-bath",
+                    parent_unit="u1",
+                ),
+                _unit(
+                    "u3",
+                    "annex-2",
+                    "Annex 2 (decommissioned)",
+                    sleeps=2,
+                    bathroom="shared",
+                    bathroom_group="annex-bath",
+                    is_active=False,
+                    parent_unit="u1",
+                ),
+            ],
+            fetch_assignments=[
+                _rec(
+                    household_cm_id=2000001,
+                    person_cm_id=0,
+                    units=["u1"],
+                    expand={"units": [_rec(id="u1", code="annex", name="The Annex")]},
+                ),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert {u.code: u.bathroom for u in roster.units}["annex"] == "none"
+        assert roster.parties[0].effective_bathroom == "none"
+
+    @pytest.mark.asyncio
     async def test_unplaced_party_is_unknown(self) -> None:
         repo = _repo(
             fetch_session=FAMILY_SESSION,
@@ -3831,8 +3890,12 @@ class TestUnitBathroomResolution:
     """kindred#2502 -- `LodgingUnitSummary.bathroom`, resolved over LEAF
     descendants rather than read off the container's own row.
 
-    The fourth twin of `power_coverage` / `fridge_coverage` / `ramp_coverage`,
-    and the last amenity that was still answered from the row itself. All 15
+    The fifth in-place resolver, beside `power_coverage`, `fridge_coverage`,
+    `ramp_coverage` and `ac_coverage` — and the last amenity that was still
+    answered from the row itself. It is the only one of the five that
+    overwrites the registry column rather than writing a `*_coverage` grade
+    beside it, because `bathroom` is a four-value enum every surface already
+    reads. All 15
     production containers store `bathroom = "none"` -- a building is not a
     room -- while 13 of them have at least one room that records one, so the
     unit card drew no bathroom on every whole-house card while both its
@@ -3966,6 +4029,86 @@ class TestUnitBathroomResolution:
         roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
 
         assert {u.code: u.bathroom for u in roster.units}["block"] == "private"
+
+    @pytest.mark.asyncio
+    async def test_a_deactivated_room_does_not_answer_for_the_building(self) -> None:
+        """The twin of `TestUnitPowerCoverage`'s test of the same name, and the
+        case this class had no coverage for while the power and fridge classes
+        both did.
+
+        Nobody can be placed in a retired room, so it cannot supply the
+        building's bathroom -- the same `is_active` filter `_effective_sleeps`
+        applies when totalling a combined container's rooms. The live room
+        below records none; only the retired one records a bathroom, so the
+        building has none to inherit.
+
+        `TestPartyEffectiveBathroom.test_a_retired_room_does_not_supply_the
+        _placement_its_bathroom` is the OTHER LANE on this identical registry,
+        and it read `private` until the filter went on both walks. The pair is
+        pinned on both sides now, because one field answering differently in
+        the picker and in the placement is the defect this whole change closes.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("c1", "annex", "The Annex", is_container=True, bathroom="none"),
+                _unit(
+                    "u1",
+                    "annex-1",
+                    "Annex 1",
+                    sleeps=2,
+                    bathroom="none",
+                    bathroom_group="annex-bath",
+                    parent_unit="c1",
+                ),
+                _unit(
+                    "u2",
+                    "annex-2",
+                    "Annex 2 (decommissioned)",
+                    sleeps=2,
+                    bathroom="shared",
+                    bathroom_group="annex-bath",
+                    is_active=False,
+                    parent_unit="c1",
+                ),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert {u.code: u.bathroom for u in roster.units}["annex"] == "none"
+
+    @pytest.mark.asyncio
+    async def test_a_building_with_no_active_room_left_keeps_its_own_row(self) -> None:
+        """The degenerate case, and it is ruled the OPPOSITE way to power.
+
+        `_resolve_power_coverage` refuses to answer here and reports `unknown`,
+        because a container's stored `has_power = 0` is not a claim anybody
+        made -- 13 of the 15 production containers carry it while their rooms
+        are powered. `bathroom` is different, and the difference is the whole
+        reason this resolver may fall back at all: a container's stored `none`
+        IS a deliberate registry convention, entered because a building is not
+        a room. So with nothing left to inherit, the row it already holds is
+        the honest answer rather than an absence of one.
+        """
+        repo = _repo(
+            fetch_session=FAMILY_SESSION,
+            fetch_units=[
+                _unit("c1", "annex", "The Annex", is_container=True, bathroom="none"),
+                _unit(
+                    "u1",
+                    "annex-1",
+                    "Annex 1",
+                    sleeps=2,
+                    bathroom="shared",
+                    bathroom_group="annex-bath",
+                    is_active=False,
+                    parent_unit="c1",
+                ),
+            ],
+        )
+        roster = await LodgingRosterService(repo).build_roster(2026, 1000001)
+
+        assert {u.code: u.bathroom for u in roster.units}["annex"] == "none"
 
 
 class TestUnitPowerCoverage:

--- a/tests/unit/api/services/test_lodging_rules.py
+++ b/tests/unit/api/services/test_lodging_rules.py
@@ -156,30 +156,71 @@ class TestEffectiveBathroom:
 class TestContainerBathroom:
     """kindred#2022's second gap. All 15 registry containers store
     bathroom = "none" on their own row -- a building is not a room -- which
-    short-circuits `effective_bathroom`'s exclusivity branch (line 108-109)
-    before it ever runs. A party that books the whole container (the
-    health-center apartments: two bedrooms over one shared bath, normally
-    let whole) needs the container's input substituted from its leaves
-    instead. This is that substitution, kept OUTSIDE `effective_bathroom`
-    itself -- that function stays the same four-argument pure test the
-    class above already pins, rather than growing a fifth argument to know
-    about children it has no way to walk.
+    short-circuits `effective_bathroom`'s exclusivity branch before it ever
+    runs. A party that books the whole container needs the container's input
+    substituted from its leaves instead. This is that substitution, kept
+    OUTSIDE `effective_bathroom` itself -- that function stays the same
+    four-argument pure test the class above already pins.
+
+    ⚠️ THIS TAKES THE LEAVES' (bathroom, group) PAIRS, NOT BARE GROUP IDS.
+    Grading on group identity alone cannot see whether any leaf actually HAS
+    a bathroom, and the registry contains one group whose members all record
+    "none" while sitting beside a bathhouse -- so identity-only grading
+    answered "private" for a whole-let of rooms with no bathroom in them,
+    on a need that is asked for medical reasons. The pairs are what close it.
     """
 
     def test_leaves_sharing_one_group_inherit_shared(self) -> None:
-        assert container_bathroom(frozenset({"hc-dh-bath"})) == ("shared", "hc-dh-bath")
+        assert container_bathroom(frozenset({("shared", "grp-a"), ("shared", "grp-a")})) == (
+            "shared",
+            "grp-a",
+        )
 
     def test_leaves_with_no_group_inherit_nothing(self) -> None:
-        assert container_bathroom(frozenset({""})) == ("none", "")
+        assert container_bathroom(frozenset({("shared", "")})) == ("none", "")
 
     def test_leaves_split_across_groups_inherit_nothing(self) -> None:
         """Ambiguous -- rooms that don't share one physical bathroom have no
         single answer, so the container reports exactly what its own
-        registry row already says."""
-        assert container_bathroom(frozenset({"group-a", "group-b"})) == ("none", "")
+        registry row already says.
+
+        ⚠️ This is a FALSE NEGATIVE that is deliberately preserved: four
+        registry buildings whose every room has a bathroom report "none"
+        because their rooms span two groups. Widening it is a redefinition
+        of what "this building has a bathroom" means and is gated on an
+        owner ruling, so it is pinned here rather than fixed silently.
+        """
+        assert container_bathroom(frozenset({("shared", "grp-a"), ("shared", "grp-b")})) == (
+            "none",
+            "",
+        )
 
     def test_no_leaves_inherit_nothing(self) -> None:
         assert container_bathroom(frozenset()) == ("none", "")
+
+    def test_leaves_agreeing_on_a_group_but_recording_no_bathroom_inherit_nothing(self) -> None:
+        """THE BATHHOUSE FALSE POSITIVE, and the reason this function takes
+        pairs.
+
+        A two-room building whose rooms both record `bathroom = "none"` while
+        sharing one non-empty group: the rooms walk to a bathhouse, and the
+        group names that bathhouse rather than a bathroom inside either room.
+        Grading on group identity alone returned ("shared", group), which
+        `effective_bathroom` then upgraded to "private" for a whole-let --
+        a GREEN verdict on a medical in-cabin bathroom request for two rooms
+        with no bathroom in them. A group is only inheritable when some leaf
+        behind it actually has a bathroom.
+        """
+        assert container_bathroom(frozenset({("none", "grp-bathhouse")})) == ("none", "")
+
+    def test_one_leaf_with_a_bathroom_carries_the_shared_group(self) -> None:
+        """The mixed case: not every room needs its own bathroom for the
+        group to be real -- one is enough, because the group is what they
+        physically share."""
+        assert container_bathroom(frozenset({("none", "grp-a"), ("shared", "grp-a")})) == (
+            "shared",
+            "grp-a",
+        )
 
 
 class TestAmenityCoverage:


### PR DESCRIPTION
Three amenity-resolution defects found by auditing the container/leaf/merge/split logic against the needs-vs-meets grading, after two were reported from production — **plus the bathroom grading axis itself**, which moves from exclusivity to presence on the owner's 2026-08-20 ruling.

## ⚠️ A shared bathroom now SATISFIES a request that previously showed red

This is a change to what a staff-facing mark means, so it goes first rather than in a footnote.

Until now, a household flagged `needs_private_bathroom` was graded met only by a `private` bathroom. A cabin with a bathroom **inside it that two parties split** drew a red glyph and printed "No private bathroom" on the roster. It no longer does: presence is the axis, and the wording moves with it to "Bathroom in unit" / "No bathroom in unit".

Owner ruling, verbatim: *"the glyph should not grade exclusivity, just 'do they have a bathroom (shared or private)'"* and *"sharing a bathroom for whatever reason still provides people a bathroom."*

The axis was never exclusivity to begin with. The CampMinder question behind the flag asks for *"a bathroom that doesn't require you to leave your cabin"* — so `shared` means a bathroom **inside** the cabin, and walking to a bathhouse is not `shared`, it records as `none` and still reads unmet. The column's name is the thing that is wrong here; renaming it is a deliberate follow-up.

**What it moves, measured:** across 2026's three weekends that have bathroom-asking families placed, **7 placed families** move from *unmet* to *settled* on the roster's attention sections — 5, 1 and 1. On the largest of the three, "No private bathroom" went 8 → 0 and "No bathroom in unit" 0 → 3, verified live against both stacks. **What it costs, accepted on the record:** the ~3–5 households a year who need a bathroom nobody else uses lose an automatic red mark and are found by reading the request instead.

This also ends a one-release contradiction rather than creating one: the unit card already drew its bathroom mark on presence, so a room could show "has a bathroom" while the family placed on it showed a red bathroom glyph, off the same field. One axis now, on every surface — card, glyph, roster wording, Assign modal and map peek.

## What was wrong

**A whole-house card showed no bathroom while both its rooms showed one the moment staff split it.** All 15 registry containers store `bathroom = "none"` on their own row — a building is not a room — and 13 of them have at least one room that records one. `_build_units` scored each unit against a one-element slot containing itself, so `effective_bathroom` short-circuited on the blank value and it reached the wire untouched.

Power, fridge and step-free are immune because they are resolved by a **second pass** that runs once the tree index exists. Bathroom predates that pattern and was never moved across — the blocker was ordering, not design. `_resolve_bathroom` is that missing twin.

It answers for an **empty** container, which is the point. The party path was already correct, but only once something was placed, so the same building graded unmet in the picker and met once the family landed in it. Most containers are never placed into. This is also why the issue's original proposal — thread the drawn slot's codes into `_build_units` — could not work; #2502's body has been corrected.

**`container_bathroom` graded on group identity and never read a single leaf's bathroom value.** A `bathroom_group` says which rooms share one bathroom; it never says the bathroom is inside any of them. One registry group names a bathhouse its two rooms walk to, and both record `bathroom = "none"` — identity alone returned a shared group, which the exclusivity branch upgraded to `private` on a whole-let. That is a **satisfied verdict on a medical in-cabin bathroom request for two rooms with no bathroom in them**. It now takes `(bathroom, group)` pairs.

**`has_ac` had no resolver at all.** It sat in the schema between two fields that both have twins, and three surfaces read it raw. Seven of the 15 containers record `has_ac = 0` with AC-bearing rooms, so merging a house hid a mark both its rooms carry.

## Measured against the 2026-08-20 production snapshot

118 units, 15 containers, 103 rooms, all active and all confirmed. Every figure below was re-derived by running the shipped functions over the real registry, not taken from a summary.

| | before | after |
|---|---|---|
| containers reporting the bathroom their rooms have | 0 of 15 | **8 of 15** |
| the bathhouse case | `private` (satisfied) | `none` |
| containers that should report none and changed | — | **0** |
| units answering the bathroom need | 6 of 118 | **36 of 118** |

That last row moved twice, and the two halves are separable: the presence ruling takes 6 → 28, and `_resolve_bathroom` takes 28 → 36. Six comments and two reference docs quoted the old **6 of 118** and the **112 of 118** cards a bathroom hatch would fire on; the live figures are **36** and **82**, and all eight sites are corrected here. The registration side is now 479 rows, of which 66 ask for a bathroom and 48 for power.

## Also shipping — four staff-visible changes beyond the three defects

**1. The details panel and roster toolbar gain the two needs they were silently dropping.** `AccessibilityFlagList` held a second, hard-coded four-branch needs table beside `NEED_GLYPHS`; it now derives from it. The panel gains **Fridge** and **Step-free** rows and the roster toolbar gains the two matching filter chips (4 → 6). Six 2026 households ask for a fridge and no roster surface said so — one of them sits on a card drawing a red fridge glyph while the panel's "Housing needs" section did not mention a fridge. `needs_step_free` is 0 on all 479 rows until a sync runs, so that chip matches nobody today; the wiring is correct and waiting on data (#2072).

**2. The map peek trades a raw boolean for the resolved step-free grade — and shows MORE, not less.** The `Accessible` item read the raw `is_accessible` column, which has no resolver and so carries the same container trap as every other raw read on that card. It is replaced by `Step-free`, gated on `ramp_coverage === 'all'`. Measured over all 118 units: `is_accessible` is true on **2**, `ramp_coverage: 'all'` on **6**, and both of the 2 are inside the 6 — a strict superset, nothing lost. Both `is_accessible` rows are rooms inside a house the board draws whole by default, so on the default draw level the old item rendered on **0** map slots and the new one renders on **4**. Which column staff mean by "accessible" is a genuine product question this does not settle; it belongs to #2327, and this change only stops the peek reading a column with no container resolution.

**3. `rosterAttention.resolvePartyUnit` no longer coin-flips on a multi-code placement.** It returned `members[0]` — the storage order of the `units` relation — which is CodeRabbit's finding on PR #2505. It now builds the set of drawn cards a placement is actually represented by (`representingCards`) and grades against the **worst** of them (`worstCard`).

**Zero verdicts move, re-measured over all 122 of 2026's placements** rather than argued: not one placement's candidate cards disagree on `power_coverage`, and no household that asks for a fridge or step-free sits on a set that disagrees on those either. Nine placements do have cards that disagree on `fridge_coverage` and four on `ramp_coverage` — none of them is asked for by the family in it. The roster's two graded needs are safe either way, because bathroom is read off the server's `effective_bathroom` and never off the card. So this is a latent fix: one merge across a fridge-disagreeing pair makes it visible, and swapping two ids in the relation would have flipped the answer.

**4. The map peek gains an over-capacity gate it never had.** `mapModel` now carries `spanWidth`, and the amber "beds over capacity" verdict is withheld for a party spread across several rooms — the same gate both board surfaces already take. Zero spanning parties exist in 2026, so nothing on screen moves; this is a guard on a reachable state.

**Roster section counts:** `ROSTER_NEEDS` is unchanged at `['bathroom', 'power']`, so items 1–4 above move **no** roster section count. The bathroom axis change at the top of this body does, by exactly the 7 placed families named there — that is the only number on this PR that moves for a reason other than arithmetic, and it is the point of #2501 rather than a side effect.

## What is deliberately NOT fixed here

Four buildings whose every room has a bathroom still report none, because their rooms span two `bathroom_group`s. Widening that was **proposed and rejected on owner review**: it is only sound if the groups are mutually reachable, and the registry does not model that. One building's upper pair share an internal living space while its lower pair share a corridor, and you go outside to get between them — so each group has a bathroom, but a family let the whole building does not have one bathroom they all share.

Filed as **#2510**. The false negative is pinned by a test and called out in both docstrings so it cannot be "fixed" by accident.

A fully-occupied whole-house card still counts its beds as free — that one moves printed numbers on the stats bar and embeds a policy, so it waits for a ruling under **#2503**.

## Review follow-up

A review of this branch found one real defect and five falsified comments; all are fixed in `af0bb825`.

**The defect: two lanes, one field, different answers.** `_resolve_bathroom` filters its leaf walk to `is_active` — a room nobody can be placed in does not answer for its building — and `_resolve_party_bathroom` walked the same tree unfiltered. A container with one live room recording no bathroom and one **retired** room recording a shared one, both in the same group, graded `none` on the card and `private` on the family placed into it: the retired room counted twice over, once to supply a bathroom nobody can use and again to complete the group the exclusivity branch checks. Dormant today (the registry has zero inactive rows) and live the moment staff retire a room. Both lanes take the same filter now, and both hand the **unfiltered** group membership to `effective_bathroom`, so a group with a retired member holds at `shared` on both paths rather than upgrading on either.

**The comments.** Three "only on THIS path" notes and a "third and last read of it" sat directly above the commit that wired all five resolvers into both orchestrators. `_resolve_amenity_coverage` said "all three resolvers above" while the new one called itself the fourth caller. And the summary-path note said four of five resolvers move no number there, leaving the fifth unexplained — the gap CodeRabbit read as grounds to delete `_resolve_bathroom`'s call. The true answer is **all five**, now stated with both halves verified: `_build_counts` reads no coverage field and no bathroom, and `_resolve_party_bathroom` recomputes a container's answer from its leaves rather than reading the container's own column. The call stays, because the asymmetry between the two orchestrators is the defect rather than a consequence of it.

## Also

Removes a real lodging unit name from a comment in `api/`. **The Lodging Name Guard passes with it present** — real unit and area names are also sitting in `pocketbase/sync/*_test.go` — so the guard has a blind spot. Reported rather than swept; not in scope here.

## Testing

TDD throughout — every test written and watched fail first, including the bathhouse case failing as `('shared', ...)` and the retired-room case failing as `'private' == 'none'`, which is each defect reproducing. The two mixed-active guard tests were mutation-checked by removing the filter and reading the exit code.

- 6618 pass, 41 skipped on the pre-push runner (6645 / 23 with a live PocketBase). Frontend: 452 files, 7247 tests, all green.
- ruff, mypy, tsc, eslint, prettier, markdownlint, api-types freshness all green. `scripts/pre-push-verify.sh` exits 0.
- Verified against every production container by running the fixed functions over the real registry, not only against fixtures.

Closes #2501.
Closes #2502.

Refs #2510, #2503, #2327.
