### PR TITLE
feat(api,frontend): Share Bunk With moves to the bottom and starts collapsed

### DIFF
--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -551,9 +551,11 @@ class ShareRequestSummary(BaseModel):
     # family-authored blocks and `request_text` are not gated. See
     # `_may_read_staff_notes` in api/routers/lodging.py.
     #
-    # Ordered by `REQUEST_TEXT_SOURCES` -- family-authored blocks first, staff
-    # notes last. A source field with no text produces NO block: kindred#2255's
-    # ruling for this same modal leaves no "nothing applicable" clutter behind.
+    # Ordered by `REQUEST_TEXT_SOURCES` -- a staff-specified order (kindred#2476,
+    # owner ruling 2026-08-21), NOT derived from authorship or volume. `Share
+    # Bunk With` is family-authored and sorts last, after both staff notes. A
+    # source field with no text produces NO block: kindred#2255's ruling for
+    # this same modal leaves no "nothing applicable" clutter behind.
     request_blocks: list[RequestTextBlock] = Field(default_factory=list)
 
     # What the board actually places on. `preference` above stays the raw

--- a/api/services/lodging_rules.py
+++ b/api/services/lodging_rules.py
@@ -373,11 +373,12 @@ class RequestTextSource(NamedTuple):
 
     `label` is the CampMinder field name VERBATIM, including the misnamed
     `COVID-19 Bunking Requests` -- the field that has plainly been repurposed
