### PR TITLE
fix(frontend): the housing board sorts units alpha within an area, not by tree depth

### DIFF
--- a/frontend/src/components/weekend/boardLayout.test.ts
+++ b/frontend/src/components/weekend/boardLayout.test.ts
@@ -1170,25 +1170,25 @@ describe('buildBoard — area grouping and colour', () => {
   })
 
   it('sorts a unit numbered past 9 numerically, not as a string (kindred#2518 review)', () => {
-    // Plain `localeCompare` treats the number as a string, so "Manzanita 10"
+    // Plain `localeCompare` treats the number as a string, so "Cedar 10"
     // sorts as if its first character were "1" and lands ahead of
-    // "Manzanita 2" — every production area's numbering is single-digit
-    // today, which is exactly why this was latent, but summer's equivalent
-    // sort (`BunkingBoardByArea.tsx`) already numeric-compares trailing
-    // digits so "B-2" precedes "B-10", and the board must not regress that
-    // the moment an area's numbering crosses into double digits.
+    // "Cedar 2" — every production area's numbering is single-digit today,
+    // which is exactly why this was latent, but summer's equivalent sort
+    // (`BunkingBoardByArea.tsx`) already numeric-compares trailing digits so
+    // "B-2" precedes "B-10", and the board must not regress that the moment
+    // an area's numbering crosses into double digits.
     const board = buildBoard(
       [],
       [
-        unit({ unit_id: 'u1', code: 'manzanita-10', name: 'Manzanita 10' }),
-        unit({ unit_id: 'u2', code: 'manzanita-9', name: 'Manzanita 9' }),
-        unit({ unit_id: 'u3', code: 'manzanita-2', name: 'Manzanita 2' }),
+        unit({ unit_id: 'u1', code: 'cedar-10', name: 'Cedar 10' }),
+        unit({ unit_id: 'u2', code: 'cedar-9', name: 'Cedar 9' }),
+        unit({ unit_id: 'u3', code: 'cedar-2', name: 'Cedar 2' }),
       ]
     )
     expect(board.areas[0]?.slots.map((slot) => slot.unit.code)).toEqual([
-      'manzanita-2',
-      'manzanita-9',
-      'manzanita-10',
+      'cedar-2',
+      'cedar-9',
+      'cedar-10',
     ])
   })
 

--- a/frontend/src/components/weekend/boardLayout.test.ts
+++ b/frontend/src/components/weekend/boardLayout.test.ts
@@ -397,7 +397,11 @@ describe('buildBoard — which units get a card', () => {
       [unit(), staffUnit({ unit_id: 'u2', code: 'aspen-lodge', name: 'Aspen Lodge' })]
     )
     const slots = board.areas.flatMap((area) => area.slots)
-    expect(slots.map((slot) => slot.unit.code)).toEqual(['cedar-1', 'aspen-lodge'])
+    // Both fall in the same default area, so they now sort alphabetically by
+    // name (kindred#2514) — "Aspen Lodge" before "Cedar 1". The membership
+    // this test is actually about is unaffected: staff housing that still
+    // holds a party never disappears.
+    expect(slots.map((slot) => slot.unit.code)).toEqual(['aspen-lodge', 'cedar-1'])
     expect(board.offBoard).toHaveLength(0)
     expect(board.unplaced).toHaveLength(0)
   })
@@ -1127,13 +1131,19 @@ describe('buildBoard — area grouping and colour', () => {
     ])
   })
 
