### PR TITLE
fix(scripts): the lodging name guard stopped exempting comments

### DIFF
--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -925,7 +925,7 @@ class _BathroomIndex(NamedTuple):
 
     units_by_code: dict[str, LodgingUnitSummary]
     # Immediate children only, keyed by the PARENT's code. Nesting (a
-    # container inside a container, e.g. Doctor's House under a larger
+    # container inside a container, e.g. an apartment under a larger
     # block) is walked at read time in `leaf_codes_under`, mirroring
     # `drawn_units`' own upward walk of the same `parent_code` relation.
     children_by_parent: dict[str, tuple[LodgingUnitSummary, ...]]

--- a/api/services/lodging_rules.py
+++ b/api/services/lodging_rules.py
@@ -143,9 +143,10 @@ def effective_bathroom(
 ) -> str:
     """Spec §3.2.1 — private vs shared depends on the merge state.
 
-    Tioga 1 and Tioga 2 are each `shared`, because two families normally
-    split them. Merge both and the same bathroom becomes `private`, so
-    merging can itself be the accommodation for a medical bathroom request.
+    Two rooms sharing one bathroom are each `shared`, because two families
+    normally split them. Merge both and the same bathroom becomes `private`,
+    so merging can itself be the accommodation for a medical bathroom
+    request.
 
     Args:
         bathroom: the unit's own value ("", "none", "private", "shared").

--- a/docs/investigation-not-bunk-with-bug.md
+++ b/docs/investigation-not-bunk-with-bug.md
@@ -2,29 +2,34 @@
 
 ## Date: 2026-01-20
 
+> **Redacted 2026-08-20 (kindred#2512).** This file is tracked and public and used to
+> carry real camper names and real CampMinder IDs throughout, including a verbatim dump
+> of all 31 not_bunk_with records. Names and IDs below are the repo's fictional set; the
+> record dump is gone. See the "All 31 not_bunk_with Records" section for what it held.
+
 ## Original Problem
 
-Camper 6325675 (Gabriella Bauer-Kahan) has a raw `not_bunk_with` field containing "Amalia Smith", but processed records showed siblings as targets (Aiden and Rebecca Bauer-Kahan) instead.
+Camper 1000001 (Emma Johnson) has a raw `not_bunk_with` field containing "Riley Sam", but processed records showed siblings as targets (Liam and Olivia Johnson) instead.
 
 ## Root Cause Found and Fixed
 
 ### Issue: AI Hallucinating "SIBLING" Placeholder
 
-The AI (GPT-4.1-nano) was incorrectly outputting `target_name = "SIBLING"` for plain name inputs like "Amalia Smith".
+The AI (GPT-4.1-nano) was incorrectly outputting `target_name = "SIBLING"` for plain name inputs like "Riley Sam".
 
 **Evidence from debug logs:**
 ```text
-[AI-PARSE] Input: field='Do Not Share Bunk With' requester='Gabriella Bauer-Kahan' text='Amalia Smith'
+[AI-PARSE] Input: field='Do Not Share Bunk With' requester='Emma Johnson' text='Riley Sam'
 [AI-PARSE] Output: targets=['SIBLING'] request_types=['not_bunk_with']  # WRONG!
 ```
 
-The SIBLING placeholder then triggered `placeholder_expander.py` to expand it to actual siblings (Aiden and Rebecca Bauer-Kahan).
+The SIBLING placeholder then triggered `placeholder_expander.py` to expand it to actual siblings (Liam and Olivia Johnson).
 
 ### Fix Applied
 
 Removed the SIBLING placeholder entirely from `config/prompts/parse_not_bunk_with.txt` because:
 
-1. **Analysis of all 31 not_bunk_with records showed ZERO actual sibling references** - All records contain explicit names like "Amalia Smith", "Kyla Udell", etc.
+1. **Analysis of all 31 not_bunk_with records showed ZERO actual sibling references** - All records contain explicit names like "Riley Sam", "Samuel Johnson", etc.
 2. **The SIBLING placeholder was causing false positives** - The AI was hallucinating it for normal names
 
 **Changes made to `config/prompts/parse_not_bunk_with.txt`:**
@@ -35,8 +40,8 @@ Removed the SIBLING placeholder entirely from `config/prompts/parse_not_bunk_wit
 
 **After fix:**
 ```text
-[AI-PARSE] Input: field='Do Not Share Bunk With' requester='Gabriella Bauer-Kahan' text='Amalia Smith'
-[AI-PARSE] Output: targets=['Amalia Smith'] request_types=['not_bunk_with']  # CORRECT!
+[AI-PARSE] Input: field='Do Not Share Bunk With' requester='Emma Johnson' text='Riley Sam'
+[AI-PARSE] Output: targets=['Riley Sam'] request_types=['not_bunk_with']  # CORRECT!
 ```
 
 ## Debug Logging Added
@@ -83,11 +88,11 @@ Note: `source_field` is NOT in the unique index.
 
 **Example from logs:**
 ```text
-Person 19640456 (Bennett Levis) already has:
-  requestee_id=14761236, type=not_bunk_with, session=1235406, source=BunkingNotes Notes
+Person 1000002 (Liam Garcia) already has:
+  requestee_id=1000003, type=not_bunk_with, session=1000006, source=BunkingNotes Notes
 
 Processing tries to create:
-  requestee_id=14761236, type=not_bunk_with, session=1235406, source=Do Not Share Bunk With
+  requestee_id=1000003, type=not_bunk_with, session=1000006, source=Do Not Share Bunk With
   → 400 error: validation_not_unique
 ```
 
@@ -104,12 +109,12 @@ Some names don't resolve because the person doesn't exist in the database.
 
 **Example:**
 ```text
-Input: "Addy Kniffin & Pallie Rocchino"
-AI Output: targets=['Addy Kniffin', 'Pallie Rocchino']  # Correct parsing
+Input: "Riley Sam & Samuel Johnson"
+AI Output: targets=['Riley Sam', 'Samuel Johnson']  # Correct parsing
 
 Phase 2 Resolution:
-  - "Pallie Rocchino" → resolved=True, person=6053459
-  - "Addy Kniffin" → resolved=False, candidates=0  # No match found
+  - "Samuel Johnson" → resolved=True, person=1000005
+  - "Riley Sam" → resolved=False, candidates=0  # No match found
 ```
 
 This is expected behavior when the target person isn't in the database (might not be attending camp, misspelled name, etc.). The system creates a placeholder request with negative ID.
@@ -120,109 +125,34 @@ Some `original_bunk_requests` records have `requester_id = NULL` even though the
 
 **Example:**
 ```text
-Record for Noa Segev:
-  requester = (relation to persons record with cm_id=17542317)
-  requester_id = None  # Should be 17542317
+Record for Olivia Chen:
+  requester = (relation to persons record with cm_id=1000004)
+  requester_id = None  # Should be 1000004
 ```
 
 This doesn't break processing (code uses the relation), but is inconsistent.
 
-## All 31 not_bunk_with Records (for reference)
+## All 31 not_bunk_with Records
 
-```text
-Requester: Kitty Dougherty
-Content: 'Not with Arya Shachar/other Hasner kids if possible'
+**Removed.** This section used to paste all 31 records verbatim out of production: a
+requester's real name and, in the content field, the real names of the other campers they
+asked not to be bunked with. That is exactly the data `CLAUDE.md` §4 forbids putting in a
+tracked artifact, and this file is tracked and public. Removed rather than translated,
+because a verbatim dump of who does not want to bunk with whom has no engineering value
+once the counts below are recorded — the analysis it supported is the part worth keeping,
+and it is kept.
 
-Requester: Henry Heindl
-Content: 'Adam Taichman'
+What the 31 records actually showed:
 
-Requester: Sivan Stone
-Content: "Sloane 'Lex' Cherniss"
+| | count |
+|---|---|
+| records total | 31 |
+| naming a person explicitly | 31 |
+| using a sibling reference ("my brother", "twin", ...) | **0** |
+| carrying more than one target in one free-text field | several, `&`- and `/`-separated |
 
-Requester: Aaron Markman
-Content: 'Itayi Simon Nyamuzuwe'
-
-Requester: Milo Aufrecht
-Content: 'Aleko (Alexander) Levis'
-
-Requester: Marley Brewer
-Content: 'Izu Montoya'
-
-Requester: Bennett Levis
-Content: "Rezi Sobel Robinson (Ses 4), Avigdor Sussman Corace (?) Declan O'Brian (Ses 2) Lorenzo Rossi (?)"
-
-Requester: Noga Levy
-Content: 'Neg req Ashley Connorton in Ses 3'
-
-Requester: Zaiden Livingston
-Content: "Declan O'Brien"
-
-Requester: Caleb Reichenberg
-Content: 'Arlo Spiro'
-
-Requester: Ivy Hershenson
-Content: 'Different unit than Sebby Kreamer'
-
-Requester: Sofia Rae
-Content: 'Kyla Udell'
-
-Requester: Ally Erlikh
-Content: 'Sasha Smirnova (mom understands that they will be together)'
-
-Requester: Autumn Guinan
-Content: 'Noga Levy'
-
-Requester: Nico Jacques
-Content: 'Olive Miskie'
-
-Requester: Santi Westbury
-Content: 'Sammy Dimond'
-
-Requester: Eleanor Yanow
-Content: 'Madeline Yanow'
-
-Requester: Shira Berman
-Content: 'Zoe Corbett and Thelma Poxon-Hudson'
-
-Requester: Oliver Dewar
-Content: "Declan O'Brien"
-
-Requester: Yael Marks
-Content: 'Sadie Mander'
-
-Requester: Lev Crispi
-Content: 'separate from Vivienne Cooper (family friends just want separation), separate from Matan Altman'
-
-Requester: Gabby Bauer-Kahan
-Content: 'Amalia Smith'
-
-Requester: Leah Rutter
-Content: 'Lola Tenorio-Metz, Ari Sotomayor (ideal if all 3 are in separate cabins but ok if not)'
-
-Requester: Sadie Zalewski
-Content: "Ses 3 G4 '24 - Havia Leonard, Zara Quiter, Samara Reynolds, Elana Schaevitz, Audrey & Sasha Weinberg"
-
-Requester: Jenny Eckert
-Content: 'Ellie Evans'
-
-Requester: Arielle Schriner
-Content: 'Talia Zimmerman (neg relationship together at hebrew school) - ok if together but Shoshie call if so'
-
-Requester: Harper Tong
-Content: 'Lizzy Diamond'
-
-Requester: Noa Segev
-Content: 'Addy Kniffin & Pallie Rocchino'
-
-Requester: Ethan Przybyla
-Content: 'Aleko Levis & Jude Schliffer'
-
-Requester: Zoey Corbett
-Content: 'Kyla Udell'
-
-Requester: Olivia Lieberman
-Content: 'Natalie Goldstein'
-```
+To re-read them, query `original_bunk_requests` for the year and source field directly.
+Do not paste the result back into a tracked file.
 
 **Key observation:** None of these contain sibling references like "my brother", "twin", etc. All use explicit names.
 
@@ -247,13 +177,13 @@ uv run python -m bunking.sync.bunk_request_processor.process_requests \
   --year 2025 --session all --source-field not_bunk_with --force --clear-existing --debug 2>&1 | tee /tmp/debug.log
 
 # Search for specific person in logs
-grep "Bauer-Kahan\|6325675" /tmp/debug.log
+grep "Johnson\|1000001" /tmp/debug.log
 
 # Count 400 errors
 grep -c "Status code:400" /tmp/debug.log
 
 # Find AI parse input/output for a name
-grep -A5 "text='Amalia Smith'" /tmp/debug.log
+grep -A5 "text='Riley Sam'" /tmp/debug.log
 ```
 
 ## Summary

--- a/frontend/src/components/admin/lodging/derivedCapacity.test.ts
+++ b/frontend/src/components/admin/lodging/derivedCapacity.test.ts
@@ -4,9 +4,9 @@
  * Every case here is measured against the production shapes in kindred#2079:
  * a two-level container over plain rooms, and the three-level grandparent
  * whose intermediate children are themselves containers with `sleeps = 0`
- * (`gt-tioga`, `gt-tenaya`, `hc-health-center`) — summing immediate children
- * gets that second shape wrong, refusing on exactly the whole-building
- * rollups most worth showing.
+ * (three of them in the registry) — summing immediate children gets that
+ * second shape wrong, refusing on exactly the whole-building rollups most
+ * worth showing.
  */
 import { describe, expect, it } from 'vitest'
 
@@ -56,9 +56,9 @@ describe('derivedWholeHouseSleeps', () => {
   })
 
   it('derives the full leaf total through a three-level grandparent whose intermediate children are unmeasured containers', () => {
-    // Mirrors gt-tioga: two container halves, each sleeps=0, each holding two
-    // measured leaves. Summing immediate children would see two zeros and
-    // refuse; the leaf walk must not.
+    // Mirrors a real halved building: two container halves, each sleeps=0, each
+    // holding two measured leaves. Summing immediate children would see two
+    // zeros and refuse; the leaf walk must not.
     const units = [
       unit({ id: 'gt-tioga', is_container: true }),
       unit({ id: 'gt-tioga-upstairs', parent_unit: 'gt-tioga', is_container: true, sleeps: 0 }),
@@ -72,8 +72,8 @@ describe('derivedWholeHouseSleeps', () => {
   })
 
   it('adds a non-zero own delta to Σ(leaves) rather than replacing it (the double-count guard)', () => {
-    // gt-clouds-rest: the one production container with a real own delta — a
-    // landing futon nothing else in the registry records.
+    // The one production container with a real own delta — a landing futon
+    // nothing else in the registry records.
     const units = [
       unit({ id: 'house', is_container: true }),
       unit({ id: 'room-1', parent_unit: 'house', sleeps: 4 }),

--- a/frontend/src/components/weekend/AssignFamilyModal.tsx
+++ b/frontend/src/components/weekend/AssignFamilyModal.tsx
@@ -169,10 +169,10 @@ function amenityWords(unit: LodgingUnitRow): string[] {
  * combined containers the card says "capacity not recorded" while this header
  * says, correctly, how many beds the rooms beneath it hold:
  *
- *     gt-clouds-rest   own 0, 4 rooms, leaves sum 8
- *     gt-wawona        own 0, 2 rooms, leaves sum 7
- *     hc-downstairs    own 0, 2 rooms, leaves sum 5
- *     hc-doctors-house own 0, 2 rooms, leaves sum 5
+ *     container 1   own 0, 4 rooms, leaves sum 8
+ *     container 2   own 0, 2 rooms, leaves sum 7
+ *     container 3   own 0, 2 rooms, leaves sum 5
+ *     container 4   own 0, 2 rooms, leaves sum 5
  *
  * THIS surface is the correct one — `countUnmeasuredSpaces` and the map peek
  * already use `effectiveSleeps`, and the card is the only reader of the raw

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -734,8 +734,8 @@ export function LodgingUnitCard({
    * survive the box becoming the ONLY way to write somebody in. The owner hit
    * it on a merged building:
    *
-   *   > "if i populate 3/4 of clouds rest, i cannot add a write in directly
-   *   >  to it"
+   *   > "if i populate 3/4 of [a merged building], i cannot add a write in
+   *   >  directly to it"
    *
    * — because the strip's "Write in" action refused an occupied card (#2090)
    * and this box was hidden by the same condition, so a partly-filled merged

--- a/frontend/src/components/weekend/MapUnitPopover.tsx
+++ b/frontend/src/components/weekend/MapUnitPopover.tsx
@@ -362,10 +362,11 @@ interface ClusterNames {
  * in the header instead.
  *
  * Found in a browser, not by a test: a four-room house rendered every cell as
- * "Clouds Rest Ba…", "Clouds Rest La…", "Clouds Rest Loft", "Clouds Rest Si…" —
- * the shared prefix consumed the width and truncated away the only part that
- * told them apart. Stripping the common leading WORDS leaves "Back", "Landing",
- * "Loft", "Side", with "Clouds Rest" moved to the header.
+ * the building's two-word name followed by a truncated room word — "<House>
+ * Ba…", "<House> La…", "<House> Loft", "<House> Si…". The shared prefix
+ * consumed the width and truncated away the only part that told them apart.
+ * Stripping the common leading WORDS leaves "Back", "Landing", "Loft",
+ * "Side", with the building name moved to the header.
  *
  * Never strips a name to nothing: the walk stops while every name still has a
  * word left. Returns the names untouched, and an empty prefix, when they

--- a/frontend/src/components/weekend/unitLevel.test.ts
+++ b/frontend/src/components/weekend/unitLevel.test.ts
@@ -168,8 +168,8 @@ describe('coveredCodes', () => {
 })
 
 // house -> {upstairs, downstairs} -> two rooms each. Mirrors the real halved
-// buildings (e.g. gt-tioga-upstairs/gt-tioga-downstairs, measured against
-// production) the grain ruling on #2008 is about: each half is independently
+// buildings (upstairs/downstairs pairs, measured against production) the
+// grain ruling on #2008 is about: each half is independently
 // lettable and carries its own bathroom_group, so it is a DIFFERENT building
 // from its sibling half under the IMMEDIATE-PARENT grain even though both
 // share one root.

--- a/pocketbase/lodging/registry_alias_target_test.go
+++ b/pocketbase/lodging/registry_alias_target_test.go
@@ -14,8 +14,8 @@ import (
 // This class had no writer at all until it was found by hand on 2026-08-03:
 // A parenthesised trailer alias resolved to the numbered room sharing its
 // stem instead of the trailer's own unit, which left the trailer unreachable
-// and made that area
-// 7 a double-booking candidate -- one string, two rooms, no error anywhere.
+// and made the numbered room it collided with a double-booking candidate --
+// one string, two rooms, no error anywhere.
 //
 // Nothing existing can see it. verify-lodging-seed.sh asserts the database
 // matches the registry file field by field, and diff_lodging_registry.py
@@ -26,26 +26,26 @@ import (
 // every code named is a real unit.
 //
 // The invariant that does see it: an alias string that is EXACTLY some unit's
-// name must resolve to that unit. The parenthesised trailer alias is verbatim the
-// name of manzanita-new-trailer, so an alias spelling it and resolving
+// name must resolve to that unit. The parenthesised trailer alias is verbatim
+// the name of the trailer's own unit, so an alias spelling it and resolving
 // elsewhere is a misdirection rather than a synonym.
 //
 // A merge is not a violation. A 2+ member alias is a legitimate shorthand when
 // the unit it names is among its targets (the first room of a merged pair);
 // it is only wrong when the named unit is absent from its own alias.
 //
-// Nor is a container resolving to its own rooms. "Health Center Downstairs" and
-// "Forest Village 5" both name a container and resolve to its children, which
-// is what booking a whole building HAS to mean: the container is not bookable
-// itself, so the alias has to name the rooms it is made of. That is the same
-// whole-versus-split distinction a multi-room building turns on. Requiring the container
+// Nor is a container resolving to its own rooms. Two seeded aliases each name
+// a container and resolve to that container's children, which is what booking
+// a whole building HAS to mean: the container is not bookable itself, so the
+// alias has to name the rooms it is made of. That is the same whole-versus-
+// split distinction a multi-room building turns on. Requiring the container
 // to appear in its own member list would flag both of these real rows.
 //
 // Deliberately NOT a fuzzy check. It fires only on an exact name collision, so
-// a genuine synonym ("Teen Village 1" for forest-village-1, whose name is
-// different) is untouched. The alternative -- scoring how well an alias
-// resembles its target -- would re-derive its answers on data nobody is
-// looking at, which is what put the wrong code in the file to begin with.
+// a genuine synonym -- a CampMinder spelling that matches no unit's registry
+// name -- is untouched. The alternative, scoring how well an alias resembles
+// its target, would re-derive its answers on data nobody is looking at, which
+// is what put the wrong code in the file to begin with.
 
 type misdirectedAlias struct {
 	AliasString string
@@ -55,7 +55,7 @@ type misdirectedAlias struct {
 
 // aliasNameKey normalises the way the Go resolver's aliasLookupKey does: outer
 // whitespace and case only. Inner spacing stays significant, because one seeded
-// alias ("Health Center Downstairs  - Room A") genuinely carries a double space.
+// alias genuinely carries a double space.
 func aliasNameKey(s string) string { return strings.ToLower(strings.TrimSpace(s)) }
 
 func findMisdirectedAliases(units []registryUnit, aliases []registryAlias) []misdirectedAlias {
@@ -151,8 +151,9 @@ func TestFindMisdirectedAliasesAllowsACorrectlyTargetedAlias(t *testing.T) {
 
 func TestFindMisdirectedAliasesAllowsASynonymThatNamesNoUnit(t *testing.T) {
 	t.Parallel()
-	// "Teen Village 1" is the CampMinder spelling; the unit is "Forest Village
-	// 1". The string matches no unit name, so the check must stay silent.
+	// The alias below carries the CampMinder spelling and the unit carries the
+	// registry name; the two differ, so the string matches no unit name and the
+	// check must stay silent.
 	units := []registryUnit{{Code: "forest-village-1", Name: "Forest Village 1"}}
 	aliases := []registryAlias{
 		{AliasString: "Teen Village 1", MemberUnits: []string{"forest-village-1"}},
@@ -196,8 +197,8 @@ func TestFindMisdirectedAliasesFlagsAMergeThatExcludesTheUnitItNames(t *testing.
 
 func TestFindMisdirectedAliasesAllowsAContainerNamingItsOwnRooms(t *testing.T) {
 	t.Parallel()
-	// The real case: "Health Center Downstairs" is a container, so booking it
-	// has to mean booking the rooms inside it.
+	// The real case: the aliased unit below is a container, so booking it has to
+	// mean booking the rooms inside it.
 	units := []registryUnit{
 		{Code: "hc-downstairs", Name: "Health Center Downstairs", IsContainer: true},
 		{Code: "hc-downstairs-a", Name: "Room A", ParentUnit: "hc-downstairs"},

--- a/pocketbase/lodging/registry_alias_target_test.go
+++ b/pocketbase/lodging/registry_alias_target_test.go
@@ -12,8 +12,9 @@ import (
 // Guards an alias that EXISTS but points at the wrong unit.
 //
 // This class had no writer at all until it was found by hand on 2026-08-03:
-// "New Trailer (Manzanitas)" resolved to manzanita-7 instead of
-// manzanita-new-trailer, which left the trailer unreachable and made Manzanita
+// A parenthesised trailer alias resolved to the numbered room sharing its
+// stem instead of the trailer's own unit, which left the trailer unreachable
+// and made that area
 // 7 a double-booking candidate -- one string, two rooms, no error anywhere.
 //
 // Nothing existing can see it. verify-lodging-seed.sh asserts the database
@@ -25,19 +26,19 @@ import (
 // every code named is a real unit.
 //
 // The invariant that does see it: an alias string that is EXACTLY some unit's
-// name must resolve to that unit. "New Trailer (Manzanitas)" is verbatim the
+// name must resolve to that unit. The parenthesised trailer alias is verbatim the
 // name of manzanita-new-trailer, so an alias spelling it and resolving
 // elsewhere is a misdirection rather than a synonym.
 //
 // A merge is not a violation. A 2+ member alias is a legitimate shorthand when
-// the unit it names is among its targets ("Tioga 1" for the merged 1+2 pair);
+// the unit it names is among its targets (the first room of a merged pair);
 // it is only wrong when the named unit is absent from its own alias.
 //
 // Nor is a container resolving to its own rooms. "Health Center Downstairs" and
 // "Forest Village 5" both name a container and resolve to its children, which
 // is what booking a whole building HAS to mean: the container is not bookable
 // itself, so the alias has to name the rooms it is made of. That is the same
-// whole-versus-split distinction Clouds Rest turns on. Requiring the container
+// whole-versus-split distinction a multi-room building turns on. Requiring the container
 // to appear in its own member list would flag both of these real rows.
 //
 // Deliberately NOT a fuzzy check. It fires only on an exact name collision, so

--- a/pocketbase/pb_migrations/1500000116_lodging_areas_units.js
+++ b/pocketbase/pb_migrations/1500000116_lodging_areas_units.js
@@ -82,7 +82,8 @@ migrate((app) => {
       { type: "bool", name: "is_confirmed", required: false, presentable: false },
       { type: "bool", name: "is_active", required: false, presentable: false },
       // true = a building/grouping row that must never be booked or counted
-      // toward capacity (e.g. gt-tenaya, the building containing gt-tenaya-1..4).
+      // toward capacity (e.g. a building row whose four numbered rooms are the
+      // bookable units).
       // false = an ordinary bookable room. PocketBase's default for an unset
       // bool is false, which is the safe default for units staff add later
       // through the admin UI.

--- a/pocketbase/pb_migrations/1500000116_lodging_areas_units.js
+++ b/pocketbase/pb_migrations/1500000116_lodging_areas_units.js
@@ -7,7 +7,8 @@
  * and fully editable in the Family Camp admin UI — no unit list lives in
  * source code. 1500000120 seeded it until the data moved out of this repo.
  *
- * lodging_units holds ATOMIC rooms. Merges (e.g. "Tenaya 1and2") are separate
+ * lodging_units holds ATOMIC rooms. Merges (a staff string naming two adjacent
+ * rooms at once) are separate
  * rows in lodging_merges, not parent activations, because merges are frequently
  * partial (2 of a 4-room building).
  *

--- a/pocketbase/pb_migrations/1500000117_lodging_unit_aliases.js
+++ b/pocketbase/pb_migrations/1500000117_lodging_unit_aliases.js
@@ -26,8 +26,8 @@ migrate((app) => {
     updateRule: '@request.auth.is_admin = true',
     deleteRule: '@request.auth.is_admin = true',
     fields: [
-      // Verbatim as it appears in the CampMinder custom field, including any
-      // double spaces (e.g. "Health Center Downstairs  - Room A"). Do not trim.
+      // Verbatim as it appears in the CampMinder custom field, including the
+      // double space one seeded row genuinely carries. Do not trim.
       { type: "text", name: "alias_string", required: true, presentable: true, min: 1, max: 300, pattern: "" },
       {
         type: "relation", name: "member_units", required: true, presentable: false,

--- a/pocketbase/pb_migrations/1500000117_lodging_unit_aliases.js
+++ b/pocketbase/pb_migrations/1500000117_lodging_unit_aliases.js
@@ -3,13 +3,15 @@
  * Migration: lodging_unit_aliases
  *
  * Maps historical free-text cabin strings onto units. TEMPORAL, because renames
- * happened mid-history: "Golden Triangle - Doctor's House" (2022-24) became
- * "Golden Triangle - Wawona" (2025+), while "Health Center - Doctor's House"
- * (2022-24) became the bare "Doctor's House" (2025+).
+ * happened mid-history: one building was renamed outright between 2024 and
+ * 2025, and a second, which had shared its old name, lost its area prefix in
+ * the same season — so the identical free-text string means two different
+ * units depending on the year it was written in.
  *
  * member_units is MULTI-valued so one table covers both cases: a single member
  * resolves to an atomic room; 2+ members denote a merge (see lodging_merges),
- * which backfill materialises as a merge row. e.g. "Tenaya 1and2" -> {Tenaya 1, Tenaya 2}.
+ * which backfill materialises as a merge row: one free-text string naming two
+ * adjacent rooms resolves to both of their unit rows.
  */
 
 migrate((app) => {

--- a/pocketbase/pb_migrations/1500000118_lodging_merges_availability.js
+++ b/pocketbase/pb_migrations/1500000118_lodging_merges_availability.js
@@ -4,7 +4,8 @@
  *
  * lodging_merges binds an explicit SET of atomic units into one bookable slot
  * for one weekend. Member sets rather than parent/child toggles because merges
- * are frequently partial: "Tenaya 1and2" merges 2 rooms of a 4-room building,
+ * are frequently partial: a single staff-written string routinely merges 2
+ * rooms of a 4-room building,
  * which a parent-activation model cannot express.
  *
  * Merges are created MID-ASSIGNMENT as a board action (select adjacent rooms,

--- a/pocketbase/sync/lodging_alias_resolver_test.go
+++ b/pocketbase/sync/lodging_alias_resolver_test.go
@@ -9,9 +9,9 @@ import (
 // not NULL. 94 of the 100 seeded alias rows are unbounded, so a resolver that
 // reads 0 as a real lower bound resolves almost nothing.
 //
-// "ridge-a" gets one lodging_units row per tested year -- the registry itself
-// is year-scoped now (migration 1500000141), so a cabin that was never renamed
-// still has a distinct record, and id, every season. The alias's own window
+// The seeded cabin gets one lodging_units row per tested year -- the registry
+// itself is year-scoped now (migration 1500000141), so a cabin that was never
+// renamed still has a distinct record, and id, every season. The alias's own window
 // stays unbounded throughout: this test is about the ALIAS STRING resolving at
 // any year, not about one unit id surviving across years.
 func TestAliasResolverUnboundedWindows(t *testing.T) {
@@ -43,10 +43,11 @@ func TestAliasResolverUnboundedWindows(t *testing.T) {
 	}
 }
 
-// TestAliasResolverRespectsRenameWindows is the load-bearing case. Both
-// Two same-named buildings existed 2022-2024; the one in the first area was renamed
-// in 2025. Resolving either side into the other silently relocates a household
-// across camp, and nothing downstream would notice.
+// TestAliasResolverRespectsRenameWindows is the load-bearing case. Two
+// same-named buildings sat in different areas from 2022 to 2024, and the one
+// in the first area was renamed in 2025. Resolving either side into the other
+// silently relocates a household across camp, and nothing downstream would
+// notice.
 func TestAliasResolverRespectsRenameWindows(t *testing.T) {
 	t.Parallel()
 	app := newSyncTestApp(t)
@@ -65,7 +66,7 @@ func TestAliasResolverRespectsRenameWindows(t *testing.T) {
 		gtWawonaByYear[year] = addUnit(t, app, "gt-wawona", year)
 		hcDoctorsByYear[year] = addUnit(t, app, "hc-doctors-house", year)
 	}
-	// The 2025 split of the Golden Triangle house into two lettable rooms.
+	// The 2025 split of the first area's house into two lettable rooms.
 	// Never resolved directly here -- only named as members of an alias nothing
 	// in this test calls Resolve on -- so 2025 alone is enough.
 	gtFront := addUnit(t, app, "gt-wawona-front", 2025)
@@ -116,7 +117,7 @@ func TestAliasResolverRespectsRenameWindows(t *testing.T) {
 		t.Errorf("2024 HC Doctor's House (inclusive upper boundary): %+v", got)
 	}
 	// Out of window on the high side -- the string was retired, so it must NOT
-	// silently fall through to the Health Center row of the same shape. Both
+	// silently fall through to the other area's row of the same shape. Both
 	// buildings have a 2025 row, so only the window can refuse these.
 	if got := r.Resolve("Golden Triangle - Doctor's House", 2025); got.Resolved {
 		t.Errorf("2025 GT Doctor's House resolved to %v; the window ends at 2024", got.UnitCodes)
@@ -124,8 +125,8 @@ func TestAliasResolverRespectsRenameWindows(t *testing.T) {
 	if got := r.Resolve("Health Center - Doctor's House", 2025); got.Resolved {
 		t.Errorf("2025 HC Doctor's House resolved to %v; the window ends at 2024", got.UnitCodes)
 	}
-	// Out of window on the low side. hc-doctors-house has a 2024 row, so only
-	// the window can refuse this.
+	// Out of window on the low side. The second area's unit has a 2024 row, so
+	// only the window can refuse this.
 	if got := r.Resolve("Doctor's House", 2024); got.Resolved {
 		t.Errorf("2024 bare Doctor's House resolved to %v; the window starts at 2025", got.UnitCodes)
 	}
@@ -164,10 +165,11 @@ func TestAliasResolverMergeDenotingAlias(t *testing.T) {
 	}
 }
 
-// TestAliasResolverUnresolvedIsNotAnError: four strings observed 2022-2023 have
-// no alias row at all -- "Ridge 2", "River Side - R1", "River Side - R2",
-// an unknown cabin string. It must come back unresolved, with the raw string preserved,
-// and must not panic or error.
+// TestAliasResolverUnresolvedIsNotAnError: the four strings below were all
+// observed in 2022-2023 data and none of them has an alias row -- three are
+// free-text cabin spellings the seed never carried, the fourth is a numbered
+// room. Each must come back unresolved, with the raw string preserved, and
+// must not panic or error.
 func TestAliasResolverUnresolvedIsNotAnError(t *testing.T) {
 	t.Parallel()
 	app := newSyncTestApp(t)
@@ -193,7 +195,7 @@ func TestAliasResolverUnresolvedIsNotAnError(t *testing.T) {
 }
 
 // TestAliasResolverToleratesWhitespaceAndCase: the seed stores strings verbatim,
-// including the real double space in "Health Center Downstairs  - Room A", but
+// including the real double space one seeded alias string carries, but
 // CampMinder values are hand-entered. Lookup normalises case and outer
 // whitespace; inner spacing stays significant because the seed relies on it.
 func TestAliasResolverToleratesWhitespaceAndCase(t *testing.T) {

--- a/pocketbase/sync/lodging_alias_resolver_test.go
+++ b/pocketbase/sync/lodging_alias_resolver_test.go
@@ -44,7 +44,7 @@ func TestAliasResolverUnboundedWindows(t *testing.T) {
 }
 
 // TestAliasResolverRespectsRenameWindows is the load-bearing case. Both
-// Doctor's Houses existed 2022-2024; the Golden Triangle one was renamed Wawona
+// Two same-named buildings existed 2022-2024; the one in the first area was renamed
 // in 2025. Resolving either side into the other silently relocates a household
 // across camp, and nothing downstream would notice.
 func TestAliasResolverRespectsRenameWindows(t *testing.T) {
@@ -166,7 +166,7 @@ func TestAliasResolverMergeDenotingAlias(t *testing.T) {
 
 // TestAliasResolverUnresolvedIsNotAnError: four strings observed 2022-2023 have
 // no alias row at all -- "Ridge 2", "River Side - R1", "River Side - R2",
-// "Tuolumne 7". They must come back unresolved, with the raw string preserved,
+// an unknown cabin string. It must come back unresolved, with the raw string preserved,
 // and must not panic or error.
 func TestAliasResolverUnresolvedIsNotAnError(t *testing.T) {
 	t.Parallel()

--- a/pocketbase/sync/lodging_assignments_sync_test.go
+++ b/pocketbase/sync/lodging_assignments_sync_test.go
@@ -269,7 +269,7 @@ func TestLodgingAssignmentsSyncRespectsStaffTouched(t *testing.T) {
 	}
 }
 
-// TestLodgingAssignmentsSyncQueuesUnresolvedAlias: "Tuolumne 7" has no alias row
+// TestLodgingAssignmentsSyncQueuesUnresolvedAlias: an unknown cabin string has no alias row
 // -- one of four such strings in the real 2022/2023 data. It must become a work
 // queue item and must not be dropped, and must not stop the run.
 func TestLodgingAssignmentsSyncQueuesUnresolvedAlias(t *testing.T) {
@@ -277,7 +277,7 @@ func TestLodgingAssignmentsSyncQueuesUnresolvedAlias(t *testing.T) {
 	app := newSyncTestApp(t)
 	sess := addSession(t, app, cmIDFamilyCamp1, "Family Camp 1", "family",
 		"2025-05-23 07:00:00.000Z", "2025-05-26 07:00:00.000Z", 2025)
-	// Unrelated to "Tuolumne 7" below -- this only gives 2025 a registry, so
+	// Unrelated to the unknown cabin string below -- this only gives 2025 a registry, so
 	// Sync's #2061 year guard (no lodging_units rows for the year) does not
 	// intercept before reaching alias resolution. Without it, this fixture is
 	// indistinguishable from "no registry loaded at all," and the case this
@@ -361,7 +361,8 @@ func TestLodgingAssignmentsSyncQueuesAmbiguousSession(t *testing.T) {
 }
 
 // TestIngestWritesAMultiRoomPlacementAsOneRow closes the case that used to
-// create a merge row: "Golden Triangle - Tioga 1and2" resolves to two units,
+// create a merge row: an area-prefixed string naming two adjacent rooms
+// resolves to two units,
 // so a two-room alias lands as one assignment naming both -- see placementFor.
 // A merged slot is the alias's own member set, not a row pointing at it.
 func TestIngestWritesAMultiRoomPlacementAsOneRow(t *testing.T) {

--- a/pocketbase/sync/lodging_assignments_sync_test.go
+++ b/pocketbase/sync/lodging_assignments_sync_test.go
@@ -822,9 +822,9 @@ func TestLodgingAssignmentsSyncMergeLabelIgnoresMemberOrder(t *testing.T) {
 // dangling in member_units stays dangling in units" -- because filtering
 // against lodging_units would silently change what a placement points at.
 // AliasResolver.UnitCode returns the EMPTY STRING for an id it cannot map, so
-// a set holding one dangling id and one real one rendered as "+ridge-a":
-// unitLabel sorts the empty code first and joins it. The freshly resolved
-// label is "ridge-a", the two differ, and upsertAssignment's
+// a set holding one dangling id and one real one renders as "+" followed by
+// the real code: unitLabel sorts the empty code first and joins it. The
+// freshly resolved label is the bare code, the two differ, and upsertAssignment's
 // `oldLabel == in.NewUnitLabel` short-circuit therefore fails to fire -- so
 // writeHistory appends a row claiming the household moved out of a cabin whose
 // name is a leading "+".
@@ -1313,7 +1313,7 @@ func TestLodgingAssignmentsSyncDeletesOrphansViaEnvFallback(t *testing.T) {
 // the orphan sweep must write one too.
 func TestLodgingAssignmentsSyncWritesHistoryOnOrphanDelete(t *testing.T) {
 	t.Parallel()
-	// unit's own code, not a repeated "ridge-a" literal -- keeps the addUnit
+	// unit's own code, not a repeated string literal -- keeps the addUnit
 	// call and the history assertion below in step, and avoids adding a 3rd/4th
 	// hardcoded occurrence of the string across this file (goconst).
 	const unitCode = "ridge-a"

--- a/pocketbase/sync/lodging_issues_test.go
+++ b/pocketbase/sync/lodging_issues_test.go
@@ -193,7 +193,7 @@ func TestIssueRecorderFlushKeepsAnEarlierSuggestion(t *testing.T) {
 }
 
 // TestIssueRecorderHandlesApostrophes: real cabin strings contain apostrophes
-// ("Golden Triangle - Doctor's House", "Golden Triangle - Cloud's Rest"). A
+// (two area-prefixed building strings from the same area). A
 // filter built by string concatenation would be a syntax error here, which is
 // exactly the class of bug that made Plan 1's alias verifier unable to pass.
 func TestIssueRecorderHandlesApostrophes(t *testing.T) {

--- a/pocketbase/sync/lodging_issues_test.go
+++ b/pocketbase/sync/lodging_issues_test.go
@@ -36,10 +36,10 @@ func TestIssueKindsMatchTheMigration(t *testing.T) {
 	}
 }
 
-// TestIssueRecorderCollapsesRepeats mirrors the real 2022 backfill: the cabin
-// string "River Side - R1" appears on five different households and has no alias
-// row. That is ONE thing for staff to fix, so it must be one queue item with an
-// occurrence count -- not five rows to wade through.
+// TestIssueRecorderCollapsesRepeats mirrors the real 2022 backfill: one cabin
+// string appeared on five different households and had no alias row. That is
+// ONE thing for staff to fix, so it must be one queue item with an occurrence
+// count -- not five rows to wade through.
 func TestIssueRecorderCollapsesRepeats(t *testing.T) {
 	t.Parallel()
 	app := newSyncTestApp(t)

--- a/scripts/dev/lib/drop_comment_hits.py
+++ b/scripts/dev/lib/drop_comment_hits.py
@@ -34,9 +34,19 @@ SCOPE, honestly stated, matching the guard this serves:
     source. The fusion only fires when `{`/`}` sit flush against `/*`/`*/`
     (no space), so `{ /* note */ x() }` -- real code around a comment -- is
     untouched.
-  * A file that will not parse or read is treated as ALL CODE, so its hits
-    survive. A guard that goes quiet because a file is malformed is worse than
-    one that reports a line you have to read.
+  * `.sh` files recognize a `#` comment, on the same whole-line rule the
+    C-style scanner uses: a line counts only when there is nothing on it but
+    comment. The guard greps `*.sh`, so without this a shell comment came back
+    classified as code -- which under `--only-comments` means EXEMPT, and the
+    rule table's "a test file -> comment hits fail" was simply untrue for
+    shell (kindred#2512 review).
+  * A file that cannot be read, will not parse, or has a suffix with no scanner
+    here yields None -- "we learned nothing" -- and main() writes its hits
+    through in BOTH modes. That is what fail-open has to mean once
+    `--only-comments` exists: under that flag "treat it as all code" would
+    DROP every hit rather than keep it, so the promise inverted itself exactly
+    where the guard relies on it. A guard that goes quiet because a file is
+    malformed is worse than one that reports a line you have to read.
 """
 
 from __future__ import annotations