-    as the general bunking-request question and carries 205 of the 382
-    households rostered into a 2026 family session. Owner ruling 2026-08-17:
-    "call them the original fieldnames for now until staff can weigh in after
-    it's live". A display-names issue gets filed once they have. Do not
-    "improve" these strings.
+    as the general bunking-request question and carries 238 of the 479
+    households rostered into a 2026 family-camp registration (kindred#2476,
+    re-measured 2026-08-21). Owner ruling 2026-08-17: "call them the original
+    fieldnames for now until staff can weigh in after it's live". A
+    display-names issue gets filed once they have. Do not "improve" these
+    strings.
     """
 
     label: str

--- a/api/services/lodging_rules.py
+++ b/api/services/lodging_rules.py
@@ -384,14 +384,23 @@ class RequestTextSource(NamedTuple):
     authorship: RequestTextAuthorship
 
 
-# ORDERED, and the order is the panel's block order. Family-authored fields
-# first so a household's own ask leads, staff-authored notes last; within a
-# lane, by 2026 coverage, so the field staff read most often is at the top.
+# ORDERED, and the order is the panel's block order.
+#
+# kindred#2476, owner ruling 2026-08-21: this order is what STAFF ASKED FOR.
+# It is NOT derived from authorship or volume, and it must NOT be re-derived
+# from the data by a later reader. On 2026 family-camp households
+# `Share Bunk With` is the SECOND MOST POPULATED of the six blocks (234 of
+# 479) -- ahead of `Shared-request` (114) and `FAM CAMP-Share Comments` (0)
+# -- yet staff placed it last. The order used to be "family-authored fields
+# first, staff notes last, each lane sorted by 2026 coverage"; that rule no
+# longer holds (`Share Bunk With` is family-authored and sorts after both
+# staff notes) and must not be reinstated by "correcting" the order back to
+# match volume or authorship.
 #
 # Counts are rostered households on `pocketbase/pb_data/data-prod.db`,
-# denominator 382 (`status_id = 2`, 2026's eight family sessions):
-# COVID-19 Bunking Requests 205, Share Bunk With 104, Shared-request 100,
-# BunkingNotes Notes 28, Internal Bunk Notes 8.
+# denominator 479 (2026 family-camp registrations):
+# COVID-19 Bunking Requests 238, Share Bunk With 234, Shared-request 114,
+# BunkingNotes Notes 111, Internal Bunk Notes 10.
 #
 # `FAM CAMP-Share Comments` is 0 for 2026 and is carried anyway. It is one of
 # the three fields the Go ingest already joins into `request_text` (live
@@ -411,11 +420,11 @@ class RequestTextSource(NamedTuple):
 #   an immaterial source field.
 REQUEST_TEXT_SOURCES: tuple[RequestTextSource, ...] = (
     RequestTextSource("COVID-19 Bunking Requests", "family"),
-    RequestTextSource("Share Bunk With", "family"),
     RequestTextSource("Shared-request", "family"),
     RequestTextSource("FAM CAMP-Share Comments", "family"),
     RequestTextSource("BunkingNotes Notes", "staff"),
     RequestTextSource("Internal Bunk Notes", "staff"),
+    RequestTextSource("Share Bunk With", "family"),
 )
 
 # The family-camp lane: CampMinder custom-field ids, matching the three

--- a/frontend/src/components/weekend/ShareRequestPanel.test.tsx
+++ b/frontend/src/components/weekend/ShareRequestPanel.test.tsx
@@ -20,7 +20,10 @@
  * Layout is the owner's 2026-08-17 ruling, a hybrid of two mockup options:
  * blocks start EXPANDED (nothing hidden behind a click, because a scanning
  * eye must not miss request text) and every block is COLLAPSIBLE (a staff
- * member facing the seven-entry household can fold them away).
+ * member facing the seven-entry household can fold them away). kindred#2476
+ * (owner ruling 2026-08-21) tunes this: `Share Bunk With` alone now starts
+ * COLLAPSED -- see the `describe('Share Bunk With starts collapsed...')`
+ * block below -- every other block keeps the EXPANDED default above.
  *
  * Shape it is built against, measured on the 2026 production snapshot over
  * the 382 households rostered into a family session: 270 carry any text, 142

--- a/frontend/src/components/weekend/ShareRequestPanel.test.tsx
+++ b/frontend/src/components/weekend/ShareRequestPanel.test.tsx
@@ -348,7 +348,9 @@ describe('per-field split', () => {
           request_text: 'first; second',
           request_blocks: [
             block('Shared-request', [{ text: 'first' }]),
-            block('Share Bunk With', [{ text: 'second' }]),
+            // NOT `Share Bunk With` -- kindred#2476 starts it folded, and
+            // this test asserts both entries render.
+            block('FAM CAMP-Share Comments', [{ text: 'second' }]),
           ],
         })}
       />
@@ -365,7 +367,9 @@ describe('per-child split', () => {
       <ShareRequestPanel
         share={share({
           request_blocks: [
-            block('Share Bunk With', [
+            // NOT `Share Bunk With` -- kindred#2476 starts it folded, and
+            // this test asserts both entries render without a click.
+            block('FAM CAMP-Share Comments', [
               { text: 'With Olivia Chen', contributors: ['Emma Johnson'] },
               { text: 'With Riley Sam', contributors: ['Liam Johnson'] },
             ]),
@@ -435,7 +439,10 @@ describe('expanded by default, collapsible by click', () => {
         share={share({
           request_blocks: [
             block('COVID-19 Bunking Requests', [{ text: 'A quiet cabin, please' }]),
-            block('Share Bunk With', [{ text: 'Cabin with a fridge' }]),
+            // NOT `Share Bunk With` -- kindred#2476 starts it folded by
+            // default, which would make "leaves its neighbour open" true for
+            // the wrong reason. `Shared-request` keeps the old default.
+            block('Shared-request', [{ text: 'Cabin with a fridge' }]),
           ],
         })}
       />
@@ -466,6 +473,64 @@ describe('expanded by default, collapsible by click', () => {
 
     fireEvent.click(header)
     expect(screen.getByText('A cabin on the flat, please')).toBeInTheDocument()
+  })
+})
+
+describe('Share Bunk With starts collapsed; its siblings do not (kindred#2476)', () => {
+  // Owner ruling 2026-08-21, tuning the 2026-08-17 "blocks start EXPANDED"
+  // ruling: `Share Bunk With` alone starts folded. Every other block keeps
+  // the old default.
+  it('renders Share Bunk With folded on first paint while a sibling stays open', () => {
+    render(
+      <ShareRequestPanel
+        share={share({
+          request_blocks: [
+            block('COVID-19 Bunking Requests', [{ text: 'A quiet cabin, please' }]),
+            block('Share Bunk With', [{ text: 'Cabin with a fridge' }]),
+          ],
+        })}
+      />
+    )
+
+    expect(screen.getByText('A quiet cabin, please')).toBeInTheDocument()
+    expect(screen.queryByText('Cabin with a fridge')).not.toBeInTheDocument()
+    // The header stays, or there is nothing left to click to open it.
+    expect(screen.getByText('Share Bunk With')).toBeInTheDocument()
+  })
+
+  it('opens Share Bunk With on click, same as any other block', () => {
+    render(
+      <ShareRequestPanel
+        share={share({
+          request_blocks: [block('Share Bunk With', [{ text: 'Cabin with a fridge' }])],
+        })}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Share Bunk With' }))
+    expect(screen.getByText('Cabin with a fridge')).toBeInTheDocument()
+  })
+
+  it('THE TRAP: a household switch re-collapses Share Bunk With rather than opening it', () => {
+    // Applying the collapsed default only to the initial `useState` seed is
+    // not enough -- the reset-on-household-change branch re-seeds `folded`
+    // too (the panel is never remounted between families; see the comment
+    // on that branch), and a bare `new Set()` there would open Share Bunk
+    // With for every household after the first, the moment staff click the
+    // next family.
+    const first = share({
+      request_blocks: [block('Share Bunk With', [{ text: "The first family's fridge ask" }])],
+    })
+    const second = share({
+      request_blocks: [block('Share Bunk With', [{ text: "The second family's fridge ask" }])],
+    })
+
+    const { rerender } = render(<ShareRequestPanel share={first} />)
+    expect(screen.queryByText("The first family's fridge ask")).not.toBeInTheDocument()
+
+    rerender(<ShareRequestPanel share={second} />)
+
+    expect(screen.queryByText("The second family's fridge ask")).not.toBeInTheDocument()
   })
 })
 
@@ -589,7 +654,11 @@ describe('the heaviest real household still fits a 416px panel', () => {
               { text: 'one', contributors: ['Emma Johnson'] },
               { text: 'two', contributors: ['Liam Johnson'] },
             ]),
-            block('Share Bunk With', [
+            // NOT `Share Bunk With` -- kindred#2476 starts that one folded
+            // by default, which would collapse two of the seven entries this
+            // test exists to prove all render. `FAM CAMP-Share Comments` is
+            // a real family field that keeps the old expanded-by-default.
+            block('FAM CAMP-Share Comments', [
               { text: 'three', contributors: ['Emma Johnson'] },
               { text: 'four', contributors: ['Liam Johnson'] },
             ]),

--- a/frontend/src/components/weekend/ShareRequestPanel.tsx
+++ b/frontend/src/components/weekend/ShareRequestPanel.tsx
@@ -30,8 +30,15 @@
  * Layout is the owner's 2026-08-17 ruling, a hybrid of two mockup options:
  * blocks start EXPANDED, because a scanning eye must not miss request text,
  * and each is COLLAPSIBLE, because 9 of 382 rostered 2026 households render
- * four blocks and one renders seven entries inside them. The expectation is
- * explicitly that this ships and gets tuned against real staff use.
+ * four blocks and one renders seven entries inside them. The expectation was
+ * explicitly that this would ship and get tuned against real staff use.
+ *
+ * kindred#2476 (owner ruling 2026-08-21) is that tuning: `Share Bunk With`
+ * now starts COLLAPSED — see `DEFAULT_FOLDED` below — while every other
+ * block keeps the 2026-08-17 default. It also moves to the LAST block
+ * server-side (`REQUEST_TEXT_SOURCES`, `api/services/lodging_rules.py`), by
+ * staff request rather than by volume: on 2026 family-camp households it is
+ * the second most populated of the six.
  *
  * Labels are the ORIGINAL CampMinder field names, verbatim, UNLESS THE OWNER
  * NAMED ONE. That was the 2026-08-17 ruling — "call them the original
@@ -145,6 +152,22 @@ export interface ShareRequestPanelProps {
   share: ShareRequest
 }
 
+/**
+ * Source fields that start FOLDED, kindred#2476 (owner ruling 2026-08-21).
+ * Every field not listed here keeps the 2026-08-17 default of starting
+ * expanded. `Share Bunk With` is the one exception, not a new baseline —
+ * do not fold anything else in here on your own judgement.
+ */
+const DEFAULT_FOLDED: ReadonlySet<string> = new Set(['Share Bunk With'])
+
+function isDefaultFolded(folded: ReadonlySet<string>): boolean {
+  if (folded.size !== DEFAULT_FOLDED.size) return false
+  for (const sourceField of folded) {
+    if (!DEFAULT_FOLDED.has(sourceField)) return false
+  }
+  return true
+}
+
 /** Blocks with nothing left to say after trimming render nothing at all. */
 function withText(blocks: RequestTextBlockRow[]): RequestTextBlockRow[] {
   return blocks
@@ -236,11 +259,18 @@ export function ShareRequestPanel({ share }: ShareRequestPanelProps) {
   // Effect would add a commit pass and paint the previous family's fold
   // first. `share` is referentially stable per party (`usePanelParty`
   // memoises it), so a parent re-render does not unfold anything.
-  const [folded, setFolded] = useState<ReadonlySet<string>>(() => new Set())
+  //
+  // `DEFAULT_FOLDED` is applied in BOTH the initial seed below AND the reset
+  // branch — that duplication is deliberate, not an oversight. A panel is
+  // never remounted between households (see above), so the reset branch is
+  // where every household after the first actually gets its starting fold;
+  // seeding only the `useState` initializer would open `Share Bunk With` the
+  // moment staff click the next family.
+  const [folded, setFolded] = useState<ReadonlySet<string>>(() => new Set(DEFAULT_FOLDED))
   const [foldedFor, setFoldedFor] = useState<ShareRequest>(share)
   if (foldedFor !== share) {
     setFoldedFor(share)
-    if (folded.size > 0) setFolded(new Set())
+    if (!isDefaultFolded(folded)) setFolded(new Set(DEFAULT_FOLDED))
   }
   const toggleFold = useCallback((sourceField: string) => {
     setFolded((current) => {

--- a/tests/unit/api/services/test_lodging_rules.py
+++ b/tests/unit/api/services/test_lodging_rules.py
@@ -324,36 +324,51 @@ class TestRampCoverage:
 
 
 class TestRequestTextSourceRegistry:
-    """The five free-text bunk-request source fields, and the two excluded ones.
+    """The six free-text bunk-request source fields, in the block order staff
+    put in front of the panel (kindred#2476, owner ruling 2026-08-21).
 
     kindred#2330. The registry is one ordered tuple rather than a map so the
     panel's block order is a property of the rule layer, not of whichever
     order PocketBase happened to page the rows back in.
 
-    Measured on `pocketbase/pb_data/data-prod.db`, denominator 382 households
-    rostered into one of 2026's eight family sessions (`status_id = 2`):
-    `COVID-19 Bunking Requests` 205, `Share Bunk With` 104, `Shared-request`
-    100, `BunkingNotes Notes` 28, `Internal Bunk Notes` 8.
+    Measured on `pocketbase/pb_data/data-prod.db`, denominator 479 households
+    rostered into a 2026 family-camp registration:
+    `COVID-19 Bunking Requests` 238, `Share Bunk With` 234, `Shared-request`
+    114, `BunkingNotes Notes` 111, `Internal Bunk Notes` 10.
     `FAM CAMP-Share Comments` is 0 for 2026 and is carried anyway -- it is one
     of the three fields the Go ingest already joins into `request_text`
     (2024-2025 only), so dropping it here would lose those years' text.
     """
 
