### PR TITLE
fix(frontend): the fold chevron no longer dismisses the family details panel

### DIFF
--- a/frontend/src/components/BunkingBoardByArea.clickoutside.test.tsx
+++ b/frontend/src/components/BunkingBoardByArea.clickoutside.test.tsx
@@ -36,6 +36,42 @@ describe('weekend lodging board click-outside predicate', () => {
     expect(shouldKeepPanelsOpen({ ctrlKey: false, metaKey: false, target: name })).toBe(true)
     card.remove()
   })
+  it('keeps the panel open when the click detached its own target, as the fold chevron does', () => {
+    // Regression for #2476, reported from the weekend board: clicking the fold
+    // chevron in `ShareRequestPanel` dismissed `FamilyDetailsPanel` instead of
+    // collapsing the block, while clicking the block's NAME — same `<button>`,
+    // a few pixels to the right — collapsed correctly. That reads like a
+    // geometry bug and is emphatically not one.
+    //
+    // `ChevronDown` and `ChevronRight` are DIFFERENT component types, so
+    // toggling unmounts one `<svg>` and mounts the other instead of mutating
+    // it in place. React flushes that re-render synchronously for a discrete
+    // event at its root-container listener, which sits BELOW `document` — so
+    // by the time the same native click reaches the dead-space listener on
+    // `document`, `event.target` is an orphan. `closest()` on an orphan walks
+    // a tree with no ancestors and matches NOTHING: not the `[data-panel]`
+    // wrapper, not the `<button>`. The predicate then reads a click on an
+    // interactive control inside a panel as dead space.
+    //
+    // Confirmed in a real browser (React 19): the chevron click reports
+    // `isConnected === false`, the label click `true`. jsdom cannot reproduce
+    // it, because Testing Library's `act()` defers the re-render until after
+    // the whole dispatch, leaving the node attached — which is why this is
+    // pinned here, on the predicate, rather than through the hook.
+    const panel = document.createElement('div')
+    panel.setAttribute('data-panel', 'family-details')
+    const button = document.createElement('button')
+    const chevron = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    button.appendChild(chevron)
+    panel.appendChild(button)
+    document.body.appendChild(panel)
+
+    // What React does between the click and the document listener.
+    chevron.remove()
+
+    expect(shouldKeepPanelsOpen({ ctrlKey: false, metaKey: false, target: chevron })).toBe(true)
+    panel.remove()
+  })
 })
 
 describe('BunkingBoardByArea click-outside predicate', () => {

--- a/frontend/src/utils/clickoutsidePredicate.ts
+++ b/frontend/src/utils/clickoutsidePredicate.ts
@@ -18,6 +18,23 @@ export function shouldKeepPanelsOpen(e: {
   const target = e.target as HTMLElement | null
   if (!target || typeof target.closest !== 'function') return false
 
+  // A target that is no longer in the document was removed by this very
+  // click's own handling, and every check below is `closest()`, which walks
+  // ancestors an orphan no longer has — so it would match nothing and the
+  // click would read as dead space.
+  //
+  // This is not a corner case: a toggle that swaps one icon component for
+  // another (`ChevronDown` -> `ChevronRight`) unmounts the clicked node
+  // rather than mutating it, and React flushes that re-render synchronously
+  // for a discrete event at its root-container listener — which sits below
+  // `document`, where the dead-space listener lives. Clicking the fold
+  // chevron in `ShareRequestPanel` therefore dismissed `FamilyDetailsPanel`
+  // (#2476) while clicking the label a few pixels right did not, because
+  // only the icon was replaced.
+  //
+  // Detachment means the app handled the click, so keep the panels open.
+  if (!target.isConnected) return true
+
   const isOnPanel = target.closest(
     '[data-panel="camper-details"], [data-panel="family-details"], [data-panel="lock-group"], [data-panel="lock-action-bar"], [data-panel="lock-group-picker"]'
   )


### PR DESCRIPTION
Completes #2476. Asks 1 and 2 (block reorder, starts collapsed) shipped in #2521; this is ask 3.

## The defect

Clicking the fold chevron in `ShareRequestPanel` dismissed `FamilyDetailsPanel` instead of
collapsing the block. Clicking the block's **name** — the same `<button>`, a few pixels to the
right — collapsed correctly.

## Why the recorded diagnosis was wrong

#2476 said the fix was *"about the modal's dismiss region overlapping the button's left edge"*.
There is no such region. Verified against `main`:

- `FamilyDetailsPanel`'s backdrop is `pointer-events-none` — it can never receive a click.
- The real dismiss path is `useDismissOnDeadSpace` + `shouldKeepPanelsOpen`, which decides by
  **DOM ancestry, not coordinates**. There is no geometry in it at all.
- That predicate exempts the chevron *twice* — as `[data-panel="family-details"]` and as `button`.

All of which is true, and none of which saves it, because of what happens to the node.

## The actual cause: the click detaches its own target

`ChevronDown` and `ChevronRight` are **different component types**, so toggling unmounts one
`<svg>` and mounts the other rather than mutating it in place. React flushes that re-render
synchronously for a discrete event at its **root-container** listener — which sits *below*
`document`, where the dead-space listener lives. So by the time the same native click finishes
bubbling, `event.target` is an orphan.

Every check in `shouldKeepPanelsOpen` is `closest()`. On an orphan that walks a tree with no
ancestors and matches **nothing** — not the panel wrapper, not the button. A click on an
interactive control inside a panel read as dead space.

Only the icon is swapped, which is exactly why the label was safe.

## Measured, in a real browser (React 19)

| clicked | `isConnected` | predicate | result |
|---|---|---|---|
| chevron (before) | `false` | `false` | panel dismissed ❌ |
| label (before) | `true` | `true` | protected ✅ |
| chevron (after) | `false` | `true` | **panel stays open** ✅ |

Detachment is inherent to the swap and does not go away; the predicate now handles it.

## The fix

One guard in the **shared** predicate: a target no longer in the document was removed by this
click's own handling, so the app handled the click and the panels stay open.

Fixed there rather than in the panel, so the whole class is closed for all three consumers
(summer board, both weekend surfaces) — any toggle swapping one icon component for another inside
a panel had the same defect.

## Deliberately not done

- **No change to `ShareRequestPanel`.** Making the chevron persist (one component with a rotation
  transform) would fix this one instance and leave the class open.
- **No `stopPropagation`** on the toggle, which would mask the same bug for one button and quietly
  break dismissal from anywhere else in that subtree.
- **Pinned on the predicate, not the hook.** jsdom cannot reproduce this: Testing Library's `act()`
  defers the re-render until after the whole dispatch, so the node is still attached and a
  hook-level test passes against the broken code. A first attempt at that test did exactly that and
  was discarded rather than kept as false assurance — the browser measurement above is why this is
  a predicate test.

Closes #2476.