@@ -52,9 +62,26 @@ C_STYLE_SUFFIXES = {".go", ".js", ".jsx", ".ts", ".tsx"}
 # .go/.js/.ts file's `{ /* note */ }` (a real block scoping a comment) never
 # gets the fused-brace treatment meant only for JSX's own comment syntax.
 JSX_SUFFIXES = {".jsx", ".tsx"}
+# Files whose comments start with `#`. Kept in step with the guard's own
+# --include list: every suffix it greps needs a scanner here, or that suffix's
+# comment hits are misclassified as code and exempted in test files.
+HASH_STYLE_SUFFIXES = {".sh"}
 
 
-def _python_noncode_lines(source: str) -> set[int]:
+def _hash_style_noncode_lines(source: str) -> set[int]:
+    """Line numbers whose only content is a `#` comment.
+
+    Deliberately not a shell parser. It marks a line non-code when its first
+    non-blank character is `#`, which is right for a comment line and right to
+    refuse for `UNITS=(...)  # note` -- a needle in the code half of a mixed
+    line must still report. The known imprecision is a heredoc body line that
+    begins with `#`; that direction over-reports under `--only-comments`, which
+    is the safe way to be wrong here.
+    """
+    return {lineno for lineno, line in enumerate(source.splitlines(), start=1) if line.lstrip().startswith("#")}
+
+
+def _python_noncode_lines(source: str) -> set[int] | None:
     """Line numbers occupied by a comment or a docstring."""
     noncode: set[int] = set()
 
