### PR TITLE
feat(frontend): four dialogs play the Modal exit fade instead of vanishing (tier 2)

### DIFF
--- a/frontend/src/components/CamperCohortsSection.test.tsx
+++ b/frontend/src/components/CamperCohortsSection.test.tsx
@@ -9,30 +9,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor, fireEvent } from '../test/testUtils'
 import { CamperCohortsSection } from './CamperCohortsSection'
-import type { CamperCohorts, CohortEntry } from '../hooks/useCamperCohorts'
-
-// Helper: build a CohortEntry with empty attendees array (cohort attendees
-// are tested separately in useCamperCohorts.test.ts).
-function entry(label: string, count: number): CohortEntry {
-  return { label, count, attendees: [] }
-}
-
-// Helper: build a CamperCohorts fixture with default sessionType / allGenders.
-function cohorts(parts: {
-  school?: CohortEntry | null
-  congregation?: CohortEntry | null
-  city?: CohortEntry | null
-  sessionType?: string
-  allGenders?: boolean
-}): CamperCohorts {
-  return {
-    school: parts.school ?? null,
-    congregation: parts.congregation ?? null,
-    city: parts.city ?? null,
-    sessionType: parts.sessionType ?? 'main',
-    allGenders: parts.allGenders ?? false,
-  }
-}
+import {
+  cohortEntry as entry,
+  cohortsFixture as cohorts,
+  matchedAttendee,
+} from '../test/cohortFixtures'
 
 // Mock the hooks — test the component in isolation
 const mockUseCamperCohorts = vi.fn()
