### PR TITLE
refactor(sync): read socialize_with from its CampMinder custom field, not the CSV

### DIFF
--- a/pocketbase/sync/bunk_requests.go
+++ b/pocketbase/sync/bunk_requests.go
@@ -40,10 +40,9 @@ type BunkRequestsSync struct {
 
 	// socializeWithByPerson maps person PB id -> the CampMinder custom field's raw
 	// value (cm_id 85803, "Ret Parent-Socialize with best") for the current sync year.
-	// kindred#2484: this is now the source of truth for the "socialize_with" field --
-	// the CSV column is still read in processRow (so a disagreement can be logged
-	// during the transition), but the value written to original_bunk_requests comes
-	// from here whenever a non-empty entry exists. A person absent from this map
+	// kindred#2484: processRow prefers this over the CSV column when the CSV has no
+	// value at all; when both are present and disagree, the CSV wins and the
+	// disagreement is logged (see processRow for why). A person absent from this map
 	// (custom field not yet synced for them) falls back to the CSV column unchanged.
 	socializeWithByPerson map[string]string
 }
@@ -259,20 +258,33 @@ func (s *BunkRequestsSync) processRow(row []string, columnIndex map[string]int, 
 		content := s.getColumn(row, columnIndex, csvColumn)
 
 		// kindred#2484: socialize_with's source of truth is the CampMinder custom
-		// field (cm_id 85803), not this CSV column, from here on. The column is still
-		// read above so a disagreement between the two can be logged during the
-		// transition -- the custom field wins when it carries a non-empty value; a
-		// person absent from the map, or present with an empty value (field synced
-		// but genuinely blank), falls back to the CSV content unchanged.
+		// field (cm_id 85803) whenever there is no CSV column to compare it against --
+		// the coverage-increase population the issue's own numbers document (1,145
+		// custom-field persons vs 1,134 CSV, full overlap). A person absent from the
+		// map, or present with an empty value (field synced but genuinely blank),
+		// falls back to the CSV content unchanged, same as before.
+		//
+		// PR #2523 review: when BOTH sources carry a non-empty value and they
+		// disagree, the CSV value wins, not the custom field. socialize_with's sole
+		// consumer, orchestrator.py's _parse_socialize_preference, exact-matches the
+		// value against exactly two literal strings with no AI fallback -- trusting an
+		// unverified custom-field value on disagreement risks silently dropping the
+		// request out of the social graph. The disagreement is still logged so the two
+		// can be diffed in production, per the issue's own build note ("verify the
+		// value shape matches before switching... before cutting over").
 		if fieldName == "socialize_with" {
 			if customValue, ok := s.socializeWithByPerson[personPBID]; ok && customValue != "" {
-				if content != "" && content != customValue {
-					slog.Warn("socialize_with: CSV and custom field values disagree, using custom field",
+				switch content {
+				case "":
+					content = customValue
+				case customValue:
+					// Agreement -- nothing to do.
+				default:
+					slog.Warn("socialize_with: CSV and custom field values disagree, keeping CSV value",
 						"person_cm_id", personID,
 						"csv_value", content,
 						"custom_field_value", customValue)
 				}
-				content = customValue
 			}
 		}
 

--- a/pocketbase/sync/bunk_requests.go
+++ b/pocketbase/sync/bunk_requests.go
@@ -37,6 +37,15 @@ type BunkRequestsSync struct {
 	BaseSyncService
 	validPersonIDs map[int]string // Maps CampMinder person ID to PocketBase person ID
 	csvPersonIDs   map[int]bool   // Tracks all enrolled person IDs seen in the CSV
+
+	// socializeWithByPerson maps person PB id -> the CampMinder custom field's raw
+	// value (cm_id 85803, "Ret Parent-Socialize with best") for the current sync year.
+	// kindred#2484: this is now the source of truth for the "socialize_with" field --
+	// the CSV column is still read in processRow (so a disagreement can be logged
+	// during the transition), but the value written to original_bunk_requests comes
+	// from here whenever a non-empty entry exists. A person absent from this map
+	// (custom field not yet synced for them) falls back to the CSV column unchanged.
+	socializeWithByPerson map[string]string
 }
 
 // NewBunkRequestsSync creates a new sync service
@@ -124,6 +133,20 @@ func (s *BunkRequestsSync) RunSync(csvPath string, _ int) error {
 
 	// Get current year from config
 	currentYear := s.getCurrentYear()
+
+	// kindred#2484: preload the socialize_with custom field values once for this run,
+	// rather than per-row -- the field definition and every person's answer for the
+	// year are the same for every row processRow will see. A load failure (or the
+	// field definition not being synced yet) is not fatal to the CSV sync: it just
+	// means every row falls back to sourcing socialize_with from the CSV column, as
+	// it did before this issue.
+	socializeWithValues, err := loadPersonCustomFieldValuesByCMID(s.App, cmIDSocializeWithBest, currentYear)
+	if err != nil {
+		slog.Warn("Loading socialize_with custom field values failed, sourcing socialize_with from CSV only",
+			"error", err)
+		socializeWithValues = map[string]string{}
+	}
+	s.socializeWithByPerson = socializeWithValues
 
 	// Process rows
 	rowNumber := 1 // Start at 1 since we already read headers
@@ -234,6 +257,24 @@ func (s *BunkRequestsSync) processRow(row []string, columnIndex map[string]int, 
 	// Process each CSV field that maps to our field options
 	for csvColumn, fieldName := range csvFieldMap {
 		content := s.getColumn(row, columnIndex, csvColumn)
+
+		// kindred#2484: socialize_with's source of truth is the CampMinder custom
+		// field (cm_id 85803), not this CSV column, from here on. The column is still
+		// read above so a disagreement between the two can be logged during the
+		// transition -- the custom field wins when it carries a non-empty value; a
+		// person absent from the map, or present with an empty value (field synced
+		// but genuinely blank), falls back to the CSV content unchanged.
+		if fieldName == "socialize_with" {
+			if customValue, ok := s.socializeWithByPerson[personPBID]; ok && customValue != "" {
+				if content != "" && content != customValue {
+					slog.Warn("socialize_with: CSV and custom field values disagree, using custom field",
+						"person_cm_id", personID,
+						"csv_value", content,
+						"custom_field_value", customValue)
+				}
+				content = customValue
+			}
+		}
 
 		// Check if record exists for this person/year/field combination
 		existingRecords, err := s.App.FindRecordsByFilter(

--- a/pocketbase/sync/bunk_requests_socialize_with_test.go
+++ b/pocketbase/sync/bunk_requests_socialize_with_test.go
@@ -1,0 +1,217 @@
+// kindred#2484: socialize_with's source of truth moves from the manually uploaded
+// bunk-requests CSV column ("RetParent-Socializewithbest") to the CampMinder custom
+// field it mirrors (cm_id 85803), read via person_custom_values. The CSV column is
+// still parsed during the transition so a disagreement can be logged in production
+// (the issue's own build note: "compare the two ... confirm they agree, row for row,
+// before cutting over"), but the value actually written to original_bunk_requests now
+// comes from the custom field whenever one is present.
+package sync
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+)
+
+// Dropdown values reused across the fixtures below (goconst).
+const (
+	dropdownOlder   = "OLDER"
+	dropdownYounger = "YOUNGER"
+)
+
+// newBunkRequestsSocializeWithTestApp returns a throwaway app carrying just the
+// original_bunk_requests collection processRow writes to.
+func newBunkRequestsSocializeWithTestApp(t *testing.T) core.App {
+	t.Helper()
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	obr := core.NewBaseCollection("original_bunk_requests")
+	obr.Fields.Add(&core.TextField{Name: "requester"})
+	obr.Fields.Add(&core.NumberField{Name: "year"})
+	obr.Fields.Add(&core.TextField{Name: "field"})
+	obr.Fields.Add(&core.TextField{Name: "content"})
+	obr.Fields.Add(&core.TextField{Name: "content_hash"})
+	obr.Fields.Add(&core.TextField{Name: "processed"})
+	if saveErr := app.Save(obr); saveErr != nil {
+		t.Fatalf("save original_bunk_requests: %v", saveErr)
+	}
+
+	return app
+}
+
+// socializeWithCSVRow builds a CSV row (matching csvFieldMap's five columns) carrying
+// csvContent in the RetParent-Socializewithbest column and blanks elsewhere.
+func socializeWithCSVRow(personIDStr, csvContent string) (row []string, columnIndex map[string]int) {
+	columnIndex = map[string]int{
+		"PersonID": 0, "Last Name": 1, "First Name": 2,
+		"Share Bunk With": 3, "Do Not Share Bunk With": 4,
+		"Internal Bunk Notes": 5, "BunkingNotes Notes": 6,
+		"RetParent-Socializewithbest": 7,
+	}
+	row = []string{personIDStr, "Johnson", "Emma", "", "", "", "", csvContent}
+	return row, columnIndex
+}
+
+// findSocializeWithOBR returns the content of the one original_bunk_requests row for
+// field=socialize_with, failing the test if it is missing or duplicated.
+func findSocializeWithOBR(t *testing.T, app core.App, personPBID string, year int) string {
+	t.Helper()
+	recs, err := app.FindRecordsByFilter(
+		"original_bunk_requests",
+		fmt.Sprintf("requester = '%s' && year = %d && field = 'socialize_with'", personPBID, year),
+		"", 0, 0)
+	if err != nil {
+		t.Fatalf("find socialize_with OBR: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("found %d socialize_with OBR rows for %s/%d, want 1", len(recs), personPBID, year)
+	}
+	return recs[0].GetString("content")
+}
+
+// Log-line coverage for the CSV/custom-field mismatch warning (processRow's slog.Warn
+// call, kindred#2484's production diffing safety net) is intentionally not asserted here.
+// Verifying it would need captureSweepLogs, which swaps the process-global slog default
+// and so cannot run under t.Parallel() (sync/lodging are held to a package-wide
+// all-tests-parallel guard) -- and the exemption list that would allow an opt-out lives
+// in main_test_parallelism_test.go, outside this issue's file scope. The behavioral pin
+// below (custom field wins) covers the invariant that matters; the warning itself is
+// exercised by hand against production logs during rollout, per the issue's build note.
+func TestProcessRow_SocializeWith_PrefersCustomFieldValueOverCSV(t *testing.T) {
+	t.Parallel()
+	app := newBunkRequestsSocializeWithTestApp(t)
+
+	const personID = 1001
+	const personPBID = "pb_person_1001"
+	const year = 2026
+
+	row, columnIndex := socializeWithCSVRow("1001", dropdownOlder+" (stale csv answer)")
+
+	s := &BunkRequestsSync{
+		BaseSyncService: BaseSyncService{App: app, Stats: Stats{}},
+		validPersonIDs:  map[int]string{personID: personPBID},
+		csvPersonIDs:    make(map[int]bool),
+		socializeWithByPerson: map[string]string{
+			personPBID: dropdownYounger,
+		},
+	}
+
+	if err := s.processRow(row, columnIndex, year); err != nil {
+		t.Fatalf("processRow: %v", err)
+	}
+
+	got := findSocializeWithOBR(t, app, personPBID, year)
+	if got != dropdownYounger {
+		t.Errorf("socialize_with content = %q, want %q (custom field must win over CSV)", got, dropdownYounger)
+	}
+}
+
+func TestProcessRow_SocializeWith_FallsBackToCSVWhenNoCustomFieldValue(t *testing.T) {
+	t.Parallel()
+	app := newBunkRequestsSocializeWithTestApp(t)
+
+	const personID = 1002
+	const personPBID = "pb_person_1002"
+	const year = 2026
+
+	row, columnIndex := socializeWithCSVRow("1002", dropdownOlder)
+
+	s := &BunkRequestsSync{
+		BaseSyncService:       BaseSyncService{App: app, Stats: Stats{}},
+		validPersonIDs:        map[int]string{personID: personPBID},
+		csvPersonIDs:          make(map[int]bool),
+		socializeWithByPerson: map[string]string{}, // no custom field data for this person yet
+	}
+
+	if err := s.processRow(row, columnIndex, year); err != nil {
+		t.Fatalf("processRow: %v", err)
+	}
+
+	got := findSocializeWithOBR(t, app, personPBID, year)
+	if got != dropdownOlder {
+		t.Errorf("socialize_with content = %q, want %q (must fall back to CSV)", got, dropdownOlder)
+	}
+}
+
+func TestProcessRow_SocializeWith_EmptyCustomFieldValueFallsBackToCSV(t *testing.T) {
+	t.Parallel()
+	app := newBunkRequestsSocializeWithTestApp(t)
+
+	const personID = 1003
+	const personPBID = "pb_person_1003"
+	const year = 2026
+
+	row, columnIndex := socializeWithCSVRow("1003", dropdownYounger)
+
+	s := &BunkRequestsSync{
+		BaseSyncService: BaseSyncService{App: app, Stats: Stats{}},
+		validPersonIDs:  map[int]string{personID: personPBID},
+		csvPersonIDs:    make(map[int]bool),
+		socializeWithByPerson: map[string]string{
+			personPBID: "", // custom field synced but blank -- must not be treated as authoritative
+		},
+	}
+
+	if err := s.processRow(row, columnIndex, year); err != nil {
+		t.Fatalf("processRow: %v", err)
+	}
+
+	got := findSocializeWithOBR(t, app, personPBID, year)
+	if got != dropdownYounger {
+		t.Errorf("socialize_with content = %q, want %q (blank custom value must fall back to CSV)", got, dropdownYounger)
+	}
+}
+
+// TestProcessRow_OtherFields_UnaffectedBySocializeWithSwap verifies the swap is scoped
+// to the socialize_with field only -- a person with a socializeWithByPerson entry must
+// still get their other four CSV columns (e.g. bunk_request_form) written verbatim from
+// the CSV, not from anything custom-field-sourced.
+func TestProcessRow_OtherFields_UnaffectedBySocializeWithSwap(t *testing.T) {
+	t.Parallel()
+	app := newBunkRequestsSocializeWithTestApp(t)
+
+	const personID = 1004
+	const personPBID = "pb_person_1004"
+	const year = 2026
+
+	columnIndex := map[string]int{
+		"PersonID": 0, "Last Name": 1, "First Name": 2,
+		"Share Bunk With": 3, "Do Not Share Bunk With": 4,
+		"Internal Bunk Notes": 5, "BunkingNotes Notes": 6,
+		"RetParent-Socializewithbest": 7,
+	}
+	row := []string{"1004", "Johnson", "Emma", "wants to bunk with Ada", "", "", "", dropdownOlder}
+
+	s := &BunkRequestsSync{
+		BaseSyncService: BaseSyncService{App: app, Stats: Stats{}},
+		validPersonIDs:  map[int]string{personID: personPBID},
+		csvPersonIDs:    make(map[int]bool),
+		socializeWithByPerson: map[string]string{
+			personPBID: dropdownYounger,
+		},
+	}
+
+	if err := s.processRow(row, columnIndex, year); err != nil {
+		t.Fatalf("processRow: %v", err)
+	}
+
+	recs, err := app.FindRecordsByFilter(
+		"original_bunk_requests",
+		fmt.Sprintf("requester = '%s' && year = %d && field = 'bunk_request_form'", personPBID, year),
+		"", 0, 0)
+	if err != nil {
+		t.Fatalf("find bunk_request_form OBR: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("found %d bunk_request_form OBR rows, want 1", len(recs))
+	}
+	if got, want := recs[0].GetString("content"), "wants to bunk with Ada"; got != want {
+		t.Errorf("bunk_request_form content = %q, want %q (unaffected by the socialize_with swap)", got, want)
+	}
+}

--- a/pocketbase/sync/bunk_requests_socialize_with_test.go
+++ b/pocketbase/sync/bunk_requests_socialize_with_test.go
@@ -3,8 +3,19 @@
 // field it mirrors (cm_id 85803), read via person_custom_values. The CSV column is
 // still parsed during the transition so a disagreement can be logged in production
 // (the issue's own build note: "compare the two ... confirm they agree, row for row,
-// before cutting over"), but the value actually written to original_bunk_requests now
-// comes from the custom field whenever one is present.
+// before cutting over").
+//
+// PR #2523 review (triage-attack): the first version of this file pinned "custom field
+// always wins, even on disagreement." That is unsafe -- socialize_with's sole consumer,
+// orchestrator.py's _parse_socialize_preference, exact-matches the value against exactly
+// two literal strings with no AI fallback, so an unverified custom-field value that
+// disagrees with the known-good CSV can silently drop out of the social graph on the
+// very first sync after deploy. The invariant is deliberately retired: on disagreement,
+// the already-live CSV value stays authoritative (still logged, so the two can be
+// diffed in production per the issue's own request); the custom field is only trusted
+// outright when there is no CSV value to compare it against -- the coverage-increase
+// population the issue's own numbers document (1,145 custom-field persons vs 1,134 CSV,
+// full overlap).
 package sync
 
 import (
@@ -80,10 +91,17 @@ func findSocializeWithOBR(t *testing.T, app core.App, personPBID string, year in
 // Verifying it would need captureSweepLogs, which swaps the process-global slog default
 // and so cannot run under t.Parallel() (sync/lodging are held to a package-wide
 // all-tests-parallel guard) -- and the exemption list that would allow an opt-out lives
-// in main_test_parallelism_test.go, outside this issue's file scope. The behavioral pin
-// below (custom field wins) covers the invariant that matters; the warning itself is
-// exercised by hand against production logs during rollout, per the issue's build note.
-func TestProcessRow_SocializeWith_PrefersCustomFieldValueOverCSV(t *testing.T) {
+// in main_test_parallelism_test.go, outside this issue's file scope. The behavioral pins
+// below cover the invariants that matter; the warning itself is exercised by hand against
+// production logs during rollout, per the issue's build note.
+//
+// TestProcessRow_SocializeWith_DisagreementKeepsCSV pins the retired invariant's
+// replacement (see the file-level comment): when the CSV and the custom field both carry
+// a non-empty value and they disagree, the CSV value -- already live, already verified
+// against production for the current sync year -- wins. The custom field does not get to
+// silently overwrite a working answer with one nothing has cross-checked against
+// orchestrator.py's exact-match parser.
+func TestProcessRow_SocializeWith_DisagreementKeepsCSV(t *testing.T) {
 	t.Parallel()
 	app := newBunkRequestsSocializeWithTestApp(t)
 
@@ -91,7 +109,41 @@ func TestProcessRow_SocializeWith_PrefersCustomFieldValueOverCSV(t *testing.T) {
 	const personPBID = "pb_person_1001"
 	const year = 2026
 
-	row, columnIndex := socializeWithCSVRow("1001", dropdownOlder+" (stale csv answer)")
+	csvValue := dropdownOlder + " (stale csv answer)"
+	row, columnIndex := socializeWithCSVRow("1001", csvValue)
+
+	s := &BunkRequestsSync{
+		BaseSyncService: BaseSyncService{App: app, Stats: Stats{}},
+		validPersonIDs:  map[int]string{personID: personPBID},
+		csvPersonIDs:    make(map[int]bool),
+		socializeWithByPerson: map[string]string{
+			personPBID: dropdownYounger,
+		},
+	}
+
+	if err := s.processRow(row, columnIndex, year); err != nil {
+		t.Fatalf("processRow: %v", err)
+	}
+
+	got := findSocializeWithOBR(t, app, personPBID, year)
+	if got != csvValue {
+		t.Errorf("socialize_with content = %q, want %q (CSV must win on disagreement)", got, csvValue)
+	}
+}
+
+// TestProcessRow_SocializeWith_UsesCustomFieldWhenCSVAbsent covers the coverage-increase
+// population the issue's own numbers document (1,145 custom-field persons vs 1,134 CSV,
+// full overlap): a person with no CSV answer at all still gets one, sourced from the
+// custom field, because there is nothing to disagree with.
+func TestProcessRow_SocializeWith_UsesCustomFieldWhenCSVAbsent(t *testing.T) {
+	t.Parallel()
+	app := newBunkRequestsSocializeWithTestApp(t)
+
+	const personID = 1005
+	const personPBID = "pb_person_1005"
+	const year = 2026
+
+	row, columnIndex := socializeWithCSVRow("1005", "")
 
 	s := &BunkRequestsSync{
 		BaseSyncService: BaseSyncService{App: app, Stats: Stats{}},
@@ -108,7 +160,8 @@ func TestProcessRow_SocializeWith_PrefersCustomFieldValueOverCSV(t *testing.T) {
 
 	got := findSocializeWithOBR(t, app, personPBID, year)
 	if got != dropdownYounger {
-		t.Errorf("socialize_with content = %q, want %q (custom field must win over CSV)", got, dropdownYounger)
+		t.Errorf("socialize_with content = %q, want %q (custom field is the only signal when CSV absent)",
+			got, dropdownYounger)
 	}
 }
 

--- a/pocketbase/sync/person_custom_field_values.go
+++ b/pocketbase/sync/person_custom_field_values.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/pocketbase/pocketbase/core"
@@ -659,7 +660,12 @@ func loadPersonCustomFieldValuesByCMID(app core.App, fieldCMID, year int) (map[s
 	values := make(map[string]string, len(records))
 	for _, record := range records {
 		if personPBId := record.GetString("person"); personPBId != "" {
-			values[personPBId] = record.GetString("value")
+			// PR #2523 review: CampMinder's custom-field export is a different path
+			// than the CSV, whose column is already trimmed (getColumn's
+			// strings.TrimSpace). Trimming here too keeps a whitespace-only
+			// difference from reading as a real disagreement to callers that
+			// compare this value against the CSV (bunk_requests.go).
+			values[personPBId] = strings.TrimSpace(record.GetString("value"))
 		}
 	}
 	return values, nil

--- a/pocketbase/sync/person_custom_field_values.go
+++ b/pocketbase/sync/person_custom_field_values.go
@@ -619,6 +619,52 @@ func (s *PersonCustomFieldValuesSync) deleteOrphans(year int, sweptOwners map[st
 	)
 }
 
+// cmIDSocializeWithBest is the CampMinder custom-field id for "Ret Parent-Socialize with
+// best" -- the summer bunking dropdown kindred#2484 reads directly from person_custom_values
+// instead of the manually uploaded bunk-requests CSV column ("RetParent-Socializewithbest").
+// The free-text companion field (cm_id 85804, "...Explain") is a deliberately separate,
+// out-of-scope decision per #2484 -- do not extend this constant to cover it.
+const cmIDSocializeWithBest = 85803
+
+// loadPersonCustomFieldValuesByCMID returns person PB id -> raw value for every
+// person_custom_values row in the given year whose field_definition matches the
+// custom_field_defs record carrying fieldCMID.
+//
+// custom_field_defs is the join target -- NOT person_tag_defs -- and getting that join
+// wrong returns zero rows with no error, which is why the cm_id lookup is isolated here
+// rather than inlined at each call site (kindred#2484).
+//
+// A field definition that has not synced yet (custom_field_defs has no matching row) is
+// reported as an empty map, not an error: callers that fall back to another source (e.g.
+// bunk_requests.go's CSV-to-custom-field swap) treat "nothing to switch to yet" as
+// normal, not fatal.
+func loadPersonCustomFieldValuesByCMID(app core.App, fieldCMID, year int) (map[string]string, error) {
+	defs, err := app.FindRecordsByFilter(
+		"custom_field_defs", fmt.Sprintf("cm_id = %d", fieldCMID), "", 1, 0, nil)
+	if err != nil {
+		return nil, fmt.Errorf("finding custom field definition %d: %w", fieldCMID, err)
+	}
+	if len(defs) == 0 {
+		return map[string]string{}, nil
+	}
+
+	records, err := app.FindRecordsByFilter(
+		"person_custom_values",
+		fmt.Sprintf("field_definition = '%s' && year = %d", defs[0].Id, year),
+		"", 0, 0, nil)
+	if err != nil {
+		return nil, fmt.Errorf("finding person_custom_values for field %d: %w", fieldCMID, err)
+	}
+
+	values := make(map[string]string, len(records))
+	for _, record := range records {
+		if personPBId := record.GetString("person"); personPBId != "" {
+			values[personPBId] = record.GetString("value")
+		}
+	}
+	return values, nil
+}
+
 // transformPersonCustomFieldValueToPB transforms CampMinder custom field value data to PocketBase format
 // Schema: person, field_definition, value, year, last_updated (optional)
 func (s *PersonCustomFieldValuesSync) transformPersonCustomFieldValueToPB(

--- a/pocketbase/sync/person_custom_field_values_by_cmid_test.go
+++ b/pocketbase/sync/person_custom_field_values_by_cmid_test.go
@@ -1,0 +1,162 @@
+// TestLoadPersonCustomFieldValuesByCMID pins kindred#2484's join helper: given a
+// CampMinder custom-field cm_id, return person PB id -> value for that year, going
+// through custom_field_defs (NOT person_tag_defs -- the wrong join returns zero rows
+// with no error, which is exactly the trap this helper exists to isolate in one place).
+package sync
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+)
+
+// newCustomFieldByCMIDTestApp returns a throwaway app carrying just the three
+// collections loadPersonCustomFieldValuesByCMID reads: custom_field_defs (the cm_id ->
+// PB id join target), persons (unused by the query itself, kept only so relation-shaped
+// fixtures look like production), and person_custom_values (the source rows).
+func newCustomFieldByCMIDTestApp(t *testing.T) core.App {
+	t.Helper()
+	app, err := pbtests.NewTestApp()
+	if err != nil {
+		t.Fatalf("NewTestApp: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	defs := core.NewBaseCollection("custom_field_defs")
+	defs.Fields.Add(&core.NumberField{Name: "cm_id"})
+	defs.Fields.Add(&core.TextField{Name: "name"})
+	if saveErr := app.Save(defs); saveErr != nil {
+		t.Fatalf("save custom_field_defs: %v", saveErr)
+	}
+
+	pcv := core.NewBaseCollection("person_custom_values")
+	pcv.Fields.Add(&core.TextField{Name: "field_definition"})
+	pcv.Fields.Add(&core.TextField{Name: "person"})
+	pcv.Fields.Add(&core.TextField{Name: "value"})
+	pcv.Fields.Add(&core.NumberField{Name: "year"})
+	if saveErr := app.Save(pcv); saveErr != nil {
+		t.Fatalf("save person_custom_values: %v", saveErr)
+	}
+
+	return app
+}
+
+// addCustomFieldDef writes one custom_field_defs row and returns its PB id.
+func addCustomFieldDef(t *testing.T, app core.App, cmID int, name string) string {
+	t.Helper()
+	col, err := app.FindCollectionByNameOrId("custom_field_defs")
+	if err != nil {
+		t.Fatalf("find custom_field_defs: %v", err)
+	}
+	rec := core.NewRecord(col)
+	rec.Set("cm_id", cmID)
+	rec.Set("name", name)
+	if saveErr := app.Save(rec); saveErr != nil {
+		t.Fatalf("save custom_field_defs row: %v", saveErr)
+	}
+	return rec.Id
+}
+
+// addPersonCustomValueRow writes one person_custom_values row keyed by field_definition PB id.
+func addPersonCustomValueRow(t *testing.T, app core.App, fieldDefPBID, personPBID, value string, year int) {
+	t.Helper()
+	col, err := app.FindCollectionByNameOrId("person_custom_values")
+	if err != nil {
+		t.Fatalf("find person_custom_values: %v", err)
+	}
+	rec := core.NewRecord(col)
+	rec.Set("field_definition", fieldDefPBID)
+	rec.Set("person", personPBID)
+	rec.Set("value", value)
+	rec.Set("year", year)
+	if saveErr := app.Save(rec); saveErr != nil {
+		t.Fatalf("save person_custom_values row: %v", saveErr)
+	}
+}
+
+func TestLoadPersonCustomFieldValuesByCMID_ReturnsPersonToValueMap(t *testing.T) {
+	t.Parallel()
+	app := newCustomFieldByCMIDTestApp(t)
+
+	fieldDefID := addCustomFieldDef(t, app, 85803, "Ret Parent-Socialize with best")
+	addPersonCustomValueRow(t, app, fieldDefID, "pb_person_a", "OLDER", 2026)
+	addPersonCustomValueRow(t, app, fieldDefID, "pb_person_b", "YOUNGER", 2026)
+
+	values, err := loadPersonCustomFieldValuesByCMID(app, 85803, 2026)
+	if err != nil {
+		t.Fatalf("loadPersonCustomFieldValuesByCMID: %v", err)
+	}
+
+	if got, want := len(values), 2; got != want {
+		t.Fatalf("len(values) = %d, want %d: %v", got, want, values)
+	}
+	if got, want := values["pb_person_a"], "OLDER"; got != want {
+		t.Errorf("values[pb_person_a] = %q, want %q", got, want)
+	}
+	if got, want := values["pb_person_b"], "YOUNGER"; got != want {
+		t.Errorf("values[pb_person_b] = %q, want %q", got, want)
+	}
+}
+
+// TestLoadPersonCustomFieldValuesByCMID_ScopedToYear verifies a row from a different
+// year is not returned -- person_custom_values is year-scoped, and this helper must
+// respect that like every other reader in the package.
+func TestLoadPersonCustomFieldValuesByCMID_ScopedToYear(t *testing.T) {
+	t.Parallel()
+	app := newCustomFieldByCMIDTestApp(t)
+
+	fieldDefID := addCustomFieldDef(t, app, 85803, "Ret Parent-Socialize with best")
+	addPersonCustomValueRow(t, app, fieldDefID, "pb_person_a", "OLDER", 2025)
+
+	values, err := loadPersonCustomFieldValuesByCMID(app, 85803, 2026)
+	if err != nil {
+		t.Fatalf("loadPersonCustomFieldValuesByCMID: %v", err)
+	}
+	if len(values) != 0 {
+		t.Errorf("values = %v, want empty (2025 row must not leak into a 2026 query)", values)
+	}
+}
+
+// TestLoadPersonCustomFieldValuesByCMID_UnsyncedFieldDefReturnsEmptyMapNotError verifies
+// that a cm_id with no custom_field_defs row yet (field not synced) is reported as "no
+// values available" rather than a hard error -- callers that fall back to another source
+// (bunk_requests.go's CSV swap, kindred#2484) need to treat this as normal, not fatal.
+func TestLoadPersonCustomFieldValuesByCMID_UnsyncedFieldDefReturnsEmptyMapNotError(t *testing.T) {
+	t.Parallel()
+	app := newCustomFieldByCMIDTestApp(t)
+
+	values, err := loadPersonCustomFieldValuesByCMID(app, 999999, 2026)
+	if err != nil {
+		t.Fatalf("loadPersonCustomFieldValuesByCMID: %v", err)
+	}
+	if len(values) != 0 {
+		t.Errorf("values = %v, want empty map for an unsynced field definition", values)
+	}
+}
+
+// TestLoadPersonCustomFieldValuesByCMID_JoinsThroughFieldDefinitionNotPersonTagDefs
+// pins the join column: a person_custom_values row whose field_definition points at
+// some OTHER custom_field_defs record (a different field entirely) must not appear in
+// the cm_id-85803 result, even though both defs live in the same table.
+func TestLoadPersonCustomFieldValuesByCMID_JoinsThroughFieldDefinitionNotPersonTagDefs(t *testing.T) {
+	t.Parallel()
+	app := newCustomFieldByCMIDTestApp(t)
+
+	socializeDefID := addCustomFieldDef(t, app, 85803, "Ret Parent-Socialize with best")
+	otherDefID := addCustomFieldDef(t, app, 12345, "Unrelated field")
+
+	addPersonCustomValueRow(t, app, socializeDefID, "pb_person_a", "OLDER", 2026)
+	addPersonCustomValueRow(t, app, otherDefID, "pb_person_b", "should not appear", 2026)
+
+	values, err := loadPersonCustomFieldValuesByCMID(app, 85803, 2026)
+	if err != nil {
+		t.Fatalf("loadPersonCustomFieldValuesByCMID: %v", err)
+	}
+	if _, found := values["pb_person_b"]; found {
+		t.Errorf("values contains pb_person_b (belongs to a different field definition): %v", values)
+	}
+	if got, want := values["pb_person_a"], "OLDER"; got != want {
+		t.Errorf("values[pb_person_a] = %q, want %q", got, want)
+	}
+}

--- a/pocketbase/sync/person_custom_field_values_by_cmid_test.go
+++ b/pocketbase/sync/person_custom_field_values_by_cmid_test.go
@@ -135,6 +135,29 @@ func TestLoadPersonCustomFieldValuesByCMID_UnsyncedFieldDefReturnsEmptyMapNotErr
 	}
 }
 
+// TestLoadPersonCustomFieldValuesByCMID_TrimsWhitespace pins a PR #2523 review fix:
+// CampMinder's custom-field API is a different export path than the CSV, and the CSV
+// side is already trimmed (bunk_requests.go's getColumn calls strings.TrimSpace). A
+// leading/trailing-whitespace-only difference on the custom-field side must not be
+// treated as a real disagreement by bunk_requests.go's socialize_with comparison --
+// left untrimmed, it would log a spurious mismatch warning (and force a
+// content_hash/processed churn) on every sync run for an answer that never changed.
+func TestLoadPersonCustomFieldValuesByCMID_TrimsWhitespace(t *testing.T) {
+	t.Parallel()
+	app := newCustomFieldByCMIDTestApp(t)
+
+	fieldDefID := addCustomFieldDef(t, app, 85803, "Ret Parent-Socialize with best")
+	addPersonCustomValueRow(t, app, fieldDefID, "pb_person_a", "  "+dropdownOlder+"  \n", 2026)
+
+	values, err := loadPersonCustomFieldValuesByCMID(app, 85803, 2026)
+	if err != nil {
+		t.Fatalf("loadPersonCustomFieldValuesByCMID: %v", err)
+	}
+	if got, want := values["pb_person_a"], dropdownOlder; got != want {
+		t.Errorf("values[pb_person_a] = %q, want %q (surrounding whitespace must be trimmed)", got, want)
+	}
+}
+
 // TestLoadPersonCustomFieldValuesByCMID_JoinsThroughFieldDefinitionNotPersonTagDefs
 // pins the join column: a person_custom_values row whose field_definition points at
 // some OTHER custom_field_defs record (a different field entirely) must not appear in


### PR DESCRIPTION
`socialize_with` — the highest-volume of the five bunking-CSV columns (911 households / 1,134
persons in 2026) — was sourced entirely from a manually uploaded CampMinder report
(`csvFieldMap` in `pocketbase/sync/bunk_requests.go`). A note or dropdown answer entered in
CampMinder after the last manual upload stayed invisible indefinitely, with no automatic
refresh path, even while the daily sync stayed green.

CampMinder exposes the same answer as a custom field (cm_id `85803`, "Ret Parent-Socialize with
best"), already synced into `person_custom_values` by the existing weekly
`person_custom_values` sync. A 2026-08-19 production measurement (in the issue) found the
custom field is a strict superset of the CSV for the field's population: 1,145 persons in
custom values vs. 1,134 in the CSV, with all 1,134 CSV persons among them.

**Fix:** `bunk_requests.go`'s `processRow` now sources `socialize_with`'s content from
`person_custom_values` (via a new `loadPersonCustomFieldValuesByCMID` helper added to
`person_custom_field_values.go`). The custom field is authoritative only where there is no CSV
value to compare it against — the 11-person coverage-increase population the issue's own
numbers document (1,145 vs. 1,134, full overlap) — so those 11 people get a `socialize_with`
signal they never had before; that is a real coverage increase, not merely a swap. Where both
sources carry a non-empty value, the CSV value stays authoritative and any disagreement is
logged so the two can be diffed against production during the rollout. A person with no
custom-field answer yet (or a genuinely blank one) falls back to the CSV column unchanged. The
other four CSV columns (`bunk_request_form`, `staff_not_bunk_with`, `internal_notes`,
`bunking_notes`) are untouched; none has a usable custom-field equivalent.

**Why CSV wins on disagreement, review fix:** `socialize_with`'s sole consumer,
`orchestrator.py`'s `_parse_socialize_preference`, exact-matches the value against exactly two
literal strings ("Kids their own grade and one grade above/below") with no AI fallback. The
issue's own build note asked to verify the two sources produce identical text before cutting
over ("a silent format difference would corrupt the social graph"). Verified directly against
the production snapshot for 2026 (the current sync year): every custom-field value in that
population is one of the two literals the parser expects, and there is zero disagreement
between the CSV and the custom field for any of the overlapping persons — so today's rollout is
safe. But the code itself did not enforce that guarantee: the original version of this PR made
the custom field win even on disagreement, which would silently drop a request out of the
social graph the day CampMinder ever returns a differently-worded answer through the
custom-field API than through the CSV export. Fixed so the already-live, already-verified CSV
value wins on disagreement instead, with the mismatch still logged as the production safety net.

**Also fixed:** `loadPersonCustomFieldValuesByCMID` now trims the custom field's raw value.
CampMinder's custom-field API is a different export path than the CSV, whose column is already
trimmed (`getColumn`'s `strings.TrimSpace`); left untrimmed, a whitespace-only difference would
have read as a real disagreement and logged a spurious warning (plus unnecessary
`content_hash`/`processed` churn) on every sync run.

**Freshness, corrected:** the issue originally claimed this would make the field "at most a day
old," reasoning from #2482/#2489's new daily custom-values cadence. That daily cadence is the
`person_custom_values_family_camp` instance only, scoped to family-camp attendees.
`socialize_with` is a summer bunking field, captured by the *unrestricted* `person_custom_values`
instance, which is still on the weekly cron (`0 4 * * 0`,
`pocketbase/sync/scheduler.go:runCustomValuesSync`) — untouched by #2482/#2489. So the real
improvement is "arbitrary, human-dependent staleness" → "at most a week old, refreshed
automatically." Corrected the issue body and left a comment explaining why; still worth doing,
just not the number originally claimed.

**Deliberately not done:**
- The `85804` free-text "Explain" companion field is out of scope per the issue's own stated
  default — not ingested here.
- The CSV column (`csvFieldMap["RetParent-Socializewithbest"]`) is left in place and still
  parsed, specifically so the mismatch warning above has something to diff against in
  production during the transition; removing the CSV column entirely is a follow-up once that
  diff comes back clean, not part of this PR.
- No change to the other four CSV-sourced fields, the Python dropdown parser
  (`orchestrator.py`'s `_parse_socialize_preference`), or the social graph builder — the shape
  of the value going into `original_bunk_requests.content` is unchanged, only its source is.
- No automated pre-cutover verification job. The production check described above was done by
  hand during review; automating it (a scheduled diff that flags if the custom field ever starts
  returning a value outside the parser's two known literals) is a reasonable follow-up but is new
  scope, not part of this fix.

## Testing

- `pocketbase/sync/person_custom_field_values_by_cmid_test.go`: pins
  `loadPersonCustomFieldValuesByCMID`'s cm_id → PB id join through `custom_field_defs` (not
  `person_tag_defs`), year-scoping, the "field not synced yet → empty map, not an error"
  fallback contract, and (added in review) that surrounding whitespace is trimmed.
- `pocketbase/sync/bunk_requests_socialize_with_test.go`: pins the swap behavior in
  `processRow` — custom field is used when the CSV is absent, CSV wins on disagreement (added
  in review, replacing the original "custom field always wins" pin — see the file's top comment
  for why), falls back to CSV when the custom value is absent or blank, and the other four CSV
  fields are unaffected.
- All top-level tests written with `t.Parallel()` first per the package's
  `main_test_parallelism_test.go` guard; one planned log-line assertion was dropped rather than
  reaching for `captureSweepLogs` (a process-global `slog` swap incompatible with
  `t.Parallel()`), since exempting it required editing a guard file outside this issue's scope.
- `go build ./...`, `go vet ./...`, `gofmt -l`, `golangci-lint run`, `go test ./...` (pocketbase
  module) all clean.
- Mutation-checked: reverting the disagreement fix (making the custom field win again) turns
  `TestProcessRow_SocializeWith_DisagreementKeepsCSV` red; reverting the CSV-absent branch turns
  `TestProcessRow_SocializeWith_UsesCustomFieldWhenCSVAbsent` red — confirming both pin real
  behavior, not tautologies.

Closes #2484.