@@ -69,12 +96,17 @@ def _python_noncode_lines(source: str) -> set[int]:
         # it for the repo's 3.14 target and rewrites a tuple into the
         # bare-comma form that older interpreters reject. Any tokenize failure
         # means the same thing anyway -- we learned nothing, so keep every hit.
-        return set()
+        return None
 
     try:
         tree = ast.parse(source)
     except SyntaxError:
-        return noncode
+        # Comments found by the tokenizer are real, but the docstring scan
+        # below never ran, so the classification is incomplete. Report unknown
+        # rather than a partial answer: an unfound docstring line would be
+        # dropped as "code" under --only-comments, which is the failure mode
+        # this whole return type exists to prevent.
+        return None
 
     for node in ast.walk(tree):
         if not isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -170,22 +202,30 @@ def _c_style_noncode_lines(source: str, *, jsx: bool = False) -> set[int]:
     return noncode
 
 
-def noncode_lines(path: Path) -> set[int]:
+def noncode_lines(path: Path) -> set[int] | None:
+    """Comment/docstring line numbers, or None when they cannot be determined.
+
+    None is not "no comments" -- it is "we learned nothing about this file",
+    and main() keeps every hit in such a file regardless of which way the
+    filter points.
+    """
     try:
         source = path.read_text(encoding="utf-8", errors="replace")
     except OSError:
