### PR TITLE
feat(frontend): the lodging board drops the shared-cabin stinger and its rule text

### DIFF
--- a/frontend/src/components/weekend/LodgingBoard.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.test.tsx
@@ -532,39 +532,13 @@ describe('LodgingBoard — the consent flag', () => {
     expect(screen.getByText('1 family did not request sharing')).toBeInTheDocument()
   })
 
-  it('summarises the flag count at the top of the board', () => {
+  // The board-level "N shared cabins need a look" stinger and its
+  // accompanying consent-rule paragraph were struck (kindred, 2026-08-23):
+  // the per-slot flag below is what staff actually act on, and the banner
+  // summarised a count nothing else on the board reads.
+  it('renders no board-level flag banner or consent-rule text', () => {
     sharedBoard()
-    expect(screen.getByText(/1 shared cabin needs a look/i)).toBeInTheDocument()
-  })
-
-  it('says nothing when there is nothing to flag', () => {
-    render(<LodgingBoard parties={[]} units={[unit()]} year={2026} />, { wrapper })
     expect(screen.queryByText(/needs a look/i)).not.toBeInTheDocument()
-  })
-
-  // HANDOFF §4 defers two consent questions to the drag PR — does a named
-  // partner count as mutual, and does silence count as consent — with the
-  // instruction to SAY ON THE SURFACE what the board flags on. The code had
-  // already answered both (`named` does not flag, `unknown` does); what was
-  // missing was staff being able to read the rule anywhere. Once staff can
-  // create a shared cabin by dragging, an unexplained amber flag is a rule
-  // they have to reverse-engineer from behaviour.
-  it('states the rule it flags on, so an amber cabin is not a mystery', () => {
-    sharedBoard()
-    const rule = screen.getByTestId('consent-rule')
-    // Silence is NOT consent — the household is chased for the form, not
-    // moved. Matched without the apostrophe on purpose: the copy uses a
-    // typographic ’, and pinning punctuation makes the test fail on a
-    // rewording that changes nothing about the rule.
-    expect(rule).toHaveTextContent(/answered the cabin form/i)
-    // A named partner is not verified mutual: that needs request names
-    // resolved to households (spec §7.3, unbuilt), so staff judge from the
-    // panel rather than the board refusing.
-    expect(rule).toHaveTextContent(/not checked for mutual/i)
-  })
-
-  it('does not lecture when no cabin is flagged', () => {
-    render(<LodgingBoard parties={[]} units={[unit()]} year={2026} />, { wrapper })
     expect(screen.queryByTestId('consent-rule')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -38,7 +38,7 @@ import {
   type DragEndEvent,
   type DragStartEvent,
 } from '@dnd-kit/core'
-import { ChevronDown, ChevronRight, Info, TriangleAlert } from 'lucide-react'
+import { ChevronDown, ChevronRight, Info } from 'lucide-react'
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { useSearchParams } from 'react-router'
 
@@ -613,42 +613,6 @@ export function LodgingBoard({
           See its doc for why siblinghood is equivalent to wrapping. */}
       <BoardMorphBoundary slotCodes={slotCodes} unitsByCode={unitsByCode} />
       <div className="flex flex-col gap-3">
-        {/* The mode chip that used to lead this row moved to the header badge,
-            where summer keeps it. The row itself is now conditional: left
-            unconditional it renders empty and still spends the parent's gap. */}
-        {board.flaggedCount > 0 && (
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-2.5 py-1 text-xs font-semibold text-amber-800 dark:bg-amber-950/50 dark:text-amber-300">
-              <TriangleAlert className="h-3.5 w-3.5 flex-shrink-0" />
-              {board.flaggedCount === 1
-                ? '1 shared cabin needs a look'
-                : `${String(board.flaggedCount)} shared cabins need a look`}
-            </span>
-          </div>
-        )}
-
-        {/* The rule behind the amber, stated where the amber is.
-
-            HANDOFF §4 deferred two consent questions to this PR: does a NAMED
-            partner satisfy "mutual", and does a blank share gate count as
-            consent? The code had already answered both — `named` does not
-            flag, silence does — and this is the half that was missing. Once
-            staff can create a shared cabin by dragging, a flag whose rule is
-            invisible is one they have to infer from behaviour, and inferring
-            it wrongly in the permissive direction is the failure this whole
-            surface exists to prevent.
-
-            Rendered only alongside a flag, so it is an explanation rather
-            than a lecture on a clean board. */}
-        {board.flaggedCount > 0 && (
-          <p data-testid="consent-rule" className="text-muted-foreground text-xs">
-            A shared cabin is flagged when someone in it did not request sharing, hasn&rsquo;t
-            answered the cabin form, or gave two answers that disagree. A named partner is{' '}
-            <strong className="font-semibold">not checked for mutual agreement</strong> — open the
-            family to see who they asked for.
-          </p>
-        )}
-
         <div className="card-lodge overflow-hidden">
           <div className="flex flex-col gap-5 p-3">
             {board.areas.length === 0 ? (

--- a/frontend/src/components/weekend/boardLayout.test.ts
+++ b/frontend/src/components/weekend/boardLayout.test.ts
@@ -640,7 +640,8 @@ describe('buildBoard — a party across several rooms', () => {
   it('does not flag a family alone in its own rooms as a shared cabin', () => {
     // `consentFlag` needs two parties in one slot. One family across two rooms
     // is one party in each, and nothing to ask staff about.
-    expect(buildBoard([merged()], twoRooms).flaggedCount).toBe(0)
+    const board = buildBoard([merged()], twoRooms)
+    expect(board.areas[0]?.slots.every((slot) => slot.consent === null)).toBe(true)
   })
 
   it('loses nobody, and counts each party once however many rooms it holds', () => {
@@ -774,7 +775,6 @@ describe('buildBoard — consent flagging on ELIGIBILITY, not the gate', () => {
       [unit()]
     )
     expect(board.areas[0]?.slots[0]?.consent).toBeNull()
-    expect(board.flaggedCount).toBe(0)
   })
 
   it('does not flag a party who declined and got a room to itself', () => {
@@ -854,11 +854,6 @@ describe('buildBoard — consent flagging on ELIGIBILITY, not the gate', () => {
     // more from maybe_mutual. The board read them as permissive.
     const slot = shared(['declined', 'open'], 'yes_share').areas[0]?.slots[0]
     expect(slot?.consent?.declinedCount).toBe(1)
-  })
-
-  it('reports how many slots are flagged across the whole board', () => {
-    expect(shared(['declined', 'open']).flaggedCount).toBe(1)
-    expect(shared(['open', 'open']).flaggedCount).toBe(0)
   })
 })
 
@@ -1466,7 +1461,6 @@ describe('buildBoard — consent flag follows leaf overlap, not the card (task-1
     expect(board.areas[0]?.slots[0]?.unit.code).toBe('house')
     expect(board.areas[0]?.slots[0]?.parties).toHaveLength(2)
     expect(board.areas[0]?.slots[0]?.consent).toBeNull()
-    expect(board.flaggedCount).toBe(0)
   })
 
   it('flags two households the merge rolled onto one card from the SAME room', () => {
@@ -1478,7 +1472,6 @@ describe('buildBoard — consent flag follows leaf overlap, not the card (task-1
       combinedHouse
     )
     expect(board.areas[0]?.slots[0]?.consent).not.toBeNull()
-    expect(board.flaggedCount).toBe(1)
   })
 
   it('flags a CONTAINER-named household against one named a room beneath it, split', () => {
@@ -1505,7 +1498,8 @@ describe('buildBoard — consent flag follows leaf overlap, not the card (task-1
     expect(shared?.consent).not.toBeNull()
     // `r2` holds only the fanned-down container party, so it is nobody's
     // share: one slot flagged, not two.
-    expect(board.flaggedCount).toBe(1)
+    const r2 = board.areas[0]?.slots.find((slot) => slot.unit.code === 'r2')
+    expect(r2?.consent).toBeNull()
   })
 
   it('flags a CONTAINER-named household against one named a room beneath it, combined', () => {
@@ -1523,7 +1517,6 @@ describe('buildBoard — consent flag follows leaf overlap, not the card (task-1
     expect(board.areas[0]?.slots[0]?.unit.code).toBe('house')
     expect(board.areas[0]?.slots[0]?.parties).toHaveLength(2)
     expect(board.areas[0]?.slots[0]?.consent).not.toBeNull()
-    expect(board.flaggedCount).toBe(1)
   })
 
   it('flags a multi-room party whose rooms overlap a single-room party', () => {
@@ -1590,7 +1583,6 @@ describe('buildBoard — consent flag follows leaf overlap, not the card (task-1
       [unit()]
     )
     expect(board.areas[0]?.slots[0]?.consent).not.toBeNull()
-    expect(board.flaggedCount).toBe(1)
   })
 })
 
@@ -1706,9 +1698,9 @@ describe('overlappingPartyKeys — a two-unit alias is ambiguous, not a confirme
 
   // Through `buildBoard`, the real entry point the board renders from --
   // `overlappingPartyKeys` is not what staff see. `consentFlag` reads its
-  // output and `flaggedCount` sums the result, so the amber ring is what the
-  // guard actually silences; a test only on the helper would pass even if the
-  // wiring above it stopped reading the guarded value.
+  // output, so the amber ring is what the guard actually silences; a test
+  // only on the helper would pass even if the wiring above it stopped
+  // reading the guarded value.
   function aliasBoard(householdCount: number) {
     const parties = Array.from({ length: householdCount }, (_, index) =>
       party({
@@ -1741,7 +1733,6 @@ describe('overlappingPartyKeys — a two-unit alias is ambiguous, not a confirme
 
   it('raises no amber flag on the BOARD for two households on one two-unit alias', () => {
     const board = aliasBoard(2)
-    expect(board.flaggedCount).toBe(0)
     expect(board.areas.flatMap((area) => area.slots).map((slot) => slot.consent)).toEqual([
       null,
       null,
@@ -1749,7 +1740,10 @@ describe('overlappingPartyKeys — a two-unit alias is ambiguous, not a confirme
   })
 
   it('still raises the board flag once a third household claims the same two units', () => {
-    expect(aliasBoard(3).flaggedCount).toBeGreaterThan(0)
+    const board = aliasBoard(3)
+    expect(board.areas.flatMap((area) => area.slots).some((slot) => slot.consent !== null)).toBe(
+      true
+    )
   })
 })
 
@@ -1858,11 +1852,13 @@ describe('overlappingPartyKeys — a CONTAINER is ambiguous on the same terms as
 
   it('raises no amber flag on the BOARD for two households on one two-room container', () => {
     const board = containerBoard(2)
-    expect(board.flaggedCount).toBe(0)
     expect(board.areas.flatMap((area) => area.slots).map((slot) => slot.consent)).toEqual([null])
   })
 
   it('still raises the board flag once a third household is named at the same container', () => {
-    expect(containerBoard(3).flaggedCount).toBeGreaterThan(0)
+    const board = containerBoard(3)
+    expect(board.areas.flatMap((area) => area.slots).some((slot) => slot.consent !== null)).toBe(
+      true
+    )
   })
 })

--- a/frontend/src/components/weekend/boardLayout.ts
+++ b/frontend/src/components/weekend/boardLayout.ts
@@ -521,7 +521,6 @@ export interface BoardModel {
   unplaced: RosterPartyRow[]
   /** Placed, but on something the board cannot draw a card for. */
   offBoard: RosterPartyRow[]
-  flaggedCount: number
 }
 
 /**
@@ -1012,11 +1011,9 @@ export function buildBoard(parties: RosterPartyRow[], units: LodgingUnitRow[]): 
     string,
     { name: string; sortOrder: number; slots: BoardSlot[]; partyKeys: Set<string> }
   >()
-  let flaggedCount = 0
   for (const unit of drawn) {
     const slotParties = partiesByCode.get(unit.code) ?? []
     const consent = consentFlag(slotParties, units)
-    if (consent) flaggedCount += 1
 
     const key = areaKey(unit)
     const bucket = buckets.get(key) ?? {
@@ -1089,7 +1086,7 @@ export function buildBoard(parties: RosterPartyRow[], units: LodgingUnitRow[]): 
     }
   })
 
-  return { areas, unplaced, offBoard, flaggedCount }
+  return { areas, unplaced, offBoard }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Removes the board-level "N shared cabin(s) need a look" amber stinger and the consent-rule paragraph beneath it from the family board's lodging view.
- Removes `flaggedCount`, the `BoardModel` field that only fed those two elements — dead once the banner is gone.
- Leaves everything else untouched: the per-slot amber ring (`consentFlagged`), the per-family "did not request sharing" chip, and the lodging map's own consent flag rendering all key off the separate `consent` / `ConsentFlag` field, which stays exactly as it was.

## Test plan
- [x] Updated `LodgingBoard.test.tsx` and `boardLayout.test.ts` first (TDD), confirmed the new assertion failed against the pre-removal code, then implemented the removal
- [x] `npx vitest run` — 459 files / 7487 tests passing
- [x] `npm run type-check` — clean
- [x] `bash scripts/pre-push-verify.sh` — all checks passed (prettier, eslint, tsc, vitest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)