### PR TITLE
feat(frontend): the board answers "does this family go here?" in three states

### DIFF
--- a/docs/reference/lodging-board-vs-summer.md
+++ b/docs/reference/lodging-board-vs-summer.md
@@ -64,7 +64,7 @@ empty string and proves nothing — pin **classes** in vitest and measure
 | ---------- | ------------------------ | ---------------------------- | ------------------ |
 | Base class | `.card-lodge`            | `.card-lodge`                | done               |
 | Radius     | `rounded-2xl` (16px)     | same                         | done               |
-| Border     | `border-2 border-border` | same, + `border-t-[3px]` hue | done               |
+| Border     | `border-2 border-border` | same (no per-unit hue — §6)  | done               |
 | Shadow     | two-layer lodge          | same                         | done               |
 | Padding    | `p-4` (16px)             | `p-2.5 px-3`                 | **divergent — §6** |
 | Row rhythm | `mb-3` (12px)            | `gap-2` (8px)                | **divergent — §6** |
@@ -170,8 +170,9 @@ the figure and **one** emphasis state, for the only actionable case; two cards
 qualify on 2026 data.
 
 Consequently the over-capacity emphasis is `text-destructive` on the figure and
-nothing else, **not** summer's border treatment. See §6 on why the border is
-full. (This paragraph used to end "plus a chip". kindred#2072 stage 3 struck the
+nothing else, **not** summer's border treatment. See §6 — the border is no
+longer full (kindred#2528 struck the hue top edge), but only the arithmetic
+argument here ever depended on the figure, and that stands. (This paragraph used to end "plus a chip". kindred#2072 stage 3 struck the
 `Over capacity` pill — it stated at chip weight exactly what the figure states
 in colour, on the two cards a weekend that qualify. `LodgingUnitCard.test.tsx`
 pins its absence.)

--- a/docs/reference/lodging-board-vs-summer.md
+++ b/docs/reference/lodging-board-vs-summer.md
@@ -163,8 +163,9 @@ different decision entirely (kindred#2072, B·1 and B·2).
 ramp is a percentage of a fixed capacity of 12 and has five distinguishable
 states. Family rooms average about five beds and plenty sleep two, where the same
 ramp is a binary wearing four colours — green on the first occupant, orange on
-the second. The card's border already carries the area hue (§3.10) and the amber
-consent edge, so a third channel would compete for one surface. What is kept is
+the second. (The border argument in the original ruling has partly lapsed — the
+area hue left the card in kindred#2528 — but the arithmetic one above has not,
+and it is what decided this.) What is kept is
 the figure and **one** emphasis state, for the only actionable case; two cards
 qualify on 2026 data.
 
@@ -388,19 +389,29 @@ tall because it holds 10–14 campers; a lodging unit holds nothing, one party, 
 occasionally two. `boardLayout.ts`'s header explains this. Do not make family
 cards summer-height.
 
-**The area hue stripe** (`border-t-[3px]` plus the section dot) is §3.10 and must
-survive any chrome change. It is an inline `borderTopColor`, so it outranks
-`.card-lodge`'s `border-border` and its `border-primary/50` hover. There is a
-test pinning it.
+**The area hue stripe came OFF the card on 2026-08-21** (kindred#2528). This
+paragraph used to say the opposite — that the stripe must survive any chrome
+change, and that a test pinned it. Both were true until the owner ruled;
+the test now asserts the card carries no inline style at all.
 
-Note the coupling: `boardLayout.ts` justifies the eight-hue ramp as decorative
-_because_ "the section headers do the actual grouping". **Sections and hue stand
-or fall together.** Removing the sections obliges you to delete the hue or
-re-justify it against §3.10.
+The reasoning is the coupling this paragraph already named. `boardLayout.ts`
+justifies the eight-hue ramp as decorative _because_ "the section headers do the
+actual grouping" — so the hue was never load-bearing on the card, and it was
+carried FOUR times over (the `<section>`, the heading, the header dot, and 73
+card top-edges). Only the card edge was on every card, always on. **The section
+dot is now its only carrier on the board**, at 8 instances instead of 73.
 
-**The card border is full.** Area hue on top, amber for consent all round. That
-is why over-capacity took a text colour rather than summer's
-`border-destructive/50`, and why any future state needs somewhere else to live.
+Sections and hue still stand or fall together: removing the sections obliges you
+to restore a per-unit carrier or re-justify the ramp against §3.10. The MAP
+keeps its per-unit hue, because it has no section headers.
+
+**The card border is no longer full.** It carried the area hue on top and amber
+for consent all round, which is why over-capacity took a text colour rather than
+summer's `border-destructive/50`. The area hue is gone (kindred#2528), so the top
+edge is free — but the text colour stays, and is now doing MORE work: the
+drag-time "no room for this family" mark reuses it deliberately, because it is
+the same statement as over-capacity rather than a second vocabulary for it.
+A future state may take the freed edge; do not assume the border is still full.
 The `Over capacity` chip that used to accompany that text colour is struck
 (kindred#2072): it stated at chip weight exactly what the red figure states in
 colour.

--- a/docs/reference/weekend-card-vocabulary.md
+++ b/docs/reference/weekend-card-vocabulary.md
@@ -172,7 +172,7 @@ resolved by an implementer without guessing.
 | Question                                                                                                                          | Ruling                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **An unresolvable coverage graded `fits`.** A cabin nobody has measured drew the glyph in full hue, which asserts the need is met | Owner, verbatim: _"unknown values should not equal fits, across all surfaces on the glyphs, its unconfirmed information."_ `needVerdict` reports `unmet`. The losing argument — the absence of evidence is not evidence of absence — is true and insufficient: `fits` is a claim too, and two glyph states are ruled, so there was never a neutral option. Measured: **3 glyphs move** across 2026's twelve weekends; **no roster section count moves** |
-| **The drag-time hatch reads the same rule and must not**                                                                          | Excluded, with the number. 102 of 118 cabins carry `ramp_coverage: unknown`, so reading it as unmet takes a step-free household's hatched cabins from **32 of 944 pairs to 848** — 3.4% to 90%, a hatch that has stopped discriminating. `needsFit` passes `needGlyphs.UnknownReading` explicitly; the coverage derivation is still single-sourced                                                                                                      |
+| **The drag-time hatch reads the same rule and must not**                                                                          | Excluded, with the number. 102 of 118 cabins carry `ramp_coverage: unknown`, so reading it as unmet takes a step-free household's hatched cabins from **32 of 944 pairs to 848** — 3.4% to 90%, a hatch that has stopped discriminating. ⚠️ superseded 2026-08-21 (kindred#2528): `resolveDragFit` intercepts `unknown` BEFORE `needVerdict` and passes no `unknownIs` at all, because unrecorded coverage must make NEITHER claim — no hatch (the bar is evidence of absence) and no match (a positive mark must not read unconfirmed as met). The 848/90% figure is why it still does not hatch. The coverage derivation is still single-sourced                                                                                                      |
 | **Returning wore `forest-700`, the same ink as the card's own text**                                                              | `green-700` / `green-300`. R3 takes the words away, so colour is the only thing separating Returning from First-time — and forest-700 measures **1.08 : 1** against `--foreground` where green-700 is 2.87 : 1. One semantic green on the board; `forest` stays the lodge's chrome                                                                                                                                                                      |
 
 ## 6. Policies with no line of code to sit on
@@ -276,11 +276,27 @@ The roster therefore called twelve entirely-powered buildings unpowered while
 the board's own hatch called them fine. All three call the resolver now.
 
 WHICH needs a surface reports is still per-surface, and each scope is written
-down where it lives rather than implied: the drag hatch grades three, the roster
-grades two (adding fridge and step-free moves parties between staff-facing
-section counts and needs its own ruling), and the card draws all four.
+down where it lives rather than implied: **the drag-time mark grades all four**
+(kindred#2528 — it graded three until 2026-08-21), the roster grades two (adding
+fridge and step-free moves parties between staff-facing section counts and needs
+its own ruling), and the card draws all four.
 
-**Bathroom is the one excluded from the hatch on arithmetic, and the arithmetic
+⚠️ **THE EXCLUSION BELOW WAS REVERSED ON 2026-08-21 (kindred#2528). Bathroom is
+graded.** The arithmetic in this section is still correct and is kept because it
+is the reasoning the reversal had to answer — do not re-narrow `resolveDragFit`
+from it. What changed is not the numbers but what the mark IS:
+
+- The 82-of-118 argument is about a mark that could only ever be NEGATIVE, where
+  firing on nine cabins in ten says nothing. Half the mark is now positive, and a
+  positive mark that skipped bathroom would call a cabin a MATCH for a household
+  whose bathroom need it never checked. That is a worse failure than a wash.
+- The mark now aligns with the glyphs, which have always drawn all four.
+- Bathroom moved to the PROSPECTIVE axis at the same time. On the `placed`
+  reading it took `party.effective_bathroom` and ignored the target unit, so it
+  was a board-wide constant — every card or none — which cannot mean anything
+  per card. The 82 figure is the prospective one and survives the move.
+
+**Bathroom was the one excluded from the hatch on arithmetic, and the arithmetic
 moved twice on 2026-08-20** — re-derived against the production snapshot by
 running the shipped functions over all 118 units, not carried forward:
 
@@ -292,5 +308,6 @@ running the shipped functions over all 118 units, not carried forward:
 
 #2502's `_resolve_bathroom` moves 8 of the 15 containers from `none` to a
 bathroom their rooms actually have, which is why the presence figure improved
-again after #2501 landed. 82 of 118 is still a wash, so the exclusion stands —
-but quote 82, not 90.
+again after #2501 landed. 82 of 118 is a wash on a purely negative mark, which
+is why the exclusion stood at the time — if you quote the figure, quote 82, not
+90. It no longer decides the scope; see the note above.

--- a/frontend/src/components/weekend/AssignFamilyModal.test.tsx
+++ b/frontend/src/components/weekend/AssignFamilyModal.test.tsx
@@ -120,6 +120,33 @@ describe('AssignFamilyModal — the header states beds FREE (owner ruling 2026-0
     expect(screen.getByTestId('assign-capacity')).toHaveTextContent('2 of 4 beds free')
   })
 
+  it('states no free-bed count for a room somebody is written into', () => {
+    // The rows below this header refuse a capacity claim on a written-into
+    // room (a write-in is not a party, so every occupancy figure reads it as
+    // empty — `capacityVerdict`). A header asserting "N of M beds free" over
+    // rows that decline the same arithmetic is the modal disagreeing with
+    // itself about the same cabin.
+    renderModal({
+      unit: unit({
+        sleeps: 4,
+        write_ins: [
+          {
+            unit_id: 'u1',
+            unit_code: 'ridge-1',
+            unit_name: 'Ridge 1',
+            occupant_name: 'Emma Johnson',
+            note: '',
+          },
+        ],
+      }),
+      occupants: 0,
+    })
+    expect(screen.getByTestId('assign-capacity')).toHaveTextContent(
+      'Sleeps 4 · occupancy not counted (write-in)'
+    )
+    expect(screen.getByTestId('assign-capacity')).not.toHaveTextContent('beds free')
+  })
+
   it('says nothing it cannot support when nobody has measured the room', () => {
     renderModal({ unit: unit({ sleeps: null }), occupants: 0 })
     expect(screen.getByTestId('assign-capacity')).toHaveTextContent('Capacity not recorded')

--- a/frontend/src/components/weekend/AssignFamilyModal.tsx
+++ b/frontend/src/components/weekend/AssignFamilyModal.tsx
@@ -71,6 +71,7 @@ import { resolveNeedGlyphs } from './needGlyphs'
 import { partyKey } from './partyKey'
 import { placementCandidates, type PlacementCandidate } from './placementCandidates'
 import { effectiveSleeps, partyBeds } from './rosterAttention'
+import { hasWriteIn } from './writeIn'
 
 export interface AssignFamilyModalProps {
   isOpen: boolean
@@ -255,6 +256,13 @@ function capacitySentence(
 ): string {
   const capacity = effectiveSleeps(unit, units)
   if (capacity === null) return 'Capacity not recorded'
+  // A written-into room has an occupant no `occupants` figure counts (a
+  // write-in is not a party — kindred#2439), so a free-bed number here would
+  // be one the card itself refuses to print (it shows an em dash) and one the
+  // candidate rows below DECLINE to grade against (`capacityVerdict`'s own
+  // write-in gate). The header states what it knows — the capacity — and
+  // stops there, or the modal disagrees with itself about the same cabin.
+  if (hasWriteIn(unit)) return `Sleeps ${String(capacity)} · occupancy not counted (write-in)`
   // The card's own gate, mirrored — see `spanWidth`'s doc. A spanning
   // placement keeps its figure and loses the claim.
   if (occupants > capacity && spanWidth === 0) {

--- a/frontend/src/components/weekend/FamilyCard.test.tsx
+++ b/frontend/src/components/weekend/FamilyCard.test.tsx
@@ -37,6 +37,24 @@ import { FamilyCard, FamilyCardPreview } from './FamilyCard'
 // `role`/`tabIndex` are hard-coded, not context-derived), so this exists only
 // to render the same tree the real board renders, not to make the
 // assertions below possible.
+/**
+ * Counts BODY renders: `resolveNeedGlyphs` runs once per `FamilyCardChips`
+ * render, and the chips render exactly when the memo'd body does — so its
+ * call count is the body's render count, visible without exporting the inner
+ * component. See the matching harness in `LodgingUnitCard.test.tsx`.
+ */
+const bodyRenders = vi.hoisted(() => ({ count: 0 }))
+vi.mock('./needGlyphs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./needGlyphs')>()
+  return {
+    ...actual,
+    resolveNeedGlyphs: (...args: Parameters<typeof actual.resolveNeedGlyphs>) => {
+      bodyRenders.count += 1
+      return actual.resolveNeedGlyphs(...args)
+    },
+  }
+})
+
 vi.mock('@dnd-kit/core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@dnd-kit/core')>()
   return {
@@ -1813,5 +1831,30 @@ describe('FamilyCard — the mandatory-accommodation chip is renamed', () => {
     )
     expect(screen.getByText('Needs Accommodation')).toBeInTheDocument()
     expect(screen.queryByText('Accommodation required')).not.toBeInTheDocument()
+  })
+})
+
+describe('FamilyCard — the shell/body split actually bails (perf)', () => {
+  /*
+   * 133 placed family cards re-rendered 1,636 times in one measured drag
+   * sweep before the split; the memo is what stops that, and it only holds
+   * while every prop keeps its identity. The control case proves the counter
+   * can see a real re-render, so a pass is not vacuous.
+   */
+  it('a re-render with identical props does not re-run the body', () => {
+    const theParty = party()
+    const onOpen = vi.fn()
+    const view = render(<FamilyCard party={theParty} onOpen={onOpen} />)
+    const before = bodyRenders.count
+    view.rerender(<FamilyCard party={theParty} onOpen={onOpen} />)
+    expect(bodyRenders.count).toBe(before)
+  })
+
+  it('control: a changed prop identity DOES re-run the body', () => {
+    const theParty = party()
+    const view = render(<FamilyCard party={theParty} onOpen={vi.fn()} />)
+    const before = bodyRenders.count
+    view.rerender(<FamilyCard party={theParty} onOpen={vi.fn()} />)
+    expect(bodyRenders.count).toBeGreaterThan(before)
   })
 })

--- a/frontend/src/components/weekend/FamilyCard.tsx
+++ b/frontend/src/components/weekend/FamilyCard.tsx
@@ -80,7 +80,11 @@
  * parties: a person-grain party (an adult weekend guest) IS the identity, so
  * its `display_name` stays.
  */
-import { useDraggable } from '@dnd-kit/core'
+import {
+  useDraggable,
+  type DraggableAttributes,
+  type DraggableSyntheticListeners,
+} from '@dnd-kit/core'
 import { Repeat, Star, User, Users } from 'lucide-react'
 import { Fragment, memo } from 'react'
 
@@ -676,9 +680,16 @@ function FamilyCardChips({
 const CARD_FRAME =
   'group border-border flex w-full flex-col gap-1 rounded-xl border-2 p-2.5 text-left'
 
+/**
+ * The dnd-kit hook results the shell hands the memo'd body — dnd-kit's OWN
+ * types, not `Record<string, unknown>`: erased, `attributes` and `listeners`
+ * collapse into one structural type, and swapping them at the call site —
+ * exactly the mistake the conditional spread below exists to prevent — would
+ * type-check.
+ */
 interface FamilyDnd {
-  attributes: Record<string, unknown>
-  listeners: Record<string, unknown> | undefined
+  attributes: DraggableAttributes
+  listeners: DraggableSyntheticListeners
   setNodeRef: (n: HTMLElement | null) => void
   isDragging: boolean
 }
@@ -771,8 +782,8 @@ export function FamilyCard(props: FamilyCardProps) {
   return (
     <FamilyCardInner
       {...props}
-      attributes={attributes as unknown as Record<string, unknown>}
-      listeners={listeners as unknown as Record<string, unknown> | undefined}
+      attributes={attributes}
+      listeners={listeners}
       setNodeRef={setNodeRef}
       isDragging={isDragging}
     />

--- a/frontend/src/components/weekend/FamilyCard.tsx
+++ b/frontend/src/components/weekend/FamilyCard.tsx
@@ -82,7 +82,7 @@
  */
 import { useDraggable } from '@dnd-kit/core'
 import { Repeat, Star, User, Users } from 'lucide-react'
-import { Fragment } from 'react'
+import { Fragment, memo } from 'react'
 
 import type { LodgingUnitRow, PartyChildRow, RosterPartyRow } from '../../types/lodging'
 import { displayCampMinderAge, displayTruncatedAge } from '../../utils/age'
@@ -676,25 +676,25 @@ function FamilyCardChips({
 const CARD_FRAME =
   'group border-border flex w-full flex-col gap-1 rounded-xl border-2 p-2.5 text-left'
 
-export function FamilyCard({
+interface FamilyDnd {
+  attributes: Record<string, unknown>
+  listeners: Record<string, unknown> | undefined
+  setNodeRef: (n: HTMLElement | null) => void
+  isDragging: boolean
+}
+
+const FamilyCardInner = memo(function FamilyCardInner({
   party,
   unit,
   sharedSlot = false,
   inQueue = false,
   isDraggable = false,
   onOpen,
-}: FamilyCardProps) {
-  // `disabled` does NOT prevent registration — dnd-kit registers the node in
-  // `draggableNodes` unconditionally and `disabled` only nulls the listeners
-  // (verified in @dnd-kit/core 6.3.1). What gates the interaction is the
-  // conditional spread below, which four tests pin. `disabled` is kept for
-  // the `aria-disabled` it sets and as a second refusal to hand back
-  // listeners.
-  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
-    id: partyKey(party),
-    disabled: !isDraggable,
-  })
-
+  attributes,
+  listeners,
+  setNodeRef,
+  isDragging,
+}: FamilyCardProps & FamilyDnd) {
   return (
     // NOT a `<button>` (kindred#2222) — a `<div>` frame, so the chip row
     // below can host a real interactive trigger (kindred#2250) as a SIBLING
@@ -744,6 +744,38 @@ export function FamilyCard({
       </button>
       <FamilyCardChips party={party} unit={unit} sharedSlot={sharedSlot} />
     </div>
+  )
+})
+
+/**
+ * PERF: the dnd-kit subscription, and nothing else.
+ *
+ * `useDraggable` subscribes to dnd-kit's InternalContext, whose identity
+ * changes on every `over` transition — so with the hook inside the card body
+ * every family card on the board re-rendered each time the pointer crossed a
+ * cabin boundary. Measured on a 73-card board holding 133 placed families:
+ * 1,636 body renders across one sweep. Here the hook lives in a shell whose
+ * only job is to read it, and the body is `memo`'d.
+ */
+export function FamilyCard(props: FamilyCardProps) {
+  // `disabled` does NOT prevent registration — dnd-kit registers the node in
+  // `draggableNodes` unconditionally and `disabled` only nulls the listeners
+  // (verified in @dnd-kit/core 6.3.1). What gates the interaction is the
+  // conditional spread in the body, which four tests pin. `disabled` is kept
+  // for the `aria-disabled` it sets and as a second refusal to hand back
+  // listeners.
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: partyKey(props.party),
+    disabled: props.isDraggable !== true,
+  })
+  return (
+    <FamilyCardInner
+      {...props}
+      attributes={attributes as unknown as Record<string, unknown>}
+      listeners={listeners as unknown as Record<string, unknown> | undefined}
+      setNodeRef={setNodeRef}
+      isDragging={isDragging}
+    />
   )
 }
 

--- a/frontend/src/components/weekend/LodgingBoard.drag.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.drag.test.tsx
@@ -64,8 +64,24 @@ vi.mock('../../hooks/useUnitMerge', () => ({
 
 /** The last `onDragEnd` the board handed to DndContext. */
 let onDragEnd: ((event: unknown) => void) | undefined
+/** Its `onDragCancel` sibling — Escape, resize, tab-hide mid-drag. */
+let onDragCancel: (() => void) | undefined
 /** Its `onDragStart` sibling — the half the needs-misfit hatch (#1912) rides on. */
 let onDragStart: ((event: unknown) => void) | undefined
+
+// The collision policy is STATEFUL (it holds the last cabin the pointer was
+// inside), so the board must clear it at every gesture boundary — one gesture
+// inheriting the previous gesture's hold is a wrong drop target waiting for a
+// gutter release. jsdom can't drive the real detector (no rects), so the
+// wiring is pinned by spying on `reset` instead.
+const collisionReset = vi.fn()
+vi.mock('./boardCollision', () => ({
+  createBoardCollisionDetection: () => {
+    const detect = () => []
+    detect.reset = collisionReset
+    return detect
+  },
+}))
 
 vi.mock('@dnd-kit/core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@dnd-kit/core')>()
@@ -75,13 +91,16 @@ vi.mock('@dnd-kit/core', async (importOriginal) => {
       children,
       onDragEnd: handler,
       onDragStart: startHandler,
+      onDragCancel: cancelHandler,
     }: {
       children: ReactNode
       onDragEnd: (e: unknown) => void
       onDragStart: (e: unknown) => void
+      onDragCancel: () => void
     }) => {
       onDragEnd = handler
       onDragStart = startHandler
+      onDragCancel = cancelHandler
       return <div data-testid="dnd-context">{children}</div>
     },
   }
@@ -93,6 +112,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   onDragEnd = undefined
   onDragStart = undefined
+  onDragCancel = undefined
   placementOptions = []
   client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 })
@@ -411,5 +431,39 @@ describe('LodgingBoard — placing a family from the space itself (kindred#2080)
       unitCode: 'cedar-2',
       unitName: 'Cedar 2',
     })
+  })
+})
+
+describe('LodgingBoard — the collision hold is cleared at every gesture boundary', () => {
+  /*
+   * The detector holds the last cabin the pointer was inside
+   * (`boardCollision.ts`), and the board owns clearing it — a hold that
+   * survives into the NEXT gesture would make the drop ring open on a cabin
+   * from the previous drag. Three boundaries, because dnd-kit fires
+   * `onDragCancel` INSTEAD of `onDragEnd` on Escape, a resize, or a tab hide.
+   */
+  it('resets on drag start, so no gesture inherits the previous hold', () => {
+    renderBoard()
+    collisionReset.mockClear()
+    startDrag('household-101')
+    expect(collisionReset).toHaveBeenCalled()
+  })
+
+  it('resets on drag end', () => {
+    renderBoard()
+    collisionReset.mockClear()
+    drop('household-101', null)
+    expect(collisionReset).toHaveBeenCalled()
+  })
+
+  it('resets on drag cancel — the boundary that never reaches onDragEnd', () => {
+    renderBoard()
+    if (!onDragCancel) throw new Error('the board never registered a drag-cancel handler')
+    collisionReset.mockClear()
+    const cancel = onDragCancel
+    act(() => {
+      cancel()
+    })
+    expect(collisionReset).toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -232,11 +232,11 @@ export function LodgingBoard({
     scenario,
   })
 
-  // Memoised because `mergeUnit` closes over it: rebuilt each render, it would
-  // give that callback a new identity every time and defeat the point of the
-  // `useCallback`. Cheap either way at ~120 units, but the lint rule is right.
   // The shared WeakMap-cached index (`unitLevel`), not a local `useMemo` copy
-  // of the same map — one instance per `units` array, everywhere.
+  // of the same map — one instance per `units` array, everywhere. `mergeUnit`
+  // closes over it and lists it as a `useCallback` dep, and the cache is what
+  // keeps that identity stable across renders (at least as stable as the
+  // `useMemo` this replaced).
   const unitsByCode = indexUnitsByCode(units)
 
   const sensors = useSensors(

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -487,10 +487,15 @@ export function LodgingBoard({
                         ) : (
                           <ChevronDown className="text-muted-foreground h-3.5 w-3.5 flex-shrink-0" />
                         )}
-                        {/* Area colour is a SECONDARY channel (§3.10). This dot
-                          and the card's top edge carry it; the heading below
-                          does the actual grouping, so nothing depends on
-                          telling violet from rose. */}
+                        {/* Area colour is a SECONDARY channel (§3.10), and this dot
+                          is now its ONLY carrier on the board — the card's top
+                          edge lost it on 2026-08-21, taking 73 always-on marks
+                          down to 8. The heading below does the actual
+                          grouping, so nothing depends on telling violet from
+                          rose, which is exactly why the card could give it up.
+                          The map still draws the hue per unit: it has no
+                          section headers, so position is its only other
+                          grouping and the pills genuinely need a key. */}
                         <span
                           className="h-2 w-2 flex-shrink-0 rounded-full"
                           style={{ backgroundColor: area.hue }}
@@ -523,7 +528,6 @@ export function LodgingBoard({
                             // the same `overlappingPartyKeys` the slot flag
                             // already ran with these units in `buildBoard`.
                             units={units}
-                            hue={area.hue}
                             canPlace={canPlace}
                             canSetAvailability={canSetAvailability}
                             // THIS card's unit, or ANY of the ones holding a

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -39,7 +39,7 @@ import {
   type DragStartEvent,
 } from '@dnd-kit/core'
 import { ChevronDown, ChevronRight, Info, TriangleAlert } from 'lucide-react'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { useSearchParams } from 'react-router'
 
 import { useDismissOnDeadSpace } from '../../hooks/useDismissOnDeadSpace'
@@ -49,6 +49,7 @@ import { useUnitAvailability } from '../../hooks/useUnitAvailability'
 import { useUnitMerge } from '../../hooks/useUnitMerge'
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
 import { areaTokens, buildBoard } from './boardLayout'
+import { indexUnitsByCode } from './unitLevel'
 import { createBoardCollisionDetection } from './boardCollision'
 import {
   mergeDragUnit,
@@ -234,7 +235,9 @@ export function LodgingBoard({
   // Memoised because `mergeUnit` closes over it: rebuilt each render, it would
   // give that callback a new identity every time and defeat the point of the
   // `useCallback`. Cheap either way at ~120 units, but the lint rule is right.
-  const unitsByCode = useMemo(() => new Map(units.map((unit) => [unit.code, unit])), [units])
+  // The shared WeakMap-cached index (`unitLevel`), not a local `useMemo` copy
+  // of the same map — one instance per `units` array, everywhere.
+  const unitsByCode = indexUnitsByCode(units)
 
   const sensors = useSensors(
     // The same activation constraints summer uses. The distance threshold is
@@ -250,10 +253,16 @@ export function LodgingBoard({
   // chose. The policy itself, and why it HOLDS the last cabin across a gutter,
   // lives in `boardCollision.ts`.
   //
-  // Memoised because it is STATEFUL — the held cabin is the state — so a fresh
-  // one per render would forget the hold on every board render and put the
-  // flapping back.
-  const collisionDetection = useMemo(() => createBoardCollisionDetection(), [])
+  // A REF, not `useMemo`, because the detector is STATEFUL — the held cabin
+  // is the state. `useMemo` is documented as a cache React may discard, and a
+  // discard mid-gesture would silently lose the hold and put the flapping
+  // back with nothing to notice it. A ref is the primitive that actually
+  // promises one instance for the component's lifetime.
+  const collisionDetectionRef = useRef<ReturnType<typeof createBoardCollisionDetection> | null>(
+    null
+  )
+  collisionDetectionRef.current ??= createBoardCollisionDetection()
+  const collisionDetection = collisionDetectionRef.current
 
   const handleDragStart = (event: DragStartEvent) => {
     // One gesture must never inherit the previous gesture's held cabin.
@@ -319,7 +328,8 @@ export function LodgingBoard({
   // party droppable stays disabled board-wide (`LodgingUnitCard`'s
   // `mergeDragActive` gate) and every non-sibling card sits dimmed and
   // unclickable (`pointer-events-none`) until staff happen to start another
-  // drag. Same two resets as `handleDragEnd`'s first two lines — see
+  // drag. The same resets `handleDragEnd` opens with — the collision hold and
+  // both drag states — see
   // `useLockGroupDragDrop.tsx`'s `handleDragCancel` for the same shape on
   // summer's own drag gesture.
   const handleDragCancel = () => {

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -33,8 +33,6 @@ import {
   DragOverlay,
   MouseSensor,
   TouchSensor,
-  pointerWithin,
-  rectIntersection,
   useSensor,
   useSensors,
   type DragEndEvent,
@@ -51,6 +49,7 @@ import { useUnitAvailability } from '../../hooks/useUnitAvailability'
 import { useUnitMerge } from '../../hooks/useUnitMerge'
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
 import { areaTokens, buildBoard } from './boardLayout'
+import { createBoardCollisionDetection } from './boardCollision'
 import {
   mergeDragUnit,
   resolveDrop,
@@ -100,6 +99,35 @@ export interface LodgingBoardProps {
  * most of the point of moving this out of `useState`.
  */
 const CLOSED_PARAM = 'closed'
+
+/*
+ * MODULE SCOPE, and that placement is load-bearing rather than tidiness.
+ *
+ * `useSensor` memoises on `[sensor, options]` and `useSensors` on the sensor
+ * array (@dnd-kit/core 6.3.1). An options object written inline is a new
+ * identity on every board render, so the memo misses, `activators` is rebuilt,
+ * and `useSyntheticListeners` hands EVERY draggable on the board a fresh
+ * `listeners` object. That is a prop change on every family card and every
+ * card's merge handle, which defeats their `memo` wholesale — measured at
+ * pick-up: 133 of 133 family-card bodies re-rendered for no reason.
+ */
+const MOUSE_ACTIVATION = { activationConstraint: { distance: 10 } }
+
+/*
+ * dnd-kit's auto-scroller defaults to a scrollBy every 5ms — 200 scroll
+ * events/second, each one re-entering DndContext's scroll listeners while the
+ * browser is also painting a ~5,500px board (the real 2026 boards are five
+ * viewports tall, so every cross-area placement rides the auto-scroller).
+ * Tripling the tick and the per-tick step keeps the same ~2,000px/s velocity
+ * at a third of the event rate.
+ *
+ * Measured on the production build, real Family Camp 2 data: dropped frames
+ * per 1,000px auto-scrolled went 3.4 → ~1.9, and script-per-pixel fell ~10%.
+ * A modest win, not a dramatic one — the remaining cost of the auto-scroll
+ * leg is the browser painting the board, not script.
+ */
+const AUTO_SCROLL = { interval: 15, acceleration: 30 }
+const TOUCH_ACTIVATION = { activationConstraint: { delay: 100, tolerance: 5 } }
 
 export function LodgingBoard({
   parties,
@@ -212,20 +240,24 @@ export function LodgingBoard({
     // The same activation constraints summer uses. The distance threshold is
     // what keeps a card that is also a button clickable: a plain click never
     // travels 10px, so it opens the details panel instead of starting a drag.
-    useSensor(MouseSensor, { activationConstraint: { distance: 10 } }),
-    useSensor(TouchSensor, { activationConstraint: { delay: 100, tolerance: 5 } })
+    useSensor(MouseSensor, MOUSE_ACTIVATION),
+    useSensor(TouchSensor, TOUCH_ACTIVATION)
   )
 
   // Pointer-within first, falling back to rect intersection — summer's, and
   // for the same reason: without it a drop released over dead space snaps to
   // whichever cabin happens to be nearest, placing a family somewhere nobody
-  // chose.
-  const collisionDetection = (args: Parameters<typeof pointerWithin>[0]) => {
-    const pointerCollisions = pointerWithin(args)
-    return pointerCollisions.length > 0 ? pointerCollisions : rectIntersection(args)
-  }
+  // chose. The policy itself, and why it HOLDS the last cabin across a gutter,
+  // lives in `boardCollision.ts`.
+  //
+  // Memoised because it is STATEFUL — the held cabin is the state — so a fresh
+  // one per render would forget the hold on every board render and put the
+  // flapping back.
+  const collisionDetection = useMemo(() => createBoardCollisionDetection(), [])
 
   const handleDragStart = (event: DragStartEvent) => {
+    // One gesture must never inherit the previous gesture's held cabin.
+    collisionDetection.reset()
     const activeId = String(event.active.id)
     const mergeUnit = mergeDragUnit(activeId, units)
     if (mergeUnit !== null) {
@@ -239,6 +271,7 @@ export function LodgingBoard({
   }
 
   const handleDragEnd = (event: DragEndEvent) => {
+    collisionDetection.reset()
     setDragging(null)
     setDraggingMergeUnit(null)
 
@@ -290,6 +323,7 @@ export function LodgingBoard({
   // `useLockGroupDragDrop.tsx`'s `handleDragCancel` for the same shape on
   // summer's own drag gesture.
   const handleDragCancel = () => {
+    collisionDetection.reset()
     setDragging(null)
     setDraggingMergeUnit(null)
   }
@@ -418,6 +452,7 @@ export function LodgingBoard({
 
   return (
     <DndContext
+      autoScroll={AUTO_SCROLL}
       sensors={sensors}
       collisionDetection={collisionDetection}
       onDragStart={handleDragStart}

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -25,12 +25,35 @@ import { LodgingUnitCard } from './LodgingUnitCard'
  */
 let overDroppableId: string | null = null
 
+// `setNodeRef` is ONE stable fn, not a fresh `vi.fn()` per call — the real
+// hook's setNodeRef is `useCallback([])`-stable, and a per-render fake defeats
+// the shell's own `useCallback` and with it the body memo the shell exists
+// for, making the memo test below pass vacuously.
+const stableSetNodeRef = vi.fn()
+
+/**
+ * Counts BODY renders: `slotOccupancy` is called exactly once per
+ * `LodgingUnitCardInner` render and by nothing else in this tree, so its call
+ * count is the body's render count — which is how the memo tests below can
+ * see a bail-out without exporting the inner component.
+ */
+const bodyRenders = vi.hoisted(() => ({ count: 0 }))
+vi.mock('./boardLayout', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./boardLayout')>()
+  return {
+    ...actual,
+    slotOccupancy: (...args: Parameters<typeof actual.slotOccupancy>) => {
+      bodyRenders.count += 1
+      return actual.slotOccupancy(...args)
+    },
+  }
+})
 vi.mock('@dnd-kit/core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@dnd-kit/core')>()
   return {
     ...actual,
     useDroppable: (args: { id: string; disabled?: boolean }) => ({
-      setNodeRef: vi.fn(),
+      setNodeRef: stableSetNodeRef,
       isOver: args.disabled !== true && args.id === overDroppableId,
     }),
   }
@@ -2804,17 +2827,6 @@ describe('LodgingUnitCard — the drag-time match and the capacity red', () => {
     expect(card(container)).toHaveClass('bg-primary/10')
   })
 
-  it('reddens the occupancy figure when the family will not fit', () => {
-    const { container } = render(
-      <LodgingUnitCard
-        slot={slot({ unit: powered({ sleeps: 2 }) })}
-        draggingParty={asksNothing}
-        onOpenParty={vi.fn()}
-      />
-    )
-    expect(within(card(container)).getByText('0/2')).toHaveClass('text-destructive')
-  })
-
   it('reddens for a family that asked for NOTHING, whose board is otherwise silent', () => {
     // Deliberately not gated on the mode switch. A family with no requirements
     // never moves the board out of its resting state, but "you will not fit
@@ -2897,6 +2909,45 @@ describe('LodgingUnitCard — the drag-time match and the capacity red', () => {
     expect(card(container)).not.toHaveClass('bg-primary/20')
   })
 
+  it('never matches a card whose party straddles beyond it', () => {
+    // The third leg of `dragCapacity.known`, pinned separately because
+    // mutation-testing found it was the only one that could be deleted with
+    // the suite still green. A straddling placement makes the card's occupant
+    // count an UPPER BOUND, not a fact (`slotOccupancy`), and a positive
+    // claim must not be built on one — even with beds apparently to spare.
+    const straddler = party({
+      party_size: 2,
+      unit_code: 'cedar-1',
+      unit_codes: ['cedar-1', 'elsewhere-9'],
+    })
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: powered({ sleeps: 20 }), parties: [straddler] })}
+        draggingParty={needsPower}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(card(container)).not.toHaveClass('bg-primary/20')
+  })
+
+  it('does not redden a card whose party straddles beyond it, either', () => {
+    // Same bound, negative direction: "you will not fit" asserted from an
+    // occupant count that is not a fact would be as false as the match.
+    const straddler = party({
+      party_size: 2,
+      unit_code: 'cedar-1',
+      unit_codes: ['cedar-1', 'elsewhere-9'],
+    })
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: powered({ sleeps: 2 }), parties: [straddler] })}
+        draggingParty={asksNothing}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(within(card(container)).getByText(/\/2$/)).not.toHaveClass('text-destructive')
+  })
+
   it('does not redden a room somebody is written into either', () => {
     // The other half of the write-in rule. The figure already prints an em
     // dash because there is no count; reddening it would assert "no room"
@@ -2932,5 +2983,33 @@ describe('LodgingUnitCard — the drag-time match and the capacity red', () => {
       <LodgingUnitCard slot={slot({ unit: powered({ sleeps: 2 }) })} onOpenParty={vi.fn()} />
     )
     expect(within(card(container)).getByText('0/2')).not.toHaveClass('text-destructive')
+  })
+})
+
+describe('LodgingUnitCard — the shell/body split actually bails (perf)', () => {
+  /*
+   * The whole point of the shell is that dnd-kit's context churn re-renders
+   * the SHELL on every `over` flip while the memo'd body stands still. The
+   * split has already been silently defeated twice — inline `useSensor`
+   * options and `useUnitMerge`'s unstable `setCombined`, each a fresh prop
+   * identity on every render — and 7,000+ tests stayed green both times,
+   * because nothing asserted the bail-out itself. These do. The control case
+   * proves the counter can see a real re-render, so a pass is not vacuous.
+   */
+  it('a re-render with identical props does not re-run the body', () => {
+    const theSlot = slot()
+    const onOpenParty = vi.fn()
+    const view = render(<LodgingUnitCard slot={theSlot} onOpenParty={onOpenParty} />)
+    const before = bodyRenders.count
+    view.rerender(<LodgingUnitCard slot={theSlot} onOpenParty={onOpenParty} />)
+    expect(bodyRenders.count).toBe(before)
+  })
+
+  it('control: a changed prop identity DOES re-run the body', () => {
+    const theSlot = slot()
+    const view = render(<LodgingUnitCard slot={theSlot} onOpenParty={vi.fn()} />)
+    const before = bodyRenders.count
+    view.rerender(<LodgingUnitCard slot={theSlot} onOpenParty={vi.fn()} />)
+    expect(bodyRenders.count).toBeGreaterThan(before)
   })
 })

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -6,7 +6,7 @@
  *
  * Fictional data throughout.
  */
-import { fireEvent, render, screen, within } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -123,7 +123,7 @@ function slot(overrides: Partial<BoardSlot> = {}): BoardSlot {
 
 describe('LodgingUnitCard', () => {
   it('names the unit', () => {
-    render(<LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />)
+    render(<LodgingUnitCard slot={slot()} onOpenParty={vi.fn()} />)
     expect(screen.getByText('Cedar 1')).toBeInTheDocument()
   })
 
@@ -137,19 +137,13 @@ describe('LodgingUnitCard', () => {
      * the point of the second assertion: an empty unmeasured room reads
      * `0/—`, never `0/0`.
      */
-    render(
-      <LodgingUnitCard
-        slot={slot({ unit: unit({ sleeps: null }) })}
-        hue="hsl(160 45% 42%)"
-        onOpenParty={vi.fn()}
-      />
-    )
+    render(<LodgingUnitCard slot={slot({ unit: unit({ sleeps: null }) })} onOpenParty={vi.fn()} />)
     expect(screen.getByText('0/—')).toBeInTheDocument()
     expect(screen.queryByText('0/0')).not.toBeInTheDocument()
   })
 
   it('shows how many spaces the unit sleeps when it is known', () => {
-    render(<LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />)
+    render(<LodgingUnitCard slot={slot()} onOpenParty={vi.fn()} />)
     const occupancy = screen.getByTestId('unit-occupancy')
     fireEvent.focus(occupancy)
     expect(screen.getByRole('tooltip')).toHaveTextContent(/Sleeps 5/)
@@ -159,7 +153,7 @@ describe('LodgingUnitCard', () => {
     // kindred#2177. The occupancy figure is the smallest trigger on the board,
     // so the primitive's transparent 24px hit target does the tap-target work
     // — NOT a drawn box, which would collide with the dashed empty-room edge.
-    render(<LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />)
+    render(<LodgingUnitCard slot={slot()} onOpenParty={vi.fn()} />)
     const occupancy = screen.getByTestId('unit-occupancy')
     expect(occupancy.tagName).toBe('BUTTON')
     expect(occupancy).not.toHaveAttribute('title')
@@ -198,7 +192,6 @@ describe('LodgingUnitCard', () => {
               }),
             ],
           })}
-          hue="hsl(160 45% 42%)"
           onOpenParty={vi.fn()}
         />
       )
@@ -223,7 +216,6 @@ describe('LodgingUnitCard', () => {
               }),
             ],
           })}
-          hue="hsl(160 45% 42%)"
           onOpenParty={vi.fn()}
         />
       )
@@ -257,7 +249,6 @@ describe('LodgingUnitCard', () => {
               }),
             ],
           })}
-          hue="hsl(160 45% 42%)"
           onOpenParty={vi.fn()}
         />
       )
@@ -294,7 +285,6 @@ describe('LodgingUnitCard', () => {
               }),
             ],
           })}
-          hue="hsl(160 45% 42%)"
           onOpenParty={vi.fn()}
         />
       )
@@ -308,7 +298,7 @@ describe('LodgingUnitCard', () => {
 
   it('describes the unit NAME without turning it into a tooltip trigger', () => {
     // The occupancy `<span>` carried the tooltip, never the `<h3>` beside it.
-    render(<LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />)
+    render(<LodgingUnitCard slot={slot()} onOpenParty={vi.fn()} />)
     expect(screen.getByText('Cedar 1').tagName).toBe('H3')
   })
 
@@ -335,7 +325,6 @@ describe('LodgingUnitCard', () => {
     const { container } = render(
       <LodgingUnitCard
         slot={slot({ parties: [party(), party({ household_cm_id: 102, display_name: 'Garcia' })] })}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -355,7 +344,6 @@ describe('LodgingUnitCard', () => {
             reason: '1 family did not request sharing',
           },
         })}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -368,9 +356,7 @@ describe('LodgingUnitCard', () => {
     // "deactivated" and is retired in favour of `bg-primary/10` — `--primary`
     // IS the board's forest hue (index.css), just at resting-state strength
     // rather than the drop target's `bg-primary/5` accent.
-    const { container } = render(
-      <LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />
-    )
+    const { container } = render(<LodgingUnitCard slot={slot()} onOpenParty={vi.fn()} />)
     const card = container.querySelector('[data-unit-card]')
     expect(card).toHaveClass('bg-primary/10')
     expect(card).not.toHaveClass('bg-muted/25')
@@ -389,7 +375,6 @@ describe('LodgingUnitCard', () => {
         slot={slot({
           unit: unit({ inventory_class: 'staff_default', is_family_available: false }),
         })}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -397,14 +382,21 @@ describe('LodgingUnitCard', () => {
     expect(screen.queryByText('Staff')).not.toBeInTheDocument()
   })
 
-  it('carries the area hue on its top edge as a secondary channel', () => {
-    // §3.10 — eight hues is at the limit of distinguishability, so this is
-    // decoration over a layout that already groups by section header.
-    const { container } = render(
-      <LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />
-    )
+  it('carries no area hue — the card frame is a constant in every state', () => {
+    // REWRITTEN. This asserted the opposite until 2026-08-21, and §3.10's own
+    // comment is why the reversal is safe rather than a loss: "the section
+    // headers do the actual grouping and this degrades to decoration". Area
+    // identity had FOUR carriers on the board — the `<section>`, the heading,
+    // the header dot, and 73 card top-edges — and the card edge was the only
+    // one on every card, always on.
+    //
+    // Taking it off is what frees the card's frame. No state now touches
+    // `border-color`, `border-width` or the title, so every mark lives in
+    // `background-color` or `background-image` and the three drag states can
+    // share one channel without racing.
+    const { container } = render(<LodgingUnitCard slot={slot()} onOpenParty={vi.fn()} />)
     const card = container.querySelector('[data-unit-card]')
-    expect(card).toHaveStyle({ borderTopColor: 'hsl(160 45% 42%)' })
+    expect(card?.getAttribute('style')).toBeNull()
   })
 
   it('keys two adult-weekend individuals in one room apart', () => {
@@ -432,7 +424,6 @@ describe('LodgingUnitCard', () => {
             }),
           ],
         })}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -447,7 +438,6 @@ describe('LodgingUnitCard', () => {
     render(
       <LodgingUnitCard
         slot={slot({ unit: unit({ is_active: false }), parties: [party()] })}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -480,21 +470,14 @@ describe('LodgingUnitCard — a held unit refuses the drop outright (#2087)', ()
      */
     overDroppableId = unitDroppableId('cedar-1')
     const { container } = render(
-      <LodgingUnitCard
-        slot={slot({ unit: held })}
-        hue="hsl(160 45% 42%)"
-        canPlace
-        onOpenParty={vi.fn()}
-      />
+      <LodgingUnitCard slot={slot({ unit: held })} canPlace onOpenParty={vi.fn()} />
     )
     expect(card(container)).toHaveClass('border-primary')
   })
 
   it('keeps an ordinary unheld unit droppable enabled (regression guard)', () => {
     overDroppableId = unitDroppableId('cedar-1')
-    const { container } = render(
-      <LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" canPlace onOpenParty={vi.fn()} />
-    )
+    const { container } = render(<LodgingUnitCard slot={slot()} canPlace onOpenParty={vi.fn()} />)
     expect(card(container)).toHaveClass('border-primary')
   })
 })
@@ -504,7 +487,6 @@ describe('LodgingUnitCard — the split control belongs to containers only', () 
     render(
       <LodgingUnitCard
         slot={slot({ unit: unit({ code: 'house', is_container: true, is_combined: true }) })}
-        hue="hsl(160 45% 42%)"
         canMerge
         onSplit={vi.fn()}
         onOpenParty={vi.fn()}
@@ -523,7 +505,6 @@ describe('LodgingUnitCard — the split control belongs to containers only', () 
     render(
       <LodgingUnitCard
         slot={slot({ unit: unit({ is_container: false, is_combined: true }) })}
-        hue="hsl(160 45% 42%)"
         canMerge
         onSplit={vi.fn()}
         onOpenParty={vi.fn()}
@@ -549,7 +530,6 @@ describe('LodgingUnitCard — the merge handle is reachable without a pointer', 
     render(
       <LodgingUnitCard
         slot={slot({ unit: room })}
-        hue="hsl(160 45% 42%)"
         canMerge
         onMerge={onMerge}
         onOpenParty={vi.fn()}
@@ -564,7 +544,6 @@ describe('LodgingUnitCard — the merge handle is reachable without a pointer', 
     render(
       <LodgingUnitCard
         slot={slot({ unit: room })}
-        hue="hsl(160 45% 42%)"
         canMerge
         savingMerge
         onMerge={vi.fn()}
@@ -610,7 +589,6 @@ describe('LodgingUnitCard — the per-party sharing chip follows ROOM overlap, n
             }),
           ],
         })}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -629,7 +607,6 @@ describe('LodgingUnitCard — the per-party sharing chip follows ROOM overlap, n
             declinedParty({ household_cm_id: 102, display_name: 'Beta', unit_code: 'r1' }),
           ],
         })}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -660,7 +637,6 @@ describe('LodgingUnitCard — the per-party sharing chip follows ROOM overlap, n
             }),
           ],
         })}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -689,7 +665,6 @@ describe('LodgingUnitCard — the per-party sharing chip follows ROOM overlap, n
           ],
         })}
         units={rooms}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -716,7 +691,6 @@ describe('LodgingUnitCard — the per-party sharing chip follows ROOM overlap, n
           ],
         })}
         units={rooms}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -734,7 +708,6 @@ describe('LodgingUnitCard — the per-party sharing chip follows ROOM overlap, n
             declinedParty({ household_cm_id: 102, display_name: 'Beta' }),
           ],
         })}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -789,7 +762,6 @@ describe('LodgingUnitCard — the whole-building mark is STRUCK from the card (k
           ],
         })}
         units={halvedHouseUnits}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -804,7 +776,6 @@ describe('LodgingUnitCard — the whole-building mark is STRUCK from the card (k
           parties: [party({ household_cm_id: 101, unit_code: 'up-r1', unit_codes: ['up-r1'] })],
         })}
         units={halvedHouseUnits}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -832,7 +803,6 @@ describe('LodgingUnitCard — the whole-building mark is STRUCK from the card (k
           ],
         })}
         units={halvedHouseUnits}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -850,7 +820,6 @@ describe('LodgingUnitCard — the whole-building mark is STRUCK from the card (k
  * tiers instead of four and must still resolve in the same order.
  */
 describe('LodgingUnitCard — no shared-space ring (#2179)', () => {
-  const hue = 'hsl(160 45% 42%)'
   const sharedParties = [party(), party({ household_cm_id: 102, display_name: 'Garcia' })]
   const declinedConsent = {
     declinedCount: 1,
@@ -869,7 +838,7 @@ describe('LodgingUnitCard — no shared-space ring (#2179)', () => {
     // The mark that used to live here. The card now says "two families" in
     // the chip below and in nothing else.
     const { container } = render(
-      <LodgingUnitCard slot={slot({ parties: sharedParties })} hue={hue} onOpenParty={vi.fn()} />
+      <LodgingUnitCard slot={slot({ parties: sharedParties })} onOpenParty={vi.fn()} />
     )
     expect(card(container).style.boxShadow).toBe('')
   })
@@ -881,20 +850,29 @@ describe('LodgingUnitCard — no shared-space ring (#2179)', () => {
     // the composed ring could never hand back.
     for (const parties of [[], [party()], sharedParties]) {
       const { container, unmount } = render(
-        <LodgingUnitCard slot={slot({ parties })} hue={hue} onOpenParty={vi.fn()} />
+        <LodgingUnitCard slot={slot({ parties })} onOpenParty={vi.fn()} />
       )
       expect(card(container).style.boxShadow).toBe('')
       unmount()
     }
   })
 
-  it('keeps the area hue on the top edge — that is not a ring', () => {
-    // Explicitly NOT struck. `borderTopColor` is §3.10's secondary channel,
-    // and the deletion above must not take it with it.
+  it('carries NO area hue, and no inline style at all', () => {
+    // REWRITTEN, not adapted. This test used to assert the opposite — that
+    // `borderTopColor` kept §3.10's secondary channel on the card — and it was
+    // right until the 2026-08-21 ruling took the area colour off the card
+    // entirely. The hue is not lost: the section header above each grid draws
+    // it as a dot, at 8 instances instead of 73, which is where the grouping
+    // actually happens (`boardLayout.ts` §3.10 says the headers do it and the
+    // per-card hue "degrades to decoration").
+    //
+    // Asserting the ABSENCE of an inline style rather than a specific border
+    // colour, because the point is that the card's frame is now a constant:
+    // no state touches `border-color`, `border-width` or the title.
     const { container } = render(
-      <LodgingUnitCard slot={slot({ parties: sharedParties })} hue={hue} onOpenParty={vi.fn()} />
+      <LodgingUnitCard slot={slot({ parties: sharedParties })} onOpenParty={vi.fn()} />
     )
-    expect(card(container)).toHaveStyle({ borderTopColor: hue })
+    expect(card(container).getAttribute('style')).toBeNull()
   })
 
   it('promotes the consent ring to ring-2', () => {
@@ -904,7 +882,6 @@ describe('LodgingUnitCard — no shared-space ring (#2179)', () => {
     const { container } = render(
       <LodgingUnitCard
         slot={slot({ parties: sharedParties, consent: declinedConsent })}
-        hue={hue}
         onOpenParty={vi.fn()}
       />
     )
@@ -919,7 +896,6 @@ describe('LodgingUnitCard — no shared-space ring (#2179)', () => {
     const { container } = render(
       <LodgingUnitCard
         slot={slot({ parties: sharedParties, consent: declinedConsent })}
-        hue={hue}
         onOpenParty={vi.fn()}
       />
     )
@@ -931,12 +907,7 @@ describe('LodgingUnitCard — no shared-space ring (#2179)', () => {
     // tiers silently reindex, so each one is re-pinned rather than assumed.
     overDroppableId = unitDroppableId('cedar-1')
     const { container } = render(
-      <LodgingUnitCard
-        slot={slot({ parties: sharedParties })}
-        hue={hue}
-        canPlace
-        onOpenParty={vi.fn()}
-      />
+      <LodgingUnitCard slot={slot({ parties: sharedParties })} canPlace onOpenParty={vi.fn()} />
     )
     expect(card(container)).toHaveClass('border-primary')
   })
@@ -947,7 +918,6 @@ describe('LodgingUnitCard — no shared-space ring (#2179)', () => {
     const { container } = render(
       <LodgingUnitCard
         slot={slot({ unit: room, parties: sharedParties })}
-        hue={hue}
         mergeSourceUnit={draggedSibling}
         onOpenParty={vi.fn()}
       />
@@ -958,7 +928,7 @@ describe('LodgingUnitCard — no shared-space ring (#2179)', () => {
   it('leaves a plain occupied card with no ring class at all', () => {
     // The bottom tier. `plain` has to stay reachable after the table shrinks.
     const { container } = render(
-      <LodgingUnitCard slot={slot({ parties: [party()] })} hue={hue} onOpenParty={vi.fn()} />
+      <LodgingUnitCard slot={slot({ parties: [party()] })} onOpenParty={vi.fn()} />
     )
     expect(card(container)).not.toHaveClass('border-amber-400')
     expect(card(container)).not.toHaveClass('border-primary')
@@ -975,7 +945,6 @@ describe('LodgingUnitCard — no shared-space ring (#2179)', () => {
     const { container } = render(
       <LodgingUnitCard
         slot={slot({ parties: sharedParties, consent: declinedConsent })}
-        hue={hue}
         canPlace
         onOpenParty={vi.fn()}
       />
@@ -996,7 +965,6 @@ describe('LodgingUnitCard — no shared-space ring (#2179)', () => {
     const { container } = render(
       <LodgingUnitCard
         slot={slot({ unit: room })}
-        hue={hue}
         mergeSourceUnit={validSibling}
         onOpenParty={vi.fn()}
       />
@@ -1015,7 +983,6 @@ describe('LodgingUnitCard — no shared-space ring (#2179)', () => {
     const { container } = render(
       <LodgingUnitCard
         slot={slot({ unit: room, parties: sharedParties, consent: declinedConsent })}
-        hue={hue}
         mergeSourceUnit={draggedSibling}
         onOpenParty={vi.fn()}
       />
@@ -1030,7 +997,6 @@ describe('LodgingUnitCard — no shared-space ring (#2179)', () => {
     const { container } = render(
       <LodgingUnitCard
         slot={slot({ unit: room })}
-        hue={hue}
         mergeSourceUnit={draggedSibling}
         onOpenParty={vi.fn()}
       />
@@ -1041,9 +1007,7 @@ describe('LodgingUnitCard — no shared-space ring (#2179)', () => {
 
   it('keeps the empty-room dashed cue visible under an active drop target', () => {
     overDroppableId = unitDroppableId('cedar-1')
-    const { container } = render(
-      <LodgingUnitCard slot={slot()} hue={hue} canPlace onOpenParty={vi.fn()} />
-    )
+    const { container } = render(<LodgingUnitCard slot={slot()} canPlace onOpenParty={vi.fn()} />)
     expect(card(container)).toHaveClass('border-primary')
     expect(card(container)).toHaveClass('border-dashed')
   })
@@ -1060,9 +1024,7 @@ describe('LodgingUnitCard — no shared-space ring (#2179)', () => {
     // it that mattered for a real, high-frequency gesture: hovering a family
     // drag over an empty room.
     overDroppableId = unitDroppableId('cedar-1')
-    const { container } = render(
-      <LodgingUnitCard slot={slot()} hue={hue} canPlace onOpenParty={vi.fn()} />
-    )
+    const { container } = render(<LodgingUnitCard slot={slot()} canPlace onOpenParty={vi.fn()} />)
     expect(card(container)).toHaveClass('bg-primary/5')
     expect(card(container)).not.toHaveClass('bg-primary/10')
     expect(card(container)).not.toHaveClass('bg-muted/25')
@@ -1106,21 +1068,25 @@ describe('LodgingUnitCard — the open-space title marker (#2093)', () => {
   // forest tint is a RESTING-STATE signal only, suppressed the instant this
   // card becomes an active drop target — and never spent on a held room,
   // which is empty but not open.
-  const hue = 'hsl(160 45% 42%)'
 
-  it('spends the forest tint on an open unit title — colour AND weight, not dimmed', () => {
-    render(<LodgingUnitCard slot={slot()} hue={hue} onOpenParty={vi.fn()} />)
-    const title = screen.getByText('Cedar 1')
-    expect(title).toHaveClass('text-primary')
-    expect(title).toHaveClass('font-bold')
-    expect(title).not.toHaveClass('text-foreground')
-    expect(title).not.toHaveClass('font-semibold')
-    expect(title).not.toHaveClass('text-muted-foreground')
-    expect(title).not.toHaveClass('opacity-40')
+  it('leaves an OPEN unit title identical to an occupied one — the wash carries it alone', () => {
+    // REWRITTEN. #2093 gave the open marker two halves, a forest wash and a
+    // bold primary title, coupled to one flag so they could not drift. The
+    // owner struck the title half on 2026-08-21: the wash carries the resting
+    // signal by itself.
+    //
+    // Asserted against an OCCUPIED card rather than against literal classes,
+    // because the invariant is sameness — no state touches the title, so a
+    // future mark that reaches for `color` or `font-weight` fails here.
+    render(<LodgingUnitCard slot={slot()} onOpenParty={vi.fn()} />)
+    const openTitle = screen.getByText('Cedar 1').className
+    cleanup()
+    render(<LodgingUnitCard slot={slot({ parties: [party()] })} onOpenParty={vi.fn()} />)
+    expect(screen.getByText('Cedar 1').className).toBe(openTitle)
   })
 
   it('leaves an occupied unit title in the plain foreground weight', () => {
-    render(<LodgingUnitCard slot={slot({ parties: [party()] })} hue={hue} onOpenParty={vi.fn()} />)
+    render(<LodgingUnitCard slot={slot({ parties: [party()] })} onOpenParty={vi.fn()} />)
     const title = screen.getByText('Cedar 1')
     expect(title).toHaveClass('text-foreground')
     expect(title).toHaveClass('font-semibold')
@@ -1134,7 +1100,7 @@ describe('LodgingUnitCard — the open-space title marker (#2093)', () => {
     // gets, sharing the identical `openMarkerActive` gate rather than a
     // second, independently-derived condition that could drift from it.
     overDroppableId = unitDroppableId('cedar-1')
-    render(<LodgingUnitCard slot={slot()} hue={hue} canPlace onOpenParty={vi.fn()} />)
+    render(<LodgingUnitCard slot={slot()} canPlace onOpenParty={vi.fn()} />)
     const title = screen.getByText('Cedar 1')
     expect(title).not.toHaveClass('text-primary')
     expect(title).not.toHaveClass('font-bold')
@@ -1171,7 +1137,6 @@ describe('LodgingUnitCard — the open-space title marker (#2093)', () => {
         slot={slot({
           unit: unit({ write_ins: [cover()], occupant_name: 'Emma Johnson' }),
         })}
-        hue={hue}
         canPlace
         onOpenParty={vi.fn()}
       />
@@ -1198,7 +1163,6 @@ describe('LodgingUnitCard — the open-space title marker (#2093)', () => {
     const { container } = render(
       <LodgingUnitCard
         slot={slot({ unit: unit({ write_ins: [cover({ occupant_name: '' })] }) })}
-        hue={hue}
         canPlace
         onOpenParty={vi.fn()}
       />
@@ -1221,7 +1185,6 @@ describe('LodgingUnitCard — the open-space title marker (#2093)', () => {
             reason: 'Overflow weekend',
           }),
         })}
-        hue={hue}
         canPlace
         onOpenParty={vi.fn()}
       />
@@ -1232,8 +1195,6 @@ describe('LodgingUnitCard — the open-space title marker (#2093)', () => {
 })
 
 describe('the write-in occupant card (kindred#2078)', () => {
-  const hue = 'hsl(160 45% 42%)'
-
   it('draws the occupant in the well, where the board prints occupancy', () => {
     // The name used to be a small italic muted line under the badge row while
     // the well below said "Drop families here" -- the room read as empty and
@@ -1247,7 +1208,6 @@ describe('the write-in occupant card (kindred#2078)', () => {
             is_family_available: false,
           }),
         })}
-        hue={hue}
         canPlace
         onOpenParty={vi.fn()}
       />
@@ -1270,7 +1230,6 @@ describe('the write-in occupant card (kindred#2078)', () => {
             is_family_available: false,
           }),
         })}
-        hue={hue}
         canSetAvailability
         onSetAvailability={vi.fn()}
         onOpenParty={vi.fn()}
@@ -1281,7 +1240,7 @@ describe('the write-in occupant card (kindred#2078)', () => {
   })
 
   it('does not draw an occupant card on an ordinary open room', () => {
-    render(<LodgingUnitCard slot={slot()} hue={hue} canPlace onOpenParty={vi.fn()} />)
+    render(<LodgingUnitCard slot={slot()} canPlace onOpenParty={vi.fn()} />)
 
     // The empty well draws NOTHING now — not an occupant card, and not the
     // struck invitation sentence either.
@@ -1303,7 +1262,6 @@ describe('the write-in occupant card (kindred#2078)', () => {
             is_family_available: false,
           }),
         })}
-        hue={hue}
         canPlace
         onOpenParty={vi.fn()}
       />
@@ -1380,7 +1338,6 @@ describe('LodgingUnitCard — summer’s type scale', () => {
             reason: 'One household declined sharing',
           },
         })}
-        hue="hsl(160 45% 42%)"
         canSetAvailability
         onSetAvailability={vi.fn()}
         canMerge
@@ -1396,14 +1353,12 @@ describe('LodgingUnitCard — summer’s type scale', () => {
 
   it('leaves no arbitrary pixel sizes on an empty slot either', () => {
     // The empty state is its own branch and carried its own `text-[11px]`.
-    const { container } = render(
-      <LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />
-    )
+    const { container } = render(<LodgingUnitCard slot={slot()} onOpenParty={vi.fn()} />)
     expect(arbitraryTextSizes(container)).toEqual([])
   })
 
   it('titles the unit at summer’s text-lg', () => {
-    render(<LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />)
+    render(<LodgingUnitCard slot={slot()} onOpenParty={vi.fn()} />)
     expect(screen.getByText('Cedar 1')).toHaveClass('text-lg')
   })
 
@@ -1419,14 +1374,14 @@ describe('LodgingUnitCard — summer’s type scale', () => {
      * Pinned as a ROLE rather than a tag name: the font comes from the element
      * being a heading, so that is the thing that must not regress.
      */
-    render(<LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />)
+    render(<LodgingUnitCard slot={slot()} onOpenParty={vi.fn()} />)
     expect(screen.getByRole('heading', { name: 'Cedar 1', level: 3 })).toBeInTheDocument()
   })
 
   it('sets the capacity figure at summer’s body size', () => {
     // Summer prints `{occupancy}/{capacity}` at `text-sm`. The figure is the
     // second thing read on the card; at 11px it read as a footnote.
-    render(<LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />)
+    render(<LodgingUnitCard slot={slot()} onOpenParty={vi.fn()} />)
     // Matched loosely: the title gained the occupancy count alongside the
     // capacity. What this test pins is the SIZE of that element, not its
     // wording — the wording has its own tests.
@@ -1445,7 +1400,6 @@ describe('LodgingUnitCard — summer’s type scale', () => {
             reason: 'One household declined sharing',
           },
         })}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -1466,7 +1420,6 @@ describe('LodgingUnitCard — summer’s type scale', () => {
           unit: unit({ is_active: false, is_confirmed: false }),
           parties: [party(), party({ household_cm_id: 102, display_name: 'Garcia' })],
         })}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -1491,18 +1444,14 @@ describe('LodgingUnitCard — how full the room is', () => {
    */
   it('says how many are in the room, not just what it sleeps', () => {
     render(
-      <LodgingUnitCard
-        slot={slot({ parties: [party({ party_size: 3 })] })}
-        hue="hsl(160 45% 42%)"
-        onOpenParty={vi.fn()}
-      />
+      <LodgingUnitCard slot={slot({ parties: [party({ party_size: 3 })] })} onOpenParty={vi.fn()} />
     )
     expect(screen.getByText('3/5')).toBeInTheDocument()
   })
 
   it('distinguishes an empty room from a full one', () => {
     // The whole point: before this, both rendered "5".
-    render(<LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />)
+    render(<LodgingUnitCard slot={slot()} onOpenParty={vi.fn()} />)
     expect(screen.getByText('0/5')).toBeInTheDocument()
   })
 
@@ -1510,7 +1459,6 @@ describe('LodgingUnitCard — how full the room is', () => {
     render(
       <LodgingUnitCard
         slot={slot({ unit: unit({ sleeps: 4 }), parties: [party({ party_size: 6 })] })}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -1524,11 +1472,7 @@ describe('LodgingUnitCard — how full the room is', () => {
 
   it('leaves a room within capacity unmarked', () => {
     render(
-      <LodgingUnitCard
-        slot={slot({ parties: [party({ party_size: 5 })] })}
-        hue="hsl(160 45% 42%)"
-        onOpenParty={vi.fn()}
-      />
+      <LodgingUnitCard slot={slot({ parties: [party({ party_size: 5 })] })} onOpenParty={vi.fn()} />
     )
     expect(screen.getByText('5/5')).not.toHaveClass('text-destructive')
     expect(screen.queryByText('Over capacity')).not.toBeInTheDocument()
@@ -1540,7 +1484,6 @@ describe('LodgingUnitCard — how full the room is', () => {
     render(
       <LodgingUnitCard
         slot={slot({ unit: unit({ sleeps: null }), parties: [party({ party_size: 9 })] })}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -1567,7 +1510,6 @@ describe('LodgingUnitCard — how full the room is', () => {
           parties: [party({ party_size: 6, unit_code: '', unit_codes: ['r1', 'r2'] })],
         })}
         units={[house, r1, r2]}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -1589,13 +1531,7 @@ describe('LodgingUnitCard — how full the room is', () => {
    */
 
   it('says nothing about spanning on an ordinary room', () => {
-    render(
-      <LodgingUnitCard
-        slot={slot({ parties: [party()] })}
-        hue="hsl(160 45% 42%)"
-        onOpenParty={vi.fn()}
-      />
-    )
+    render(<LodgingUnitCard slot={slot({ parties: [party()] })} onOpenParty={vi.fn()} />)
     expect(screen.queryByText(/Spans/)).not.toBeInTheDocument()
   })
 })
@@ -1622,9 +1558,7 @@ describe('LodgingUnitCard — the occupant well', () => {
   }
 
   it('gives an empty slot a well that grows with the row', () => {
-    const { container } = render(
-      <LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />
-    )
+    const { container } = render(<LodgingUnitCard slot={slot()} onOpenParty={vi.fn()} />)
     // B·2: the min-height is struck and `flex-1` is not. They were always two
     // decisions — the floor lifted an empty card toward the occupied median,
     // and `flex-1` is what makes the grid's stretch survivable at all.
@@ -1635,11 +1569,7 @@ describe('LodgingUnitCard — the occupant well', () => {
   it('gives an occupied slot the same well, so rows agree', () => {
     // Same element in both branches on purpose. Two wells drift.
     const { container } = render(
-      <LodgingUnitCard
-        slot={slot({ parties: [party()] })}
-        hue="hsl(160 45% 42%)"
-        onOpenParty={vi.fn()}
-      />
+      <LodgingUnitCard slot={slot({ parties: [party()] })} onOpenParty={vi.fn()} />
     )
     expect(well(container)).not.toHaveClass('min-h-[100px]')
     expect(well(container)).toHaveClass('flex-1')
@@ -1670,9 +1600,7 @@ describe('LodgingUnitCard — the occupant well', () => {
      * session nearly did. A dead class spreading by imitation is the
      * `forest-950` failure CLAUDE.md §4 cites (#1894).
      */
-    const { container } = render(
-      <LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />
-    )
+    const { container } = render(<LodgingUnitCard slot={slot()} onOpenParty={vi.fn()} />)
     expect(container.querySelector('[data-unit-card]')).not.toHaveClass('hover:shadow-lodge-lg')
     // The chrome that DOES carry the hover, so this test fails loudly if the
     // card ever stops being a `.card-lodge` rather than silently passing.
@@ -1695,9 +1623,7 @@ describe('LodgingUnitCard — the occupant well', () => {
      * party and the same rhythm is most of it. Measured at −148px across the
      * board, 8.3%, and about −15% of column height together with B·2.
      */
-    const { container } = render(
-      <LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />
-    )
+    const { container } = render(<LodgingUnitCard slot={slot()} onOpenParty={vi.fn()} />)
     const card = container.querySelector('[data-unit-card]')
     expect(card).toHaveClass('gap-2')
     expect(card).not.toHaveClass('gap-3')
@@ -1707,7 +1633,6 @@ describe('LodgingUnitCard — the occupant well', () => {
     const { container } = render(
       <LodgingUnitCard
         slot={slot({ parties: [party(), party({ household_cm_id: 102, display_name: 'Garcia' })] })}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -1743,7 +1668,6 @@ describe('LodgingUnitCard — shareability left the card (kindred#2026 → kindr
     render(
       <LodgingUnitCard
         slot={slot({ unit: unit({ shareability: 'shareable' }) })}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -1751,7 +1675,7 @@ describe('LodgingUnitCard — shareability left the card (kindred#2026 → kindr
   })
 
   it('says nothing on a one-family room either', () => {
-    render(<LodgingUnitCard slot={slot()} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />)
+    render(<LodgingUnitCard slot={slot()} onOpenParty={vi.fn()} />)
     expect(screen.queryByText('Shared OK')).not.toBeInTheDocument()
     expect(screen.queryByText('Sharing unset')).not.toBeInTheDocument()
   })
@@ -1763,7 +1687,6 @@ describe('LodgingUnitCard — shareability left the card (kindred#2026 → kindr
           unit: unit({ is_container: true, is_combined: true, shareability: 'shareable' }),
           parties: [party(), party({ household_cm_id: 102, display_name: 'Garcia' })],
         })}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -1778,7 +1701,6 @@ describe('LodgingUnitCard — shareability left the card (kindred#2026 → kindr
     render(
       <LodgingUnitCard
         slot={slot({ unit: unit({ shareability: 'unknown', is_confirmed: true }) })}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -1802,7 +1724,6 @@ describe('LodgingUnitCard — the needs-misfit hatch (#1912)', () => {
    * able to appear at once mid-drag; a card dimmed for a fit miss reads as a
    * weaker refusal rather than as a different kind of statement.
    */
-  const hue = 'hsl(160 45% 42%)'
   /** Enough of the arbitrary property to identify the mark, whatever its period. */
   const HATCH = '[background-image:repeating-linear-gradient'
   const needsPower = party({ flags: { needs_power: true } })
@@ -1824,7 +1745,6 @@ describe('LodgingUnitCard — the needs-misfit hatch (#1912)', () => {
     const { container } = render(
       <LodgingUnitCard
         slot={slot({ unit: unit({ power_coverage: 'none' }) })}
-        hue={hue}
         onOpenParty={vi.fn()}
       />
     )
@@ -1836,7 +1756,6 @@ describe('LodgingUnitCard — the needs-misfit hatch (#1912)', () => {
     const { container } = render(
       <LodgingUnitCard
         slot={slot({ unit: unit({ power_coverage: 'none' }) })}
-        hue={hue}
         draggingParty={needsPower}
         onOpenParty={vi.fn()}
       />
@@ -1849,7 +1768,6 @@ describe('LodgingUnitCard — the needs-misfit hatch (#1912)', () => {
     const none = render(
       <LodgingUnitCard
         slot={slot({ unit: unit({ power_coverage: 'none' }) })}
-        hue={hue}
         draggingParty={needsPower}
         onOpenParty={vi.fn()}
       />
@@ -1857,7 +1775,6 @@ describe('LodgingUnitCard — the needs-misfit hatch (#1912)', () => {
     const some = render(
       <LodgingUnitCard
         slot={slot({ unit: unit({ power_coverage: 'some' }) })}
-        hue={hue}
         draggingParty={needsPower}
         onOpenParty={vi.fn()}
       />
@@ -1869,8 +1786,8 @@ describe('LodgingUnitCard — the needs-misfit hatch (#1912)', () => {
     expect(tight).not.toBe(wide)
     // Same ink, different spacing. If the two ever differ in their colour
     // stop, the grade has quietly moved onto a strength channel.
-    expect(tight).toContain('hsl(var(--foreground)_/_0.1)')
-    expect(wide).toContain('hsl(var(--foreground)_/_0.1)')
+    expect(tight).toContain('hsl(var(--foreground)_/_0.06)')
+    expect(wide).toContain('hsl(var(--foreground)_/_0.06)')
     expect(some.container.querySelector('[data-unit-card]')).toHaveAttribute(
       'data-needs-fit',
       'partial'
@@ -1881,7 +1798,6 @@ describe('LodgingUnitCard — the needs-misfit hatch (#1912)', () => {
     const { container } = render(
       <LodgingUnitCard
         slot={slot({ unit: unit({ power_coverage: 'none' }) })}
-        hue={hue}
         canPlace
         draggingParty={needsPower}
         onOpenParty={vi.fn()}
@@ -1897,7 +1813,6 @@ describe('LodgingUnitCard — the needs-misfit hatch (#1912)', () => {
     const { container } = render(
       <LodgingUnitCard
         slot={slot({ unit: unit({ power_coverage: 'all' }) })}
-        hue={hue}
         draggingParty={needsPower}
         onOpenParty={vi.fn()}
       />
@@ -1909,7 +1824,6 @@ describe('LodgingUnitCard — the needs-misfit hatch (#1912)', () => {
     const { container } = render(
       <LodgingUnitCard
         slot={slot({ unit: unit({ power_coverage: 'none' }) })}
-        hue={hue}
         draggingParty={party()}
         onOpenParty={vi.fn()}
       />
@@ -1923,7 +1837,6 @@ describe('LodgingUnitCard — the needs-misfit hatch (#1912)', () => {
     const { container } = render(
       <LodgingUnitCard
         slot={slot({ unit: unit({ has_power: false, power_coverage: 'all' }) })}
-        hue={hue}
         draggingParty={needsPower}
         onOpenParty={vi.fn()}
       />
@@ -1931,21 +1844,27 @@ describe('LodgingUnitCard — the needs-misfit hatch (#1912)', () => {
     expect(hatchClass(container)).toBe('')
   })
 
-  it('composes with the open-space forest tint rather than suppressing it', () => {
-    // ORTHOGONAL properties: #2093's tint is `background-color`, this is
-    // `background-image`. Both paint, at full strength — an empty space that
-    // does not meet the need is still an empty space. No suppression logic
-    // belongs between them, and adding any would be reaching into #2093's
-    // own gate.
+  it('SUPPRESSES the open-space forest tint — a conflict is not an invitation', () => {
+    // REWRITTEN, and it reverses. The old rule let the two compose because
+    // they sit on orthogonal properties: the tint is `background-color`, the
+    // hatch `background-image`. That was true and it was the wrong call — the
+    // card said "drop here" and "no" at once, and drawn at board scale the
+    // composite read as a dull, deactivated grey rather than a warning.
+    //
+    // The owner ruled on 2026-08-21 that the negative wins. A conflict now
+    // gains the hazard texture AND loses the invitation, which is two halves
+    // of one mark rather than two marks arguing. It is decided at
+    // `dragFit.state` — one enum, one winner — not by two CSS rules racing
+    // over a byte offset, which is the collapse `RING_CLASSES` exists to kill.
     const { container } = render(
       <LodgingUnitCard
         slot={slot({ unit: unit({ power_coverage: 'none' }) })}
-        hue={hue}
         draggingParty={needsPower}
         onOpenParty={vi.fn()}
       />
     )
-    expect(card(container)).toHaveClass('bg-primary/10')
+    expect(card(container)).not.toHaveClass('bg-primary/10')
+    expect(card(container)).not.toHaveClass('bg-primary/20')
     expect(hatchClass(container)).not.toBe('')
   })
 })
@@ -1967,7 +1886,6 @@ describe('LodgingUnitCard — placing a family from the space itself (kindred#20
    * land — against the control that exists now. The one that changed meaning
    * is called out where it sits.
    */
-  const HUE = 'hsl(160 45% 42%)'
   const unplaced = party({
     household_cm_id: 202,
     display_name: 'Garcia',
@@ -1984,7 +1902,6 @@ describe('LodgingUnitCard — placing a family from the space itself (kindred#20
     const view = render(
       <LodgingUnitCard
         slot={slot()}
-        hue={HUE}
         canPlace={true}
         unplacedParties={[unplaced]}
         onPlaceParty={onPlaceParty}
@@ -2163,9 +2080,7 @@ describe('LodgingUnitCard — no sr-only text of any kind (kindred#2348)', () =>
   })
 
   it('renders no sr-only node and no aria-live region at rest', () => {
-    const { container } = render(
-      <LodgingUnitCard slot={infantSlot} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />
-    )
+    const { container } = render(<LodgingUnitCard slot={infantSlot} onOpenParty={vi.fn()} />)
     expect(container.querySelectorAll('.sr-only')).toHaveLength(0)
     expect(container.querySelectorAll('[aria-live]')).toHaveLength(0)
   })
@@ -2174,7 +2089,7 @@ describe('LodgingUnitCard — no sr-only text of any kind (kindred#2348)', () =>
     // The measured defect: find-in-page matched `infant` four times on the
     // Housing tab and highlighted nothing, because `ui/Tooltip` mirrored
     // every closed bubble's sentence into an `sr-only` span.
-    render(<LodgingUnitCard slot={infantSlot} hue="hsl(160 45% 42%)" onOpenParty={vi.fn()} />)
+    render(<LodgingUnitCard slot={infantSlot} onOpenParty={vi.fn()} />)
     expect(screen.queryByText(/exempt from the bed count/)).not.toBeInTheDocument()
     fireEvent.focus(screen.getByTestId('unit-occupancy'))
     expect(screen.getByRole('tooltip')).toHaveTextContent(
@@ -2184,7 +2099,6 @@ describe('LodgingUnitCard — no sr-only text of any kind (kindred#2348)', () =>
 })
 
 describe('LodgingUnitCard — the write-in chip, dropped in favour of the well (kindred#2252)', () => {
-  const HUE = 'hsl(160 45% 42%)'
   const WRITTEN_IN = unit({
     write_ins: [cover()],
     occupant_name: 'Emma Johnson',
@@ -2196,7 +2110,7 @@ describe('LodgingUnitCard — the write-in chip, dropped in favour of the well (
     // "Write-in" chip in the badge row, and the occupant's own name in the
     // `WriteInCard` drawn in the well below. The chip is gone from THIS card;
     // the well is untouched.
-    render(<LodgingUnitCard slot={slot({ unit: WRITTEN_IN })} hue={HUE} onOpenParty={vi.fn()} />)
+    render(<LodgingUnitCard slot={slot({ unit: WRITTEN_IN })} onOpenParty={vi.fn()} />)
 
     expect(screen.getByText('Emma Johnson')).toBeInTheDocument()
     expect(screen.queryByText('Write-in')).not.toBeInTheDocument()
@@ -2229,7 +2143,6 @@ describe('LodgingUnitCard — the write-in chip, dropped in favour of the well (
             family_available_override: true,
           }),
         })}
-        hue={HUE}
         onOpenParty={vi.fn()}
       />
     )
@@ -2250,11 +2163,8 @@ describe('LodgingUnitCard — T2: the amenities ride the TITLE row', () => {
    * the last one. The board lives in a 280–292px band, so it sits on the
    * cliff rather than past it.
    */
-  const HUE = 'hsl(160 45% 42%)'
   const renderUnit = (overrides: Partial<LodgingUnitRow>) =>
-    render(
-      <LodgingUnitCard slot={slot({ unit: unit(overrides) })} hue={HUE} onOpenParty={vi.fn()} />
-    )
+    render(<LodgingUnitCard slot={slot({ unit: unit(overrides) })} onOpenParty={vi.fn()} />)
 
   it('draws only what the room actually has', () => {
     const { container } = renderUnit({
@@ -2403,13 +2313,10 @@ describe('LodgingUnitCard — T2: the amenities ride the TITLE row', () => {
 })
 
 describe('LodgingUnitCard — the FOOTER row', () => {
-  const HUE = 'hsl(160 45% 42%)'
-
   it('carries Assign, Merge and Split together, below the well', () => {
     const { container } = render(
       <LodgingUnitCard
         slot={slot({ unit: unit({ parent_code: 'house', is_container: false }) })}
-        hue={HUE}
         canPlace={true}
         unplacedParties={[]}
         onPlaceParty={vi.fn()}
@@ -2431,7 +2338,6 @@ describe('LodgingUnitCard — the FOOTER row', () => {
     render(
       <LodgingUnitCard
         slot={slot({ unit: unit({ is_container: true, is_combined: true }) })}
-        hue={HUE}
         canMerge={true}
         onSplit={vi.fn()}
         onOpenParty={vi.fn()}
@@ -2445,7 +2351,7 @@ describe('LodgingUnitCard — the FOOTER row', () => {
   it('is absent entirely when the card offers no control at all', () => {
     // A read-only board. An empty footer would spend a row saying nothing —
     // the same reasoning the meta row now follows.
-    render(<LodgingUnitCard slot={slot()} hue={HUE} onOpenParty={vi.fn()} />)
+    render(<LodgingUnitCard slot={slot()} onOpenParty={vi.fn()} />)
     expect(screen.queryByTestId('unit-footer')).not.toBeInTheDocument()
   })
 })
@@ -2464,10 +2370,9 @@ describe('LodgingUnitCard — the meta row survives ONLY for what needs it (0a)'
    * confirmed — so every live card gets ruling 12's outcome, and both marks
    * keep a home for when kindred#2500 makes a new season start unconfirmed.
    */
-  const HUE = 'hsl(160 45% 42%)'
 
   it('draws NO meta row on an ordinary card', () => {
-    render(<LodgingUnitCard slot={slot()} hue={HUE} onOpenParty={vi.fn()} />)
+    render(<LodgingUnitCard slot={slot()} onOpenParty={vi.fn()} />)
     expect(screen.queryByTestId('unit-meta')).not.toBeInTheDocument()
   })
 
@@ -2475,7 +2380,6 @@ describe('LodgingUnitCard — the meta row survives ONLY for what needs it (0a)'
     render(
       <LodgingUnitCard
         slot={slot({ unit: unit({ is_active: false }), parties: [party()] })}
-        hue={HUE}
         onOpenParty={vi.fn()}
       />
     )
@@ -2484,11 +2388,7 @@ describe('LodgingUnitCard — the meta row survives ONLY for what needs it (0a)'
 
   it('draws it for a cabin nobody has checked this season', () => {
     render(
-      <LodgingUnitCard
-        slot={slot({ unit: unit({ is_confirmed: false }) })}
-        hue={HUE}
-        onOpenParty={vi.fn()}
-      />
+      <LodgingUnitCard slot={slot({ unit: unit({ is_confirmed: false }) })} onOpenParty={vi.fn()} />
     )
     expect(within(screen.getByTestId('unit-meta')).getByText('Reconfirm space')).toBeInTheDocument()
   })
@@ -2503,15 +2403,10 @@ describe('LodgingUnitCard — Reconfirm space is re-gated on is_confirmed (rulin
    * the moment kindred#2500 makes a new year start unconfirmed: every unit
    * flagged at season start, worked down as staff check them.
    */
-  const HUE = 'hsl(160 45% 42%)'
 
   it('fires on an unconfirmed cabin', () => {
     render(
-      <LodgingUnitCard
-        slot={slot({ unit: unit({ is_confirmed: false }) })}
-        hue={HUE}
-        onOpenParty={vi.fn()}
-      />
+      <LodgingUnitCard slot={slot({ unit: unit({ is_confirmed: false }) })} onOpenParty={vi.fn()} />
     )
     expect(screen.getByText('Reconfirm space')).toBeInTheDocument()
   })
@@ -2521,7 +2416,6 @@ describe('LodgingUnitCard — Reconfirm space is re-gated on is_confirmed (rulin
       const view = render(
         <LodgingUnitCard
           slot={slot({ unit: unit({ is_confirmed: true, shareability }) })}
-          hue={HUE}
           onOpenParty={vi.fn()}
         />
       )
@@ -2537,7 +2431,6 @@ describe('LodgingUnitCard — Reconfirm space is re-gated on is_confirmed (rulin
     render(
       <LodgingUnitCard
         slot={slot({ unit: unit({ is_confirmed: false, shareability: 'shareable' }) })}
-        hue={HUE}
         onOpenParty={vi.fn()}
       />
     )
@@ -2555,13 +2448,11 @@ describe('LodgingUnitCard — the marks kindred#2072 STRUCK from the unit card',
    * Every one of them survives on another surface where it still discriminates
    * (`MapUnitPopover`, the units admin table) — the split `Staff` already took.
    */
-  const HUE = 'hsl(160 45% 42%)'
 
   it('draws no "Over capacity" pill — the red figure absorbed it', () => {
     render(
       <LodgingUnitCard
         slot={slot({ unit: unit({ sleeps: 1 }), parties: [party({ party_size: 4 })] })}
-        hue={HUE}
         onOpenParty={vi.fn()}
       />
     )
@@ -2578,7 +2469,6 @@ describe('LodgingUnitCard — the marks kindred#2072 STRUCK from the unit card',
         slot={slot({
           parties: [party({ household_cm_id: 1 }), party({ household_cm_id: 2 })],
         })}
-        hue={HUE}
         onOpenParty={vi.fn()}
       />
     )
@@ -2589,7 +2479,6 @@ describe('LodgingUnitCard — the marks kindred#2072 STRUCK from the unit card',
     render(
       <LodgingUnitCard
         slot={slot({ unit: unit({ shareability: 'shareable' }) })}
-        hue={HUE}
         onOpenParty={vi.fn()}
       />
     )
@@ -2606,7 +2495,6 @@ describe('LodgingUnitCard — the marks kindred#2072 STRUCK from the unit card',
           unit: unit({ shareability: 'single_party' }),
           parties: [party({ household_cm_id: 1 }), party({ household_cm_id: 2 })],
         })}
-        hue={HUE}
         onOpenParty={vi.fn()}
       />
     )
@@ -2627,7 +2515,6 @@ describe('LodgingUnitCard — the marks kindred#2072 STRUCK from the unit card',
           unit({ unit_id: 'r1', code: 'up-r1', parent_code: 'upstairs' }),
           unit({ unit_id: 'r2', code: 'up-r2', parent_code: 'upstairs' }),
         ]}
-        hue={HUE}
         onOpenParty={vi.fn()}
       />
     )
@@ -2642,7 +2529,6 @@ describe('LodgingUnitCard — the marks kindred#2072 STRUCK from the unit card',
     render(
       <LodgingUnitCard
         slot={slot({ unit: unit({ is_container: true, is_combined: true }) })}
-        hue={HUE}
         onOpenParty={vi.fn()}
       />
     )
@@ -2658,7 +2544,6 @@ describe('LodgingUnitCard — the marks kindred#2072 STRUCK from the unit card',
         slot={slot({
           unit: unit({ inventory_class: 'staff_default', family_available_override: true }),
         })}
-        hue={HUE}
         canSetAvailability={true}
         onSetAvailability={vi.fn()}
         onOpenParty={vi.fn()}
@@ -2676,7 +2561,6 @@ describe('LodgingUnitCard — the marks kindred#2072 STRUCK from the unit card',
     render(
       <LodgingUnitCard
         slot={slot({ parties: [] })}
-        hue={HUE}
         canPlace={true}
         unplacedParties={[]}
         onPlaceParty={vi.fn()}
@@ -2689,7 +2573,7 @@ describe('LodgingUnitCard — the marks kindred#2072 STRUCK from the unit card',
 
   it('keeps the dashed border that now carries the empty state alone', () => {
     const { container } = render(
-      <LodgingUnitCard slot={slot({ parties: [] })} hue={HUE} onOpenParty={vi.fn()} />
+      <LodgingUnitCard slot={slot({ parties: [] })} onOpenParty={vi.fn()} />
     )
     expect(container.querySelector('[data-unit-card]')?.className).toContain('border-dashed')
   })
@@ -2701,14 +2585,13 @@ describe('LodgingUnitCard — B·1 and B·2, the card gets shorter', () => {
    * from the padding and gap (8.3%), and the well's `min-h-[100px]` on top of
    * it, for about −15% of column height.
    */
-  const HUE = 'hsl(160 45% 42%)'
 
   it('drops the well’s min-height', () => {
     // B·2. The min-height lifted an empty card off its 139px floor toward the
     // 188px occupied median; with the empty-state sentence gone there is
     // nothing left in an empty well to give height to, and 81% of live cards
     // are empty.
-    const { container } = render(<LodgingUnitCard slot={slot()} hue={HUE} onOpenParty={vi.fn()} />)
+    const { container } = render(<LodgingUnitCard slot={slot()} onOpenParty={vi.fn()} />)
     const well = container.querySelector('[data-testid="occupant-well"]')
     expect(well?.className).not.toContain('min-h-[100px]')
     // `flex-1` STAYS: it is what makes the grid's stretch survivable, and it
@@ -2722,7 +2605,7 @@ describe('LodgingUnitCard — B·1 and B·2, the card gets shorter', () => {
     // campers, so 16px of padding is a small fraction of a tall card, where
     // a lodging card holds nothing or one party and the same padding is most
     // of it.
-    const { container } = render(<LodgingUnitCard slot={slot()} hue={HUE} onOpenParty={vi.fn()} />)
+    const { container } = render(<LodgingUnitCard slot={slot()} onOpenParty={vi.fn()} />)
     const card = container.querySelector('[data-unit-card]')
     expect(card?.className).toContain('p-2.5')
     expect(card?.className).toContain('px-3')
@@ -2787,7 +2670,6 @@ describe('LodgingUnitCard — the denominator is the WHOLE space (owner ruling 2
       <LodgingUnitCard
         slot={slot({ unit: house, parties: [party({ party_size: 3, unit_code: 'gt-house' })] })}
         units={registry}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -2802,7 +2684,6 @@ describe('LodgingUnitCard — the denominator is the WHOLE space (owner ruling 2
       <LodgingUnitCard
         slot={slot({ unit: unit({ sleeps: 5 }), parties: [party({ party_size: 3 })] })}
         units={[unit({ sleeps: 5 })]}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -2823,7 +2704,6 @@ describe('LodgingUnitCard — the denominator is the WHOLE space (owner ruling 2
       <LodgingUnitCard
         slot={slot({ unit: house, parties: [party({ party_size: 3, unit_code: 'gt-house' })] })}
         units={[house, roomA, unmeasured]}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -2838,7 +2718,6 @@ describe('LodgingUnitCard — the denominator is the WHOLE space (owner ruling 2
       <LodgingUnitCard
         slot={slot({ unit: house, parties: [party({ party_size: 9, unit_code: 'gt-house' })] })}
         units={registry}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
@@ -2851,10 +2730,136 @@ describe('LodgingUnitCard — the denominator is the WHOLE space (owner ruling 2
       <LodgingUnitCard
         slot={slot({ unit: house, parties: [party({ party_size: 7, unit_code: 'gt-house' })] })}
         units={registry}
-        hue="hsl(160 45% 42%)"
         onOpenParty={vi.fn()}
       />
     )
     expect(screen.getByTestId('unit-occupancy')).not.toHaveClass('text-destructive')
+  })
+})
+
+/**
+ * The drag-time signal's two NEW marks (kindred#2528).
+ *
+ * The hatch above is the negative half and predates this. What is new is the
+ * positive half — a match, drawn as the resting wash at double strength — and
+ * the capacity figure turning red. Between them the card now answers "does
+ * this family go here?" in three states rather than two.
+ *
+ * Fictional data throughout.
+ */
+describe('LodgingUnitCard — the drag-time match and the capacity red', () => {
+  const needsPower = party({ flags: { needs_power: true }, party_size: 2 })
+  const asksNothing = party({ party_size: 6 })
+
+  function card(container: HTMLElement): HTMLElement {
+    const el = container.querySelector('[data-unit-card]')
+    if (!el) throw new Error('no card rendered')
+    return el as HTMLElement
+  }
+  const powered = (over: Partial<LodgingUnitRow> = {}) =>
+    unit({ power_coverage: 'all', has_power: true, sleeps: 6, ...over })
+
+  it('washes a matching cabin at double the resting strength', () => {
+    // The match is MORE OF THE GREEN THE BOARD ALREADY SPEAKS, not a new hue.
+    // #1912: the board's hues are committed, so a fifth meaning cannot have a
+    // fifth colour. 10% at rest, 20% for a match — one channel, one job.
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: powered() })}
+        draggingParty={needsPower}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(card(container)).toHaveClass('bg-primary/20')
+    expect(card(container)).not.toHaveClass('bg-primary/10')
+  })
+
+  it('leaves an empty cabin at its resting 10% when there is nothing to say', () => {
+    // The third state. An empty cabin that neither conflicts nor matches is
+    // drawn EXACTLY as it was at rest, so a drag changes nothing it has
+    // nothing to say about. Here: powered, so no conflict; too small for the
+    // party, so no match.
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: powered({ sleeps: 1 }) })}
+        draggingParty={needsPower}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(card(container)).toHaveClass('bg-primary/10')
+    expect(card(container)).not.toHaveClass('bg-primary/20')
+  })
+
+  it('never matches a cabin for a family that asked for nothing', () => {
+    // The withhold rule, at the card. 368 of 479 2026 registrations ask no
+    // housing need; the board must not light up for them.
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: powered({ sleeps: 10 }) })}
+        draggingParty={party({ party_size: 2 })}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(card(container)).not.toHaveClass('bg-primary/20')
+    expect(card(container)).toHaveClass('bg-primary/10')
+  })
+
+  it('reddens the occupancy figure when the family will not fit', () => {
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: powered({ sleeps: 2 }) })}
+        draggingParty={asksNothing}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(within(card(container)).getByText('0/2')).toHaveClass('text-destructive')
+  })
+
+  it('reddens for a family that asked for NOTHING, whose board is otherwise silent', () => {
+    // Deliberately not gated on the mode switch. A family with no requirements
+    // never moves the board out of its resting state, but "you will not fit
+    // here" is still true and is the only question they have.
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: powered({ sleeps: 2 }) })}
+        draggingParty={asksNothing}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(card(container)).not.toHaveClass('bg-primary/20')
+    expect(within(card(container)).getByText('0/2')).toHaveClass('text-destructive')
+  })
+
+  it('keeps the figure at its OWN numbers — the party in flight is never added in', () => {
+    // The card goes on reporting who is actually placed. Adding the dragged
+    // party would make the figure a projection, and N/M has always described
+    // placed people.
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: powered({ sleeps: 4 }), parties: [party({ party_size: 3 })] })}
+        draggingParty={asksNothing}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(within(card(container)).getByText('3/4')).toBeInTheDocument()
+  })
+
+  it('leaves the figure alone when nobody has measured the cabin', () => {
+    // The one thing the board does not know. Never claim from it.
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: powered({ sleeps: null }) })}
+        draggingParty={asksNothing}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(within(card(container)).getByText('0/—')).not.toHaveClass('text-destructive')
+  })
+
+  it('does not redden at rest, when no family is in flight', () => {
+    const { container } = render(
+      <LodgingUnitCard slot={slot({ unit: powered({ sleeps: 2 }) })} onOpenParty={vi.fn()} />
+    )
+    expect(within(card(container)).getByText('0/2')).not.toHaveClass('text-destructive')
   })
 })

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -2856,6 +2856,27 @@ describe('LodgingUnitCard — the drag-time match and the capacity red', () => {
     expect(within(card(container)).getByText('0/—')).not.toHaveClass('text-destructive')
   })
 
+  it('yields the wash to the drop ring on a matching cabin under the cursor', () => {
+    // BOTH set `background-color`. Without the guard a matching card that is
+    // also the active drop target puts `bg-primary/20` and `RING_CLASSES`'
+    // `bg-primary/5` in one class list and lets the emitted stylesheet order
+    // decide — the byte-offset race `RING_CLASSES` exists to kill, and the
+    // same reason `openMarkerActive` has always stood down for a drop target.
+    //
+    // The ring wins: "you are here" outranks "this cabin is like this".
+    overDroppableId = unitDroppableId('cedar-1')
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: powered() })}
+        draggingParty={needsPower}
+        canPlace
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(card(container)).toHaveClass('bg-primary/5')
+    expect(card(container)).not.toHaveClass('bg-primary/20')
+  })
+
   it('does not redden at rest, when no family is in flight', () => {
     const { container } = render(
       <LodgingUnitCard slot={slot({ unit: powered({ sleeps: 2 }) })} onOpenParty={vi.fn()} />

--- a/frontend/src/components/weekend/LodgingUnitCard.test.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.test.tsx
@@ -2877,6 +2877,56 @@ describe('LodgingUnitCard — the drag-time match and the capacity red', () => {
     expect(card(container)).not.toHaveClass('bg-primary/20')
   })
 
+  it('never matches a room somebody is written into', () => {
+    // `slotOccupancy` sums `partySize` over `slot.parties`, and a write-in is
+    // not a party — it contributes 0 (kindred#2439). So the free-bed count is
+    // the WHOLE cabin, and a match would be drawn on a room the very same card
+    // refuses to call empty: it withholds the resting tint because "a room
+    // somebody is already sleeping in is not empty", and it prints an em dash
+    // rather than a numerator because it has no count to print. Washing green
+    // at DOUBLE the withheld tint, off free beds derived from the count it
+    // just refused to assert, is the loudest possible version of that
+    // contradiction.
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: powered({ sleeps: 5, write_ins: [cover()] }) })}
+        draggingParty={needsPower}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(card(container)).not.toHaveClass('bg-primary/20')
+  })
+
+  it('does not redden a room somebody is written into either', () => {
+    // The other half of the write-in rule. The figure already prints an em
+    // dash because there is no count; reddening it would assert "no room"
+    // from the very number the card refuses to state.
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: powered({ sleeps: 2, write_ins: [cover()] }) })}
+        draggingParty={asksNothing}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(within(card(container)).getByText('—/2')).not.toHaveClass('text-destructive')
+  })
+
+  it('does not tell the family they will not fit in the cabin they are in', () => {
+    // Moving a PLACED family between cabins is the board's core operation, so
+    // the dragged party is routinely already an occupant of some card. Its own
+    // beds must not count against it there, or its current cabin reddens to
+    // say it will not fit somewhere it demonstrably does.
+    const staying = party({ party_size: 3 })
+    const { container } = render(
+      <LodgingUnitCard
+        slot={slot({ unit: powered({ sleeps: 3 }), parties: [staying] })}
+        draggingParty={staying}
+        onOpenParty={vi.fn()}
+      />
+    )
+    expect(within(card(container)).getByText('3/3')).not.toHaveClass('text-destructive')
+  })
+
   it('does not redden at rest, when no family is in flight', () => {
     const { container } = render(
       <LodgingUnitCard slot={slot({ unit: powered({ sleeps: 2 }) })} onOpenParty={vi.fn()} />

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -13,7 +13,7 @@
  */
 import { useDraggable, useDroppable } from '@dnd-kit/core'
 import { Bath, Merge, Plug, Plus, Snowflake, Split } from 'lucide-react'
-import { useState } from 'react'
+import { memo, useCallback, useState } from 'react'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
 import { Tooltip } from '../ui/Tooltip'
@@ -257,7 +257,22 @@ export interface LodgingUnitCardProps {
   onOpenParty: (party: RosterPartyRow) => void
 }
 
-export function LodgingUnitCard({
+interface DndBridge {
+  mergeAttributes: Record<string, unknown>
+  mergeListeners: Record<string, unknown> | undefined
+  setMergeDragRef: (n: HTMLElement | null) => void
+  isMergeOver: boolean
+  isUnitOver: boolean
+  setCardRef: (n: HTMLDivElement | null) => void
+}
+
+const LodgingUnitCardInner = memo(function LodgingUnitCardInner({
+  mergeAttributes,
+  mergeListeners,
+  setMergeDragRef,
+  isMergeOver,
+  isUnitOver,
+  setCardRef,
   slot,
   units = [],
   canPlace = false,
@@ -273,7 +288,7 @@ export function LodgingUnitCard({
   unplacedParties = [],
   onPlaceParty,
   onOpenParty,
-}: LodgingUnitCardProps) {
+}: LodgingUnitCardProps & DndBridge) {
   const { unit, parties, consent } = slot
   // Suppressed for a write-in ONLY on this card (kindred#2252). The chip and
   // the well's `WriteInCard` below said the same thing twice — the occupant's
@@ -437,25 +452,12 @@ export function LodgingUnitCard({
   const mergeDragActive = mergeSourceUnit !== null
   const isValidTarget = isValidMergeTarget(mergeSourceUnit, unit)
 
-  const {
-    attributes: mergeAttributes,
-    listeners: mergeListeners,
-    setNodeRef: setMergeDragRef,
-  } = useDraggable({
-    id: mergeDragId(unit.code),
-    disabled: !canMerge,
-  })
-
   // A SEPARATE droppable from the party target below, registered on the same
   // card: `resolveMergeDrop` requires BOTH ids to carry the `merge:` prefix,
   // so a party dropped here must land on `unitDroppableId`, never this one.
   // Disabled whenever this card is not a legal target for whatever is
   // currently being dragged — which is also "always" when no card drag is in
   // flight, since `isValidMergeTarget` refuses a `null` source.
-  const { setNodeRef: setMergeDropRef, isOver: isMergeOver } = useDroppable({
-    id: mergeDragId(unit.code),
-    disabled: !isValidTarget,
-  })
 
   // Every room accepts a drop while placement is live, including a full or
   // unsuitable one. The fit check is advisory by design: a misfit is surfaced
@@ -500,20 +502,11 @@ export function LodgingUnitCard({
   // room" — the em-dash occupancy figure and the open-space to-do tint — and
   // none of them is a refusal.
   const writtenInto = writeIns.length > 0
-  const { setNodeRef: setUnitDropRef, isOver: isUnitOver } = useDroppable({
-    id: unitDroppableId(unit.code),
-    disabled: !canPlace || mergeDragActive,
-  })
 
   // Whether THIS card's Assign modal is open. Per-card state rather than
   // board-level: the modal names one cabin and writes to one cabin, and
   // hoisting it would make every card re-render when any card opened one.
   const [assignOpen, setAssignOpen] = useState(false)
-
-  const setCardRef = (node: HTMLDivElement | null) => {
-    setUnitDropRef(node)
-    setMergeDropRef(node)
-  }
 
   /*
    * Which of the three mutually-exclusive RING states wins — see
@@ -1425,5 +1418,68 @@ export function LodgingUnitCard({
         />
       )}
     </div>
+  )
+})
+
+/**
+ * The dnd-kit subscription, and nothing else.
+ *
+ * `useDroppable`/`useDraggable` subscribe to dnd-kit's InternalContext, whose
+ * identity changes on every `over` transition — dnd-kit publishes through
+ * React context, which has no selective subscription, so every subscriber
+ * re-renders on every flip. With the hooks inside the card body that meant
+ * all ~73 card bodies re-rendered each time the pointer crossed a cabin
+ * boundary (measured: 47% of a drag's wall-clock spent in long tasks).
+ * Here the hooks live in a shell whose whole job is to read them; the body
+ * is `memo`'d, and on an `over` flip exactly TWO bodies re-render — the card
+ * gaining the ring and the card losing it. The shell still re-runs on every
+ * flip (the context subscription is the shell), which is the cheap part:
+ * a props spread and a memo bail.
+ *
+ * `FamilyCard` wears the same split, and the memo only holds while every
+ * prop is identity-stable — `useUnitMerge` learned that the hard way (see
+ * its `mutateAsync` dep), and the sensor options are module constants in
+ * `LodgingBoard` for the same reason.
+ */
+export function LodgingUnitCard(props: LodgingUnitCardProps) {
+  const { slot, canPlace = false, canMerge = false, mergeSourceUnit = null } = props
+  const unit = slot.unit
+  const isValidTarget = isValidMergeTarget(mergeSourceUnit, unit)
+  const mergeDragActive = mergeSourceUnit !== null
+
+  const {
+    attributes: mergeAttributes,
+    listeners: mergeListeners,
+    setNodeRef: setMergeDragRef,
+  } = useDraggable({ id: mergeDragId(unit.code), disabled: !canMerge })
+
+  const { setNodeRef: setMergeDropRef, isOver: isMergeOver } = useDroppable({
+    id: mergeDragId(unit.code),
+    disabled: !isValidTarget,
+  })
+
+  const { setNodeRef: setUnitDropRef, isOver: isUnitOver } = useDroppable({
+    id: unitDroppableId(unit.code),
+    disabled: !canPlace || mergeDragActive,
+  })
+
+  const setCardRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      setUnitDropRef(node)
+      setMergeDropRef(node)
+    },
+    [setUnitDropRef, setMergeDropRef]
+  )
+
+  return (
+    <LodgingUnitCardInner
+      {...props}
+      mergeAttributes={mergeAttributes as unknown as Record<string, unknown>}
+      mergeListeners={mergeListeners as unknown as Record<string, unknown> | undefined}
+      setMergeDragRef={setMergeDragRef}
+      isMergeOver={isMergeOver}
+      isUnitOver={isUnitOver}
+      setCardRef={setCardRef}
+    />
   )
 }

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -138,7 +138,6 @@ export interface LodgingUnitCardProps {
    * no container is named, which is every leaf card.
    */
   units?: LodgingUnitRow[]
-  /** The area's colour — a SECONDARY channel (§3.10), never the only one. */
   /** Placement is live: a scenario is selected and the user holds `bunking.manage`. */
   canPlace?: boolean
   /**
@@ -820,7 +819,13 @@ export function LodgingUnitCard({
     // is one enum rather than three rules racing over a byte offset. A
     // conflict draws NO wash at all: losing the invitation is half the mark
     // and gaining the hatch is the other half.
-    dragFit.state === 'match' ? 'bg-primary/20' : '',
+    // `ringState !== 'dropTarget'` for the reason `openMarkerActive` carries
+    // the same guard: `RING_CLASSES.dropTarget` sets `bg-primary/5`, so a
+    // matching card under the cursor would put two `background-color`
+    // utilities in one class list and let the emitted stylesheet order decide
+    // — the byte-offset race that table exists to kill. The drop ring wins,
+    // because "you are here" outranks "this cabin is like this".
+    dragFit.state === 'match' && ringState !== 'dropTarget' ? 'bg-primary/20' : '',
     openMarkerActive && dragFit.state === 'neutral' ? 'bg-primary/10' : '',
     // `background-image`, which competes with no other channel on this card.
     dragFit.state === 'conflict' ? NEEDS_HATCH_CLASSES[dragFit.severity] : '',
@@ -878,8 +883,8 @@ export function LodgingUnitCard({
        * OTHER, which is exactly why `ringState` above picks one rather than
        * concatenating four; the dashed/dimmed fragments alongside it are
        * additive on purpose (see their own comments) and never race anything
-       * in this table. The hue top edge is a separate inline style and
-       * outranks all of it, which is what keeps §3.10's secondary channel
+       * in this table. The hue top edge USED TO BE a separate inline style
+       * that outranked all of it; it is gone (2026-08-21) and §3.10's channel
        * alive underneath whichever state wins.
        *
        * NO `hover:shadow-lodge-lg` HERE, though `BunkCard` carries one. That

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -22,7 +22,7 @@ import { AssignFamilyModal } from './AssignFamilyModal'
 import { isValidMergeTarget, mergeDragId, unitDroppableId } from './dragPlacement'
 import { FamilyCard } from './FamilyCard'
 import { partyHeadcount } from './householdIdentity'
-import { resolveDragFit, type DragFit } from './needsFit'
+import { hasNoRoom, resolveDragFit, type DragCapacity, type DragFit } from './needsFit'
 import { resolveRingPrecedence } from './ringPrecedence'
 import { effectiveSleeps } from './rosterAttention'
 import { partyKey } from './partyKey'
@@ -718,14 +718,21 @@ export function LodgingUnitCard({
    *
    * Withholding costs a match the board might have been entitled to draw,
    * which is the safe direction for a claim.
+   *
+   * Built ONCE, and both drag-time capacity marks read it: `resolveDragFit`
+   * gates the match on it, and `hasNoRoom` reddens the figure from it. They
+   * were separate inline expressions until the write-in rule had to be applied
+   * to both by hand.
    */
+  const dragCapacity: DragCapacity = {
+    known: capacityKnown && spanWidth === 0 && !writtenInto,
+    free: freeBeds,
+  }
+
   const dragFit: DragFit =
     draggingParty === null
       ? { state: 'neutral', severity: 'fits' }
-      : resolveDragFit(draggingParty, unit, {
-          known: capacityKnown && spanWidth === 0 && !writtenInto,
-          free: freeBeds,
-        })
+      : resolveDragFit(draggingParty, unit, dragCapacity)
 
   /*
    * The N/M figure in red mid-drag: no room for the family in hand. THE SAME
@@ -734,10 +741,9 @@ export function LodgingUnitCard({
    * never added in, so the card goes on reporting who is actually placed.
    *
    * Every cabin without room, on every drag — including cards already hatched
-   * for a requirement. The only cabins exempt are the ones whose free-bed
-   * count is not a fact: unmeasured capacity, a straddling party, and a
-   * wholesale write-in. Those are not exceptions to the rule so much as
-   * cabins the rule has nothing to say about. Narrower scopes were considered
+   * for a requirement. The cabins it stays off are the ones `dragCapacity`
+   * already declares unknowable above, so the exemption is stated once rather
+   * than restated here. Narrower scopes were considered
    * and dropped on PREDICTABILITY (owner, 2026-08-21): a red that appears for
    * some families and not others makes staff reverse-engineer the rule.
    *
@@ -745,12 +751,7 @@ export function LodgingUnitCard({
    * with no requirements never moves the board out of its resting state, but
    * "you will not fit here" is still true and is the only question they have.
    */
-  const noRoomForDrag =
-    draggingParty !== null &&
-    capacityKnown &&
-    spanWidth === 0 &&
-    !writtenInto &&
-    freeBeds < partySize(draggingParty)
+  const noRoomForDrag = draggingParty !== null && hasNoRoom(draggingParty, dragCapacity)
 
   /*
    * kindred#2179's warning: a second party in a space classified for ONE.

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -704,9 +704,10 @@ const LodgingUnitCardInner = memo(function LodgingUnitCardInner({
    * in flight there is nothing to be a misfit FOR and nothing to match, and a
    * board marked all the time says nothing at all.
    *
-   * ADVISORY. Nothing below this line touches `useDroppable`, `opacity` or
-   * `pointer-events` — the drop is still accepted, exactly as the comment on
-   * the party droppable in the shell insists it must be.
+   * ADVISORY. Nothing this value feeds touches `useDroppable`, `opacity` or
+   * `pointer-events` — the shell's droppables never read it, so the drop is
+   * still accepted, exactly as the comment on the party droppable in the
+   * shell insists it must be.
    */
   const dragFit: DragFit =
     draggingParty === null ? NEUTRAL : resolveDragFit(draggingParty, unit, dragCapacity)

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -98,12 +98,18 @@ const RING_CLASSES: Record<'dropTarget' | 'consentFlagged' | 'plain', string> = 
  * here meets the need", which is a different KIND of statement rather than a
  * weaker refusal, so it stays at full contrast: legible, droppable, flagged.
  *
- * Additive, never a `RING_CLASSES` entry, for the reason that table's own doc
- * gives: it exists only for channels that fight over one CSS property
- * (`border-color`, `box-shadow`). `background-image` competes with neither —
- * including with #2093's `bg-primary/10` open-space tint, which is
- * `background-color`. The two compose deliberately: a drag-state mark over a
- * resting-state marker, each still saying its own true thing.
+ * Still the only occupant of `background-image`, and still never a
+ * `RING_CLASSES` entry — that table exists for channels that fight over one
+ * CSS property, and nothing contends for this one.
+ *
+ * ⚠️ IT NO LONGER COMPOSES WITH THE FOREST TINT, and this comment used to say
+ * it did. The two sit on orthogonal properties, so they CAN co-render; the
+ * owner ruled on 2026-08-21 that they must not. A conflict draws the hatch
+ * and loses the wash — gaining the hazard and losing the invitation are two
+ * halves of one mark. Drawn at board scale the old composite read as a dull
+ * deactivated grey rather than a warning, which is the visual language #2093
+ * had just moved the open marker away from. The exclusion is enforced by
+ * `dragFit.state` being ONE enum, not by these two rules racing.
  *
  * Degree is the hatch PERIOD and only the period — same angle, same ink, same
  * alpha, tighter lines. Grading NONE from SOME on a second channel is exactly
@@ -654,20 +660,17 @@ export function LodgingUnitCard({
       : `Capacity not recorded · ${String(occupants)} placed${infantExemptionClause}`
 
   /*
-   * Whether this space meets the needs of the family in flight (#1912) —
-   * `'fits' | 'partial' | 'unmet'`, resolved by `needsFit.ts` against the
-   * SERVER's `power_coverage`, which is taken over the unit's leaf
-   * descendants rather than off its own row. Twelve of the fourteen 2026
-   * family-pool containers record `has_power = 0` while every leaf beneath
-   * them has power, so judging a building by the raw flag would mark twelve
+   * Where the family in flight stands against this space — one `DragFit`,
+   * resolved by `needsFit.ts` against the SERVER's resolved coverage rather
+   * than the unit's own row. Twelve of the fourteen 2026 family-pool
+   * containers record `has_power = 0` while every leaf beneath them has
+   * power, so judging a building by the raw flag would mark twelve
    * entirely-powered buildings unpowered. The TITLE ROW's own plug reads the
-   * same resolved field since kindred#2072's T2 — it used to render the raw
-   * flag, and promoting that to the most prominent row on the card is what
-   * made fixing it part of the same change.
+   * same resolved field since kindred#2072's T2.
    *
-   * `'fits'` at rest, and that is the state, not a fallback: with no family
-   * in flight there is nothing to be a misfit FOR, and a board hatched all
-   * the time says nothing at all.
+   * `'neutral'` at rest, and that is the state, not a fallback: with no
+   * family in flight there is nothing to be a misfit FOR and nothing to
+   * match, and a board marked all the time says nothing at all.
    *
    * ADVISORY. Nothing below this line touches `useDroppable`, `opacity` or
    * `pointer-events` — the drop is still accepted, exactly as the comment on
@@ -681,12 +684,47 @@ export function LodgingUnitCard({
    * positive claim must not be built on one. Withholding costs a match the
    * board might have been entitled to draw, which is the safe direction.
    */
+  /*
+   * Beds the family in flight already holds ON THIS CARD, added back before
+   * anything asks whether it fits.
+   *
+   * Moving a PLACED family between cabins is the board's core operation, so
+   * the dragged party is routinely an occupant of some card already. Counting
+   * its own beds against it makes its current cabin claim it will not fit
+   * somewhere it demonstrably does — and on a shared card it is worse, because
+   * the cabin it is being moved OUT of is exactly the one staff are looking at.
+   */
+  const dragOccupiesHere =
+    draggingParty !== null && slot.parties.some((p) => partyKey(p) === partyKey(draggingParty))
+  // `capacityKnown` is an aliased `!== null` check that TypeScript narrows
+  // through, which is why `capacity` needs no fallback inside it.
+  const freeBeds = capacityKnown
+    ? capacity - occupants + (dragOccupiesHere && draggingParty ? partySize(draggingParty) : 0)
+    : 0
+
+  /*
+   * `known` is withheld on THREE conditions, and the third is not obvious.
+   *
+   * `spanWidth > 0` — the occupant count is an upper bound, not a fact, so a
+   * positive claim must not be built on it (see `slotOccupancy`).
+   *
+   * `writtenInto` — `slotOccupancy` sums `partySize` over `slot.parties`, and
+   * a write-in is not a party (kindred#2439), so it contributes ZERO and the
+   * cabin reads as wholly free. This card already refuses to call such a room
+   * empty and already prints an em dash rather than a numerator, for the same
+   * reason: it has no count. Letting the match wash fire off that absent count
+   * would put the loudest positive mark on the card on the strength of the one
+   * number the card declines to assert.
+   *
+   * Withholding costs a match the board might have been entitled to draw,
+   * which is the safe direction for a claim.
+   */
   const dragFit: DragFit =
     draggingParty === null
       ? { state: 'neutral', severity: 'fits' }
       : resolveDragFit(draggingParty, unit, {
-          known: capacityKnown && spanWidth === 0,
-          free: capacityKnown ? capacity - occupants : 0,
+          known: capacityKnown && spanWidth === 0 && !writtenInto,
+          free: freeBeds,
         })
 
   /*
@@ -695,8 +733,11 @@ export function LodgingUnitCard({
    * statement — and the figure KEEPS ITS OWN NUMBERS. The party in flight is
    * never added in, so the card goes on reporting who is actually placed.
    *
-   * Every cabin without room, on every drag, with no exceptions — including
-   * cards already hatched for a requirement. Narrower scopes were considered
+   * Every cabin without room, on every drag — including cards already hatched
+   * for a requirement. The only cabins exempt are the ones whose free-bed
+   * count is not a fact: unmeasured capacity, a straddling party, and a
+   * wholesale write-in. Those are not exceptions to the rule so much as
+   * cabins the rule has nothing to say about. Narrower scopes were considered
    * and dropped on PREDICTABILITY (owner, 2026-08-21): a red that appears for
    * some families and not others makes staff reverse-engineer the rule.
    *
@@ -708,7 +749,8 @@ export function LodgingUnitCard({
     draggingParty !== null &&
     capacityKnown &&
     spanWidth === 0 &&
-    capacity - occupants < partySize(draggingParty)
+    !writtenInto &&
+    freeBeds < partySize(draggingParty)
 
   /*
    * kindred#2179's warning: a second party in a space classified for ONE.
@@ -884,7 +926,8 @@ export function LodgingUnitCard({
        * concatenating four; the dashed/dimmed fragments alongside it are
        * additive on purpose (see their own comments) and never race anything
        * in this table. The hue top edge USED TO BE a separate inline style
-       * that outranked all of it; it is gone (2026-08-21) and §3.10's channel
+       * that outranked all of it; it is gone (2026-08-21), so these borders
+       * now reach the top edge too and §3.10's channel lives
        * alive underneath whichever state wins.
        *
        * NO `hover:shadow-lodge-lg` HERE, though `BunkCard` carries one. That

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -17,12 +17,12 @@ import { useState } from 'react'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
 import { Tooltip } from '../ui/Tooltip'
-import { overlappingPartyKeys, slotOccupancy, type BoardSlot } from './boardLayout'
+import { overlappingPartyKeys, partySize, slotOccupancy, type BoardSlot } from './boardLayout'
 import { AssignFamilyModal } from './AssignFamilyModal'
 import { isValidMergeTarget, mergeDragId, unitDroppableId } from './dragPlacement'
 import { FamilyCard } from './FamilyCard'
 import { partyHeadcount } from './householdIdentity'
-import { resolveNeedsFit } from './needsFit'
+import { resolveDragFit, type DragFit } from './needsFit'
 import { resolveRingPrecedence } from './ringPrecedence'
 import { effectiveSleeps } from './rosterAttention'
 import { partyKey } from './partyKey'
@@ -120,9 +120,9 @@ const RING_CLASSES: Record<'dropTarget' | 'consentFlagged' | 'plain', string> = 
  */
 const NEEDS_HATCH_CLASSES: Record<'unmet' | 'partial', string> = {
   unmet:
-    '[background-image:repeating-linear-gradient(45deg,transparent_0_4px,hsl(var(--foreground)_/_0.1)_4px_5px)]',
+    '[background-image:repeating-linear-gradient(45deg,transparent_0_4px,hsl(var(--foreground)_/_0.06)_4px_7px)]',
   partial:
-    '[background-image:repeating-linear-gradient(45deg,transparent_0_10px,hsl(var(--foreground)_/_0.1)_10px_11px)]',
+    '[background-image:repeating-linear-gradient(45deg,transparent_0_12px,hsl(var(--foreground)_/_0.06)_12px_15px)]',
 }
 
 export interface LodgingUnitCardProps {
@@ -139,7 +139,6 @@ export interface LodgingUnitCardProps {
    */
   units?: LodgingUnitRow[]
   /** The area's colour — a SECONDARY channel (§3.10), never the only one. */
-  hue: string
   /** Placement is live: a scenario is selected and the user holds `bunking.manage`. */
   canPlace?: boolean
   /**
@@ -256,7 +255,6 @@ export interface LodgingUnitCardProps {
 export function LodgingUnitCard({
   slot,
   units = [],
-  hue,
   canPlace = false,
   canSetAvailability = false,
   savingAvailability = false,
@@ -676,7 +674,42 @@ export function LodgingUnitCard({
    * `pointer-events` — the drop is still accepted, exactly as the comment on
    * the party droppable above insists it must be.
    */
-  const needsFit = draggingParty === null ? 'fits' : resolveNeedsFit(draggingParty, unit)
+  /*
+   * THE DRAG-TIME STATE, resolved once.
+   *
+   * `known` is withheld when `spanWidth > 0`, exactly as `overCapacity` is:
+   * there the occupant count is an upper bound rather than a fact, and a
+   * positive claim must not be built on one. Withholding costs a match the
+   * board might have been entitled to draw, which is the safe direction.
+   */
+  const dragFit: DragFit =
+    draggingParty === null
+      ? { state: 'neutral', severity: 'fits' }
+      : resolveDragFit(draggingParty, unit, {
+          known: capacityKnown && spanWidth === 0,
+          free: capacityKnown ? capacity - occupants : 0,
+        })
+
+  /*
+   * The N/M figure in red mid-drag: no room for the family in hand. THE SAME
+   * treatment `overCapacity` already uses at rest, because it is the same
+   * statement — and the figure KEEPS ITS OWN NUMBERS. The party in flight is
+   * never added in, so the card goes on reporting who is actually placed.
+   *
+   * Every cabin without room, on every drag, with no exceptions — including
+   * cards already hatched for a requirement. Narrower scopes were considered
+   * and dropped on PREDICTABILITY (owner, 2026-08-21): a red that appears for
+   * some families and not others makes staff reverse-engineer the rule.
+   *
+   * Deliberately NOT gated on the party having asked for anything. A family
+   * with no requirements never moves the board out of its resting state, but
+   * "you will not fit here" is still true and is the only question they have.
+   */
+  const noRoomForDrag =
+    draggingParty !== null &&
+    capacityKnown &&
+    spanWidth === 0 &&
+    capacity - occupants < partySize(draggingParty)
 
   /*
    * kindred#2179's warning: a second party in a space classified for ONE.
@@ -783,29 +816,30 @@ export function LodgingUnitCard({
   const cardStateClassName = [
     RING_CLASSES[ringState],
     dashed ? 'border-dashed' : '',
-    openMarkerActive ? 'bg-primary/10' : '',
-    // Additive and UNGATED against everything above it — see
-    // `NEEDS_HATCH_CLASSES`. `background-image` competes with no other
-    // channel on this card, tint included.
-    needsFit === 'fits' ? '' : NEEDS_HATCH_CLASSES[needsFit],
+    // ONE CHANNEL, THREE STATES, mutually exclusive because `dragFit.state`
+    // is one enum rather than three rules racing over a byte offset. A
+    // conflict draws NO wash at all: losing the invitation is half the mark
+    // and gaining the hatch is the other half.
+    dragFit.state === 'match' ? 'bg-primary/20' : '',
+    openMarkerActive && dragFit.state === 'neutral' ? 'bg-primary/10' : '',
+    // `background-image`, which competes with no other channel on this card.
+    dragFit.state === 'conflict' ? NEEDS_HATCH_CLASSES[dragFit.severity] : '',
     dimmed ? 'pointer-events-none opacity-40' : '',
   ]
     .filter(Boolean)
     .join(' ')
 
-  // The title half of the same forest-tint signal (#2093) — additive for the
-  // identical reason `dashed` itself is (see that comment above): `color`
-  // and `font-weight` on this child `<h3>` don't compete with the parent's
-  // `border-color`/`box-shadow`/`background-color` channels, so this is a
-  // plain either/or on ONE property pair rather than a `RING_CLASSES` entry.
-  // Deliberately reuses `openMarkerActive` rather than bare `dashed`: the
-  // owner ruling frames the tint as ONE resting-state signal, and a title
-  // that stayed bold forest while the background wash had already stood down
-  // — for an active drop target, or for a room somebody is written into —
-  // would be the two halves of the same mark silently drifting apart.
-  const openTitleClassName = openMarkerActive
-    ? 'text-primary font-bold'
-    : 'text-foreground font-semibold'
+  /*
+   * NO STATE TOUCHES THE TITLE (owner, 2026-08-21).
+   *
+   * #2093 coupled the forest wash and a bold primary title to one flag so the
+   * two halves could not drift apart. The title half is simply gone — for the
+   * open marker and for the match alike — leaving the card's type at ONE
+   * weight and ONE colour in every state. `background-color` is the only
+   * channel the open marker speaks now, which is what lets the drag-time
+   * states share it without a race.
+   */
+  const titleClassName = 'text-foreground font-semibold'
 
   return (
     <div
@@ -819,15 +853,16 @@ export function LodgingUnitCard({
       // and the board registers Mouse and Touch sensors only, so there is no
       // keyboard drag for a screen reader to be mid-way through. The roster's
       // own `attentionSections` is where the same fact is stated in text.
-      {...(needsFit === 'fits' ? {} : { 'data-needs-fit': needsFit })}
+      {...(dragFit.state === 'conflict' ? { 'data-needs-fit': dragFit.severity } : {})}
       ref={setCardRef}
-      // The area's top edge, and NOTHING else — §3.10's secondary channel,
-      // which the #2179 deletion deliberately did not take with it. No
-      // `boxShadow` here any more: `.card-lodge`'s own elevation and its
+      // No inline style at all now. The area's top edge went with the
+      // 2026-08-21 ruling — §3.10's hue is carried by the section header dot,
+      // which is where the grouping actually happens, so the card's border is
+      // a constant in every state. No `boxShadow` here either: `.card-lodge`'s
+      // own elevation and its
       // `:hover` lift are both the `box-shadow` property, and an inline value
       // beats a stylesheet rule outright, so the struck ring was silently
       // flattening every shared card's hover.
-      style={{ borderTopColor: hue }}
       /*
        * `.card-lodge` is summer's card chrome, not a lookalike — the same
        * class `BunkCard` wears (CLAUDE.md §4, "Family Camp Models Summer").
@@ -888,7 +923,7 @@ export function LodgingUnitCard({
        * ~244px inner width can least afford, so the vertical tightening is the
        * aggressive half and the horizontal one is not.
        */
-      className={`card-lodge flex flex-col gap-2 border-t-[3px] p-2.5 px-3 ${cardStateClassName}`}
+      className={`card-lodge flex flex-col gap-2 p-2.5 px-3 ${cardStateClassName}`}
     >
       {/* THE TITLE ROW — T2, and the amenities ride it as a VARIABLE BLOCK.
           A fixed three-icon slot truncates six of the 73 drawn names at the
@@ -916,7 +951,7 @@ export function LodgingUnitCard({
             `min-w-0` is what lets `truncate` fire at all: a flex child's
             default `min-width: auto` refuses to shrink below its content, and
             the title now has icons beside it competing for the row. */}
-        <h3 className={`min-w-0 truncate text-lg ${openTitleClassName}`}>{unit.name}</h3>
+        <h3 className={`min-w-0 truncate text-lg ${titleClassName}`}>{unit.name}</h3>
         {/* PRESENCE, AND NEVER WHICH KIND (ruling 2). The meta row spelled
             this out as `Bath Private` / `Bath Shared`; the CampMinder question
             behind the family's flag asks for "a bathroom that doesn't require
@@ -1005,7 +1040,9 @@ export function LodgingUnitCard({
           content={occupancyTooltip}
           data-testid="unit-occupancy"
           className={`ml-auto text-sm tabular-nums ${
-            overCapacity ? 'text-destructive font-semibold' : 'text-muted-foreground'
+            overCapacity || noRoomForDrag
+              ? 'text-destructive font-semibold'
+              : 'text-muted-foreground'
           }`}
         >
           {/* An unmeasured room keeps the em dash as its DENOMINATOR. `0/0`

--- a/frontend/src/components/weekend/LodgingUnitCard.tsx
+++ b/frontend/src/components/weekend/LodgingUnitCard.tsx
@@ -11,7 +11,12 @@
  * renders as an em dash: the API already maps PocketBase's stored 0 to null,
  * and "sleeps 0" would be a lie about a cabin nobody has measured.
  */
-import { useDraggable, useDroppable } from '@dnd-kit/core'
+import {
+  useDraggable,
+  useDroppable,
+  type DraggableAttributes,
+  type DraggableSyntheticListeners,
+} from '@dnd-kit/core'
 import { Bath, Merge, Plug, Plus, Snowflake, Split } from 'lucide-react'
 import { memo, useCallback, useState } from 'react'
 
@@ -22,7 +27,7 @@ import { AssignFamilyModal } from './AssignFamilyModal'
 import { isValidMergeTarget, mergeDragId, unitDroppableId } from './dragPlacement'
 import { FamilyCard } from './FamilyCard'
 import { partyHeadcount } from './householdIdentity'
-import { hasNoRoom, resolveDragFit, type DragCapacity, type DragFit } from './needsFit'
+import { NEUTRAL, hasNoRoom, resolveDragFit, type DragCapacity, type DragFit } from './needsFit'
 import { resolveRingPrecedence } from './ringPrecedence'
 import { effectiveSleeps } from './rosterAttention'
 import { partyKey } from './partyKey'
@@ -257,18 +262,35 @@ export interface LodgingUnitCardProps {
   onOpenParty: (party: RosterPartyRow) => void
 }
 
+/**
+ * What the shell hands the memo'd body: the dnd-kit hook results, plus the
+ * two merge-gate facts derived from them. dnd-kit's OWN types, not
+ * `Record<string, unknown>` — erased, `mergeAttributes` and `mergeListeners`
+ * become the same structural type and swapping them at the call site would
+ * type-check, which is exactly the mistake the handle's comment warns about.
+ */
 interface DndBridge {
-  mergeAttributes: Record<string, unknown>
-  mergeListeners: Record<string, unknown> | undefined
+  mergeAttributes: DraggableAttributes
+  mergeListeners: DraggableSyntheticListeners
   setMergeDragRef: (n: HTMLElement | null) => void
   isMergeOver: boolean
   isUnitOver: boolean
   setCardRef: (n: HTMLDivElement | null) => void
+  /**
+   * Derived in the SHELL, which already needs both to gate the droppables,
+   * and ridden down here rather than re-derived from `mergeSourceUnit` —
+   * two derivations 1,000 lines apart is how a card ends up dimmed and
+   * unclickable while still an enabled drop target, or the reverse.
+   */
+  mergeDragActive: boolean
+  isValidTarget: boolean
 }
 
 const LodgingUnitCardInner = memo(function LodgingUnitCardInner({
   mergeAttributes,
   mergeListeners,
+  mergeDragActive,
+  isValidTarget,
   setMergeDragRef,
   isMergeOver,
   isUnitOver,
@@ -280,7 +302,10 @@ const LodgingUnitCardInner = memo(function LodgingUnitCardInner({
   savingAvailability = false,
   onSetAvailability,
   canMerge = false,
-  mergeSourceUnit = null,
+  // NOT destructured here: `mergeSourceUnit` is the SHELL's input — the body
+  // receives the two facts derived from it (`mergeDragActive`,
+  // `isValidTarget`) through the bridge instead, so there is exactly one
+  // derivation.
   draggingParty = null,
   onSplit,
   onMerge,
@@ -449,38 +474,7 @@ const LodgingUnitCardInner = memo(function LodgingUnitCardInner({
    */
   const showSplitControl =
     canMerge && unit.is_container === true && unit.is_combined === true && onSplit !== undefined
-  const mergeDragActive = mergeSourceUnit !== null
-  const isValidTarget = isValidMergeTarget(mergeSourceUnit, unit)
 
-  // A SEPARATE droppable from the party target below, registered on the same
-  // card: `resolveMergeDrop` requires BOTH ids to carry the `merge:` prefix,
-  // so a party dropped here must land on `unitDroppableId`, never this one.
-  // Disabled whenever this card is not a legal target for whatever is
-  // currently being dragged — which is also "always" when no card drag is in
-  // flight, since `isValidMergeTarget` refuses a `null` source.
-
-  // Every room accepts a drop while placement is live, including a full or
-  // unsuitable one. The fit check is advisory by design: a misfit is surfaced
-  // on the board's hatch channel (#1912), never refused at the door, so
-  // refusing here would turn an advisory signal into a hard block. This once
-  // read "every cabin is unconfirmed until staff walk the property" — no longer
-  // true, 118 of 118 confirmed in the production snapshot of 2026-08-06 — but
-  // the rule never depended on it.
-  //
-  // Disabled for every card while a MERGE drag is in flight: without this, a
-  // card being dragged onto a sibling would sit over two overlapping,
-  // simultaneously-enabled droppables — this one and the merge droppable
-  // above — and which one dnd-kit resolves `over` to would be a tie decided
-  // by hook registration order, not by which gesture is actually in flight.
-  //
-  // NOT disabled on a WRITTEN-INTO unit any more — kindred#2432, owner ruling
-  // 2026-08-18: *"we should be able to add families to any write in space, or
-  // add a write in to a family space — regardless of which came first."* This
-  // read `|| held` until then, the AFFORDANCE half of #2090's refusal, whose
-  // enforcing half lived in `resolveDrop`. Both went in the same change, and
-  // they have to: leaving this one would keep the card from ever reporting
-  // `isOver`, so a drop the resolver now accepts could never be aimed at it.
-  //
   // Read through `writeInEntries` rather than as an inline
   // `family_available_override === false`, which is what this was until
   // kindred#2078. Three consumers on this card shared that expression under
@@ -653,31 +647,6 @@ const LodgingUnitCardInner = memo(function LodgingUnitCardInner({
       : `Capacity not recorded · ${String(occupants)} placed${infantExemptionClause}`
 
   /*
-   * Where the family in flight stands against this space — one `DragFit`,
-   * resolved by `needsFit.ts` against the SERVER's resolved coverage rather
-   * than the unit's own row. Twelve of the fourteen 2026 family-pool
-   * containers record `has_power = 0` while every leaf beneath them has
-   * power, so judging a building by the raw flag would mark twelve
-   * entirely-powered buildings unpowered. The TITLE ROW's own plug reads the
-   * same resolved field since kindred#2072's T2.
-   *
-   * `'neutral'` at rest, and that is the state, not a fallback: with no
-   * family in flight there is nothing to be a misfit FOR and nothing to
-   * match, and a board marked all the time says nothing at all.
-   *
-   * ADVISORY. Nothing below this line touches `useDroppable`, `opacity` or
-   * `pointer-events` — the drop is still accepted, exactly as the comment on
-   * the party droppable above insists it must be.
-   */
-  /*
-   * THE DRAG-TIME STATE, resolved once.
-   *
-   * `known` is withheld when `spanWidth > 0`, exactly as `overCapacity` is:
-   * there the occupant count is an upper bound rather than a fact, and a
-   * positive claim must not be built on one. Withholding costs a match the
-   * board might have been entitled to draw, which is the safe direction.
-   */
-  /*
    * Beds the family in flight already holds ON THIS CARD, added back before
    * anything asks whether it fits.
    *
@@ -722,10 +691,25 @@ const LodgingUnitCardInner = memo(function LodgingUnitCardInner({
     free: freeBeds,
   }
 
+  /*
+   * Where the family in flight stands against this space — one `DragFit`,
+   * resolved by `needsFit.ts` against the SERVER's resolved coverage rather
+   * than the unit's own row. Twelve of the fourteen 2026 family-pool
+   * containers record `has_power = 0` while every leaf beneath them has
+   * power, so judging a building by the raw flag would mark twelve
+   * entirely-powered buildings unpowered. The TITLE ROW's own plug reads the
+   * same resolved field since kindred#2072's T2.
+   *
+   * `NEUTRAL` at rest, and that is the state, not a fallback: with no family
+   * in flight there is nothing to be a misfit FOR and nothing to match, and a
+   * board marked all the time says nothing at all.
+   *
+   * ADVISORY. Nothing below this line touches `useDroppable`, `opacity` or
+   * `pointer-events` — the drop is still accepted, exactly as the comment on
+   * the party droppable in the shell insists it must be.
+   */
   const dragFit: DragFit =
-    draggingParty === null
-      ? { state: 'neutral', severity: 'fits' }
-      : resolveDragFit(draggingParty, unit, dragCapacity)
+    draggingParty === null ? NEUTRAL : resolveDragFit(draggingParty, unit, dragCapacity)
 
   /*
    * The N/M figure in red mid-drag: no room for the family in hand. THE SAME
@@ -921,8 +905,8 @@ const LodgingUnitCardInner = memo(function LodgingUnitCardInner({
        * additive on purpose (see their own comments) and never race anything
        * in this table. The hue top edge USED TO BE a separate inline style
        * that outranked all of it; it is gone (2026-08-21), so these borders
-       * now reach the top edge too and §3.10's channel lives
-       * alive underneath whichever state wins.
+       * now reach the top edge too. §3.10's channel did not move underneath —
+       * it left the card entirely, for the section header's dot.
        *
        * NO `hover:shadow-lodge-lg` HERE, though `BunkCard` carries one. That
        * class is inert: `.shadow-lodge-*` are hand-written rules in `@layer
@@ -1453,11 +1437,40 @@ export function LodgingUnitCard(props: LodgingUnitCardProps) {
     setNodeRef: setMergeDragRef,
   } = useDraggable({ id: mergeDragId(unit.code), disabled: !canMerge })
 
+  // A SEPARATE droppable from the party target below, registered on the same
+  // card: `resolveMergeDrop` requires BOTH ids to carry the `merge:` prefix,
+  // so a party dropped here must land on `unitDroppableId`, never this one.
+  // Disabled whenever this card is not a legal target for whatever is
+  // currently being dragged — which is also "always" when no card drag is in
+  // flight, since `isValidMergeTarget` refuses a `null` source.
+
   const { setNodeRef: setMergeDropRef, isOver: isMergeOver } = useDroppable({
     id: mergeDragId(unit.code),
     disabled: !isValidTarget,
   })
 
+  // Every room accepts a drop while placement is live, including a full or
+  // unsuitable one. The fit check is advisory by design: a misfit is surfaced
+  // on the board's hatch channel (#1912), never refused at the door, so
+  // refusing here would turn an advisory signal into a hard block. This once
+  // read "every cabin is unconfirmed until staff walk the property" — no longer
+  // true, 118 of 118 confirmed in the production snapshot of 2026-08-06 — but
+  // the rule never depended on it.
+  //
+  // Disabled for every card while a MERGE drag is in flight: without this, a
+  // card being dragged onto a sibling would sit over two overlapping,
+  // simultaneously-enabled droppables — this one and the merge droppable
+  // above — and which one dnd-kit resolves `over` to would be a tie decided
+  // by hook registration order, not by which gesture is actually in flight.
+  //
+  // NOT disabled on a WRITTEN-INTO unit any more — kindred#2432, owner ruling
+  // 2026-08-18: *"we should be able to add families to any write in space, or
+  // add a write in to a family space — regardless of which came first."* This
+  // read `|| held` until then, the AFFORDANCE half of #2090's refusal, whose
+  // enforcing half lived in `resolveDrop`. Both went in the same change, and
+  // they have to: leaving this one would keep the card from ever reporting
+  // `isOver`, so a drop the resolver now accepts could never be aimed at it.
+  //
   const { setNodeRef: setUnitDropRef, isOver: isUnitOver } = useDroppable({
     id: unitDroppableId(unit.code),
     disabled: !canPlace || mergeDragActive,
@@ -1474,12 +1487,14 @@ export function LodgingUnitCard(props: LodgingUnitCardProps) {
   return (
     <LodgingUnitCardInner
       {...props}
-      mergeAttributes={mergeAttributes as unknown as Record<string, unknown>}
-      mergeListeners={mergeListeners as unknown as Record<string, unknown> | undefined}
+      mergeAttributes={mergeAttributes}
+      mergeListeners={mergeListeners}
       setMergeDragRef={setMergeDragRef}
       isMergeOver={isMergeOver}
       isUnitOver={isUnitOver}
       setCardRef={setCardRef}
+      mergeDragActive={mergeDragActive}
+      isValidTarget={isValidTarget}
     />
   )
 }

--- a/frontend/src/components/weekend/boardCollision.test.ts
+++ b/frontend/src/components/weekend/boardCollision.test.ts
@@ -91,6 +91,45 @@ describe('createBoardCollisionDetection', () => {
     ])
   })
 
+  it('a cabin-first gutter frame TARGETS the cabin after crossing the queue', () => {
+    // The drop target is `collisions[0]`. The queue-first frames above cannot
+    // tell a correct implementation from one that returns the queue alone —
+    // `over` is the queue either way. This frame stages the cabin sorting
+    // FIRST, where a lingering queue hold would flip the target from cabin to
+    // queue: the difference between placing the family and UNPLACING it.
+    const detect = detector()
+    detect(stage([UNPLACED_DROPPABLE_ID], [UNPLACED_DROPPABLE_ID, CEDAR]))
+    const result = ids(detect(stage([], [CEDAR, UNPLACED_DROPPABLE_ID])))
+    expect(result[0]).toBe(CEDAR)
+  })
+
+  it('the queue releases the hold even when a cabin sorts ahead of it', () => {
+    // `pointerWithin` ranks by corner distance, so a card under the queue's
+    // large expanded panel can sort ahead of `weekend-unplaced`. The pointer
+    // is inside the queue either way, and the release must key on the
+    // queue's PRESENCE among the pointer hits, not on it winning first place.
+    const detect = detector()
+    detect(stage([CEDAR], [CEDAR]))
+    detect(stage([WILLOW, UNPLACED_DROPPABLE_ID], [WILLOW, UNPLACED_DROPPABLE_ID, CEDAR]))
+    expect(ids(detect(stage([], [UNPLACED_DROPPABLE_ID, CEDAR, WILLOW])))).toEqual([
+      UNPLACED_DROPPABLE_ID,
+      CEDAR,
+      WILLOW,
+    ])
+  })
+
+  it('an EMPTY frame does not end the hold', () => {
+    // A frame with no usable rects at all — the drag rect over whitespace
+    // past the last section, or a transient re-measure — proves nothing
+    // about the held cabin. Only a frame that produced rects WITHOUT the
+    // held cabin shows the drag has genuinely left it; clearing on emptiness
+    // re-admits the flapping for the rest of the gesture.
+    const detect = detector()
+    detect(stage([CEDAR], [CEDAR]))
+    detect(stage([], []))
+    expect(ids(detect(stage([], [WILLOW, CEDAR])))).toEqual([CEDAR])
+  })
+
   it('falls back to rect intersection once the held cabin no longer intersects', () => {
     const detect = detector()
     detect(stage([CEDAR], [CEDAR]))

--- a/frontend/src/components/weekend/boardCollision.test.ts
+++ b/frontend/src/components/weekend/boardCollision.test.ts
@@ -1,0 +1,71 @@
+/**
+ * The board's collision policy — which cabin a drag is "over".
+ *
+ * The two dnd-kit algorithms are injected, so these assert the POLICY without
+ * building a droppable registry and measured rects. Fictional data throughout.
+ */
+import type { pointerWithin } from '@dnd-kit/core'
+import { describe, expect, it } from 'vitest'
+
+import { createBoardCollisionDetection } from './boardCollision'
+
+type CollisionArgs = Parameters<typeof pointerWithin>[0]
+type Collisions = ReturnType<typeof pointerWithin>
+
+const hit = (id: string) => ({ id, data: { droppableContainer: undefined, value: 0 } })
+
+/** The two lists a given pointer position would produce, carried on the args. */
+interface Staged {
+  pointer: string[]
+  rect: string[]
+}
+
+function stage(pointer: string[], rect: string[]): CollisionArgs {
+  return { pointer, rect } as unknown as CollisionArgs
+}
+
+function detector() {
+  return createBoardCollisionDetection({
+    pointerWithin: (args: CollisionArgs): Collisions =>
+      (args as unknown as Staged).pointer.map(hit) as Collisions,
+    rectIntersection: (args: CollisionArgs): Collisions =>
+      (args as unknown as Staged).rect.map(hit) as Collisions,
+  })
+}
+
+const ids = (collisions: Collisions) => collisions.map((collision) => String(collision.id))
+
+describe('createBoardCollisionDetection', () => {
+  it('returns the pointer hit when the pointer is inside a cabin', () => {
+    const detect = detector()
+    expect(ids(detect(stage(['unit:a'], ['unit:b'])))).toEqual(['unit:a'])
+  })
+
+  it('HOLDS the last cabin the pointer was inside while crossing a gutter', () => {
+    const detect = detector()
+    detect(stage(['unit:a'], ['unit:a', 'unit:b']))
+    // In the gutter the overlay overlaps B most — but A is still intersecting,
+    // and A is where the pointer actually was.
+    expect(ids(detect(stage([], ['unit:b', 'unit:a'])))).toEqual(['unit:a'])
+  })
+
+  it('falls back to rect intersection once the held cabin no longer intersects', () => {
+    const detect = detector()
+    detect(stage(['unit:a'], ['unit:a']))
+    expect(ids(detect(stage([], ['unit:c'])))).toEqual(['unit:c'])
+  })
+
+  it('forgets the held cabin when the gesture resets', () => {
+    const detect = detector()
+    detect(stage(['unit:a'], ['unit:a']))
+    detect.reset()
+    expect(ids(detect(stage([], ['unit:b', 'unit:a'])))).toEqual(['unit:b', 'unit:a'])
+  })
+
+  it('re-holds on the new cabin once the pointer enters one', () => {
+    const detect = detector()
+    detect(stage(['unit:a'], ['unit:a']))
+    detect(stage(['unit:b'], ['unit:b', 'unit:a']))
+    expect(ids(detect(stage([], ['unit:a', 'unit:b'])))).toEqual(['unit:b'])
+  })
+})

--- a/frontend/src/components/weekend/boardCollision.test.ts
+++ b/frontend/src/components/weekend/boardCollision.test.ts
@@ -2,15 +2,26 @@
  * The board's collision policy — which cabin a drag is "over".
  *
  * The two dnd-kit algorithms are injected, so these assert the POLICY without
- * building a droppable registry and measured rects. Fictional data throughout.
+ * building a droppable registry and measured rects. Ids are the PRODUCTION
+ * shapes from `dragPlacement` — `weekend-unit:*`, `merge:*`, and the floating
+ * queue's `weekend-unplaced` — because the first version of this file used
+ * `unit:a`-style ids and could not distinguish a namespace-blind
+ * implementation from a correct one. Fictional data throughout.
  */
 import type { pointerWithin } from '@dnd-kit/core'
 import { describe, expect, it } from 'vitest'
 
 import { createBoardCollisionDetection } from './boardCollision'
+import { UNPLACED_DROPPABLE_ID, mergeDragId, unitDroppableId } from './dragPlacement'
 
 type CollisionArgs = Parameters<typeof pointerWithin>[0]
 type Collisions = ReturnType<typeof pointerWithin>
+
+const CEDAR = unitDroppableId('cedar-1')
+const WILLOW = unitDroppableId('willow-2')
+const ASPEN = unitDroppableId('aspen-3')
+const MERGE_CEDAR = mergeDragId('cedar-1')
+const MERGE_WILLOW = mergeDragId('willow-2')
 
 const hit = (id: string) => ({ id, data: { droppableContainer: undefined, value: 0 } })
 
@@ -38,34 +49,76 @@ const ids = (collisions: Collisions) => collisions.map((collision) => String(col
 describe('createBoardCollisionDetection', () => {
   it('returns the pointer hit when the pointer is inside a cabin', () => {
     const detect = detector()
-    expect(ids(detect(stage(['unit:a'], ['unit:b'])))).toEqual(['unit:a'])
+    expect(ids(detect(stage([CEDAR], [WILLOW])))).toEqual([CEDAR])
   })
 
   it('HOLDS the last cabin the pointer was inside while crossing a gutter', () => {
     const detect = detector()
-    detect(stage(['unit:a'], ['unit:a', 'unit:b']))
-    // In the gutter the overlay overlaps B most — but A is still intersecting,
-    // and A is where the pointer actually was.
-    expect(ids(detect(stage([], ['unit:b', 'unit:a'])))).toEqual(['unit:a'])
+    detect(stage([CEDAR], [CEDAR, WILLOW]))
+    // In the gutter the overlay overlaps Willow most — but Cedar is still
+    // intersecting, and Cedar is where the pointer actually was.
+    expect(ids(detect(stage([], [WILLOW, CEDAR])))).toEqual([CEDAR])
+  })
+
+  it('holds a merge sibling the same way during a merge drag', () => {
+    const detect = detector()
+    detect(stage([MERGE_CEDAR], [MERGE_CEDAR, MERGE_WILLOW]))
+    expect(ids(detect(stage([], [MERGE_WILLOW, MERGE_CEDAR])))).toEqual([MERGE_CEDAR])
+  })
+
+  it('NEVER holds the floating unplaced queue', () => {
+    const detect = detector()
+    // The pointer crosses the queue — a fixed overlay that floats above the
+    // grid — then moves on into a gutter where the queue's big rect still
+    // intersects the overlay. The hold must not let the queue suppress the
+    // cabins beneath: a release here would UNPLACE the family.
+    detect(stage([UNPLACED_DROPPABLE_ID], [UNPLACED_DROPPABLE_ID, CEDAR]))
+    expect(ids(detect(stage([], [UNPLACED_DROPPABLE_ID, CEDAR])))).toEqual([
+      UNPLACED_DROPPABLE_ID,
+      CEDAR,
+    ])
+  })
+
+  it('crossing the queue also RELEASES a cabin held before it', () => {
+    const detect = detector()
+    detect(stage([CEDAR], [CEDAR]))
+    detect(stage([UNPLACED_DROPPABLE_ID], [UNPLACED_DROPPABLE_ID, CEDAR]))
+    // Cedar's hold must not survive the trip through the queue: the pointer
+    // has demonstrably left it.
+    expect(ids(detect(stage([], [UNPLACED_DROPPABLE_ID, CEDAR])))).toEqual([
+      UNPLACED_DROPPABLE_ID,
+      CEDAR,
+    ])
   })
 
   it('falls back to rect intersection once the held cabin no longer intersects', () => {
     const detect = detector()
-    detect(stage(['unit:a'], ['unit:a']))
-    expect(ids(detect(stage([], ['unit:c'])))).toEqual(['unit:c'])
+    detect(stage([CEDAR], [CEDAR]))
+    expect(ids(detect(stage([], [ASPEN])))).toEqual([ASPEN])
+  })
+
+  it('a hold does NOT resurrect after the held cabin has dropped out once', () => {
+    const detect = detector()
+    detect(stage([CEDAR], [CEDAR]))
+    // The drag travels far away: Cedar stops intersecting, the fallback
+    // speaks. That moment ENDS the hold —
+    detect(stage([], [ASPEN]))
+    // — so when the ~200px overlay later slides back across Cedar while the
+    // pointer sits in a gutter beside Willow, Cedar must not steal the drop.
+    expect(ids(detect(stage([], [WILLOW, CEDAR])))).toEqual([WILLOW, CEDAR])
   })
 
   it('forgets the held cabin when the gesture resets', () => {
     const detect = detector()
-    detect(stage(['unit:a'], ['unit:a']))
+    detect(stage([CEDAR], [CEDAR]))
     detect.reset()
-    expect(ids(detect(stage([], ['unit:b', 'unit:a'])))).toEqual(['unit:b', 'unit:a'])
+    expect(ids(detect(stage([], [WILLOW, CEDAR])))).toEqual([WILLOW, CEDAR])
   })
 
   it('re-holds on the new cabin once the pointer enters one', () => {
     const detect = detector()
-    detect(stage(['unit:a'], ['unit:a']))
-    detect(stage(['unit:b'], ['unit:b', 'unit:a']))
-    expect(ids(detect(stage([], ['unit:a', 'unit:b'])))).toEqual(['unit:b'])
+    detect(stage([CEDAR], [CEDAR]))
+    detect(stage([WILLOW], [WILLOW, CEDAR]))
+    expect(ids(detect(stage([], [CEDAR, WILLOW])))).toEqual([WILLOW])
   })
 })

--- a/frontend/src/components/weekend/boardCollision.ts
+++ b/frontend/src/components/weekend/boardCollision.ts
@@ -62,7 +62,6 @@ export function createBoardCollisionDetection(
   const detect = ((args: CollisionArgs): Collisions => {
     const pointerCollisions = algorithms.pointerWithin(args)
     if (pointerCollisions.length > 0) {
-      const id = String(pointerCollisions[0]?.id ?? '')
       // NEVER hold the floating unplaced queue. It is the one droppable that
       // is not a cabin on the grid — a fixed overlay hovering ABOVE the cards
       // — so its rect keeps intersecting the drag long after the pointer has
@@ -72,7 +71,16 @@ export function createBoardCollisionDetection(
       // does: the pointer has demonstrably left that cabin. Any future
       // floating droppable must join this exclusion — the rule is "hold
       // cabins", and this is the list of things that are not cabins.
-      heldId = id === UNPLACED_DROPPABLE_ID ? null : id
+      //
+      // `some`, not `[0]`: `pointerWithin` ranks by corner distance, so a
+      // card beneath the queue's large expanded panel can sort AHEAD of it
+      // while the pointer is inside the queue all the same. The release keys
+      // on the queue's presence among the hits, not on it winning first
+      // place.
+      const overQueue = pointerCollisions.some(
+        (collision) => String(collision.id) === UNPLACED_DROPPABLE_ID
+      )
+      heldId = overQueue ? null : String(pointerCollisions[0]?.id ?? '')
       return pointerCollisions
     }
 
@@ -89,7 +97,12 @@ export function createBoardCollisionDetection(
       // resurrect later in the same gesture — the ~200px overlay sliding back
       // across the old cabin while the pointer sits in a gutter somewhere
       // else would return that cabin alone and steal the drop.
-      heldId = null
+      //
+      // Only a frame that PRODUCED rects proves that, though. An empty frame
+      // — the drag rect over whitespace past the last section, a transient
+      // re-measure — says nothing about the held cabin, and clearing on it
+      // would re-admit the flapping for the rest of the gesture.
+      if (rectCollisions.length > 0) heldId = null
       return rectCollisions
     }
     return [held]

--- a/frontend/src/components/weekend/boardCollision.ts
+++ b/frontend/src/components/weekend/boardCollision.ts
@@ -38,6 +38,8 @@
  */
 import { pointerWithin, rectIntersection } from '@dnd-kit/core'
 
+import { UNPLACED_DROPPABLE_ID } from './dragPlacement'
+
 type CollisionArgs = Parameters<typeof pointerWithin>[0]
 type Collisions = ReturnType<typeof pointerWithin>
 
@@ -60,7 +62,17 @@ export function createBoardCollisionDetection(
   const detect = ((args: CollisionArgs): Collisions => {
     const pointerCollisions = algorithms.pointerWithin(args)
     if (pointerCollisions.length > 0) {
-      heldId = String(pointerCollisions[0]?.id ?? '')
+      const id = String(pointerCollisions[0]?.id ?? '')
+      // NEVER hold the floating unplaced queue. It is the one droppable that
+      // is not a cabin on the grid — a fixed overlay hovering ABOVE the cards
+      // — so its rect keeps intersecting the drag long after the pointer has
+      // moved on. Held, it would suppress every cabin under it and turn a
+      // gutter release into an UNPLACE. Crossing it also ends whatever cabin
+      // hold was in force, for the same reason the fallback branch below
+      // does: the pointer has demonstrably left that cabin. Any future
+      // floating droppable must join this exclusion — the rule is "hold
+      // cabins", and this is the list of things that are not cabins.
+      heldId = id === UNPLACED_DROPPABLE_ID ? null : id
       return pointerCollisions
     }
 
@@ -71,7 +83,16 @@ export function createBoardCollisionDetection(
     // returning the held one alone is the same answer with no ambiguity about
     // ordering.
     const held = rectCollisions.find((collision) => String(collision.id) === heldId)
-    return held === undefined ? rectCollisions : [held]
+    if (held === undefined) {
+      // The held cabin no longer intersects: the drag has genuinely left it,
+      // and the hold ENDS HERE rather than lying dormant. Kept, it would
+      // resurrect later in the same gesture — the ~200px overlay sliding back
+      // across the old cabin while the pointer sits in a gutter somewhere
+      // else would return that cabin alone and steal the drop.
+      heldId = null
+      return rectCollisions
+    }
+    return [held]
   }) as BoardCollisionDetection
 
   detect.reset = () => {

--- a/frontend/src/components/weekend/boardCollision.ts
+++ b/frontend/src/components/weekend/boardCollision.ts
@@ -1,0 +1,82 @@
+/**
+ * Which cabin the drag is over — the board's collision policy, in one place.
+ *
+ * POINTER FIRST, and that half is summer's: without it a drop released over
+ * dead space snaps to whichever cabin happens to be nearest, placing a family
+ * somewhere nobody chose.
+ *
+ * The half that is new is what happens when the pointer is inside NO cabin.
+ * The board is a wrapping grid with a 12px gap, so a pointer travelling
+ * between two cards spends several frames in a gutter. `pointerWithin` returns
+ * nothing there, and the `rectIntersection` fallback scores by overlap of the
+ * DRAGGED RECT — a ~200px overlay that straddles several cards — so the winner
+ * is frequently a card the pointer never entered, and it changes as the
+ * overlay slides.
+ *
+ * Measured on the board at 1600px, one deliberate diagonal move across four
+ * intended targets: SIX `over` transitions including two reversals, one of
+ * them an 86ms flash on a card the pointer never touched. That is visible as
+ * the drop ring clicking between neighbours — and it is not only cosmetic,
+ * because the ring and the drop target are the same `over`. Releasing during
+ * the flap places the family in a cabin the pointer was never over.
+ *
+ * So: while the pointer is in dead space, HOLD the last cabin it was actually
+ * inside, for as long as that cabin is still among the rects the drag
+ * overlaps. Once it is not — the drag has genuinely left — the fallback speaks
+ * again, and a release over dead space still lands somewhere rather than being
+ * silently dropped.
+ *
+ * Stateful across calls BY DESIGN, which is why this is a factory rather than
+ * a bare function: the held cabin is the state. `reset()` clears it, and the
+ * board calls that on drag start and end so one gesture can never inherit the
+ * previous gesture's hold.
+ *
+ * The two algorithms are injected so the policy is testable without building
+ * dnd-kit's droppable registry and measured rects — the same reason
+ * `ringPrecedence` and `needsFit` are pure modules rather than logic inside
+ * the card.
+ */
+import { pointerWithin, rectIntersection } from '@dnd-kit/core'
+
+type CollisionArgs = Parameters<typeof pointerWithin>[0]
+type Collisions = ReturnType<typeof pointerWithin>
+
+interface CollisionAlgorithms {
+  pointerWithin: (args: CollisionArgs) => Collisions
+  rectIntersection: (args: CollisionArgs) => Collisions
+}
+
+export interface BoardCollisionDetection {
+  (args: CollisionArgs): Collisions
+  /** Forget the held cabin. The board calls this on drag start and drag end. */
+  reset: () => void
+}
+
+export function createBoardCollisionDetection(
+  algorithms: CollisionAlgorithms = { pointerWithin, rectIntersection }
+): BoardCollisionDetection {
+  let heldId: string | null = null
+
+  const detect = ((args: CollisionArgs): Collisions => {
+    const pointerCollisions = algorithms.pointerWithin(args)
+    if (pointerCollisions.length > 0) {
+      heldId = String(pointerCollisions[0]?.id ?? '')
+      return pointerCollisions
+    }
+
+    const rectCollisions = algorithms.rectIntersection(args)
+    if (heldId === null) return rectCollisions
+
+    // `find`, not a filter: dnd-kit reads the FIRST collision as `over`, so
+    // returning the held one alone is the same answer with no ambiguity about
+    // ordering.
+    const held = rectCollisions.find((collision) => String(collision.id) === heldId)
+    return held === undefined ? rectCollisions : [held]
+  }) as BoardCollisionDetection
+
+  detect.reset = () => {
+    heldId = null
+  }
+
+  return detect
+}

--- a/frontend/src/components/weekend/boardLayout.ts
+++ b/frontend/src/components/weekend/boardLayout.ts
@@ -56,6 +56,7 @@ import {
   buildingsSpanned,
   coveredCodes,
   drawnUnits,
+  indexUnitsByCode,
   representingCodes,
   wholeBuildingHeld,
 } from './unitLevel'
@@ -209,7 +210,7 @@ export interface SlotOccupancy {
  * because the second copy had not been told.
  */
 export function slotOccupancy(slot: BoardSlot, units: LodgingUnitRow[]): SlotOccupancy {
-  const unitsByCode = new Map(units.map((unit) => [unit.code, unit]))
+  const unitsByCode = indexUnitsByCode(units)
   const covered = new Set(coveredCodes(slot.unit, units))
   let occupants = 0
   let spanWidth = 0
@@ -650,7 +651,7 @@ export function overlappingPartyKeys(
   parties: RosterPartyRow[],
   units: LodgingUnitRow[]
 ): Set<string> {
-  const unitsByCode = new Map(units.map((unit) => [unit.code, unit]))
+  const unitsByCode = indexUnitsByCode(units)
 
   // Expanded ONCE, then used for both the grouping and the overlap. Two
   // separate expansions is how the guard and the thing it guards drifted apart
@@ -730,7 +731,7 @@ export function wholeBuildingHolders(
   parties: RosterPartyRow[],
   units: LodgingUnitRow[]
 ): Set<string> {
-  const unitsByCode = new Map(units.map((unit) => [unit.code, unit]))
+  const unitsByCode = indexUnitsByCode(units)
   const holders = new Set<string>()
   for (const party of parties) {
     const leaves = occupiedLeafCodes(party, units, unitsByCode)
@@ -915,7 +916,7 @@ function isPlanningInventory(unit: LodgingUnitRow): boolean {
 }
 
 function indexPayload(parties: RosterPartyRow[], units: LodgingUnitRow[]) {
-  const unitsByCode = new Map(units.map((unit) => [unit.code, unit]))
+  const unitsByCode = indexUnitsByCode(units)
 
   // Which units get a card, at each tree's resolved level. Replaces the old
   // "every non-container leaf" rule: a combined container IS a card now, and

--- a/frontend/src/components/weekend/mapModel.ts
+++ b/frontend/src/components/weekend/mapModel.ts
@@ -14,7 +14,7 @@
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
 import { buildBoard, slotOccupancy, type ConsentFlag } from './boardLayout'
 import { effectiveSleeps } from './rosterAttention'
-import { coveredCodes } from './unitLevel'
+import { coveredCodes, indexUnitsByCode } from './unitLevel'
 
 /** Why the map cannot draw a party the board can. */
 export type OffMapReason =
@@ -162,7 +162,7 @@ function offMapReason(party: RosterPartyRow): OffMapReason {
  */
 function unitRoomCount(unit: LodgingUnitRow, units: LodgingUnitRow[]): number {
   if (unit.is_container !== true) return 1
-  const byCode = new Map(units.map((row) => [row.code, row]))
+  const byCode = indexUnitsByCode(units)
   const active = coveredCodes(unit, units).filter(
     (code) => byCode.get(code)?.is_active !== false
   ).length

--- a/frontend/src/components/weekend/needGlyphs.ts
+++ b/frontend/src/components/weekend/needGlyphs.ts
@@ -86,27 +86,6 @@ export type NeedKey = 'bathroom' | 'power' | 'fridge' | 'step_free'
  */
 export type NeedReading = 'placed' | 'prospective'
 
-/**
- * WHAT AN `unknown` COVERAGE MEANS: not met — `fits` is not silence, it is
- * the mark in its full hue asserting the need is met, and the owner ruling of
- * 2026-08-20 (*"unknown values should not equal fits, across all surfaces on
- * the glyphs, its unconfirmed information"*) forbids unconfirmed information
- * reading that way.
- *
- * ONE READING NOW, where there used to be a parameter. `UnknownReading` let
- * the drag-time hatch read `unknown` as `'fits'` instead, because the hatch
- * is an interruption whose bar is evidence of absence — and the number behind
- * that was not close: 102 of 118 cabins carry `ramp_coverage: 'unknown'`, so
- * reading it as unmet took a step-free household's hatched cabins from 32 of
- * 944 pairs to 848. That escape moved into the resolver itself on 2026-08-21:
- * `resolveDragFit` intercepts `unknown` BEFORE grading (its rule 2 —
- * unrecorded coverage makes neither claim, conflict nor match), so no caller
- * asks this table about `unknown` with hatch semantics any more, and the
- * parameter came out rather than sitting reachable-but-never-passed. The
- * reasoning is kept because it is the answer to "why doesn't the hatch just
- * grade unknown like the glyphs do" — it still doesn't, one layer up.
- */
-
 export interface NeedGlyphSpec {
   readonly key: NeedKey
   /** The household's asked-for need. */
@@ -349,6 +328,20 @@ export function needCoverage(
  * whose `ramp_coverage` the server could not resolve. The roster's section
  * counts do not move at all — `ROSTER_NEEDS` grades bathroom and power, and
  * every placed party's coverage for those two is already `all` or `none`.
+ *
+ * ONE READING OF `unknown` NOW, where there used to be a parameter.
+ * `UnknownReading` let the drag-time hatch read `unknown` as `'fits'`
+ * instead, because the hatch is an interruption whose bar is evidence of
+ * absence — and the number behind that was not close: 102 of 118 cabins carry
+ * `ramp_coverage: 'unknown'`, so reading it as unmet took a step-free
+ * household's hatched cabins from 32 of 944 pairs to 848. That escape moved
+ * into the resolver itself on 2026-08-21: `resolveDragFit` intercepts
+ * `unknown` BEFORE grading (its rule 2 — unrecorded coverage makes neither
+ * claim), so no caller asks this table about `unknown` with hatch semantics
+ * any more, and the parameter came out rather than sitting
+ * reachable-but-never-passed. The reasoning is kept because it answers "why
+ * doesn't the hatch just grade unknown like the glyphs do" — it still
+ * doesn't, one layer up.
  */
 export function needVerdict(key: NeedKey, coverage: Coverage): NeedsFit {
   if (coverage === 'none') return 'unmet'

--- a/frontend/src/components/weekend/needGlyphs.ts
+++ b/frontend/src/components/weekend/needGlyphs.ts
@@ -87,35 +87,25 @@ export type NeedKey = 'bathroom' | 'power' | 'fridge' | 'step_free'
 export type NeedReading = 'placed' | 'prospective'
 
 /**
- * WHAT AN `unknown` COVERAGE MEANS FOR THE MARK BEING DRAWN, and the two marks
- * genuinely ask different questions.
+ * WHAT AN `unknown` COVERAGE MEANS: not met — `fits` is not silence, it is
+ * the mark in its full hue asserting the need is met, and the owner ruling of
+ * 2026-08-20 (*"unknown values should not equal fits, across all surfaces on
+ * the glyphs, its unconfirmed information"*) forbids unconfirmed information
+ * reading that way.
  *
- *   `'unmet'`  — the default, and every GLYPH. The glyph reports what is known
- *                about the cabin, and `fits` is not silence: it is the mark in
- *                its full hue, asserting the need is met. Owner ruling
- *                2026-08-20 — *"unknown values should not equal fits, across
- *                all surfaces on the glyphs, its unconfirmed information."*
- *
- *   `'fits'`   — the drag-time HATCH, and this is not a leftover. The hatch is
- *                not a report, it is an INTERRUPTION: it darkens a cabin under
- *                a card being dragged to say "not this one". Its bar is
- *                therefore evidence of ABSENCE, not absence of evidence.
- *
- * ⚠️ THE NUMBER IS WHY, AND IT IS NOT CLOSE. 102 of 118 cabins carry
- * `ramp_coverage: 'unknown'` — nobody has assessed them, which is exactly what
- * the three-value select exists to record. Measured across 2026's twelve
- * weekends: reading `unknown` as unmet in the hatch takes a step-free
- * household's hatched cabins from **32 of 944 pairs to 848** — 3.4% to 90%. A
- * hatch that fires on nine cabins in ten has stopped saying anything, which is
- * the same failure as a queue drawn red all the time. The glyph, on the same
- * data, moves THREE marks.
- *
- * This is one grading with two documented readings, not two tables. The
- * coverage derivation is still single-sourced in `needCoverage`; only what an
- * absent answer MEANS differs, and it differs at one call site with a reason
- * written at both ends. `needsFit` is that call site.
+ * ONE READING NOW, where there used to be a parameter. `UnknownReading` let
+ * the drag-time hatch read `unknown` as `'fits'` instead, because the hatch
+ * is an interruption whose bar is evidence of absence — and the number behind
+ * that was not close: 102 of 118 cabins carry `ramp_coverage: 'unknown'`, so
+ * reading it as unmet took a step-free household's hatched cabins from 32 of
+ * 944 pairs to 848. That escape moved into the resolver itself on 2026-08-21:
+ * `resolveDragFit` intercepts `unknown` BEFORE grading (its rule 2 —
+ * unrecorded coverage makes neither claim, conflict nor match), so no caller
+ * asks this table about `unknown` with hatch semantics any more, and the
+ * parameter came out rather than sitting reachable-but-never-passed. The
+ * reasoning is kept because it is the answer to "why doesn't the hatch just
+ * grade unknown like the glyphs do" — it still doesn't, one layer up.
  */
-export type UnknownReading = Extract<NeedsFit, 'unmet' | 'fits'>
 
 export interface NeedGlyphSpec {
   readonly key: NeedKey
@@ -360,11 +350,7 @@ export function needCoverage(
  * counts do not move at all — `ROSTER_NEEDS` grades bathroom and power, and
  * every placed party's coverage for those two is already `all` or `none`.
  */
-export function needVerdict(
-  key: NeedKey,
-  coverage: Coverage,
-  unknownIs: UnknownReading = 'unmet'
-): NeedsFit {
+export function needVerdict(key: NeedKey, coverage: Coverage): NeedsFit {
   if (coverage === 'none') return 'unmet'
   if (coverage === 'some') return needGlyph(key).someIs
   // The fifth grade, reachable only from `ramp_coverage`. It says the space
@@ -372,7 +358,7 @@ export function needVerdict(
   // "nothing here" in every reading of it, and softer than `some`, which is
   // about a building whose rooms disagree.
   if (coverage === 'partial') return 'partial'
-  if (coverage === 'unknown') return unknownIs
+  if (coverage === 'unknown') return 'unmet'
   return 'fits'
 }
 

--- a/frontend/src/components/weekend/needsFit.test.ts
+++ b/frontend/src/components/weekend/needsFit.test.ts
@@ -48,17 +48,18 @@ function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
 describe('worseOf', () => {
   /*
    * The combining rule, tested directly rather than through
-   * `resolveNeedsFit`: a `resolveNeedsFit` assertion would pass just as
+   * `resolveDragFit`: a `resolveDragFit` assertion would pass just as
    * happily against a combiner that kept the LAST verdict rather than the
    * worst, and so would pin nothing.
    *
    * ⚠️ This used to say the reason was that `NEEDS_DIMENSIONS` holds ONE
    * entry. That symbol was deleted by kindred#2072, and the claim had already
    * been false since kindred#2224 added the fridge entry. The table is
-   * `needGlyphs.NEED_GLYPHS` now and carries four, of which
-   * `needsFit.HATCHED_NEEDS` grades three — so the direct test stays for the
-   * reason its twin in `needsFit.ts` gives: it is the one that still holds if
-   * the scope ever shrinks back to one.
+   * `needGlyphs.NEED_GLYPHS` now and carries four, and `resolveDragFit`
+   * grades all four — the `HATCHED_NEEDS` subset that once narrowed it to
+   * three is gone (kindred#2528). The direct test stays for the reason its
+   * twin in `needsFit.ts` gives: it is the one that still holds if the scope
+   * ever shrinks back to one.
    */
   it('keeps the worse verdict whichever side it arrives on', () => {
     expect(worseOf('unmet', 'fits')).toBe('unmet')

--- a/frontend/src/components/weekend/needsFit.test.ts
+++ b/frontend/src/components/weekend/needsFit.test.ts
@@ -15,7 +15,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
-import { resolveDragFit, worseOf } from './needsFit'
+import { hasNoRoom, resolveDragFit, worseOf } from './needsFit'
 
 function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
   return {
@@ -299,5 +299,52 @@ describe('resolveDragFit — the resolved coverage is the only input', () => {
         { known: true, free: 6 }
       ).state
     ).toBe('match')
+  })
+})
+
+describe('hasNoRoom — the capacity predicate, single-sourced', () => {
+  /*
+   * Extracted because it was written TWICE: once inside `resolveDragFit` to
+   * gate the match, and once inline in `LodgingUnitCard` to redden the N/M
+   * figure. Nothing tied the two together, and they had already been edited in
+   * lockstep by hand once (the write-in rule) — a silent divergence was one
+   * forgotten edit away, and neither the type checker nor any test would have
+   * caught it.
+   */
+  const three = party({ party_size: 3 })
+
+  it('is false when the beds are not a fact — nothing to claim from', () => {
+    expect(hasNoRoom(three, { known: false, free: 0 })).toBe(false)
+    expect(hasNoRoom(three, { known: false, free: -5 })).toBe(false)
+  })
+
+  it('is true only when a known count falls short', () => {
+    expect(hasNoRoom(three, { known: true, free: 2 })).toBe(true)
+    expect(hasNoRoom(three, { known: true, free: 0 })).toBe(true)
+  })
+
+  it('treats a party that exactly fills the cabin as fitting', () => {
+    // The boundary, pinned. `free === size` is a fit, not a miss.
+    expect(hasNoRoom(three, { known: true, free: 3 })).toBe(false)
+  })
+
+  it('is true on a cabin already over capacity', () => {
+    expect(hasNoRoom(three, { known: true, free: -1 })).toBe(true)
+  })
+
+  it('agrees with resolveDragFit — the two marks can never contradict', () => {
+    // THE GUARD THAT WAS MISSING. If capacity says "no room" then the match
+    // must be withheld, for every combination of the inputs. A future edit to
+    // one site and not the other breaks this and nothing else.
+    const asksPower = party({ flags: { needs_power: true }, party_size: 3 })
+    const good = unit({ power_coverage: 'all' })
+    for (const known of [true, false]) {
+      for (const free of [-1, 0, 2, 3, 9]) {
+        const capacity = { known, free }
+        if (hasNoRoom(asksPower, capacity)) {
+          expect(resolveDragFit(asksPower, good, capacity).state).not.toBe('match')
+        }
+      }
+    }
   })
 })

--- a/frontend/src/components/weekend/needsFit.test.ts
+++ b/frontend/src/components/weekend/needsFit.test.ts
@@ -15,7 +15,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
-import { resolveNeedsFit, worseOf } from './needsFit'
+import { resolveDragFit, worseOf } from './needsFit'
 
 function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
   return {
@@ -38,284 +38,12 @@ function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
     grain: 'household',
     household_cm_id: 101,
     display_name: 'Johnson',
+    // A real size. Capacity now gates the match, so a party of nobody would
+    // fit everywhere and quietly hide every capacity assertion below.
+    party_size: 2,
     ...overrides,
   }
 }
-
-describe('resolveNeedsFit', () => {
-  it('marks nothing for a family that asked for nothing', () => {
-    expect(resolveNeedsFit(party(), unit({ power_coverage: 'none' }))).toBe('fits')
-  })
-
-  it('marks a space where no room meets the need as unmet', () => {
-    expect(
-      resolveNeedsFit(party({ flags: { needs_power: true } }), unit({ power_coverage: 'none' }))
-    ).toBe('unmet')
-  })
-
-  it('marks a space where only some rooms meet it as partial', () => {
-    expect(
-      resolveNeedsFit(party({ flags: { needs_power: true } }), unit({ power_coverage: 'some' }))
-    ).toBe('partial')
-  })
-
-  it('marks nothing when every room meets the need', () => {
-    expect(
-      resolveNeedsFit(party({ flags: { needs_power: true } }), unit({ power_coverage: 'all' }))
-    ).toBe('fits')
-  })
-
-  it('marks nothing when nobody has recorded the amenity', () => {
-    // `unknown` is the absence of evidence, and the mark STATES something
-    // about a space. "Nothing here has power" is not a claim an unconfirmed
-    // row supports — the same bar `rosterAttention` applies to the roster's
-    // own fit check.
-    expect(
-      resolveNeedsFit(party({ flags: { needs_power: true } }), unit({ power_coverage: 'unknown' }))
-    ).toBe('fits')
-  })
-
-  it('treats a payload with no coverage field at all as unrecorded', () => {
-    const bare = unit()
-    delete (bare as { power_coverage?: string }).power_coverage
-    expect(resolveNeedsFit(party({ flags: { needs_power: true } }), bare)).toBe('fits')
-  })
-
-  it('never reads the raw row — a building with no power but powered rooms fits', () => {
-    // The 12-of-14 trap: twelve of the fourteen 2026 family-pool containers
-    // record `has_power = 0` while every leaf beneath them has power. The
-    // server resolves that; this must not second-guess it off the raw flag.
-    expect(
-      resolveNeedsFit(
-        party({ flags: { needs_power: true } }),
-        unit({ has_power: false, power_coverage: 'all' })
-      )
-    ).toBe('fits')
-  })
-
-  it('ignores a need no dimension answers yet', () => {
-    // `needs_private_bathroom` is a real flag with no entry in the table, so
-    // it contributes nothing and the power verdict stands alone. This does
-    // NOT pin the combining rule — with one dimension the loop can only ever
-    // run once, so `worseOf` below is where that rule is actually pinned.
-    expect(
-      resolveNeedsFit(
-        party({ flags: { needs_power: true, needs_private_bathroom: true } }),
-        unit({ power_coverage: 'none' })
-      )
-    ).toBe('unmet')
-  })
-})
-
-describe('resolveNeedsFit — the fridge dimension (kindred#2224)', () => {
-  /*
-   * Dimension two, and the issue's own claim about dimension one: a second
-   * criterion is a further entry in `NEEDS_DIMENSIONS` and nothing else. It
-   * arrives with no new glyph, no new colour and no new chip — the card's
-   * visual treatment of needs belongs to kindred#2072.
-   *
-   * The demand it answers was invisible: `needs_accommodation` is a GATE
-   * question and the substance landed in free text nothing read. Six of the 42
-   * accommodation-gated 2026 households name a refrigerator, against 12 of 118
-   * units carrying one. 2026 is only 16% placed, so 6 is the SHAPE of the
-   * demand, not a rate.
-   */
-  it('marks a space where no room has a fridge as unmet', () => {
-    expect(
-      resolveNeedsFit(party({ flags: { needs_fridge: true } }), unit({ fridge_coverage: 'none' }))
-    ).toBe('unmet')
-  })
-
-  it('marks a space where only some rooms have one as partial', () => {
-    // Advisory-softer, the same reading power takes: a building where some
-    // rooms have a fridge is a real improvement on one where none do. This is
-    // NOT the `is_accessible` shape, where SOME is worse than NONE because it
-    // invites the placement that lands in one of the other rooms — the owner's
-    // 2026-08-15 ruling that a SHARED fridge satisfies the need is what
-    // settles that, since a fridge one room over is still a fridge.
-    expect(
-      resolveNeedsFit(party({ flags: { needs_fridge: true } }), unit({ fridge_coverage: 'some' }))
-    ).toBe('partial')
-  })
-
-  it('marks nothing when every room has one', () => {
-    expect(
-      resolveNeedsFit(party({ flags: { needs_fridge: true } }), unit({ fridge_coverage: 'all' }))
-    ).toBe('fits')
-  })
-
-  it('marks nothing when nobody has recorded the amenity', () => {
-    expect(
-      resolveNeedsFit(
-        party({ flags: { needs_fridge: true } }),
-        unit({ fridge_coverage: 'unknown' })
-      )
-    ).toBe('fits')
-  })
-
-  it('never reads the raw row — the shared-fridge ruling lives server-side', () => {
-    // A SHARED FRIDGE IS A FRIDGE (owner, 2026-08-15), and the OR that says so
-    // is in `_resolve_fridge_coverage`. Re-deriving it here off `has_fridge`
-    // would put a second implementation of one ruling on the client, where it
-    // could disagree.
-    expect(
-      resolveNeedsFit(
-        party({ flags: { needs_fridge: true } }),
-        unit({ has_fridge: false, has_shared_fridge: true, fridge_coverage: 'all' })
-      )
-    ).toBe('fits')
-  })
-
-  it('leaves a family that did not ask for one unmarked', () => {
-    expect(resolveNeedsFit(party(), unit({ fridge_coverage: 'none' }))).toBe('fits')
-  })
-
-  it('takes the WORSE of two dimensions, in either order', () => {
-    // With two real entries the loop can finally run twice, so this is the
-    // first assertion through `resolveNeedsFit` that can distinguish
-    // "worst wins" from "the last dimension wins".
-    const powerUnmet = unit({ power_coverage: 'none', fridge_coverage: 'all' })
-    const fridgeUnmet = unit({ power_coverage: 'all', fridge_coverage: 'none' })
-    const both = party({ flags: { needs_power: true, needs_fridge: true } })
-
-    expect(resolveNeedsFit(both, powerUnmet)).toBe('unmet')
-    expect(resolveNeedsFit(both, fridgeUnmet)).toBe('unmet')
-    expect(resolveNeedsFit(both, unit({ power_coverage: 'some', fridge_coverage: 'all' }))).toBe(
-      'partial'
-    )
-  })
-
-  it('keeps the two dimensions independent — one need never reads the other coverage', () => {
-    expect(
-      resolveNeedsFit(
-        party({ flags: { needs_power: true } }),
-        unit({ power_coverage: 'all', fridge_coverage: 'none' })
-      )
-    ).toBe('fits')
-    expect(
-      resolveNeedsFit(
-        party({ flags: { needs_fridge: true } }),
-        unit({ power_coverage: 'none', fridge_coverage: 'all' })
-      )
-    ).toBe('fits')
-  })
-})
-
-describe('resolveNeedsFit — the step-free dimension (kindred#2438)', () => {
-  /*
-   * Dimension three, and the first one whose supply column is NOT a boolean.
-   * `has_ramp` is a three-value select (`yes` / `no` / `partial`, blank = NOT
-   * ASSESSED, migration 1500000131), which is why `ramp_coverage` carries a
-   * fifth grade the other two do not.
-   *
-   * Measured on the 2026 snapshot, household grain, both housing narratives:
-   * 14 of the 86 households carrying any narrative describe a mobility or
-   * step-free need, against 6 naming a fridge — more than twice the signal that
-   * justified shipping the fridge dimension. Supply: 14 of 118 units carry a
-   * staff assessment (5 yes / 5 partial / 4 no), which a BOOLEAN read of the
-   * select reports as 0 of 118. 2026 is only 16% placed, so 14 is the SHAPE of
-   * the demand, not a rate.
-   */
-  it('marks a space where no room is step-free as unmet', () => {
-    expect(
-      resolveNeedsFit(party({ flags: { needs_step_free: true } }), unit({ ramp_coverage: 'none' }))
-    ).toBe('unmet')
-  })
-
-  it('marks a space where only SOME rooms are step-free as unmet, not partial', () => {
-    // ⚠️ NOT the fridge reading. This is the `is_accessible` reasoning the
-    // module doc already spells out: a building advertising two step-free
-    // rooms out of ten invites precisely the placement that lands in one of
-    // the other eight. A fridge one room over is still a fridge a family can
-    // use; a ramp one room over is not.
-    expect(
-      resolveNeedsFit(party({ flags: { needs_step_free: true } }), unit({ ramp_coverage: 'some' }))
-    ).toBe('unmet')
-  })
-
-  it('marks a space whose best room is a QUALIFIED ramp as partial', () => {
-    // The fifth grade, and the reason the supply column is a select. Three of
-    // the five production `partial` units carry the ramp qualifier in `notes`
-    // — "look at this one" is exactly what the softer hatch says.
-    expect(
-      resolveNeedsFit(
-        party({ flags: { needs_step_free: true } }),
-        unit({ ramp_coverage: 'partial' })
-      )
-    ).toBe('partial')
-  })
-
-  it('marks nothing when every room is step-free', () => {
-    expect(
-      resolveNeedsFit(party({ flags: { needs_step_free: true } }), unit({ ramp_coverage: 'all' }))
-    ).toBe('fits')
-  })
-
-  it('marks nothing when nobody has assessed the space', () => {
-    // 104 of 118 production units are blank. Marking them would assert "no
-    // ramp" about cabins nobody has looked at — the exact inversion the select
-    // exists to prevent, and the reason the server resolves `unknown`.
-    expect(
-      resolveNeedsFit(
-        party({ flags: { needs_step_free: true } }),
-        unit({ ramp_coverage: 'unknown' })
-      )
-    ).toBe('fits')
-  })
-
-  it('never reads the raw has_ramp — a truthy string would invert the mark', () => {
-    // `has_ramp` is a STRING, so `'no'` is TRUTHY. Any consumer filtering on
-    // truthiness renders "step-free" on the four cabins staff assessed as
-    // explicitly having NO ramp. The resolved field is the only safe read, and
-    // this pins that the dimension takes it.
-    expect(
-      resolveNeedsFit(
-        party({ flags: { needs_step_free: true } }),
-        unit({ has_ramp: 'no', ramp_coverage: 'all' })
-      )
-    ).toBe('fits')
-    expect(
-      resolveNeedsFit(
-        party({ flags: { needs_step_free: true } }),
-        unit({ has_ramp: 'yes', ramp_coverage: 'none' })
-      )
-    ).toBe('unmet')
-  })
-
-  it('leaves a family that did not ask unmarked', () => {
-    expect(resolveNeedsFit(party(), unit({ ramp_coverage: 'none' }))).toBe('fits')
-  })
-
-  it('keeps the three dimensions independent', () => {
-    expect(
-      resolveNeedsFit(
-        party({ flags: { needs_step_free: true } }),
-        unit({ power_coverage: 'none', fridge_coverage: 'none', ramp_coverage: 'all' })
-      )
-    ).toBe('fits')
-    expect(
-      resolveNeedsFit(
-        party({ flags: { needs_power: true } }),
-        unit({ power_coverage: 'all', ramp_coverage: 'none' })
-      )
-    ).toBe('fits')
-  })
-
-  it('takes the WORSE of a soft ramp verdict and a hard one', () => {
-    expect(
-      resolveNeedsFit(
-        party({ flags: { needs_power: true, needs_step_free: true } }),
-        unit({ power_coverage: 'none', ramp_coverage: 'partial' })
-      )
-    ).toBe('unmet')
-    expect(
-      resolveNeedsFit(
-        party({ flags: { needs_power: true, needs_step_free: true } }),
-        unit({ power_coverage: 'all', ramp_coverage: 'partial' })
-      )
-    ).toBe('partial')
-  })
-})
 
 describe('worseOf', () => {
   /*
@@ -345,5 +73,217 @@ describe('worseOf', () => {
     expect(worseOf('fits', 'fits')).toBe('fits')
     expect(worseOf('partial', 'partial')).toBe('partial')
     expect(worseOf('unmet', 'unmet')).toBe('unmet')
+  })
+})
+
+/**
+ * kindred#2528 — the drag-time signal's THREE-VALUED state.
+ *
+ * `resolveNeedsFit` answered one question ("how badly does this space miss?")
+ * and the board asked it to serve two marks pointing in opposite directions.
+ * `resolveDragFit` answers the whole question once: is this cabin a conflict,
+ * a match, or neither.
+ *
+ * These are NOT adapted from the tests above. The specification changed —
+ * `unknown` coverage used to read as `fits` and now makes no claim at all, and
+ * capacity has entered a grading that never saw it — so the old assertions
+ * pin an invariant that no longer holds. See CLAUDE.md §4 on rewriting rather
+ * than adapting a test when the spec moves.
+ *
+ * Fictional data throughout.
+ */
+describe('resolveDragFit — the three states', () => {
+  const roomy = { known: true, free: 6 } as const
+
+  it('is neutral for a family that asked for nothing, however good the cabin', () => {
+    // The withhold rule. Every empty cabin fits a family with no requirements,
+    // so a mark saying so carries nothing — and the board must not switch out
+    // of its resting state at all. 368 of 479 2026 registrations are this family.
+    expect(resolveDragFit(party(), unit({ power_coverage: 'all' }), roomy).state).toBe('neutral')
+  })
+
+  it('is a conflict when an asked need is unmet, and reports the severity', () => {
+    const fit = resolveDragFit(
+      party({ flags: { needs_power: true } }),
+      unit({ power_coverage: 'none' }),
+      roomy
+    )
+    expect(fit.state).toBe('conflict')
+    expect(fit.severity).toBe('unmet')
+  })
+
+  it('carries `partial` severity through, so the hatch can draw a sparser grade', () => {
+    const fit = resolveDragFit(
+      party({ flags: { needs_power: true } }),
+      unit({ power_coverage: 'some' }),
+      roomy
+    )
+    expect(fit.state).toBe('conflict')
+    expect(fit.severity).toBe('partial')
+  })
+
+  it('is a match when every asked need is met and the party fits the free beds', () => {
+    expect(
+      resolveDragFit(
+        party({ flags: { needs_power: true } }),
+        unit({ power_coverage: 'all' }),
+        roomy
+      ).state
+    ).toBe('match')
+  })
+
+  it('takes the WORSE severity across two failing needs, in either order', () => {
+    const both = { flags: { needs_power: true, needs_fridge: true } }
+    const a = resolveDragFit(
+      party(both),
+      unit({ power_coverage: 'some', fridge_coverage: 'none' }),
+      roomy
+    )
+    const b = resolveDragFit(
+      party(both),
+      unit({ power_coverage: 'none', fridge_coverage: 'some' }),
+      roomy
+    )
+    expect(a.severity).toBe('unmet')
+    expect(b.severity).toBe('unmet')
+  })
+})
+
+describe('resolveDragFit — capacity gates the match and never causes a conflict', () => {
+  it('withholds the match when the party does not fit, without hatching the card', () => {
+    // The owner ruling: a full cabin is not a bad cabin, it is a cabin with
+    // nothing left in it. Measured before it was settled — letting capacity
+    // hatch took a six-person family asking NOTHING to 45 of 73 cards.
+    const fit = resolveDragFit(
+      party({ flags: { needs_power: true } }),
+      unit({ power_coverage: 'all' }),
+      { known: true, free: 1 }
+    )
+    expect(fit.state).toBe('neutral')
+  })
+
+  it('withholds the match when capacity was never measured', () => {
+    const fit = resolveDragFit(
+      party({ flags: { needs_power: true } }),
+      unit({ power_coverage: 'all' }),
+      { known: false, free: 0 }
+    )
+    expect(fit.state).toBe('neutral')
+  })
+
+  it('still reports the conflict when the cabin both misses a need and has no room', () => {
+    const fit = resolveDragFit(
+      party({ flags: { needs_power: true } }),
+      unit({ power_coverage: 'none' }),
+      { known: true, free: 0 }
+    )
+    expect(fit.state).toBe('conflict')
+  })
+})
+
+describe('resolveDragFit — unrecorded coverage makes NEITHER claim', () => {
+  it('does not hatch a cabin nobody has assessed', () => {
+    // The hatch is an INTERRUPTION, so its bar is evidence of absence rather
+    // than absence of evidence. 104 of 118 units carry no step-free assessment.
+    expect(
+      resolveDragFit(
+        party({ flags: { needs_step_free: true } }),
+        unit({ ramp_coverage: 'unknown' }),
+        { known: true, free: 6 }
+      ).state
+    ).toBe('neutral')
+  })
+
+  it('does not MATCH a cabin nobody has assessed either', () => {
+    // The half this used to get wrong. A match is a positive claim, like a
+    // glyph's full hue, and the 2026-08-20 ruling says unconfirmed information
+    // must not read as met. Before this rule a step-free household saw 21
+    // matches on the design board, every one of them never assessed.
+    const fit = resolveDragFit(
+      party({ flags: { needs_step_free: true } }),
+      unit({ ramp_coverage: 'unknown' }),
+      { known: true, free: 6 }
+    )
+    expect(fit.state).not.toBe('match')
+    expect(fit.state).toBe('neutral')
+  })
+
+  it('lets a recorded need decide even when another asked need is unrecorded', () => {
+    const fit = resolveDragFit(
+      party({ flags: { needs_step_free: true, needs_power: true } }),
+      unit({ ramp_coverage: 'unknown', power_coverage: 'none' }),
+      { known: true, free: 6 }
+    )
+    expect(fit.state).toBe('conflict')
+  })
+
+  it('withholds the match when one asked need is recorded and another is not', () => {
+    const fit = resolveDragFit(
+      party({ flags: { needs_step_free: true, needs_power: true } }),
+      unit({ ramp_coverage: 'unknown', power_coverage: 'all' }),
+      { known: true, free: 6 }
+    )
+    expect(fit.state).toBe('neutral')
+  })
+})
+
+describe('resolveDragFit — bathroom is graded, on the prospective axis', () => {
+  it('grades bathroom, which the old hatch left out entirely', () => {
+    // `HATCHED_NEEDS` used to be power/fridge/step-free. The mark is aligning
+    // with the glyphs, which draw all four.
+    const fit = resolveDragFit(
+      party({ flags: { needs_private_bathroom: true } }),
+      unit({ bathroom: 'none' }),
+      { known: true, free: 6 }
+    )
+    expect(fit.state).toBe('conflict')
+  })
+
+  it('asks whether THIS cabin meets it, not what the party already has', () => {
+    // The axis change. On the `placed` reading bathroom reads
+    // `party.effective_bathroom` and ignores the target unit — every card or
+    // none, which cannot mean anything per card.
+    const asks = { flags: { needs_private_bathroom: true } }
+    const yes = resolveDragFit(
+      party({ ...asks, effective_bathroom: 'none' }),
+      unit({ bathroom: 'private' }),
+      { known: true, free: 6 }
+    )
+    const no = resolveDragFit(
+      party({ ...asks, effective_bathroom: 'private' }),
+      unit({ bathroom: 'none' }),
+      { known: true, free: 6 }
+    )
+    expect(yes.state).toBe('match')
+    expect(no.state).toBe('conflict')
+  })
+})
+
+describe('resolveDragFit — the resolved coverage is the only input', () => {
+  it('never reads the raw row — a building with no power but powered rooms is a match', () => {
+    // The 12-of-14 trap: twelve of the fourteen 2026 family-pool containers
+    // record `has_power = 0` while every leaf beneath them has power. The
+    // server resolves that; this must not second-guess it off the raw flag.
+    expect(
+      resolveDragFit(
+        party({ flags: { needs_power: true } }),
+        unit({ has_power: false, power_coverage: 'all' }),
+        { known: true, free: 6 }
+      ).state
+    ).toBe('match')
+  })
+
+  it('never reads the raw row — the shared-fridge ruling lives server-side', () => {
+    // A SHARED FRIDGE IS A FRIDGE (owner, 2026-08-15), and the OR that says so
+    // is in `_resolve_fridge_coverage`. Re-deriving it here off `has_fridge`
+    // would put a second implementation of one ruling on the client, where it
+    // could disagree.
+    expect(
+      resolveDragFit(
+        party({ flags: { needs_fridge: true } }),
+        unit({ has_fridge: false, has_shared_fridge: true, fridge_coverage: 'all' }),
+        { known: true, free: 6 }
+      ).state
+    ).toBe('match')
   })
 })

--- a/frontend/src/components/weekend/needsFit.test.ts
+++ b/frontend/src/components/weekend/needsFit.test.ts
@@ -185,7 +185,8 @@ describe('resolveDragFit — capacity gates the match and never causes a conflic
 describe('resolveDragFit — unrecorded coverage makes NEITHER claim', () => {
   it('does not hatch a cabin nobody has assessed', () => {
     // The hatch is an INTERRUPTION, so its bar is evidence of absence rather
-    // than absence of evidence. 104 of 118 units carry no step-free assessment.
+    // than absence of evidence. 102 of 118 units still read `unknown` once
+    // `ramp_coverage` has resolved (104 hold a blank raw `has_ramp`).
     expect(
       resolveDragFit(
         party({ flags: { needs_step_free: true } }),

--- a/frontend/src/components/weekend/needsFit.test.ts
+++ b/frontend/src/components/weekend/needsFit.test.ts
@@ -209,6 +209,18 @@ describe('resolveDragFit — unrecorded coverage makes NEITHER claim', () => {
     expect(fit.state).toBe('neutral')
   })
 
+  it('treats a payload with no coverage field at all as unrecorded', () => {
+    // The Pydantic-default gotcha, ported from the deleted `resolveNeedsFit`
+    // suite: the API can omit the key entirely, and `?? 'unknown'` is what
+    // catches it. Without this, a missing field would fall through to
+    // `needVerdict` and be graded as though somebody had recorded something.
+    const bare = unit()
+    delete (bare as Partial<LodgingUnitRow>).power_coverage
+    expect(
+      resolveDragFit(party({ flags: { needs_power: true } }), bare, { known: true, free: 6 }).state
+    ).toBe('neutral')
+  })
+
   it('lets a recorded need decide even when another asked need is unrecorded', () => {
     const fit = resolveDragFit(
       party({ flags: { needs_step_free: true, needs_power: true } }),

--- a/frontend/src/components/weekend/needsFit.ts
+++ b/frontend/src/components/weekend/needsFit.ts
@@ -112,6 +112,30 @@ export interface DragCapacity {
 const NEUTRAL: DragFit = { state: 'neutral', severity: 'fits' }
 
 /**
+ * Does this space have no room for this party?
+ *
+ * EXPORTED, and the single definition of the rule, because the board asks it
+ * twice for two different marks: `resolveDragFit` below gates the match on it,
+ * and `LodgingUnitCard` reddens the N/M figure with it. Those two used to be
+ * separate inline expressions in separate modules with nothing tying them
+ * together — they were edited in lockstep by hand once already (the write-in
+ * rule), and a silent divergence was one forgotten edit away. Neither the type
+ * checker nor any test would have caught it, because "the match wash and the
+ * red figure agree about the same cabin" was nobody's assertion.
+ *
+ * `known: false` yields FALSE, not true. A count that is not a fact cannot
+ * support the claim "you will not fit here" any more than it can support a
+ * match — the caller withholds `known` for an unmeasured cabin, a straddling
+ * party, and a wholesale write-in, and all three mean the same thing here:
+ * nothing to say.
+ *
+ * The boundary is `<`, so a party that exactly fills a cabin FITS.
+ */
+export function hasNoRoom(party: RosterPartyRow, capacity: DragCapacity): boolean {
+  return capacity.known && capacity.free < partySize(party)
+}
+
+/**
  * Is this cabin a conflict, a match, or neither, for the family in flight?
  *
  * FOUR NEEDS, not three. The mark grades what the glyphs draw — the narrowed
@@ -180,6 +204,6 @@ export function resolveDragFit(
 
   if (conflict) return { state: 'conflict', severity: worst }
   if (unrecorded) return NEUTRAL
-  if (!capacity.known || capacity.free < partySize(party)) return NEUTRAL
+  if (!capacity.known || hasNoRoom(party, capacity)) return NEUTRAL
   return { state: 'match', severity: 'fits' }
 }

--- a/frontend/src/components/weekend/needsFit.ts
+++ b/frontend/src/components/weekend/needsFit.ts
@@ -135,7 +135,13 @@ const NEUTRAL: DragFit = { state: 'neutral', severity: 'fits' }
  *    hatch is an interruption and its bar is evidence of absence; not a match,
  *    because a positive mark is a claim and the 2026-08-20 ruling says
  *    unconfirmed information must not read as met. `has_ramp` is the only
- *    registry field that carries one, on 104 of 118 units — and kindred#2526
+ *    registry field that carries one: 104 of 118 units hold a blank raw
+ *    `has_ramp`, of which 102 are still `unknown` once `ramp_coverage` has
+ *    walked the leaves — a few blank containers have rooms that answer for
+ *    them. Quote 102 wherever the figure feeds the hatched-pairs arithmetic
+ *    (`weekend-card-vocabulary.md`), 104 for the raw assessment gap. This
+ *    reads the RESOLVED value, so 102 is the number that reaches here. And
+ *    kindred#2526
  *    may remove the state entirely, at which point this branch stops being
  *    reachable rather than stops being correct.
  *

--- a/frontend/src/components/weekend/needsFit.ts
+++ b/frontend/src/components/weekend/needsFit.ts
@@ -54,7 +54,7 @@ export type NeedsFit = (typeof FIT_ORDER)[number]
  * once narrowed it to three is gone. The direct test stays, because it is the
  * one that still holds if the scope ever shrinks back to one.
  */
-export function worseOf(a: NeedsFit, b: NeedsFit): NeedsFit {
+export function worseOf<T extends NeedsFit>(a: T, b: T): T {
   return FIT_ORDER.indexOf(a) <= FIT_ORDER.indexOf(b) ? a : b
 }
 
@@ -109,7 +109,14 @@ export interface DragCapacity {
   readonly free: number
 }
 
-const NEUTRAL: DragFit = { state: 'neutral', severity: 'fits' }
+/**
+ * Exported for the ONE caller with a legitimate at-rest value —
+ * `LodgingUnitCard` with no family in flight. Hand-rolling the literal there
+ * would be the one place the three-state shape is still written by hand, in a
+ * module that exists to stop that; and a shared constant is also a stable
+ * identity, where a fresh object per card per render defeats memo equality.
+ */
+export const NEUTRAL: DragFit = { state: 'neutral', severity: 'fits' }
 
 /**
  * Does this space have no room for this party?
@@ -142,6 +149,14 @@ export function hasNoRoom(party: RosterPartyRow, capacity: DragCapacity): boolea
  * `HATCHED_NEEDS` that left `bathroom` out is gone, and with it the argument
  * that a board hatched almost everywhere says nothing: that argument was about
  * a mark that could only ever be negative, and half of this one is positive.
+ *
+ * REAFFIRMED by the owner, 2026-08-21, with the production number on the
+ * table: bathroom has no blank values in the registry (90 of 118 spaces are
+ * `none`), so a bathroom-asking family hatches most of the board at once —
+ * and that is the point: "all four booleans must match — the hatch fires on a
+ * family that requests anything." An asymmetric reading (bathroom gates the
+ * match but never hatches) was put to the owner in the same review and
+ * REJECTED; do not reintroduce it as a tidy-up.
  *
  * THE PROSPECTIVE AXIS. Every need is graded as "would THIS cabin meet it?".
  * Only `bathroom` reads the argument at all, and on the old `'placed'` reading
@@ -197,7 +212,7 @@ export function resolveDragFit(
     }
     const verdict = needVerdict(glyph.key, coverage)
     if (verdict !== 'fits') {
-      worst = worseOf(verdict, worst) as Exclude<NeedsFit, 'fits'>
+      worst = worseOf(verdict, worst)
       conflict = true
     }
   }

--- a/frontend/src/components/weekend/needsFit.ts
+++ b/frontend/src/components/weekend/needsFit.ts
@@ -29,7 +29,8 @@
  * testable without rendering ~82 cards.
  */
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
-import { askedNeedGlyphs, needVerdict, type NeedKey } from './needGlyphs'
+import { partySize } from './boardLayout'
+import { askedNeedGlyphs, needVerdict } from './needGlyphs'
 
 /** Worst first. The order of this array IS the precedence. */
 const FIT_ORDER = ['unmet', 'partial', 'fits'] as const
@@ -53,69 +54,112 @@ export function worseOf(a: NeedsFit, b: NeedsFit): NeedsFit {
 }
 
 /**
- * WHICH needs the drag-time hatch grades — deliberately not all four.
+ * The drag-time state of one cabin, for one family in flight.
  *
- * The GRADING is one rule now, in `needGlyphs.ts`, and that is the
- * consolidation kindred#2072 asked for: for a given (need, party, cabin) every
- * surface must reach the same verdict. WHICH needs a surface reports is a
- * separate question, and each surface scopes it for its own reason — this list
- * is that reason, written down rather than implied.
+ * THREE VALUES, NOT TWO, and they are mutually exclusive by TYPE rather than
+ * by a rule somebody has to remember to apply. This mirrors
+ * `LodgingUnitCard`'s `ringState`, which is the board's established shape for
+ * "one winner among competing marks".
  *
- * `bathroom` is out, and it is the only one that had to be argued.
- *
- * Only 36 of 118 units answer the bathroom need, so a hatch that graded it
- * would fire on 82 cards the moment any of the 41 bathroom-asking households
- * on 2026's family weekends was picked up — at most 12 of them sit on any one
- * weekend, but every card is on screen for each. Both rescues are already IN
- * that figure and neither is enough: kindred#2501 moved the axis from
- * exclusivity to presence (6 of 118 → 28) and kindred#2502's
- * `_resolve_bathroom` gave 8 of the 15 containers the bathroom their rooms
- * record (28 → 36), taking the hatch from 112 cards to 82.
- *
- * "A mark that is always on is chrome staff learn to read past"
- * (`unitBadges.ts`, on the struck shared-space ring) — a board hatched almost
- * everywhere says nothing at all, which is the same reasoning
- * `resolveNeedsFit` already applies at rest.
- *
- * The bathroom need is NOT unreported. It draws a per-family glyph on the card
- * itself (kindred#2072), where it is one household's fact rather than a
- * board-wide wash, and `rosterAttention` grades it for the roster's own
- * sections.
+ * The previous `resolveNeedsFit` returned a single `NeedsFit`, and the board
+ * asked that one verdict to drive two marks pointing in opposite directions:
+ * a hatch, which must not fire on absence of evidence, and a positive match,
+ * which must not CLAIM on absence of evidence. No single reading of `unknown`
+ * can serve both, which is why the state is resolved here instead.
  */
-const HATCHED_NEEDS: readonly NeedKey[] = ['power', 'fridge', 'step_free']
+export type DragFitState = 'conflict' | 'match' | 'neutral'
 
 /**
- * How well `unit` meets `party`'s needs.
+ * A DISCRIMINATED UNION, so `severity` cannot be read on a state that has no
+ * severity and a conflict cannot carry `'fits'`. The exclusivity the design
+ * asks for is enforced by the type rather than by a rule a caller has to
+ * remember — which is the whole reason the three states were collapsed into
+ * one value.
  *
- * The verdict per need comes from `needGlyphs.needVerdict`, which is the ONE
- * grading — this function's own job is the combining rule (worst wins) and the
- * scope above, nothing else. It used to carry a third copy of the
- * coverage-to-verdict mapping, which is how the roster and the board came to
- * disagree about whether a container had power.
- *
- * ⚠️ `'fits'` FOR AN UNKNOWN COVERAGE, WHICH IS NOT WHAT THE GLYPHS DO, and
- * the difference is deliberate rather than a missed sweep. The owner ruled on
- * 2026-08-20 that unconfirmed information must not read as met **on the
- * glyphs** — a glyph reports what is known, and its full hue is itself a claim.
- * The hatch is a different mark asking a different question: it is an
- * INTERRUPTION over a cabin being dragged onto, so its bar is evidence of
- * ABSENCE rather than absence of evidence.
- *
- * The number decides it. 102 of 118 cabins carry `ramp_coverage: 'unknown'`,
- * because nobody has assessed them — which is what the three-value select
- * exists to record. Measured across 2026's twelve weekends: reading `unknown`
- * as unmet here takes a step-free household's hatched cabins from **32 of 944
- * pairs to 848**, from 3.4% to 90%. A hatch that fires on nine cabins in ten
- * has stopped saying anything. The same rule costs the glyphs three marks.
- *
- * See `needGlyphs.UnknownReading`, which carries the full argument. This is the
- * only call site that passes anything but the default.
+ * Severity is the hatch PERIOD and only the period (kindred#1912); grading
+ * NONE from SOME on a second channel is the collapse that ruling struck.
  */
-export function resolveNeedsFit(party: RosterPartyRow, unit: LodgingUnitRow): NeedsFit {
-  let worst: NeedsFit = 'fits'
-  for (const glyph of askedNeedGlyphs(party)) {
-    if (!HATCHED_NEEDS.includes(glyph.key)) continue
-    worst = worseOf(needVerdict(glyph.key, glyph.coverage(party, unit, 'placed'), 'fits'), worst)
+export type DragFit =
+  | { readonly state: 'conflict'; readonly severity: Exclude<NeedsFit, 'fits'> }
+  | { readonly state: 'match' | 'neutral'; readonly severity: 'fits' }
+
+/**
+ * What the card already knows about its own beds, passed in rather than
+ * re-derived.
+ *
+ * `known` is `effectiveSleeps(...) !== null`: a cabin nobody has measured.
+ * `free` is capacity minus placed occupants and MAY BE NEGATIVE on a card that
+ * is already over. The caller withholds this when `spanWidth > 0`, where the
+ * occupant count is an upper bound rather than a fact — see `slotOccupancy`.
+ */
+export interface DragCapacity {
+  readonly known: boolean
+  readonly free: number
+}
+
+const NEUTRAL: DragFit = { state: 'neutral', severity: 'fits' }
+
+/**
+ * Is this cabin a conflict, a match, or neither, for the family in flight?
+ *
+ * FOUR NEEDS, not three. The mark grades what the glyphs draw — the narrowed
+ * `HATCHED_NEEDS` that left `bathroom` out is gone, and with it the argument
+ * that a board hatched almost everywhere says nothing: that argument was about
+ * a mark that could only ever be negative, and half of this one is positive.
+ *
+ * THE PROSPECTIVE AXIS. Every need is graded as "would THIS cabin meet it?".
+ * Only `bathroom` reads the argument at all, and on the old `'placed'` reading
+ * it took `party.effective_bathroom` and ignored the target unit entirely —
+ * a board-wide constant, every card or none, which cannot mean anything
+ * per-card.
+ *
+ * THREE RULES, IN ORDER, and each is a decision with a number behind it:
+ *
+ * 1. A party that asks for NOTHING earns no match. Every cabin with room fits
+ *    it, so a mark saying so carries nothing, and the board does not leave its
+ *    resting state at all. 368 of 479 2026 registrations ask no housing need.
+ *
+ * 2. UNRECORDED COVERAGE MAKES NEITHER CLAIM. Not a conflict, because the
+ *    hatch is an interruption and its bar is evidence of absence; not a match,
+ *    because a positive mark is a claim and the 2026-08-20 ruling says
+ *    unconfirmed information must not read as met. `has_ramp` is the only
+ *    registry field that carries one, on 104 of 118 units — and kindred#2526
+ *    may remove the state entirely, at which point this branch stops being
+ *    reachable rather than stops being correct.
+ *
+ * 3. CAPACITY GATES THE MATCH AND NEVER CAUSES A CONFLICT. A full cabin is not
+ *    a bad cabin, it is a cabin with nothing left in it. Measured before it was
+ *    settled: letting capacity hatch took a six-person family asking NOTHING
+ *    from 0 marked cards to 45 of 73. Capacity already has a per-card carrier
+ *    in the N/M figure; the needs have none.
+ */
+export function resolveDragFit(
+  party: RosterPartyRow,
+  unit: LodgingUnitRow,
+  capacity: DragCapacity
+): DragFit {
+  const asked = askedNeedGlyphs(party)
+  if (asked.length === 0) return NEUTRAL
+
+  let worst: Exclude<NeedsFit, 'fits'> = 'partial'
+  let conflict = false
+  let unrecorded = false
+
+  for (const glyph of asked) {
+    const coverage = glyph.coverage(party, unit, 'prospective')
+    if (coverage === 'unknown') {
+      unrecorded = true
+      continue
+    }
+    const verdict = needVerdict(glyph.key, coverage)
+    if (verdict !== 'fits') {
+      worst = conflict ? (worseOf(verdict, worst) as Exclude<NeedsFit, 'fits'>) : verdict
+      conflict = true
+    }
   }
-  return worst
+
+  if (conflict) return { state: 'conflict', severity: worst }
+  if (unrecorded) return NEUTRAL
+  if (!capacity.known || capacity.free < partySize(party)) return NEUTRAL
+  return { state: 'match', severity: 'fits' }
 }

--- a/frontend/src/components/weekend/needsFit.ts
+++ b/frontend/src/components/weekend/needsFit.ts
@@ -42,12 +42,13 @@ export type NeedsFit = (typeof FIT_ORDER)[number]
  *
  * Exported, and a named function rather than an inline comparison in the loop
  * below. It was written when the dimension table held exactly ONE entry, so the
- * loop could never run twice and no assertion made through `resolveNeedsFit`
+ * loop could never run twice and no assertion made through the resolver
  * could distinguish "worst wins" from "the last dimension wins" — the
  * combining rule would otherwise have shipped untested, so it was pinned
- * directly. That table is `needGlyphs.NEED_GLYPHS` now and carries four, of
- * which `HATCHED_NEEDS` below grades three; the direct test stays, because it
- * is the one that still holds if the scope ever shrinks back to one.
+ * directly. That table is `needGlyphs.NEED_GLYPHS` now and carries four, and
+ * `resolveDragFit` below grades all four — the `HATCHED_NEEDS` subset that
+ * once narrowed it to three is gone. The direct test stays, because it is the
+ * one that still holds if the scope ever shrinks back to one.
  */
 export function worseOf(a: NeedsFit, b: NeedsFit): NeedsFit {
   return FIT_ORDER.indexOf(a) <= FIT_ORDER.indexOf(b) ? a : b

--- a/frontend/src/components/weekend/needsFit.ts
+++ b/frontend/src/components/weekend/needsFit.ts
@@ -16,10 +16,14 @@
  *        invalid merge target, and by that alone since kindred#2432 struck
  *        the written-into space's refusal (#2087/#2090). Not this.
  *   hatch (`background-image`, at FULL strength)= ADVISORY MISFIT. This.
- *   forest tint                                  = open and available, at rest
- *        only (#2093).
+ *   forest tint (`background-color`)             = open and available at rest
+ *        (#2093) — AND, since 2026-08-21, the drag-time match at double
+ *        strength. One channel, three exclusive states.
  *
- * So the mark this feeds changes `background-image` and nothing else. Putting
+ * So the marks this feeds are `background-image` for the negative and
+ * `background-color` for the positive; the module header used to say
+ * `background-image` and nothing else, which stopped being true when the
+ * mark grew a positive half. Putting
  * fit on opacity would have made it read as a weaker refusal rather than as a
  * different kind of statement, which is exactly the collapse the vocabulary
  * ruling exists to prevent.
@@ -68,21 +72,28 @@ export function worseOf(a: NeedsFit, b: NeedsFit): NeedsFit {
  * which must not CLAIM on absence of evidence. No single reading of `unknown`
  * can serve both, which is why the state is resolved here instead.
  */
-export type DragFitState = 'conflict' | 'match' | 'neutral'
+type DragFitState = 'conflict' | 'match' | 'neutral'
 
 /**
- * A DISCRIMINATED UNION, so `severity` cannot be read on a state that has no
- * severity and a conflict cannot carry `'fits'`. The exclusivity the design
+ * A DISCRIMINATED UNION, so a conflict cannot carry `'fits'` and a match
+ * cannot carry a severity that would draw a hatch. The exclusivity the design
  * asks for is enforced by the type rather than by a rule a caller has to
  * remember — which is the whole reason the three states were collapsed into
  * one value.
+ *
+ * `severity` is present on BOTH members deliberately, so `NEUTRAL` and the
+ * card's at-rest value can be plain literals; it is the VALUE that is
+ * constrained per member, not the key's presence.
  *
  * Severity is the hatch PERIOD and only the period (kindred#1912); grading
  * NONE from SOME on a second channel is the collapse that ruling struck.
  */
 export type DragFit =
-  | { readonly state: 'conflict'; readonly severity: Exclude<NeedsFit, 'fits'> }
-  | { readonly state: 'match' | 'neutral'; readonly severity: 'fits' }
+  | {
+      readonly state: Extract<DragFitState, 'conflict'>
+      readonly severity: Exclude<NeedsFit, 'fits'>
+    }
+  | { readonly state: Exclude<DragFitState, 'conflict'>; readonly severity: 'fits' }
 
 /**
  * What the card already knows about its own beds, passed in rather than
@@ -142,6 +153,8 @@ export function resolveDragFit(
   const asked = askedNeedGlyphs(party)
   if (asked.length === 0) return NEUTRAL
 
+  // `'partial'` is the softest non-`fits` grade, so it is the identity
+  // element for `worseOf` and the accumulator needs no first-pass special case.
   let worst: Exclude<NeedsFit, 'fits'> = 'partial'
   let conflict = false
   let unrecorded = false
@@ -154,7 +167,7 @@ export function resolveDragFit(
     }
     const verdict = needVerdict(glyph.key, coverage)
     if (verdict !== 'fits') {
-      worst = conflict ? (worseOf(verdict, worst) as Exclude<NeedsFit, 'fits'>) : verdict
+      worst = worseOf(verdict, worst) as Exclude<NeedsFit, 'fits'>
       conflict = true
     }
   }

--- a/frontend/src/components/weekend/placementCandidates.test.ts
+++ b/frontend/src/components/weekend/placementCandidates.test.ts
@@ -192,6 +192,32 @@ describe('candidateFit', () => {
     expect(result.notes).toContain('Over capacity · needs 6, 4 free')
   })
 
+  it('says nothing about a room somebody is written into', () => {
+    // A write-in is not a party (kindred#2439), so it contributes nothing to
+    // any occupancy figure a caller could thread in — the free-bed count on a
+    // written-into room is the WHOLE cabin, a number the card itself refuses
+    // to assert (it prints an em dash). The row must not claim "fits" off
+    // that number, nor "does not fit" off its equally-false complement: no
+    // count, no claim, exactly the unmeasured-capacity reading above.
+    const writtenInto = unit({
+      write_ins: [
+        {
+          unit_id: 'u1',
+          unit_code: 'cedar-1',
+          unit_name: 'Cedar 1',
+          occupant_name: 'Emma Johnson',
+          note: '',
+        },
+      ],
+    })
+    const small = candidateFit(party({ party_size: 2 }), writtenInto, [])
+    expect(small.fit).toBe('fits')
+    expect(small.notes).toEqual([])
+    const large = candidateFit(party({ party_size: 6 }), writtenInto, [])
+    expect(large.fit).toBe('fits')
+    expect(large.notes).toEqual([])
+  })
+
   it('says nothing about capacity nobody has recorded', () => {
     const result = candidateFit(party({ party_size: 6 }), unit({ sleeps: null }), [])
     expect(result.fit).toBe('fits')

--- a/frontend/src/components/weekend/placementCandidates.ts
+++ b/frontend/src/components/weekend/placementCandidates.ts
@@ -79,7 +79,7 @@ import { partyIdentityLabel } from './householdIdentity'
 import { resolveNeedGlyphs } from './needGlyphs'
 import { worseOf, type NeedsFit } from './needsFit'
 import { effectiveSleeps, partyBeds } from './rosterAttention'
-import { writeInEntries } from './writeIn'
+import { hasWriteIn } from './writeIn'
 
 /** The picker's verdict for one party against one space. `needsFit`'s vocabulary. */
 export type CandidateFitLevel = NeedsFit
@@ -162,7 +162,7 @@ function capacityVerdict(
   // — the board's match/red, the card figure, and now this row — so a
   // written-into cabin cannot read "fits" in the picker while the card it was
   // opened from refuses to print a numerator at all.
-  if (writeInEntries(unit).length > 0) return { fit: 'fits', note: null }
+  if (hasWriteIn(unit)) return { fit: 'fits', note: null }
   const beds = partyBeds(party)
   // `Math.max(0, …)` for the same reason the header does it: a room already
   // over its capacity has nothing left, never a negative number of beds.

--- a/frontend/src/components/weekend/placementCandidates.ts
+++ b/frontend/src/components/weekend/placementCandidates.ts
@@ -79,6 +79,7 @@ import { partyIdentityLabel } from './householdIdentity'
 import { resolveNeedGlyphs } from './needGlyphs'
 import { worseOf, type NeedsFit } from './needsFit'
 import { effectiveSleeps, partyBeds } from './rosterAttention'
+import { writeInEntries } from './writeIn'
 
 /** The picker's verdict for one party against one space. `needsFit`'s vocabulary. */
 export type CandidateFitLevel = NeedsFit
@@ -151,6 +152,17 @@ function capacityVerdict(
 ): DimensionVerdict {
   const capacity = effectiveSleeps(unit, units)
   if (capacity === null) return { fit: 'fits', note: null }
+  // A written-into room has an occupant no occupancy figure counts — a
+  // write-in is not a party (kindred#2439), so `occupied` reads the room as
+  // empty however it was derived. Every number this verdict could state is
+  // therefore false in one direction or the other, and the reading is the
+  // unmeasured-capacity one above: no count, no claim. This is the same rule
+  // the card's own drag marks apply (`dragCapacity.known` in
+  // `LodgingUnitCard`), reaching the third surface that asks "is there room"
+  // — the board's match/red, the card figure, and now this row — so a
+  // written-into cabin cannot read "fits" in the picker while the card it was
+  // opened from refuses to print a numerator at all.
+  if (writeInEntries(unit).length > 0) return { fit: 'fits', note: null }
   const beds = partyBeds(party)
   // `Math.max(0, …)` for the same reason the header does it: a room already
   // over its capacity has nothing left, never a negative number of beds.

--- a/frontend/src/components/weekend/rosterAttention.ts
+++ b/frontend/src/components/weekend/rosterAttention.ts
@@ -28,7 +28,7 @@
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
 import { partyHeadcount } from './householdIdentity'
 import { needCoverage, needGlyph, needVerdict } from './needGlyphs'
-import { coveredCodes, drawnUnits, representingCodes } from './unitLevel'
+import { coveredCodes, drawnUnits, indexUnitsByCode, representingCodes } from './unitLevel'
 
 /** Ordered most urgent first. The order of this array IS the section order. */
 export const ATTENTION_ORDER = ['required', 'unmet', 'unplaced', 'unverified', 'settled'] as const
@@ -186,12 +186,13 @@ function representingCards(
  * unmeasured room grades `unmet` while `some` may grade `partial`, and
  * `unknown` beats `partial` for the same reason.
  *
- * ⚠️ THAT HOLDS FOR THE GLYPH READING, WHICH IS THE ONLY ONE THIS FEEDS. The
- * drag-time hatch reads `unknown` as `fits` (`UnknownReading` in
- * `needGlyphs.ts`), and under that reading a fold of `{unknown, some}` would
- * be softer than `some` alone. The hatch grades a candidate cabin the party is
- * not in, never a resolved placement, so it never sees one of these rows — if
- * that ever changes, this ladder needs a second one beside it.
+ * ⚠️ THAT HOLDS FOR THE GLYPH READING, WHICH IS THE ONLY ONE `needVerdict`
+ * HAS since 2026-08-21. The drag-time state no longer reads `unknown` at all
+ * — `resolveDragFit` intercepts it before grading (unrecorded coverage makes
+ * neither claim), so the old hatch-side `unknown → fits` reading, under which
+ * a fold of `{unknown, some}` would have been softer than `some` alone, is
+ * gone along with its `UnknownReading` parameter. If a drag-time reading of
+ * `unknown` ever returns, this ladder needs a second one beside it.
  *
  * `partial` is ramp-only and `shared`/`private` are bathroom-only, so the
  * three vocabularies get three constants rather than one union that would
@@ -468,10 +469,12 @@ export function attentionSections(
   }))
 }
 
-/** Index the roster's units by code so each row can find its own cabin. */
-export function indexUnitsByCode(units: LodgingUnitRow[]): Map<string, LodgingUnitRow> {
-  return new Map(units.map((unit) => [unit.code, unit]))
-}
+/**
+ * Index the roster's units by code so each row can find its own cabin.
+ * The implementation moved to `unitLevel` when it grew a WeakMap cache; this
+ * re-export keeps the import surface its callers already use.
+ */
+export { indexUnitsByCode } from './unitLevel'
 
 /**
  * Family spaces whose capacity nobody has recorded.
@@ -548,7 +551,7 @@ export function effectiveSleeps(unit: LodgingUnitRow, units: LodgingUnitRow[]): 
   const own = unit.sleeps ?? null
   if (unit.is_container !== true) return own
 
-  const byCode = new Map(units.map((row) => [row.code, row]))
+  const byCode = indexUnitsByCode(units)
   const leaves = coveredCodes(unit, units)
     .map((code) => byCode.get(code))
     .filter((leaf): leaf is LodgingUnitRow => leaf !== undefined && leaf.is_active !== false)

--- a/frontend/src/components/weekend/unitLevel.ts
+++ b/frontend/src/components/weekend/unitLevel.ts
@@ -38,9 +38,27 @@ import type { LodgingUnitRow } from '../../types/lodging'
  * ⚠️ KEYED ON IDENTITY, NOT CONTENTS. A caller that MUTATES a `units` array in
  * place would read a stale index. Nothing does: `units` reaches these helpers
  * straight from the query cache, which this app treats as immutable, and
- * `buildBoard` copies before it sorts.
+ * `buildBoard` copies before it sorts. The RETURNED maps are shared for the
+ * same reason — every caller for one `units` array gets the same instance, so
+ * mutating one would corrupt every other reader. Read them, never write them.
  */
 const childIndexByUnits = new WeakMap<LodgingUnitRow[], Map<string, LodgingUnitRow[]>>()
+const codeIndexByUnits = new WeakMap<LodgingUnitRow[], Map<string, LodgingUnitRow>>()
+
+/**
+ * The roster's units indexed by code — the same cache discipline as
+ * `childrenByParent` above, and here for the same measured reason: this map
+ * was being rebuilt inline at ELEVEN call sites across the board helpers,
+ * two of them (`slotOccupancy`, `overlappingPartyKeys`) once per card per
+ * render — ~17,000 Map insertions per board render for identical answers.
+ */
+export function indexUnitsByCode(units: LodgingUnitRow[]): Map<string, LodgingUnitRow> {
+  const cached = codeIndexByUnits.get(units)
+  if (cached !== undefined) return cached
+  const map = new Map(units.map((unit) => [unit.code, unit]))
+  codeIndexByUnits.set(units, map)
+  return map
+}
 
 function childrenByParent(units: LodgingUnitRow[]): Map<string, LodgingUnitRow[]> {
   const cached = childIndexByUnits.get(units)
@@ -175,7 +193,7 @@ export function buildingKey(
  * this" is exactly how the two numbers would start disagreeing.
  */
 export function buildingGroups(units: LodgingUnitRow[]): Map<string, string[]> {
-  const unitsByCode = new Map(units.map((unit) => [unit.code, unit]))
+  const unitsByCode = indexUnitsByCode(units)
   const groups = new Map<string, string[]>()
   for (const unit of units) {
     if (unit.is_container === true) continue
@@ -237,7 +255,7 @@ export function wholeBuildingHeld(
   occupiedLeaves: ReadonlySet<string>,
   units: LodgingUnitRow[]
 ): boolean {
-  const unitsByCode = new Map(units.map((unit) => [unit.code, unit]))
+  const unitsByCode = indexUnitsByCode(units)
   const groups = buildingGroups(units)
   const touchedKeys = new Set<string>()
   for (const leaf of occupiedLeaves) {
@@ -254,7 +272,7 @@ export function wholeBuildingHeld(
 /** The units that get a card, at the level each tree resolves to. */
 export function drawnUnits(units: LodgingUnitRow[]): LodgingUnitRow[] {
   const children = childrenByParent(units)
-  const byCode = new Map(units.map((unit) => [unit.code, unit]))
+  const byCode = indexUnitsByCode(units)
   const roots = units.filter((unit) => {
     const parent = unit.parent_code ?? ''
     return parent === '' || !byCode.has(parent)

--- a/frontend/src/components/weekend/unitLevel.ts
+++ b/frontend/src/components/weekend/unitLevel.ts
@@ -22,7 +22,30 @@
  */
 import type { LodgingUnitRow } from '../../types/lodging'
 
+/**
+ * The parent index, cached against the ARRAY IDENTITY that produced it.
+ *
+ * `coveredCodes` below rebuilds this on every call, and the board calls
+ * `coveredCodes` a great deal: 472 times on the first render of a 73-card
+ * board and 352 times on every re-render, each one walking all ~118 units. The
+ * work is the same answer every time, because within one render pass every
+ * caller is handed the same `units` array.
+ *
+ * A `WeakMap` on that array is the whole fix — no call-site churn, no
+ * threading an index through five signatures, and it falls out of memory with
+ * the array when React Query replaces the roster.
+ *
+ * ⚠️ KEYED ON IDENTITY, NOT CONTENTS. A caller that MUTATES a `units` array in
+ * place would read a stale index. Nothing does: `units` reaches these helpers
+ * straight from the query cache, which this app treats as immutable, and
+ * `buildBoard` copies before it sorts.
+ */
+const childIndexByUnits = new WeakMap<LodgingUnitRow[], Map<string, LodgingUnitRow[]>>()
+
 function childrenByParent(units: LodgingUnitRow[]): Map<string, LodgingUnitRow[]> {
+  const cached = childIndexByUnits.get(units)
+  if (cached !== undefined) return cached
+
   const map = new Map<string, LodgingUnitRow[]>()
   for (const unit of units) {
     const parent = unit.parent_code ?? ''
@@ -31,6 +54,7 @@ function childrenByParent(units: LodgingUnitRow[]): Map<string, LodgingUnitRow[]
     if (bucket) bucket.push(unit)
     else map.set(parent, [unit])
   }
+  childIndexByUnits.set(units, map)
   return map
 }
 

--- a/frontend/src/hooks/useUnitMerge.test.tsx
+++ b/frontend/src/hooks/useUnitMerge.test.tsx
@@ -184,3 +184,22 @@ describe('useUnitMerge', () => {
     expect(toastError).toHaveBeenCalledWith(expect.stringContaining('split'))
   })
 })
+
+describe('useUnitMerge — setCombined is identity-stable across renders', () => {
+  it('returns the same function on a re-render that changes nothing', () => {
+    /*
+     * The board hands `setCombined` (as `onSplit`/`onMerge`) to every one of
+     * ~73 memo'd unit cards. This hook once depended on the whole `mutation`
+     * object — a fresh identity from TanStack Query on every render — which
+     * silently defeated all 73 memos on every board render. The dep is
+     * `mutateAsync` now, like both sibling hooks; this pins it there.
+     */
+    const { result, rerender } = renderHook(
+      () => useUnitMerge({ year: YEAR, sessionCmId: SESSION, scenario: DRAFT }),
+      { wrapper }
+    )
+    const first = result.current.setCombined
+    rerender()
+    expect(result.current.setCombined).toBe(first)
+  })
+})

--- a/frontend/src/hooks/useUnitMerge.ts
+++ b/frontend/src/hooks/useUnitMerge.ts
@@ -76,6 +76,8 @@ export function useUnitMerge({ year, sessionCmId, scenario }: UseUnitMergeOption
     },
   })
 
+  const { mutateAsync } = mutation
+
   const setCombined = useCallback(
     async (unitId: string, unitName: string, combined: boolean) => {
       // ONE condition, not three, and not `scenario === ''` — see the file
@@ -83,9 +85,16 @@ export function useUnitMerge({ year, sessionCmId, scenario }: UseUnitMergeOption
       // `session_cm_id` `gt=0`, and the board defaults it to 0 for the tests
       // that do not exercise writes.
       if (sessionCmId <= 0) return
-      await mutation.mutateAsync({ unitId, unitName, combined })
+      await mutateAsync({ unitId, unitName, combined })
     },
-    [mutation, sessionCmId]
+    // `mutateAsync`, NOT `mutation` — the whole result object is a new
+    // identity on every render, which made `setCombined` unstable, and with it
+    // the board's `onSplit`/`onMerge`. That is a prop change on all ~73 unit
+    // cards on every board render, defeating their `memo` (measured: 73 of 73
+    // card bodies re-rendered on drag start for no reason). Both sibling
+    // hooks — `useUnitAvailability` and `useLodgingPlacement` — already depend
+    // on `mutateAsync`; this one was the outlier.
+    [mutateAsync, sessionCmId]
   )
 
   return {

--- a/frontend/src/hooks/useUnitMerge.ts
+++ b/frontend/src/hooks/useUnitMerge.ts
@@ -90,10 +90,12 @@ export function useUnitMerge({ year, sessionCmId, scenario }: UseUnitMergeOption
     // `mutateAsync`, NOT `mutation` — the whole result object is a new
     // identity on every render, which made `setCombined` unstable, and with it
     // the board's `onSplit`/`onMerge`. That is a prop change on all ~73 unit
-    // cards on every board render, defeating their `memo` (measured: 73 of 73
-    // card bodies re-rendered on drag start for no reason). Both sibling
-    // hooks — `useUnitAvailability` and `useLodgingPlacement` — already depend
-    // on `mutateAsync`; this one was the outlier.
+    // cards on EVERY board render, defeating their `memo` on renders where
+    // nothing about them changed. (Drag start itself legitimately re-renders
+    // every card — `draggingParty` is a real prop change there; the bug's cost
+    // was every OTHER render paying the same price.) Both sibling hooks —
+    // `useUnitAvailability` and `useLodgingPlacement` — already depend on
+    // `mutateAsync`; this one was the outlier.
     [mutateAsync, sessionCmId]
   )
 


### PR DESCRIPTION
The weekend board's drag-time signal, rebuilt around one three-valued state.

Picking a family up used to ask the card a single question — "how badly does this space miss?" — and
then asked that one verdict to drive two marks pointing in opposite directions. It now resolves the
whole question once: **conflict, match, or neither.**

## What a card does now

| state | mark |
|---|---|
| **conflict** — an asked need is not met | the hatch, **and the resting wash stands down** |
| **match** — every asked need met, and the party fits the free beds | the resting wash at double strength (`bg-primary/20`) |
| **neutral** — nothing to say | exactly what it looked like at rest |

Plus, independent of all three: **the N/M figure turns red on any cabin without room for the family
in hand**, keeping its own numbers — the party in flight is never added in.

## The decisions, and why each one is the way it is

**The negative wins, structurally.** `DragFit` is a discriminated union, so a card cannot be a
conflict and a match — not because a rule says so but because the type does. A conflict *gains* the
hazard texture and *loses* the invitation; that is two halves of one mark rather than two marks
arguing. This reverses a prior rule that let the tint and the hatch compose on orthogonal
properties. That rule was technically true and visually wrong: the card said "drop here" and "no" at
once, and at board scale the composite read as deactivated grey rather than a warning.

**Texture for the negative, more forest for the positive.** #1912 already ruled the misfit mark is
texture and nothing else, because the board's hues are committed. A match is not a new kind of thing
— it is the strongest version of the green the board already speaks — so no new hue enters a board
that has none free, and neither mark needs a per-theme value.

**Capacity gates the match and never causes a conflict.** A full cabin is not a bad cabin; it is a
cabin with nothing left in it. Measured before it was settled: letting capacity hatch took a
six-person family asking *nothing* from 0 marked cards to 45 of 73. Capacity already has a per-card
carrier in the N/M figure; the needs have none.

**A party that asks for nothing earns no match**, and the board does not switch modes at all. Every
cabin with room fits such a family, so a mark saying so carries nothing — and **368 of 479** 2026
registrations ask no housing need, so this is what most drags do.

**Unrecorded coverage makes neither claim.** Not a conflict, because the hatch is an interruption
and its bar is evidence of absence; not a match, because a positive mark is a claim and the
2026-08-20 ruling says unconfirmed information must not read as met. No single reading of `unknown`
could serve both marks, which is why the state is resolved in one place now. In the registry this
reaches exactly one field: `has_ramp` — 104 of 118 units hold a blank raw value, of which **102**
still read `unknown` once `ramp_coverage` has walked the leaves, and 102 is the number that reaches
the grading. Before this rule a step-free household saw 21 matches, every one a cabin nobody has
ever assessed.

**Four needs, not three, on the prospective axis.** The mark grades what the glyphs draw — the
narrowed `HATCHED_NEEDS` that left `bathroom` out is gone. Its argument was about a mark that could
only ever be negative, and half of this one is positive. Bathroom also moves to "would THIS cabin
meet it?"; on the old reading it took `party.effective_bathroom` and ignored the target entirely —
a board-wide constant, every card or none, which cannot mean anything per card.

**Capacity red on every drag.** Narrower scopes were considered and dropped on predictability: a red
that appears for some families and not others makes staff reverse-engineer the rule. It does mean a
card can carry a hatch *and* a red figure — two different facts, two channels.

The only cabins either capacity mark skips are the ones whose free-bed count is not a fact:
unmeasured capacity, a straddling party, and a **wholesale write-in** — which contributes no
`partySize` to `slotOccupancy` (kindred#2439), so the cabin reads as wholly free. Those are not
exceptions to the rule so much as cabins the rule has nothing to say about. And the family in flight
gets its **own beds added back** on the card it currently occupies, or its present cabin would claim
it will not fit somewhere it demonstrably does — routine, since moving a placed family between
cabins is the board's core operation.

## What comes off the card

**The area colour, from the top edge.** Area identity had four carriers on the board — the
`<section>`, the heading, the header dot, and 73 card top-edges — and only the card edge was on every
card, always on. `boardLayout.ts` §3.10 already said the headers do the grouping and the per-card hue
"degrades to decoration". It survives at 8 instances instead of 73. The map keeps its per-unit hue:
it has no section headers, so position is its only other grouping.

**The bold primary title.** #2093 coupled a forest wash and a bold title to one flag so the halves
could not drift; the title half is struck for the open marker and the match alike. The card's type is
now one weight and one colour in every state.

Between them, **the card's frame is a constant** — no state touches `border-color`, `border-width` or
the title, so every mark lives in `background-color` or `background-image` and the three drag states
share one channel without racing. The dashed edge on an empty card stays, and now dashes a plain
border rather than chopping the area accent.

**The hatch is retuned**: `1px / 5px / 10%` becomes `3px / 7px / 6%`, with the `partial` variant at
`3px / 15px`. Roughly the same mean ink over three times the stroke width — a broad soft stroke
rather than a hairline, which is what lets it sit on plain card ground now that the wash stands down
beneath it. This amends #1912's base values; its mechanism is untouched, and severity is still the
period and only the period.

## One rule, one definition

`hasNoRoom(party, capacity)` is the single definition of "no room for this family", exported from
`needsFit.ts` and used by both marks that ask it — `resolveDragFit` gates the match on it, and the
card reddens the N/M figure from it, reading one `DragCapacity` built once. They were separate inline
expressions in separate modules until the write-in rule had to be applied to both by hand in the same
commit; patching only one would have left the match correct and the red wrong on the same card, with
nothing to catch it. A property test now asserts the two can never contradict.

The three conditions that make a bed count unknowable — unmeasured capacity, a straddling party, a
wholesale write-in — are stated once where that object is built. `known: false` yields false rather
than true, deliberately: a count that is not a fact cannot support "you will not fit here" any more
than it can support a match.

## Tests

`resolveNeedsFit` and its three describes are **deleted, not adapted** — the specification moved
under them (`unknown` used to read as `fits`; capacity was not graded at all), so they pinned an
invariant that no longer holds. Four card tests are **rewritten** carrying why, one of which reverses
outright. The two "never reads the raw row" guards were ported rather than lost: they stop a
server-side ruling being re-derived on the client.

Every rule above was mutation-checked — removing it turns tests red. Full frontend suite green: 452
files, 7261 tests.

Reviewed by CodeRabbit and by two independent adversarial passes against the design mockup. Four
real defects came out of that and are fixed in-branch: the drop ring losing to the match wash on one
card (both set `background-color`), the write-in rule above, the self-occupancy arithmetic above,
and a set of comments and **checked-in decision records** that still described the superseded
behaviour as current — `lodging-board-vs-summer.md` said the area hue stripe "must survive any chrome
change", and `weekend-card-vocabulary.md` said bathroom's exclusion from the hatch "stands". Both are
corrected in place; the bathroom arithmetic is kept, because it is the reasoning the reversal had to
answer.

## Deliberately not in this PR

- **#2527** — whether the board *should* match an occupied cabin. To be precise about what ships:
  a match keys on "has beds free", so it **can** land on an occupied cabin that still has room, and
  this PR does not change that. What is deferred is the ruling on whether that is right — the board
  arguably proposes a share there, and the four sharing fields it would be asserting over are not
  settled. Do not widen, restrict or make the behaviour explicit as a follow-up tidy-up; it has an
  owner on it.
- **#2526** — taking registry values at face value. When `unknown` goes away, the branch that handles
  it stops being reachable rather than stops being correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Performance

Dragging a family was slow enough to be a bad user experience, and none of it was the fit logic —
the pure resolution math costs **2.45ms for the whole board**. Profiled on a production-scale board
(73 cards, 133 placed families), the drag spent **47% of its wall-clock in main-thread long tasks**
(p50 124ms, worst frame 388ms), all of it re-rendering:

- **dnd-kit publishes `over` through React context**, so every `useDroppable`/`useDraggable` caller
  re-rendered on every cabin boundary the pointer crossed — 1,636 `FamilyCard` body renders in one
  sweep. Both cards are now split into a thin shell that owns the dnd subscription and a `memo`'d
  body: an `over` flip re-renders **exactly the two bodies** whose ring changed.
- **Two identity bugs silently defeated that memo**: `useSensor` options written inline (a fresh
  `listeners` object for every draggable on every board render) and `useUnitMerge.setCombined`
  depending on the whole `mutation` object where both sibling hooks already depend on `mutateAsync`.
  Until the second fix landed, the first bought nothing — measured, not assumed.
- **`childrenByParent` rebuilt its parent index on every `coveredCodes` call** — 472 on first paint,
  352 per re-render. Cached per units-array identity in a `WeakMap`; the identity-keying hazard is
  documented at the cache.
- **The auto-scroller's 5ms tick** — 200 scroll events/s against a board that is five viewports tall
  in real 2026 data — is retuned to 15ms at the same velocity. A modest, honest win; the comment
  carries the measured numbers.

One behaviour fix came out of the profiling: `pointerWithin` returns nothing in the 12px grid
gutters, and the `rectIntersection` fallback scores by *overlay* overlap, so the drop ring — and the
real drop target, which is the same `over` — visited cabins the pointer never entered, with
reversals. `boardCollision.ts` now holds the last cabin the pointer was actually inside while it
still intersects, so releasing over a gutter lands where the ring says. Pinned by 5 tests,
mutation-checked; the ring flap measured 13 moves → 9 on the same path.

After (production build, real Family Camp 2 board): sweep long tasks **1×350ms → 0**, script
**897ms → 227–297ms**; auto-scroll worst stall **235ms → 68–80ms**. The remaining auto-scroll cost
is browser paint of a 5,500px page, which no React change reaches.