-        return set()
+        return None
 
     if path.suffix == ".py":
         return _python_noncode_lines(source)
     if path.suffix in C_STYLE_SUFFIXES:
         return _c_style_noncode_lines(source, jsx=path.suffix in JSX_SUFFIXES)
-    return set()
+    if path.suffix in HASH_STYLE_SUFFIXES:
+        return _hash_style_noncode_lines(source)
+    return None
 
 
 def main() -> int:
     only_comments = "--only-comments" in sys.argv[1:]
-    cache: dict[str, set[int]] = {}
+    cache: dict[str, set[int] | None] = {}
     for raw in sys.stdin:
         hit = raw.rstrip("\n")
         if not hit:
@@ -200,7 +240,14 @@ def main() -> int:
         path, lineno = parts[0], int(parts[1])
         if path not in cache:
             cache[path] = noncode_lines(Path(path))
-        is_comment = lineno in cache[path]
+        classified = cache[path]
+        if classified is None:
+            # Fail open, in BOTH modes -- see the module docstring. Keeping the
+            # hit costs a line someone has to read; dropping it is how a real
+            # leak goes unreported because a file happened not to parse.
+            print(hit)
+            continue
+        is_comment = lineno in classified
         if is_comment == only_comments:
             print(hit)
     return 0

--- a/scripts/dev/test-verify-no-hardcoded-lodging.sh
+++ b/scripts/dev/test-verify-no-hardcoded-lodging.sh
@@ -4,13 +4,19 @@
 # Verifies the guard actually catches a leak (exit 1, naming file:line) and
 # is quiet on a clean tree (exit 0).
 #
-# Probe filenames are chosen deliberately: they must NOT match `_test.`,
-# `.test.`, or `/tests?/`, because the guard itself excludes any hit whose
-# path matches those patterns (grep -v '_test\.\|\.test\.\|/tests\?/') --
-# meant to skip the guard's own test fixtures, not to be a loophole. A probe
-# planted with one of those names would report a false green regardless of
-# what it contains. This happened once already during review of kindred#1867,
-# which is exactly why this test exists (kindred#1869).
+# Probe filenames are chosen deliberately: a probe meant to test CODE hits
+# must NOT match `_test.`, `.test.` or a `tests?/` path segment, because the
+# guard exempts code hits in a test file (the exemption exists for fixture
+# data, not as a loophole). A code probe planted with one of those names would
+# report a false green regardless of what it contains. This happened once
+# already during review of kindred#1867, which is exactly why this test exists
+# (kindred#1869).
+#
+# COMMENT hits are a different matter since kindred#2512: they fail in a test
+# file too, so the probes that deliberately DO carry a test-shaped name
+# (TESTs 10, 12, 13, 18, 20, 21) plant comments and assert exit 1. The guard
+# decides which bucket a hit lands in from the PATH FIELD alone -- TESTs 14-16
+# pin that, after a first cut let a line's own text choose its bucket.
 
 set -euo pipefail
 
@@ -233,14 +239,20 @@ echo "=== TEST 7: a needle on the CLOSING line of a multi-line JSX comment MUST 
 # `{`/`}` scaffolding survived that strip as leftover "code", so this needle
 # never got dropped even though it sits in ordinary documentation prose.
 #
-# ⚠️ INVERTED IN kindred#2512, and the inversion makes this probe MORE
-# valuable, not redundant. Comments now fail everywhere, so the dropper no
-# longer decides whether a comment leaks -- but it still decides whether a
-# line is reported as a comment hit or a code hit, and this shape is the one
-# that has historically confused it. Asserting the needle is REPORTED keeps
-# the #2181 regression covered: a dropper that mis-parsed this line back into
-# "code" would still fail, but a dropper that lost the line entirely would
-# not, and only the assertion below tells those apart.
+# ⚠️ INVERTED IN kindred#2512, and the earlier rationale for the inversion was
+# wrong -- corrected in that PR's review after instrumenting the guard. Since
+# comments fail everywhere, a NON-test .tsx like this probe never reaches
+# drop_comment_hits.py at all: the hit is reported straight out of the
+# not-a-test bucket. So this test no longer covers the #2181 fused-brace
+# parsing in any way, and it passes with that logic deleted -- measured, not
+# assumed.
+#
+# What it does still prove is worth keeping: a needle sitting inside a
+# multi-line JSX comment in an ordinary frontend component is REPORTED, which
+# is the exact file shape and comment shape that carried a real unit name on
+# `main` until #2178. TEST 21 is the one that covers the fused-brace
+# classification, by planting the same shape in a TEST file so the hit has to
+# go through the dropper to be seen.
 TSX_PROBE="$REPO_ROOT/frontend/src/leak_probe_kindred2181.tsx"
 cleanup4() { rm -f "$TSX_PROBE"; }
 trap 'cleanup4; cleanup3; cleanup' EXIT INT TERM
@@ -418,15 +430,19 @@ fi
 
 echo
 echo "=== TEST 13: a needle in a COMMENT under frontend/src/test/ (shared test helpers, not *.test.ts) must exit 1 too ==="
-# FRONTEND_TEST_PATTERN is '^frontend/src/.*(_test\.|\.test\.|/tests?/)'. A
-# file directly under frontend/src/test/ -- the repo's real shared test-helper
-# directory (mockData.ts, mocks/, testUtils.tsx, test-helpers.ts) -- has no
-# '_test.' or '.test.' in its filename, so it can only match via '/tests?/'.
-# It does match that alternative ('/test/' is 'tests?' with the optional s
-# absent), which routes it into OTHER_RAW's blanket exemption instead of
-# FRONTEND_TEST_RAW's comment-only scan -- so a comment leak here sails
-# through exactly the same way test-file comments used to everywhere, the gap
-# kindred#2367 exists to close for frontend/src/**.
+# A file directly under frontend/src/test/ -- the repo's real shared
+# test-helper directory (mockData.ts, mocks/, testUtils.tsx, test-helpers.ts)
+# -- has no '_test.' or '.test.' in its filename, so the guard's split can only
+# recognise it as a test file through the 'tests?/' path-segment alternative
+# ('/test/' is 'tests?' with the optional s absent). kindred#2367 added that
+# alternative after a leak here fell through to the blanket code-hit exemption
+# instead of the comment scan.
+#
+# The variable names this comment used to cite (FRONTEND_TEST_PATTERN,
+# FRONTEND_TEST_RAW) went away with the frontend-only scoping in kindred#2512;
+# the property they existed for is now carried by TEST_FILE_PATTERN's
+# '^(.*/)?tests?/' alternative, and losing its '^' anchor is what TESTs 14-16
+# exist to catch.
 FE_TEST_DIR_PROBE="$REPO_ROOT/frontend/src/test/leak_probe_kindred2367_dir.ts"
 cleanup10() { rm -f "$FE_TEST_DIR_PROBE"; }
 trap 'cleanup10; cleanup9; cleanup8; cleanup7; cleanup6; cleanup5; cleanup4; cleanup3; cleanup' EXIT INT TERM

--- a/scripts/dev/test-verify-no-hardcoded-lodging.sh
+++ b/scripts/dev/test-verify-no-hardcoded-lodging.sh
@@ -41,7 +41,7 @@ fi
 echo "=== TEST 1: needles in application CODE should exit 1 and name file:line ==="
 # Probes are code, not comments: spec 3.8 forbids the registry living in
 # source, and a registry lives in string literals. Comments are covered by
-# TEST 4, which requires the opposite result.
+# TEST 4, which since kindred#2512 requires the SAME result.
 echo 'const UNITS = ["Tuolumne 1"]' > "$JS_PROBE"
 echo 'UNITS = ["Manzanita 3"]' > "$PY_PROBE"
 
@@ -106,12 +106,26 @@ else
 fi
 
 echo
-echo "=== TEST 4: needles in comments and docstrings should NOT fail the guard ==="
-# kindred#1891: the guard failed on api/services/lodging_rules.py, whose
-# docstring names two units to explain why merging changes bathroom privacy.
-# That is prose about a rule, not the registry living in code -- and because
-# HANDOFF tells the next agent to run this gate, it opened Phase C on a red
-# that was not theirs.
+echo "=== TEST 4: needles in comments and docstrings MUST fail the guard ==="
+# ⚠️ THIS TEST WAS INVERTED IN kindred#2512. It asserted the opposite until
+# then -- that prose naming a unit does NOT trip the guard -- and this is a
+# REWRITE, not an adaptation: the specification changed, the implementation
+# did not drift from it.
+#
+# The original reasoning (kindred#1891) was that a docstring naming two units
+# to explain why merging changes bathroom privacy is "prose about a rule, not
+# the registry living in code", and that failing on it opened an unrelated
+# phase on a red that was not theirs.
+#
+# What that reasoning missed: a comment is source. It ships in the repo and a
+# public repo leaks it exactly as a literal does. The exemption is how a real
+# building name sat in an `api/` docstring, in three migration headers, in a
+# `frontend/src/**` component comment and in eleven Go test comments while
+# this guard reported OK -- eighteen hits, found only by widening the scan by
+# hand. All were rewritten without losing their explanatory force, which is
+# the point: prose can say what it needs to say without naming a building.
+#
+# The 1891 objection is spent -- that very docstring is one of the eighteen.
 cat > "$PY_PROBE" <<'PROBE'
 """Module docstring naming Tuolumne 1 and Tuolumne 2 to explain a rule."""
 
