### PR TITLE
feat(frontend): the map shows write-in occupants, as the board does

### DIFF
--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -295,8 +295,10 @@ export function LodgingUnitCard({
    *
    * With all four gone the function draws NOTHING on a board card, so the
    * render site is deleted rather than left standing and quiet. The function
-   * itself is untouched: `MapUnitPopover`'s header and its collapsed grid cell
-   * still call it, and on that surface the marks still discriminate.
+   * itself is untouched, and `MapUnitPopover`'s header and its collapsed grid
+   * cell still call it — but for `Building`/`Staff`/`Released` ONLY.
+   * kindred#2499 gated `Write-in` off there too, so that arm now draws on no
+   * surface at all; the map names the occupant instead.
    */
   // On every unit this card can be a SLOT for, which includes a COMBINED
   // container and excludes a split one.

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -276,9 +276,10 @@ export function LodgingUnitCard({
   // the well's `WriteInCard` below said the same thing twice — the occupant's
   // own name, once as a slate "Write-in" chip and once spelled out in the
   // well — and the well is the one that actually names them, so the chip is
-  // redundant here. `reservationBadge` itself is untouched: `MapUnitPopover`'s
-  // header and its collapsed grid cell draw no `WriteInCard` of their own and
-  // still call it directly, so the chip is still the only signal there.
+  // redundant here. `MapUnitPopover` since dropped it too (kindred#2499, owner
+  // ruling: staff bunk on the board, the map is for visibility and checks), so
+  // NO surface draws "Write-in" now — see `writeInBadgeApplies` for why the arm
+  // nevertheless stays in `reservationBadge`.
   /*
    * ⚠️ `reservationBadge` IS NO LONGER READ HERE, and every one of its arms is
    * a ruling rather than an omission (vocabulary §3).

--- a/frontend/src/components/weekend/MapUnitPopover.test.tsx
+++ b/frontend/src/components/weekend/MapUnitPopover.test.tsx
@@ -814,11 +814,67 @@ describe('MapUnitPopover — a cluster of rooms', () => {
       ),
     ]
     render(<MapUnitPopover units={house} hue={HUE} onOpenParty={vi.fn()} />)
-    // Per #2499 the cell no longer carries "Write-in" — but it MUST still
-    // carry "Inactive", which is a different fact (the room is unbookable)
-    // and the half of this test that was never in question.
-    expect(screen.getByTitle(/Cedar 2.*Inactive/i)).toBeInTheDocument()
+    // Per #2499 the cell no longer carries the "Write-in" CHIP LABEL — but it
+    // must now NAME THE OCCUPANT instead, and must still carry "Inactive",
+    // which is a different fact (the room is unbookable) and the half of this
+    // test that was never in question.
+    expect(screen.getByTitle(/Cedar 2.*Emma Johnson.*Inactive/i)).toBeInTheDocument()
     expect(screen.queryByTitle(/Write-in/i)).not.toBeInTheDocument()
+    // The cell must NOT call a room somebody sleeps in empty. Scoped to
+    // Cedar 2 — Cedar 1 carries no write-in and no party, so "empty" is the
+    // correct answer for it and must survive.
+    expect(screen.queryByTitle(/Cedar 2.*empty/i)).not.toBeInTheDocument()
+    expect(screen.getByTitle(/Cedar 1 — empty/i)).toBeInTheDocument()
+  })
+
+  it('names the occupant in a write-in-only cluster cell rather than calling it empty', () => {
+    // Regression caught by review of the first cut of kindred#2499: `DetailCard`
+    // and `ClusterSummary` were taught about write-in occupants and
+    // `FootprintGrid` was not, so its cell still built `label`/`who`/`base`
+    // from `entry.parties[0]` alone. A write-in-only room — the COMMON case,
+    // since most write-ins are non-rostered staff and carry no party — fell to
+    // the `${name} — empty` branch, directly beneath a summary now reporting
+    // that same room as taken. One popover, two contradictory answers.
+    const house = [
+      mapUnit(row({ unit_id: 'u1', code: 'cedar-1', name: 'Cedar 1' })),
+      mapUnit(
+        row({
+          unit_id: 'u2',
+          code: 'cedar-2',
+          name: 'Cedar 2',
+          write_ins: [
+            cover({
+              unit_id: 'u2',
+              unit_code: 'cedar-2',
+              unit_name: 'Cedar 2',
+              occupant_name: 'Liam Garcia',
+            }),
+          ],
+          is_family_available: false,
+        })
+      ),
+    ]
+    render(<MapUnitPopover units={house} hue={HUE} onOpenParty={vi.fn()} />)
+    expect(screen.getByText('2 · 1 taken, 1 open')).toBeInTheDocument()
+    expect(screen.getByTitle(/Cedar 2.*Liam Garcia/i)).toBeInTheDocument()
+    expect(screen.queryByTitle(/Cedar 2 — empty/i)).not.toBeInTheDocument()
+  })
+
+  it('keeps a write-in-only cell INERT — there is no party to open behind it', () => {
+    const onOpenParty = vi.fn()
+    const house = [
+      mapUnit(row({ unit_id: 'u1', code: 'cedar-1', name: 'Cedar 1' })),
+      mapUnit(
+        row({
+          unit_id: 'u2',
+          code: 'cedar-2',
+          name: 'Cedar 2',
+          write_ins: [cover({ unit_id: 'u2', unit_code: 'cedar-2', unit_name: 'Cedar 2' })],
+        })
+      ),
+    ]
+    render(<MapUnitPopover units={house} hue={HUE} onOpenParty={vi.fn()} />)
+    expect(onOpenParty).not.toHaveBeenCalled()
   })
 
   it('says WHICH room in a cluster carries the consent flag', () => {

--- a/frontend/src/components/weekend/MapUnitPopover.test.tsx
+++ b/frontend/src/components/weekend/MapUnitPopover.test.tsx
@@ -1266,3 +1266,98 @@ describe('MapUnitPopover — the whole-building marker, extended from the board 
     expect(screen.queryByText('Write-in')).not.toBeInTheDocument()
   })
 })
+
+/**
+ * kindred#2499, owner ruling: the map treats a write-in the way the BOARD
+ * does — as an occupant — rather than as a chip beside an otherwise empty
+ * room.
+ *
+ * The board settled this in kindred#2078: "the room read as EMPTY AND CLOSED
+ * when in truth it was FULL. This is the same fact, printed where the board
+ * prints occupancy." Its well stacks `WriteInCard` and `FamilyCard` together,
+ * because "a shared space is not a new KIND of card; it is a card with two
+ * occupants in it."
+ *
+ * The map's "Occupied by" row is its equivalent of that well, and it said
+ * `empty` for a room somebody is sleeping in. These pin the fix.
+ *
+ * The shared unit is `writeInEntries` — the tree-aware, server-ordered
+ * resolver the board already calls — NOT the presentation: the board draws
+ * cards, the map draws a compact list, and those grammars are deliberately
+ * different.
+ */
+describe('MapUnitPopover write-in occupants (kindred#2499)', () => {
+  it('names the write-in occupant instead of calling the room empty', () => {
+    render(
+      <MapUnitPopover
+        units={[mapUnit(row({ write_ins: [cover()], is_family_available: false }))]}
+        hue={HUE}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
+    expect(screen.queryByText('empty')).not.toBeInTheDocument()
+  })
+
+  it('lists a write-in and a placed family together, as one well of occupants', () => {
+    render(
+      <MapUnitPopover
+        units={[
+          mapUnit(row({ write_ins: [cover({ occupant_name: 'Liam Garcia' })] }), [party('Chen')]),
+        ]}
+        hue={HUE}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Liam Garcia')).toBeInTheDocument()
+    expect(screen.getByText('Chen')).toBeInTheDocument()
+  })
+
+  it('says the occupant is not named rather than printing a blank', () => {
+    // Mirrors `WriteInCard`'s UNNAMED fallback, now shared from `writeIn.ts`
+    // so the two surfaces cannot word it differently.
+    render(
+      <MapUnitPopover
+        units={[mapUnit(row({ write_ins: [cover({ occupant_name: '' })] }))]}
+        hue={HUE}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Occupant not named')).toBeInTheDocument()
+  })
+
+  it('does NOT make the occupant look clickable — there is no panel behind one', () => {
+    // `WriteInCard`'s ruling, carried across: "a card that looks interactive
+    // and is not is worse than plain text." A family opens its panel; a
+    // write-in has none.
+    const onOpenParty = vi.fn()
+    render(
+      <MapUnitPopover
+        units={[mapUnit(row({ write_ins: [cover()] }))]}
+        hue={HUE}
+        onOpenParty={onOpenParty}
+      />
+    )
+    expect(screen.getByText('Emma Johnson').closest('button')).toBeNull()
+  })
+
+  it('counts a written-into room as taken in the cluster summary, not open', () => {
+    // The count keyed on `parties.length`, and a write-in occupant is by
+    // definition NOT a rostered party — so a full room was reported open,
+    // contradicting kindred#2078 on the very surface that ruling was about.
+    const house = [
+      mapUnit(row({ unit_id: 'u1', code: 'cedar-1', name: 'Cedar 1' })),
+      mapUnit(
+        row({
+          unit_id: 'u2',
+          code: 'cedar-2',
+          name: 'Cedar 2',
+          write_ins: [cover({ unit_id: 'u2', unit_code: 'cedar-2', unit_name: 'Cedar 2' })],
+          is_family_available: false,
+        })
+      ),
+    ]
+    render(<MapUnitPopover units={house} hue={HUE} onOpenParty={vi.fn()} />)
+    expect(screen.getByText('2 · 1 taken, 1 open')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/weekend/MapUnitPopover.test.tsx
+++ b/frontend/src/components/weekend/MapUnitPopover.test.tsx
@@ -197,7 +197,15 @@ describe('MapUnitPopover — one room', () => {
     expect(onOpenParty).toHaveBeenCalledWith(johnson)
   })
 
-  it('badges a written-into room, reusing the inventory and board wording', () => {
+  it('draws NO write-in chip on a written-into room, because bunking happens on the board', () => {
+    // ⛔ RETIRED 2026-08-21 by owner ruling on #2499. This asserted the
+    // OPPOSITE — that the map badges a written-into room — and it is rewritten
+    // rather than adapted, because the specification changed, not the code.
+    //
+    // Staff bunk on the BOARD; the map is for visibility and checks. Write-in
+    // occupancy is board business, so the map draws no "Write-in" chip. The
+    // map's two call sites now apply the same `writeInBadgeApplies` gate the
+    // unit card has used since kindred#2252, so the two surfaces agree.
     // `reservationBadge` is the shared source for this; a second copy is how
     // the three surfaces start disagreeing about what the word means. It
     // INHERITED kindred#2078's rename for free, which is the point — this
@@ -217,7 +225,7 @@ describe('MapUnitPopover — one room', () => {
         onOpenParty={vi.fn()}
       />
     )
-    expect(screen.getByText('Write-in')).toBeInTheDocument()
+    expect(screen.queryByText('Write-in')).not.toBeInTheDocument()
   })
 
   it('says a deactivated room is inactive', () => {
@@ -806,8 +814,11 @@ describe('MapUnitPopover — a cluster of rooms', () => {
       ),
     ]
     render(<MapUnitPopover units={house} hue={HUE} onOpenParty={vi.fn()} />)
-    expect(screen.getByTitle(/Cedar 2.*Write-in.*Inactive/i)).toBeInTheDocument()
-    expect(screen.queryByTitle(/Cedar 1.*Write-in/i)).not.toBeInTheDocument()
+    // Per #2499 the cell no longer carries "Write-in" — but it MUST still
+    // carry "Inactive", which is a different fact (the room is unbookable)
+    // and the half of this test that was never in question.
+    expect(screen.getByTitle(/Cedar 2.*Inactive/i)).toBeInTheDocument()
+    expect(screen.queryByTitle(/Write-in/i)).not.toBeInTheDocument()
   })
 
   it('says WHICH room in a cluster carries the consent flag', () => {
@@ -1215,7 +1226,15 @@ describe('MapUnitPopover — the whole-building marker, extended from the board 
     expect(garciaChip.textContent).not.toContain('Whole building')
   })
 
-  it('renders the whole-building badge and a write-in badge together, legibly', () => {
+  it('renders the whole-building badge alone, the write-in chip having been dropped', () => {
+    // ⛔ RETIRED 2026-08-21 by owner ruling on #2499. This asserted the
+    // OPPOSITE — that the map badges a written-into room — and it is rewritten
+    // rather than adapted, because the specification changed, not the code.
+    //
+    // Staff bunk on the BOARD; the map is for visibility and checks. Write-in
+    // occupancy is board business, so the map draws no "Write-in" chip. The
+    // map's two call sites now apply the same `writeInBadgeApplies` gate the
+    // unit card has used since kindred#2252, so the two surfaces agree.
     // #2078 added the write-in badge (via `reservationBadge`, unit-level, in
     // the DetailCard's status list) after this issue was filed. It is
     // orthogonal to `wholeBuildingKeys` (party-keyed) — a room can carry both
@@ -1239,10 +1258,11 @@ describe('MapUnitPopover — the whole-building marker, extended from the board 
         wholeBuildingKeys={new Set([partyKey(johnson)])}
       />
     )
-    const writeIn = screen.getByText('Write-in')
-    const wholeBuilding = screen.getByText('Whole building')
-    expect(writeIn).toBeInTheDocument()
-    expect(wholeBuilding).toBeInTheDocument()
-    expect(writeIn).not.toBe(wholeBuilding)
+    // The whole-building badge is untouched by #2499 and must survive; only
+    // the write-in chip goes. Asserting both keeps this test pinning the
+    // thing it was written for — that these are two independent signals —
+    // rather than silently narrowing to one.
+    expect(screen.getByText('Whole building')).toBeInTheDocument()
+    expect(screen.queryByText('Write-in')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/weekend/MapUnitPopover.tsx
+++ b/frontend/src/components/weekend/MapUnitPopover.tsx
@@ -31,6 +31,7 @@ import type { MapUnit } from './mapModel'
 import { partyKey } from './partyKey'
 import { partyAttention, partyBeds } from './rosterAttention'
 import { reservationBadge, shareabilityBadge, writeInBadgeApplies } from './unitBadges'
+import { writeInEntries, writeInOccupantLabel, type WriteInEntry } from './writeIn'
 
 /**
  * The board's `border-amber-400`, reused rather than re-picked. A consent flag
@@ -226,6 +227,27 @@ function partyPeopleLabel(party: RosterPartyRow): string {
   return people.join(' · ')
 }
 
+/**
+ * Write-in occupants, drawn INERT.
+ *
+ * `WriteInCard`'s ruling, carried to this surface: no `useDraggable` and not a
+ * `<button>`, because "a card that looks interactive and is not is worse than
+ * plain text". A family opens its panel; there is no panel behind a write-in
+ * and nowhere to send the click. Ordered before the families to match the
+ * order the board's well already stacks them in.
+ */
+function writeInOccupants(entries: WriteInEntry[]): ReactNode {
+  return entries.map((entry) => (
+    <span
+      key={entry.source.unitId}
+      data-testid="map-popover-writein"
+      className="text-foreground text-right text-xs"
+    >
+      {writeInOccupantLabel(entry.occupant)}
+    </span>
+  ))
+}
+
 function occupantButtons(
   parties: RosterPartyRow[],
   onOpenParty: (party: RosterPartyRow) => void
@@ -260,13 +282,18 @@ function DetailCard({ entry, hue, onOpenParty, wholeBuildingKeys }: DetailCardPr
   // raw understates a four-room house as sleeping one. The map draws such a
   // house as a single mark, so this lone card is exactly where that lands.
   const capacityKnown = capacity !== null
-  // kindred#2499, owner ruling: no "Write-in" chip on the map. Staff bunk on
-  // the BOARD; the map is for visibility and checks, so write-in occupancy is
-  // board business. Gated through `writeInBadgeApplies` — the same gate
-  // `LodgingUnitCard` has used since kindred#2252 — rather than by re-deriving
-  // it here, so the two surfaces cannot drift. Every OTHER arm of
-  // `reservationBadge` (`Building`, `Staff`, `Released`) is untouched.
+  // No "Write-in" chip, for `LodgingUnitCard`'s reason (kindred#2252) rather
+  // than a new one: the occupant is NAMED in "Occupied by" below, so a chip
+  // beside it repeats the same fact under a second name. Gated through the
+  // shared `writeInBadgeApplies` rather than re-derived here, so the two
+  // surfaces cannot drift. Every OTHER arm of `reservationBadge` (`Building`,
+  // `Staff`, `Released`) is untouched.
   const badge = writeInBadgeApplies(unit) ? null : reservationBadge(unit)
+  // kindred#2499: a write-in is an OCCUPANT, exactly as it is on the board.
+  // `writeInEntries` is the board's own resolver — tree-aware (a building's
+  // row closes its rooms and vice versa) and ordered by the server — so the
+  // two surfaces answer "who is in this room" from one place.
+  const writeIns = writeInEntries(unit)
   const bedsNeeded = parties.reduce((sum, party) => sum + partyBeds(party), 0)
   /*
    * THE AMBER IS A CLAIM, AND `spanWidth` IS WHAT WITHHOLDS IT — the same gate
@@ -349,7 +376,14 @@ function DetailCard({ entry, hue, onOpenParty, wholeBuildingKeys }: DetailCardPr
         <div className="flex justify-between gap-3">
           <dt className="text-muted-foreground">Occupied by</dt>
           <dd className="flex flex-col items-end gap-0.5">
-            {parties.length > 0 ? occupantButtons(parties, onOpenParty) : <em>empty</em>}
+            {parties.length > 0 || writeIns.length > 0 ? (
+              <>
+                {writeInOccupants(writeIns)}
+                {occupantButtons(parties, onOpenParty)}
+              </>
+            ) : (
+              <em>empty</em>
+            )}
           </dd>
         </div>
       </dl>
@@ -506,6 +540,30 @@ interface SummaryFamily {
   flagged: boolean
 }
 
+/**
+ * Every write-in across the cluster, DEDUPED BY THE ROW THAT HOLDS IT.
+ *
+ * A building's row closes each of its rooms, so the same cover comes back
+ * once per drawn unit; listing it per room would name one occupant four
+ * times for one building. Keyed on `source.unitId` — the row — rather than
+ * the occupant's name, because two rooms can genuinely hold two different
+ * people who happen to share a name, and collapsing those would hide one.
+ *
+ * Server order is preserved, as `writeInEntries` requires.
+ */
+function summaryWriteIns(units: MapUnit[]): WriteInEntry[] {
+  const out: WriteInEntry[] = []
+  const seen = new Set<string>()
+  for (const entry of units) {
+    for (const writeIn of writeInEntries(entry.unit)) {
+      if (seen.has(writeIn.source.unitId)) continue
+      seen.add(writeIn.source.unitId)
+      out.push(writeIn)
+    }
+  }
+  return out
+}
+
 function summaryFamilies(units: MapUnit[]): SummaryFamily[] {
   const out: SummaryFamily[] = []
   const byKey = new Map<string, SummaryFamily>()
@@ -554,8 +612,16 @@ function ClusterSummary({
   const rooms = units.reduce((total, entry) => total + entry.roomCount, 0)
   // A drawn unit is taken as a WHOLE: a family holding a combined house holds
   // every room in it, which is what "combined" means.
+  // A write-in counts here, kindred#2499. This keyed on `parties.length`
+  // alone, and a write-in occupant is by definition NOT a rostered party — so
+  // a room somebody sleeps in was reported OPEN, which is the very thing
+  // kindred#2078 ruled against ("the room read as empty and closed when in
+  // truth it was full"). It is a ROOM count, so an occupant with no known
+  // party size still answers it; no figure is invented.
   const taken = units.reduce(
-    (total, entry) => total + (entry.parties.length > 0 ? entry.roomCount : 0),
+    (total, entry) =>
+      total +
+      (entry.parties.length > 0 || writeInEntries(entry.unit).length > 0 ? entry.roomCount : 0),
     0
   )
   // ONE unmeasured room leaves the building total unknown — a partial sum
@@ -572,6 +638,7 @@ function ClusterSummary({
   // counts its beds once per door, and can print more placed than the
   // building sleeps. One chip, one household, one bed total.
   const placed = families.reduce((total, { party }) => total + partyBeds(party), 0)
+  const writeIns = summaryWriteIns(units)
 
   return (
     <div className="flex min-w-[11rem] flex-col gap-1.5">
@@ -600,10 +667,27 @@ function ClusterSummary({
           name per line. */}
       <div className="flex flex-col gap-1">
         <span className="text-muted-foreground text-xs">Occupied by</span>
-        {families.length === 0 ? (
+        {families.length === 0 && writeIns.length === 0 ? (
           <em className="text-muted-foreground text-xs">empty</em>
         ) : (
           <ul className="flex flex-col gap-1">
+            {/* Ahead of the families, in the order the board's own well stacks
+                them. The frame is `FamilyCard`'s minus its behaviour — the
+                same trade `WriteInCard` makes on the board — so an occupant
+                reads as an occupant without reading as a button. */}
+            {writeIns.map((entry) => (
+              <li key={entry.source.unitId}>
+                <div
+                  data-testid="map-popover-writein"
+                  style={{ borderColor: hue }}
+                  className="bg-card flex w-full flex-col items-start gap-0.5 rounded-md border px-1.5 py-1 text-left"
+                >
+                  <span className="text-foreground text-[11px] font-semibold">
+                    {writeInOccupantLabel(entry.occupant)}
+                  </span>
+                </div>
+              </li>
+            ))}
             {families.map(({ party, flagged: notConsented }) => (
               <li key={partyKey(party)}>
                 <button

--- a/frontend/src/components/weekend/MapUnitPopover.tsx
+++ b/frontend/src/components/weekend/MapUnitPopover.tsx
@@ -30,7 +30,7 @@ import { CONSENT_AMBER } from './mapColors'
 import type { MapUnit } from './mapModel'
 import { partyKey } from './partyKey'
 import { partyAttention, partyBeds } from './rosterAttention'
-import { reservationBadge, shareabilityBadge } from './unitBadges'
+import { reservationBadge, shareabilityBadge, writeInBadgeApplies } from './unitBadges'
 
 /**
  * The board's `border-amber-400`, reused rather than re-picked. A consent flag
@@ -260,7 +260,13 @@ function DetailCard({ entry, hue, onOpenParty, wholeBuildingKeys }: DetailCardPr
   // raw understates a four-room house as sleeping one. The map draws such a
   // house as a single mark, so this lone card is exactly where that lands.
   const capacityKnown = capacity !== null
-  const badge = reservationBadge(unit)
+  // kindred#2499, owner ruling: no "Write-in" chip on the map. Staff bunk on
+  // the BOARD; the map is for visibility and checks, so write-in occupancy is
+  // board business. Gated through `writeInBadgeApplies` — the same gate
+  // `LodgingUnitCard` has used since kindred#2252 — rather than by re-deriving
+  // it here, so the two surfaces cannot drift. Every OTHER arm of
+  // `reservationBadge` (`Building`, `Staff`, `Released`) is untouched.
+  const badge = writeInBadgeApplies(unit) ? null : reservationBadge(unit)
   const bedsNeeded = parties.reduce((sum, party) => sum + partyBeds(party), 0)
   /*
    * THE AMBER IS A CLAIM, AND `spanWidth` IS WHAT WITHHOLDS IT — the same gate
@@ -703,7 +709,9 @@ function FootprintGrid({
           // A held or deactivated room that said nothing here would be
           // indistinguishable from a bookable one.
           const notes: string[] = []
-          const cellBadge = reservationBadge(entry.unit)
+          // Same kindred#2499 gate as the header above. "Inactive" still
+          // reaches the title — that is a different fact from a write-in.
+          const cellBadge = writeInBadgeApplies(entry.unit) ? null : reservationBadge(entry.unit)
           if (cellBadge) notes.push(cellBadge.label)
           if (entry.unit.is_active === false) notes.push('Inactive')
           if (entry.consent) notes.push(CONSENT_PHRASE)

--- a/frontend/src/components/weekend/MapUnitPopover.tsx
+++ b/frontend/src/components/weekend/MapUnitPopover.tsx
@@ -551,11 +551,11 @@ interface SummaryFamily {
  *
  * Server order is preserved, as `writeInEntries` requires.
  */
-function summaryWriteIns(units: MapUnit[]): WriteInEntry[] {
+function summaryWriteIns(resolved: { writeIns: WriteInEntry[] }[]): WriteInEntry[] {
   const out: WriteInEntry[] = []
   const seen = new Set<string>()
-  for (const entry of units) {
-    for (const writeIn of writeInEntries(entry.unit)) {
+  for (const entry of resolved) {
+    for (const writeIn of entry.writeIns) {
       if (seen.has(writeIn.source.unitId)) continue
       seen.add(writeIn.source.unitId)
       out.push(writeIn)
@@ -618,10 +618,14 @@ function ClusterSummary({
   // kindred#2078 ruled against ("the room read as empty and closed when in
   // truth it was full"). It is a ROOM count, so an occupant with no known
   // party size still answers it; no figure is invented.
-  const taken = units.reduce(
-    (total, entry) =>
-      total +
-      (entry.parties.length > 0 || writeInEntries(entry.unit).length > 0 ? entry.roomCount : 0),
+  //
+  // Resolved ONCE per unit and shared by both readers: `taken` asks "does this
+  // unit carry any", the list below asks "which, deduped across the cluster".
+  // Two questions, one pass.
+  const resolved = units.map((entry) => ({ entry, writeIns: writeInEntries(entry.unit) }))
+  const taken = resolved.reduce(
+    (total, { entry, writeIns }) =>
+      total + (entry.parties.length > 0 || writeIns.length > 0 ? entry.roomCount : 0),
     0
   )
   // ONE unmeasured room leaves the building total unknown — a partial sum
@@ -638,7 +642,7 @@ function ClusterSummary({
   // counts its beds once per door, and can print more placed than the
   // building sleeps. One chip, one household, one bed total.
   const placed = families.reduce((total, { party }) => total + partyBeds(party), 0)
-  const writeIns = summaryWriteIns(units)
+  const writeIns = summaryWriteIns(resolved)
 
   return (
     <div className="flex min-w-[11rem] flex-col gap-1.5">
@@ -771,9 +775,25 @@ function FootprintGrid({
               ? `${partyIdentityLabel(first)} +${String(extra)}`
               : partyIdentityLabel(first)
             : shortName
+          // kindred#2499: a write-in is an occupant here too. This branch
+          // read `parties` alone, so a write-in-only room — the COMMON case,
+          // since most write-ins are non-rostered staff carrying no party —
+          // described itself as "empty" directly beneath a summary reporting
+          // it as taken. One popover, two contradictory answers.
+          //
+          // Only the DESCRIPTION changes. The visible `label` stays the room
+          // name and `first` still gates the filled style, so the cell remains
+          // the inert spatial picker it was — there is no party to open behind
+          // a write-in, and a cell that looked placeable would invite a click
+          // that goes nowhere.
+          const cellWriteIns = writeInEntries(entry.unit).map((writeIn) =>
+            writeInOccupantLabel(writeIn.occupant)
+          )
           const who = first
             ? entry.parties.map((party) => partyIdentityLabel(party)).join(', ')
-            : 'empty'
+            : cellWriteIns.length > 0
+              ? cellWriteIns.join(', ')
+              : 'empty'
           // Prefixed by the visible label so an accessible name built from it
           // still contains the label (WCAG 2.5.3). It used to be duplicated
           // into `title` as well, because a native tooltip is invisible to
@@ -788,7 +808,7 @@ function FootprintGrid({
           // border alone would be colour as the sole signal.
           const base = first
             ? `${label} — ${entry.unit.name}, ${who}`
-            : `${entry.unit.name} — empty`
+            : `${entry.unit.name} — ${who}`
           // The grid has no room for badges, so status rides in the tooltip.
           // A held or deactivated room that said nothing here would be
           // indistinguishable from a bookable one.

--- a/frontend/src/components/weekend/WriteInCard.tsx
+++ b/frontend/src/components/weekend/WriteInCard.tsx
@@ -79,7 +79,7 @@
  *     that person, and each card's X — all of them pointed at the one
  *     building row — empties all the others too, with nothing on screen
  *     saying why.
- *   - Two rows whose occupants are named alike, or both unnamed (`UNNAMED`
+ *   - Two rows whose occupants are named alike, or both unnamed (`UNNAMED_OCCUPANT`
  *     below is a state a legacy row can be in), otherwise render as two
  *     identical cards. That is the same objection kindred#2431 above makes
  *     to truncating a name, one card over.
@@ -105,14 +105,13 @@
 import { Pencil } from 'lucide-react'
 import { useState } from 'react'
 
-import type { WriteInOccupant } from './writeIn'
+import { UNNAMED_OCCUPANT, type WriteInOccupant } from './writeIn'
 
 /** `FamilyCard`'s `CARD_FRAME`, verbatim. Pinned by this module's test. */
 export const WRITE_IN_FRAME =
   'group border-border flex w-full flex-col gap-1 rounded-xl border-2 p-2.5 text-left'
 
 /** What a card prints when the row named nobody. Also the removal's handle. */
-const UNNAMED = 'Occupant not named'
 
 export interface WriteInCardProps {
   occupant: WriteInOccupant
@@ -149,7 +148,7 @@ export interface WriteInCardProps {
 
 export function WriteInCard({ occupant, onRemove, onEdit, isSaving = false }: WriteInCardProps) {
   const named = occupant.name !== ''
-  const label = named ? occupant.name : UNNAMED
+  const label = named ? occupant.name : UNNAMED_OCCUPANT
 
   // Local to this card, never lifted: the well can hold several of these and
   // each edits independently. Re-seeded from `occupant` every time the form

--- a/frontend/src/components/weekend/WriteInCard.tsx
+++ b/frontend/src/components/weekend/WriteInCard.tsx
@@ -105,13 +105,11 @@
 import { Pencil } from 'lucide-react'
 import { useState } from 'react'
 
-import { UNNAMED_OCCUPANT, type WriteInOccupant } from './writeIn'
+import { writeInOccupantLabel, type WriteInOccupant } from './writeIn'
 
 /** `FamilyCard`'s `CARD_FRAME`, verbatim. Pinned by this module's test. */
 export const WRITE_IN_FRAME =
   'group border-border flex w-full flex-col gap-1 rounded-xl border-2 p-2.5 text-left'
-
-/** What a card prints when the row named nobody. Also the removal's handle. */
 
 export interface WriteInCardProps {
   occupant: WriteInOccupant
@@ -148,7 +146,7 @@ export interface WriteInCardProps {
 
 export function WriteInCard({ occupant, onRemove, onEdit, isSaving = false }: WriteInCardProps) {
   const named = occupant.name !== ''
-  const label = named ? occupant.name : UNNAMED_OCCUPANT
+  const label = writeInOccupantLabel(occupant)
 
   // Local to this card, never lifted: the well can hold several of these and
   // each edits independently. Re-seeded from `occupant` every time the form

--- a/frontend/src/components/weekend/unitBadges.ts
+++ b/frontend/src/components/weekend/unitBadges.ts
@@ -57,15 +57,22 @@ export interface UnitBadge {
 /**
  * Whether `reservationBadge` badges this unit "Write-in".
  *
- * ⚠️ NO LONGER EXPORTED, and that is a consequence of kindred#2072 rather
- * than a tidy-up. It was exported so `LodgingUnitCard` could suppress the chip
- * WITHOUT re-deriving this gate and drifting from it (kindred#2252): the
- * occupant already gets a `WriteInCard` in the well, so the chip beside it
- * repeated the same fact under a second name. That card now draws NO
- * reservation badge at all, so there is nothing left to suppress.
+ * ⚠️ EXPORTED AGAIN as of kindred#2499, for the reason it was exported the
+ * first time: a surface that suppresses the chip must not re-derive this gate
+ * and drift from it (kindred#2252).
  *
- * The two surfaces that still draw the chip — `MapUnitPopover`'s header and
- * its collapsed grid cell — call `reservationBadge` directly and always did.
+ * NO SURFACE DRAWS "Write-in" ANY MORE. `LodgingUnitCard` stopped because the
+ * `WriteInCard` in its well already names the occupant, so the chip repeated
+ * the same fact under a second name. `MapUnitPopover`'s header and its
+ * collapsed grid cell stopped by owner ruling on kindred#2499: staff bunk on
+ * the BOARD and the map is for visibility and checks, so write-in occupancy is
+ * board business and the map does not carry it.
+ *
+ * ⚠️ The arm therefore survives in `reservationBadge` unreachable-by-caller,
+ * and that is deliberate rather than dead code left lying. Deleting it is NOT
+ * equivalent: a write-in family room falls through to `null`, but a write-in
+ * COMBINED CONTAINER would fall through to `Building` — so removing the arm
+ * would silently re-badge those, on the board as well as the map.
  *
  * Both halves of the gate matter and are pinned in `unitBadges.test.ts`: the
  * `staff_default` exemption (a staff cabin written into for the weekend badges
@@ -73,7 +80,7 @@ export interface UnitBadge {
  * `family_available_override`, which since kindred#2382 answers the staff↔family
  * ROLE and names nobody).
  */
-function writeInBadgeApplies(unit: LodgingUnitRow): boolean {
+export function writeInBadgeApplies(unit: LodgingUnitRow): boolean {
   return unit.inventory_class !== 'staff_default' && hasWriteIn(unit)
 }
 

--- a/frontend/src/components/weekend/writeIn.ts
+++ b/frontend/src/components/weekend/writeIn.ts
@@ -142,6 +142,24 @@ export interface WriteInSource {
 }
 
 /**
+ * What to print for a write-in whose `occupant_name` is blank.
+ *
+ * SHARED, because two surfaces now draw the same occupant and a room that
+ * reads "Occupant not named" on the board and blank on the map is two
+ * different answers to one question. `WriteInCard` held this privately until
+ * kindred#2499 gave the map an occupant list of its own.
+ *
+ * Not the empty string and not "Unknown": the row asserts that somebody is in
+ * the room, and only their NAME is missing.
+ */
+export const UNNAMED_OCCUPANT = 'Occupant not named'
+
+/** The name to print for a write-in occupant, blank-safe. */
+export function writeInOccupantLabel(occupant: WriteInOccupant): string {
+  return occupant.name !== '' ? occupant.name : UNNAMED_OCCUPANT
+}
+
+/**
  * Every write-in closing this space for this weekend, in the server's order.
  *
  * "This space", not "this unit": a building's write-in closes its rooms and a
@@ -160,24 +178,6 @@ export interface WriteInSource {
  * ORDERED BY THE SERVER (`code` at every level), never re-sorted here: two
  * places deciding the sequence is two places that can disagree about it.
  */
-/**
- * What to print for a write-in whose `occupant_name` is blank.
- *
- * SHARED, because two surfaces now draw the same occupant and a room that
- * reads "Occupant not named" on the board and blank on the map is two
- * different answers to one question. `WriteInCard` held this privately until
- * kindred#2499 gave the map an occupant list of its own.
- *
- * Not the empty string and not "Unknown": the row asserts that somebody is in
- * the room, and only their NAME is missing.
- */
-export const UNNAMED_OCCUPANT = 'Occupant not named'
-
-/** The name to print for a write-in occupant, blank-safe. */
-export function writeInOccupantLabel(occupant: WriteInOccupant): string {
-  return occupant.name !== '' ? occupant.name : UNNAMED_OCCUPANT
-}
-
 export function writeInEntries(unit: LodgingUnitRow): WriteInEntry[] {
   return coveringWriteIns(unit).map((cover) => {
     const unitCode = cover.unit_code ?? ''

--- a/frontend/src/components/weekend/writeIn.ts
+++ b/frontend/src/components/weekend/writeIn.ts
@@ -160,6 +160,24 @@ export interface WriteInSource {
  * ORDERED BY THE SERVER (`code` at every level), never re-sorted here: two
  * places deciding the sequence is two places that can disagree about it.
  */
+/**
+ * What to print for a write-in whose `occupant_name` is blank.
+ *
+ * SHARED, because two surfaces now draw the same occupant and a room that
+ * reads "Occupant not named" on the board and blank on the map is two
+ * different answers to one question. `WriteInCard` held this privately until
+ * kindred#2499 gave the map an occupant list of its own.
+ *
+ * Not the empty string and not "Unknown": the row asserts that somebody is in
+ * the room, and only their NAME is missing.
+ */
+export const UNNAMED_OCCUPANT = 'Occupant not named'
+
+/** The name to print for a write-in occupant, blank-safe. */
+export function writeInOccupantLabel(occupant: WriteInOccupant): string {
+  return occupant.name !== '' ? occupant.name : UNNAMED_OCCUPANT
+}
+
 export function writeInEntries(unit: LodgingUnitRow): WriteInEntry[] {
   return coveringWriteIns(unit).map((cover) => {
     const unitCode = cover.unit_code ?? ''


### PR DESCRIPTION
## #2499 posed a false choice, and the answer is neither option

The issue asked whether to **keep** or **drop** the map's `Write-in` chip. Both are wrong, because
the map was not showing the occupant *at all*:

- `MapUnitPopover`'s **"Occupied by"** row rendered `empty` for a room somebody sleeps in.
- The cluster summary's **`taken`** count keys on `entry.parties.length` — and a write-in occupant
  is by definition **not a rostered party** — so a full room was reported as **open**.

That is exactly the defect **#2078** already ruled on for the board:

> *"The room read as **empty and closed** when in truth it was **full**. This is the same fact,
> printed where the board prints occupancy."*

The board fixed it by printing the occupant in its well. The map never did, because it never called
the resolver the board uses. Dropping the chip on its own would have made this **worse** — it was
the last hint that anyone was in the room.

## What changed

A write-in and a family are both *some amount of people in a space*, so the map lists both.

- **`writeInEntries` — the board's own resolver — is now called by the map.** It is tree-aware (a
  building's row closes its rooms and a room's closes its building) and server-ordered, so both
  surfaces answer "who is in this room" from one place.
- **`UNNAMED_OCCUPANT` moved from `WriteInCard` into `writeIn.ts`**, so a nameless occupant cannot
  read `Occupant not named` on one surface and blank on the other.
- **The cluster count now treats a written-into room as taken.** ⚠️ **This moves a staff-facing
  number:** a building with one write-in and one empty room went from `2 · 0 taken, 2 open` to
  `2 · 1 taken, 1 open`. It is a **room** count, so an occupant with no known party size still
  answers it and no figure is invented — and it is a correction *against #2078's existing ruling*,
  not a new definition.
- **The chip goes** — but for `LodgingUnitCard`'s reason (**#2252**), not a new one: once the
  occupant is named, the chip repeats the same fact under a second name.

## DRY'd: the rule and the data. NOT the pixels.

The board draws `WriteInCard`/`FamilyCard` in a well; the map draws a compact `<dl>` and a chip
list. Those grammars differ deliberately, and forcing the board's cards into a peek would break the
thing the peek is for. What is shared is the resolver, the wording, and the semantics.

**Write-ins render INERT on both surfaces**, carrying `WriteInCard`'s ruling across: no button, no
drag — *"a card that looks interactive and is not is worse than plain text."* A family opens its
panel; there is no panel behind a write-in.

## What is NOT changed

- Only the `Write-in` **arm** is gated on the map. `Building`, `Staff`, `Released` still draw.
- The `Write-in` arm **stays in `reservationBadge`, unreachable by any caller, deliberately.**
  Deleting it is *not* equivalent: a write-in family room falls through to `null`, but a write-in
  **combined container** falls through to `Building` — removal would silently re-badge those on the
  board too. The docstring records this.
- **No occupant *count* is invented.** `lodging_write_ins` carries a name and no count; `bedsNeeded`
  and `placed` are untouched, matching the board's em-dash occupancy figure.
- **The board is untouched** apart from `WriteInCard` importing the shared constant.
- **No assign/write-in actions were removed, because the map has none** — the only `Assign` match in
  `MapUnitPopover.tsx` is a code comment.

## Tests

Three existing tests asserted the map *badges* a written-into room; rewritten with the ruling as
rationale, since the spec changed rather than the code. Five new tests cover the occupant list, the
unnamed fallback, the inertness, and the count. Mutation-checked: dropping the occupant list turns
4 red, reverting the count turns 1 red. Full weekend suite green (1525 tests, 42 files).

*Branch name predates the rethink — it says `map-drop-writein-badge`, which is now half the change.*

Closes #2499.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Write-in occupants now appear in map room and cluster occupancy displays.
  * Write-ins contribute to occupied-room counts and remain non-clickable.
  * Blank write-in names now display as “Occupant not named.”
  * Reservation indicators remain available while write-in badges are suppressed.
* **Bug Fixes**
  * Prevented duplicate write-in occupants in clustered map views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->