### PR TITLE
fix(sync): family camp adult merges tiebreak on CampMinder id

### DIFF
--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -767,6 +767,50 @@ func (s *FamilyCampDerivedSync) loadPersonHouseholdMapping(ctx context.Context, 
 	return result, nil
 }
 
+// loadPersonCampMinderIDs builds a map of person PB ID -> CampMinder person
+// id, for the durable merge tiebreak kindred#2275 needs -- see
+// customValueEntry.personCMID's doc comment for why a PocketBase record id is
+// not safe to sort by.
+//
+// A second paged query over the same "persons" collection
+// loadPersonHouseholdMapping already reads. Kept separate rather than folded
+// into that function's return value because loadPersonHouseholdMapping is
+// called directly, with its current two-value signature, from test files
+// outside this one's scope (kindred#2275 touches only family_camp_derived.go
+// and its test file) -- widening it would be a breaking change this issue is
+// not chartered to make.
+func (s *FamilyCampDerivedSync) loadPersonCampMinderIDs(ctx context.Context, year int) (map[string]int, error) {
+	result := make(map[string]int)
+
+	filter := fmt.Sprintf("year = %d && household != ''", year)
+	page := 1
+	perPage := 500
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		records, err := s.App.FindRecordsByFilter("persons", filter, sortByID, perPage, (page-1)*perPage)
+		if err != nil {
+			return nil, fmt.Errorf("querying persons page %d: %w", page, err)
+		}
+
+		for _, record := range records {
+			result[record.Id] = record.GetInt("cm_id")
+		}
+
+		if len(records) < perPage {
+			break
+		}
+		page++
+	}
+
+	return result, nil
+}
+
 // customValueEntry represents a loaded custom value
 type customValueEntry struct {
 	householdPBID string
@@ -787,6 +831,22 @@ type customValueEntry struct {
 	// Nothing may treat "" as an identity: several household values sharing the
 	// empty string are not one person, they are no person.
 	personPBID string
+	// personCMID is the answering person's CampMinder id -- kindred#2275's
+	// stable tiebreak for the first-non-empty-wins merges in processAdults.
+	//
+	// The PocketBase record id loadPersonCustomValues used to order by (and
+	// still orders its own paged query by, for the unrelated reason
+	// documented there) is arbitrary but NOT durable: the vendor sync's
+	// orphan sweep deletes and later re-admits a person_custom_values row
+	// with a brand-new random id, so the same two siblings' answers could
+	// pick a different merge winner on a later resync with no data change at
+	// all. A person's own CampMinder id survives every resync, so
+	// processAdults sorts by this field before merging instead. Owner ruling
+	// 2026-08-19: "whatever sort we choose, must be repeatable, not random."
+	//
+	// Zero (unpopulated) for a household-partition entry, which has no
+	// answering person to begin with -- see personPBID's comment.
+	personCMID int
 	// lastUpdated is CampMinder's own edit timestamp for this value. Spec 4.1
 	// resolves a form-vs-registration conflict by comparing these, not by field
 	// name precedence, so it has to survive the load.
@@ -854,6 +914,11 @@ func (s *FamilyCampDerivedSync) loadHouseholdCustomValues(
 func (s *FamilyCampDerivedSync) loadPersonCustomValues(
 	ctx context.Context, year int, fieldNameMap map[string]string, personToHousehold map[string]string,
 ) ([]customValueEntry, error) {
+	personCMID, err := s.loadPersonCampMinderIDs(ctx, year)
+	if err != nil {
+		return nil, fmt.Errorf("loading person CampMinder ids: %w", err)
+	}
+
 	var result []customValueEntry
 
 	filter := fmt.Sprintf("year = %d", year)
@@ -867,8 +932,11 @@ func (s *FamilyCampDerivedSync) loadPersonCustomValues(
 		default:
 		}
 
-		// Sorted by id, for the reason spelled out in loadHouseholdCustomValues:
-		// this is the read the request-layer precedence depends on.
+		// Sorted by id so paging is safe (no ORDER BY would let SQLite skip or
+		// repeat a row across pages -- same reasoning as
+		// loadHouseholdCustomValues). This is NOT the order processAdults'
+		// merge uses any more: see customValueEntry.personCMID and its sort in
+		// processAdults (kindred#2275).
 		records, err := s.App.FindRecordsByFilter("person_custom_values", filter, "id", perPage, (page-1)*perPage)
 		if err != nil {
 			return nil, fmt.Errorf("querying person custom values page %d: %w", page, err)
@@ -892,6 +960,7 @@ func (s *FamilyCampDerivedSync) loadPersonCustomValues(
 					fieldName:     fieldName,
 					value:         value,
 					personPBID:    personID,
+					personCMID:    personCMID[personID],
 					lastUpdated:   parsed,
 				})
 			}
@@ -929,31 +998,39 @@ func (s *FamilyCampDerivedSync) loadPersonCustomValues(
 //     would have erased every one of them.
 //
 // The person-partition loop below merges with "first non-empty wins" over a
-// slice loadPersonCustomValues returns in record-id order, so when two
-// enrolled siblings carry different answers the winner is whichever row has
-// the lower id -- which correlates with nothing. Measured over the 382
-// rostered 2026 households: 254 (household, field, adult) groups disagree
+// slice sorted by the answering person's CampMinder id (kindred#2275, owner
+// ruling 2026-08-19 -- see customValueEntry.personCMID), NOT the
+// person_custom_values record-id order loadPersonCustomValues' own paged
+// query happens to return. Measured over the 382 rostered 2026 households:
+// 254 (household, field, adult) groups have siblings that disagree, spread
 // across 113 households.
 //
-// RESOLVED for email only (owner ruling 2026-08-09, kindred#1945): when the
+// RESOLVED for email (owner ruling 2026-08-09, kindred#1945): when the
 // siblings' emails differ and are both non-empty, preferEmail breaks the tie
-// by well-formedness instead of load order -- see its doc comment. Email got
-// a rule because the harm is concrete and the rule is crisp: 5 stored adult
-// emails carry a domain typo in production, 4 of which have a correct
-// version on a sibling form that iteration order was discarding.
+// by well-formedness instead of the sibling ordering below -- see its doc
+// comment. Email got a rule because the harm is concrete and the rule is
+// crisp: 5 stored adult emails carry a domain typo in production, 4 of which
+// have a correct version on a sibling form. When validity does not
+// discriminate between the two (both well-formed, or both malformed),
+// preferEmail falls back to whichever answer this sort put first -- the same
+// CampMinder-id tiebreak as every other attribute, not a coin flip.
 //
-// STILL PENDING for every other merged field (first/last name, pronouns,
-// gender, date_of_birth, relationship): first-non-empty-wins over load order
-// stands, unchanged, because none of them has a validity notion as crisp as
-// "syntactically valid email" -- inventing one to feel consistent would be
-// guessing, not fixing. Which sibling should win there remains a product
-// decision. It is NOT coupled to whether the columns exist: kindred#1945
+// RESOLVED for every other merged field (first/last name, pronouns, gender,
+// date_of_birth, relationship_to_camper) -- owner ruling 2026-08-19,
+// kindred#2275: first-non-empty-wins STANDS, UNCHANGED as a policy; only the
+// order it runs over moved. The owner rejected both a recency rule ("none of
+// these are stable if an older child is edited later?") and a completeness
+// rule for the identical reason: either lets editing the LOSING sibling's
+// answer flip the winner. Sorting by the answering person's CampMinder id is
+// stable under exactly that edit, because the id identifying an existing
+// person never changes -- unlike a PocketBase record id, which the vendor
+// sync's orphan sweep can and does regenerate on a resync with no data
+// change. This is NOT a validity notion like preferEmail's, and does not
+// need to be one: the goal is REPEATABILITY, not picking the "better"
+// answer. It is NOT coupled to whether the columns exist: kindred#1945
 // closed 2026-08-09 refusing deletion ("No deletion of the gender /
 // date_of_birth / email / pronouns columns -- the 2026-08-07 hold stands"),
-// so column existence blocks nothing here. What #1945 left open is exactly
-// this per-attribute merge policy, and that is kindred#2275's subject.
-// Today's behavior for those fields is pinned by test instead of changed on
-// a guess.
+// so column existence blocked nothing here either.
 //
 // NORMALISED, separately from the merge (kindred#2275 phase D, owner ruling
 // 2026-08-16): date_of_birth and relationship_to_camper are rewritten into a
@@ -1015,8 +1092,17 @@ func (s *FamilyCampDerivedSync) processAdults(
 		adultMap[v.householdPBID][adultNum].name = v.value
 	}
 
-	// Process person values for adult details
-	for _, v := range personValues {
+	// Process person values for adult details. Sorted by the answering
+	// person's CampMinder id (ascending) before merging, NOT the load order
+	// loadPersonCustomValues returns them in -- kindred#2275. A local clone,
+	// not an in-place sort: personValues is also read by processRegistrations
+	// and processMedical in the same Sync() run, and neither of those needs
+	// (or should silently inherit) this ordering.
+	personValuesByCMID := slices.Clone(personValues)
+	slices.SortStableFunc(personValuesByCMID, func(a, b customValueEntry) int {
+		return a.personCMID - b.personCMID
+	})
+	for _, v := range personValuesByCMID {
 		adultNum := extractAdultNumberFromField(v.fieldName)
 		if adultNum == 0 || adultNum > 2 {
 			continue // Person fields only have Adult 1 and 2

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -1046,10 +1046,11 @@ func (s *FamilyCampDerivedSync) loadPersonCustomValues(
 // RECORDED, also separately from the merge (kindred#2275 Option B, owner
 // ruling 2026-08-17): what survives normalisation is written to the additive
 // attribute_conflicts column instead of vanishing -- see adultData.conflicts
-// and mergeFirstNonEmpty. Which answer wins is still first-non-empty over
-// load order for every attribute, and still preferEmail for email; the only
-// change is that the discarded answers are kept, keyed by column, so staff
-// can see that a slot was answered twice. What is NOT kept is a discarded
+// and mergeFirstNonEmpty. Which answer wins is still first-non-empty -- now
+// over the CampMinder-id order above, not load order -- for every attribute,
+// and still preferEmail for email; the only change from #2421 is that the
+// discarded answers are kept, keyed by column, so staff can see that a slot
+// was answered twice. What is NOT kept is a discarded
 // answer that differs from the winner only in case or whitespace -- see
 // sameAnswer, which gates the recording and nothing else.
 //
@@ -1152,11 +1153,11 @@ func (s *FamilyCampDerivedSync) processAdults(
 			adult.gender = adult.mergeFirstNonEmpty("gender", adult.gender, v.value)
 		case strings.Contains(v.fieldName, "DOB"):
 			// Normalised BEFORE the merge and before the comparison: see
-			// normalizeDateOfBirth. Which answer wins is still load order
-			// (unchanged); what normalisation buys is that two spellings of
-			// one birthday neither swap the stored value nor raise a
-			// conflict. 583 of the 1,124 diverging production groups are
-			// exactly that, and they must stay silent.
+			// normalizeDateOfBirth. Which sibling wins is the CampMinder-id
+			// sort above (kindred#2275), not load order; what normalisation
+			// buys is that two spellings of one birthday neither swap the
+			// stored value nor raise a conflict. 583 of the 1,124 diverging
+			// production groups are exactly that, and they must stay silent.
 			adult.dateOfBirth = adult.mergeFirstNonEmpty(
 				"date_of_birth", adult.dateOfBirth, normalizeDateOfBirth(v.value))
 		case strings.Contains(v.fieldName, "Relationship"):

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -2155,37 +2155,34 @@ func TestRegistrationNeedsUpdateIgnoresTheUnknownSpelling(t *testing.T) {
 	}
 }
 
-// TestProcessAdultsPersonFieldsTakeTheFirstLoadedSibling pins the CURRENT,
-// arbitrary tie-break in processAdults' per-person merge, so that changing it
-// is a deliberate, visible break rather than a silent drift.
+// TestProcessAdultsMergeTiebreaksOnCampMinderID replaces
+// TestProcessAdultsPersonFieldsTakeTheFirstLoadedSibling, which deliberately
+// pinned the PRE-kindred#2275 behavior: the winner was whichever sibling's
+// person_custom_values row happened to carry the lower PocketBase record id.
+// That key is not durable -- the vendor sync's orphan sweep deletes and later
+// re-admits a row with a brand-new random id, so the SAME two siblings'
+// answers could pick a different winner on a later resync with no data
+// change at all.
 //
-// The person-partition fields (FC-P1/P2 First/Last Name, Email, Pronouns,
-// Gender, DOB, Relationship) describe the household's ADULTS, but CampMinder
-// stores them on every enrolled child's record. A household with two children
-// therefore supplies two copies, and when a form was filled twice they can
-// disagree. processAdults resolves that with "first non-empty wins" over a
-// slice that loadPersonCustomValues returns in person_custom_values record-id
-// order -- so the winner is whichever sibling's row happens to carry the lower
-// record id, which correlates with nothing about the answer.
+// Owner ruling 2026-08-19: "whatever sort we choose, must be repeatable, not
+// random", then "none of these are stable if an older child is edited
+// later?" -- adopted answer: first-wins, with a CampMinder-id tiebreak. A
+// person's own CampMinder id survives every resync, so processAdults now
+// sorts the person-values slice by personCMID (ascending) before merging --
+// mergeFirstNonEmpty itself is UNCHANGED; only the order fed into it moved.
+// The winner is the lowest-keyed sibling with a non-empty answer, full stop.
 //
-// Measured against the production snapshot for 2026, over the 382 rostered
-// family-camp households: 254 (household, field, adult) groups have siblings
-// that disagree, spread across 113 households, and resolving by CampMinder's
-// own last_updated instead would pick a different value in 130 of them. So
-// this is a live arbitrary choice, not a theoretical one -- but it is also a
-// small one: of the columns merged here, only relationship and the split name
-// pair reach the UI (the latter solely through the roster's `name or
-// first+last` coalesce, which fires for 5 of 382 households). gender,
-// date_of_birth, email and pronouns have zero readers anywhere.
+// This test pins that policy two ways a record-id tiebreak could not:
 //
-// PENDING, deliberately: which sibling should win is a product decision, and
-// it is kindred#2275's subject. It is NOT coupled to whether the columns are
-// kept -- kindred#1945 closed 2026-08-09 refusing deletion, so that half is
-// settled and A6 is unblocked. Do not "fix" this test by changing the merge
-// until kindred#2275 rules on the per-attribute policy.
-func TestProcessAdultsPersonFieldsTakeTheFirstLoadedSibling(t *testing.T) {
+//  1. Order-independence: every permutation of the two source rows produces
+//     the identical winner (the retired test asserted only one hard-coded
+//     order, matching whichever happened to load first).
+//  2. Recency-independence: the ruling was adopted specifically because a
+//     recency rule is NOT stable under a later edit to the losing sibling's
+//     answer. The fixture gives the losing sibling (cmid 5002, "Stepmother")
+//     the newer lastUpdated on purpose, and the winner must not follow it.
+func TestProcessAdultsMergeTiebreaksOnCampMinderID(t *testing.T) {
 	t.Parallel()
-	s := &FamilyCampDerivedSync{}
 
 	// A local constant rather than the literal twice: goconst counts repeated
 	// string literals across the package and this name is already used in
@@ -2195,39 +2192,87 @@ func TestProcessAdultsPersonFieldsTakeTheFirstLoadedSibling(t *testing.T) {
 	householdValues := []customValueEntry{
 		{householdPBID: "hh_1", fieldName: "Family Camp Adult 1", value: wantName},
 	}
-	// Both entries come from the same household via two different children.
-	// Order here is the order loadPersonCustomValues yields: ascending record
-	// id. The SECOND one is the more recently edited, which is exactly why the
-	// choice matters.
-	personValues := []customValueEntry{
+
+	// cmid 5001 (Mother) must win over cmid 5002 (Stepmother) regardless of
+	// which one loads first and regardless of which one was edited more
+	// recently.
+	base := []customValueEntry{
 		{
-			householdPBID: "hh_1",
-			fieldName:     "Family Camp-Relationship to 1",
-			value:         "Mother",
-			lastUpdated:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			householdPBID: "hh_1", personPBID: "person_mother", personCMID: 5001,
+			fieldName:   "Family Camp-Relationship to 1",
+			value:       "Mother",
+			lastUpdated: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 		},
 		{
-			householdPBID: "hh_1",
-			fieldName:     "Family Camp-Relationship to 1",
-			value:         "Stepmother",
-			lastUpdated:   time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+			householdPBID: "hh_1", personPBID: "person_stepmother", personCMID: 5002,
+			fieldName:   "Family Camp-Relationship to 1",
+			value:       "Stepmother",
+			lastUpdated: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
 		},
 	}
 
-	adults := s.processAdults(householdValues, personValues)
+	for _, personValues := range permutations(base) {
+		s := &FamilyCampDerivedSync{}
+		adults := s.processAdults(householdValues, personValues)
 
-	if len(adults) != 1 {
-		t.Fatalf("expected 1 merged adult, got %d", len(adults))
+		if len(adults) != 1 {
+			t.Fatalf("expected 1 merged adult, got %d (input order %+v)", len(adults), personValues)
+		}
+		if adults[0].name != wantName {
+			t.Errorf("household `name` is the column of record: got %q", adults[0].name)
+		}
+		if adults[0].relationship != "Mother" {
+			t.Errorf(
+				"lowest CampMinder id must win regardless of load order or recency: got %q, want %q "+
+					"(input order %+v)",
+				adults[0].relationship, "Mother", personValues,
+			)
+		}
 	}
-	if adults[0].name != wantName {
-		t.Errorf("household `name` is the column of record: got %q", adults[0].name)
+}
+
+// TestProcessAdultsCampMinderIDTiebreakAppliesToDateOfBirth is the headline
+// case: date_of_birth is the single largest loss in this file -- 1,159
+// answers discarded across all years, raw and unnormalised, re-measured
+// 2026-08-21 against pocketbase/pb_data/data-prod.db (drift of +8 from the
+// 1,151 last recorded 2026-08-19; counts here move with ongoing 2026
+// registration and are not a stable constant to cite blindly).
+// Confirms the same CampMinder-id tiebreak governs date_of_birth, normalised
+// before the merge exactly as processAdults already does, and stays
+// order-independent under every permutation of the source rows.
+func TestProcessAdultsCampMinderIDTiebreakAppliesToDateOfBirth(t *testing.T) {
+	t.Parallel()
+
+	// A name is required for the row to survive processAdults' admission
+	// filter (kindred#1946) -- a slot with only a DOB and no name anywhere is
+	// not admitted as an adult at all, which is orthogonal to what this test
+	// pins.
+	householdValues := []customValueEntry{
+		{householdPBID: "hh_1", fieldName: "Family Camp Adult 1", value: "Emma Johnson"},
 	}
-	if adults[0].relationship != "Mother" {
-		t.Errorf(
-			"first-loaded sibling wins today: got %q, want %q (if you changed the merge on purpose, "+
-				"update this test and kindred#1945 together)",
-			adults[0].relationship, "Mother",
-		)
+	base := []customValueEntry{
+		{
+			householdPBID: "hh_1", personPBID: "person_a", personCMID: 7001,
+			fieldName: "Family Camp DOB 1", value: "3/4/1980",
+		},
+		{
+			householdPBID: "hh_1", personPBID: "person_b", personCMID: 7002,
+			fieldName: "Family Camp DOB 1", value: "9/2/1979",
+		},
+	}
+
+	for _, personValues := range permutations(base) {
+		s := &FamilyCampDerivedSync{}
+		adults := s.processAdults(householdValues, personValues)
+
+		if len(adults) != 1 {
+			t.Fatalf("expected 1 merged adult, got %d (input order %+v)", len(adults), personValues)
+		}
+		const want = "1980-03-04" // normalizeDateOfBirth's canonical form for the lower cmid's answer
+		if adults[0].dateOfBirth != want {
+			t.Errorf("lowest CampMinder id must win regardless of load order: got %q, want %q (input order %+v)",
+				adults[0].dateOfBirth, want, personValues)
+		}
 	}
 }
 


### PR DESCRIPTION
`processAdults` merges the household's two person-partition adult slots ("first non-empty wins")
over a slice ordered by `person_custom_values.id` -- a PocketBase record id assigned when that
particular custom value was synced from CampMinder, not tied to which person answered. That id is
random, and the vendor sync's orphan sweep deletes and later re-admits a `person_custom_values`
row with a brand-new random id whenever the underlying value is untouched but the row happens to
get swept -- so the same two siblings' answers could pick a *different* merge winner on a later
resync with no data change at all. Recounted against `pocketbase/pb_data/data-prod.db` (2026-08-21,
`?mode=ro`): **1,159 date-of-birth answers lost across 1,132 colliding household-years** (raw,
unnormalised) -- vs. 1,151 / 1,124 last recorded 2026-08-19, drift of +8 from ongoing 2026
registration. `date_of_birth` is the largest single loss in this file.

## Fix

Owner ruling 2026-08-19: *"whatever sort we choose, must be repeatable, not random"*, then *"none
of these are stable if an older child is edited later?"* -> **first-wins, with a CampMinder-id
tiebreak.**

`processAdults` now sorts a local clone of the person-values slice by the answering person's
CampMinder id (`persons.cm_id`, via the new `customValueEntry.personCMID`) before merging.
`mergeFirstNonEmpty` -- the shared helper six of the seven merged attributes already route through
-- is **unchanged**; only the order fed into it moved. A person's own CampMinder id survives every
resync, so the winner a household gets today is the winner it keeps, regardless of which row a
later sync happens to (re)create first.

This is a sort, not a per-attribute rule: it benefits `first_name`, `last_name`, `pronouns`,
`gender`, `date_of_birth` and `relationship_to_camper` (all through `mergeFirstNonEmpty`) and also
closes the residual load-order dependency in `email`'s `preferEmail` tiebreak -- when validity does
not discriminate between two candidates, `preferEmail` already documented that it falls back to
"whichever was current," which was itself load-order-dependent before this change.

The new lookup (`loadPersonCampMinderIDs`) is a second paged query over `persons`, kept separate
from `loadPersonHouseholdMapping` deliberately: that function is called directly, with its current
two-value signature, from two test files outside this issue's assigned scope
(`family_camp_enrollment_status_test.go`, `family_camp_registration_text_test.go`), so widening its
return value would be a breaking change this issue is not chartered to make.

## Correction to the issue body

The ruling block's reassurance -- "swapping the tiebreak to a CampMinder id makes the existing
choice durable **without changing which answer wins on any row today**" -- does not hold. Replaying
the real `normalizeDateOfBirth` (not a raw-string diff, which overstates disagreement ~2x by
counting formatting variance the normaliser already collapses) against every genuinely-conflicting
`Family Camp DOB 1`/`DOB 2` group in the production snapshot: of **544** groups that still disagree
after normalisation, switching from row-id to CampMinder-id ordering changes the stored winner in
**261 (48%)** -- not zero. The change *is* durable going forward, which is the property the ruling
was actually chasing, but it is not a no-op on today's data.

This does not change the fix direction and does not surprise anyone: per the issue's own
accounting, `date_of_birth` "has zero readers anywhere" in the current UI -- nothing renders this
column, so the flip changes no staff-visible number or display. Recorded on the issue (`gh issue
edit`) so the "no change today" framing is not re-cited as evidence for a future change to a column
that *is* read.

## Verified against the tree, not the issue's stale claim

The "ANCHOR SWEEP" block on the issue was right: `processAdults`' `&& adult.X == ""` guarded arms
are gone, and six of seven attributes already route through `mergeFirstNonEmpty` (shipped in
#2421). This PR's entire diff is the sort feeding that helper plus the CampMinder-id lookup that
makes the sort key durable -- `mergeFirstNonEmpty`'s own logic is untouched.

## Tests (written first, verified red, then implemented)

- `TestProcessAdultsMergeTiebreaksOnCampMinderID` replaces the now-retired
  `TestProcessAdultsPersonFieldsTakeTheFirstLoadedSibling`, which explicitly pinned the pre-fix,
  load-order-dependent behaviour and said not to "fix" it until this issue ruled. Runs every
  permutation of two siblings' answers (order-independence) and gives the *losing* sibling the
  newer `lastUpdated` on purpose (recency-independence) -- the exact two properties the owner's
  ruling was choosing between.
- `TestProcessAdultsCampMinderIDTiebreakAppliesToDateOfBirth` pins the same tiebreak on
  `date_of_birth`, the headline column, through `normalizeDateOfBirth`.
- Mutation-checked: reverting the sort call locally made both new tests fail as expected (wrong
  sibling wins for one input order), confirming they pin the tiebreak rather than passing
  vacuously; the sort was then restored.
- Full `pocketbase/sync` suite green, `go build ./...`, `gofmt`, `go vet`, and
  `golangci-lint run --config ../.golangci.yml ./sync/...` all clean.

## Deliberately NOT done

- **No UI change.** The badge/tooltip surface this issue originally scoped was explicitly dropped
  by an owner ruling recorded on the issue (`attribute_conflicts` records disagreements in the
  wrong column for 377 of 382 households); this PR is Go-only, matching that ruling and the file
  list this item was scoped to (`pocketbase/sync/family_camp_derived.go` and its test file).
- **No re-key, no migration.** The grain question (household×adult_number vs. per-camper) was
  closed 2026-08-17 (Option B: a conflict column, already shipped in #2421). This PR does not touch
  `attribute_conflicts`, `mergeFirstNonEmpty`'s conflict-recording logic, or the schema.
- **No fold into `loadPersonHouseholdMapping`.** See "Fix" above -- kept as a separate query
  specifically to avoid touching files outside this item's scope.
- **No change to `processMedical` or `processRegistrations`.** The new sort is a local clone inside
  `processAdults`; the shared `personValues` slice those two functions also read in the same
  `Sync()` run is left in its original (row-id) order, since kindred#2255 is a separate,
  differently-shaped fix (total aggregation, explicitly required to be order-independent) that this
  item does not touch.

Closes #2275.