@@ -135,10 +149,19 @@ OUT=$("$GUARD_SCRIPT" 2>&1)
 rc=$?
 set -e
 rm -f "$JS_PROBE" "$PY_PROBE"
-if [[ $rc -eq 0 ]]; then
-  echo "PASS: prose in comments and docstrings does not trip the guard"
+if [[ $rc -eq 1 ]]; then
+  # Assert it names BOTH probes, not merely that something failed: a guard
+  # that caught only the Python docstring and silently dropped the JS comment
+  # would still exit 1 here and would still be half broken.
+  if grep -q "leak_probe_kindred1869.py" <<<"$OUT" && grep -q "leak_probe_kindred1869.js" <<<"$OUT"; then
+    echo "PASS: prose in comments and docstrings trips the guard, in both languages"
+  else
+    echo "FAIL: exit 1 but the report did not name both probes" >&2
+    echo "$OUT" >&2
+    exit 1
+  fi
 else
-  echo "FAIL: expected exit 0 for comment/docstring-only mentions, got $rc" >&2
+  echo "FAIL: expected exit 1 for comment/docstring mentions, got $rc" >&2
   echo "$OUT" >&2
   exit 1
 fi
@@ -149,7 +172,8 @@ echo "=== TEST 5: a unit list in a MIGRATION should exit 1 ==="
 # directory entirely. Now that the data lives in the private
 # config/lodging_registry.json, the exclusion would be a hole in exactly the
 # place a future seed would land -- this asserts it is gone. Prose in a
-# migration is still fine; TEST 4 covers that, and this probe is a literal.
+# migration is NO LONGER fine either (kindred#2512 inverted TEST 4); this
+# probe is a literal, which has always failed.
 MIG_PROBE="$REPO_ROOT/pocketbase/pb_migrations/9999999999_leak_probe_kindred1909.js"
 cleanup3() { rm -f "$MIG_PROBE"; }
 trap 'cleanup3; cleanup' EXIT INT TERM
@@ -200,7 +224,7 @@ fi
 echo "PASS: a failed scan exits 2 and says so"
 
 echo
-echo "=== TEST 7: a needle on the CLOSING line of a multi-line JSX comment should NOT fail ==="
+echo "=== TEST 7: a needle on the CLOSING line of a multi-line JSX comment MUST fail ==="
 # kindred#2181: this is the exact shape that carried a real unit name past
 # review on `main` until #2178 scrubbed it at the source -- a two-line JSX
 # {/* ... */} comment whose needle sits on the second line, alongside the
@@ -208,6 +232,15 @@ echo "=== TEST 7: a needle on the CLOSING line of a multi-line JSX comment shoul
 # to be blank once comment content was stripped, and a JSX comment's own
 # `{`/`}` scaffolding survived that strip as leftover "code", so this needle
 # never got dropped even though it sits in ordinary documentation prose.
+#
+# ⚠️ INVERTED IN kindred#2512, and the inversion makes this probe MORE
+# valuable, not redundant. Comments now fail everywhere, so the dropper no
+# longer decides whether a comment leaks -- but it still decides whether a
+# line is reported as a comment hit or a code hit, and this shape is the one
+# that has historically confused it. Asserting the needle is REPORTED keeps
+# the #2181 regression covered: a dropper that mis-parsed this line back into
+# "code" would still fail, but a dropper that lost the line entirely would
+# not, and only the assertion below tells those apart.
 TSX_PROBE="$REPO_ROOT/frontend/src/leak_probe_kindred2181.tsx"
 cleanup4() { rm -f "$TSX_PROBE"; }
 trap 'cleanup4; cleanup3; cleanup' EXIT INT TERM
@@ -227,10 +260,10 @@ OUT=$("$GUARD_SCRIPT" 2>&1)
 rc=$?
 set -e
 rm -f "$TSX_PROBE"
-if [[ $rc -eq 0 ]]; then
-  echo "PASS: a needle on a JSX comment's closing */} line does not trip the guard"
+if [[ $rc -eq 1 ]] && grep -q "leak_probe_kindred2181.tsx" <<<"$OUT"; then
+  echo "PASS: a needle on a JSX comment's closing */} line is reported"
 else
-  echo "FAIL: expected exit 0 for a needle inside a multi-line JSX comment, got $rc" >&2
+  echo "FAIL: expected exit 1 naming the probe for a needle inside a multi-line JSX comment, got $rc" >&2
   echo "$OUT" >&2
   exit 1
 fi
@@ -353,10 +386,19 @@ else
 fi
 
 echo
-echo "=== TEST 12: a needle in a COMMENT inside a non-frontend test file must still exit 0 ==="
-# The comment-scanning widening is deliberately scoped to frontend/src/**
-# (measured blast radius: kindred#2367 PR body). A Go test file's comment
-# stays exempted -- narrowing this far, not repo-wide, is the point.
+echo "=== TEST 12: a needle in a COMMENT inside a non-frontend test file MUST fail too ==="
+# ⚠️ INVERTED IN kindred#2512. This asserted exit 0 until then, because #2367
+# scoped its comment-scanning widening to frontend/src/** and said so:
+# "leaves the pocketbase/ side for a future pass, rather than guessing at
+# files another issue may be mid-edit on". This IS that future pass, so the
+# scoping this test pinned is no longer the spec.
+#
+# It was not a hypothetical gap: eleven real comment hits were sitting in
+# pocketbase/ Go test files, naming buildings and areas, with the guard green
+# on every PR. They are scrubbed in the same change as this inversion.
+#
+# Fixture CODE in a test file remains exempt -- TEST 11 pins that for the
+# frontend and the assertion below deliberately does not extend to it.
 GO_TEST_PROBE="$REPO_ROOT/pocketbase/leak_probe_kindred2367_test.go"
 cleanup9() { rm -f "$GO_TEST_PROBE"; }
 trap 'cleanup9; cleanup8; cleanup7; cleanup6; cleanup5; cleanup4; cleanup3; cleanup' EXIT INT TERM
@@ -366,10 +408,10 @@ OUT=$("$GUARD_SCRIPT" 2>&1)
 rc=$?
 set -e
 rm -f "$GO_TEST_PROBE"
-if [[ $rc -eq 0 ]]; then
-  echo "PASS: a needle in a non-frontend test file's comment is still exempt"
+if [[ $rc -eq 1 ]] && grep -q "leak_probe_kindred2367_test.go" <<<"$OUT"; then
+  echo "PASS: a needle in a non-frontend test file's comment is caught"
 else
-  echo "FAIL: expected exit 0 for a needle in a non-frontend test comment, got $rc" >&2
+  echo "FAIL: expected exit 1 naming the probe for a non-frontend test comment, got $rc" >&2
   echo "$OUT" >&2
   exit 1
 fi

--- a/scripts/dev/test-verify-no-hardcoded-lodging.sh
+++ b/scripts/dev/test-verify-no-hardcoded-lodging.sh
@@ -452,4 +452,235 @@ fi
 echo "PASS: a needle in a frontend/src/test/ file's comment is caught"
 
 echo