@@ -286,18 +267,6 @@ describe('CamperCohortsSection', () => {
   })
 
   describe('drilldown click behavior', () => {
-    function matchedAttendee(personCmId: number, firstName: string) {
-      return {
-        attendeeId: `a${personCmId}`,
-        personCmId,
-        firstName,
-        lastName: 'Garcia',
-        preferredName: null,
-        grade: 7,
-        gender: 'M',
-      }
-    }
-
     it('clicking a cohort row opens the drilldown modal scoped to that label', async () => {
       mockUseCamperCohorts.mockReturnValue({
         cohorts: cohorts({

--- a/frontend/src/components/CamperCohortsSection.test.tsx
+++ b/frontend/src/components/CamperCohortsSection.test.tsx
@@ -356,6 +356,37 @@ describe('CamperCohortsSection', () => {
       expect(await screen.findByText(/Same city: Springfield/)).toBeInTheDocument()
     })
 
+    it('keeps the drilldown painted through the exit fade after close (kindred#2529)', async () => {
+      // The exit-fade pin. `onClose` used to null `openKind`, which unmounted
+      // the modal in the same frame — the Transition #2530 gave Modal never got
+      // to play its 150ms leave. The parent now keeps the cohort snapshot and
+      // drives a separate open flag, so the DOM must outlive the close, then go.
+      mockUseCamperCohorts.mockReturnValue({
+        cohorts: cohorts({
+          school: {
+            label: 'Riverside Elementary',
+            count: 1,
+            attendees: [matchedAttendee(1000002, 'Liam')],
+          },
+        }),
+        isLoading: false,
+      })
+
+      render(<CamperCohortsSection {...defaultProps} />)
+
+      fireEvent.click(await screen.findByRole('button', { name: /Also from Riverside Elementary/ }))
+      expect(await screen.findByText(/Same school: Riverside Elementary/)).toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole('button', { name: /close/i }))
+      // Still painted on the frame the close fires...
+      expect(screen.getByText(/Same school: Riverside Elementary/)).toBeInTheDocument()
+      // ...and gone once the leave completes (jsdom runs it on its own frame
+      // scheduling — never the declared 150ms; do not assert time).
+      await waitFor(() => {
+        expect(screen.queryByText(/Same school: Riverside Elementary/)).not.toBeInTheDocument()
+      })
+    })
+
     it('passes requestRelations from useCohortRequestRelations into the modal', async () => {
       const relations = new Map<number, Rel>([[1000002, { type: 'bunk_with', mutual: false }]])
       mockUseCohortRequestRelations.mockReturnValue({ relations, isLoading: false })

--- a/frontend/src/components/CamperCohortsSection.tsx
+++ b/frontend/src/components/CamperCohortsSection.tsx
@@ -39,9 +39,10 @@ export function CamperCohortsSection({
   // `openKind` is a RETAINED SNAPSHOT, not the open flag (kindred#2529): the
   // drill-down must stay mounted through Modal's 150ms leave transition after
   // close, so closing clears only `drillOpen` and the last-viewed cohort keeps
-  // the content renderable through the fade. The modal is hookless and renders
-  // no DOM while closed (Modal's <Transition> unmounts its children) — its
-  // element tree still evaluates on each parent render, which is cheap here.
+  // the content renderable through the fade. afterLeave then releases the
+  // snapshot — the modal is hookless, but its element tree (an attendees.map)
+  // would otherwise re-evaluate on every parent render forever after the
+  // first open, only to be discarded by the closed <Transition>.
   const [openKind, setOpenKind] = useState<CohortKind | null>(null)
   const [drillOpen, setDrillOpen] = useState(false)
 
@@ -112,6 +113,7 @@ export function CamperCohortsSection({
           requestRelations={relations}
           bunkByPerson={bunkByPerson}
           onClose={() => setDrillOpen(false)}
+          afterLeave={() => setOpenKind(null)}
         />
       )}
     </section>

--- a/frontend/src/components/CamperCohortsSection.tsx
+++ b/frontend/src/components/CamperCohortsSection.tsx
@@ -39,9 +39,9 @@ export function CamperCohortsSection({
   // `openKind` is a RETAINED SNAPSHOT, not the open flag (kindred#2529): the
   // drill-down must stay mounted through Modal's 150ms leave transition after
   // close, so closing clears only `drillOpen` and the last-viewed cohort keeps
-  // the content renderable through the fade. The modal is hookless, so a
-  // mounted-closed instance does no work — Modal's <Transition> unmounts its
-  // children while closed.
+  // the content renderable through the fade. The modal is hookless and renders
+  // no DOM while closed (Modal's <Transition> unmounts its children) — its
+  // element tree still evaluates on each parent render, which is cheap here.
   const [openKind, setOpenKind] = useState<CohortKind | null>(null)
   const [drillOpen, setDrillOpen] = useState(false)
 

--- a/frontend/src/components/CamperCohortsSection.tsx
+++ b/frontend/src/components/CamperCohortsSection.tsx
@@ -36,7 +36,14 @@ export function CamperCohortsSection({
 }: CamperCohortsSectionProps) {
   const { cohorts, isLoading } = useCamperCohorts(personCmId, sessionCmId, year)
   const { relations } = useCohortRequestRelations(personCmId, sessionCmId, year)
+  // `openKind` is a RETAINED SNAPSHOT, not the open flag (kindred#2529): the
+  // drill-down must stay mounted through Modal's 150ms leave transition after
+  // close, so closing clears only `drillOpen` and the last-viewed cohort keeps
+  // the content renderable through the fade. The modal is hookless, so a
+  // mounted-closed instance does no work — Modal's <Transition> unmounts its
+  // children while closed.
   const [openKind, setOpenKind] = useState<CohortKind | null>(null)
+  const [drillOpen, setDrillOpen] = useState(false)
 
   // Union of every cohort's matched person ids — feeds the bunk lookup so
   // switching between school/congregation/city tabs reuses the same query.
@@ -71,7 +78,10 @@ export function CamperCohortsSection({
             <button
               key={row.kind}
               type="button"
-              onClick={() => setOpenKind(row.kind)}
+              onClick={() => {
+                setOpenKind(row.kind)
+                setDrillOpen(true)
+              }}
               className="text-muted-foreground hover:bg-muted/50 hover:text-foreground flex w-full items-center gap-1.5 rounded px-1 py-0.5 text-left text-xs transition-colors"
               data-testid="cohort-row"
               data-cohort-kind={row.kind}
@@ -93,7 +103,7 @@ export function CamperCohortsSection({
 
       {openKind && openEntry && (
         <CohortDrillDownModal
-          open
+          open={drillOpen}
           kind={openKind}
           label={openEntry.label}
           selfDisplayName={selfDisplayName}
@@ -101,7 +111,7 @@ export function CamperCohortsSection({
           attendees={openEntry.attendees}
           requestRelations={relations}
           bunkByPerson={bunkByPerson}
-          onClose={() => setOpenKind(null)}
+          onClose={() => setDrillOpen(false)}
         />
       )}
     </section>

--- a/frontend/src/components/CohortDrillDownModal.tsx
+++ b/frontend/src/components/CohortDrillDownModal.tsx
@@ -48,6 +48,8 @@ interface CohortDrillDownModalProps {
    */
   reserveSidePanel?: boolean
   onClose: () => void
+  /** Forwarded to Modal — fires when the leave completes; parents use it to release their retained snapshot (kindred#2529). */
+  afterLeave?: () => void
 }
 
 const KIND_TITLE: Record<CohortKind, string> = {
@@ -130,6 +132,7 @@ export function CohortDrillDownModal({
   bunkByPerson,
   reserveSidePanel = true,
   onClose,
+  afterLeave,
 }: CohortDrillDownModalProps) {
   const count = attendees.length
   const camperWord = count === 1 ? 'camper' : 'campers'
@@ -154,6 +157,7 @@ export function CohortDrillDownModal({
     <Modal
       isOpen={open}
       onClose={onClose}
+      {...(afterLeave !== undefined && { afterLeave })}
       header={header}
       ariaLabelledBy="cohort-modal-title"
       size="lg"

--- a/frontend/src/components/SessionView.diagnostics.guard.test.ts
+++ b/frontend/src/components/SessionView.diagnostics.guard.test.ts
@@ -22,16 +22,23 @@ import { describe, expect, it } from 'vitest'
 const src = readFileSync(resolve(__dirname, './SessionView.tsx'), 'utf-8')
 
 describe('SessionView solver-diagnostics close path (kindred#2529)', () => {
-  // The render block from the modal's JSX tag to the end of its props.
-  const start = src.indexOf('<SolverDiagnosticsModal')
-  const block = src.slice(start, src.indexOf('/>', start))
+  // The render block: from the retained-snapshot gate through the modal's
+  // self-closing tag. Anchoring on the gate rather than the tag makes the
+  // latch assertion below part of the extraction itself.
+  const gate = src.indexOf('{diagnostics && (')
+  const start = src.indexOf('<SolverDiagnosticsModal', gate)
+  const block = gate === -1 || start === -1 ? '' : src.slice(gate, src.indexOf('/>', start))
 
-  it('still renders the diagnostics modal (anchor for the assertions below)', () => {
-    expect(start).toBeGreaterThan(-1)
+  it('keeps the retained-snapshot latch — the modal renders only behind {diagnostics && …}', () => {
+    // The latch IS the mechanism: null until the first reviewable solve,
+    // then kept across closes so the mounted dialog can play the exit fade.
+    expect(gate).toBeGreaterThan(-1)
+    expect(start).toBeGreaterThan(gate)
     expect(block).toContain('setShowDiagnostics(false)')
   })
 
   it('does NOT null the diagnostics payload on close — the exit fade needs it', () => {
+    expect(block.length).toBeGreaterThan(0)
     expect(block).not.toContain('setDiagnostics(null)')
   })
 })

--- a/frontend/src/components/SessionView.diagnostics.guard.test.ts
+++ b/frontend/src/components/SessionView.diagnostics.guard.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Source guard: the solver-diagnostics payload must outlive close (kindred#2529).
+ *
+ * SessionView is a heavy integration component that is not practical to render
+ * in a unit test (see SessionView.session-reset.test.tsx for the precedent),
+ * so this pins the one line that matters as a source assertion, the way
+ * index.css.guard.test.ts pins its invariants.
+ *
+ * The mechanism: `{diagnostics && <SolverDiagnosticsModal>}` is a retained
+ * snapshot latch — null until the first infeasible solve, then permanently
+ * set, with `showDiagnostics` driving the fade. If onClose nulls the payload
+ * again, the modal unmounts on the same frame the close fires and Modal's
+ * 150ms leave transition (#2530) never plays. SolverDiagnosticsModal renders
+ * the "No diagnostic detail is available" fallback for a never-populated
+ * payload, and each reviewable solver run overwrites it, so retaining the
+ * last payload is safe.
+ */
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { describe, expect, it } from 'vitest'
+
+const src = readFileSync(resolve(__dirname, './SessionView.tsx'), 'utf-8')
+
+describe('SessionView solver-diagnostics close path (kindred#2529)', () => {
+  // The render block from the modal's JSX tag to the end of its props.
+  const start = src.indexOf('<SolverDiagnosticsModal')
+  const block = src.slice(start, src.indexOf('/>', start))
+
+  it('still renders the diagnostics modal (anchor for the assertions below)', () => {
+    expect(start).toBeGreaterThan(-1)
+    expect(block).toContain('setShowDiagnostics(false)')
+  })
+
+  it('does NOT null the diagnostics payload on close — the exit fade needs it', () => {
+    expect(block).not.toContain('setDiagnostics(null)')
+  })
+})

--- a/frontend/src/components/SessionView.diagnostics.guard.test.ts
+++ b/frontend/src/components/SessionView.diagnostics.guard.test.ts
@@ -24,21 +24,43 @@ const src = readFileSync(resolve(__dirname, './SessionView.tsx'), 'utf-8')
 describe('SessionView solver-diagnostics close path (kindred#2529)', () => {
   // The render block: from the retained-snapshot gate through the modal's
   // self-closing tag. Anchoring on the gate rather than the tag makes the
-  // latch assertion below part of the extraction itself.
+  // latch assertion below part of the extraction itself. Every index is
+  // guarded — an unguarded end would make slice() run to end-of-file and
+  // both assertions silently measure unrelated source (#2539 scan round 2).
   const gate = src.indexOf('{diagnostics && (')
   const start = src.indexOf('<SolverDiagnosticsModal', gate)
-  const block = gate === -1 || start === -1 ? '' : src.slice(gate, src.indexOf('/>', start))
+  const end = start === -1 ? -1 : src.indexOf('/>', start)
+  const block = gate === -1 || start === -1 || end === -1 ? '' : src.slice(gate, end)
+
+  // onClose's own arrow body, extracted separately: the payload rule below is
+  // about the CLOSE path specifically. Clearing on afterLeave is the
+  // OPPOSITE of the bug — that fires only after the fade has completed, when
+  // the DOM is already gone — so the guard must not forbid it (round-2
+  // finding 1: the first version banned setDiagnostics(null) anywhere in the
+  // block, which vetoed the correct afterLeave cleanup).
+  const closeStart = block.indexOf('onClose=')
+  const closeEnd = closeStart === -1 ? -1 : block.indexOf('}}', closeStart)
+  const closeBody = closeStart === -1 || closeEnd === -1 ? '' : block.slice(closeStart, closeEnd)
 
   it('keeps the retained-snapshot latch — the modal renders only behind {diagnostics && …}', () => {
     // The latch IS the mechanism: null until the first reviewable solve,
     // then kept across closes so the mounted dialog can play the exit fade.
     expect(gate).toBeGreaterThan(-1)
     expect(start).toBeGreaterThan(gate)
-    expect(block).toContain('setShowDiagnostics(false)')
+    expect(end).toBeGreaterThan(start)
+    expect(closeBody).toContain('setShowDiagnostics(false)')
   })
 
-  it('does NOT null the diagnostics payload on close — the exit fade needs it', () => {
-    expect(block.length).toBeGreaterThan(0)
-    expect(block).not.toContain('setDiagnostics(null)')
+  it('does NOT null the diagnostics payload in onClose — the exit fade needs it', () => {
+    expect(closeBody.length).toBeGreaterThan(0)
+    expect(closeBody).not.toContain('setDiagnostics(null)')
+  })
+
+  it('DOES drop the payload once the fade completes, via afterLeave', () => {
+    // The other half of the retention contract: keep the payload through the
+    // leave, then release it so the mounted-closed modal stops re-rendering
+    // its report on every SessionView render forever (round-2 finding 3).
+    expect(block).toContain('afterLeave')
+    expect(block).toContain('setDiagnostics(null)')
   })
 })

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -524,13 +524,19 @@ export default function SessionView() {
       {/* Solver Progress Modal */}
       <SolverProgressModal state={solverProgress.state} onClose={solverProgress.close} />
 
-      {/* #1638 — Solver Diagnostics Modal (infeasibility review) */}
+      {/* #1638 — Solver Diagnostics Modal (infeasibility review). The
+          `diagnostics &&` gate is a retained-snapshot latch (kindred#2529):
+          null until the first reviewable solve, then kept across closes so
+          the mounted dialog can play Modal's 150ms exit fade — nulling the
+          payload here would blank and unmount it on the same frame the close
+          fires. Each reviewable run overwrites the payload, and the modal
+          renders its own empty-state fallback, so retaining the last one is
+          safe. Pinned by SessionView.diagnostics.guard.test.ts. */}
       {diagnostics && (
         <SolverDiagnosticsModal
           isOpen={showDiagnostics}
           onClose={() => {
             setShowDiagnostics(false)
-            setDiagnostics(null)
           }}
           diagnostics={diagnostics}
           sessionCmId={session.cm_id}

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -526,17 +526,23 @@ export default function SessionView() {
 
       {/* #1638 — Solver Diagnostics Modal (infeasibility review). The
           `diagnostics &&` gate is a retained-snapshot latch (kindred#2529):
-          null until the first reviewable solve, then kept across closes so
-          the mounted dialog can play Modal's 150ms exit fade — nulling the
-          payload here would blank and unmount it on the same frame the close
-          fires. Each reviewable run overwrites the payload, and the modal
-          renders its own empty-state fallback, so retaining the last one is
-          safe. Pinned by SessionView.diagnostics.guard.test.ts. */}
+          null until the first reviewable solve, then kept through the close
+          so the mounted dialog can play Modal's 150ms exit fade — nulling
+          the payload in onClose would blank and unmount it on the same frame
+          the close fires. afterLeave releases it once the fade has actually
+          completed, so the panel does not keep re-rendering the full report
+          on every render forever after (and re-arming the latch is safe:
+          setShowDiagnostics(true) has exactly one call site, which always
+          sets a fresh payload first). Pinned both ways by
+          SessionView.diagnostics.guard.test.ts. */}
       {diagnostics && (
         <SolverDiagnosticsModal
           isOpen={showDiagnostics}
           onClose={() => {
             setShowDiagnostics(false)
+          }}
+          afterLeave={() => {
+            setDiagnostics(null)
           }}
           diagnostics={diagnostics}
           sessionCmId={session.cm_id}

--- a/frontend/src/components/SolverDiagnosticsModal.tsx
+++ b/frontend/src/components/SolverDiagnosticsModal.tsx
@@ -9,6 +9,8 @@ import { ErrorBoundary } from './ErrorBoundary'
 interface Props {
   isOpen: boolean
   onClose: () => void
+  /** Forwarded to Modal — fires when the leave completes; SessionView uses it to release the retained diagnostics payload (kindred#2529). */
+  afterLeave?: () => void
   diagnostics: SolverDiagnostics
   sessionCmId: number | null
   year: number
@@ -24,6 +26,7 @@ function compactDetail(detail: Record<string, unknown> | null | undefined): stri
 export default function SolverDiagnosticsModal({
   isOpen,
   onClose,
+  afterLeave,
   diagnostics,
   sessionCmId,
   year,
@@ -55,6 +58,7 @@ export default function SolverDiagnosticsModal({
     <Modal
       isOpen={isOpen}
       onClose={onClose}
+      {...(afterLeave !== undefined && { afterLeave })}
       header={header}
       size="2xl"
       scrollable

--- a/frontend/src/components/admin/lodging/LodgingUnitsPanel.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitsPanel.test.tsx
@@ -535,24 +535,67 @@ describe('LodgingUnitsPanel — the editor opens in a modal', () => {
   })
 
   it('closes on Cancel, returning to the list', async () => {
+    // REWRITE for kindred#2529, not an adaptation: this test used to assert
+    // the dialog was gone synchronously, which pinned the pre-#2530 vanish.
+    // The dialog now outlives the close by Modal's leave transition, so gone
+    // is an eventually — the linger itself is pinned by the exit-fade test
+    // below.
     const user = userEvent.setup()
     await renderPanel()
 
     await user.click(screen.getByRole('button', { name: 'Edit Cabin A' }))
     await user.click(screen.getByRole('button', { name: 'Cancel' }))
 
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
     expect(screen.getByText('Cabin A')).toBeInTheDocument()
   })
 
+  it('keeps the editor painted through the exit fade after Cancel (kindred#2529)', async () => {
+    // The exit-fade pin. `{editing !== null && <Modal>}` used to unmount the
+    // dialog in the same frame Cancel fired; `editing` is now a retained
+    // snapshot and a separate flag drives isOpen, so the DOM must outlive
+    // the close, then go.
+    const user = userEvent.setup()
+    await renderPanel()
+
+    await user.click(screen.getByRole('button', { name: 'Edit Cabin A' }))
+    expect(screen.getByLabelText('Name')).toHaveValue('Cabin A')
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+    // Still painted on the frame the close fires...
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    // ...and gone once the leave completes.
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+  })
+
+  it('moves focus into the form when the SAME unit is reopened after a close (kindred#2529)', async () => {
+    // With `editing` retained across the close, the focus effect can no
+    // longer key on `editing` changing — reopening the same unit leaves it
+    // unchanged. The effect keys on the open flag's rising edge instead;
+    // this fails if that wiring regresses to the old dependency.
+    const user = userEvent.setup()
+    await renderPanel()
+
+    await user.click(screen.getByRole('button', { name: 'Edit Cabin A' }))
+    await waitFor(() => expect(screen.getByLabelText('Name')).toHaveFocus())
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+
+    await user.click(screen.getByRole('button', { name: 'Edit Cabin A' }))
+    await waitFor(() => expect(screen.getByLabelText('Name')).toHaveFocus())
+  })
+
   it('closes on Escape', async () => {
+    // REWRITE for kindred#2529 — same synchronous-gone assertion as Cancel
+    // above; see that test's comment.
     const user = userEvent.setup()
     await renderPanel()
 
     await user.click(screen.getByRole('button', { name: 'Edit Cabin A' }))
     await user.keyboard('{Escape}')
 
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
   })
 })
 

--- a/frontend/src/components/admin/lodging/LodgingUnitsPanel.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitsPanel.test.tsx
@@ -568,31 +568,37 @@ describe('LodgingUnitsPanel — the editor opens in a modal', () => {
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
   })
 
-  it('moves focus into the form when the SAME unit is reopened after a close (kindred#2529)', async () => {
-    // With `editing` retained across the close, the focus effect can no
-    // longer key on `editing` changing — reopening the same unit leaves it
-    // unchanged. The effect keys on the open flag's rising edge instead;
-    // this fails if that wiring regresses to the old dependency.
+  it('reopening WITHIN the exit fade shows a fresh form, not the abandoned draft (kindred#2529)', async () => {
+    // The #2539 scan's blocking finding: an interrupted leave never unmounts
+    // the form, and with an unchanged key React reuses the instance — so a
+    // Cancel followed by a fast reopen surfaced the abandoned draft, and the
+    // next Save would have written it. That is the exact stale-write hazard
+    // this dialog's own docstring says it exists to close. The form's key is
+    // now a nonce bumped on every open, so every open remounts fresh.
     const user = userEvent.setup()
     await renderPanel()
 
     await user.click(screen.getByRole('button', { name: 'Edit Cabin A' }))
-    await waitFor(() => expect(screen.getByLabelText('Name')).toHaveFocus())
+    const name = screen.getByLabelText('Name')
+    await user.clear(name)
+    await user.type(name, 'STALE DRAFT')
 
     await user.click(screen.getByRole('button', { name: 'Cancel' }))
-    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
-
+    // Reopen before the leave completes — no waitFor between close and open.
     await user.click(screen.getByRole('button', { name: 'Edit Cabin A' }))
-    await waitFor(() => expect(screen.getByLabelText('Name')).toHaveFocus())
+    expect(screen.getByLabelText('Name')).toHaveValue('Cabin A')
   })
 
   it('closes on Escape', async () => {
     // REWRITE for kindred#2529 — same synchronous-gone assertion as Cancel
-    // above; see that test's comment.
+    // above; see that test's comment. The open-precondition below is what
+    // keeps the final waitFor from passing vacuously against a dialog that
+    // never opened (#2539 scan finding 3).
     const user = userEvent.setup()
     await renderPanel()
 
     await user.click(screen.getByRole('button', { name: 'Edit Cabin A' }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
     await user.keyboard('{Escape}')
 
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())

--- a/frontend/src/components/admin/lodging/LodgingUnitsPanel.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitsPanel.test.tsx
@@ -583,10 +583,32 @@ describe('LodgingUnitsPanel — the editor opens in a modal', () => {
     await user.clear(name)
     await user.type(name, 'STALE DRAFT')
 
+    const dialogBefore = screen.getByRole('dialog')
     await user.click(screen.getByRole('button', { name: 'Cancel' }))
     // Reopen before the leave completes — no waitFor between close and open.
     await user.click(screen.getByRole('button', { name: 'Edit Cabin A' }))
+    // Same element = the leave really was interrupted, which is the case
+    // this test exists for. Without this, a timing change that let the
+    // leave complete would unmount + freshly remount the subtree and the
+    // value assertion below would pass vacuously (#2539 scan round 2).
+    expect(screen.getByRole('dialog')).toBe(dialogBefore)
     expect(screen.getByLabelText('Name')).toHaveValue('Cabin A')
+  })
+
+  it('moves focus back into the form when switching records while the editor is open (kindred#2529)', async () => {
+    // Pins editorNonce in the focus effect's deps. A record switch while the
+    // dialog is already open flips no open state, so Modal's beforeEnter
+    // never re-fires — the nonce bump is the only thing that pulls focus off
+    // the just-clicked Edit button and back into the remounted form.
+    const user = userEvent.setup()
+    await renderPanel()
+
+    await user.click(screen.getByRole('button', { name: 'Edit Cabin A' }))
+    await waitFor(() => expect(screen.getByLabelText('Name')).toHaveFocus())
+
+    await user.click(screen.getByRole('button', { name: 'Edit North Lodge' }))
+    expect(screen.getByLabelText('Name')).toHaveValue('North Lodge')
+    await waitFor(() => expect(screen.getByLabelText('Name')).toHaveFocus())
   })
 
   it('closes on Escape', async () => {

--- a/frontend/src/components/admin/lodging/LodgingUnitsPanel.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitsPanel.tsx
@@ -83,28 +83,22 @@ export function LodgingUnitsPanel() {
   const areasQuery = useLodgingAreas()
 
   /**
-   * Move FOCUS to the editor whenever it opens — including switching straight
-   * from editing one unit to another, since the form never unmounts in between
-   * (see the `key` below).
+   * Move FOCUS into the editor form in the cases Modal cannot cover. Modal's
+   * own `beforeEnter` handles the plain open (it fires on every false→true
+   * flip of `editorOpen`, `appear` included), so this effect exists for the
+   * two paths that flip no open state:
+   *
+   * 1. `areasQuery.isSuccess` resolving AFTER the dialog opened — until the
+   *    areas resolve, the dialog holds the "Loading areas…" paragraph and
+   *    there is nothing to focus; when the real form mounts, this pulls
+   *    focus off the trigger behind the backdrop.
+   * 2. A record switch while the dialog is already open — `openEditor` bumps
+   *    `editorNonce`, the form remounts under its nonce key, and this
+   *    refocuses it (the just-clicked Edit row button holds focus otherwise).
    *
    * This used to scroll as well, because the editor mounted above a 93-row
-   * table and opening it otherwise produced no visible change below the fold —
-   * and the natural response, clicking Edit again or on a different row, is
-   * exactly how a stale-record write went unnoticed. The dialog solves that
-   * outright: it is unmissable without moving anything, so the staffer keeps
-   * their place in the list. Only the focus half is still needed, and the
-   * shared Modal does not set initial focus itself.
-   *
-   * `areasQuery.isSuccess` IS A DEPENDENCY, not a stray one — and it is why
-   * this effect sits BELOW the query rather than up with the other state. The
-   * form is gated on that flag: until the areas resolve, the dialog holds the
-   * "Loading areas…" paragraph and there is nothing to focus. Opening the
-   * editor during a slow areas fetch therefore runs this effect against an
-   * empty dialog, and keyed on `[editing]` alone it would never re-run once
-   * the real form mounts — leaving focus on the trigger behind the backdrop,
-   * which for an aria-modal dialog strands a keyboard or screen-reader user
-   * outside it entirely. Only the success branch renders anything focusable
-   * (the error branch is a message paragraph), so this one flag covers it.
+   * table; the dialog made the scroll half obsolete and the shared Modal now
+   * owns open-focus, so what remains is exactly the two cases above.
    */
   useEffect(() => {
     if (!editorOpen) return

--- a/frontend/src/components/admin/lodging/LodgingUnitsPanel.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitsPanel.tsx
@@ -42,7 +42,19 @@ import { groupUnitsByArea, type UnitSort } from './unitSort'
 export function LodgingUnitsPanel() {
   const queryClient = useQueryClient()
   const { currentYear } = useCurrentYear()
+  // `editing` is a RETAINED SNAPSHOT, not the open flag (kindred#2529): the
+  // editor dialog must stay mounted through Modal's 150ms leave transition
+  // after close, so closing clears only `editorOpen` and the last-edited
+  // record keeps the header renderable through the fade. The form itself
+  // lives inside Modal's children, which <Transition> unmounts once the
+  // leave completes — so no per-field reset is needed here.
   const [editing, setEditing] = useState<LodgingUnitRecord | 'new' | null>(null)
+  const [editorOpen, setEditorOpen] = useState(false)
+
+  const openEditor = (unit: LodgingUnitRecord | 'new') => {
+    setEditing(unit)
+    setEditorOpen(true)
+  }
   const [areasOpen, setAreasOpen] = useState(false)
   const [sort, setSort] = useState<UnitSort>({ field: 'name', desc: false })
   const [selected, setSelected] = useState<Set<string>>(new Set())
@@ -89,12 +101,12 @@ export function LodgingUnitsPanel() {
    * (the error branch is a message paragraph), so this one flag covers it.
    */
   useEffect(() => {
-    if (editing === null) return
+    if (!editorOpen) return
     formRef.current?.querySelector<HTMLElement>('input, select, textarea')?.focus()
-  }, [editing, areasQuery.isSuccess])
+  }, [editorOpen, editing, areasQuery.isSuccess])
 
   const refresh = () => {
-    setEditing(null)
+    setEditorOpen(false)
     setSelected(new Set())
     invalidateLodgingRegistryQueries(queryClient)
   }
@@ -181,7 +193,7 @@ export function LodgingUnitsPanel() {
           <button
             type="button"
             onClick={() => {
-              setEditing('new')
+              openEditor('new')
             }}
             className={BUTTON_PRIMARY}
           >
@@ -223,9 +235,9 @@ export function LodgingUnitsPanel() {
           two-column grid that `lg` would collapse. */}
       {editing !== null && (
         <Modal
-          isOpen
+          isOpen={editorOpen}
           onClose={() => {
-            setEditing(null)
+            setEditorOpen(false)
           }}
           header={
             /* The forest band from the sessions landing header, same tokens and
@@ -299,7 +311,7 @@ export function LodgingUnitsPanel() {
                   invalidateLodgingRegistryQueries(queryClient)
                 }}
                 onCancel={() => {
-                  setEditing(null)
+                  setEditorOpen(false)
                 }}
               />
             ) : (
@@ -360,7 +372,7 @@ export function LodgingUnitsPanel() {
                     onToggleSelect={(unitId) => {
                       setSelected((s) => toggleIn(s, unitId))
                     }}
-                    onEdit={setEditing}
+                    onEdit={openEditor}
                     onConfirm={(unit) => void handleConfirm([unit.id])}
                     onDeactivate={(unit) => void handleDeactivate(unit)}
                   />

--- a/frontend/src/components/admin/lodging/LodgingUnitsPanel.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitsPanel.tsx
@@ -50,10 +50,16 @@ export function LodgingUnitsPanel() {
   // leave completes — so no per-field reset is needed here.
   const [editing, setEditing] = useState<LodgingUnitRecord | 'new' | null>(null)
   const [editorOpen, setEditorOpen] = useState(false)
+  // Bumped on EVERY open and used as the form's key, so each open remounts a
+  // fresh form even when the previous leave was interrupted by the reopen —
+  // an interrupted leave never unmounts the children, and a reused instance
+  // surfaced the abandoned draft for the next Save to write (#2539 scan).
+  const [editorNonce, setEditorNonce] = useState(0)
 
   const openEditor = (unit: LodgingUnitRecord | 'new') => {
     setEditing(unit)
     setEditorOpen(true)
+    setEditorNonce((n) => n + 1)
   }
   const [areasOpen, setAreasOpen] = useState(false)
   const [sort, setSort] = useState<UnitSort>({ field: 'name', desc: false })
@@ -103,7 +109,7 @@ export function LodgingUnitsPanel() {
   useEffect(() => {
     if (!editorOpen) return
     formRef.current?.querySelector<HTMLElement>('input, select, textarea')?.focus()
-  }, [editorOpen, editing, areasQuery.isSuccess])
+  }, [editorOpen, editorNonce, areasQuery.isSuccess])
 
   const refresh = () => {
     setEditorOpen(false)
@@ -239,6 +245,14 @@ export function LodgingUnitsPanel() {
           onClose={() => {
             setEditorOpen(false)
           }}
+          // Drop the retained snapshot once the fade has actually finished —
+          // the gate goes false, the whole subtree unmounts, and the panel
+          // stops re-evaluating the header JSX on every subsequent render.
+          // An interrupted leave never fires this, which is correct: the
+          // dialog is open again and still needs its data.
+          afterLeave={() => {
+            setEditing(null)
+          }}
           header={
             /* The forest band from the sessions landing header, same tokens and
                same shape: dark gradient, amber glyph in a translucent chip,
@@ -292,12 +306,15 @@ export function LodgingUnitsPanel() {
                 opened against an empty area list can only end in a server
                 rejection the staffer reads as their own mistake. */}
             {areasQuery.isSuccess ? (
-              /* Keyed on the record so React remounts rather than reusing the
-                 same instance — otherwise the form's useState initialisers
-                 never re-run when `unit` changes, and a submit after switching
-                 records writes the PREVIOUS unit's fields to the new one. */
+              /* Keyed on the per-open nonce so React remounts rather than
+                 reusing the same instance. The nonce covers BOTH hazards: a
+                 record switch while open (the useState initialisers never
+                 re-run when `unit` changes, so a submit after switching would
+                 write the previous unit's fields), and a reopen that
+                 interrupts the exit fade (the leave never unmounted the form,
+                 so the abandoned draft survived — #2539 scan finding 1). */
               <LodgingUnitForm
-                key={editing === 'new' ? 'new' : editing.id}
+                key={editorNonce}
                 areas={areasQuery.items}
                 units={unitsQuery.items}
                 unit={editing === 'new' ? undefined : editing}

--- a/frontend/src/components/camper/IdentityPanel.test.tsx
+++ b/frontend/src/components/camper/IdentityPanel.test.tsx
@@ -9,9 +9,8 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { BrowserRouter } from 'react-router'
 import type { ReactNode } from 'react'
+import { createWrapper } from '../../test/testUtils'
 import { CurrentYearContext, type CurrentYearContextType } from '../../hooks/useCurrentYear'
 import { IdentityPanel } from './IdentityPanel'
 import type { Camper } from '../../types/app-types'
@@ -36,19 +35,21 @@ const YEAR_CONTEXT: CurrentYearContextType = {
   isYearReady: true,
 }
 
-let client: QueryClient
+// Compose over testUtils' shared wrapper (QueryClient + Router) rather than
+// hand-rolling both — the year context is the only layer this file adds.
+// `createWrapper()` is called once per TEST, not inside the wrapper body,
+// so a re-render does not rebuild the QueryClient underneath assertions.
+let Base: ReturnType<typeof createWrapper>
 beforeEach(() => {
-  client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  Base = createWrapper()
   vi.clearAllMocks()
 })
 
 function wrapper({ children }: { children: ReactNode }) {
   return (
-    <QueryClientProvider client={client}>
-      <BrowserRouter>
-        <CurrentYearContext.Provider value={YEAR_CONTEXT}>{children}</CurrentYearContext.Provider>
-      </BrowserRouter>
-    </QueryClientProvider>
+    <Base>
+      <CurrentYearContext.Provider value={YEAR_CONTEXT}>{children}</CurrentYearContext.Provider>
+    </Base>
   )
 }
 

--- a/frontend/src/components/camper/IdentityPanel.test.tsx
+++ b/frontend/src/components/camper/IdentityPanel.test.tsx
@@ -15,6 +15,7 @@ import type { ReactNode } from 'react'
 import { CurrentYearContext, type CurrentYearContextType } from '../../hooks/useCurrentYear'
 import { IdentityPanel } from './IdentityPanel'
 import type { Camper } from '../../types/app-types'
+import { cohortsFixture, matchedAttendee } from '../../test/cohortFixtures'
 
 const mockUseCamperCohorts = vi.fn()
 vi.mock('../../hooks/useCamperCohorts', () => ({
@@ -72,27 +73,13 @@ const cohortContext = {
 describe('IdentityPanel cohort drill-down exit fade (kindred#2529)', () => {
   it('keeps the drilldown painted through the exit fade after close', async () => {
     mockUseCamperCohorts.mockReturnValue({
-      cohorts: {
+      cohorts: cohortsFixture({
         school: {
           label: 'Riverside Elementary',
           count: 1,
-          attendees: [
-            {
-              attendeeId: 'a2',
-              personCmId: 1000002,
-              firstName: 'Liam',
-              lastName: 'Garcia',
-              preferredName: null,
-              grade: 6,
-              gender: 'M',
-            },
-          ],
+          attendees: [matchedAttendee(1000002, 'Liam')],
         },
-        congregation: null,
-        city: null,
-        sessionType: 'main',
-        allGenders: false,
-      },
+      }),
       isLoading: false,
     })
 

--- a/frontend/src/components/camper/IdentityPanel.test.tsx
+++ b/frontend/src/components/camper/IdentityPanel.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * IdentityPanel cohort drill-down: exit-fade behavior (kindred#2529).
+ *
+ * The panel is otherwise covered through CamperDetail integration; this file
+ * exists for the one behavior that needs the panel's own state machine — the
+ * drill-down modal must stay mounted through Modal's 150ms leave transition
+ * after close, which means `openKind` is a retained snapshot and a separate
+ * flag drives `open`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { BrowserRouter } from 'react-router'
+import type { ReactNode } from 'react'
+import { CurrentYearContext, type CurrentYearContextType } from '../../hooks/useCurrentYear'
+import { IdentityPanel } from './IdentityPanel'
+import type { Camper } from '../../types/app-types'
+
+const mockUseCamperCohorts = vi.fn()
+vi.mock('../../hooks/useCamperCohorts', () => ({
+  useCamperCohorts: (...args: unknown[]) => mockUseCamperCohorts(...args),
+}))
+vi.mock('../../hooks/useCohortRequestRelations', () => ({
+  useCohortRequestRelations: () => ({ relations: new Map(), isLoading: false }),
+}))
+vi.mock('../../hooks/useCohortBunkAssignments', () => ({
+  useCohortBunkAssignments: () => ({ bunkByPerson: new Map(), isLoading: false }),
+}))
+
+const YEAR_CONTEXT: CurrentYearContextType = {
+  currentYear: 2026,
+  setCurrentYear: vi.fn(),
+  availableYears: [2026],
+  isTransitioning: false,
+  isYearReady: true,
+}
+
+let client: QueryClient
+beforeEach(() => {
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  vi.clearAllMocks()
+})
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={client}>
+      <BrowserRouter>
+        <CurrentYearContext.Provider value={YEAR_CONTEXT}>{children}</CurrentYearContext.Provider>
+      </BrowserRouter>
+    </QueryClientProvider>
+  )
+}
+
+const camper = {
+  id: 'c1',
+  cm_id: 1000001,
+  first_name: 'Emma',
+  last_name: 'Johnson',
+  birthdate: '2014-03-05',
+  gender: 'F',
+  grade: 6,
+  school: 'Riverside Elementary',
+} as unknown as Camper
+
+const cohortContext = {
+  personCmId: 1000001,
+  sessionCmId: 201,
+  year: 2026,
+  selfDisplayName: 'Emma',
+}
+
+describe('IdentityPanel cohort drill-down exit fade (kindred#2529)', () => {
+  it('keeps the drilldown painted through the exit fade after close', async () => {
+    mockUseCamperCohorts.mockReturnValue({
+      cohorts: {
+        school: {
+          label: 'Riverside Elementary',
+          count: 1,
+          attendees: [
+            {
+              attendeeId: 'a2',
+              personCmId: 1000002,
+              firstName: 'Liam',
+              lastName: 'Garcia',
+              preferredName: null,
+              grade: 6,
+              gender: 'M',
+            },
+          ],
+        },
+        congregation: null,
+        city: null,
+        sessionType: 'main',
+        allGenders: false,
+      },
+      isLoading: false,
+    })
+
+    render(
+      <IdentityPanel
+        camper={camper}
+        location={null}
+        congregation={null}
+        pronouns="she/her"
+        defaultExpanded
+        cohortContext={cohortContext}
+      />,
+      { wrapper }
+    )
+
+    fireEvent.click(await screen.findByTestId('cohort-badge-school'))
+    expect(await screen.findByText(/Same school: Riverside Elementary/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /close modal/i }))
+    // Still painted on the frame the close fires — the retained cohort
+    // snapshot is what keeps the content renderable through the leave.
+    expect(screen.getByText(/Same school: Riverside Elementary/)).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.queryByText(/Same school: Riverside Elementary/)).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/components/camper/IdentityPanel.tsx
+++ b/frontend/src/components/camper/IdentityPanel.tsx
@@ -56,7 +56,17 @@ export function IdentityPanel({
 }: IdentityPanelProps) {
   const [isExpanded, setIsExpanded] = useState(defaultExpanded)
   const viewingYear = useYear()
+  // `openKind` is a RETAINED SNAPSHOT, not the open flag (kindred#2529) —
+  // same shape as CamperCohortsSection: closing clears only `drillOpen`, so
+  // the drill-down stays mounted (and its content stays renderable) through
+  // Modal's 150ms leave transition instead of vanishing in one frame.
   const [openKind, setOpenKind] = useState<CohortKind | null>(null)
+  const [drillOpen, setDrillOpen] = useState(false)
+
+  const openCohort = (kind: CohortKind) => {
+    setOpenKind(kind)
+    setDrillOpen(true)
+  }
 
   const personCmId = cohortContext?.personCmId ?? null
   const sessionCmId = cohortContext?.sessionCmId ?? 0
@@ -151,7 +161,7 @@ export function IdentityPanel({
               subValue={`${formatGradeOrdinal(camper.grade)} Grade`}
               cohortKind="school"
               cohortCount={cohortContext ? (cohorts?.school?.count ?? 0) : 0}
-              onOpenCohort={() => setOpenKind('school')}
+              onOpenCohort={() => openCohort('school')}
             />
             <CohortField
               icon={MapPin}
@@ -159,7 +169,7 @@ export function IdentityPanel({
               value={location ?? 'Not specified'}
               cohortKind="city"
               cohortCount={cohortContext ? (cohorts?.city?.count ?? 0) : 0}
-              onOpenCohort={() => setOpenKind('city')}
+              onOpenCohort={() => openCohort('city')}
             />
             <CohortField
               icon={Building2}
@@ -167,7 +177,7 @@ export function IdentityPanel({
               value={congregation ?? 'Not provided'}
               cohortKind="congregation"
               cohortCount={cohortContext ? (cohorts?.congregation?.count ?? 0) : 0}
-              onOpenCohort={() => setOpenKind('congregation')}
+              onOpenCohort={() => openCohort('congregation')}
             />
           </div>
         </div>
@@ -175,7 +185,7 @@ export function IdentityPanel({
 
       {openKind && openEntry && cohorts && cohortContext && (
         <CohortDrillDownModal
-          open
+          open={drillOpen}
           kind={openKind}
           label={openEntry.label}
           selfDisplayName={cohortContext.selfDisplayName}
@@ -184,7 +194,7 @@ export function IdentityPanel({
           requestRelations={relations}
           bunkByPerson={bunkByPerson}
           reserveSidePanel={false}
-          onClose={() => setOpenKind(null)}
+          onClose={() => setDrillOpen(false)}
         />
       )}
     </div>

--- a/frontend/src/components/camper/IdentityPanel.tsx
+++ b/frontend/src/components/camper/IdentityPanel.tsx
@@ -59,7 +59,8 @@ export function IdentityPanel({
   // `openKind` is a RETAINED SNAPSHOT, not the open flag (kindred#2529) —
   // same shape as CamperCohortsSection: closing clears only `drillOpen`, so
   // the drill-down stays mounted (and its content stays renderable) through
-  // Modal's 150ms leave transition instead of vanishing in one frame.
+  // Modal's 150ms leave transition, and afterLeave releases the snapshot
+  // once the fade completes so the element tree stops re-evaluating.
   const [openKind, setOpenKind] = useState<CohortKind | null>(null)
   const [drillOpen, setDrillOpen] = useState(false)
 
@@ -195,6 +196,7 @@ export function IdentityPanel({
           bunkByPerson={bunkByPerson}
           reserveSidePanel={false}
           onClose={() => setDrillOpen(false)}
+          afterLeave={() => setOpenKind(null)}
         />
       )}
     </div>

--- a/frontend/src/components/session/SessionLastUploadChip.test.tsx
+++ b/frontend/src/components/session/SessionLastUploadChip.test.tsx
@@ -73,6 +73,34 @@ describe('SessionLastUploadChip', () => {
     expect(screen.getByTestId('changes-modal')).toHaveAttribute('data-open', 'true')
   })
 
+  it('does not re-pop the dialog when the upload summary transiently disappears (kindred#2529)', () => {
+    // `open` used to survive the `if (!session || !runId) return null` branch,
+    // so a transient summary loss (refetch gap, weekend switch) left it true —
+    // and when data returned, the always-mounted dialog re-opened itself with
+    // no click, via Modal's `appear`. The chip now corrects `open` at render
+    // time on that branch.
+    const good = {
+      runId: 'r1',
+      finishedAt: 't',
+      global: null,
+      session: { total: 14, autoMatched: 14, needReview: 0 },
+    }
+    set(good)
+    const { rerender, container } = render(
+      <SessionLastUploadChip sessionCmId={1} agSessionCmIds={[]} sessionName="Session 2" />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /view last upload changes/i }))
+    expect(screen.getByTestId('changes-modal')).toHaveAttribute('data-open', 'true')
+
+    set({ ...good, session: null })
+    rerender(<SessionLastUploadChip sessionCmId={1} agSessionCmIds={[]} sessionName="Session 2" />)
+    expect(container).toBeEmptyDOMElement()
+
+    set(good)
+    rerender(<SessionLastUploadChip sessionCmId={1} agSessionCmIds={[]} sessionName="Session 2" />)
+    expect(screen.getByTestId('changes-modal')).toHaveAttribute('data-open', 'false')
+  })
+
   it('shows review segment when needReview>0', () => {
     set({
       runId: 'r1',

--- a/frontend/src/components/session/SessionLastUploadChip.test.tsx
+++ b/frontend/src/components/session/SessionLastUploadChip.test.tsx
@@ -1,9 +1,13 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 
 vi.mock('../../hooks/session/useLastUploadSummary', () => ({ useLastUploadSummary: vi.fn() }))
 vi.mock('./SessionUploadChangesModal', () => ({
-  default: () => <div data-testid="changes-modal" />,
+  // Exposes isOpen so the always-mounted pin below can see the chip's wiring
+  // without rendering the real dialog (which would need a QueryClient).
+  default: ({ isOpen }: { isOpen: boolean }) => (
+    <div data-testid="changes-modal" data-open={String(isOpen)} />
+  ),
 }))
 import { useLastUploadSummary } from '../../hooks/session/useLastUploadSummary'
 import SessionLastUploadChip from './SessionLastUploadChip'
@@ -47,6 +51,26 @@ describe('SessionLastUploadChip', () => {
     render(<SessionLastUploadChip sessionCmId={1} agSessionCmIds={[]} sessionName="Session 2" />)
     expect(screen.getByText(/14 new/)).toBeInTheDocument()
     expect(screen.queryByText(/review/i)).not.toBeInTheDocument()
+  })
+
+  it('mounts the modal closed and drives isOpen from the chip (kindred#2529)', () => {
+    // The chip used to gate the dialog with `{open && ...}`, unmounting it in
+    // the same frame the close fired — Modal's 150ms exit fade never played.
+    // The dialog is now always rendered (once session+runId resolve) and the
+    // chip drives its isOpen prop.
+    set({
+      runId: 'r1',
+      finishedAt: 't',
+      global: null,
+      session: { total: 14, autoMatched: 14, needReview: 0 },
+    })
+    render(<SessionLastUploadChip sessionCmId={1} agSessionCmIds={[]} sessionName="Session 2" />)
+
+    const stub = screen.getByTestId('changes-modal')
+    expect(stub).toHaveAttribute('data-open', 'false')
+
+    fireEvent.click(screen.getByRole('button', { name: /view last upload changes/i }))
+    expect(screen.getByTestId('changes-modal')).toHaveAttribute('data-open', 'true')
   })
 
   it('shows review segment when needReview>0', () => {

--- a/frontend/src/components/session/SessionLastUploadChip.tsx
+++ b/frontend/src/components/session/SessionLastUploadChip.tsx
@@ -13,7 +13,8 @@ export default function SessionLastUploadChip({ sessionCmId, agSessionCmIds, ses
   const { runId, session } = useLastUploadSummary(sessionCmId, agSessionCmIds)
   const [open, setOpen] = useState(false)
 
-  // Render-time correction, same pattern as WeekendRosterPage's party latch:
+  // Render-time correction, same pattern as usePanelParty's render-time
+  // clearing (hooks/usePanelParty.ts):
   // when the summary transiently disappears (refetch gap), this early return
   // unmounts the always-mounted dialog below — and a latched `open` would
   // make it re-open itself via Modal's `appear` the moment data returns.

--- a/frontend/src/components/session/SessionLastUploadChip.tsx
+++ b/frontend/src/components/session/SessionLastUploadChip.tsx
@@ -33,14 +33,17 @@ export default function SessionLastUploadChip({ sessionCmId, agSessionCmIds, ses
           </span>
         )}
       </button>
-      {open && (
-        <SessionUploadChangesModal
-          runId={runId}
-          sessionCmIds={cmIds}
-          sessionName={sessionName}
-          onClose={() => setOpen(false)}
-        />
-      )}
+      {/* Always mounted once session+runId resolve (kindred#2529): the old
+          `{open && ...}` gate unmounted the dialog on the frame the close
+          fired, so Modal's exit fade never played. The dialog's query gates
+          on isOpen, so mounted-closed it fetches nothing. */}
+      <SessionUploadChangesModal
+        isOpen={open}
+        runId={runId}
+        sessionCmIds={cmIds}
+        sessionName={sessionName}
+        onClose={() => setOpen(false)}
+      />
     </>
   )
 }

--- a/frontend/src/components/session/SessionLastUploadChip.tsx
+++ b/frontend/src/components/session/SessionLastUploadChip.tsx
@@ -13,7 +13,14 @@ export default function SessionLastUploadChip({ sessionCmId, agSessionCmIds, ses
   const { runId, session } = useLastUploadSummary(sessionCmId, agSessionCmIds)
   const [open, setOpen] = useState(false)
 
-  if (!session || !runId) return null
+  // Render-time correction, same pattern as WeekendRosterPage's party latch:
+  // when the summary transiently disappears (refetch gap), this early return
+  // unmounts the always-mounted dialog below — and a latched `open` would
+  // make it re-open itself via Modal's `appear` the moment data returns.
+  if (!session || !runId) {
+    if (open) setOpen(false)
+    return null
+  }
 
   const cmIds = [sessionCmId, ...agSessionCmIds].filter((k): k is number => typeof k === 'number')
 

--- a/frontend/src/components/session/SessionUploadChangesModal.test.tsx
+++ b/frontend/src/components/session/SessionUploadChangesModal.test.tsx
@@ -31,6 +31,27 @@ describe('SessionUploadChangesModal', () => {
     mock([])
     render(
       <SessionUploadChangesModal
+        isOpen
+        runId="r1"
+        sessionCmIds={[1000001]}
+        sessionName="Session 2"
+        onClose={() => {}}
+      />,
+      { wrapper }
+    )
+    await Promise.resolve()
+    expect(fetchSessionUploadChanges).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch while mounted-closed (kindred#2529 always-mounted conversion)', async () => {
+    // The chip now renders this dialog permanently and drives isOpen, so the
+    // exit fade can play. The query must therefore gate on isOpen — without
+    // that, every session chip on the page fetches its upload changes on
+    // mount whether the dialog was ever opened.
+    mock([])
+    render(
+      <SessionUploadChangesModal
+        isOpen={false}
         runId="r1"
         sessionCmIds={[1000001]}
         sessionName="Session 2"
@@ -65,6 +86,7 @@ describe('SessionUploadChangesModal', () => {
     ])
     render(
       <SessionUploadChangesModal
+        isOpen
         runId="r1"
         sessionCmIds={[1]}
         sessionName="Session 2"
@@ -82,6 +104,7 @@ describe('SessionUploadChangesModal', () => {
     mock([])
     render(
       <SessionUploadChangesModal
+        isOpen
         runId="r1"
         sessionCmIds={[1]}
         sessionName="Session 2"

--- a/frontend/src/components/session/SessionUploadChangesModal.tsx
+++ b/frontend/src/components/session/SessionUploadChangesModal.tsx
@@ -9,6 +9,8 @@ import {
 import { queryKeys } from '../../utils/queryKeys'
 
 interface Props {
+  /** Always-mounted by the chip (kindred#2529) so the exit fade can play. */
+  isOpen: boolean
   runId: string
   sessionCmIds: number[]
   sessionName: string
@@ -23,6 +25,7 @@ function isReview(r: UploadChangeRow): boolean {
 }
 
 export default function SessionUploadChangesModal({
+  isOpen,
   runId,
   sessionCmIds,
   sessionName,
@@ -37,7 +40,10 @@ export default function SessionUploadChangesModal({
   } = useQuery({
     queryKey: queryKeys.sessionUploadChanges(runId, sessionCmIds),
     queryFn: () => fetchSessionUploadChanges(runId, sessionCmIds, fetchWithAuth),
-    enabled: !isAuthLoading,
+    // isOpen gates the fetch because this dialog is now mounted for the whole
+    // life of its chip (kindred#2529) — without it, every session chip on the
+    // page would fetch its upload changes on mount, opened or not.
+    enabled: isOpen && !isAuthLoading,
   })
 
   const byCamper = new Map<number, { name: string; rows: UploadChangeRow[] }>()
@@ -57,7 +63,13 @@ export default function SessionUploadChangesModal({
   const isEmpty = !isLoading && !isError && groups.length === 0
 
   return (
-    <Modal isOpen onClose={onClose} title={`What's new — ${sessionName}`} size="md" scrollable>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={`What's new — ${sessionName}`}
+      size="md"
+      scrollable
+    >
       {isLoading && (
         <div className="text-muted-foreground flex items-center justify-center gap-2 py-12">
           <Loader2 className="h-4 w-4 animate-spin" />

--- a/frontend/src/components/session/SessionUploadChangesModal.tsx
+++ b/frontend/src/components/session/SessionUploadChangesModal.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Loader2 } from 'lucide-react'
 import Modal from '../ui/Modal'
@@ -41,24 +42,29 @@ export default function SessionUploadChangesModal({
     queryKey: queryKeys.sessionUploadChanges(runId, sessionCmIds),
     queryFn: () => fetchSessionUploadChanges(runId, sessionCmIds, fetchWithAuth),
     // isOpen gates the fetch because this dialog is now mounted for the whole
-    // life of its chip (kindred#2529) — without it, every session chip on the
-    // page would fetch its upload changes on mount, opened or not.
+    // life of its chip (kindred#2529) — without it, the chip's page would
+    // fetch upload changes on mount whether the dialog was ever opened.
     enabled: isOpen && !isAuthLoading,
   })
 
-  const byCamper = new Map<number, { name: string; rows: UploadChangeRow[] }>()
-  for (const r of rows) {
-    const g = byCamper.get(r.requester_cm_id) ?? { name: r.requester_name, rows: [] }
-    g.rows.push(r)
-    byCamper.set(r.requester_cm_id, g)
-  }
-  const groups = [...byCamper.entries()]
-    .map(([cmId, g]) => ({ cmId, ...g }))
-    .sort((a, b) => {
-      const ar = a.rows.some(isReview) ? 0 : 1
-      const br = b.rows.some(isReview) ? 0 : 1
-      return ar - br
-    })
+  // Memoized because this component is now mounted for the life of its chip
+  // (kindred#2529) — without it the grouping re-ran on every parent render,
+  // closed or not (frontend/CLAUDE.md, "Derived values in page components").
+  const groups = useMemo(() => {
+    const byCamper = new Map<number, { name: string; rows: UploadChangeRow[] }>()
+    for (const r of rows) {
+      const g = byCamper.get(r.requester_cm_id) ?? { name: r.requester_name, rows: [] }
+      g.rows.push(r)
+      byCamper.set(r.requester_cm_id, g)
+    }
+    return [...byCamper.entries()]
+      .map(([cmId, g]) => ({ cmId, ...g }))
+      .sort((a, b) => {
+        const ar = a.rows.some(isReview) ? 0 : 1
+        const br = b.rows.some(isReview) ? 0 : 1
+        return ar - br
+      })
+  }, [rows])
 
   const isEmpty = !isLoading && !isError && groups.length === 0
 

--- a/frontend/src/components/session/SessionUploadChangesModal.tsx
+++ b/frontend/src/components/session/SessionUploadChangesModal.tsx
@@ -34,11 +34,7 @@ export default function SessionUploadChangesModal({
 }: Props) {
   const { fetchWithAuth, isAuthLoading } = useApiWithAuth()
 
-  const {
-    data: rows = [],
-    isLoading,
-    isError,
-  } = useQuery({
+  const { data, isLoading, isError } = useQuery({
     queryKey: queryKeys.sessionUploadChanges(runId, sessionCmIds),
     queryFn: () => fetchSessionUploadChanges(runId, sessionCmIds, fetchWithAuth),
     // isOpen gates the fetch because this dialog is now mounted for the whole
@@ -50,7 +46,12 @@ export default function SessionUploadChangesModal({
   // Memoized because this component is now mounted for the life of its chip
   // (kindred#2529) — without it the grouping re-ran on every parent render,
   // closed or not (frontend/CLAUDE.md, "Derived values in page components").
+  // The `?? []` lives INSIDE the memo: a `data: rows = []` default mints a
+  // fresh array on every undefined render — the whole mounted-closed
+  // lifetime — and defeats the dependency (#2539 scan round 2, and the same
+  // trap frontend/CLAUDE.md documents).
   const groups = useMemo(() => {
+    const rows = data ?? []
     const byCamper = new Map<number, { name: string; rows: UploadChangeRow[] }>()
     for (const r of rows) {
       const g = byCamper.get(r.requester_cm_id) ?? { name: r.requester_name, rows: [] }
@@ -64,7 +65,7 @@ export default function SessionUploadChangesModal({
         const br = b.rows.some(isReview) ? 0 : 1
         return ar - br
       })
-  }, [rows])
+  }, [data])
 
   const isEmpty = !isLoading && !isError && groups.length === 0
 

--- a/frontend/src/components/ui/Modal.test.tsx
+++ b/frontend/src/components/ui/Modal.test.tsx
@@ -943,6 +943,56 @@ describe('Modal', () => {
       await waitFor(() => expect(screen.queryByTestId('modal-content')).not.toBeInTheDocument())
     })
 
+    it('fires afterLeave once, only after the leave completes', async () => {
+      // The retained-snapshot parents (kindred#2529) release their data in
+      // afterLeave — if it fired on the close frame instead of after the
+      // fade, the dialog would blank mid-leave, the exact bug the retention
+      // exists to prevent.
+      const afterLeave = vi.fn()
+      const { rerender } = render(
+        <Modal isOpen={true} onClose={() => {}} afterLeave={afterLeave} title="AL">
+          <p>Modal content</p>
+        </Modal>
+      )
+      rerender(
+        <Modal isOpen={false} onClose={() => {}} afterLeave={afterLeave} title="AL">
+          <p>Modal content</p>
+        </Modal>
+      )
+      // Not on the frame isOpen flips — the DOM is still painted.
+      expect(afterLeave).not.toHaveBeenCalled()
+      await waitFor(() => expect(afterLeave).toHaveBeenCalledTimes(1))
+      // ...and by then the DOM is gone, so releasing data cannot blank it.
+      expect(screen.queryByTestId('modal-content')).not.toBeInTheDocument()
+    })
+
+    it('does NOT fire afterLeave when a reopen interrupts the leave', async () => {
+      // The other half of the contract LodgingUnitsPanel's snapshot drop
+      // rests on: an interrupted leave means the dialog is open again and
+      // still needs its data, so the release must not fire. (jsdom completes
+      // an uninterrupted leave in well under 100ms — the linger test above —
+      // so the settle below is long enough to catch a wrongly-fired release.)
+      const afterLeave = vi.fn()
+      const { rerender } = render(
+        <Modal isOpen={true} onClose={() => {}} afterLeave={afterLeave} title="AL2">
+          <p>Modal content</p>
+        </Modal>
+      )
+      rerender(
+        <Modal isOpen={false} onClose={() => {}} afterLeave={afterLeave} title="AL2">
+          <p>Modal content</p>
+        </Modal>
+      )
+      rerender(
+        <Modal isOpen={true} onClose={() => {}} afterLeave={afterLeave} title="AL2">
+          <p>Modal content</p>
+        </Modal>
+      )
+      await new Promise((resolve) => setTimeout(resolve, 120))
+      expect(afterLeave).not.toHaveBeenCalled()
+      expect(screen.getByTestId('modal-content')).toBeInTheDocument()
+    })
+
     it('moves focus inside the dialog when opened by TOGGLING isOpen on a mounted Modal', async () => {
       // The Q12 regression pin, and the single test shape this 7,254-test
       // suite lacked: every prior rerender() in this file goes open->closed,

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -16,6 +16,12 @@ import {
 interface ModalProps {
   isOpen: boolean
   onClose: () => void
+  /**
+   * Fires when the leave transition COMPLETES (not when it is interrupted by
+   * a reopen). For parents holding a retained snapshot (kindred#2529) this is
+   * the moment the data can be safely dropped — the DOM is already gone.
+   */
+  afterLeave?: () => void
   title?: string
   header?: ReactNode // Custom header content (overrides title)
   footer?: ReactNode // Footer content
@@ -199,6 +205,7 @@ function getFocusable(container: HTMLElement): HTMLElement[] {
 export function Modal({
   isOpen,
   onClose,
+  afterLeave,
   title,
   header,
   footer,
@@ -336,7 +343,7 @@ export function Modal({
     // Headless UI skips the enter transition AND its `beforeEnter` on an
     // initially-true `show` — no animation and no initial focus for the
     // majority of dialogs. The mount-open focus tests fail if it is removed.
-    <Transition show={isOpen} appear>
+    <Transition show={isOpen} appear {...(afterLeave !== undefined && { afterLeave })}>
       {/* pointer-events-none on the WRAPPER, always — the backdrop and panel
           re-enable themselves below, and drop it again in their leave classes.
           This is what makes D12's accepted trade real: during the exit fade

--- a/frontend/src/test/cohortFixtures.ts
+++ b/frontend/src/test/cohortFixtures.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared cohort fixtures for the drill-down test surfaces
+ * (CamperCohortsSection.test.tsx, IdentityPanel.test.tsx) — extracted so the
+ * two files stop carrying diverging copies of the same shapes (#2539 scan).
+ */
+import type { CamperCohorts, CohortEntry } from '../hooks/useCamperCohorts'
+
+/** A CohortEntry with an empty attendees array (attendee content is tested in useCamperCohorts.test.ts). */
+export function cohortEntry(label: string, count: number): CohortEntry {
+  return { label, count, attendees: [] }
+}
+
+/** A CamperCohorts fixture with default sessionType / allGenders. */
+export function cohortsFixture(parts: {
+  school?: CohortEntry | null
+  congregation?: CohortEntry | null
+  city?: CohortEntry | null
+  sessionType?: string
+  allGenders?: boolean
+}): CamperCohorts {
+  return {
+    school: parts.school ?? null,
+    congregation: parts.congregation ?? null,
+    city: parts.city ?? null,
+    sessionType: parts.sessionType ?? 'main',
+    allGenders: parts.allGenders ?? false,
+  }
+}
+
+/** One matched cohort attendee, fictional-name set per tests/CLAUDE.md. */
+export function matchedAttendee(personCmId: number, firstName: string) {
+  return {
+    attendeeId: `a${personCmId}`,
+    personCmId,
+    firstName,
+    lastName: 'Garcia',
+    preferredName: null,
+    grade: 7,
+    gender: 'M',
+  }
+}


### PR DESCRIPTION
## What

Four dialogs now play Modal's 150ms exit fade instead of vanishing in one frame — the mechanically-safe half of the #2529 tier-2 audit. The other six candidates need per-dialog reset machinery and moved to #2538 with the full audit evidence.

The shared shape: each parent's mount gate doubled as the close mechanism, so the dialog unmounted on the frame the close fired and the `<Transition>` #2530 gave `ui/Modal` never got to play its leave. The fix separates the two — the *data* becomes a retained snapshot that outlives the close, and a dedicated flag drives `isOpen`.

## Per surface

| dialog | change |
|---|---|
| **CohortDrillDownModal** (CamperCohortsSection + IdentityPanel) | `openKind` retained across close; new `drillOpen` flag drives `open`. The modal is hookless, and Modal's Transition unmounts children while closed, so a mounted-closed instance does no work. |
| **SolverDiagnosticsModal** (SessionView) | `onClose` no longer nulls the diagnostics payload — the `{diagnostics && …}` gate is now a retained-snapshot latch (null until first reviewable solve, then kept). Each reviewable run overwrites the payload; the modal's own empty-state covers the never-populated case. |
| **SessionUploadChangesModal** (SessionLastUploadChip) | Always mounted once session+runId resolve; new `isOpen` prop; query gated `enabled: isOpen && !isAuthLoading` so mounted-closed chips fetch nothing. |
| **LodgingUnitsPanel** internal unit editor | `editing` retained across close; new `editorOpen` flag. Focus effect re-keys on the open flag's rising edge (a retained `editing` no longer changes when the same unit is reopened). The `LodgingSettingsTab` tab gate is untouched — it is not a modal gate. |

## Why no reset-on-open machinery here

State *inside* Modal's children (e.g. `LodgingUnitForm`) is wiped by the Transition's own unmount when the leave completes. Only state held in the dialog-owning component itself survives — and none of these four holds any. That distinction is exactly what splits this PR from #2538.

## Tests (written first, verified red)

- Exit-fade pin per surface: content still painted on the frame the close fires, gone after the leave — red against the old immediate-unmount on all four.
- `SessionUploadChangesModal` no-fetch-while-closed pin; chip always-mounted/isOpen-threading pin.
- `SessionView.diagnostics.guard.test.ts` source guard pins the deleted `setDiagnostics(null)` (SessionView itself is not practical to render in a unit test — precedent in `SessionView.session-reset.test.tsx`).
- Same-unit-reopen refocus pin for the panel's re-keyed focus effect.
- Two pre-existing tests asserting synchronous-gone (`closes on Cancel` / `closes on Escape`) were **rewritten, not adapted** — they pinned the pre-#2530 vanish; comments say so.
- Mutation-checked: four mechanism reverts each turn exactly their pin red.

Full suite: **457 files / 7,343 tests green**; `pre-push-verify.sh` (prettier, eslint, tsc, vitest) all pass.

Closes #2529.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Scan cycle (fresh-context subagent, floor 60, CodeRabbit deliberately skipped)

Eleven findings; owner ruled fix 1–7, 10, 11 (8 and 9 held for discussion). Applied in-branch:

- **Finding 1 (85, confirmed by execution):** an interrupted leave never unmounts the form, so Cancel + fast reopen surfaced the abandoned draft and the next Save would have written it. `LodgingUnitForm` now keys on a per-open nonce — every open remounts fresh; the nonce also covers the record-switch case the old record-id key existed for. Repro pinned as a test, red first.
- **Finding 5:** `ui/Modal` gains an optional `afterLeave`; the panel drops its retained `editing` snapshot when the fade completes, ending the permanent header-JSX re-evaluation. An interrupted leave correctly never fires it.
- **Finding 2:** the false focus pin (focus actually came from Modal's `beforeEnter`) is replaced by the finding-1 repro; the focus effect keys on the nonce.
- **Finding 3:** `closes on Escape` gains its open precondition (was vacuous).
- **Finding 4 (pre-existing):** the chip corrects a latched `open` at render time when the upload summary transiently disappears — previously the returning dialog re-opened itself via `appear`. Pinned, red first.
- **Finding 6:** the upload-changes grouping is `useMemo`'d now that the dialog is permanently mounted.
- **Finding 7:** the diagnostics guard anchors on and asserts the `{diagnostics && …}` latch itself.
- **Findings 10/11:** cohort test fixtures deduplicated into `test/cohortFixtures.ts`; mounted-closed comment accuracy.

All three new mechanisms mutation-checked (nonce key, chip reset, latch). Suite 7,344 green; pre-push-verify all-pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved modal closing behavior so content remains available during exit animations and is removed only after transitions complete.
  - Prevented stale lodging editor data when reopening or switching records.
  - Preserved solver diagnostics while closing the diagnostics modal.
  - Prevented unnecessary data loading for closed upload-change dialogs.

- **Tests**
  - Added coverage for modal transitions, reopening, state resets, and retained diagnostics.
  - Added shared fixtures for consistent cohort testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->