### PR TITLE
feat(frontend): internal bunk notes starts collapsed in the family panel

### DIFF
--- a/frontend/src/components/weekend/ShareRequestPanel.test.tsx
+++ b/frontend/src/components/weekend/ShareRequestPanel.test.tsx
@@ -21,9 +21,11 @@
  * blocks start EXPANDED (nothing hidden behind a click, because a scanning
  * eye must not miss request text) and every block is COLLAPSIBLE (a staff
  * member facing the seven-entry household can fold them away). kindred#2476
- * (owner ruling 2026-08-21) tunes this: `Share Bunk With` alone now starts
- * COLLAPSED -- see the `describe('Share Bunk With starts collapsed...')`
- * block below -- every other block keeps the EXPANDED default above.
+ * (owner ruling 2026-08-21) tunes this: `Share Bunk With` starts COLLAPSED --
+ * see the `describe('Share Bunk With and Internal Bunk Notes start
+ * collapsed...')` block below. A follow-up staff ruling (2026-08-21) adds
+ * `Internal Bunk Notes` to that same starts-collapsed set, mirroring the
+ * precedent -- every other block keeps the EXPANDED default above.
  *
  * Shape it is built against, measured on the 2026 production snapshot over
  * the 382 households rostered into a family session: 270 carry any text, 142
@@ -426,7 +428,11 @@ describe('expanded by default, collapsible by click', () => {
         share={share({
           request_blocks: [
             block('COVID-19 Bunking Requests', [{ text: 'A quiet cabin, please' }]),
-            block('Internal Bunk Notes', [{ text: 'Called the family Tuesday.' }], 'staff'),
+            // NOT `Internal Bunk Notes` -- the 2026-08-21 follow-up ruling
+            // starts it folded, and this test asserts both entries render
+            // without a click. `BunkingNotes Notes` is the other staff field
+            // and keeps the old expanded-by-default.
+            block('BunkingNotes Notes', [{ text: 'Called the family Tuesday.' }], 'staff'),
           ],
         })}
       />
@@ -479,10 +485,12 @@ describe('expanded by default, collapsible by click', () => {
   })
 })
 