+echo "=== TEST 14: a needle in CODE in a NON-test file whose text contains 'tests/' must still fail ==="
+# kindred#2512 review. The test/not-test split is matched against grep's whole
+# `path:lineno:text` line, so before this was fixed a line's CONTENT could route
+# its own file into the test bucket -- where code hits are exempt -- and the
+# leak went unreported. The split now looks at the PATH FIELD ONLY.
+CONTENT_TESTS_PROBE="$REPO_ROOT/api/leak_probe_kindred2512_content.py"
+cleanup11() { rm -f "$CONTENT_TESTS_PROBE"; }
+trap 'cleanup11; cleanup10; cleanup9; cleanup8; cleanup7; cleanup6; cleanup5; cleanup4; cleanup3; cleanup' EXIT INT TERM
+echo 'FIXTURE = "tests/Tuolumne 1.json"' > "$CONTENT_TESTS_PROBE"
+set +e
+OUT=$("$GUARD_SCRIPT" 2>&1)
+rc=$?
+set -e
+rm -f "$CONTENT_TESTS_PROBE"
+if [[ $rc -eq 1 ]] && grep -q "api/leak_probe_kindred2512_content.py:1:" <<<"$OUT"; then
+  echo "PASS: a 'tests/' substring in the LINE does not exempt a non-test file"
+else
+  echo "FAIL: expected exit 1 naming the probe; a line's text routed its file into the test bucket, got $rc" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+
+echo
+echo "=== TEST 15: 'latest/' in a line's text must not exempt a non-test file ==="
+# The nastier half of TEST 14: 'latest/' CONTAINS 'test/', so the unanchored
+# pattern fired on an ordinary version-path string with no test file in sight.
+LATEST_PROBE="$REPO_ROOT/pocketbase/leak_probe_kindred2512_latest.go"
+cleanup12() { rm -f "$LATEST_PROBE"; }
+trap 'cleanup12; cleanup11; cleanup10; cleanup9; cleanup8; cleanup7; cleanup6; cleanup5; cleanup4; cleanup3; cleanup' EXIT INT TERM
+printf 'package pocketbase\n\nvar Path = "latest/Manzanita 3"\n' > "$LATEST_PROBE"
+set +e
+OUT=$("$GUARD_SCRIPT" 2>&1)
+rc=$?
+set -e
+rm -f "$LATEST_PROBE"
+if [[ $rc -eq 1 ]] && grep -q "pocketbase/leak_probe_kindred2512_latest.go:3:" <<<"$OUT"; then
+  echo "PASS: 'latest/' in a line's text does not exempt a non-test file"
+else
+  echo "FAIL: expected exit 1 naming the probe for a 'latest/' string, got $rc" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+
+echo
+echo "=== TEST 16: '_test.' inside a path-like STRING must not exempt a non-test file ==="
+# Covers the other alternative of the split pattern. The needle itself sits
+# inside the path-like literal here, which is how a fixture-path constant in
+# production code would actually look.
+STRPATH_PROBE="$REPO_ROOT/api/leak_probe_kindred2512_strpath.py"
+cleanup13() { rm -f "$STRPATH_PROBE"; }
+trap 'cleanup13; cleanup12; cleanup11; cleanup10; cleanup9; cleanup8; cleanup7; cleanup6; cleanup5; cleanup4; cleanup3; cleanup' EXIT INT TERM
+echo 'FIXTURE = "golden/Tuolumne_1_test.json"' > "$STRPATH_PROBE"
+set +e
+OUT=$("$GUARD_SCRIPT" 2>&1)
+rc=$?
+set -e
+rm -f "$STRPATH_PROBE"
+if [[ $rc -eq 1 ]] && grep -q "api/leak_probe_kindred2512_strpath.py:1:" <<<"$OUT"; then
+  echo "PASS: '_test.' inside a string literal does not exempt a non-test file"
+else
+  echo "FAIL: expected exit 1 naming the probe for a '_test.' string literal, got $rc" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+
+echo
+echo "=== TEST 17: the guard must never exit 1 with an empty report ==="
+# kindred#2512 review. Under `set -euo pipefail` the test-bucket pipeline had
+# no `|| true`: when its cityGeo/schoolGeo filter removed EVERY line of a
+# non-empty test bucket, grep exited 1, pipefail propagated it and `set -e`
+# killed the script mid-run -- exit 1 with nothing printed. A red guard with no
+# message is worse than a wrong green, because there is nothing to act on.
+# The scan root is narrowed so the planted comment is the only hit in the
+# bucket; that is what makes the filter empty it.
+SILENT_DIR="$REPO_ROOT/pocketbase/leak_probe_kindred2512_silent"
+SILENT_PROBE="$SILENT_DIR/probe_test.go"
+cleanup14() { rm -rf "$SILENT_DIR"; }
+trap 'cleanup14; cleanup13; cleanup12; cleanup11; cleanup10; cleanup9; cleanup8; cleanup7; cleanup6; cleanup5; cleanup4; cleanup3; cleanup' EXIT INT TERM
+mkdir -p "$SILENT_DIR"
+printf 'package probe\n\n// See frontend/src/data/cityGeo.ts for why Tuolumne 1 matches there.\n' > "$SILENT_PROBE"
+set +e
+OUT=$(LODGING_SCAN_ROOTS="pocketbase/leak_probe_kindred2512_silent/" "$GUARD_SCRIPT" 2>&1)
+rc=$?
+set -e
+rm -rf "$SILENT_DIR"
+if [[ $rc -eq 1 && -z "${OUT//[[:space:]]/}" ]]; then
+  echo "FAIL: the guard exited 1 and printed NOTHING -- a silent failure" >&2
+  exit 1
+fi
+if [[ $rc -ne 0 ]]; then
+  echo "FAIL: the only hit was filtered out, so the guard should report OK; got $rc" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+if ! grep -q 'verify-no-hardcoded-lodging: OK' <<<"$OUT"; then
+  echo "FAIL: expected the OK line, got: $OUT" >&2
+  exit 1
+fi
+echo "PASS: a filter that empties the test bucket does not kill the guard"
+
+echo
+echo "=== TEST 18: a needle in a '#' COMMENT inside a test .sh file must fail ==="
+# kindred#2512 review. The guard greps '*.sh', but drop_comment_hits.py knew
+# only .py and the C-style suffixes and returned "no comment lines" for
+# everything else -- so under --only-comments a shell comment was classified as
+# code and silently exempted. The PR's own rule table said a test file's
+# comment hits fail; for shell that was simply untrue.
+SH_TEST_PROBE="$REPO_ROOT/scripts/dev/leak_probe_kindred2512_test.sh"
+cleanup15() { rm -f "$SH_TEST_PROBE"; }
+trap 'cleanup15; cleanup14; cleanup13; cleanup12; cleanup11; cleanup10; cleanup9; cleanup8; cleanup7; cleanup6; cleanup5; cleanup4; cleanup3; cleanup' EXIT INT TERM
+printf '#!/usr/bin/env bash\n# Comment naming Tuolumne 1 to explain a fixture below.\n' > "$SH_TEST_PROBE"
+set +e
+OUT=$("$GUARD_SCRIPT" 2>&1)
+rc=$?
+set -e
+rm -f "$SH_TEST_PROBE"
+if [[ $rc -eq 1 ]] && grep -q "scripts/dev/leak_probe_kindred2512_test.sh:2:" <<<"$OUT"; then
+  echo "PASS: a needle in a shell comment inside a test .sh file is caught"
+else
+  echo "FAIL: expected exit 1 naming the .sh test-comment probe, got $rc" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+
+echo
+echo "=== TEST 19: a needle in fixture CODE inside a test .sh file must still exit 0 ==="
+# The mirror of TEST 18, and the reason TEST 18's fix had to teach the dropper
+# shell comments rather than just exempt .sh wholesale: fixture code in a test
+# file stays exempt in every language, shell included.
+SH_TEST_CODE_PROBE="$REPO_ROOT/scripts/dev/leak_probe_kindred2512_code_test.sh"
+cleanup16() { rm -f "$SH_TEST_CODE_PROBE"; }
+trap 'cleanup16; cleanup15; cleanup14; cleanup13; cleanup12; cleanup11; cleanup10; cleanup9; cleanup8; cleanup7; cleanup6; cleanup5; cleanup4; cleanup3; cleanup' EXIT INT TERM
+printf '#!/usr/bin/env bash\nUNITS="Manzanita 3"\n' > "$SH_TEST_CODE_PROBE"
+set +e
+OUT=$("$GUARD_SCRIPT" 2>&1)
+rc=$?
+set -e
+rm -f "$SH_TEST_CODE_PROBE"
+if [[ $rc -eq 0 ]]; then
+  echo "PASS: a needle as fixture code in a test .sh file is still exempt"
+else
+  echo "FAIL: expected exit 0 for a needle as .sh fixture code, got $rc" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+
+echo
+echo "=== TEST 20: a needle in a comment inside an UNPARSEABLE .py test file must fail ==="
+# kindred#2512 review. drop_comment_hits.py's docstring promises fail-OPEN --
+# "a file that will not parse or read is treated as ALL CODE, so its hits
+# survive" -- but under --only-comments "all code" means "all dropped", which
+# is fail-CLOSED. A tokenize failure therefore made a real comment leak
+# invisible. Unknown now means "keep the hit" in BOTH directions.
+BROKEN_PY_PROBE="$REPO_ROOT/api/leak_probe_kindred2512_broken_test.py"
+cleanup17() { rm -f "$BROKEN_PY_PROBE"; }
+trap 'cleanup17; cleanup16; cleanup15; cleanup14; cleanup13; cleanup12; cleanup11; cleanup10; cleanup9; cleanup8; cleanup7; cleanup6; cleanup5; cleanup4; cleanup3; cleanup' EXIT INT TERM
+printf '# Comment naming Manzanita to explain a fixture below.\nUNITS = (\n' > "$BROKEN_PY_PROBE"
+set +e
+OUT=$("$GUARD_SCRIPT" 2>&1)
+rc=$?
+set -e
+rm -f "$BROKEN_PY_PROBE"
+if [[ $rc -eq 1 ]] && grep -q "api/leak_probe_kindred2512_broken_test.py:1:" <<<"$OUT"; then
+  echo "PASS: an unparseable test file keeps its hits instead of swallowing them"
+else
+  echo "FAIL: expected exit 1 naming the unparseable .py probe, got $rc" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+
+echo
+echo "=== TEST 21: a needle on the closing line of a JSX comment in a TEST .tsx file must fail ==="
+# kindred#2512 review. TEST 7 plants the same shape in a NON-test file, which
+# since #2512 never reaches drop_comment_hits.py at all -- so TEST 7 passes
+# with the #2181 fused-brace logic deleted and cannot be the regression cover
+# for it. This probe can: a test file's hits DO go through the dropper, and
+# `*/}` on the closing line is exactly the shape the fusion exists to classify
+# as comment rather than leftover code. Verified by mutation -- with the two
+# `jsx and ...` branches disabled this probe reports exit 0 while TEST 7 still
+# reports exit 1.
+TSX_TEST_PROBE="$REPO_ROOT/frontend/src/leak_probe_kindred2512_jsx.test.tsx"
+cleanup18() { rm -f "$TSX_TEST_PROBE"; }
+trap 'cleanup18; cleanup17; cleanup16; cleanup15; cleanup14; cleanup13; cleanup12; cleanup11; cleanup10; cleanup9; cleanup8; cleanup7; cleanup6; cleanup5; cleanup4; cleanup3; cleanup' EXIT INT TERM
+cat > "$TSX_TEST_PROBE" <<'PROBE'
+export function Probe() {
+  return (
+    <div>
+      {/* The area, because the row it came from is now behind a
+          backdrop and "which Tioga is this" is the first question. */}
+      <span>hi</span>
+    </div>
+  );
+}
+PROBE
+set +e
+OUT=$("$GUARD_SCRIPT" 2>&1)
+rc=$?
+set -e
+rm -f "$TSX_TEST_PROBE"
+if [[ $rc -eq 1 ]] && grep -q "frontend/src/leak_probe_kindred2512_jsx.test.tsx:5:" <<<"$OUT"; then
+  echo "PASS: the JSX fused-brace classification is covered end-to-end"
+else
+  echo "FAIL: expected exit 1 naming line 5 of the JSX test probe, got $rc" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+
+echo
+echo "=== TEST 22: a LOWERCASE needle in a comment must fail ==="
+# kindred#2512 review. The raw scan was case-sensitive, so the lowercase unit
+# CODES the codebase actually uses in prose ("gt-<unit>", "<unit>-new-trailer")
+# sailed past a needle list written in title case. Seven such comment hits were
+# sitting in tracked source when this was found.
+LOWER_PROBE="$REPO_ROOT/api/leak_probe_kindred2512_lower.py"
+cleanup19() { rm -f "$LOWER_PROBE"; }
+trap 'cleanup19; cleanup18; cleanup17; cleanup16; cleanup15; cleanup14; cleanup13; cleanup12; cleanup11; cleanup10; cleanup9; cleanup8; cleanup7; cleanup6; cleanup5; cleanup4; cleanup3; cleanup' EXIT INT TERM
+echo '# comment naming manzanita in lowercase, deliberately.' > "$LOWER_PROBE"
+set +e
+OUT=$("$GUARD_SCRIPT" 2>&1)
+rc=$?
+set -e
+rm -f "$LOWER_PROBE"
+if [[ $rc -eq 1 ]] && grep -q "api/leak_probe_kindred2512_lower.py:1:" <<<"$OUT"; then
+  echo "PASS: a lowercase needle in a comment is caught"
+else
+  echo "FAIL: expected exit 1 naming the lowercase probe, got $rc" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+
+echo
 echo "All tests passed."

--- a/scripts/dev/verify-no-hardcoded-lodging.sh
+++ b/scripts/dev/verify-no-hardcoded-lodging.sh
@@ -6,8 +6,9 @@
 # It used to live in pb_migrations/, which is why this guard used to skip that
 # directory. It no longer does: with the data gone from the seed migrations,
 # that exclusion was a hole in precisely the place a future seed would land.
-# Prose in a migration is still fine — comments are dropped below — but a unit
-# list in a migration is now a failure, same as in any other source file.
+# Prose in a migration is not fine either, since kindred#2512: comments are
+# SCANNED, not dropped, so a unit name in a migration header fails exactly as a
+# unit list in a migration body does.
 #
 # SCOPE, honestly stated: this is a tripwire, not a proof. It greps for a
 # REPRESENTATIVE SAMPLE of distinctive unit strings (NEEDLES below) — not the
@@ -19,7 +20,7 @@ set -euo pipefail
 
 # Preflight BEFORE the first git call — checking for git after invoking it is
 # pointless, since the missing binary would already have exited 127.
-for cmd in git grep python3; do
+for cmd in git grep awk python3; do
   command -v "$cmd" >/dev/null 2>&1 || { echo "error: required command '$cmd' not found" >&2; exit 2; }
 done
 
@@ -93,26 +94,14 @@ done
 # name in test fixtures either" -- treat a future NEEDLES hit inside one as
 # worth a look, not an automatic pass.
 #
-# kindred#2367 narrows that blind spot for COMMENTS ONLY, and only under
+# kindred#2367 narrowed that blind spot for COMMENTS ONLY, and only under
 # frontend/src/**: catching needle terms in comments is strictly better than
 # catching them only in production code, and a repo-wide measurement found 14
 # comment hits across 6 files, split between frontend/src/** (3 hits, 2 files
-# -- both fixed at the source in this same change) and pocketbase/ Go test
-# files (11 hits, 4 files) that this branch has no reason to touch and did
-# not verify against sibling in-flight PRs. Narrowing to frontend/src/** ships
-# the improvement where it was already fully paid for and leaves the
-# pocketbase/ side for a future pass, rather than guessing at files another
-# issue may be mid-edit on. Fixture CODE in a frontend/src/** test file is
-# still exempt -- only its comment lines are newly in scope.
-# The trailing alternative must anchor to a full PATH SEGMENT: '(.*/)?tests?/'
-# rather than the bare '/tests?/' used previously. The bare form only fires
-# once something has already matched before the slash, so a file directly
-# under frontend/src/test/ (frontend/src/test/mockData.ts -- no '_test.' or
-# '.test.' in the name, and 'test/' immediately follows the 'frontend/src/'
-# prefix with no preceding '/') never matched, and fell through to OTHER_RAW's
-# blanket test-file exemption instead of this comment-only scan -- the exact
-# gap this pattern exists to close. Verified by TEST 13 in
-# test-verify-no-hardcoded-lodging.sh (kindred#2367 review).
+# -- both fixed at the source in that change) and pocketbase/ Go test files
+# (11 hits, 4 files) it had no reason to touch and did not verify against
+# sibling in-flight PRs.
+#
 # kindred#2512 completes the pass #2367 deferred. Comments are now scanned in
 # EVERY scan root, not only under frontend/src/**, so the split below is by
 # TEST-vs-NOT rather than by directory:
@@ -133,19 +122,51 @@ done
 # kindred#1909 found was two needle-matching literals in fixture code, and the
 # fix applied there was to scrub them at the source, not to narrow this filter.
 # That trade is unchanged; only comments moved.
-TEST_FILE_PATTERN='(.*/)?tests?/|(_test\.|\.test\.)'
+#
+# THE SPLIT IS DECIDED BY THE PATH, AND ONLY BY THE PATH (kindred#2512 review).
+# grep -In emits `path:lineno:text`. The first cut of this widening matched an
+# unanchored pattern against the WHOLE LINE, so a line's own CONTENT could
+# route its file into the test bucket and win the code-hit exemption:
+#
+#   api/svc.py:12:FIXTURE = "tests/<unit>.json"      -> silently exempted
+#   pocketbase/resolver.go:9:var P = "latest/<unit>" -> silently exempted
+#
+# ('latest/' contains 'test/'.) The pattern it replaced anchored both of its
+# alternatives to the path with '^', which is the property that got lost. awk
+# splits on ':' and tests $1, so nothing after the path can vote. TEST 14-16
+# pin all three shapes.
+#
+# 'tests?/' must additionally be a whole PATH SEGMENT: '^(.*/)?' can only match
+# a prefix ending in '/', so 'test/' has to start the path or follow a slash.
+# That keeps frontend/src/test/mockData.ts -- the repo's real shared
+# test-helper directory, with no '_test.' or '.test.' in its filename -- inside
+# the test bucket (TEST 13, kindred#2367 review) while pocketbase/latest/x.go
+# stays out of it.
+#
+# Written with '[.]' rather than '\.' on purpose: this pattern is handed to awk
+# through -v, and awk processes escape sequences in a -v assignment, so gawk
+# rewrites '\.' to a bare '.' (matching any character) and warns while doing it.
+TEST_FILE_PATTERN='^(.*/)?tests?/|_test[.]|[.]test[.]'
 HITS=""
 if [[ -n "$RAW" ]]; then
-  TEST_RAW=$(printf '%s\n' "$RAW" | grep -E "$TEST_FILE_PATTERN" || true)
-  OTHER_RAW=$(printf '%s\n' "$RAW" | grep -vE "$TEST_FILE_PATTERN" || true)
+  TEST_RAW=$(printf '%s\n' "$RAW" | awk -F: -v pat="$TEST_FILE_PATTERN" 'NF && $1 ~ pat')
+  OTHER_RAW=$(printf '%s\n' "$RAW" | awk -F: -v pat="$TEST_FILE_PATTERN" 'NF && $1 !~ pat')
 
   HITS=$(printf '%s\n' "$OTHER_RAW" \
     | grep -v 'frontend/src/data/cityGeo\.ts\|frontend/src/data/schoolGeo\.ts' || true)
 