-  it('never reorders the units WITHIN an area — only the area order changes', () => {
-    // The payload already arrives unit-alphabetical within an area (the
-    // repository's own query sorts `area.sort_order,name`); `buildBoard`
-    // must not second-guess that order once an area's rank moves it. Here
-    // the two units are handed in already-alphabetical order inside an area
-    // that the rank reorder moves to the FRONT of the board, and they must
-    // stay in that same relative order.
+  it('sorts units WITHIN an area alphabetically, regardless of payload order (kindred#2514)', () => {
+    // REWRITE, not an adaptation — this test used to pin the opposite
+    // invariant ("never reorders ... the repository's own query already
+    // sorts"). That assumption was wrong: `drawnUnits` (unitLevel.ts) walks
+    // the registry tree BREADTH-FIRST, so a unit's depth in the tree — not
+    // its name — decides its position in the payload `buildBoard` receives.
+    // A root-level unit is emitted before any room nested under a container,
+    // whatever either is named, which is exactly what kindred#2514 reported
+    // ("containers should be alpha within categories, not containers
+    // first"). `buildBoard` must now sort explicitly rather than trust the
+    // payload's order. Here the units are handed in reverse-alphabetical —
+    // the shape a BFS walk produces when depth runs opposite to name — and
+    // must still come out alphabetical.
     const board = buildBoard(
       [],
       [
@@ -1141,16 +1151,16 @@ describe('buildBoard — area grouping and colour', () => {
           area_code: 'NR',
           area_name: 'North Ridge',
           area_sort_order: 1,
-          code: 'ridge-1',
-          name: 'Ridge 1',
+          code: 'ridge-2',
+          name: 'Ridge 2',
         }),
         unit({
           unit_id: 'u2',
           area_code: 'NR',
           area_name: 'North Ridge',
           area_sort_order: 1,
-          code: 'ridge-2',
-          name: 'Ridge 2',
+          code: 'ridge-1',
+          name: 'Ridge 1',
         }),
         unit({ unit_id: 'u3', area_code: 'CG', area_name: 'Cedar Grove', area_sort_order: 9 }),
       ]

--- a/frontend/src/components/weekend/boardLayout.test.ts
+++ b/frontend/src/components/weekend/boardLayout.test.ts
@@ -1169,6 +1169,29 @@ describe('buildBoard — area grouping and colour', () => {
     expect(board.areas[0]?.slots.map((slot) => slot.unit.code)).toEqual(['ridge-1', 'ridge-2'])
   })
 
+  it('sorts a unit numbered past 9 numerically, not as a string (kindred#2518 review)', () => {
+    // Plain `localeCompare` treats the number as a string, so "Manzanita 10"
+    // sorts as if its first character were "1" and lands ahead of
+    // "Manzanita 2" — every production area's numbering is single-digit
+    // today, which is exactly why this was latent, but summer's equivalent
+    // sort (`BunkingBoardByArea.tsx`) already numeric-compares trailing
+    // digits so "B-2" precedes "B-10", and the board must not regress that
+    // the moment an area's numbering crosses into double digits.
+    const board = buildBoard(
+      [],
+      [
+        unit({ unit_id: 'u1', code: 'manzanita-10', name: 'Manzanita 10' }),
+        unit({ unit_id: 'u2', code: 'manzanita-9', name: 'Manzanita 9' }),
+        unit({ unit_id: 'u3', code: 'manzanita-2', name: 'Manzanita 2' }),
+      ]
+    )
+    expect(board.areas[0]?.slots.map((slot) => slot.unit.code)).toEqual([
+      'manzanita-2',
+      'manzanita-9',
+      'manzanita-10',
+    ])
+  })
+
   it('keeps two areas apart when they share a blank code but not a name', () => {
     // The API sends `area_code: ""` for anything it cannot resolve, so
     // bucketing on the code alone silently merges them.

--- a/frontend/src/components/weekend/boardLayout.ts
+++ b/frontend/src/components/weekend/boardLayout.ts
@@ -1043,7 +1043,15 @@ export function buildBoard(parties: RosterPartyRow[], units: LodgingUnitRow[]): 
     bucket.slots.sort((a, b) => {
       const orderDiff = areaSortOrder(a.unit) - areaSortOrder(b.unit)
       if (orderDiff !== 0) return orderDiff
-      return a.unit.name.localeCompare(b.unit.name)
+      // `numeric: true` so "Manzanita 10" sorts after "Manzanita 9", not
+      // ahead of "Manzanita 2" — plain localeCompare treats the trailing
+      // number as a string and puts "1…" before "2…". Every production
+      // area's numbering is single-digit today, which is why a plain
+      // compare shipped unnoticed in review, but summer's equivalent sort
+      // (`BunkingBoardByArea.tsx`) already numeric-compares for exactly
+      // this reason, and the board must not regress it (review finding on
+      // kindred#2518).
+      return a.unit.name.localeCompare(b.unit.name, undefined, { numeric: true })
     })
   }
 

--- a/frontend/src/components/weekend/boardLayout.ts
+++ b/frontend/src/components/weekend/boardLayout.ts
@@ -1024,15 +1024,27 @@ export function buildBoard(parties: RosterPartyRow[], units: LodgingUnitRow[]): 
       slots: [],
       partyKeys: new Set<string>(),
     }
-    // Units are pushed in the PAYLOAD's order and never re-sorted here — the
-    // repository's own query already sorts `area.sort_order,name`, so a
-    // unit's position within its area stays alphabetical without this
-    // function touching it (owner ruling, kindred#2076: "intra unit remains
-    // alpha"). Only which AREA a unit's slot lands in, and where that area
-    // falls below, changes.
+    // Sorted explicitly below, NOT trusted from payload order: `drawnUnits`
+    // (unitLevel.ts) walks the registry tree breadth-first, so a unit's
+    // depth in the tree — not its name — decided its position here, and
+    // containers drew ahead of other buildings' rooms regardless of name
+    // (kindred#2514). Push in whatever order arrives; sort after the loop.
     bucket.slots.push({ unit, parties: slotParties, consent })
     for (const slotParty of slotParties) bucket.partyKeys.add(partyKey(slotParty))
     buckets.set(key, bucket)
+  }
+
+  // A unit's position WITHIN its area, sorted here rather than trusted from
+  // the payload (kindred#2514) — `(area_sort_order, name)`. Every unit in one
+  // bucket shares an area, so `area_sort_order` is already constant within
+  // it; this sorts by name in practice, and carries the area term only so a
+  // bucket's ordering rule reads the same as the areas' own below.
+  for (const bucket of buckets.values()) {
+    bucket.slots.sort((a, b) => {
+      const orderDiff = areaSortOrder(a.unit) - areaSortOrder(b.unit)
+      if (orderDiff !== 0) return orderDiff
+      return a.unit.name.localeCompare(b.unit.name)
+    })
   }
 
   // Ordered by the Manage screen's area rank (kindred#2076) — the board

--- a/frontend/src/components/weekend/boardLayout.ts
+++ b/frontend/src/components/weekend/boardLayout.ts
@@ -1043,11 +1043,11 @@ export function buildBoard(parties: RosterPartyRow[], units: LodgingUnitRow[]): 
     bucket.slots.sort((a, b) => {
       const orderDiff = areaSortOrder(a.unit) - areaSortOrder(b.unit)
       if (orderDiff !== 0) return orderDiff
-      // `numeric: true` so "Manzanita 10" sorts after "Manzanita 9", not
-      // ahead of "Manzanita 2" — plain localeCompare treats the trailing
-      // number as a string and puts "1…" before "2…". Every production
-      // area's numbering is single-digit today, which is why a plain
-      // compare shipped unnoticed in review, but summer's equivalent sort
+      // `numeric: true` so "Cedar 10" sorts after "Cedar 9", not ahead of
+      // "Cedar 2" — plain localeCompare treats the trailing number as a
+      // string and puts "1…" before "2…". Every production area's
+      // numbering is single-digit today, which is why a plain compare
+      // shipped unnoticed in review, but summer's equivalent sort
       // (`BunkingBoardByArea.tsx`) already numeric-compares for exactly
       // this reason, and the board must not regress it (review finding on
       // kindred#2518).


### PR DESCRIPTION
`buildBoard` bucketed units in whatever order the payload's `drawn` list arrived in, on the strength of a stale comment claiming the repository's own query already sorted `area.sort_order,name`. That assumption was broken upstream: `unitLevel.ts`'s `drawnUnits` walks the registry tree breadth-first, appending descendants to the tail of its queue, so a unit's DEPTH in the tree decided its position, not its name. Every root-level unit — parentless rooms and combined containers alike — drew ahead of any room nested under a non-combined container, whatever either was called. Staff saw containers cluster ahead of other buildings' rooms within an area, exactly as reported ("containers should be alpha within categories, not containers first").

## Fix

Sort each area's bucket by `(area_sort_order, name)` after the payload is bucketed (`boardLayout.ts`, `buildBoard`), rather than trusting payload order. Corrected the stale comment at that spot describing the old (wrong) assumption.

## "Categories" — resolved as area, not `inventory_class`

The issue's open question was which grouping "categories" meant. Read out of the tree: `inventory_class` groups nothing on the board today — its only uses are visibility and badge predicates (`boardLayout.ts:914`, `unitBadges.ts:77/:105/:143`). There is no code path that buckets, sorts, or headers by it. Reading "categories" as `inventory_class` would mean inventing a grouping the board has never had, not fixing a sort — so this reads it as area, the board's actual (and only) grouping.

## Tests

- Rewrote `never reorders the units WITHIN an area` (`boardLayout.test.ts`) — it pinned the old, wrong invariant that payload order should survive untouched. It now feeds units in reverse-alphabetical order (the shape a BFS walk produces when depth runs opposite name) and asserts the board still sorts them alphabetically. Comment says why it's a rewrite, not an adaptation.
- Updated one incidental-order assertion in `keeps staff housing that still holds a party` — both fixture units land in the same default area, so the correct alphabetical order flipped; the assertion under test (membership — a party never disappears) is unaffected.
- Mutation-checked: removing the new sort turns both tests red.

## Deliberately did not do

- Did not touch `unitLevel.ts`'s breadth-first walk or `drawnUnits`, and did not touch `unitLevel.test.ts`'s pinned emission-order assertions. The walk order is unchanged; only where `buildBoard` re-sorts before drawing changed. Those tests still pass untouched.

Closes #2514.