-    def test_the_registry_is_the_ruled_five_plus_the_dormant_share_comments(self) -> None:
+    def test_the_registry_order_is_what_staff_asked_for(self) -> None:
+        """kindred#2476: `Share Bunk With` moves from position 2 to position 6
+        by owner ruling, NOT by measuring the columns. On 2026 family-camp
+        households it is the SECOND MOST POPULATED of the six blocks (234 of
+        479) -- ahead of `Shared-request` (114) and `FAM CAMP-Share Comments`
+        (0) -- yet staff put it last. The order is what staff asked for; it
+        must not be re-derived from volume (or from authorship -- see the
+        next test) by a later reader who measures the columns and "corrects"
+        it back."""
         assert [source.label for source in REQUEST_TEXT_SOURCES] == [
             "COVID-19 Bunking Requests",
-            "Share Bunk With",
             "Shared-request",
             "FAM CAMP-Share Comments",
             "BunkingNotes Notes",
             "Internal Bunk Notes",
+            "Share Bunk With",
         ]
 
-    def test_family_authored_blocks_sort_ahead_of_staff_authored_ones(self) -> None:
-        """An internal note must never read as a family's own ask, so the two
-        staff fields land at the bottom of the panel as well as in grey."""
+    def test_the_order_is_staff_specified_not_authorship_derived(self) -> None:
+        """kindred#2476 deliberately retires the older invariant that every
+        family-authored block sorts ahead of every staff-authored one --
+        `Share Bunk With` is family-authored and now sorts after both staff
+        notes. The OLD rationale was authorship (an internal note must never
+        read as a family's own ask); the ordering ruling replaces it with a
+        staff-specified order that is not derived from authorship, and must
+        not be re-derived from authorship by a later reader who notices this
+        no longer sorts family-before-staff."""
         authorship = [source.authorship for source in REQUEST_TEXT_SOURCES]