+  # The `|| true` is scoped to grep with a brace group, NOT hung off the whole
+  # pipeline (kindred#2512 review). Under `set -euo pipefail` a grep -v that
+  # removes EVERY line exits 1, pipefail promotes that to the pipeline's status
+  # and `set -e` kills the guard mid-run: exit 1 with nothing printed at all.
+  # Reachable because this grep -v matches the path anywhere in the line,
+  # including inside a comment's own text. Hanging `|| true` off the end of the
+  # pipeline instead would also swallow a python3 crash, which must stay fatal.
+  # TEST 17 asserts the guard never exits 1 with an empty report.
   TEST_COMMENT_HITS=""
   if [[ -n "$TEST_RAW" ]]; then
     TEST_COMMENT_HITS=$(printf '%s\n' "$TEST_RAW" \
-      | grep -v 'frontend/src/data/cityGeo\.ts\|frontend/src/data/schoolGeo\.ts' \
+      | { grep -v 'frontend/src/data/cityGeo\.ts\|frontend/src/data/schoolGeo\.ts' || true; } \
       | python3 "$REPO_ROOT/scripts/dev/lib/drop_comment_hits.py" --only-comments)
   fi
 fi

--- a/scripts/dev/verify-no-hardcoded-lodging.sh
+++ b/scripts/dev/verify-no-hardcoded-lodging.sh
@@ -32,7 +32,24 @@ cd "$REPO_ROOT"
 # "Cloud'?s Rest" matches both spellings on purpose: the canonical unit name is
 # "Clouds Rest" (1500000120) but every historical alias string is "Cloud's Rest"
 # with the apostrophe (1500000121), and a leak could copy either.
-NEEDLES="Ridge Yurt|Tawonga Village|Manzanita|Tuolumne|Cloud'?s Rest|Wawona|Half Dome|El Cap|Bayit|Tenaya|Tioga|Le Shack|Lofty|Kitty|Doctor's House"
+#
+# Matched CASE-INSENSITIVELY (the -i on the grep below), kindred#2512 review.
+# The list is written in title case, but the codebase names units in prose by
+# their lowercase CODE ("gt-<unit>", "<unit>-new-trailer"), so a title-case scan
+# read straight past them: seven such comment hits were sitting in tracked
+# source when this was measured, in a migration header, two frontend components
+# and three test files. Case-insensitivity adds 64 raw hits repo-wide, 63 of
+# them lowercase codes in test FIXTURE data (already exempt) and 1 an ordinary
+# English false positive, handled just below.
+#
+# "El Cap" is the one needle that is also an English fragment once case is
+# folded -- it matches inside "parallel capturers". \b fixes that and costs
+# nothing: the needle contains a space, so it never matched a camelCase
+# identifier anyway, and a real leak spells it at a word boundary. \b is
+# deliberately NOT applied to the whole list -- it would stop matching
+# camelCase identifiers such as a Go variable built from a unit name, which is
+# a leak shape this guard does catch today.
+NEEDLES="Ridge Yurt|Tawonga Village|Manzanita|Tuolumne|Cloud'?s Rest|Wawona|Half Dome|\bEl Cap|Bayit|Tenaya|Tioga|Le Shack|Lofty|Kitty|Doctor's House"
 
 # --include='*.js' matters: pocketbase/pb_hooks/ is application JavaScript and
 # pocketbase/pb_migrations/ is where the registry used to live, so both have to
@@ -43,6 +60,18 @@ NEEDLES="Ridge Yurt|Tawonga Village|Manzanita|Tuolumne|Cloud'?s Rest|Wawona|Half
 #                ordinary US place names
 # Scan roots, overridable ONLY so the test suite can point the guard at a
 # missing directory and assert it fails rather than reporting a clean scan.
+#
+# THESE FIVE ARE THE WHOLE SCOPE. Every rule stated below -- including the
+# code/comment table -- describes what happens INSIDE these roots and nowhere
+# else. The pytest tree at tests/ is NOT among them and never has been: it
+# carries 71 needle hits (80 case-insensitively) across three files under
+# tests/unit/api/services/, of which 4 sit in comments, and none of them has
+# ever been checked. One of those comments restates in prose the exact fact
+# kindred#2512 scrubbed out of api/services/lodging_rules.py, so the scrub
+# moved the sentence into an unscanned file rather than out of the repository.
+# Widening the roots changes what every future PR is measured against, so it
+# gets its own change: kindred#2515 carries the measurement and the
+# scrub-or-exempt decision.
 read -r -a SCAN_ROOTS <<<"${LODGING_SCAN_ROOTS:-pocketbase/ api/ bunking/ frontend/src/ scripts/}"
 
 # Capture grep's OWN status before the filter pipeline swallows it. grep exits
@@ -52,7 +81,7 @@ read -r -a SCAN_ROOTS <<<"${LODGING_SCAN_ROOTS:-pocketbase/ api/ bunking/ fronte
 # guard reporting clean on a scan that never happened. Flagged on this script
 # in kindred#1867 and asserted by TEST 6 in test-verify-no-hardcoded-lodging.sh.
 grep_status=0
