### PR TITLE
fix(sync): close the family-camp bounded custom-values jobs' lock, phase, and log gaps

### DIFF
--- a/pocketbase/main_test_parallelism_test.go
+++ b/pocketbase/main_test_parallelism_test.go
@@ -111,6 +111,8 @@ var serialGroups = []struct {
 			"TestProcessAssignment_SaveFailure_IsInfraError",
 			"TestProcessEnrollment_MissingSessionID_IsRejected",
 			"TestProcessEnrollment_SaveFailure_IsInfraError",
+			"TestPersonCustomFieldValuesSync_CompletionLogUsesBoundedJobName",
+			"TestHouseholdCustomFieldValuesSync_CompletionLogUsesBoundedJobName",
 		},
 	},
 	{

--- a/pocketbase/sync/api.go
+++ b/pocketbase/sync/api.go
@@ -1242,7 +1242,7 @@ func processQueuedSyncs(orchestrator *Orchestrator) {
 	case "phase":
 		// Run all jobs in the phase sequentially
 		phase := Phase(qs.Service)
-		jobs := GetJobsForPhase(phase)
+		jobs := phaseExecutionJobs(phase)
 		slog.Info("Queued phase sync: Running jobs",
 			"phase", phase, "year", qs.Year, "jobs", jobs, "debug", qs.Debug)
 
@@ -1470,8 +1470,13 @@ func handleWeeklySync(e *core.RequestEvent, scheduler *Scheduler) error {
 func handleCustomValuesSync(e *core.RequestEvent, scheduler *Scheduler) error {
 	orchestrator := scheduler.GetOrchestrator()
 
-	// Check if custom values sync is already running
-	if orchestrator.IsRunning("person_custom_values") || orchestrator.IsRunning("household_custom_values") {
+	// Check if custom values sync is already running. Collection-group-aware (kindred#2491
+	// Face A): the daily cron's bounded family-camp jobs ("person_custom_values_family_camp",
+	// "household_custom_values_family_camp" -- kindred#2489) write these exact same
+	// collections under different registered names, so a check against only the two literal
+	// unrestricted names missed them.
+	if orchestrator.IsCustomValuesCollectionRunning("person_custom_values") ||
+		orchestrator.IsCustomValuesCollectionRunning("household_custom_values") {
 		return e.JSON(http.StatusConflict, map[string]any{
 			"error": "Custom values sync already in progress",
 		})
@@ -2144,6 +2149,39 @@ func handleHouseholdDemographicsSync(e *core.RequestEvent, scheduler *Scheduler)
 	})
 }
 
+// familyCampBoundedCustomValuesJobs names the two daily-cron-only custom-values instances
+// (kindred#2489) that phaseExecutionJobs excludes from an admin-triggered PhaseExpensive run.
+var familyCampBoundedCustomValuesJobs = map[string]bool{
+	"person_custom_values_family_camp":    true,
+	"household_custom_values_family_camp": true,
+}
+
+// phaseExecutionJobs returns the jobs actually run for phase -- the list handleRunPhase and
+// processQueuedSyncs iterate to start syncs, as opposed to GetJobsForPhase's classification
+// list (used for phase metadata/UI in handleGetPhases and pinned as including all four
+// custom-values jobs by family_camp_daily_cadence_test.go's TestSyncJobMeta_
+// FamilyCampBoundedJobsAreExpensivePhase).
+//
+// For PhaseExpensive specifically, it drops the two bounded family-camp jobs
+// (kindred#2489): they are always covered minutes earlier by the daily cron
+// (getDailySyncJobs), so an admin running the "Custom Values" phase on demand would otherwise
+// re-fetch the identical family-camp cohort a second time -- kindred#2491 Face C, measured at
+// ~11.5 min of rate-limited CampMinder quota burned for values already fresh. GetJobsForPhase
+// itself is left untouched; only the execution list is filtered.
+func phaseExecutionJobs(phase Phase) []string {
+	jobs := GetJobsForPhase(phase)
+	if phase != PhaseExpensive {
+		return jobs
+	}
+	filtered := make([]string, 0, len(jobs))
+	for _, j := range jobs {
+		if !familyCampBoundedCustomValuesJobs[j] {
+			filtered = append(filtered, j)
+		}
+	}
+	return filtered
+}
+
 // handleGetPhases returns list of available sync phases with metadata
 func handleGetPhases(e *core.RequestEvent) error {
 	phases := GetAllPhases()
@@ -2234,7 +2272,7 @@ func handleRunPhase(e *core.RequestEvent, scheduler *Scheduler) error {
 	}
 
 	// Get jobs for this phase
-	jobs := GetJobsForPhase(phase)
+	jobs := phaseExecutionJobs(phase)
 	if len(jobs) == 0 {
 		return e.JSON(http.StatusBadRequest, map[string]any{
 			"error": "No jobs found for phase: " + string(phase),

--- a/pocketbase/sync/api_test.go
+++ b/pocketbase/sync/api_test.go
@@ -1995,3 +1995,200 @@ func TestNormalizeSession(t *testing.T) {
 		})
 	}
 }
+
+// =============================================================================
+// kindred#2491: the family-camp bounded custom-values jobs share collections with the
+// unbounded ones but not their lock, phase slot, or log label. Face A + Face C below.
+// =============================================================================
+
+// TestHandleCustomValuesSyncRejectsWhenFamilyCampBoundedGroupmateRunning pins Face A's
+// original report: handleCustomValuesSync's front guard used to check only the literal names
+// "person_custom_values" / "household_custom_values" via orchestrator.IsRunning, so it did not
+// see the bounded daily family-camp jobs (kindred#2489) as writers of the same collections and
+// would return 200 "Custom values sync triggered" while one was still in flight.
+func TestHandleCustomValuesSyncRejectsWhenFamilyCampBoundedGroupmateRunning(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		boundedJob    string
+		registerBound func(o *Orchestrator)
+	}{
+		{
+			name:       "person bounded pass blocks the endpoint",
+			boundedJob: "person_custom_values_family_camp",
+			registerBound: func(o *Orchestrator) {
+				o.RegisterService("person_custom_values_family_camp",
+					&MockService{name: "person_custom_values_family_camp"})
+			},
+		},
+		{
+			name:       "household bounded pass blocks the endpoint",
+			boundedJob: "household_custom_values_family_camp",
+			registerBound: func(o *Orchestrator) {
+				o.RegisterService("household_custom_values_family_camp",
+					&MockService{name: "household_custom_values_family_camp"})
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scheduler := NewScheduler(nil)
+			orchestrator := scheduler.GetOrchestrator()
+			tc.registerBound(orchestrator)
+
+			if err := orchestrator.MarkSyncRunning(tc.boundedJob); err != nil {
+				t.Fatalf("MarkSyncRunning(%q): %v", tc.boundedJob, err)
+			}
+
+			re := &core.RequestEvent{}
+			re.Request = httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+			rec := httptest.NewRecorder()
+			re.Response = rec
+
+			if err := handleCustomValuesSync(re, scheduler); err != nil {
+				t.Fatalf("handler returned error: %v", err)
+			}
+
+			if rec.Code != http.StatusConflict {
+				t.Errorf("expected %d (already running), got %d: %s",
+					http.StatusConflict, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestHandleCustomValuesSyncAllowsRunWhenNothingRunning is the control case: with nothing
+// running (bounded or unrestricted), the endpoint must still succeed.
+func TestHandleCustomValuesSyncAllowsRunWhenNothingRunning(t *testing.T) {
+	t.Parallel()
+	scheduler := NewScheduler(nil)
+
+	re := &core.RequestEvent{}
+	re.Request = httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+	rec := httptest.NewRecorder()
+	re.Response = rec
+
+	if err := handleCustomValuesSync(re, scheduler); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+}
+
+// TestPhaseExecutionJobsExcludesFamilyCampBoundedForExpensivePhase pins Face C: an admin
+// running the "Custom Values" (PhaseExpensive) phase used to re-run the two bounded family-camp
+// jobs alongside the unrestricted ones, because GetJobsForPhase(PhaseExpensive) -- built from
+// syncJobMeta -- lists all four jobs. The bounded jobs are always covered by the daily cron
+// (getDailySyncJobs) minutes before an admin-triggered phase run would otherwise re-fetch the
+// identical family-camp cohort, burning ~11.5 min of rate-limited CampMinder quota for values
+// already fresh.
+//
+// GetJobsForPhase itself is deliberately left untouched (see TestSyncJobMeta_
+// FamilyCampBoundedJobsAreExpensivePhase in family_camp_daily_cadence_test.go, which pins the
+// two bounded jobs' classification as PhaseExpensive) -- phaseExecutionJobs filters the
+// *execution* list at the two call sites that actually run a phase (handleRunPhase,
+// processQueuedSyncs) without changing what GetJobsForPhase reports for phase metadata/UI.
+func TestPhaseExecutionJobsExcludesFamilyCampBoundedForExpensivePhase(t *testing.T) {
+	t.Parallel()
+
+	jobs := phaseExecutionJobs(PhaseExpensive)
+
+	for _, excluded := range []string{"person_custom_values_family_camp", "household_custom_values_family_camp"} {
+		for _, j := range jobs {
+			if j == excluded {
+				t.Errorf("phaseExecutionJobs(PhaseExpensive) = %v, must not include %q "+
+					"-- it is always covered by the daily cron", jobs, excluded)
+			}
+		}
+	}
+
+	for _, included := range []string{"person_custom_values", "household_custom_values"} {
+		found := false
+		for _, j := range jobs {
+			if j == included {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("phaseExecutionJobs(PhaseExpensive) = %v, missing %q", jobs, included)
+		}
+	}
+
+	// GetJobsForPhase itself must be untouched -- family_camp_daily_cadence_test.go's
+	// TestSyncJobMeta_FamilyCampBoundedJobsAreExpensivePhase pins that it still lists all four.
+	classified := GetJobsForPhase(PhaseExpensive)
+	if len(classified) != 4 {
+		t.Errorf("GetJobsForPhase(PhaseExpensive) = %v, expected phaseExecutionJobs to filter "+
+			"a copy, not mutate the underlying classification", classified)
+	}
+
+	// Every other phase must pass through unfiltered.
+	for _, phase := range GetAllPhases() {
+		if phase == PhaseExpensive {
+			continue
+		}
+		want := GetJobsForPhase(phase)
+		got := phaseExecutionJobs(phase)
+		if len(got) != len(want) {
+			t.Errorf("phaseExecutionJobs(%q) = %v, want unfiltered %v", phase, got, want)
+			continue
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("phaseExecutionJobs(%q)[%d] = %q, want %q", phase, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// TestHandleRunPhaseImmediateResponseExcludesFamilyCampBoundedJobs is the HTTP-level half of
+// Face C: the "jobs" field handleRunPhase echoes back (and actually iterates to run) for
+// ?phase=expensive must not list the two bounded family-camp jobs.
+func TestHandleRunPhaseImmediateResponseExcludesFamilyCampBoundedJobs(t *testing.T) {
+	t.Parallel()
+	scheduler := NewScheduler(nil)
+
+	re := &core.RequestEvent{}
+	re.Request = httptest.NewRequest(http.MethodPost, "/?year=2025&phase=expensive", http.NoBody)
+	rec := httptest.NewRecorder()
+	re.Response = rec
+
+	if err := handleRunPhase(re, scheduler); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var body struct {
+		Jobs []string `json:"jobs"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	for _, excluded := range []string{"person_custom_values_family_camp", "household_custom_values_family_camp"} {
+		for _, j := range body.Jobs {
+			if j == excluded {
+				t.Errorf("handleRunPhase(?phase=expensive) jobs = %v, must not include %q",
+					body.Jobs, excluded)
+			}
+		}
+	}
+	for _, included := range []string{"person_custom_values", "household_custom_values"} {
+		found := false
+		for _, j := range body.Jobs {
+			if j == included {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("handleRunPhase(?phase=expensive) jobs = %v, missing %q", body.Jobs, included)
+		}
+	}
+}

--- a/pocketbase/sync/household_custom_field_values.go
+++ b/pocketbase/sync/household_custom_field_values.go
@@ -125,7 +125,7 @@ func (s *HouseholdCustomFieldValuesSync) Sync(ctx context.Context) error {
 			"session", s.Session,
 			"year", year)
 		s.SyncSuccessful = true
-		s.LogSyncComplete("HouseholdCustomFieldValues")
+		s.LogSyncComplete(jobName)
 		return nil
 	}
 
@@ -225,7 +225,7 @@ func (s *HouseholdCustomFieldValuesSync) Sync(ctx context.Context) error {
 		slog.Warn("WAL checkpoint failed", "error", err)
 	}
 
-	s.LogSyncComplete("HouseholdCustomFieldValues")
+	s.LogSyncComplete(jobName)
 	return nil
 }
 

--- a/pocketbase/sync/household_custom_field_values.go
+++ b/pocketbase/sync/household_custom_field_values.go
@@ -16,6 +16,12 @@ import (
 // Service name constant - uses new table name
 const serviceNameHouseholdCustomValues = "household_custom_values"
 
+// serviceNameHouseholdCustomValuesFamilyCamp must match orchestrator.go's
+// RegisterService("household_custom_values_family_camp", ...) call for the bounded daily
+// instance (kindred#2489). logJobName uses it so the bounded pass's own logs are
+// distinguishable from the unrestricted sweep's (kindred#2491 Face D).
+const serviceNameHouseholdCustomValuesFamilyCamp = "household_custom_values_family_camp"
+
 // HouseholdCustomFieldValuesSync handles syncing custom field values for households from
 // CampMinder. The unrestricted instance (Session=DefaultSession) is ON-DEMAND -- weekly cron +
 // manual runs only -- because a year-wide sweep is 1 API call per household. A second,
@@ -55,6 +61,15 @@ func (s *HouseholdCustomFieldValuesSync) Name() string {
 	return serviceNameHouseholdCustomValues
 }
 
+// logJobName is the household twin of PersonCustomFieldValuesSync.logJobName -- see that
+// method's comment for the full rationale (kindred#2491 Face D).
+func (s *HouseholdCustomFieldValuesSync) logJobName() string {
+	if s.FamilyCampBounded {
+		return serviceNameHouseholdCustomValuesFamilyCamp
+	}
+	return serviceNameHouseholdCustomValues
+}
+
 // SetDryRun implements the orchestrator's DryRunnable interface (kindred#2351). Declared
 // explicitly rather than inherited by embedding BaseSyncService -- see that field's doc
 // comment on BaseSyncService for why a promoted setter is not safe. Setting it also gates
@@ -72,9 +87,10 @@ func (s *HouseholdCustomFieldValuesSync) SetSession(session string) {
 // Sync performs the household custom field values sync
 func (s *HouseholdCustomFieldValuesSync) Sync(ctx context.Context) error {
 	year := s.Client.GetSeasonID()
+	jobName := s.logJobName()
 
 	// Start the sync process
-	s.LogSyncStart(serviceNameHouseholdCustomValues)
+	s.LogSyncStart(jobName)
 	s.Stats = Stats{}
 	s.SyncSuccessful = false
 
@@ -105,6 +121,7 @@ func (s *HouseholdCustomFieldValuesSync) Sync(ctx context.Context) error {
 
 	if len(householdIDs) == 0 {
 		slog.Info("No households to sync custom field values for",
+			"job", jobName,
 			"session", s.Session,
 			"year", year)
 		s.SyncSuccessful = true
@@ -113,6 +130,7 @@ func (s *HouseholdCustomFieldValuesSync) Sync(ctx context.Context) error {
 	}
 
 	slog.Info("Syncing custom field values for households",
+		"job", jobName,
 		"count", len(householdIDs),
 		"session", s.Session,
 		"year", year)

--- a/pocketbase/sync/household_custom_field_values_test.go
+++ b/pocketbase/sync/household_custom_field_values_test.go
@@ -228,3 +228,25 @@ func TestHouseholdCustomFieldValuesTrackingMatchesOrphanLookup(t *testing.T) {
 		t.Errorf("yearScopedKey %q != orphanLookupKey %q", yearScopedKey, orphanLookupKey)
 	}
 }
+
+// TestHouseholdCustomFieldValuesSync_LogJobName is the household twin of
+// TestPersonCustomFieldValuesSync_LogJobName -- see that test's comment for the full rationale
+// (kindred#2491 Face D).
+func TestHouseholdCustomFieldValuesSync_LogJobName(t *testing.T) {
+	t.Parallel()
+
+	unbounded := &HouseholdCustomFieldValuesSync{}
+	if got, want := unbounded.logJobName(), serviceNameHouseholdCustomValues; got != want {
+		t.Errorf("logJobName() (unbounded) = %q, want %q", got, want)
+	}
+
+	bounded := &HouseholdCustomFieldValuesSync{FamilyCampBounded: true}
+	if got, want := bounded.logJobName(), "household_custom_values_family_camp"; got != want {
+		t.Errorf("logJobName() (FamilyCampBounded) = %q, want %q -- must match orchestrator.go's "+
+			"RegisterService(\"household_custom_values_family_camp\", ...) name", got, want)
+	}
+
+	if got, want := bounded.Name(), serviceNameHouseholdCustomValues; got != want {
+		t.Errorf("Name() must stay %q regardless of FamilyCampBounded, got %q", want, got)
+	}
+}

--- a/pocketbase/sync/household_custom_field_values_test.go
+++ b/pocketbase/sync/household_custom_field_values_test.go
@@ -2,8 +2,14 @@
 package sync
 
 import (
+	"context"
 	"strings"
 	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+
+	"github.com/camp/kindred/pocketbase/campminder"
 )
 
 const testFieldDefPBID = "pb_field_100"
@@ -248,5 +254,53 @@ func TestHouseholdCustomFieldValuesSync_LogJobName(t *testing.T) {
 
 	if got, want := bounded.Name(), serviceNameHouseholdCustomValues; got != want {
 		t.Errorf("Name() must stay %q regardless of FamilyCampBounded, got %q", want, got)
+	}
+}
+
+// TestHouseholdCustomFieldValuesSync_CompletionLogUsesBoundedJobName is the household twin of
+// TestPersonCustomFieldValuesSync_CompletionLogUsesBoundedJobName -- see that test's comment
+// for the full rationale (kindred#2491 Face D: Sync()'s two LogSyncComplete call sites still
+// hardcoded the literal "HouseholdCustomFieldValues" even after logJobName started feeding
+// LogSyncStart and the cohort log).
+func TestHouseholdCustomFieldValuesSync_CompletionLogUsesBoundedJobName(t *testing.T) {
+	// Not t.Parallel(): t.Setenv panics if the test may run in parallel, and captureSweepLogs
+	// swaps the process-global slog default for the test's duration.
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	col := core.NewBaseCollection("camp_sessions")
+	col.Fields.Add(&core.NumberField{Name: "year"})
+	col.Fields.Add(&core.TextField{Name: "session_type"})
+	col.Fields.Add(&core.NumberField{Name: "cm_id"})
+	if saveErr := app.Save(col); saveErr != nil {
+		t.Fatalf("create camp_sessions: %v", saveErr)
+	}
+
+	t.Setenv("CAMPMINDER_PRIMARY_KEY", "test-subscription-key")
+	client, err := campminder.NewClient(&campminder.Config{APIKey: "test-key", ClientID: "test-client", SeasonID: 2026})
+	if err != nil {
+		t.Fatalf("campminder.NewClient: %v", err)
+	}
+
+	s := NewHouseholdCustomFieldValuesSync(app, client)
+	s.FamilyCampBounded = true
+
+	logs := captureSweepLogs(t)
+
+	if syncErr := s.Sync(context.Background()); syncErr != nil {
+		t.Fatalf("Sync: %v", syncErr)
+	}
+
+	output := logs.String()
+	if !strings.Contains(output, "service=household_custom_values_family_camp") {
+		t.Errorf("completion log must carry the bounded instance's own job name "+
+			"(service=household_custom_values_family_camp), got:\n%s", output)
+	}
+	if strings.Contains(output, "service=HouseholdCustomFieldValues") {
+		t.Errorf("completion log must not use the old ambiguous literal "+
+			"service=HouseholdCustomFieldValues, got:\n%s", output)
 	}
 }

--- a/pocketbase/sync/orchestrator.go
+++ b/pocketbase/sync/orchestrator.go
@@ -703,6 +703,55 @@ func (o *Orchestrator) IsRunning(syncType string) bool {
 	return exists && status.Status == statusRunning
 }
 
+// customValuesCollectionGroup maps each job that writes to a shared custom-values PocketBase
+// collection to a group key for that collection. The bounded daily family-camp jobs
+// ("person_custom_values_family_camp", "household_custom_values_family_camp" -- kindred#2489)
+// are registered under distinct service names but write the exact same person_custom_values /
+// household_custom_values collections as their unrestricted counterparts (the weekly sweep and
+// on-demand runs), so a mutual-exclusion check keyed on the literal job name does not see them
+// as the same writer. That gap is kindred#2491: the daily cron's bounded pass and the weekly
+// unrestricted sweep (or an operator's on-demand run) could interleave against the same
+// collection, racing a concurrent write against deleteOrphans's own read.
+//
+// person_custom_values and household_custom_values are deliberately in separate groups --
+// RunCustomValuesSync documents running them in parallel as safe because they write
+// independent collections via independent CampMinder endpoints, and this map must not widen
+// the lock across that boundary.
+var customValuesCollectionGroup = map[string]string{
+	"person_custom_values":                "person_custom_values",
+	"person_custom_values_family_camp":    "person_custom_values",
+	"household_custom_values":             "household_custom_values",
+	"household_custom_values_family_camp": "household_custom_values",
+}
+
+// customValuesGroupRunningLocked reports whether any currently running job shares syncType's
+// custom-values collection group (see customValuesCollectionGroup) -- including syncType
+// itself. For a syncType outside that map this is exactly the same check IsRunning(syncType)
+// makes. Callers must already hold o.mu (read or write lock) -- this function takes no lock of
+// its own so it can be composed into an existing check-and-mark critical section.
+func (o *Orchestrator) customValuesGroupRunningLocked(syncType string) bool {
+	group, tracked := customValuesCollectionGroup[syncType]
+	for name, status := range o.runningJobs {
+		if status.Status != statusRunning {
+			continue
+		}
+		if name == syncType || (tracked && customValuesCollectionGroup[name] == group) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsCustomValuesCollectionRunning is the exported, self-locking form of
+// customValuesGroupRunningLocked for callers outside the orchestrator (api.go's on-demand
+// handlers) that need to check before starting a run rather than as part of one atomic
+// check-and-mark critical section.
+func (o *Orchestrator) IsCustomValuesCollectionRunning(syncType string) bool {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	return o.customValuesGroupRunningLocked(syncType)
+}
+
 // GetRunningJobs returns all currently running jobs
 func (o *Orchestrator) GetRunningJobs() []string {
 	o.mu.RLock()
@@ -920,8 +969,15 @@ func (o *Orchestrator) runSingleSyncInternal(
 		status.Trigger, status.BatchID, status.Year = origin.trigger, origin.batchID, origin.year
 		o.mu.Unlock()
 	} else {
-		// No pre-marked status - check if something else is running
-		if o.IsRunning(syncType) {
+		// No pre-marked status - check if something else is running. Uses the collection-
+		// group-aware check (not the plain IsRunning(syncType)) so the daily cron's bounded
+		// family-camp pass and the weekly unrestricted sweep exclude each other even though
+		// they run under different registered names (kindred#2491 Face B) -- this is the path
+		// both getDailySyncJobs (via runSyncAndWait) and RunCustomValuesSync take.
+		o.mu.RLock()
+		blocked := o.customValuesGroupRunningLocked(syncType)
+		o.mu.RUnlock()
+		if blocked {
 			return "", fmt.Errorf("sync already in progress: %s", syncType)
 		}
 
@@ -1029,7 +1085,12 @@ func (o *Orchestrator) RunSingleSyncWithService(
 	parentCtx context.Context, syncType string, service Service, origin runOrigin,
 ) error {
 	o.mu.Lock()
-	if existing, exists := o.runningJobs[syncType]; exists && existing.Status == statusRunning {
+	// Collection-group-aware check (kindred#2491 Face A): a plain runningJobs[syncType] lookup
+	// missed that the bounded family-camp jobs write the same collection under a different
+	// registered name, so an operator's on-demand person_custom_values / household_custom_values
+	// run could start while the daily cron's bounded pass was still in flight. Checked under the
+	// same lock as the mark below, so the atomicity #1881/#2105 rely on is unchanged.
+	if o.customValuesGroupRunningLocked(syncType) {
 		o.mu.Unlock()
 		return fmt.Errorf("sync already in progress: %s", syncType)
 	}

--- a/pocketbase/sync/orchestrator_test.go
+++ b/pocketbase/sync/orchestrator_test.go
@@ -3082,6 +3082,47 @@ func TestOrchestrator_GetChangedCollections(t *testing.T) {
 			t.Errorf("expected empty map for unknown sync type, got %d entries", len(changed))
 		}
 	})
+
+	// The bounded family-camp jobs (kindred#2489) write the exact same person_custom_values /
+	// household_custom_values collections as their unrestricted counterparts, but
+	// SyncJobToCollections (table_exporter.go) never gained entries for their registered names
+	// -- a code-review finding on kindred#2491 (the same "new job name unrecognized by an
+	// identity-keyed map" root cause this issue's own three faces are about, just a fourth
+	// consumer). Without this, GetChangedCollections() -- which iterates ALL of
+	// o.lastCompletedStatus, not just the current run's jobs -- silently drops the bounded
+	// pass's real changes, and the Sheets export skip-optimization skips exporting
+	// person_custom_values/household_custom_values even though the daily cron just wrote fresh
+	// data to them.
+	t.Run("bounded family-camp jobs map to the same collections as their unrestricted siblings", func(t *testing.T) {
+		o := NewOrchestrator(nil)
+
+		now := time.Now()
+		o.mu.Lock()
+		o.lastCompletedStatus["person_custom_values_family_camp"] = &Status{
+			Type:    "person_custom_values_family_camp",
+			Status:  statusCompleted,
+			EndTime: &now,
+			Summary: Stats{Created: 3, Updated: 1},
+		}
+		o.lastCompletedStatus["household_custom_values_family_camp"] = &Status{
+			Type:    "household_custom_values_family_camp",
+			Status:  statusCompleted,
+			EndTime: &now,
+			Summary: Stats{Created: 2},
+		}
+		o.mu.Unlock()
+
+		changed := o.GetChangedCollections()
+
+		if !changed["person_custom_values"] {
+			t.Error("expected person_custom_values to be in changed collections after the " +
+				"bounded family-camp pass completed with real changes")
+		}
+		if !changed["household_custom_values"] {
+			t.Error("expected household_custom_values to be in changed collections after the " +
+				"bounded family-camp pass completed with real changes")
+		}
+	})
 }
 
 // TestDailySyncDoesNotIncludeTransformPhase tests that daily sync excludes all transform jobs

--- a/pocketbase/sync/orchestrator_test.go
+++ b/pocketbase/sync/orchestrator_test.go
@@ -4327,6 +4327,122 @@ func TestRunSingleSyncWithServiceConcurrentCallsExactlyOneWins(t *testing.T) {
 	}
 }
 
+// TestRunSingleSyncRejectsCustomValuesCollectionGroupConflict pins kindred#2491 Face B: the
+// bounded daily family-camp jobs ("person_custom_values_family_camp",
+// "household_custom_values_family_camp", added by kindred#2489) write the exact same
+// PocketBase collections as their unrestricted counterparts, but under a distinct registered
+// name -- so runSingleSyncInternal's old `IsRunning(syncType)` check (keyed on the literal
+// name) let the daily 3am cron's bounded pass and the weekly Sunday 4am unrestricted sweep run
+// concurrently against the same collection, racing deleteOrphans against a concurrent write.
+//
+// This exercises the path getDailySyncJobs / RunCustomValuesSync actually take --
+// runSyncAndWait -> runSingleSyncInternal -- via the public RunSingleSync wrapper.
+func TestRunSingleSyncRejectsCustomValuesCollectionGroupConflict(t *testing.T) {
+	t.Parallel()
+
+	markRunning := func(o *Orchestrator, syncType string) {
+		o.mu.Lock()
+		o.runningJobs[syncType] = &Status{Type: syncType, Status: statusRunning}
+		o.mu.Unlock()
+	}
+
+	t.Run("family-camp bounded blocks the unrestricted groupmate", func(t *testing.T) {
+		t.Parallel()
+		o := NewOrchestrator(nil)
+		o.RegisterService("person_custom_values", &MockService{name: "person_custom_values"})
+		markRunning(o, "person_custom_values_family_camp")
+
+		if err := o.RunSingleSync(context.Background(), "person_custom_values"); err == nil {
+			t.Error("expected person_custom_values to be rejected while its family-camp " +
+				"bounded groupmate is running -- they write the same collection")
+		}
+	})
+
+	t.Run("unrestricted blocks the family-camp bounded groupmate", func(t *testing.T) {
+		t.Parallel()
+		o := NewOrchestrator(nil)
+		o.RegisterService("household_custom_values_family_camp",
+			&MockService{name: "household_custom_values_family_camp"})
+		markRunning(o, "household_custom_values")
+
+		if err := o.RunSingleSync(context.Background(), "household_custom_values_family_camp"); err == nil {
+			t.Error("expected household_custom_values_family_camp to be rejected while the " +
+				"unrestricted household_custom_values is running")
+		}
+	})
+
+	t.Run("person and household groups do not cross-block", func(t *testing.T) {
+		t.Parallel()
+		o := NewOrchestrator(nil)
+		o.RegisterService("household_custom_values", &MockService{name: "household_custom_values"})
+		markRunning(o, "person_custom_values_family_camp")
+
+		// RunCustomValuesSync's doc comment says running person_custom_values and
+		// household_custom_values in parallel is safe because they write independent
+		// collections -- the group-scoped fix must not widen the lock across that boundary.
+		if err := o.RunSingleSync(context.Background(), "household_custom_values"); err != nil {
+			t.Errorf("household_custom_values must not be blocked by a running "+
+				"person_custom_values_family_camp -- different collection, got: %v", err)
+		}
+	})
+
+	t.Run("unrelated job names are unaffected", func(t *testing.T) {
+		t.Parallel()
+		o := NewOrchestrator(nil)
+		o.RegisterService("sessions", &MockService{name: "sessions"})
+		markRunning(o, "person_custom_values_family_camp")
+
+		if err := o.RunSingleSync(context.Background(), "sessions"); err != nil {
+			t.Errorf("an unrelated job must not be blocked by a running custom-values job, got: %v", err)
+		}
+	})
+}
+
+// TestRunSingleSyncWithServiceRejectsCustomValuesCollectionGroupConflict mirrors
+// TestRunSingleSyncWithServiceRejectsConcurrentRunForSameType but across the bounded/
+// unrestricted name split (kindred#2491 Face A for the two session-scoped handlers, which
+// route through RunSingleSyncWithService with request-scoped instances -- see #2105).
+func TestRunSingleSyncWithServiceRejectsCustomValuesCollectionGroupConflict(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		o := NewOrchestrator(nil)
+
+		bounded := &mockYearService{name: "person_custom_values_family_camp", delay: 100 * time.Millisecond}
+		if err := o.RunSingleSyncWithService(
+			context.Background(), "person_custom_values_family_camp", bounded, newBatch(triggerManual),
+		); err != nil {
+			t.Fatalf("starting the bounded pass should succeed, got: %v", err)
+		}
+
+		unrestricted := &mockYearService{name: "person_custom_values"}
+		err := o.RunSingleSyncWithService(
+			context.Background(), "person_custom_values", unrestricted, newBatch(triggerManual),
+		)
+		if err == nil {
+			t.Fatal("expected the unrestricted person_custom_values run to be rejected while " +
+				"the family-camp bounded pass is in flight")
+		}
+		if unrestricted.callCount.Load() != 0 {
+			t.Error("a rejected run must never execute Sync on its service instance")
+		}
+
+		// household_custom_values is a different collection group -- must still be free to run
+		// concurrently with the person-side bounded pass.
+		household := &mockYearService{name: "household_custom_values"}
+		if err := o.RunSingleSyncWithService(
+			context.Background(), "household_custom_values", household, newBatch(triggerManual),
+		); err != nil {
+			t.Errorf("household_custom_values must not be blocked by a running "+
+				"person_custom_values_family_camp, got: %v", err)
+		}
+
+		time.Sleep(200 * time.Millisecond)
+		if bounded.callCount.Load() != 1 {
+			t.Errorf("expected the bounded pass to have run exactly once, got %d", bounded.callCount.Load())
+		}
+	})
+}
+
 // TestCustomFieldValuesHandlersReserveBeforeMutatingSharedState pins the fix for #2105.
 //
 // Both on-demand custom-field-values handlers (person and household) used to fetch the

--- a/pocketbase/sync/person_custom_field_values.go
+++ b/pocketbase/sync/person_custom_field_values.go
@@ -129,7 +129,7 @@ func (s *PersonCustomFieldValuesSync) Sync(ctx context.Context) error {
 			"session", s.Session,
 			"year", year)
 		s.SyncSuccessful = true
-		s.LogSyncComplete("PersonCustomFieldValues")
+		s.LogSyncComplete(jobName)
 		return nil
 	}
 
@@ -229,7 +229,7 @@ func (s *PersonCustomFieldValuesSync) Sync(ctx context.Context) error {
 		slog.Warn("WAL checkpoint failed", "error", err)
 	}
 
-	s.LogSyncComplete("PersonCustomFieldValues")
+	s.LogSyncComplete(jobName)
 	return nil
 }
 

--- a/pocketbase/sync/person_custom_field_values.go
+++ b/pocketbase/sync/person_custom_field_values.go
@@ -16,6 +16,12 @@ import (
 // Service name constant - uses new table name
 const serviceNamePersonCustomValues = "person_custom_values"
 
+// serviceNamePersonCustomValuesFamilyCamp must match orchestrator.go's
+// RegisterService("person_custom_values_family_camp", ...) call for the bounded daily instance
+// (kindred#2489). logJobName uses it so the bounded pass's own logs are distinguishable from
+// the unrestricted sweep's (kindred#2491 Face D).
+const serviceNamePersonCustomValuesFamilyCamp = "person_custom_values_family_camp"
+
 // PersonCustomFieldValuesSync handles syncing custom field values for persons from CampMinder.
 // The unrestricted instance (Session=DefaultSession) is ON-DEMAND -- weekly cron + manual runs
 // only -- because a year-wide sweep is 1 API call per person. A second, FamilyCampBounded
@@ -55,6 +61,19 @@ func (s *PersonCustomFieldValuesSync) Name() string {
 	return serviceNamePersonCustomValues
 }
 
+// logJobName returns the registered job name this instance is actually running as: the bounded
+// family-camp name when FamilyCampBounded is set, the unrestricted name otherwise. Sync() uses
+// this (not the fixed Name()) for LogSyncStart and its cohort-size log line, so an operator
+// reading logs can tell the nightly bounded pass apart from the weekly unrestricted sweep --
+// before this both logged identically as "person_custom_values" even though they cover
+// different cohorts on different schedules (kindred#2491 Face D).
+func (s *PersonCustomFieldValuesSync) logJobName() string {
+	if s.FamilyCampBounded {
+		return serviceNamePersonCustomValuesFamilyCamp
+	}
+	return serviceNamePersonCustomValues
+}
+
 // SetDryRun implements the orchestrator's DryRunnable interface (kindred#2351). Declared
 // explicitly rather than inherited by embedding BaseSyncService -- see that field's doc
 // comment on BaseSyncService for why a promoted setter is not safe. Setting it also gates
@@ -72,9 +91,10 @@ func (s *PersonCustomFieldValuesSync) SetSession(session string) {
 // Sync performs the person custom field values sync
 func (s *PersonCustomFieldValuesSync) Sync(ctx context.Context) error {
 	year := s.Client.GetSeasonID()
+	jobName := s.logJobName()
 
 	// Start the sync process
-	s.LogSyncStart(serviceNamePersonCustomValues)
+	s.LogSyncStart(jobName)
 	s.Stats = Stats{}
 	s.SyncSuccessful = false
 
@@ -105,6 +125,7 @@ func (s *PersonCustomFieldValuesSync) Sync(ctx context.Context) error {
 
 	if len(personIDs) == 0 {
 		slog.Info("No persons to sync custom field values for",
+			"job", jobName,
 			"session", s.Session,
 			"year", year)
 		s.SyncSuccessful = true
@@ -113,6 +134,7 @@ func (s *PersonCustomFieldValuesSync) Sync(ctx context.Context) error {
 	}
 
 	slog.Info("Syncing custom field values for persons",
+		"job", jobName,
 		"count", len(personIDs),
 		"session", s.Session,
 		"year", year)

--- a/pocketbase/sync/person_custom_field_values_test.go
+++ b/pocketbase/sync/person_custom_field_values_test.go
@@ -2,8 +2,14 @@
 package sync
 
 import (
+	"context"
 	"strings"
 	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+
+	"github.com/camp/kindred/pocketbase/campminder"
 )
 
 const testPersonPBID = "pb_person_123"
@@ -257,5 +263,63 @@ func TestPersonCustomFieldValuesSync_LogJobName(t *testing.T) {
 	// TestPersonCustomFieldValuesSync_Name), only logJobName's own return value should vary.
 	if got, want := bounded.Name(), serviceNamePersonCustomValues; got != want {
 		t.Errorf("Name() must stay %q regardless of FamilyCampBounded, got %q", want, got)
+	}
+}
+
+// TestPersonCustomFieldValuesSync_CompletionLogUsesBoundedJobName is the sibling gap
+// TestPersonCustomFieldValuesSync_LogJobName does not reach: logJobName is correct, but before
+// this test Sync()'s two LogSyncComplete call sites (the "nothing to sync" early return and the
+// end-of-run summary) still passed the hardcoded literal "PersonCustomFieldValues" instead of
+// jobName. That is the exact ambiguity kindred#2491 Face D's problem statement names -- "an
+// operator diagnosing stale data...sees person_custom_values completing nightly" -- the word
+// "completing" is this log line, the one carrying the created/updated/errors counts, not just
+// the start line LogSyncStart already fixed.
+//
+// Exercises the bounded instance's own "nothing to sync" early return (zero family-camp
+// sessions in the year), which needs no CampMinder mock: GetFamilyCampSessionCMIDs queries only
+// camp_sessions, finds none, and getPersonIDsToSync returns an empty slice before any network
+// call would happen.
+func TestPersonCustomFieldValuesSync_CompletionLogUsesBoundedJobName(t *testing.T) {
+	// Not t.Parallel(): t.Setenv panics if the test may run in parallel, and captureSweepLogs
+	// swaps the process-global slog default for the test's duration.
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	col := core.NewBaseCollection("camp_sessions")
+	col.Fields.Add(&core.NumberField{Name: "year"})
+	col.Fields.Add(&core.TextField{Name: "session_type"})
+	col.Fields.Add(&core.NumberField{Name: "cm_id"})
+	if saveErr := app.Save(col); saveErr != nil {
+		t.Fatalf("create camp_sessions: %v", saveErr)
+	}
+
+	// GetSeasonID is a pure getter -- no network call -- so a real *campminder.Client built
+	// from a fake key is sufficient here (see attendees_dryrun_test.go's identical rationale).
+	t.Setenv("CAMPMINDER_PRIMARY_KEY", "test-subscription-key")
+	client, err := campminder.NewClient(&campminder.Config{APIKey: "test-key", ClientID: "test-client", SeasonID: 2026})
+	if err != nil {
+		t.Fatalf("campminder.NewClient: %v", err)
+	}
+
+	s := NewPersonCustomFieldValuesSync(app, client)
+	s.FamilyCampBounded = true
+
+	logs := captureSweepLogs(t)
+
+	if syncErr := s.Sync(context.Background()); syncErr != nil {
+		t.Fatalf("Sync: %v", syncErr)
+	}
+
+	output := logs.String()
+	if !strings.Contains(output, "service=person_custom_values_family_camp") {
+		t.Errorf("completion log must carry the bounded instance's own job name "+
+			"(service=person_custom_values_family_camp), got:\n%s", output)
+	}
+	if strings.Contains(output, "service=PersonCustomFieldValues") {
+		t.Errorf("completion log must not use the old ambiguous literal "+
+			"service=PersonCustomFieldValues, got:\n%s", output)
 	}
 }

--- a/pocketbase/sync/person_custom_field_values_test.go
+++ b/pocketbase/sync/person_custom_field_values_test.go
@@ -230,3 +230,32 @@ func TestPersonCustomFieldValuesTrackingMatchesOrphanLookup(t *testing.T) {
 		t.Errorf("yearScopedKey %q != orphanLookupKey %q", yearScopedKey, orphanLookupKey)
 	}
 }
+
+// TestPersonCustomFieldValuesSync_LogJobName pins kindred#2491 Face D: Sync() used to call
+// LogSyncStart(serviceNamePersonCustomValues) unconditionally, so the daily cron's bounded
+// family-camp pass (FamilyCampBounded=true) logged "Starting sync service=person_custom_values"
+// -- byte-identical to the weekly unrestricted sweep, even though the two cover different
+// cohorts on different schedules. logJobName must resolve to the bounded instance's own
+// registered name (orchestrator.go's "person_custom_values_family_camp") when FamilyCampBounded
+// is set, and leave the unrestricted instance's logging exactly as it was.
+func TestPersonCustomFieldValuesSync_LogJobName(t *testing.T) {
+	t.Parallel()
+
+	unbounded := &PersonCustomFieldValuesSync{}
+	if got, want := unbounded.logJobName(), serviceNamePersonCustomValues; got != want {
+		t.Errorf("logJobName() (unbounded) = %q, want %q", got, want)
+	}
+
+	bounded := &PersonCustomFieldValuesSync{FamilyCampBounded: true}
+	if got, want := bounded.logJobName(), "person_custom_values_family_camp"; got != want {
+		t.Errorf("logJobName() (FamilyCampBounded) = %q, want %q -- must match orchestrator.go's "+
+			"RegisterService(\"person_custom_values_family_camp\", ...) name so the log line "+
+			"identifies which instance ran", got, want)
+	}
+
+	// Name() itself must stay unchanged -- it is not the registered lock/log identity (see
+	// TestPersonCustomFieldValuesSync_Name), only logJobName's own return value should vary.
+	if got, want := bounded.Name(), serviceNamePersonCustomValues; got != want {
+		t.Errorf("Name() must stay %q regardless of FamilyCampBounded, got %q", want, got)
+	}
+}

--- a/pocketbase/sync/table_exporter.go
+++ b/pocketbase/sync/table_exporter.go
@@ -53,6 +53,14 @@ var SyncJobToCollections = map[string][]string{
 	"person_custom_values":    {"person_custom_values"},
 	"household_custom_values": {"household_custom_values"},
 	"session_groups":          {"session_groups"},
+	// Bounded daily family-camp instances (kindred#2489) of the two jobs directly above --
+	// same collections, distinct registered name (kindred#2491: a mutual-exclusion guard,
+	// phase enumeration, and log label all had this identical gap for the same reason).
+	// GetChangedCollections iterates every completed job by its registered name, so without
+	// these the bounded pass's real writes were silently dropped from the export
+	// skip-optimization and the daily cron's fresh data never got exported.
+	"person_custom_values_family_camp":    {"person_custom_values"},
+	"household_custom_values_family_camp": {"household_custom_values"},
 	// Derived tables
 	"family_camp_derived": {"family_camp_adults", "family_camp_registrations", "family_camp_medical"},
 	// Assignment ingest. Present so the export-skip optimisation knows which


### PR DESCRIPTION
## What

`#2489` registered the bounded daily family-camp custom-values instances
(`person_custom_values_family_camp`, `household_custom_values_family_camp`) as service names
*distinct from* the unrestricted `person_custom_values` / `household_custom_values` jobs they
sit alongside. Both bounded instances write the **same** PocketBase collections as their
unrestricted counterparts, but under a different registered name — so anything that keyed
mutual exclusion, phase execution, or its own log line on the literal job name treated them as
unrelated writers. Four faces of that one root cause, fixed together (same two sync files, same
afternoon's work):

- **Face A** — `api.go`'s three on-demand handlers (`handleCustomValuesSync`,
  `handlePersonCustomFieldValuesSync`, `handleHouseholdCustomFieldValuesSync`) guarded against a
  duplicate run with `IsRunning("person_custom_values")` / `IsRunning("household_custom_values")`
  — the literal unrestricted names only. An operator triggering an on-demand sync while the
  daily cron's bounded pass was in flight was not blocked, so the two runs could interleave
  against the same collection and race a concurrent write against the other's `deleteOrphans`
  read.
- **Face B** — the orchestrator's own in-progress guard (`runningJobs[syncType]`, checked in
  `runSingleSyncInternal`) has the identical gap for the **cron-vs-cron** case `api.go` doesn't
  cover: the daily 03:00 cron's bounded pass and the Sunday 04:00 unrestricted sweep run under
  different registered names and did not exclude each other. Low-severity in practice — a
  failing write increments `Stats.Errors` and skips that owner from the orphan sweep for the
  run (fail-safe, not data loss; the next run self-heals) — but the same root cause as Face A.
- **Face C** — the admin "Custom Values" phase button runs `GetJobsForPhase(PhaseExpensive)`,
  which now lists all **four** jobs. Triggering it re-fetches the ~447 family-camp households
  and 781 persons the daily cron already covered minutes earlier — **≈11.5 min of rate-limited
  CampMinder quota burned for values already fresh**, every time an admin runs that phase.
  Nothing corrupted; pure duplicated quota.
- **Face D** — `Sync()` unconditionally logged
  `LogSyncStart(serviceNamePersonCustomValues)` regardless of which instance was running, so the
  03:00 family-camp pass emitted `Starting sync service=person_custom_values` — byte-identical
  to the Sunday full sweep, with `session=all` in the cohort log because the bounded instance
  ignores `Session`. An operator diagnosing stale data from the logs alone would conclude the
  year-wide sweep runs nightly. It does not.

## Fix

- **`orchestrator.go`**: a `customValuesCollectionGroup` map ties each of the four job names to
  its underlying collection ("person" or "household"), plus
  `customValuesGroupRunningLocked` (used inside existing lock-held check-and-mark sections) and
  its exported self-locking form `IsCustomValuesCollectionRunning`. `runSingleSyncInternal`
  (the path both `getDailySyncJobs`'s cron and `RunCustomValuesSync`'s weekly sweep take) and
  `RunSingleSyncWithService` (the path the two session-scoped handlers take) now check the
  group, not the literal name — closing Face A and Face B in the same two call sites that
  already held the lock, so the atomicity `#1881`/`#2105` established is unchanged.
  `person_custom_values` and `household_custom_values` stay in separate groups, so
  `RunCustomValuesSync`'s documented "safe to run in parallel" behavior (independent
  collections, independent CampMinder endpoints) is preserved.
- **`api.go`**: `handleCustomValuesSync`'s front guard (the one handler that doesn't route
  through `RunSingleSyncWithService`) now calls `IsCustomValuesCollectionRunning` for both
  names, closing Face A there too. A new `phaseExecutionJobs(phase)` filters the two bounded
  jobs out of `PhaseExpensive`'s *execution* list at the two call sites that actually run a
  phase (`handleRunPhase`, `processQueuedSyncs`) — closing Face C.
- **`person_custom_field_values.go` / `household_custom_field_values.go`**: a new `logJobName()`
  method returns the bounded instance's own registered name when `FamilyCampBounded` is set.
  `Sync()` uses it for `LogSyncStart` and adds a `job` field to both cohort-size log lines —
  closing Face D.

### Deliberate divergence from the issue's literal Face C wording

The issue's suggested fix was to "exclude [the bounded jobs] from the phase enumeration" —
i.e., change what `GetJobsForPhase(PhaseExpensive)` (built from `syncJobMeta`) returns. That
function is pinned by `family_camp_daily_cadence_test.go`'s
`TestSyncJobMeta_FamilyCampBoundedJobsAreExpensivePhase`, added deliberately in `#2489` to
assert the two bounded jobs *are* classified as `PhaseExpensive`, consistent with their
unrestricted siblings. Changing `GetJobsForPhase` itself would have silently retired that
pinned invariant.

Instead, `GetJobsForPhase` — and the phase metadata `handleGetPhases` reports for the admin
UI — is left untouched; only the two call sites that actually **execute** a phase filter
through the new `phaseExecutionJobs`. Same measured defect closed (no duplicated quota burn on
an admin-triggered run), no existing pinned test touched.

## What this deliberately does not do

- Does not change `GetJobsForPhase`/`syncJobMeta`'s classification of the two bounded jobs as
  `PhaseExpensive` — see the divergence note above.
- Does not fully re-architect `runSingleSyncInternal`'s check-then-mark sequence into one
  atomic critical section for the general case. The `existingStatus == nil` branch's check and
  its later `runningJobs[syncType] = status` write are still two separate lock acquisitions
  (pre-existing shape, unrelated to this issue) — the group-aware check closes the specific
  name-mismatch gap this issue reports without widening the change into that pre-existing,
  narrower TOCTOU window, which the issue itself calls speculative and out of scope
  ("only the exact conditions of a lost write need further verification before fixing").
- Does not touch `MarkSyncRunning`'s own `IsRunning` check — its only production callers are
  the `process_requests` handlers, unrelated to the four custom-values job names.
- Frontend: none touched. This is Go-only, as scoped.

Closes #2491.