-        assert authorship == ["family", "family", "family", "family", "staff", "staff"]
+        assert authorship == ["family", "family", "family", "staff", "staff", "family"]
 
     def test_the_two_staff_authored_fields_are_the_bunking_csv_notes(self) -> None:
         """All 34 `BunkingNotes` values end in an inline staff signature and


### PR DESCRIPTION
## Summary

Two of #2476's three asks. `Share Bunk With` moves to the last of the six
request-text blocks (a staff-specified order, not derived from authorship or
volume), and it now starts collapsed while its five siblings stay expanded.

**The third ask — the chevron hit-target / dismiss-region bug — is NOT
included. See "Deliberately not done" below. This issue stays OPEN.**

## 1. Block order (`api/services/lodging_rules.py`)

`REQUEST_TEXT_SOURCES` placed `Share Bunk With` second of six. Owner ruling
2026-08-21: staff asked for it last — `COVID-19 Bunking Requests`,
`Shared-request`, `FAM CAMP-Share Comments`, `BunkingNotes Notes`,
`Internal Bunk Notes`, `Share Bunk With`. One-line reorder; nothing else in
the tuple moves.

This retires two previously pinned test invariants on purpose:
- The exact-order assertion on `REQUEST_TEXT_SOURCES`.
- The authorship invariant that every family-authored block sorted ahead of
  every staff-authored one — `Share Bunk With` is family-authored and now
  sorts after both staff notes.

Both are rewritten with the new rationale, written into the test bodies: the
order is what staff asked for, and it must not be re-derived from
authorship or volume by a later reader. On 2026 family-camp households
(denominator 479), `Share Bunk With` is the SECOND MOST POPULATED of the six
blocks (234) — ahead of `Shared-request` (114) and `FAM CAMP-Share Comments`
(0) — yet staff put it last.

## 2. Starts collapsed (`frontend/src/components/weekend/ShareRequestPanel.tsx`)

`Share Bunk With` now starts folded; the other five blocks keep the
2026-08-17 "start expanded" default. The default has to be applied in TWO
places — the initial `useState` seed and the reset-on-household-change
branch — because the panel is never remounted between families; applying it
only to the initializer would re-open the block the moment staff click the
next household. A dedicated test (`THE TRAP: a household switch
re-collapses Share Bunk With rather than opening it`) pins this, and was
verified to fail against that half-fix before the full fix landed.

The stale 2026-08-17 doc comment ("blocks start EXPANDED … explicitly that
this ships and gets tuned against real staff use") is rewritten to record
this as that tuning.

Three pre-existing tests used `Share Bunk With` as incidental fixture data
for assertions unrelated to fold state (per-field split, per-child split,
"leaves its neighbour open"). Swapped to a different family field so they
keep testing what they always tested without becoming entangled with the
new default-fold exception.

## Deliberately NOT done

**Ask 3 — "change arrow on side to click" (the chevron hit-target /
dismiss-region bug) — is not implemented here.** #2476 frames this as an
interaction bug: clicking the chevron near the panel's left edge dismisses
`FamilyDetailsPanel` instead of collapsing the block, while clicking the
field name (further right, same `<button>`) works correctly.

I could not identify a code path that reproduces this from static analysis
with the confidence needed to fix it correctly:

- `FamilyDetailsPanel`'s own backdrop (`family-panel-backdrop`) is a
  self-closing `pointer-events-none` div — it can never be the real target
  of a browser click, so its `onClick={handleClose}` cannot be what fires.
- The dismiss mechanism actually wired at all three `FamilyDetailsPanel`
  call sites is `useDismissOnDeadSpace` + `shouldKeepPanelsOpen`
  (`utils/clickoutsidePredicate.ts`), which decides on DOM ancestry
  (`target.closest('[data-panel="family-details"]')`,
  `target.closest('button, …')`). The chevron toggle is a `<button>`
  nested inside `[data-panel="family-details"]`, so any click whose real
  DOM target is that button is protected by two independent checks in that
  predicate, regardless of how close to the visual edge it sits.
- The only account I can square with the reported symptom is a genuine
  pixel-level miss — the 12px chevron icon, sitting near the panel's own
  left padding, occasionally receiving a click whose real coordinates land
  outside the panel's DOM subtree entirely. Confirming that (and picking
  the right fix — hit-target margin vs. something else) needs a live
  browser, not jsdom (no real layout engine) and not more code reading.

I attempted to verify this empirically against a live environment via the
Playwright MCP browser, but the shared browser instance was held by a
concurrent session for the duration of this work
(`Error: Browser is already in use for .../mcp-chrome-9cfc516`) and never
freed up. Rather than ship a speculative fix for a mechanism I can't pin
down or test-drive, I'm leaving Ask 3 for a follow-up with real-browser
verification.

## Also flagged, not fixed here (file out of this item's scope)

`api/services/lodging_roster_service.py:350` documents the roster-block
order as "family-authored first, staff notes last" — now stale after this
reorder. That file isn't in this item's file list; noting it here so the
staleness isn't lost.

Part of #2476.
