### PR TITLE
feat(pb,sync,api,frontend): medical narratives keep the family's words alone, the gate becomes a pill

### DIFF
--- a/api/schemas/lodging.py
+++ b/api/schemas/lodging.py
@@ -56,6 +56,34 @@ MEDICAL_NARRATIVE_FIELD_NAMES: frozenset[str] = frozenset(
     }
 )
 
+# The five structured gate answers on family_camp_medical (kindred#2542).
+#
+# Kept SEPARATE from MEDICAL_NARRATIVE_FIELD_NAMES above: a gate is one of
+# "yes" / "no" / "", not a disclosure sentence, and kindred#2409 spent a PR
+# making that vocabulary accurate. They carry the same protection under their
+# own name -- kept out of every roster payload here, out of every export by
+# `gateColumns` in pocketbase/sync/lodging_medical_narrative_test.go, and a
+# test asserts the two lists are identical.
+MEDICAL_GATE_FIELD_NAMES: frozenset[str] = frozenset(
+    {
+        "allergy_gate",
+        "dietary_gate",
+        "special_needs_gate",
+        "physician_gate",
+        "cpap_gate",
+    }
+)
+
+# A household's answer to one medical gate question.
+#
+# THREE STATES. "unknown" is this layer's rendering of the column's empty
+# string: the household never reached the question. It is never coerced into
+# "no" -- in 2026, 430 of 900 households answered the allergy gate No and 224
+# never answered it, and telling staff a family declined a question they were
+# never shown is a different claim from the truth. Same shape, and the same
+# reason, as SharePreference below.
+MedicalGate = Literal["yes", "no", "unknown"]
+
 # The 3-state gate, straight from family_camp_registrations.share_cabin_gate.
 # "unknown" is this layer's rendering of the column's empty string: nobody
 # answered. It is never coerced into permission to pair.
@@ -846,8 +874,8 @@ class WeekendRosterResponse(BaseModel):
 
 
 class HouseholdMedicalResponse(BaseModel):
-    """Narrative medical text. Served by ONE endpoint gated on
-    `bunking.manage`. Never nested elsewhere."""
+    """Narrative medical text and the gate answers beside it. Served by ONE
+    endpoint gated on `bunking.manage`. Never nested elsewhere."""
 
     household_cm_id: int
     year: int
@@ -859,6 +887,15 @@ class HouseholdMedicalResponse(BaseModel):
     additional_info: str = ""
     bathroom_explain: str = ""
     accommodation_explain: str = ""
+
+    # The gate answers, split out of the narrative columns by kindred#2542. The
+    # panel renders these as a pill beside the row label; the narrative above
+    # holds the family's own words alone.
+    allergy_gate: MedicalGate = "unknown"
+    dietary_gate: MedicalGate = "unknown"
+    special_needs_gate: MedicalGate = "unknown"
+    physician_gate: MedicalGate = "unknown"
+    cpap_gate: MedicalGate = "unknown"
 
 
 # What is known about where a household slept in one year (kindred#2073).

--- a/api/services/lodging_roster_service.py
+++ b/api/services/lodging_roster_service.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 from api.constants.lodging import INFANT_BED_EXEMPT_MONTHS, is_attending_adult_name
 from api.schemas.lodging import (
+    MEDICAL_GATE_FIELD_NAMES,
     MEDICAL_NARRATIVE_FIELD_NAMES,
     AccessibilityFlagSummary,
     EffectiveBathroom,
@@ -31,6 +32,7 @@ from api.schemas.lodging import (
     HouseholdMedicalResponse,
     HousingState,
     LodgingUnitSummary,
+    MedicalGate,
     PartyAdult,
     PartyChild,
     ProximityKind,
@@ -128,6 +130,22 @@ _NO_PLACEMENT = _Placement("", "", False, ())
 def _s(record: Any, field: str, default: str = "") -> str:
     value = getattr(record, field, default)
     return default if value is None else str(value)
+
+
+def _gate(record: Any, field: str) -> MedicalGate:
+    """One medical gate answer, with the column's empty string named.
+
+    `_s` alone would emit "", which is not a member of MedicalGate. A value
+    outside the vocabulary reads as "unknown" rather than raising: the panel
+    showing no pill is a better failure than the endpoint 500ing on a row a
+    future migration widened.
+    """
+    value = _s(record, field)
+    if value == "yes":
+        return "yes"
+    if value == "no":
+        return "no"
+    return "unknown"
 
 
 def _i(record: Any, field: str, default: int = 0) -> int:
@@ -1902,6 +1920,7 @@ class LodgingRosterService:
             household_cm_id=household_cm_id,
             year=year,
             **{field: _s(record, field) for field in sorted(MEDICAL_NARRATIVE_FIELD_NAMES)},
+            **{field: _gate(record, field) for field in sorted(MEDICAL_GATE_FIELD_NAMES)},
         )
 
     async def _housing_names(self) -> HousingNameResolver:

--- a/docs/reference/family-camp-field-provenance.md
+++ b/docs/reference/family-camp-field-provenance.md
@@ -410,13 +410,23 @@ Known pairs — housing plus the medical forms that use the same convention:
 
 ### The splice: a gate and its explanation can survive from different children
 
-`processRegistrations` and `processMedical` collapse each field to household grain
-**independently**, taking the first non-empty value over an id-sorted list of person
-values. Because the two halves of a pair are separate fields, their winners can be
-different children.
+**Historical, and fixed — the table below measures the code as it stood before
+2026-08-19.** `processRegistrations` and `processMedical` then collapsed each field to
+household grain **independently**, taking the first non-empty value over an id-sorted list
+of person values; because the two halves of a pair are separate fields, their winners could
+be different children.
+
+Two changes have since retired that mechanism in `processMedical`. kindred#2255 (#2450,
+2026-08-19) replaced first-non-empty-wins with `medicalAnswers`, which keeps every distinct
+answer every household member gave to a field. kindred#2542 (2026-08-22) then moved the gate
+answer out of the narrative column into its own three-state `*_gate` column, where the
+household's verdict is the OR of its members' answers (`gateVerdict`). Neither half of a pair
+picks a winner any more, so there is no id-min row for either half to be spliced from.
+`processRegistrations` was never the splice risk: it stores its gates as household-wide OR
+booleans.
 
 Measured share of households (where both halves have a value) whose **id-min gate row and
-id-min explain row belong to different children**:
+id-min explain row belonged to different children**, on the pre-#2450 code:
 
 | Pair | 2024 | 2025 | 2026 |
 |------|------|------|------|
@@ -425,10 +435,13 @@ id-min explain row belong to different children**:
 | Housing Accommodation | — | — | 11 / 30 · 36.7% |
 | Bathroom | — | — | 17 / 45 · 37.8% |
 
-**Of the four rows above, this is worse than losing a sibling's text for Special Needs and
-CPAP only.** Those two pairs concatenate a **stored gate string** with a stored explanation
-in `processMedical`, so the two halves of one question get spliced across two children and
-the explanation staff read does not necessarily describe the need that raised the flag.
+**Of the four rows above, this was worse than losing a sibling's text for Special Needs and
+CPAP only.** Those two pairs concatenated a **stored gate string** with a stored explanation
+in `processMedical`, so the two halves of one question got spliced across two children and
+the explanation staff read did not necessarily describe the need that raised the flag. Since
+kindred#2542 no gate string is stored in a narrative column at all: `special_needs_info` and
+`cpap_info` hold the family's own words, and the gate sits beside them in
+`special_needs_gate` / `cpap_gate` as an OR across the household.
 
 **Housing Accommodation and Bathroom are not the same claim, and their rows should not be
 read against the other two.** Both gates are stored as household-wide OR booleans by
@@ -459,18 +472,26 @@ form — so a future change that gives a gate its own column does not, by itself
 unless the collapse rule for both halves moves together, in the same change, from
 first-non-empty-wins to something that never picks a winner.
 
+**Satisfied as of kindred#2542 (2026-08-22) — and the rule's own escape clause is what it is
+measured against, not waived.** A gate did get its own column, but by the time it did,
+neither half selected a winner: kindred#2255 (#2450, 2026-08-19) moved *both* halves off
+first-non-empty-wins in one change, to `medicalAnswers`, which keeps every distinct answer;
+kindred#2542 then made the gate's own collapse an explicit OR over every member's answer
+(`gateVerdict`) and left the narrative column holding every distinct sentence. Splitting the
+halves into separate columns therefore reintroduces no winner for the split to expose.
+
 The special-occasion pair is the first one collapsed that way (2026-08-13,
 `registrationText.specialOccasions` in `family_camp_registration_text.go`): the two fields
 are accumulated per answering person and deduplicated as one unit, so one parent's answer
 fanned onto three children still collapses to a single value while two members who each
-answered keep both explanations beside the gate that member gave. The other four pairs
-measured above (Special Needs, CPAP, Housing Accommodation, Bathroom) still collapse
-independently in `processMedical` — that is kindred#2255. Allergies, Dietary Needs and
-`Family Camp-Physician ` are not merely the same shape on the form: `processMedical`
-concatenates each one's stored gate string with its stored explanation exactly as it does
-for Special Needs and CPAP, so they are in the same splice class and any fix has to cover
-them. They are not measured in the table above — which is why the ceiling is stated as the
-highest *measured* one. Adult-Bathroom's collapse behavior has not been measured here
+answered keep both explanations beside the gate that member gave. kindred#2255 (#2450) then did the same for
+every field `processMedical` reads, and kindred#2542 split the five medical gates into their
+own columns. Special Needs, CPAP, Allergies, Dietary Needs and `Family Camp-Physician ` are
+one class and were fixed as one: none of them collapses independently any more, and none
+concatenates a stored gate string with a stored explanation. Housing Accommodation and
+Bathroom never stored a gate string — their gates are `processRegistrations` booleans, as
+above. The last three are not measured in the table above, which is why its ceiling is stated
+as the highest *measured* one. Adult-Bathroom's collapse behavior has not been measured here
 either.
 
 ---

--- a/docs/reference/family-camp-grain-collapse.md
+++ b/docs/reference/family-camp-grain-collapse.md
@@ -108,12 +108,18 @@ The only site with a written-down, reviewed policy.
 
 ### `processMedical` — `family_camp_derived.go:1146-1159`, then `:1161-1262`
 
-| # | Column | Line | Rule |
-|---|---|---|---|
-| M0 | *the flatten itself* | `:1155-1157` | first-wins across **every** field name, before any per-field logic. **This one site is behind M1-M8** |
-| M1 | `cpap_info` | `:1179-1192` | first-wins, **plus a `break` at `:1183`** keeping the older camper generation (171577) over the newer (256582). Adult-CPAP (256933) is correctly additive |
-| M2-M5 | `physician_info`, `special_needs_info`, `allergy_info`, `dietary_info` | `:1194-1232` | each concatenates a **gate token with a narrative**, chosen independently by M0 — so the two halves can come from different people |
-| M6-M8 | `additional_info`, `bathroom_explain`, `accommodation_explain` | `:1234-1253` | first-wins |
+⚠️ **M0-M5 are FIXED. The Rule column below is the pre-2026-08-19 inventory, and its line
+anchors are pre-#2450 too — locate `processMedical`, `medicalAnswers` and `gateVerdict` by
+name, never by these numbers.** kindred#2255 (#2450, 2026-08-19) replaced the flatten;
+kindred#2542 (2026-08-22) split the gates into their own columns. The **Now** column says
+what each site does today.
+
+| # | Column | Line | Rule (pre-#2450) | Now |
+|---|---|---|---|---|
+| M0 | *the flatten itself* | `:1155-1157` | first-wins across **every** field name, before any per-field logic. **This one site is behind M1-M8** | `medicalAnswers` keeps every distinct answer per field, in canonical order — no winner |
+| M1 | `cpap_info` | `:1179-1192` | first-wins, **plus a `break` at `:1183`** keeping the older camper generation (171577) over the newer (256582). Adult-CPAP (256933) is correctly additive | the `break` is gone; the three CPAP fields OR into `cpap_gate`, and `cpap_info` holds only `Family Medical-CPAP Explain` |
+| M2-M5 | `physician_info`, `special_needs_info`, `allergy_info`, `dietary_info` | `:1194-1232` | each concatenates a **gate token with a narrative**, chosen independently by M0 — so the two halves can come from different people | no concatenation: the gate is an OR into `*_gate`, the narrative column holds the explain field's distinct answers alone |
+| M6-M8 | `additional_info`, `bathroom_explain`, `accommodation_explain` | `:1234-1253` | first-wins | dedup-and-join through `medicalAnswers` (#2450); no gate half to unpick |
 
 ---
 
@@ -202,7 +208,7 @@ decision).
 | Issue | Sites | Status against the tree |
 |---|---|---|
 | `#2257` | tracking | Says "20 sites, three mechanisms". The catalogue finds **26 sites**; 20 lossy is right |
-| `#2255` | M0 + the M1 `break` | Anchors correct. Reproduced: 330 rows reading `"No; <narrative>"` (243 with 2+ answerers); 703 household-years hold both camper CPAP generations, **70 disagreeing** |
+| `#2255` | M0 + the M1 `break` | **SHIPPED in two parts — #2450 (2026-08-19) replaced the flatten and the `break`; kindred#2542 (2026-08-22) gave the five gates their own three-state columns.** Anchors were correct. Reproduced: 330 rows reading `"No; <narrative>"` (243 with 2+ answerers); 703 household-years hold both camper CPAP generations, **70 disagreeing** |
 | `#2274` | R1-R6 | **SHIPPED 2026-08-13** (dedup-and-join, plus kindred#2276's occasion detail routed into R4). **Every cell had been reproduced exactly:** Trans ETA 420/428/121 · Goals 240/247/0 · Anything else 73/75/29 · Share Cabins 30/30/24 · Shared Cabin 16/16/16 · Special occasions 14/14/5. Its one wrong anchor — "the person loop at `:757`" — was corrected in the body before implementation; cite the **person loop inside `processRegistrations`** by name rather than by line, since it has moved three times in a week |
 | `#2275` | A1-A7 | **Reproduced exactly:** DOB 1,124 colliding / **1,151 lost** · first name 791/801 · gender 511/513 · relationship 315/323 · email 326 colliding. Its latent-collision warning is real and confirmed: `FAM CAMP Adult 1/2 Gender-Other` (240871/240872) and `FAM Camp Adult 1/2-Pronouns other` (241040/241042) would funnel into the `gender`/`pronouns` arms and carry zero values in every year |
 | `#2269` | C4 | Not a data-loss site — C1's collapse is correct; the review flag is what is missing. Correctly scoped |
@@ -250,13 +256,15 @@ every site above. Both `#2255` and `#2275` name it.
    other; read them as contradictory only if you assume there is one JSON-or-columns decision
    to make, and there is not. `#2275` closes here.
 
-   **`#2255` does not wait for step 2 or this step.** Like `#2274`, it ships its fix directly
-   against the existing collapse function rather than through the per-answer dual-write table
-   this step's ordering implies: it makes each medical gate column nullable (three states —
-   answered Yes, answered No, never reached that question block, since families reach
-   different question blocks rather than uniformly declining) and binds each gate to its
-   explain as one non-selecting collapse in `processMedical` — the same "bind the pair, never
-   select" rule `#2274` applied to `processRegistrations`. **`#2274` did not wait for step 2
+   **`#2255` did not wait for step 2 or this step, and is now SHIPPED.** Like `#2274`, it
+   shipped its fix directly against the existing collapse function rather than through the
+   per-answer dual-write table this step's ordering implies. #2450 (2026-08-19) replaced the
+   flatten with `medicalAnswers`, a non-selecting collapse over every field — the same "bind
+   the pair, never select" rule `#2274` applied to `processRegistrations`. kindred#2542
+   (2026-08-22) finished it: each medical gate now has its own nullable column (three states —
+   answered `"yes"`, answered `"no"`, and `""` for never reaching that question block, since
+   families reach different question blocks rather than uniformly declining), collapsed by OR
+   in `gateVerdict`, and the narrative column beside it holds the family's own words alone. **`#2274` did not wait for step 2
    either** — it closed 2026-08-13 by adding the dedup-and-join directly to
    `processRegistrations`, since its six columns are plain free text with no gate/narrative
    split to unpick. Step 0 shipped with it: `customValueEntry` now carries `personPBID`.