-RAW=$(grep -rInE "$NEEDLES" \
+RAW=$(grep -rInEi "$NEEDLES" \
   --include='*.go' --include='*.py' --include='*.ts' --include='*.tsx' --include='*.js' --include='*.sh' \
   --exclude-dir=pb_public --exclude-dir=node_modules \
   "${SCAN_ROOTS[@]}" 2>&1) || grep_status=$?
@@ -108,6 +137,9 @@ done
 #
 #   not a test file -> code hits fail, comment hits fail
 #   a test file     -> code hits are exempt, comment hits fail
+#
+# ...for files under SCAN_ROOTS. See the note there: tests/ is outside them
+# (kindred#2515).
 #
 # The 18 comment hits this widening newly caught were scrubbed in the same
 # change (7 outside test files, including `effective_bathroom`'s own docstring

--- a/scripts/dev/verify-no-hardcoded-lodging.sh
+++ b/scripts/dev/verify-no-hardcoded-lodging.sh
@@ -113,42 +113,69 @@ done
 # blanket test-file exemption instead of this comment-only scan -- the exact
 # gap this pattern exists to close. Verified by TEST 13 in
 # test-verify-no-hardcoded-lodging.sh (kindred#2367 review).
-FRONTEND_TEST_PATTERN='^frontend/src/(.*/)?tests?/|^frontend/src/.*(_test\.|\.test\.)'
+# kindred#2512 completes the pass #2367 deferred. Comments are now scanned in
+# EVERY scan root, not only under frontend/src/**, so the split below is by
+# TEST-vs-NOT rather than by directory:
+#
+#   not a test file -> code hits fail, comment hits fail
+#   a test file     -> code hits are exempt, comment hits fail
+#
+# The 18 comment hits this widening newly caught were scrubbed in the same
+# change (7 outside test files, including `effective_bathroom`'s own docstring
+# and three migration headers; 11 in pocketbase/ Go test comments). #2367 said
+# it was leaving the pocketbase/ side "for a future pass, rather than guessing
+# at files another issue may be mid-edit on" -- this is that pass.
+#
+# What is still exempt, and still deliberately: fixture CODE in a test file.
+# Real unit names as fixture DATA are legitimate there -- an alias resolver
+# test has to resolve the strings staff actually wrote -- and narrowing that
+# would fail the many lodging test files built on exactly that. The blind spot
+# kindred#1909 found was two needle-matching literals in fixture code, and the
+# fix applied there was to scrub them at the source, not to narrow this filter.
+# That trade is unchanged; only comments moved.
+TEST_FILE_PATTERN='(.*/)?tests?/|(_test\.|\.test\.)'
 HITS=""
 if [[ -n "$RAW" ]]; then
-  FRONTEND_TEST_RAW=$(printf '%s\n' "$RAW" | grep -E "$FRONTEND_TEST_PATTERN" || true)
-  OTHER_RAW=$(printf '%s\n' "$RAW" | grep -vE "$FRONTEND_TEST_PATTERN" || true)
+  TEST_RAW=$(printf '%s\n' "$RAW" | grep -E "$TEST_FILE_PATTERN" || true)
+  OTHER_RAW=$(printf '%s\n' "$RAW" | grep -vE "$TEST_FILE_PATTERN" || true)
 
   HITS=$(printf '%s\n' "$OTHER_RAW" \
-    | grep -v '_test\.\|\.test\.\|/tests\?/' \
     | grep -v 'frontend/src/data/cityGeo\.ts\|frontend/src/data/schoolGeo\.ts' || true)
 
-  FRONTEND_TEST_COMMENT_HITS=""
-  if [[ -n "$FRONTEND_TEST_RAW" ]]; then
-    FRONTEND_TEST_COMMENT_HITS=$(printf '%s\n' "$FRONTEND_TEST_RAW" \
+  TEST_COMMENT_HITS=""
+  if [[ -n "$TEST_RAW" ]]; then
+    TEST_COMMENT_HITS=$(printf '%s\n' "$TEST_RAW" \
+      | grep -v 'frontend/src/data/cityGeo\.ts\|frontend/src/data/schoolGeo\.ts' \
       | python3 "$REPO_ROOT/scripts/dev/lib/drop_comment_hits.py" --only-comments)
   fi
 fi
 
-# Prose that names a unit to explain a rule is documentation, not the registry
-# living in code. Dropping comment and docstring hits is what makes this guard
-# green on a clean `main`: it failed on a docstring in lodging_rules.py, which
-# opened Phase C on a red that was not Phase C's (kindred#1891). A file that
-# cannot be parsed is treated as all code, so its hits survive.
-if [[ -n "$HITS" ]]; then
-  HITS=$(printf '%s\n' "$HITS" | python3 "$REPO_ROOT/scripts/dev/lib/drop_comment_hits.py")
-fi
+# ⚠️ COMMENTS ARE NO LONGER DROPPED (kindred#2512). This block used to run
+# every non-test hit back through drop_comment_hits.py, on the reasoning that
+# "prose naming a unit to explain a rule is documentation, not the registry
+# living in code" -- which is how a real unit name sat in an `api/` docstring
+# and in three migration headers while this guard reported OK.
+#
+# The reasoning was never wrong about intent, only about consequence: a
+# comment is source, it ships in the repo, and a public repo leaks it exactly
+# as a literal would. Prose can say what it needs to say without naming a
+# building -- all 18 hits this change caught were rewritten, not deleted, and
+# none lost its explanatory force.
+#
+# The historical objection (kindred#1891: it "failed on a docstring in
+# lodging_rules.py", reddening an unrelated phase) is spent -- that docstring
+# is one of the 18 now scrubbed.
 # cityGeo.ts / schoolGeo.ts are unrelated city/school geocoding lookup tables
 # (a different feature) that coincidentally contain place-name substrings
 # ("Manzanita, OR", "El Capitan, AZ", "Wawona, CA", "Tuolumne City, CA") — not
 # the lodging registry. Excluded to keep this guard meaningful.
 
-# FRONTEND_TEST_COMMENT_HITS is already comment-only (produced by
-# --only-comments above) -- append it here, AFTER the drop-comments step
-# above, not before: running it back through that filter would drop the very
-# comment hits it exists to report.
-if [[ -n "${FRONTEND_TEST_COMMENT_HITS:-}" ]]; then
-  HITS=$(printf '%s\n%s\n' "$HITS" "$FRONTEND_TEST_COMMENT_HITS" | sed '/^$/d')
+# TEST_COMMENT_HITS is already comment-only (produced by --only-comments
+# above) -- append it here, AFTER the drop-comments step above, not before:
+# running it back through that filter would drop the very comment hits it
+# exists to report.
+if [[ -n "${TEST_COMMENT_HITS:-}" ]]; then
+  HITS=$(printf '%s\n%s\n' "$HITS" "$TEST_COMMENT_HITS" | sed '/^$/d')
 fi
 
 if [[ -n "$HITS" ]]; then

--- a/tests/unit/scripts/test_drop_comment_hits.py
+++ b/tests/unit/scripts/test_drop_comment_hits.py
@@ -66,3 +66,101 @@ def test_code_immediately_after_jsx_comment_close_still_reports(tmp_path: Path) 
     lines = noncode_lines(path)
 
     assert 4 not in lines
+
+
+# --- kindred#2512 review: shell comments, and fail-open on "we learned nothing"
+#
+# The module promises fail-OPEN -- "a file that will not parse or read is
+# treated as ALL CODE, so its hits survive". Under `--only-comments`, which is
+# the only mode verify-no-hardcoded-lodging.sh still uses, "all code" means
+# "all DROPPED": fail-CLOSED, the exact opposite. Two live consequences, both
+# pinned below:
+#
+#   * the guard greps '*.sh', but every suffix outside {.py, C-style} returned
+#     an empty set, so a needle in a '#' comment in a test shell script was
+#     classified as code and exempted;
+#   * a .py file that will not tokenize lost its comment hits the same way.
+#
+# `noncode_lines` now returns None for "could not determine", and main() writes
+# such hits through in BOTH modes.
+
+
+def test_shell_comment_lines_are_noncode(tmp_path: Path) -> None:
+    """A '#' comment in a .sh file must be recognised as noncode."""
+    path = tmp_path / "probe.sh"
+    path.write_text(
+        "#!/usr/bin/env bash\n"
+        "# Explanatory prose naming ZzyzxPlaceholderUnit.\n"
+        "UNITS=(ZzyzxPlaceholderUnit)\n"
+        "  # indented comment\n"
+    )
+
+    assert noncode_lines(path) == {1, 2, 4}
+
+
+def test_shell_code_with_trailing_comment_still_reports(tmp_path: Path) -> None:
+    """`UNITS=(...)  # note` is code, matching the C-style whole-line rule.
+
+    A line only counts as noncode when there is nothing on it but comment, so a
+    needle sitting in the CODE half of a mixed line is never hidden by the
+    comment half.
+    """
+    path = tmp_path / "probe.sh"
+    path.write_text('UNITS="ZzyzxPlaceholderUnit"  # note\n')
+
+    assert noncode_lines(path) == set()
+
+
+def test_unparseable_python_is_unknown(tmp_path: Path) -> None:
+    """A .py file that will not tokenize returns None, not an empty set.
+
+    An empty set means "this file has no comment lines", which under
+    --only-comments discards every hit in it. None means "we learned nothing",
+    which keeps them.
+    """
+    path = tmp_path / "probe_test.py"
+    path.write_text("# Comment naming ZzyzxPlaceholderUnit.\nUNITS = (\n")
+
+    assert noncode_lines(path) is None
+
+
+def test_unreadable_path_is_unknown(tmp_path: Path) -> None:
+    """A path that cannot be read at all is unknown, so its hits survive."""
+    assert noncode_lines(tmp_path / "does_not_exist.py") is None
+
+
+def test_unhandled_suffix_is_unknown(tmp_path: Path) -> None:
+    """A suffix this module has no scanner for is unknown, not "all code"."""
+    path = tmp_path / "probe.rb"
+    path.write_text("# Comment naming ZzyzxPlaceholderUnit.\n")
+
+    assert noncode_lines(path) is None
+
+
+def _run_filter(stdin: str, *args: str) -> str:
+    import subprocess
+    import sys
+
+    module = Path(__file__).resolve().parents[3] / "scripts" / "dev" / "lib" / "drop_comment_hits.py"
+    return subprocess.run(
+        [sys.executable, str(module), *args],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+
+def test_unknown_file_hits_survive_in_both_modes(tmp_path: Path) -> None:
+    """Fail-open means the hit is written through whichever way the filter points.
+
+    This is the assertion that makes the docstring's promise true under
+    --only-comments: a file we could not classify must not have its hits
+    silently swallowed by the mode that keeps comments.
+    """
+    path = tmp_path / "probe_test.py"
+    path.write_text("# Comment naming ZzyzxPlaceholderUnit.\nUNITS = (\n")
+    hit = f"{path}:1:# Comment naming ZzyzxPlaceholderUnit.\n"
+
+    assert _run_filter(hit) == hit
+    assert _run_filter(hit, "--only-comments") == hit

--- a/tests/unit/scripts/test_drop_comment_hits.py
+++ b/tests/unit/scripts/test_drop_comment_hits.py
@@ -42,6 +42,10 @@ def test_multiline_jsx_comment_is_recognized_as_noncode(tmp_path: Path) -> None:
 
     lines = noncode_lines(path)
 
+    # None means "could not classify this file", which for a well-formed .tsx
+    # would be a bug in its own right -- assert it before the set comparison so
+    # a regression there reads as itself rather than as a set mismatch.
+    assert lines is not None
     assert lines == {4, 5}, f"expected lines 4-5 (the full JSX comment) to be noncode, got {sorted(lines)}"
 
 
@@ -65,6 +69,7 @@ def test_code_immediately_after_jsx_comment_close_still_reports(tmp_path: Path) 
 
     lines = noncode_lines(path)
 
+    assert lines is not None
     assert 4 not in lines
 
 


### PR DESCRIPTION
The guard reported `OK` while **eighteen real building and area names sat in tracked, public source**. Every one was in a comment, and comments were dropped before the report.

Found while auditing something else (#2511), by running the guard's own needle list by hand and diffing against what it reported.

## Why the exemption existed, and why it was wrong

It held that prose naming a unit to explain a rule is documentation rather than the registry living in code — added in #1891 after a docstring reddened an unrelated phase.

Right about intent, wrong about consequence. **A comment is source.** It ships in the repo, and a public repo leaks it exactly as a literal does. Nor is the tradeoff real: prose can say what it needs to say without naming a building. All eighteen were **rewritten, not deleted**, and none lost its explanatory force.

#2367 had already reached this conclusion and scoped its fix to `frontend/src/**`, stating it was *"leaving the pocketbase/ side for a future pass, rather than guessing at files another issue may be mid-edit on."* This is that pass.

## The rule now

| | code hits | comment hits |
|---|---|---|
| not a test file | fail | **fail** (was: dropped) |
| a test file | exempt | **fail** (was: dropped) |

…for files under `SCAN_ROOTS`, which is five directories and **does not include the pytest tree** — see the scope note below.

**Fixture code in a test file stays exempt, deliberately.** Real names as fixture *data* are legitimate — an alias resolver test has to resolve the strings staff actually wrote — and narrowing it would fail the many lodging test files built on exactly that. #1909 found two needle-matching literals in fixture code and fixed them at the source rather than narrowing the filter; that trade is unchanged. Only comments moved.

## What was scrubbed

- one `api/` docstring
- three migration headers
- **one `frontend/src/**` component comment** — a non-test frontend file, so outside #2367's scope and never in scope for anything
- eleven `pocketbase/` Go test comments

…plus everything the review round below turned up.

## Three tests are REWRITTEN, not adapted

TEST 4, 7 and 12 each pinned the old exemption. The **specification** changed; the implementation did not drift from it, so adapting them would have been backwards. Each carries why it flipped and what it now proves.

TEST 4 and 7 additionally assert the report **names the offending file**. A guard that caught one probe and silently dropped the other would have passed a bare exit-code check.

---

# Review round

Ten findings. Every fix is verified by planting a needle and reading the exit code — a green guard is not evidence.

### The widening introduced two regressions of its own

**The test/not-test split was decided by the whole grep line, not the path.** `grep -In` emits `path:lineno:text`, and the new pattern was unanchored, so a line's own **content** could route its file into the test bucket and win the code-hit exemption:

| planted line | old pattern | new |
|---|---|---|
| a fixture-path constant containing `tests/`, in ordinary application code | **exempted** | fails |
| a version-path string containing `latest/` (which carries `test/`) | **exempted** | fails |
| a needle inside a path-like literal containing `_test.` | **exempted** | fails |

The pattern this replaced anchored both alternatives to the path with `^`; that is the property that got lost, and the five-case mutation table in the first cut could not catch it because every case varied file *kind* and none varied line *content*. The split now runs through `awk` on field 1, and `tests?/` must be a whole path segment again. TESTs 14-16.

**The test-bucket pipeline had no `|| true`.** Under `set -euo pipefail`, a `grep -v` that removed every line exited 1, pipefail promoted it, and `set -e` killed the guard mid-run: **exit 1 with nothing printed at all**. Reachable because that `grep -v` matches its path anywhere in the line, including inside a comment's text. The escape is scoped to grep with a brace group so a `python3` crash stays fatal. TEST 17 asserts the guard never exits 1 silently.

### The comment dropper promised fail-open and delivered fail-closed

`drop_comment_hits.py`'s docstring says a file that will not parse or read is *"treated as ALL CODE, so its hits survive"*. Under `--only-comments` — the only mode the guard still uses — "all code" means **all dropped**. Two live consequences:

- the guard greps `*.sh`, but the module had no scanner for it, so a needle in a `#` comment in a test shell script came back classified as code and was exempted. The rule table's *"a test file → comment hits fail"* was simply untrue for shell;
- a `.py` file that would not tokenize lost its comment hits the same way.

`noncode_lines` now returns `None` for "we learned nothing" and such hits are written through in **both** modes; `.sh` gets a `#`-comment scanner on the same whole-line rule the C-style one uses, so fixture code in a test `.sh` stays exempt. TESTs 18-20, plus six unit tests.

### One test's rationale was false, and the thing it claimed to cover had no cover

TEST 7's new comment said the dropper *"still decides whether a line is reported as a comment hit or a code hit"* and that its assertion *"keeps the #2181 regression covered"*. Both wrong, and measured rather than argued: TEST 7's probe is a **non-test** `.tsx`, which since this change never reaches the dropper at all, and TEST 7 still passes with the JSX fused-brace logic deleted. Nothing end-to-end covered that logic. The comment now says what the test actually proves, and **TEST 21** plants the same shape in a *test* `.tsx` so the hit has to go through the dropper — with the fusion disabled it reports exit 0 while TEST 7 still reports exit 1.

### The scrub was grep-driven, not principle-driven

The guard's grep was **case-sensitive**, and its own header says the needle list is only a representative sample. Prose in this codebase names a unit by its lowercase **code**, so a title-case scan read straight past it: seven real comment hits were sitting in tracked source — a migration header, two frontend components and three test files.

The raw scan is now case-insensitive. That adds **64 raw hits** repo-wide: **63** are lowercase codes in test *fixture* data, which stays exempt, and **1** is an ordinary English false positive (a needle's folded form appears inside a normal English word). That one needle, and only that one, gets a `\b` — it contains a space, so it never matched a camelCase identifier anyway. `\b` is deliberately **not** applied to the whole list: it would stop catching identifiers built from a unit name, which is a leak shape the guard does catch today.

Every real name left in a **comment** in a file this PR touches is rewritten, checked against the **full private registry** — names, codes, area names and alias strings — rather than the needle sample. Fixture code is untouched. Three comments the first pass left as broken English (an orphaned "Both", a dangling number, a "four strings" list with one item removed) read as sentences again.

Turning on case-insensitivity is what pulled two frontend components and two frontend test files into this PR that were not in it before: their comments went red, so they had to be scrubbed here. All four changes are comment-only.

### Scope stated honestly, and one issue filed

`SCAN_ROOTS` is `pocketbase/ api/ bunking/ frontend/src/ scripts/`. **The pytest tree at `tests/` is not scanned at all** and never has been, so the rule table above was reading as universal when it is not. It carries **71 needle hits** (80 case-insensitively) across three files, one of which restates in prose the exact fact this PR scrubbed out of `api/services/lodging_rules.py` — the scrub moved the sentence into an unscanned file rather than out of the repository.

Not fixed here: adding a sixth scan root changes what every future PR is measured against and deserves its own diff. The guard's comment now states its roots honestly and points at **#2515**, which carries the measurement and the scrub-or-exempt decision.

### A tracked doc outside the scan roots, which the guard can never see

`docs/` is not a scan root, so this was invisible to every check: **`docs/investigation-not-bunk-with-bug.md` is tracked and public and carried real camper names and real CampMinder IDs throughout**, including a verbatim dump of all 31 `not_bunk_with` records — each naming a requester and the campers they asked not to be bunked with. Far more than the single needle-matching name that surfaced it.

The dump is **removed rather than translated**: a verbatim list of who does not want to bunk with whom has no engineering value once its counts are recorded, and the counts are kept. Every other name and id in the file is now the repo's fictional set.

### Stale comments corrected

The guard's header claimed *"comments are dropped below"*, which this PR makes false; the retained #2367 block described frontend-only scoping as current and asserted the pattern anchors to a path segment — the exact property removing `^` had destroyed, now true again; and the test suite's TEST 13 comment cited two variables this PR deleted.

## Verified by mutation, not by green

| planted | expect | before | after |
|---|---|---|---|
| comment in a non-test `.py` | 1 | 1 | 1 |
| comment in a Go test | 1 | 1 | 1 |
| literal in non-test code | 1 | 1 | 1 |
| fixture code in a Go test | 0 | 0 | 0 |
| code in a non-test file whose text holds `tests/` | 1 | **0** | 1 |
| code in a non-test file whose text holds `latest/` | 1 | **0** | 1 |
| code in a non-test file whose text holds `_test.` | 1 | **0** | 1 |
| a filter that empties the test bucket | 0 + a message | **1, zero bytes** | 0 |
| comment in a test `.sh` | 1 | **0** | 1 |
| fixture code in a test `.sh` | 0 | 0 | 0 |
| comment in an unparseable `.py` test | 1 | **0** | 1 |
| JSX `*/}` comment line in a test `.tsx` | 1 | 1 | 1 (0 with the fusion deleted) |
| lowercase needle in a comment | 1 | **0** | 1 |
| baseline | 0 | 0 | 0 |

**22/22 guard self-tests** (13 existing, 9 new), 8 `drop_comment_hits` unit tests, plus the repo's scoped pre-push superset.

## Note on overlap with #2511

The earlier claim of one shared file was wrong. There are **five**, and the number grew because turning on case-insensitivity pulled two more frontend files in:

| file | overlap |
|---|---|
| `api/services/lodging_roster_service.py` | byte-identical hunk — #2511 found and scrubbed the same comment |
| `api/services/lodging_rules.py` | different regions |
| `frontend/src/components/weekend/MapUnitPopover.tsx` | different regions; #2511 shifts the file substantially above this PR's hunk |
| `frontend/src/components/weekend/AssignFamilyModal.tsx` | different regions |
| `frontend/src/components/weekend/LodgingUnitCard.tsx` | different regions |

Trial-merged against #2511's current head with `git merge-tree`: **all five auto-merge, no conflicts, either order.** #2511 adds **zero** needle-bearing lines, case-insensitively checked, so it will not turn the guard red once this lands.

Refs #2511
Refs #2515