-describe('Share Bunk With starts collapsed; its siblings do not (kindred#2476)', () => {
+describe('Share Bunk With and Internal Bunk Notes start collapsed; their siblings do not (kindred#2476, staff ruling 2026-08-21)', () => {
   // Owner ruling 2026-08-21, tuning the 2026-08-17 "blocks start EXPANDED"
-  // ruling: `Share Bunk With` alone starts folded. Every other block keeps
-  // the old default.
+  // ruling: `Share Bunk With` starts folded (kindred#2476 / PR #2521). A
+  // same-day follow-up staff ruling extends the identical treatment to
+  // `Internal Bunk Notes` -- both source fields now start folded, and every
+  // other block keeps the old default.
   it('renders Share Bunk With folded on first paint while a sibling stays open', () => {
     render(
       <ShareRequestPanel
@@ -535,6 +543,63 @@ describe('Share Bunk With starts collapsed; its siblings do not (kindred#2476)',
 
     expect(screen.queryByText("The second family's fridge ask")).not.toBeInTheDocument()
   })
+
+  it('renders Internal Bunk Notes folded on first paint while a sibling stays open', () => {
+    render(
+      <ShareRequestPanel
+        share={share({
+          request_blocks: [
+            block('COVID-19 Bunking Requests', [{ text: 'A quiet cabin, please' }]),
+            block('Internal Bunk Notes', [{ text: 'Watch the cabin split here.' }], 'staff'),
+          ],
+        })}
+      />
+    )
+
+    expect(screen.getByText('A quiet cabin, please')).toBeInTheDocument()
+    expect(screen.queryByText('Watch the cabin split here.')).not.toBeInTheDocument()
+    // The header stays, or there is nothing left to click to open it.
+    expect(screen.getByText('Internal Bunk Notes')).toBeInTheDocument()
+  })
+
+  it('opens Internal Bunk Notes on click, same as any other block', () => {
+    render(
+      <ShareRequestPanel
+        share={share({
+          request_blocks: [
+            block('Internal Bunk Notes', [{ text: 'Watch the cabin split here.' }], 'staff'),
+          ],
+        })}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Internal Bunk Notes' }))
+    expect(screen.getByText('Watch the cabin split here.')).toBeInTheDocument()
+  })
+
+  it('THE TRAP: a household switch re-collapses Internal Bunk Notes rather than opening it', () => {
+    // Same trap as Share Bunk With above, pinned separately: the default has
+    // to be applied in the reset-on-household-change branch too, or Internal
+    // Bunk Notes re-opens for every household after the first, the moment
+    // staff click the next family.
+    const first = share({
+      request_blocks: [
+        block('Internal Bunk Notes', [{ text: "The first family's cabin-split note" }], 'staff'),
+      ],
+    })
+    const second = share({
+      request_blocks: [
+        block('Internal Bunk Notes', [{ text: "The second family's cabin-split note" }], 'staff'),
+      ],
+    })
+
+    const { rerender } = render(<ShareRequestPanel share={first} />)
+    expect(screen.queryByText("The first family's cabin-split note")).not.toBeInTheDocument()
+
+    rerender(<ShareRequestPanel share={second} />)
+
+    expect(screen.queryByText("The second family's cabin-split note")).not.toBeInTheDocument()
+  })
 })
 
 describe('one treatment, and the lane is data rather than colour', () => {
@@ -571,6 +636,10 @@ describe('one treatment, and the lane is data rather than colour', () => {
         })}
       />
     )
+    // Internal Bunk Notes starts folded (2026-08-21 staff ruling) -- open it
+    // explicitly so both staff-authored entries are on screen for this rail
+    // check, same as BunkingNotes Notes which still starts expanded.
+    fireEvent.click(screen.getByRole('button', { name: 'Internal Bunk Notes' }))
 
     for (const entry of screen.getAllByTestId('request-entry')) {
       expect(entry.className).toContain('border-amber-300')

--- a/frontend/src/components/weekend/ShareRequestPanel.tsx
+++ b/frontend/src/components/weekend/ShareRequestPanel.tsx
@@ -153,12 +153,14 @@ export interface ShareRequestPanelProps {
 }
 
 /**
- * Source fields that start FOLDED, kindred#2476 (owner ruling 2026-08-21).
- * Every field not listed here keeps the 2026-08-17 default of starting
- * expanded. `Share Bunk With` is the one exception, not a new baseline —
- * do not fold anything else in here on your own judgement.
+ * Source fields that start FOLDED. `Share Bunk With` was the first,
+ * kindred#2476 (owner ruling 2026-08-21) / PR #2521. `Internal Bunk Notes`
+ * was added the same day by a follow-up staff ruling, mirroring that exact
+ * precedent. Every field not listed here keeps the 2026-08-17 default of
+ * starting expanded — do not fold anything else in here on your own
+ * judgement.
  */
-const DEFAULT_FOLDED: ReadonlySet<string> = new Set(['Share Bunk With'])
+const DEFAULT_FOLDED: ReadonlySet<string> = new Set(['Share Bunk With', 'Internal Bunk Notes'])
 
 function isDefaultFolded(folded: ReadonlySet<string>): boolean {
   if (folded.size !== DEFAULT_FOLDED.size) return false


### PR DESCRIPTION
## Summary

Staff ruling: on the weekend lodging board's family details panel, the
"Internal Bunk Notes" request block must start COLLAPSED, exactly like
"Share Bunk With" already does. That precedent shipped as kindred#2476 /
PR #2521 (`Share Bunk With` moves to the bottom of the six request blocks
and starts collapsed). This PR extends the identical starts-collapsed
treatment to `Internal Bunk Notes` — no other block's default changes.

## Server-side order — verified unchanged, no edit needed

`api/services/lodging_rules.py:422-429` (`REQUEST_TEXT_SOURCES`) already
orders `Internal Bunk Notes` (#5) below `BunkingNotes Notes` (#4), staff's
requested order from #2476:

```python
REQUEST_TEXT_SOURCES: tuple[RequestTextSource, ...] = (
    RequestTextSource("COVID-19 Bunking Requests", "family"),
    RequestTextSource("Shared-request", "family"),
    RequestTextSource("FAM CAMP-Share Comments", "family"),
    RequestTextSource("BunkingNotes Notes", "staff"),
    RequestTextSource("Internal Bunk Notes", "staff"),
    RequestTextSource("Share Bunk With", "family"),
)
```

This was read directly off `main` before touching anything — no backend
change is part of this PR.

## Frontend change

`frontend/src/components/weekend/ShareRequestPanel.tsx` — one-line addition
to `DEFAULT_FOLDED`, the set of source fields that start folded:

```diff
-const DEFAULT_FOLDED: ReadonlySet<string> = new Set(['Share Bunk With'])
+const DEFAULT_FOLDED: ReadonlySet<string> = new Set(['Share Bunk With', 'Internal Bunk Notes'])
```

The doc comment above it is updated to record both the original #2476/#2521
precedent and this follow-up ruling, so a future reader doesn't have to
reconstruct why two fields (and only two) are in that set.

## Tests (TDD — written first, verified red, then implemented)

`ShareRequestPanel.test.tsx`'s `describe('Share Bunk With starts collapsed…
(kindred#2476)')` block is renamed to `'Share Bunk With and Internal Bunk
Notes start collapsed…'` and gains three new cases mirroring the existing
`Share Bunk With` ones exactly:

- renders `Internal Bunk Notes` folded on first paint while a sibling stays open
- opens `Internal Bunk Notes` on click, same as any other block
- **THE TRAP**: a household switch re-collapses `Internal Bunk Notes` rather
  than opening it (pins that the fold default is re-applied on the
  reset-on-household-change branch, not just the initial `useState` seed —
  the same trap #2521 pinned for `Share Bunk With`)

Two pre-existing tests assumed `Internal Bunk Notes` was expanded by
default and are re-anchored, following the exact pattern #2521 used for
`Share Bunk With`:

- `'shows every answer on first render without a click'` now uses
  `BunkingNotes Notes` (the only other staff field) as its still-expanded
  fixture, with a comment explaining the swap.
- `'renders the two staff-authored fields on that SAME amber rail'` now
  explicitly clicks `Internal Bunk Notes` open before asserting on both
  entries' styling, since it no longer starts expanded.

### Red (before implementation — 3 new tests failing, 44 passing)

```
 ❯ |unit| src/components/weekend/ShareRequestPanel.test.tsx (47 tests | 3 failed) 274ms
     × renders Internal Bunk Notes folded on first paint while a sibling stays open 7ms
     × opens Internal Bunk Notes on click, same as any other block 8ms
     × THE TRAP: a household switch re-collapses Internal Bunk Notes rather than opening it 2ms

 Test Files  1 failed (1)
      Tests  3 failed | 44 passed (47)
```

### Green (after implementation)

```
 Test Files  1 passed (1)
      Tests  47 passed (47)
```

Full `weekend/` directory suite, after implementation:

```
 Test Files  43 passed (43)
      Tests  1561 passed (1561)
```

### Trap check

`git grep -n "Internal Bunk Notes" -- frontend/` confirms no remaining test
or comment pins the old expanded-by-default behavior for this field.

## Verification

`bash scripts/pre-push-verify.sh` (prettier, eslint, tsc, vitest) — all
green after a prettier auto-format pass on the test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