--- a/frontend/src/components/weekend/MedicalNarrative.test.tsx
+++ b/frontend/src/components/weekend/MedicalNarrative.test.tsx
@@ -19,6 +19,7 @@
 import { render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { Permission } from '../../constants/permissions'
 import { MedicalNarrative } from './MedicalNarrative'
 
 const isAdmin = { value: false }
@@ -53,6 +54,12 @@ beforeEach(() => {
   medicalResult.value = { data: undefined, isLoading: false, error: null }
   useHouseholdMedical.mockClear()
 })
+
+/** Grants `bunking.manage` and renders the narrative for a fixed household. */
+function renderWithPermission() {
+  permissions.value = new Set([Permission.BUNKING_MANAGE])
+  return render(<MedicalNarrative householdCmId={1} year={2026} />)
+}
 
 describe('the permission gate', () => {
   it('renders nothing for a user without bunking.manage', () => {
@@ -165,5 +172,70 @@ describe('the narrative itself', () => {
     render(<MedicalNarrative householdCmId={2000001} year={2026} />)
 
     expect(screen.getByText('Forbidden: bunking.manage required')).toBeInTheDocument()
+  })
+})
+
+describe('the gate pill', () => {
+  it('renders a pill for an answered gate and the family text below it', () => {
+    medicalResult.value = {
+      data: { allergy_gate: 'yes', allergy_info: 'carries an epinephrine auto-injector' },
+      isLoading: false,
+      error: null,
+    }
+    renderWithPermission()
+
+    expect(screen.getByText('Allergies')).toBeInTheDocument()
+    expect(screen.getByText('Yes')).toBeInTheDocument()
+    expect(screen.getByText('carries an epinephrine auto-injector')).toBeInTheDocument()
+  })
+
+  it('renders the pill with no paragraph when the family wrote nothing', () => {
+    medicalResult.value = {
+      data: { allergy_gate: 'no', allergy_info: '' },
+      isLoading: false,
+      error: null,
+    }
+    renderWithPermission()
+
+    expect(screen.getByText('Allergies')).toBeInTheDocument()
+    expect(screen.getByText('No')).toBeInTheDocument()
+  })
+
+  it('renders nothing for a gate the household never answered', () => {
+    medicalResult.value = {
+      data: { allergy_gate: 'unknown', allergy_info: '' },
+      isLoading: false,
+      error: null,
+    }
+    renderWithPermission()
+
+    // 375 of 900 households in 2026 answer some gates and not others. An
+    // unanswered gate is not a denial and must not render as one.
+    expect(screen.queryByText('Allergies')).not.toBeInTheDocument()
+  })
+
+  it('renders a narrative that has no gate at all', () => {
+    medicalResult.value = {
+      data: { additional_info: 'gluten free kitchen requested' },
+      isLoading: false,
+      error: null,
+    }
+    renderWithPermission()
+
+    expect(screen.getByText('Additional')).toBeInTheDocument()
+    expect(screen.getByText('gluten free kitchen requested')).toBeInTheDocument()
+    expect(screen.queryByText('Yes')).not.toBeInTheDocument()
+    expect(screen.queryByText('No')).not.toBeInTheDocument()
+  })
+
+  it('renders no block at all when every gate is unanswered and every column blank', () => {
+    medicalResult.value = {
+      data: { allergy_gate: 'unknown', allergy_info: '', additional_info: '' },
+      isLoading: false,
+      error: null,
+    }
+    const { container } = renderWithPermission()
+
+    expect(container).toBeEmptyDOMElement()
   })
 })

--- a/frontend/src/components/weekend/MedicalNarrative.test.tsx
+++ b/frontend/src/components/weekend/MedicalNarrative.test.tsx
@@ -239,3 +239,53 @@ describe('the gate pill', () => {
     expect(container).toBeEmptyDOMElement()
   })
 })
+
+describe('privacy: narrative text never becomes an accessible name (kindred#2348)', () => {
+  // This is a privacy assertion, not an accessibility one -- the codebase has
+  // opted out of accessibility work (frontend/CLAUDE.md). It matters here
+  // because an accessible name is a SEPARATE channel from visible text: a
+  // `getByRole(role, { name })` query, or a future screen reader, would find
+  // the sentence through it even if nobody wrote a new `sr-only` span or
+  // `aria-label`. This is exactly the leak kindred#2348 already closed
+  // everywhere else in this codebase for different reasons (routing sr-only
+  // text out entirely); the assertion here is that the pattern already holds
+  // for medical narrative specifically, and stays holding.
+  //
+  // Checked through Testing Library's own public API (queryByTitle) plus a
+  // direct look at the two other naming attributes, rather than importing an
+  // accessible-name library: MedicalNarrative renders no interactive role
+  // (no button/link/input), so "name from content" never applies here and
+  // aria-label / aria-labelledby / title are the only channels a name could
+  // leak through.
+  it('never lets rendered narrative text become an accessible name', () => {
+    const narrative = 'needs an outlet within reach of the lower bunk overnight'
+    medicalResult.value = {
+      data: {
+        allergy_gate: 'yes',
+        allergy_info: narrative,
+      },
+      isLoading: false,
+      error: null,
+    }
+    const { container } = renderWithPermission()
+
+    // The narrative is visibly on the page...
+    expect(screen.getByText(narrative)).toBeInTheDocument()
+
+    // ...but must never be reachable through a naming attribute. DO NOT "fix"
+    // a failure here by adding aria-label/title/role to MedicalNarrative --
+    // frontend/CLAUDE.md's accessibility-is-opt-out policy forbids it, and the
+    // component passing this test unmodified is the point: nothing here
+    // reaches for a naming attribute, so nothing leaks through one.
+    expect(screen.queryByTitle(narrative)).not.toBeInTheDocument()
+
+    const labelLeaks = Array.from(
+      container.querySelectorAll('[aria-label], [aria-labelledby]')
+    ).filter((el) => {
+      if (el.getAttribute('aria-label')?.includes(narrative)) return true
+      const ids = el.getAttribute('aria-labelledby')?.split(/\s+/) ?? []
+      return ids.some((id) => (document.getElementById(id)?.textContent ?? '').includes(narrative))
+    })
+    expect(labelLeaks).toEqual([])
+  })
+})

--- a/frontend/src/components/weekend/MedicalNarrative.tsx
+++ b/frontend/src/components/weekend/MedicalNarrative.tsx
@@ -24,6 +24,13 @@
  * not made on behalf of a user who cannot have the answer, and a 403 that
  * arrives anyway renders inline rather than escalating to the page
  * ErrorBoundary.
+ *
+ * kindred#2542: the gate answer renders as a pill beside the row label, not
+ * concatenated into the narrative. The API used to fold the yes/no answer
+ * into the free-text column, so a family who answered "No" and wrote nothing
+ * else showed a paragraph that read the bare word "No" — 418 of 676 populated
+ * allergy rows in 2026. The narrative column now holds the family's own words
+ * alone; the gate is its own `'yes' | 'no' | 'unknown'` field, rendered here.
  */
 import { Loader2 } from 'lucide-react'
 
@@ -41,16 +48,24 @@ export interface MedicalNarrativeProps {
   year: number
 }
 
-/** Display order, which is need-first rather than the API's field order. */
+/**
+ * Display order, which is need-first rather than the API's field order.
+ *
+ * The third entry is the row's GATE column, or null where the question has no
+ * stored gate: `additional_info` was never a gate/explain pair, and
+ * `bathroom_explain` / `accommodation_explain` keep their gates as booleans on
+ * family_camp_registrations, where `AccessibilityFlagList` already renders them
+ * one section above. Adding a row here is the one edit a new pair needs.
+ */
 const FIELDS = [
-  ['CPAP', 'cpap_info'],
-  ['Bathroom', 'bathroom_explain'],
-  ['Accommodation', 'accommodation_explain'],
-  ['Special needs', 'special_needs_info'],
-  ['Allergies', 'allergy_info'],
-  ['Dietary', 'dietary_info'],
-  ['Physician', 'physician_info'],
-  ['Additional', 'additional_info'],
+  ['CPAP', 'cpap_info', 'cpap_gate'],
+  ['Bathroom', 'bathroom_explain', null],
+  ['Accommodation', 'accommodation_explain', null],
+  ['Special needs', 'special_needs_info', 'special_needs_gate'],
+  ['Allergies', 'allergy_info', 'allergy_gate'],
+  ['Dietary', 'dietary_info', 'dietary_gate'],
+  ['Physician', 'physician_info', 'physician_gate'],
+  ['Additional', 'additional_info', null],
 ] as const
 
 export function MedicalNarrative({ householdCmId, year }: MedicalNarrativeProps) {
@@ -61,15 +76,25 @@ export function MedicalNarrative({ householdCmId, year }: MedicalNarrativeProps)
 
   if (!canRead) return null
 
-  const populated = FIELDS.map(([label, key]) => [label, data?.[key]] as const).filter(
-    ([, value]) => typeof value === 'string' && value.length > 0
-  )
+  // A row earns its place if the family wrote something OR answered the gate.
+  // "unknown" is not an answer -- the household never reached the question, and
+  // rendering it as a denial would tell staff a family declined something they
+  // were never shown.
+  const rows = FIELDS.map(([label, key, gateKey]) => {
+    const text = data?.[key]
+    const gate = gateKey ? data?.[gateKey] : undefined
+    return {
+      label,
+      text: typeof text === 'string' ? text : '',
+      gate: gate === 'yes' || gate === 'no' ? gate : null,
+    }
+  }).filter((row) => row.text.length > 0 || row.gate !== null)
 
   // Nothing to show and nothing pending. Emptiness is now discovered from the
   // payload rather than predicted by a flag, so this branch is what stands in
   // for the flag's one honest use — and an empty bordered box would read as a
   // disclosure that failed to load.
-  if (!isLoading && !error && populated.length === 0) return null
+  if (!isLoading && !error && rows.length === 0) return null
 
   return (
     <div className="rounded-r-lg border-l-2 border-red-400 bg-red-50/60 px-3 py-2 text-sm text-red-900 dark:border-red-500/60 dark:bg-red-900/20 dark:text-red-200">
@@ -80,12 +105,25 @@ export function MedicalNarrative({ householdCmId, year }: MedicalNarrativeProps)
         </span>
       )}
       {error && <span>{error.message}</span>}
-      {populated.length > 0 && (
+      {rows.length > 0 && (
         <dl className="space-y-1.5">
-          {populated.map(([label, value]) => (
-            <div key={label}>
-              <dt className="text-xs font-bold tracking-wider uppercase opacity-70">{label}</dt>
-              <dd className="whitespace-pre-wrap">{value}</dd>
+          {rows.map((row) => (
+            <div key={row.label}>
+              <dt className="flex items-center gap-1.5 text-xs font-bold tracking-wider uppercase opacity-70">
+                {row.label}
+                {row.gate !== null && (
+                  <span
+                    className={
+                      row.gate === 'yes'
+                        ? 'rounded-full bg-red-200 px-2 py-0.5 text-xs font-semibold tracking-normal text-red-900 normal-case dark:bg-red-500/30 dark:text-red-100'
+                        : 'bg-muted text-muted-foreground rounded-full px-2 py-0.5 text-xs font-semibold tracking-normal normal-case'
+                    }
+                  >
+                    {row.gate === 'yes' ? 'Yes' : 'No'}
+                  </span>
+                )}
+              </dt>
+              {row.text.length > 0 && <dd className="whitespace-pre-wrap">{row.text}</dd>}
             </div>
           ))}
         </dl>

--- a/frontend/src/types/api-generated/types.gen.ts
+++ b/frontend/src/types/api-generated/types.gen.ts
@@ -2083,8 +2083,8 @@ export type HouseholdJourneyYear = {
 /**
  * HouseholdMedicalResponse
  *
- * Narrative medical text. Served by ONE endpoint gated on
- * `bunking.manage`. Never nested elsewhere.
+ * Narrative medical text and the gate answers beside it. Served by ONE
+ * endpoint gated on `bunking.manage`. Never nested elsewhere.
  */
 export type HouseholdMedicalResponse = {
   /**
@@ -2127,6 +2127,26 @@ export type HouseholdMedicalResponse = {
    * Accommodation Explain
    */
   accommodation_explain?: string
+  /**
+   * Allergy Gate
+   */
+  allergy_gate?: 'yes' | 'no' | 'unknown'
+  /**
+   * Dietary Gate
+   */
+  dietary_gate?: 'yes' | 'no' | 'unknown'
+  /**
+   * Special Needs Gate
+   */
+  special_needs_gate?: 'yes' | 'no' | 'unknown'
+  /**
+   * Physician Gate
+   */
+  physician_gate?: 'yes' | 'no' | 'unknown'
+  /**
+   * Cpap Gate
+   */
+  cpap_gate?: 'yes' | 'no' | 'unknown'
 }
 
 /**

--- a/frontend/src/types/pocketbase-types.ts
+++ b/frontend/src/types/pocketbase-types.ts
@@ -633,18 +633,57 @@ export type FamilyCampAdultsRecord<Tattribute_conflicts = unknown> = {
   year: number
 }
 
+export const FamilyCampMedicalAllergyGateOptions = {
+  yes: 'yes',
+  no: 'no',
+} as const
+export type FamilyCampMedicalAllergyGateOptions =
+  (typeof FamilyCampMedicalAllergyGateOptions)[keyof typeof FamilyCampMedicalAllergyGateOptions]
+
+export const FamilyCampMedicalDietaryGateOptions = {
+  yes: 'yes',
+  no: 'no',
+} as const
+export type FamilyCampMedicalDietaryGateOptions =
+  (typeof FamilyCampMedicalDietaryGateOptions)[keyof typeof FamilyCampMedicalDietaryGateOptions]
+
+export const FamilyCampMedicalSpecialNeedsGateOptions = {
+  yes: 'yes',
+  no: 'no',
+} as const
+export type FamilyCampMedicalSpecialNeedsGateOptions =
+  (typeof FamilyCampMedicalSpecialNeedsGateOptions)[keyof typeof FamilyCampMedicalSpecialNeedsGateOptions]
+
+export const FamilyCampMedicalPhysicianGateOptions = {
+  yes: 'yes',
+  no: 'no',
+} as const
+export type FamilyCampMedicalPhysicianGateOptions =
+  (typeof FamilyCampMedicalPhysicianGateOptions)[keyof typeof FamilyCampMedicalPhysicianGateOptions]
+
+export const FamilyCampMedicalCpapGateOptions = {
+  yes: 'yes',
+  no: 'no',
+} as const
+export type FamilyCampMedicalCpapGateOptions =
+  (typeof FamilyCampMedicalCpapGateOptions)[keyof typeof FamilyCampMedicalCpapGateOptions]
 export type FamilyCampMedicalRecord = {
   accommodation_explain?: string
   additional_info?: string
+  allergy_gate?: FamilyCampMedicalAllergyGateOptions
   allergy_info?: string
   bathroom_explain?: string
+  cpap_gate?: FamilyCampMedicalCpapGateOptions
   cpap_info?: string
   created: IsoAutoDateString
+  dietary_gate?: FamilyCampMedicalDietaryGateOptions
   dietary_info?: string
   enrollment_status?: string
   household: RecordIdString
   id: string
+  physician_gate?: FamilyCampMedicalPhysicianGateOptions
   physician_info?: string
+  special_needs_gate?: FamilyCampMedicalSpecialNeedsGateOptions
   special_needs_info?: string
   updated: IsoAutoDateString
   year: number

--- a/pocketbase/main_test_parallelism_test.go
+++ b/pocketbase/main_test_parallelism_test.go
@@ -172,6 +172,7 @@ var serialGroups = []struct {
 			"TestBaseDeleteOrphansFromPreloadedCountsOnlyCompletedDeletes",
 			"TestBaseDeleteOrphansWarnsWhenNothingCanBeKeyed",
 			"TestFamilyCampSweepLogsProtectedNamelessAdultsFor2018",
+			"TestGateVerdictWarnsOnUnrecognizedAnswerWithoutLoggingIt",
 			"TestIsDuplicateStaffStatus",
 			"TestLoadPersonCustomValuesCountsAndLogsUnmappedAppFields",
 			"TestLoadPersonCustomValuesCountsAndLogsUnmappedFields",

--- a/pocketbase/pb_migrations/1500000171_family_camp_medical_gates.js
+++ b/pocketbase/pb_migrations/1500000171_family_camp_medical_gates.js
@@ -1,0 +1,84 @@
+/// <reference path="../pb_data/types.d.ts" />
+/**
+ * Migration: the medical gate answer leaves the narrative column (kindred#2542).
+ *
+ * CampMinder asks each of these questions in two parts -- a Yes/No gate and a
+ * free-text explanation -- and processMedical stored the pair in ONE column. So
+ * `allergy_info` read "Yes; <the family's sentence>", where the leading "Yes; "
+ * is not something the family wrote, and a household that answered No got a
+ * narrative consisting of the bare word "No" (418 of 676 populated allergy rows
+ * in 2026). These five columns take the gate, and the narrative columns keep the
+ * family's own words alone.
+ *
+ * THREE STATES, and the third is the reason this is a select and not a bool.
+ * Families reach different question blocks, so "answered No" and "never asked"
+ * are different facts: in 2026, 430 of 900 households answered the allergy gate
+ * No and 224 never answered it at all; for the physician gate it is 284 and 589.
+ * A non-nullable bool would collapse those into one `false`. The empty string is
+ * the third state, exactly as family_camp_registrations.share_cabin_gate does it
+ * (migration 1500000126) -- a non-required select, with the empty string named
+ * at the schema edge rather than stored as a word.
+ *
+ * These sit on family_camp_medical rather than family_camp_registrations
+ * deliberately: that table is admin-gated on all five rules and absent from
+ * every export config, and a gate answer is still an answer to a medical
+ * question. lodging_medical_narrative_test.go's gateColumns enforces it.
+ *
+ * PocketBase v0.23 syntax: fields.add(new Field({...})) on an existing
+ * collection. A bare add({...}) silently does nothing.
+ *
+ * The five addField() calls below are written out literally, one per column,
+ * rather than looped over an array: TestMedicalGateColumnsExistInASchemaMigration
+ * greps this file for the literal `name: "allergy_gate"` and so on, and a loop
+ * variable can never match that. Migration 1500000126 sets the same precedent.
+ *
+ * addField() is a no-op when the column is already present. That matters while
+ * this migration is unmerged: PB records an applied migration by FILENAME, so a
+ * column added to this file after a dev database already ran it would never
+ * appear there, and `Set` on a missing column is a silent no-op. Idempotent adds
+ * mean clearing the _migrations row is enough to pick the change up.
+ */
+
+/**
+ * Adds a field unless the collection already has one by that name.
+ * @param {core.Collection} collection
+ * @param {core.Field} field
+ */
+function addField(collection, field) {
+  if (!collection.fields.getByName(field.name)) {
+    collection.fields.add(field);
+  }
+}
+
+migrate((app) => {
+  const medical = app.findCollectionByNameOrId("family_camp_medical");
+  addField(medical, new Field({
+    type: "select", name: "allergy_gate", required: false, presentable: false,
+    values: ["yes", "no"], maxSelect: 1
+  }));
+  addField(medical, new Field({
+    type: "select", name: "dietary_gate", required: false, presentable: false,
+    values: ["yes", "no"], maxSelect: 1
+  }));
+  addField(medical, new Field({
+    type: "select", name: "special_needs_gate", required: false, presentable: false,
+    values: ["yes", "no"], maxSelect: 1
+  }));
+  addField(medical, new Field({
+    type: "select", name: "physician_gate", required: false, presentable: false,
+    values: ["yes", "no"], maxSelect: 1
+  }));
+  addField(medical, new Field({
+    type: "select", name: "cpap_gate", required: false, presentable: false,
+    values: ["yes", "no"], maxSelect: 1
+  }));
+  app.save(medical);
+}, (app) => {
+  const medical = app.findCollectionByNameOrId("family_camp_medical");
+  for (const name of [
+    "allergy_gate", "dietary_gate", "special_needs_gate", "physician_gate", "cpap_gate"
+  ]) {
+    medical.fields.removeByName(name);
+  }
+  app.save(medical);
+});

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -384,6 +384,19 @@ type medicalData struct {
 	// this table is one of the three keyed on (household, year) and a reader
 	// of any one of them needs the same answer.
 	enrollmentStatus string
+
+	// The household's answer to each gate question, split out of the narrative
+	// columns above (kindred#2542). Three states: "yes", "no", and "" for a
+	// question the household never reached -- see gateVerdict for why the third
+	// is not optional. These are answers to medical questions and live on this
+	// admin-gated table with the narrative, but they are STRUCTURED, not
+	// narrative: lodging_medical_narrative_test.go keeps them in their own
+	// gateColumns list rather than in narrativeColumns.
+	allergyGate      string
+	dietaryGate      string
+	specialNeedsGate string
+	physicianGate    string
+	cpapGate         string
 }
 
 // Sync executes the family camp derived computation
@@ -2033,35 +2046,6 @@ var medicalColumnLimits = map[string]int{
 	"accommodation_explain": 4000,
 }
 
-// medicalGateFields are the family-camp medical questions processMedical reads
-// whose entire answer vocabulary is "Yes" / "No" -- 2 distinct values each, 3
-// characters at the longest, across 30,124 stored answers.
-//
-// They are named because a gate cannot be concatenated the way a narrative can.
-// CampMinder asks each of these questions in two parts, a gate and a free-text
-// explanation, and processMedical stores the pair in one column. Joining two
-// people's gate answers verbatim renders "No; Yes; <A>; <B>" -- two
-// contradictory gates in front of the text -- which is why an earlier uniform
-// dedup-and-join over every field was reverted. A household's gate is the OR of
-// its answers instead: see medicalAnswers.parts.
-//
-// "Family Camp-CPAP" is a true binary gate too and is deliberately absent. The
-// CPAP column is fed by three fields of two different shapes -- the other two
-// are multi-option selects whose text says WHICH accommodation is needed -- and
-// kindred#2255 carves it out for its own pass. Absent from this map is NOT
-// absent from the rule: cpapGateParts drops that column's denials by the half
-// of the OR that survives multi-option answers, so no household's row renders a
-// gate contradicting the need beside it.
-var medicalGateFields = map[string]struct{}{
-	"Family Medical-Allergies":     {},
-	"Family Medical-Dietary Needs": {},
-	"Family Camp-Special Needs":    {},
-	"Family Camp-Physician":        {},
-}
-
-// gateAnswerYes is the affirmative token those gates store.
-const gateAnswerYes = "Yes"
-
 // The three states a family-camp medical gate can be in. The third is the whole
 // reason the column is a select and not a bool: families reach different
 // question blocks, so "answered No" and "never asked" are different facts. In
@@ -2154,74 +2138,22 @@ func gateVerdict(fieldName string, parts []string) string {
 type medicalAnswers map[string][]string
 
 // parts returns the answers to one field, ready to be concatenated into a
-// column.
+// column: every distinct answer, in canonical order, across everyone who
+// answered it. A second person's sentence is a second disclosure.
 //
-// A binary gate collapses to a single token by OR: if anyone in the household
-// said Yes, the household's answer is Yes. That is the same total aggregation
-// processRegistrations already applies to the housing flags, and it is what
-// makes the narrative join safe. Anything else keeps every distinct answer,
-// because a second person's sentence is a second disclosure.
-//
-// A gate whose answers are all negative falls through to the join rather than
-// picking one, so a vocabulary that ever widens past Yes/No is not silently
-// narrowed to whichever value sorted first.
+// It used to collapse a Yes/No gate to a single token, because the gate and its
+// explanation shared a column and joining two answerers' gates verbatim rendered
+// "No; Yes; <A>; <B>". kindred#2542 gave the gate its own column, so no gate
+// token reaches a narrative join any more and the collapse moved to gateVerdict.
 func (m medicalAnswers) parts(fieldName string) []string {
 	values := m[fieldName]
 	if len(values) == 0 {
 		return nil
 	}
-	if _, isGate := medicalGateFields[fieldName]; !isGate {
-		// Cloned because callers append the next field's parts onto this
-		// slice: handing back the map's own backing array would let one
-		// column's join overwrite another's answers.
-		return slices.Clone(values)
-	}
-	for _, v := range values {
-		if strings.EqualFold(v, gateAnswerYes) {
-			return []string{v}
-		}
-	}
+	// Cloned because callers append the next field's parts onto this slice:
+	// handing back the map's own backing array would let one column's join
+	// overwrite another's answers.
 	return slices.Clone(values)
-}
-
-// cpapGateParts drops a household's pure CPAP denials whenever anyone in it
-// disclosed a need.
-//
-// The CPAP column is the one gate/explain pair processMedical still stores as a
-// gate STRING, and docs/reference/family-camp-field-provenance.md section 4
-// names Special Needs and CPAP as the two pairs where splitting the halves does
-// real harm. Special Needs is a Yes/No gate and collapses by OR through
-// medicalGateFields; CPAP cannot, because the three CPAP fields are
-// multi-option selects whose affirmative options say WHICH accommodation is
-// needed (kindred#1875, see classifyCPAPAnswer). Two different affirmatives are
-// two different needs and both have to survive, so this is only the half of the
-// OR that applies: a household that needs an outlet needs it whoever else on
-// the form said no.
-//
-// Without it the household aggregation would put a denial and a disclosure in
-// one column -- "No; Yes, outlet needed for CPAP machine" -- which is the
-// rendered contradiction medicalGateFields exists to prevent, arriving through
-// the one column medicalGateFields does not cover. Measured on the production
-// snapshot it is 1 household-year in 2026 and 1-2 a year back to 2022: rare,
-// and on a column staff read to decide whether a family needs a powered cabin.
-//
-// Every stored answer to the three fields is either "No" or starts "Yes"
-// (30,124 values checked), so parseBoolFieldValue -- which anchors on the
-// leading token, the whole reason it is not enough to CLASSIFY these answers --
-// is exactly the right test for which of them is a denial.
-func cpapGateParts(parts []string) []string {
-	disclosed := make([]string, 0, len(parts))
-	for _, part := range parts {
-		if parseBoolFieldValue(part) {
-			disclosed = append(disclosed, part)
-		}
-	}
-	if len(disclosed) == 0 {
-		// Nobody disclosed. "No" is still an answer, and blanking it would be
-		// the silent loss this whole function's neighbors exist to end.
-		return parts
-	}
-	return disclosed
 }
 
 // joinMedicalColumn concatenates one column's parts within its declared cap,
@@ -2283,53 +2215,54 @@ func (s *FamilyCampDerivedSync) processMedical(personValues []customValueEntry) 
 			householdPBID: householdID,
 		}
 
-		// CPAP info, unioned across all three fields and deduplicated.
+		// CPAP. The three fields are one question asked in three generations, so
+		// the gate is the union of all three -- which is what makes it match the
+		// flag logic in processRegistrations, which ORs across the same three.
 		//
-		// The union is what has to match the flag logic in processRegistrations,
-		// which ORs across all three: any answer that can raise needs_power or
-		// needs_private_bathroom has to be readable in the one place staff can
-		// look for the reason. Dedup is what keeps the union honest -- the two
-		// Camper-partition names are generations of the SAME question, and
-		// answering both must not print the sentence twice.
-		//
-		// It replaces a first-non-empty-wins loop over the two camper names,
-		// which stopped at whichever had an answer: a "No" on Family Camp-CPAP
-		// hid a disclosure on FAM CAMP-CPAP outright, in 27 households in 2025
-		// and 1 in 2026 on the production snapshot, each of them carrying a
-		// housing flag their cpap_info then denied. Taking one field's answer as
-		// the household's is the same first-wins mistake medicalAnswers exists
-		// to end, one level up.
-		cpapParts := []string{}
+		// The affirmative options are multi-option sentences whose text names
+		// WHICH accommodation is needed ("Yes, outlet needed for CPAP machine"
+		// vs "Yes, bathroom or other housing accommodation ... (not CPAP
+		// related)"). That distinction is real and is NOT lost here: it is
+		// exactly what classifyCPAPAnswer resolves into needs_power and
+		// needs_private_bathroom, and AccessibilityFlagList renders both as
+		// Housing-needs rows directly above this text in the same panel section.
+		// What leaves is the wording, never the decision -- which is why this
+		// column no longer needs the pass that stood here before kindred#2542,
+		// dropping a household's pure CPAP denials whenever anyone in it
+		// disclosed a need so that "No; Yes, outlet needed for CPAP machine"
+		// could not be rendered. No gate answer reaches this column at all now,
+		// so there is nothing left for it to contradict.
+		cpapGateAnswers := make([]string, 0, 3)
 		for _, key := range []string{fieldFamilyCampCPAP, fieldFamCampCPAP, fieldAdultCPAP} {
-			for _, v := range fields.parts(key) {
-				if !slices.Contains(cpapParts, v) {
-					cpapParts = append(cpapParts, v)
-				}
-			}
+			cpapGateAnswers = append(cpapGateAnswers, fields.parts(key)...)
 		}
-		cpapParts = cpapGateParts(cpapParts)
-		cpapParts = append(cpapParts, fields.parts("Family Medical-CPAP Explain")...)
-		med.cpapInfo = s.joinMedicalColumn(householdID, "cpap_info", cpapParts)
+		med.cpapGate = gateVerdict("CPAP", cpapGateAnswers)
+		med.cpapInfo = s.joinMedicalColumn(householdID, "cpap_info",
+			fields.parts("Family Medical-CPAP Explain"))
 
-		// Physician info
-		physicianParts := fields.parts("Family Camp-Physician")
-		physicianParts = append(physicianParts, fields.parts("Family Camp-Physician If Yes")...)
-		med.physicianInfo = s.joinMedicalColumn(householdID, "physician_info", physicianParts)
+		// Physician
+		med.physicianGate = gateVerdict("Family Camp-Physician",
+			fields.parts("Family Camp-Physician"))
+		med.physicianInfo = s.joinMedicalColumn(householdID, "physician_info",
+			fields.parts("Family Camp-Physician If Yes"))
 
-		// Special needs info
-		specialParts := fields.parts("Family Camp-Special Needs")
-		specialParts = append(specialParts, fields.parts("Family Camp-Special Needs Yes")...)
-		med.specialNeedsInfo = s.joinMedicalColumn(householdID, "special_needs_info", specialParts)
+		// Special needs
+		med.specialNeedsGate = gateVerdict("Family Camp-Special Needs",
+			fields.parts("Family Camp-Special Needs"))
+		med.specialNeedsInfo = s.joinMedicalColumn(householdID, "special_needs_info",
+			fields.parts("Family Camp-Special Needs Yes"))
 
-		// Allergy info
-		allergyParts := fields.parts("Family Medical-Allergies")
-		allergyParts = append(allergyParts, fields.parts("Family Medical-Allergy Info")...)
-		med.allergyInfo = s.joinMedicalColumn(householdID, "allergy_info", allergyParts)
+		// Allergies
+		med.allergyGate = gateVerdict("Family Medical-Allergies",
+			fields.parts("Family Medical-Allergies"))
+		med.allergyInfo = s.joinMedicalColumn(householdID, "allergy_info",
+			fields.parts("Family Medical-Allergy Info"))
 
-		// Dietary info
-		dietaryParts := fields.parts("Family Medical-Dietary Needs")
-		dietaryParts = append(dietaryParts, fields.parts("Family Medical-Dietary Explain")...)
-		med.dietaryInfo = s.joinMedicalColumn(householdID, "dietary_info", dietaryParts)
+		// Dietary
+		med.dietaryGate = gateVerdict("Family Medical-Dietary Needs",
+			fields.parts("Family Medical-Dietary Needs"))
+		med.dietaryInfo = s.joinMedicalColumn(householdID, "dietary_info",
+			fields.parts("Family Medical-Dietary Explain"))
 
 		// Additional info
 		med.additionalInfo = s.joinMedicalColumn(
@@ -2365,11 +2298,16 @@ func (s *FamilyCampDerivedSync) processMedical(personValues []customValueEntry) 
 		med.accommodationExplain = s.joinMedicalColumn(
 			householdID, "accommodation_explain", accommodationParts)
 
-		// Only include if has some data
+		// A gate answer is content. 375 of 900 2026 households have nothing else
+		// once the narratives hold the family's words alone, and without this
+		// they would be absent from the result slice and swept as orphans.
 		if med.cpapInfo != "" || med.physicianInfo != "" ||
 			med.specialNeedsInfo != "" || med.allergyInfo != "" ||
 			med.dietaryInfo != "" || med.additionalInfo != "" ||
-			med.bathroomExplain != "" || med.accommodationExplain != "" {
+			med.bathroomExplain != "" || med.accommodationExplain != "" ||
+			med.allergyGate != "" || med.dietaryGate != "" ||
+			med.specialNeedsGate != "" || med.physicianGate != "" ||
+			med.cpapGate != "" {
 			result = append(result, med)
 		}
 	}

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -2796,6 +2796,11 @@ func (s *FamilyCampDerivedSync) medicalNeedsUpdate(existing *core.Record, med *m
 		existing.GetString("additional_info") != med.additionalInfo ||
 		existing.GetString("bathroom_explain") != med.bathroomExplain ||
 		existing.GetString("accommodation_explain") != med.accommodationExplain ||
+		existing.GetString("allergy_gate") != med.allergyGate ||
+		existing.GetString("dietary_gate") != med.dietaryGate ||
+		existing.GetString("special_needs_gate") != med.specialNeedsGate ||
+		existing.GetString("physician_gate") != med.physicianGate ||
+		existing.GetString("cpap_gate") != med.cpapGate ||
 		existing.GetString(enrollmentStatusColumn) != med.enrollmentStatus
 }
 
@@ -2975,6 +2980,11 @@ func (s *FamilyCampDerivedSync) upsertMedical(
 				existingRecord.Set("additional_info", med.additionalInfo)
 				existingRecord.Set("bathroom_explain", med.bathroomExplain)
 				existingRecord.Set("accommodation_explain", med.accommodationExplain)
+				existingRecord.Set("allergy_gate", med.allergyGate)
+				existingRecord.Set("dietary_gate", med.dietaryGate)
+				existingRecord.Set("special_needs_gate", med.specialNeedsGate)
+				existingRecord.Set("physician_gate", med.physicianGate)
+				existingRecord.Set("cpap_gate", med.cpapGate)
 				existingRecord.Set(enrollmentStatusColumn, med.enrollmentStatus)
 
 				if err := s.App.Save(existingRecord); err != nil {
@@ -2999,6 +3009,11 @@ func (s *FamilyCampDerivedSync) upsertMedical(
 			record.Set("additional_info", med.additionalInfo)
 			record.Set("bathroom_explain", med.bathroomExplain)
 			record.Set("accommodation_explain", med.accommodationExplain)
+			record.Set("allergy_gate", med.allergyGate)
+			record.Set("dietary_gate", med.dietaryGate)
+			record.Set("special_needs_gate", med.specialNeedsGate)
+			record.Set("physician_gate", med.physicianGate)
+			record.Set("cpap_gate", med.cpapGate)
 			record.Set(enrollmentStatusColumn, med.enrollmentStatus)
 
 			if err := s.App.Save(record); err != nil {

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -2123,6 +2123,32 @@ func gateVerdict(fieldName string, parts []string) string {
 	return verdict
 }
 
+// orGateVerdicts unions per-field gate verdicts by the same rule gateVerdict
+// itself uses to union per-person answers within one field: yes beats no
+// beats unanswered, order-independent.
+//
+// It exists for CPAP, the one gate spread across three CampMinder fields
+// (fieldFamilyCampCPAP, fieldFamCampCPAP, fieldAdultCPAP -- one question asked
+// in three generations). Calling gateVerdict once per field, then ORing the
+// results, keeps its "field" warning naming the actual field whose vocabulary
+// moved -- the promise gateVerdict's doc comment makes -- instead of the
+// single literal "CPAP" label a combined call would have to invent. The union
+// itself changes nothing observable: yes/no/unanswered is order-independent
+// whether it is computed over one combined answer list or three separate
+// ones, so processMedical's cpap_gate is identical either way.
+func orGateVerdicts(verdicts ...string) string {
+	verdict := gateVerdictUnanswered
+	for _, v := range verdicts {
+		if v == gateVerdictYes {
+			return gateVerdictYes
+		}
+		if v == gateVerdictNo {
+			verdict = gateVerdictNo
+		}
+	}
+	return verdict
+}
+
 // medicalAnswers holds one household's family-camp medical answers: every
 // distinct answer given to each field, in canonical order, across everyone who
 // answered it.
@@ -2232,11 +2258,17 @@ func (s *FamilyCampDerivedSync) processMedical(personValues []customValueEntry) 
 		// disclosed a need so that "No; Yes, outlet needed for CPAP machine"
 		// could not be rendered. No gate answer reaches this column at all now,
 		// so there is nothing left for it to contradict.
-		cpapGateAnswers := make([]string, 0, 3)
-		for _, key := range []string{fieldFamilyCampCPAP, fieldFamCampCPAP, fieldAdultCPAP} {
-			cpapGateAnswers = append(cpapGateAnswers, fields.parts(key)...)
-		}
-		med.cpapGate = gateVerdict("CPAP", cpapGateAnswers)
+		//
+		// One gateVerdict call per field, ORed by orGateVerdicts, rather than one
+		// combined call over all three fields' answers -- so a vocabulary warning
+		// names the actual CampMinder field that drifted (Family Camp-CPAP, FAM
+		// CAMP-CPAP or Adult-CPAP) instead of the aggregate label "CPAP". The
+		// verdict itself is unchanged either way: see orGateVerdicts' doc comment.
+		med.cpapGate = orGateVerdicts(
+			gateVerdict(fieldFamilyCampCPAP, fields.parts(fieldFamilyCampCPAP)),
+			gateVerdict(fieldFamCampCPAP, fields.parts(fieldFamCampCPAP)),
+			gateVerdict(fieldAdultCPAP, fields.parts(fieldAdultCPAP)),
+		)
 		med.cpapInfo = s.joinMedicalColumn(householdID, "cpap_info",
 			fields.parts("Family Medical-CPAP Explain"))
 

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -2062,6 +2062,83 @@ var medicalGateFields = map[string]struct{}{
 // gateAnswerYes is the affirmative token those gates store.
 const gateAnswerYes = "Yes"
 
+// The three states a family-camp medical gate can be in. The third is the whole
+// reason the column is a select and not a bool: families reach different
+// question blocks, so "answered No" and "never asked" are different facts. In
+// 2026, 430 of 900 households answered the allergy gate No and 224 never
+// answered it at all; for the physician gate it is 284 and 589. A bool would
+// collapse those into one false.
+const (
+	gateVerdictUnanswered = ""
+	gateVerdictNo         = "no"
+	gateVerdictYes        = "yes"
+)
+
+// gateDenials is the negative pole of the gate vocabulary -- the mirror of the
+// affirmative set parseBoolFieldValue accepts.
+var gateDenials = map[string]struct{}{
+	"no": {}, "false": {}, "0": {}, "n": {},
+}
+
+// gateVerdict collapses every household member's answer to one gate question
+// into the household's answer, by OR.
+//
+// This is the same total aggregation processRegistrations applies to the
+// housing flags, and it is the only collapse rule on this path that never picks
+// a winner: `personValues` carries one entry per person per field and
+// CampMinder asks these questions on a per-CAMPER form, so a household with two
+// enrolled children answers each question twice. It is therefore
+// order-independent, which is what docs/reference/family-camp-field-provenance.md
+// section 4's binding rule requires -- a gate and its explain must collapse as a
+// pair, and after this neither half selects a winner.
+//
+// The vocabulary is closed. Across all 35,895 stored answers to the seven gate
+// fields, every one is either a leading-token "Yes" or a member of gateDenials;
+// the four pure Yes/No gates hold 2 distinct values each, 3 characters at the
+// longest, across 30,283 answers. That measurement is what licenses collapsing
+// them to a single verdict rather than keeping every distinct answer the way the
+// narrative columns do.
+//
+// An answer outside that vocabulary is NOT stored anywhere -- it contributes no
+// verdict and does not reach the narrative column. `medicalAnswers.parts` used
+// to let one fall through into the narrative join; that valve was retired by
+// owner ruling (2026-08-22) once the gate stopped sharing the column. The
+// warning below is what replaced it, and is the only way a CampMinder
+// vocabulary change would now surface. It carries the field name and a COUNT
+// and never the answer: these are answers on a medical form, and the same
+// never-log contract joinMedicalColumn states covers them.
+func gateVerdict(fieldName string, parts []string) string {
+	verdict := gateVerdictUnanswered
+	unrecognized := 0
+
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		if parseBoolFieldValue(trimmed) {
+			verdict = gateVerdictYes
+			continue
+		}
+		if _, denied := gateDenials[strings.ToLower(trimmed)]; denied {
+			// Never downgrades a Yes already seen: the OR is the point.
+			if verdict == gateVerdictUnanswered {
+				verdict = gateVerdictNo
+			}
+			continue
+		}
+		unrecognized++
+	}
+
+	if unrecognized > 0 {
+		slog.Warn("Family camp medical gate answer outside the Yes/No vocabulary",
+			"field", fieldName, "count", unrecognized,
+			"hint", "the answer is not stored; check the CampMinder field's options")
+	}
+
+	return verdict
+}
+
 // medicalAnswers holds one household's family-camp medical answers: every
 // distinct answer given to each field, in canonical order, across everyone who
 // answered it.

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -4111,3 +4111,62 @@ func TestProcessMedicalBathroomExplainUsesTheSharedRoutingList(t *testing.T) {
 		}
 	}
 }
+
+// TestMedicalGateColumnsExistInASchemaMigration guards the failure mode that has
+// no symptom: record.Set() on a PocketBase column that does not exist is a
+// silent no-op, so a gate whose migration was never written simply never
+// persists, with nothing in the logs and nothing in the tests to notice.
+//
+// Ranges over gateColumns (lodging_medical_narrative_test.go, same package)
+// rather than a list of its own -- two identical lists in this package is
+// exactly the drift shape TestMedicalColumnLimitsMatchTheSchema above already
+// guards against for medicalColumnLimits.
+func TestMedicalGateColumnsExistInASchemaMigration(t *testing.T) {
+	t.Parallel()
+
+	paths, err := filepath.Glob("../pb_migrations/*.js")
+	if err != nil {
+		t.Fatalf("globbing migrations: %v", err)
+	}
+	if len(paths) == 0 {
+		t.Fatal("no migrations found -- this test would pass vacuously")
+	}
+
+	declared := make(map[string]string, len(gateColumns))
+	for _, path := range paths {
+		source, err := os.ReadFile(path) //nolint:gosec // fixed repo-relative glob
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+		text := string(source)
+		if !strings.Contains(text, "family_camp_medical") {
+			continue
+		}
+		for _, column := range gateColumns {
+			if strings.Contains(text, `name: "`+column+`"`) {
+				declared[column] = filepath.Base(path)
+			}
+		}
+	}
+
+	for _, column := range gateColumns {
+		path, ok := declared[column]
+		if !ok {
+			t.Errorf("family_camp_medical.%s is written by processMedical but no "+
+				"migration creates it -- record.Set() would silently no-op", column)
+			continue
+		}
+		source, err := os.ReadFile(filepath.Join("../pb_migrations", path)) //nolint:gosec // from the glob above
+		if err != nil {
+			t.Fatalf("re-reading %s: %v", path, err)
+		}
+		text := string(source)
+		if !strings.Contains(text, `"select"`) {
+			t.Errorf("%s declares %s but no select field -- the gate must be a "+
+				"three-state select, not a bool", path, column)
+		}
+		if !strings.Contains(text, `values: ["yes", "no"]`) {
+			t.Errorf(`%s declares %s without values: ["yes", "no"]`, path, column)
+		}
+	}
+}

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -4211,6 +4211,58 @@ func TestGateVerdictIsOrderIndependent(t *testing.T) {
 	}
 }
 
+// TestGateVerdictWarnsOnUnrecognizedAnswerWithoutLoggingIt pins the ONLY
+// remaining signal that a CampMinder gate field's vocabulary has drifted.
+//
+// Before kindred#2542, medicalAnswers.parts had a fall-through valve that let
+// an answer outside the Yes/No vocabulary survive into the narrative column,
+// so a widened CampMinder field was at least visible in the sheet even though
+// nothing flagged it. That valve was retired by owner ruling once the gate got
+// its own column (gateVerdict's doc comment), and gateVerdict's slog.Warn is
+// what replaced it -- if this warning stopped firing, or stopped being
+// distinguishable from routine noise, nobody would ever find out the
+// vocabulary moved.
+//
+// The warning must carry enough to act on (the field, and a count) and must
+// NEVER carry the answer text itself: these are answers on a medical form, the
+// same contract joinMedicalColumn's cap-warning states and
+// TestNarrativeIsNeverLogged enforces at the source-scan level for every other
+// slog call in this package.
+//
+// Not t.Parallel(): captureSweepLogs (orphan_sweep_test.go) swaps the
+// process-global slog default; this test is exempted in
+// pocketbase/main_test_parallelism_test.go alongside the sync package's other
+// captureSweepLogs callers.
+func TestGateVerdictWarnsOnUnrecognizedAnswerWithoutLoggingIt(t *testing.T) {
+	logs := captureSweepLogs(t)
+
+	const secretAnswer = "Only in an emergency, ask my doctor first"
+	verdict := gateVerdict("Family Medical-Allergies", []string{secretAnswer, "No"})
+
+	// The unrecognized answer must not overrule the denial that sits beside it
+	// -- TestGateVerdictOrsAcrossAnswerers already pins this at the verdict
+	// level; repeating the input here (rather than a bare unrecognized-only
+	// case) proves the warning fires on the SAME call that produces a real,
+	// stored verdict, not only on a degenerate all-garbage input.
+	if verdict != gateVerdictNo {
+		t.Fatalf("verdict = %q, want %q", verdict, gateVerdictNo)
+	}
+
+	got := logs.String()
+	if got == "" {
+		t.Fatal("gateVerdict saw an answer outside the Yes/No vocabulary and logged nothing")
+	}
+	if !strings.Contains(got, "Family Medical-Allergies") {
+		t.Errorf("warning does not name the field:\n%s", got)
+	}
+	if !strings.Contains(got, "count=1") {
+		t.Errorf("warning does not carry a count of 1 unrecognized answer:\n%s", got)
+	}
+	if strings.Contains(got, secretAnswer) {
+		t.Errorf("warning leaked the answer text -- this is a medical form:\n%s", got)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // kindred#2542: the gate answer moves to its own column and the narrative
 // columns hold the family's own words alone.

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -4170,3 +4170,57 @@ func TestMedicalGateColumnsExistInASchemaMigration(t *testing.T) {
 		}
 	}
 }
+
+func TestGateVerdictOrsAcrossAnswerers(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		parts []string
+		want  string
+	}{
+		{"nobody answered", nil, ""},
+		{"every answer empty", []string{"", "   "}, ""},
+		{"single no", []string{"No"}, "no"},
+		{"single yes", []string{"Yes"}, "yes"},
+		{"one yes among denials wins", []string{"No", "Yes", "No"}, "yes"},
+		{"denials only stay no", []string{"No", "No"}, "no"},
+		{"a CPAP option sentence is affirmative",
+			[]string{"No", "Yes, outlet needed for CPAP machine"}, "yes"},
+		{"the bathroom option sentence is affirmative too",
+			[]string{"Yes, bathroom or other housing accommodation for a medical " +
+				"(not CPAP related) or accessibility-related reason needed"}, "yes"},
+		{"case and whitespace do not matter", []string{" nO ", "  "}, "no"},
+		{"an answer outside the vocabulary is not an answer",
+			[]string{"Vegetarian"}, ""},
+		{"an unrecognized answer never becomes a denial",
+			[]string{"Vegetarian", "No"}, "no"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := gateVerdict("Family Medical-Allergies", tt.parts); got != tt.want {
+				t.Errorf("gateVerdict(%q) = %q, want %q", tt.parts, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGateVerdictIsOrderIndependent is the probe kindred#2255 prescribes instead
+// of a flakiness test. The old collapse picked a winner by load order, so the
+// only honest assertion is that permuting the input changes nothing -- and it
+// must not pin WHICH answerer wins, because none does.
+func TestGateVerdictIsOrderIndependent(t *testing.T) {
+	t.Parallel()
+	permutations := [][]string{
+		{"No", "Yes", "No"},
+		{"No", "No", "Yes"},
+		{"Yes", "No", "No"},
+	}
+	want := gateVerdict("Family Camp-Physician", permutations[0])
+	for _, parts := range permutations[1:] {
+		if got := gateVerdict("Family Camp-Physician", parts); got != want {
+			t.Errorf("gateVerdict(%q) = %q, want %q -- permuting the answers must "+
+				"not change the verdict", parts, got, want)
+		}
+	}
+}

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -212,92 +212,144 @@ func TestRegistrationFieldMapping(t *testing.T) {
 	}
 }
 
-// TestMedicalInfoBlobConcatenation tests that related medical fields are concatenated
+// gateYes/gateNo are the values a *_gate column stores, spelled out here rather
+// than read from gateVerdictYes/gateVerdictNo. A test that asserted against the
+// production constant would keep passing if the constant's VALUE changed, and
+// the stored string is what the migration's select options, the API and the
+// family panel all read -- so it is part of the specification, not an
+// implementation detail. TestMedicalGateColumnsExistInASchemaMigration pins the
+// same two spellings against the migration.
+const (
+	gateYes = "yes"
+	gateNo  = "no"
+)
+
+// TestMedicalInfoBlobConcatenation pins the shape of every gate/explain pair
+// processMedical stores: the explanation alone in the narrative column, the
+// household's answer to the gate question in its own column beside it
+// (kindred#2542). It used to assert the two glued into one string -- against a
+// test-local reimplementation rather than production -- so a household that
+// said No and explained anyway rendered "No; <the condition it denies>".
 func TestMedicalInfoBlobConcatenation(t *testing.T) {
 	t.Parallel()
+	ts := time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC)
+
 	tests := []struct {
 		name     string
 		fields   map[string]string
-		expected map[string]string
+		wantInfo map[string]string
+		wantGate map[string]string
 	}{
 		{
-			name: "CPAP info concatenation",
+			name: "CPAP explanation, gate beside it",
 			fields: map[string]string{
 				"Family Camp-CPAP":            "Yes",
 				"FAM CAMP-CPAP":               "Yes",
 				"Family Medical-CPAP Explain": "Need outlet near bed",
 			},
-			expected: map[string]string{
-				"cpap_info": "Yes; Need outlet near bed",
-			},
+			wantInfo: map[string]string{"cpap_info": "Need outlet near bed"},
+			wantGate: map[string]string{"cpap_gate": gateYes},
 		},
 		{
-			name: "Physician info concatenation",
+			name: "Physician explanation, gate beside it",
 			fields: map[string]string{
 				"Family Camp-Physician":        "Yes",
 				"Family Camp-Physician If Yes": "Dr. Emma Johnson, 555-0100",
 			},
-			expected: map[string]string{
-				"physician_info": "Yes; Dr. Emma Johnson, 555-0100",
-			},
+			wantInfo: map[string]string{"physician_info": "Dr. Emma Johnson, 555-0100"},
+			wantGate: map[string]string{"physician_gate": gateYes},
 		},
 		{
-			name: "Allergy info concatenation",
+			name: "Allergy explanation, gate beside it",
 			fields: map[string]string{
 				"Family Medical-Allergies":    "Yes",
 				"Family Medical-Allergy Info": "Peanuts, shellfish",
 			},
-			expected: map[string]string{
-				"allergy_info": "Yes; Peanuts, shellfish",
-			},
+			wantInfo: map[string]string{"allergy_info": "Peanuts, shellfish"},
+			wantGate: map[string]string{"allergy_gate": gateYes},
 		},
 		{
-			name: "Dietary info concatenation",
+			// "Vegetarian" is not in the gate vocabulary and production has
+			// never stored it there. It contributes no verdict and -- unlike
+			// the valve that used to let it fall through -- it does not reach
+			// the narrative column either, so the family's own explanation
+			// stands alone.
+			name: "an answer outside the gate vocabulary is not a verdict",
 			fields: map[string]string{
 				"Family Medical-Dietary Needs":   "Vegetarian",
 				"Family Medical-Dietary Explain": "No meat products",
 			},
-			expected: map[string]string{
-				"dietary_info": "Vegetarian; No meat products",
-			},
+			wantInfo: map[string]string{"dietary_info": "No meat products"},
+			wantGate: map[string]string{"dietary_gate": ""},
 		},
 		{
-			name: "Special needs info concatenation",
+			name: "Special needs explanation, gate beside it",
 			fields: map[string]string{
 				"Family Camp-Special Needs":     "Yes",
 				"Family Camp-Special Needs Yes": "Wheelchair accessible cabin needed",
 			},
-			expected: map[string]string{
-				"special_needs_info": "Yes; Wheelchair accessible cabin needed",
-			},
+			wantInfo: map[string]string{"special_needs_info": "Wheelchair accessible cabin needed"},
+			wantGate: map[string]string{"special_needs_gate": gateYes},
 		},
 		{
-			name: "Empty fields should not add extra separators",
+			name: "an unanswered gate leaves no separator and no verdict",
 			fields: map[string]string{
 				"Family Medical-Allergies":    "",
 				"Family Medical-Allergy Info": "Peanuts",
 			},
-			expected: map[string]string{
-				"allergy_info": "Peanuts",
-			},
+			wantInfo: map[string]string{"allergy_info": "Peanuts"},
+			wantGate: map[string]string{"allergy_gate": ""},
 		},
 		{
 			name: "Additional info standalone",
 			fields: map[string]string{
 				"Family Medical-Additional": "Prefers ground floor",
 			},
-			expected: map[string]string{
-				"additional_info": "Prefers ground floor",
-			},
+			wantInfo: map[string]string{"additional_info": "Prefers ground floor"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := concatenateMedicalFields(tt.fields)
-			for key, expectedVal := range tt.expected {
-				if result[key] != expectedVal {
-					t.Errorf("%s: %q = %q, want %q", tt.name, key, result[key], expectedVal)
+			t.Parallel()
+			s := NewFamilyCampDerivedSync(nil)
+
+			values := make([]customValueEntry, 0, len(tt.fields))
+			for name, value := range tt.fields {
+				values = append(values, customValueEntry{
+					householdPBID: "hh_johnson", fieldName: name,
+					value: value, lastUpdated: ts,
+				})
+			}
+
+			meds := s.processMedical(values)
+			if len(meds) != 1 {
+				t.Fatalf("medical rows = %d, want 1", len(meds))
+			}
+			info := map[string]string{
+				"cpap_info":          meds[0].cpapInfo,
+				"physician_info":     meds[0].physicianInfo,
+				"allergy_info":       meds[0].allergyInfo,
+				"dietary_info":       meds[0].dietaryInfo,
+				"special_needs_info": meds[0].specialNeedsInfo,
+				"additional_info":    meds[0].additionalInfo,
+			}
+			gate := map[string]string{
+				"cpap_gate":          meds[0].cpapGate,
+				"physician_gate":     meds[0].physicianGate,
+				"allergy_gate":       meds[0].allergyGate,
+				"dietary_gate":       meds[0].dietaryGate,
+				"special_needs_gate": meds[0].specialNeedsGate,
+			}
+			for column, want := range tt.wantInfo {
+				if got := info[column]; got != want {
+					t.Errorf("%s = %q, want %q -- the narrative column holds the "+
+						"family's words alone", column, got, want)
+				}
+			}
+			for column, want := range tt.wantGate {
+				if got := gate[column]; got != want {
+					t.Errorf("%s = %q, want %q", column, got, want)
 				}
 			}
 		})
@@ -1492,13 +1544,16 @@ func TestLoadFieldDefinitionsRoutesRenamedRequestFieldByCMID(t *testing.T) {
 
 // TestProcessMedicalKeepsBothCamperAndAdultCPAPNarratives: the registration
 // flags OR across the three CPAP fields because they describe DIFFERENT PEOPLE
-// -- the Camper-partition generations and the Adult-partition twin. The
-// narrative behind those flags has to follow the same rule, or staff see a
-// bathroom flag with nothing in the admin-gated record explaining it.
+// -- the Camper-partition generations and the Adult-partition twin. The medical
+// record has to follow the same rule, or staff see a bathroom flag with nothing
+// in the admin-gated record answering for it.
 //
-// "Family Camp-CPAP" and "FAM CAMP-CPAP" are name-generations of the SAME
-// question, so those two still collapse to one; Adult-CPAP is a different
-// person and is always additive.
+// Since kindred#2542 the CPAP option sentences no longer reach cpap_info, so
+// what each of the two people contributes is a GATE answer, and the household's
+// gate is the union of the three fields. The distinction between the two
+// answers -- outlet versus bathroom -- is not lost with the wording: it is
+// exactly what classifyCPAPAnswer resolves into needs_power and
+// needs_private_bathroom, which this test still asserts on the same fixture.
 func TestProcessMedicalKeepsBothCamperAndAdultCPAPNarratives(t *testing.T) {
 	t.Parallel()
 	s := NewFamilyCampDerivedSync(nil)
@@ -1524,18 +1579,19 @@ func TestProcessMedicalKeepsBothCamperAndAdultCPAPNarratives(t *testing.T) {
 	if len(meds) != 1 {
 		t.Fatalf("medical rows = %d, want 1", len(meds))
 	}
-	if !strings.Contains(meds[0].cpapInfo, "outlet") {
-		t.Errorf("cpapInfo lost the camper narrative: %q", meds[0].cpapInfo)
+	if got, want := meds[0].cpapGate, gateYes; got != want {
+		t.Errorf("cpapGate = %q, want %q -- two people disclosed and the household "+
+			"gate must carry it", got, want)
 	}
-	if !strings.Contains(strings.ToLower(meds[0].cpapInfo), "bathroom") {
-		t.Errorf("cpapInfo lost the adult narrative, leaving needs_private_bathroom "+
-			"with no explanation behind it: %q", meds[0].cpapInfo)
+	if got := meds[0].cpapInfo; got != "" {
+		t.Errorf("cpapInfo = %q, want %q -- neither option sentence is something "+
+			"the family wrote in the explain field", got, "")
 	}
 }
 
 // TestProcessMedicalCollapsesCamperCPAPGenerations is the other half: the two
 // Camper-partition names are the same question asked twice, so answering both
-// must not duplicate the sentence in the medical record.
+// yields ONE household verdict rather than a token repeated per field.
 func TestProcessMedicalCollapsesCamperCPAPGenerations(t *testing.T) {
 	t.Parallel()
 	s := NewFamilyCampDerivedSync(nil)
@@ -1546,12 +1602,19 @@ func TestProcessMedicalCollapsesCamperCPAPGenerations(t *testing.T) {
 			value: "Yes, outlet needed for CPAP machine", lastUpdated: ts},
 		{householdPBID: "hh_garcia", fieldName: "FAM CAMP-CPAP",
 			value: "Yes, outlet needed for CPAP machine", lastUpdated: ts},
+		{householdPBID: "hh_garcia", fieldName: "Family Medical-CPAP Explain",
+			value: "outlet by the lower bunk", lastUpdated: ts},
 	})
 	if len(meds) != 1 {
 		t.Fatalf("medical rows = %d, want 1", len(meds))
 	}
-	if strings.Count(strings.ToLower(meds[0].cpapInfo), "outlet") != 1 {
-		t.Errorf("cpapInfo repeated one question's answer: %q", meds[0].cpapInfo)
+	if got, want := meds[0].cpapGate, gateYes; got != want {
+		t.Errorf("cpapGate = %q, want %q -- one verdict, however many fields carry it",
+			got, want)
+	}
+	if got, want := meds[0].cpapInfo, "outlet by the lower bunk"; got != want {
+		t.Errorf("cpapInfo = %q, want %q -- the explain text once, and no gate wording",
+			got, want)
 	}
 }
 
@@ -1920,7 +1983,10 @@ func TestProcessRegistrationsHasInfantORsAcrossHousehold(t *testing.T) {
 
 // TestProcessMedicalCPAPIncludesAdultField: Adult-CPAP is admitted by
 // extraFieldCMIDs but processMedical never read it, so a household where only
-// the accompanying adult answers produced an empty cpap_info. kindred#1875.
+// the accompanying adult answers produced an empty CPAP record. kindred#1875.
+// Since kindred#2542 that answer lands in the gate column rather than in
+// cpap_info, so this asserts the field is still read -- one verdict, from
+// whichever of the three generations carries the answer.
 func TestProcessMedicalCPAPIncludesAdultField(t *testing.T) {
 	t.Parallel()
 	s := NewFamilyCampDerivedSync(nil)
@@ -1933,8 +1999,9 @@ func TestProcessMedicalCPAPIncludesAdultField(t *testing.T) {
 	if len(meds) != 1 {
 		t.Fatalf("medical rows = %d, want 1", len(meds))
 	}
-	if meds[0].cpapInfo == "" {
-		t.Error("cpapInfo empty; an adult-only CPAP answer was dropped")
+	if got, want := meds[0].cpapGate, gateYes; got != want {
+		t.Errorf("cpapGate = %q, want %q; an adult-only CPAP answer was dropped",
+			got, want)
 	}
 }
 
@@ -3270,11 +3337,14 @@ func TestProcessMedicalKeepsEveryAnswerersNarrative(t *testing.T) {
 }
 
 // TestProcessMedicalOrsTheGateAcrossAnswerers pins the half of the fix that
-// makes the join safe. A gate is a two-value Yes/No question; joining two
-// people's gate answers verbatim would render "No; Yes; <narrative>", which is
-// why an earlier uniform dedup-and-join was reverted. The household's gate is
-// the OR of its answers, so the one person who said Yes is not overruled by the
-// one who said No.
+// makes the join safe. A gate is a two-value Yes/No question asked on a
+// per-CAMPER form, so a household with two children answers it twice; the
+// household's gate is the OR of those answers, so the one person who said Yes
+// is not overruled by the one who said No.
+//
+// Since kindred#2542 the verdict lands in its own column, so the narrative
+// beside it is the family's sentence alone -- neither answerer's gate token
+// reaches it.
 //
 // The "No" is listed FIRST so the test fails against first-non-empty-wins
 // rather than passing by luck of load order.
@@ -3294,9 +3364,13 @@ func TestProcessMedicalOrsTheGateAcrossAnswerers(t *testing.T) {
 	if len(meds) != 1 {
 		t.Fatalf("medical rows = %d, want 1", len(meds))
 	}
-	if got, want := meds[0].allergyInfo, "Yes; "+medicalNarrativeA; got != want {
-		t.Errorf("allergyInfo = %q, want %q -- a denial in front of the condition "+
-			"it denies is the rendered contradiction this fixes", got, want)
+	if got, want := meds[0].allergyGate, gateYes; got != want {
+		t.Errorf("allergyGate = %q, want %q -- one answerer's denial must not "+
+			"overrule another's disclosure", got, want)
+	}
+	if got, want := meds[0].allergyInfo, medicalNarrativeA; got != want {
+		t.Errorf("allergyInfo = %q, want %q -- a gate token in front of the "+
+			"condition it denies is the rendered contradiction this fixes", got, want)
 	}
 }
 
@@ -3494,19 +3568,18 @@ func TestMedicalColumnLimitsMatchTheSchema(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// The CPAP column is the one gate/explain pair processMedical still stores as a
-// gate STRING. docs/reference/family-camp-field-provenance.md section 4 names
-// Special Needs and CPAP as the two pairs where a split across children does
-// real harm; Special Needs is now ORed, and CPAP is carved out of kindred#2255
-// for its own pass. Aggregating it the way every other field is aggregated is
-// what would put a denial and a disclosure in one column.
+// CPAP. The three fields are one question asked in three generations, and since
+// kindred#2542 they feed the cpap_gate column by OR while cpap_info holds only
+// "Family Medical-CPAP Explain" -- the family's own sentence. The affirmative
+// options name WHICH accommodation is needed, and that distinction survives in
+// needs_power / needs_private_bathroom via classifyCPAPAnswer, which the panel
+// renders as Housing-needs rows directly above this text. What leaves cpap_info
+// is the wording, never the decision.
 // ---------------------------------------------------------------------------
 
 // TestProcessMedicalDropsADeniedCPAPGateBesideADisclosedOne: one child's form
-// says No and another's says Yes. Keeping both renders
-// "No; Yes; <explanation>" -- the contradiction medicalGateFields exists to
-// prevent, reaching the row through the one column medicalGateFields does not
-// cover.
+// says No and another's says Yes. The denial must not overrule the disclosure,
+// and neither token may reach the column staff read for the explanation.
 func TestProcessMedicalDropsADeniedCPAPGateBesideADisclosedOne(t *testing.T) {
 	t.Parallel()
 	s := NewFamilyCampDerivedSync(nil)
@@ -3522,34 +3595,51 @@ func TestProcessMedicalDropsADeniedCPAPGateBesideADisclosedOne(t *testing.T) {
 	if len(meds) != 1 {
 		t.Fatalf("medical rows = %d, want 1", len(meds))
 	}
-	if got, want := meds[0].cpapInfo, "Yes; needs an outlet overnight"; got != want {
-		t.Errorf("cpapInfo = %q, want %q -- a denial in front of the need it denies", got, want)
+	if got, want := meds[0].cpapGate, gateYes; got != want {
+		t.Errorf("cpapGate = %q, want %q -- a denial in front of the need it denies", got, want)
+	}
+	if got, want := meds[0].cpapInfo, "needs an outlet overnight"; got != want {
+		t.Errorf("cpapInfo = %q, want %q -- no gate answer belongs in this column", got, want)
 	}
 }
 
 // TestProcessMedicalKeepsTwoDifferentCPAPNeeds: the CPAP fields are NOT a
 // two-value gate (kindred#1875) -- every affirmative option names WHICH
 // accommodation is needed, so two different affirmatives are two different
-// needs and neither may be collapsed away. Only the pure denial goes.
+// needs and neither may be collapsed away. Since kindred#2542 they are no
+// longer carried as sentences in cpap_info, so this asserts the place the
+// distinction now lives: both flags raised off the same answers, with the gate
+// reading yes once.
 func TestProcessMedicalKeepsTwoDifferentCPAPNeeds(t *testing.T) {
 	t.Parallel()
 	s := NewFamilyCampDerivedSync(nil)
 	ts := time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC)
 
-	const (
-		outlet   = "Yes, outlet needed for CPAP machine"
-		bathroom = "Yes, bathroom or other housing accommodation needed"
-	)
-	meds := s.processMedical([]customValueEntry{
+	const outlet = "Yes, outlet needed for CPAP machine"
+	vals := []customValueEntry{
 		{householdPBID: "hh_johnson", fieldName: "FAM CAMP-CPAP", value: "No", lastUpdated: ts},
 		{householdPBID: "hh_johnson", fieldName: "FAM CAMP-CPAP", value: outlet, lastUpdated: ts},
-		{householdPBID: "hh_johnson", fieldName: "FAM CAMP-CPAP", value: bathroom, lastUpdated: ts},
-	})
+		{householdPBID: "hh_johnson", fieldName: "FAM CAMP-CPAP", value: cpapBathroomOption, lastUpdated: ts},
+	}
+
+	regs := s.processRegistrations(nil, vals)
+	if len(regs) != 1 {
+		t.Fatalf("registrations = %d, want 1", len(regs))
+	}
+	if !regs[0].needsPower {
+		t.Error("the outlet option must still raise needsPower")
+	}
+	if !regs[0].needsPrivateBathroom {
+		t.Error("the bathroom option must still raise needsPrivateBathroom -- " +
+			"two different affirmatives are two different needs")
+	}
+
+	meds := s.processMedical(vals)
 	if len(meds) != 1 {
 		t.Fatalf("medical rows = %d, want 1", len(meds))
 	}
-	if got, want := meds[0].cpapInfo, bathroom+"; "+outlet; got != want {
-		t.Errorf("cpapInfo = %q, want %q", got, want)
+	if got, want := meds[0].cpapGate, gateYes; got != want {
+		t.Errorf("cpapGate = %q, want %q", got, want)
 	}
 }
 
@@ -3560,29 +3650,45 @@ func TestProcessMedicalKeepsTwoDifferentCPAPNeeds(t *testing.T) {
 // processRegistrations ORs BOTH fields into needs_power and
 // needs_private_bathroom, so the household got a housing flag with a cpap_info
 // that denies it. 27 households in 2025 and 1 in 2026 on the production
-// snapshot.
+// snapshot. Each generation is asked for on its own so the union cannot pass by
+// reading only one of the two names.
 func TestProcessMedicalUnionsBothCamperCPAPFields(t *testing.T) {
 	t.Parallel()
-	s := NewFamilyCampDerivedSync(nil)
-	ts := time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC)
 
 	const outlet = "Yes, outlet needed for CPAP machine"
-	meds := s.processMedical([]customValueEntry{
-		{householdPBID: "hh_johnson", fieldName: "Family Camp-CPAP", value: "No", lastUpdated: ts},
-		{householdPBID: "hh_johnson", fieldName: "FAM CAMP-CPAP", value: outlet, lastUpdated: ts},
-	})
-	if len(meds) != 1 {
-		t.Fatalf("medical rows = %d, want 1", len(meds))
+	cases := []struct {
+		name      string
+		discloser string
+		denier    string
+	}{
+		{"the successor name carries the disclosure", "FAM CAMP-CPAP", "Family Camp-CPAP"},
+		{"the older name carries the disclosure", "Family Camp-CPAP", "FAM CAMP-CPAP"},
 	}
-	if got, want := meds[0].cpapInfo, outlet; got != want {
-		t.Errorf("cpapInfo = %q, want %q -- the flag says the household needs power "+
-			"and the narrative would deny it", got, want)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := NewFamilyCampDerivedSync(nil)
+			ts := time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC)
+
+			meds := s.processMedical([]customValueEntry{
+				{householdPBID: "hh_johnson", fieldName: tc.denier, value: "No", lastUpdated: ts},
+				{householdPBID: "hh_johnson", fieldName: tc.discloser, value: outlet, lastUpdated: ts},
+			})
+			if len(meds) != 1 {
+				t.Fatalf("medical rows = %d, want 1", len(meds))
+			}
+			if got, want := meds[0].cpapGate, gateYes; got != want {
+				t.Errorf("cpapGate = %q, want %q -- the flag says the household needs "+
+					"power and the gate would deny it", got, want)
+			}
+		})
 	}
 }
 
-// TestProcessMedicalKeepsAnUnanimousCPAPDenial: dropping negatives is only the
-// half of the OR that applies. A household where nobody said Yes still has an
-// answer, and blanking it would be the silent loss this whole change ends.
+// TestProcessMedicalKeepsAnUnanimousCPAPDenial: a household where nobody said
+// Yes still ANSWERED, and "no" is not the same fact as never being asked. The
+// row must survive the has-data guard carrying that answer, with nothing in the
+// narrative column, because nobody wrote anything there.
 func TestProcessMedicalKeepsAnUnanimousCPAPDenial(t *testing.T) {
 	t.Parallel()
 	s := NewFamilyCampDerivedSync(nil)
@@ -3593,10 +3699,13 @@ func TestProcessMedicalKeepsAnUnanimousCPAPDenial(t *testing.T) {
 		{householdPBID: "hh_johnson", fieldName: "Family Camp-CPAP", value: "No", lastUpdated: ts},
 	})
 	if len(meds) != 1 {
-		t.Fatalf("medical rows = %d, want 1", len(meds))
+		t.Fatalf("medical rows = %d, want 1 -- a denial is an answer", len(meds))
 	}
-	if got, want := meds[0].cpapInfo, "No"; got != want {
-		t.Errorf("cpapInfo = %q, want %q", got, want)
+	if got, want := meds[0].cpapGate, gateNo; got != want {
+		t.Errorf("cpapGate = %q, want %q", got, want)
+	}
+	if got := meds[0].cpapInfo; got != "" {
+		t.Errorf("cpapInfo = %q, want empty -- the family wrote no explanation", got)
 	}
 }
 
@@ -4156,7 +4265,7 @@ func TestMedicalGateColumnsExistInASchemaMigration(t *testing.T) {
 				"migration creates it -- record.Set() would silently no-op", column)
 			continue
 		}
-		source, err := os.ReadFile(filepath.Join("../pb_migrations", path)) //nolint:gosec // from the glob above
+		source, err := os.ReadFile(filepath.Join("..", "pb_migrations", path)) //nolint:gosec // from the glob above
 		if err != nil {
 			t.Fatalf("re-reading %s: %v", path, err)
 		}
@@ -4222,5 +4331,145 @@ func TestGateVerdictIsOrderIndependent(t *testing.T) {
 			t.Errorf("gateVerdict(%q) = %q, want %q -- permuting the answers must "+
 				"not change the verdict", parts, got, want)
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// kindred#2542: the gate answer moves to its own column and the narrative
+// columns hold the family's own words alone.
+// ---------------------------------------------------------------------------
+
+// TestProcessMedicalSplitsTheGateFromTheNarrative is the issue in one test: the
+// family's words alone in the narrative column, the gate answer beside it.
+func TestProcessMedicalSplitsTheGateFromTheNarrative(t *testing.T) {
+	t.Parallel()
+	s := NewFamilyCampDerivedSync(nil)
+	ts := time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC)
+
+	meds := s.processMedical([]customValueEntry{
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-Allergies",
+			value: "Yes", lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-Allergy Info",
+			value: medicalNarrativeA, lastUpdated: ts},
+	})
+	if len(meds) != 1 {
+		t.Fatalf("medical rows = %d, want 1", len(meds))
+	}
+	if got, want := meds[0].allergyInfo, medicalNarrativeA; got != want {
+		t.Errorf("allergyInfo = %q, want %q -- the leading gate token is not "+
+			"something the family wrote", got, want)
+	}
+	if got, want := meds[0].allergyGate, gateYes; got != want {
+		t.Errorf("allergyGate = %q, want %q", got, want)
+	}
+}
+
+// TestProcessMedicalKeepsANarrativeBesideADenial is the 836-row rendered
+// contradiction, now expressible without a contradiction: the household says No
+// and someone still wrote a sentence. Both survive, in different columns.
+func TestProcessMedicalKeepsANarrativeBesideADenial(t *testing.T) {
+	t.Parallel()
+	s := NewFamilyCampDerivedSync(nil)
+	ts := time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC)
+
+	meds := s.processMedical([]customValueEntry{
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-Allergies",
+			value: "No", lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-Allergy Info",
+			value: medicalNarrativeA, lastUpdated: ts},
+	})
+	if len(meds) != 1 {
+		t.Fatalf("medical rows = %d, want 1", len(meds))
+	}
+	if got, want := meds[0].allergyInfo, medicalNarrativeA; got != want {
+		t.Errorf("allergyInfo = %q, want %q", got, want)
+	}
+	if got, want := meds[0].allergyGate, gateNo; got != want {
+		t.Errorf("allergyGate = %q, want %q", got, want)
+	}
+}
+
+// TestProcessMedicalDistinguishesADenialFromSilence is ruling D15: 224 of 900
+// 2026 households never answered the allergy gate and 430 answered it No. A
+// non-nullable boolean would render both as the same false.
+func TestProcessMedicalDistinguishesADenialFromSilence(t *testing.T) {
+	t.Parallel()
+	s := NewFamilyCampDerivedSync(nil)
+	ts := time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC)
+
+	meds := s.processMedical([]customValueEntry{
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-Allergies",
+			value: "No", lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-Dietary Explain",
+			value: "no gluten", lastUpdated: ts},
+	})
+	if len(meds) != 1 {
+		t.Fatalf("medical rows = %d, want 1", len(meds))
+	}
+	if got, want := meds[0].allergyGate, gateNo; got != want {
+		t.Errorf("allergyGate = %q, want %q -- answered", got, want)
+	}
+	if got, want := meds[0].physicianGate, ""; got != want {
+		t.Errorf("physicianGate = %q, want %q -- never asked, which is not a denial",
+			got, want)
+	}
+	if got, want := meds[0].dietaryGate, ""; got != want {
+		t.Errorf("dietaryGate = %q, want %q -- an explain with no gate answer "+
+			"leaves the gate unanswered rather than inferring one", got, want)
+	}
+}
+
+// TestProcessMedicalCPAPGateUnionsAllThreeGenerations: the three CPAP fields are
+// one question asked in three generations, and every affirmative option --
+// including the ones whose text names WHICH accommodation -- raises the gate.
+// The option sentence itself does not survive into cpap_info: classifyCPAPAnswer
+// already resolves it into needs_power / needs_private_bathroom, which the panel
+// renders as Housing-needs rows directly above this text.
+func TestProcessMedicalCPAPGateUnionsAllThreeGenerations(t *testing.T) {
+	t.Parallel()
+	s := NewFamilyCampDerivedSync(nil)
+	ts := time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC)
+
+	meds := s.processMedical([]customValueEntry{
+		{householdPBID: "hh_johnson", fieldName: "Family Camp-CPAP",
+			value: "No", lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "FAM CAMP-CPAP",
+			value: "Yes, outlet needed for CPAP machine", lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Adult-CPAP",
+			value: "No", lastUpdated: ts},
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-CPAP Explain",
+			value: "outlet by the lower bunk", lastUpdated: ts},
+	})
+	if len(meds) != 1 {
+		t.Fatalf("medical rows = %d, want 1", len(meds))
+	}
+	if got, want := meds[0].cpapGate, gateYes; got != want {
+		t.Errorf("cpapGate = %q, want %q", got, want)
+	}
+	if got, want := meds[0].cpapInfo, "outlet by the lower bunk"; got != want {
+		t.Errorf("cpapInfo = %q, want %q -- the option sentence is a gate answer, "+
+			"not the family's explanation", got, want)
+	}
+}
+
+// TestProcessMedicalKeepsAGateOnlyHousehold: 375 of 900 2026 households have
+// nothing but gate answers once the narratives are clean. Without the gates in
+// the has-data guard they vanish from the result slice and deleteOrphanedMedical
+// removes their rows -- taking the gate answers with them.
+func TestProcessMedicalKeepsAGateOnlyHousehold(t *testing.T) {
+	t.Parallel()
+	s := NewFamilyCampDerivedSync(nil)
+	ts := time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC)
+
+	meds := s.processMedical([]customValueEntry{
+		{householdPBID: "hh_johnson", fieldName: "Family Medical-Allergies",
+			value: "No", lastUpdated: ts},
+	})
+	if len(meds) != 1 {
+		t.Fatalf("medical rows = %d, want 1 -- a household whose only content is "+
+			"a gate answer still has content", len(meds))
+	}
+	if got, want := meds[0].allergyGate, gateNo; got != want {
+		t.Errorf("allergyGate = %q, want %q", got, want)
 	}
 }

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -356,44 +356,6 @@ func TestMedicalInfoBlobConcatenation(t *testing.T) {
 	}
 }
 
-// TestMedicalDeduplicationByHousehold tests that medical info is deduplicated per household.
-//
-// NOTE: it drives aggregateMedicalByHousehold, a test-local reimplementation,
-// and asserts only non-emptiness -- so it is blind to how production collapses a
-// household's answers and cannot fail when processMedical changes. The real
-// coverage of that is TestProcessMedicalKeepsEveryAnswerersNarrative and the
-// kindred#2255 tests beside it.
-func TestMedicalDeduplicationByHousehold(t *testing.T) {
-	t.Parallel()
-	personValues := []testPersonCustomValue{
-		// Child 1's medical info for household 100
-		{HouseholdCMID: 100, PersonCMID: 1001, FieldName: "Family Medical-Allergies", Value: "Yes"},
-		{HouseholdCMID: 100, PersonCMID: 1001, FieldName: "Family Medical-Allergy Info", Value: "Peanuts"},
-		// Child 2's medical info for same household (may have same or different data)
-		{HouseholdCMID: 100, PersonCMID: 1002, FieldName: "Family Medical-Allergies", Value: "Yes"},
-		{HouseholdCMID: 100, PersonCMID: 1002, FieldName: "Family Medical-Allergy Info", Value: "Shellfish"},
-		// Different household
-		{HouseholdCMID: 200, PersonCMID: 2001, FieldName: "Family Medical-Allergies", Value: "No"},
-	}
-
-	medicalByHousehold := aggregateMedicalByHousehold(personValues)
-
-	// Household 100 should have 1 medical record (deduplicated)
-	if len(medicalByHousehold) != 2 {
-		t.Errorf("expected 2 households with medical data, got %d", len(medicalByHousehold))
-	}
-
-	// The medical info should capture all values (concatenated or first non-empty)
-	if med, ok := medicalByHousehold[100]; ok {
-		// Should contain allergy info from at least one child
-		if med.AllergyInfo == "" {
-			t.Error("expected allergy_info for household 100, got empty")
-		}
-	} else {
-		t.Error("expected medical data for household 100")
-	}
-}
-
 // TestBoolFieldParsing exercises the PRODUCTION parseBoolFieldValue. The previous
 // version of this test called a byte-identical local copy, which is why the
 // sentence-prefixed cases below went undetected: fixing production code could
@@ -463,12 +425,6 @@ func TestEmptyDataHandling(t *testing.T) {
 	adults := extractAdultsFromHousehold(householdValues, 100)
 	if len(adults) != 0 {
 		t.Errorf("expected 0 adults for empty household data, got %d", len(adults))
-	}
-
-	// Empty medical data
-	medicalByHousehold := aggregateMedicalByHousehold(personValues)
-	if len(medicalByHousehold) != 0 {
-		t.Errorf("expected 0 medical records for empty data, got %d", len(medicalByHousehold))
 	}
 }
 
@@ -750,117 +706,6 @@ func mapRegistrationField(fieldName string) string {
 	return ""
 }
 
-// concatenateMedicalFields concatenates related medical fields into blobs
-func concatenateMedicalFields(fields map[string]string) map[string]string {
-	result := make(map[string]string)
-
-	// CPAP info
-	cpapParts := []string{}
-	for _, key := range []string{"Family Camp-CPAP", "FAM CAMP-CPAP"} {
-		if v, ok := fields[key]; ok && v != "" {
-			cpapParts = append(cpapParts, v)
-			break // Only take one "Yes/No" value
-		}
-	}
-	if v, ok := fields["Family Medical-CPAP Explain"]; ok && v != "" {
-		cpapParts = append(cpapParts, v)
-	}
-	if len(cpapParts) > 0 {
-		result["cpap_info"] = strings.Join(cpapParts, "; ")
-	}
-
-	// Physician info
-	physicianParts := []string{}
-	if v, ok := fields["Family Camp-Physician"]; ok && v != "" {
-		physicianParts = append(physicianParts, v)
-	}
-	if v, ok := fields["Family Camp-Physician If Yes"]; ok && v != "" {
-		physicianParts = append(physicianParts, v)
-	}
-	if len(physicianParts) > 0 {
-		result["physician_info"] = strings.Join(physicianParts, "; ")
-	}
-
-	// Allergy info
-	allergyParts := []string{}
-	if v, ok := fields["Family Medical-Allergies"]; ok && v != "" {
-		allergyParts = append(allergyParts, v)
-	}
-	if v, ok := fields["Family Medical-Allergy Info"]; ok && v != "" {
-		allergyParts = append(allergyParts, v)
-	}
-	if len(allergyParts) > 0 {
-		result["allergy_info"] = strings.Join(allergyParts, "; ")
-	}
-
-	// Dietary info
-	dietaryParts := []string{}
-	if v, ok := fields["Family Medical-Dietary Needs"]; ok && v != "" {
-		dietaryParts = append(dietaryParts, v)
-	}
-	if v, ok := fields["Family Medical-Dietary Explain"]; ok && v != "" {
-		dietaryParts = append(dietaryParts, v)
-	}
-	if len(dietaryParts) > 0 {
-		result["dietary_info"] = strings.Join(dietaryParts, "; ")
-	}
-
-	// Special needs info
-	specialParts := []string{}
-	if v, ok := fields["Family Camp-Special Needs"]; ok && v != "" {
-		specialParts = append(specialParts, v)
-	}
-	if v, ok := fields["Family Camp-Special Needs Yes"]; ok && v != "" {
-		specialParts = append(specialParts, v)
-	}
-	if len(specialParts) > 0 {
-		result["special_needs_info"] = strings.Join(specialParts, "; ")
-	}
-
-	// Additional info (standalone)
-	if v, ok := fields["Family Medical-Additional"]; ok && v != "" {
-		result["additional_info"] = v
-	}
-
-	return result
-}
-
-// aggregateMedicalByHousehold aggregates medical info by household
-func aggregateMedicalByHousehold(values []testPersonCustomValue) map[int]*testMedical {
-	result := make(map[int]*testMedical)
-	// Track fields by household
-	fieldsByHousehold := make(map[int]map[string]string)
-
-	for _, v := range values {
-		if fieldsByHousehold[v.HouseholdCMID] == nil {
-			fieldsByHousehold[v.HouseholdCMID] = make(map[string]string)
-		}
-
-		// First non-empty value wins
-		if _, exists := fieldsByHousehold[v.HouseholdCMID][v.FieldName]; !exists && v.Value != "" {
-			fieldsByHousehold[v.HouseholdCMID][v.FieldName] = v.Value
-		}
-	}
-
-	// Concatenate fields for each household
-	for household, fields := range fieldsByHousehold {
-		concatenated := concatenateMedicalFields(fields)
-		if len(concatenated) > 0 {
-			result[household] = &testMedical{
-				HouseholdCMID:    household,
-				AllergyInfo:      concatenated["allergy_info"],
-				DietaryInfo:      concatenated["dietary_info"],
-				CPAPInfo:         concatenated["cpap_info"],
-				PhysicianInfo:    concatenated["physician_info"],
-				SpecialNeedsInfo: concatenated["special_needs_info"],
-				AdditionalInfo:   concatenated["additional_info"],
-			}
-		}
-	}
-
-	return result
-}
-
 // ============================================================================
 // Idempotency Tests - Define expected upsert behavior
 // ============================================================================
@@ -1028,6 +873,53 @@ func TestUpsertMedicalIdempotency(t *testing.T) {
 	}
 	if stats2.Created != 0 {
 		t.Errorf("second run: expected Created=0, got %d", stats2.Created)
+	}
+}
+
+// TestMedicalNeedsUpdateSeesAGateOnlyChange is the silent-no-op guard on the
+// UPDATE side. 375 of 900 2026 households have no narrative at all, so for them
+// the gate columns are the only thing that can ever change; a comparison blind
+// to them would skip the row forever and the panel would show a stale answer.
+//
+// medicalNeedsUpdate takes a *core.Record, which TestUpsertMedicalIdempotency's
+// simulateUpsertMedical harness never touches -- that helper drives a
+// test-local map[string]*testMedRecord, not a real record. The harness here
+// instead follows TestRegistrationNeedsUpdateIgnoresTheUnknownSpelling: a bare
+// core.NewBaseCollection with just the columns this test reads, and a record
+// built with core.NewRecord and Set -- no app, no Save, since the function
+// under test only ever calls GetString.
+func TestMedicalNeedsUpdateSeesAGateOnlyChange(t *testing.T) {
+	t.Parallel()
+	col := core.NewBaseCollection("family_camp_medical")
+	col.Fields.Add(&core.TextField{Name: "cpap_info"})
+	col.Fields.Add(&core.TextField{Name: "physician_info"})
+	col.Fields.Add(&core.TextField{Name: "special_needs_info"})
+	col.Fields.Add(&core.TextField{Name: "allergy_info"})
+	col.Fields.Add(&core.TextField{Name: "dietary_info"})
+	col.Fields.Add(&core.TextField{Name: "additional_info"})
+	col.Fields.Add(&core.TextField{Name: "bathroom_explain"})
+	col.Fields.Add(&core.TextField{Name: "accommodation_explain"})
+	col.Fields.Add(&core.TextField{Name: enrollmentStatusColumn})
+	col.Fields.Add(&core.TextField{Name: "allergy_gate"})
+	col.Fields.Add(&core.TextField{Name: "dietary_gate"})
+	col.Fields.Add(&core.TextField{Name: "special_needs_gate"})
+	col.Fields.Add(&core.TextField{Name: "physician_gate"})
+	col.Fields.Add(&core.TextField{Name: "cpap_gate"})
+
+	existing := core.NewRecord(col)
+	existing.Set("allergy_gate", gateNo)
+
+	s := &FamilyCampDerivedSync{}
+
+	changed := &medicalData{householdPBID: "hh_1", allergyGate: gateYes}
+	if !s.medicalNeedsUpdate(existing, changed) {
+		t.Error("a gate-only change was invisible to medicalNeedsUpdate -- " +
+			"the row would never be rewritten")
+	}
+
+	same := &medicalData{householdPBID: "hh_1", allergyGate: gateNo}
+	if s.medicalNeedsUpdate(existing, same) {
+		t.Error("an unchanged row was reported as needing an update")
 	}
 }
 
@@ -1542,19 +1434,21 @@ func TestLoadFieldDefinitionsRoutesRenamedRequestFieldByCMID(t *testing.T) {
 	}
 }
 
-// TestProcessMedicalKeepsBothCamperAndAdultCPAPNarratives: the registration
-// flags OR across the three CPAP fields because they describe DIFFERENT PEOPLE
-// -- the Camper-partition generations and the Adult-partition twin. The medical
-// record has to follow the same rule, or staff see a bathroom flag with nothing
-// in the admin-gated record answering for it.
+// TestProcessMedicalUnionsCamperAndAdultCPAPGates: the registration flags OR
+// across the three CPAP fields because they describe DIFFERENT PEOPLE -- the
+// Camper-partition generations and the Adult-partition twin. The medical
+// record has to follow the same rule, or staff see a bathroom flag with
+// nothing in the admin-gated record answering for it.
 //
 // Since kindred#2542 the CPAP option sentences no longer reach cpap_info, so
-// what each of the two people contributes is a GATE answer, and the household's
-// gate is the union of the three fields. The distinction between the two
-// answers -- outlet versus bathroom -- is not lost with the wording: it is
-// exactly what classifyCPAPAnswer resolves into needs_power and
-// needs_private_bathroom, which this test still asserts on the same fixture.
-func TestProcessMedicalKeepsBothCamperAndAdultCPAPNarratives(t *testing.T) {
+// what each of the two people contributes is a GATE answer, and the
+// household's cpapGate is the union of the three fields. The distinction
+// between the two answers -- outlet versus bathroom -- is not lost with the
+// wording: it is exactly what classifyCPAPAnswer resolves into needs_power
+// and needs_private_bathroom, which this test still asserts on the same
+// fixture. cpapInfo itself must stay empty: neither field's answer is
+// something the family wrote into an explain box.
+func TestProcessMedicalUnionsCamperAndAdultCPAPGates(t *testing.T) {
 	t.Parallel()
 	s := NewFamilyCampDerivedSync(nil)
 	ts := time.Date(2025, 4, 21, 0, 0, 0, 0, time.UTC)
@@ -1589,34 +1483,15 @@ func TestProcessMedicalKeepsBothCamperAndAdultCPAPNarratives(t *testing.T) {
 	}
 }
 
-// TestProcessMedicalCollapsesCamperCPAPGenerations is the other half: the two
-// Camper-partition names are the same question asked twice, so answering both
-// yields ONE household verdict rather than a token repeated per field.
-func TestProcessMedicalCollapsesCamperCPAPGenerations(t *testing.T) {
-	t.Parallel()
-	s := NewFamilyCampDerivedSync(nil)
-	ts := time.Date(2025, 4, 21, 0, 0, 0, 0, time.UTC)
-
-	meds := s.processMedical([]customValueEntry{
-		{householdPBID: "hh_garcia", fieldName: "Family Camp-CPAP",
-			value: "Yes, outlet needed for CPAP machine", lastUpdated: ts},
-		{householdPBID: "hh_garcia", fieldName: "FAM CAMP-CPAP",
-			value: "Yes, outlet needed for CPAP machine", lastUpdated: ts},
-		{householdPBID: "hh_garcia", fieldName: "Family Medical-CPAP Explain",
-			value: "outlet by the lower bunk", lastUpdated: ts},
-	})
-	if len(meds) != 1 {
-		t.Fatalf("medical rows = %d, want 1", len(meds))
-	}
-	if got, want := meds[0].cpapGate, gateYes; got != want {
-		t.Errorf("cpapGate = %q, want %q -- one verdict, however many fields carry it",
-			got, want)
-	}
-	if got, want := meds[0].cpapInfo, "outlet by the lower bunk"; got != want {
-		t.Errorf("cpapInfo = %q, want %q -- the explain text once, and no gate wording",
-			got, want)
-	}
-}
+// TestProcessMedicalCollapsesCamperCPAPGenerations is deliberately absent. It
+// fed the same answer ("Yes, outlet needed...") into both Camper-partition
+// CPAP fields, so the OR that gateVerdict performs and the wrong "just take
+// one" implementation it was written to catch produce the identical verdict
+// on that fixture -- since kindred#2542 moved cpap_info down to a single
+// source field, there was no longer a second claim left for the duplicate
+// gate answers to falsify. It could not fail. The union across all three CPAP
+// fields, WITH conflicting answers so a wrong implementation actually
+// disagrees with a right one, is TestProcessMedicalCPAPGateUnionsAllThreeGenerations.
 
 // TestProcessRegistrationsMandatoryOnlyHouseholdSurvives: accommodation_is_mandatory
 // is the one stored VIP signal (owner ruling 2026-08-22), so a household whose
@@ -3295,11 +3170,13 @@ func TestAdultsCollectionHasAttributeConflictsColumn(t *testing.T) {
 // aggregation, never by picking a winner.
 //
 // The tests below are deliberately written against the PRODUCTION
-// processMedical. The two tests that look like they already cover this
-// (TestMedicalDeduplicationByHousehold, which drives a test-local
-// reimplementation and asserts only non-emptiness, and
-// TestProcessMedicalCollapsesCamperCPAPGenerations, which exercises one person)
-// are blind to the defect by construction.
+// processMedical. Two tests that looked like they already covered this were
+// blind to the defect by construction and have since been removed:
+// TestMedicalDeduplicationByHousehold drove a test-local reimplementation
+// (concatenateMedicalFields/aggregateMedicalByHousehold) and asserted only
+// non-emptiness, and TestProcessMedicalCollapsesCamperCPAPGenerations fed the
+// same answer into both fields it exercised, so it could not disagree with a
+// wrong implementation either. kindred#2542.
 // ---------------------------------------------------------------------------
 
 // medicalNarrativeA/B are placeholder disclosures. Never put a real medical

--- a/pocketbase/sync/lodging_medical_narrative_test.go
+++ b/pocketbase/sync/lodging_medical_narrative_test.go
@@ -26,6 +26,20 @@ var narrativeColumns = []string{
 	"physician_info",
 }
 
+// gateColumns are the structured gate answers that sit beside the narrative
+// columns above (kindred#2542). They are not narrative -- each is one of "yes",
+// "no" or "" -- but they are answers to the same medical questions on the same
+// admin-gated collection, so they get the same export ban. A separate list
+// rather than an entry in narrativeColumns because kindred#2409 spent a PR
+// making that vocabulary mean what it says.
+var gateColumns = []string{
+	"allergy_gate",
+	"dietary_gate",
+	"special_needs_gate",
+	"physician_gate",
+	"cpap_gate",
+}
+
 // KNOWN EXPOSURE, deliberately not fixed here. person_custom_values and
 // household_custom_values ARE exported to Google Sheets, with First Name, Last
 // Name, Field Name and the raw Value, so the medical narrative already reaches

--- a/pocketbase/sync/lodging_medical_narrative_test.go
+++ b/pocketbase/sync/lodging_medical_narrative_test.go
@@ -207,10 +207,19 @@ func TestNarrativeIsNeverLogged(t *testing.T) {
 // narrativeExprs are the Go expressions that evaluate to narrative text.
 // Separate from narrativeColumns because a log line can name either the
 // column or the struct field that feeds it.
+//
+// The five *Gate fields (kindred#2542) are listed here too even though they
+// are structured, not narrative -- guardedColumns() below is what this file
+// calls the "same export/log ban" list, and a log guard that only watched the
+// column names and not the struct fields that feed them would miss a slog
+// call built from the field directly, the same gap this list already closes
+// for the narrative columns.
 var narrativeExprs = []string{
 	"med.cpapInfo", "med.specialNeedsInfo", "med.allergyInfo",
 	"med.dietaryInfo", "med.additionalInfo", "med.bathroomExplain",
 	"med.accommodationExplain", "med.physicianInfo",
+	"med.allergyGate", "med.dietaryGate", "med.specialNeedsGate",
+	"med.physicianGate", "med.cpapGate",
 	"reg.requestText", "req.RequestText", "a.req.RequestText",
 }
 
@@ -242,9 +251,9 @@ func narrativeLogViolations(src string) []string {
 			i = j
 		}
 
-		for _, column := range narrativeColumns {
+		for _, column := range guardedColumns() {
 			if strings.Contains(call, `"`+column+`"`) {
-				out = append(out, "a slog call references the medical narrative column "+column+":\n  "+call)
+				out = append(out, "a slog call references the medical column "+column+":\n  "+call)
 			}
 		}
 		for _, expr := range narrativeExprs {

--- a/pocketbase/sync/lodging_medical_narrative_test.go
+++ b/pocketbase/sync/lodging_medical_narrative_test.go
@@ -40,6 +40,12 @@ var gateColumns = []string{
 	"cpap_gate",
 }
 
+// guardedColumns is every family_camp_medical column that must never reach an
+// export, narrative and gate together.
+func guardedColumns() []string {
+	return append(slices.Clone(narrativeColumns), gateColumns...)
+}
+
 // KNOWN EXPOSURE, deliberately not fixed here. person_custom_values and
 // household_custom_values ARE exported to Google Sheets, with First Name, Last
 // Name, Field Name and the raw Value, so the medical narrative already reaches
@@ -69,9 +75,9 @@ func TestNarrativeCollectionsAreNotExported(t *testing.T) {
 			}
 		}
 		for _, col := range cfg.Columns {
-			for _, column := range narrativeColumns {
+			for _, column := range guardedColumns() {
 				if col.Field == column {
-					t.Errorf("export %q writes medical narrative column %q to sheet %q",
+					t.Errorf("export %q writes medical column %q to sheet %q",
 						cfg.Collection, column, cfg.SheetName)
 				}
 			}

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -2867,6 +2867,24 @@ class TestMedicalFlagsAndNarrative:
         assert result.household_cm_id == 9999999
         assert result.cpap_info == ""
 
+    @pytest.mark.asyncio
+    async def test_get_household_medical_reads_an_unanswered_gate_as_unknown(self) -> None:
+        """The column's empty string is "never asked", never a denial.
+
+        In 2026, 224 of 900 households never answered the allergy gate and 430
+        answered it No; rendering the first as "no" would tell staff a family
+        declined a question they were never shown.
+        """
+        repo = _repo(
+            fetch_household_by_cm_id=_rec(id="hh_1", cm_id=2000001),
+            fetch_medical_for_household=_rec(allergy_gate="yes", dietary_gate="no", physician_gate=""),
+        )
+        result = await LodgingRosterService(repo).get_household_medical(2026, 2000001)
+
+        assert result.allergy_gate == "yes"
+        assert result.dietary_gate == "no"
+        assert result.physician_gate == "unknown"
+
 
 class TestChildUnderTwoFlag:
     """The COMPUTED baby/toddler mark (staff ruling, 2026-08-21).

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -2885,6 +2885,25 @@ class TestMedicalFlagsAndNarrative:
         assert result.dietary_gate == "no"
         assert result.physician_gate == "unknown"
 
+    @pytest.mark.asyncio
+    async def test_get_household_medical_reads_a_value_outside_the_vocabulary_as_unknown(
+        self,
+    ) -> None:
+        """A garbage NON-EMPTY value falls back to "unknown" rather than raising.
+
+        Only the empty-string case was pinned above. `_gate`'s own docstring
+        promises this: a value outside the vocabulary should read as "unknown"
+        so the panel shows no pill, rather than the endpoint 500ing on a row a
+        future migration widened.
+        """
+        repo = _repo(
+            fetch_household_by_cm_id=_rec(id="hh_1", cm_id=2000001),
+            fetch_medical_for_household=_rec(allergy_gate="maybe"),
+        )
+        result = await LodgingRosterService(repo).get_household_medical(2026, 2000001)
+
+        assert result.allergy_gate == "unknown"
+
 
 class TestChildUnderTwoFlag:
     """The COMPUTED baby/toddler mark (staff ruling, 2026-08-21).

--- a/tests/unit/api/test_lodging_medical_narrative_containment.py
+++ b/tests/unit/api/test_lodging_medical_narrative_containment.py
@@ -16,6 +16,7 @@ from typing import Any, get_args, get_origin
 from pydantic import BaseModel
 
 from api.schemas.lodging import (
+    MEDICAL_GATE_FIELD_NAMES,
     MEDICAL_NARRATIVE_FIELD_NAMES,
     HouseholdMedicalResponse,
     WeekendRosterResponse,
@@ -98,6 +99,59 @@ def test_narrative_field_names_match_the_go_guard() -> None:
     came to be missing from the original six-name Python list.
     """
     assert set(MEDICAL_NARRATIVE_FIELD_NAMES) == _go_narrative_columns()
+
+
+def _go_gate_columns() -> set[str]:
+    """The gateColumns list from the Go export guard."""
+    source = GO_NARRATIVE_GUARD.read_text()
+    block = re.search(r"var gateColumns = \[\]string\{(.*?)\}", source, re.DOTALL)
+    assert block, "could not find gateColumns in lodging_medical_narrative_test.go"
+    return set(re.findall(r'"([^"]+)"', block.group(1)))
+
+
+def test_gate_field_names_are_declared() -> None:
+    """The five family_camp_medical gate columns (kindred#2542).
+
+    Separate from MEDICAL_NARRATIVE_FIELD_NAMES on purpose: a gate is a
+    structured answer, not narrative text, and kindred#2409 spent a PR making
+    that vocabulary accurate. They get the same protection, under their own
+    name.
+    """
+    assert (
+        frozenset(
+            {
+                "allergy_gate",
+                "dietary_gate",
+                "special_needs_gate",
+                "physician_gate",
+                "cpap_gate",
+            }
+        )
+        == MEDICAL_GATE_FIELD_NAMES
+    )
+
+
+def test_gate_field_names_match_the_go_guard() -> None:
+    assert set(MEDICAL_GATE_FIELD_NAMES) == _go_gate_columns()
+
+
+def test_roster_response_graph_contains_no_gate_field() -> None:
+    leaked = _all_field_names(WeekendRosterResponse) & MEDICAL_GATE_FIELD_NAMES
+    assert not leaked, f"gate fields reachable from the roster payload: {sorted(leaked)}"
+
+
+def test_session_list_response_graph_contains_no_gate_field() -> None:
+    leaked = _all_field_names(WeekendSessionListResponse) & MEDICAL_GATE_FIELD_NAMES
+    assert not leaked, f"gate fields reachable from the session list payload: {sorted(leaked)}"
+
+
+def test_summary_response_graph_contains_no_gate_field() -> None:
+    leaked = _all_field_names(WeekendSummaryResponse) & MEDICAL_GATE_FIELD_NAMES
+    assert not leaked, f"gate reachable from WeekendSummaryResponse: {sorted(leaked)}"
+
+
+def test_household_medical_response_carries_the_gates() -> None:
+    assert set(HouseholdMedicalResponse.model_fields.keys()) >= MEDICAL_GATE_FIELD_NAMES
 
 
 def test_roster_response_graph_contains_no_narrative_field() -> None:


### PR DESCRIPTION
## What staff see

Hovering a power glyph, or opening the family panel's medical block, showed narratives like
*"Yes; <the family's sentence>"* — where the leading **"Yes; " is not something the family wrote** —
and a household whose gate answer was plain "No" got a narrative consisting of the bare word **No**.

`processMedical` concatenated the CampMinder **gate answer** with the family's explain text when it
built five of the `family_camp_medical` narrative columns. Now the gate has its own column and the
narrative holds the family's own words alone; the panel renders the gate as a pill beside the row
label, and a gate-No household shows the pill and no paragraph.

Measured on the production snapshot, year 2026 (900 rows):

| Column | Non-empty before | Started `Yes…` | Bare `No` |
|---|---:|---:|---:|
| `cpap_info` | 582 | 48 | 534 |
| `special_needs_info` | 370 | 56 | 312 |
| `allergy_info` | 676 | 246 | 418 |
| `dietary_info` | 676 | 273 | 370 |
| `physician_info` | 311 | 27 | 284 |

`bathroom_explain` and `accommodation_explain` were already the target state — born clean in
migration `1500000126`, with their gates as separate booleans — and are unchanged.

## Three states, not two

The five new columns are non-required `select`s over `["yes", "no"]`; the empty string is the third
state, **never answered**, and is published as `"unknown"`. It is never coerced into `"no"`.

Families reach different question blocks, so that distinction is real rather than defensive. In 2026:
430 of 900 households answered the allergy gate No and **224 never answered it at all**; for the
physician gate it is 284 and **589**. A non-nullable boolean would collapse both into one `false`,
and telling staff a family declined a question they were never shown is a different claim from the
truth. Same shape, and the same reason, as `family_camp_registrations.share_cabin_gate`.

## Why a display-side strip would not have worked

`cpap_info`'s gate parts are not always the literal "Yes" — the 2025 combined question stored option
sentences like *"Yes, outlet needed for CPAP machine"* and *"Yes, bathroom or other housing
accommodation … (not CPAP related) …"*. A regex at render time would either leave those or destroy
them. So the split happens at write time.

Those sentences leave `cpap_info` entirely, and that is safe because **their meaning was already
derived**: `classifyCPAPAnswer` resolves every observed shape into `needs_power` /
`needs_private_bathroom`, and `AccessibilityFlagList` renders both as Housing-needs rows directly
above this text in the same panel section. What leaves is the wording, never the decision. Both flag
totals are byte-identical before and after the re-transform (49 / 66 for 2026).

## The provenance rule this had to satisfy

`docs/reference/family-camp-field-provenance.md` §4 states that a gate and its explain must stay
bound to the same person through any transform, and explicitly pre-registers this change as not
automatically satisfying it:

> a future change that gives a gate its own column does not, by itself, satisfy it unless the
> collapse rule for both halves moves together … from first-non-empty-wins to something that never
> picks a winner.

It is satisfied here, because #2450 already moved both halves off winner-selection: the gate is an OR
across every answer and the narrative keeps every distinct answer, so neither half selects a winner
and splitting them into separate columns reintroduces none. The rule paragraph is kept verbatim and
answered beneath it.

## Containment is unchanged and now covers the gates

`family_camp_medical` is gated on `bunking.manage` and absent from every export. The five gate
columns inherit that under their own name — `MEDICAL_GATE_FIELD_NAMES` in Python, `gateColumns` in
Go, with a parity test asserting the two lists are identical, the roster-payload graph walks
extended, and both the export guard and the never-log guard now reading one shared
`guardedColumns()`. `MEDICAL_NARRATIVE_FIELD_NAMES` stays exactly the eight text columns: a gate is a
structured answer, not a disclosure sentence, and #2409 spent a PR making that vocabulary accurate.

## After merge — the data needs the transform re-run

The narrative columns are rebuilt by the transform, so existing rows keep their prefixes until it
runs. **Re-run the family-camp derived transform for every year in production after this merges.** It
reads the local raw copy of `person_custom_values`, so no CampMinder re-sync is needed and none would
help. Verified on a seeded copy: zero gate tokens left in any narrative column across all ten years.

## Two mechanisms retired

`medicalGateFields` and `cpapGateParts` both existed for one reason — the gate and the explain shared
a column, so joining two answerers' gates verbatim rendered `"No; Yes; <A>; <B>"`. With the gate in
its own column there is nothing left for either to prevent, and the OR they implemented moved into
`gateVerdict`. Their reasoning moved with them rather than being deleted.

## Tests

TDD throughout. New: the schema-migration existence guard, `gateVerdict`'s OR and order-independence,
a No-gate household keeping its explanation, the never-asked-vs-answered-No distinction, the CPAP
three-field union, a gate-only household surviving the has-data guard, `medicalNeedsUpdate` seeing a
gate-only change, the vocabulary-drift warning carrying a count and never the answer, the Python
parity and containment walks, and the panel's pill behaviour including that an unanswered gate
renders nothing.

Eight existing tests were rewritten against the new columns and three deleted — two of those a
test-local reimplementation that could not fail when production changed, and one whose duplicate
fixture became unfalsifiable once a single field feeds `cpap_info`; its replacement uses conflicting
answers, which is strictly stronger.

`pre-push-verify.sh` green; `golangci-lint` zero; frontend 7363 tests; Python full mockable suite.

## Scope

kindred#2255 is **not** addressed by this PR and stays open — its remaining half is the UI ruling
about `AccessibilityFlagList` chips gaining click-to-open, which is a different surface from these
pills.

Closes #2542.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured medical gate answers for allergies, dietary needs, special needs, physician requirements, and CPAP.
  * Gate responses support **Yes**, **No**, and **Unknown** states.
  * Medical details now display gate status alongside explanatory notes, including rows containing only a gate response.
  * CPAP answers are combined across applicable sources while preserving their explanations.

* **Documentation**
  * Updated medical data and field-provenance documentation to reflect the new gate handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->