### PR TITLE
fix(scripts): the lodging name guard now scans the pytest tree too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,9 +247,9 @@ jobs:
 
   # Lodging-name guard (spec 3.8) -- the tripwire that fails the build if a
   # real camp unit name lands in source. Unconditional like secret-scan
-  # above, not gated behind detect-changes: it scans four fixed roots
-  # (pocketbase/ api/ bunking/ frontend/src/) rather than the PR diff, so a
-  # leak added under any of them must fail regardless of which
+  # above, not gated behind detect-changes: it scans six fixed roots
+  # (pocketbase/ api/ bunking/ frontend/src/ scripts/ tests/) rather than the
+  # PR diff, so a leak added under any of them must fail regardless of which
   # detect-changes filter the touched files happen to match. It also needs a
   # real git checkout -- `git rev-parse --show-toplevel` inside the script
   # exits 128 without one -- so actions/checkout below is load-bearing, not

--- a/scripts/dev/test-verify-no-hardcoded-lodging.sh
+++ b/scripts/dev/test-verify-no-hardcoded-lodging.sh
@@ -31,7 +31,7 @@ fi
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 # Probe paths deliberately avoid the guard's own test-file exclusions (see
-# header above) and sit directly under two of the four scanned trees
+# header above) and sit directly under two of the six scanned trees
 # (pocketbase/pb_hooks -- application JS -- and api -- Python).
 JS_PROBE="$REPO_ROOT/pocketbase/pb_hooks/leak_probe_kindred1869.js"
 PY_PROBE="$REPO_ROOT/api/leak_probe_kindred1869.py"
@@ -701,7 +701,7 @@ fi
 echo
 echo "=== TEST 23: a needle in a COMMENT under tests/ must fail (kindred#2515) ==="
 # kindred#2515: SCAN_ROOTS never included tests/, so nothing under the pytest
-# tree was ever checked, in either column -- 14 real comment hits across two
+# tree was ever checked, in either column -- 17 real comment hits across two
 # files sat there while this guard reported OK. This asserts the widening: a
 # comment probe under tests/ must be caught with NO env override, the same way
 # TEST 8 asserts scripts/ is a default root rather than an opt-in one.
@@ -723,7 +723,7 @@ else
 fi
 
 echo
-echo "=== TEST 24: a needle in FIXTURE CODE under tests/ must still exit 0 ==="
+echo "=== TEST 24: under tests/, a COMMENT needle fails while FIXTURE CODE stays exempt ==="
 # The mirror of TEST 23, and why kindred#2515 chose Option A over exempting
 # tests/ wholesale: the existing test-file rule (TEST 11, TEST 19 for other
 # roots) applies here unchanged -- a real unit name as fixture DATA is
@@ -732,16 +732,33 @@ echo "=== TEST 24: a needle in FIXTURE CODE under tests/ must still exit 0 ==="
 TESTS_DIR_CODE_PROBE="$REPO_ROOT/tests/leak_probe_kindred2515_code.py"
 cleanup21() { rm -f "$TESTS_DIR_CODE_PROBE"; }
 trap 'cleanup21; cleanup20; cleanup19; cleanup18; cleanup17; cleanup16; cleanup15; cleanup14; cleanup13; cleanup12; cleanup11; cleanup10; cleanup9; cleanup8; cleanup7; cleanup6; cleanup5; cleanup4; cleanup3; cleanup' EXIT INT TERM
-echo 'UNIT = "Manzanita 3"' > "$TESTS_DIR_CODE_PROBE"
+# ONE probe carrying BOTH columns, not two probes carrying one each. An exit-0
+# assertion over a code-only probe is an absence proof: it passes identically
+# when tests/ is not scanned at all, so on its own it cannot tell "fixture code
+# is exempt" from "this file was never read". Pairing the two columns in a
+# single file forces the guard to exit 1 -- proving the file WAS scanned -- and
+# then asserting the report names only the comment line proves the code line
+# was seen and deliberately exempted. TEST 23 pins the same directory is
+# scanned; this pins the split within it.
+cat > "$TESTS_DIR_CODE_PROBE" <<'PROBE'
+UNIT = "Manzanita 3"
+# Manzanita 3
+PROBE
 set +e
 OUT=$("$GUARD_SCRIPT" 2>&1)
 rc=$?
 set -e
 rm -f "$TESTS_DIR_CODE_PROBE"
-if [[ $rc -eq 0 ]]; then
-  echo "PASS: a needle as fixture code under tests/ is still exempt"
+if [[ $rc -ne 1 ]]; then
+  echo "FAIL: expected exit 1 (the comment line must fail) for the mixed probe under tests/, got $rc" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+probe_lines=$(echo "$OUT" | grep -c "leak_probe_kindred2515_code.py" || true)
+if [[ $probe_lines -eq 1 ]] && echo "$OUT" | grep -q "leak_probe_kindred2515_code.py:2"; then
+  echo "PASS: under tests/, the comment line fails and the fixture-code line stays exempt"
 else
-  echo "FAIL: expected exit 0 for a needle as fixture code under tests/, got $rc" >&2
+  echo "FAIL: expected exactly one reported line, the COMMENT at :2; got $probe_lines line(s)" >&2
   echo "$OUT" >&2
   exit 1
 fi

--- a/scripts/dev/test-verify-no-hardcoded-lodging.sh
+++ b/scripts/dev/test-verify-no-hardcoded-lodging.sh
@@ -699,4 +699,52 @@ else
 fi
 
 echo
+echo "=== TEST 23: a needle in a COMMENT under tests/ must fail (kindred#2515) ==="
+# kindred#2515: SCAN_ROOTS never included tests/, so nothing under the pytest
+# tree was ever checked, in either column -- 14 real comment hits across two
+# files sat there while this guard reported OK. This asserts the widening: a
+# comment probe under tests/ must be caught with NO env override, the same way
+# TEST 8 asserts scripts/ is a default root rather than an opt-in one.
+TESTS_DIR_COMMENT_PROBE="$REPO_ROOT/tests/leak_probe_kindred2515.py"
+cleanup20() { rm -f "$TESTS_DIR_COMMENT_PROBE"; }
+trap 'cleanup20; cleanup19; cleanup18; cleanup17; cleanup16; cleanup15; cleanup14; cleanup13; cleanup12; cleanup11; cleanup10; cleanup9; cleanup8; cleanup7; cleanup6; cleanup5; cleanup4; cleanup3; cleanup' EXIT INT TERM
+echo '# Regression comment naming Manzanita to explain a fixture below.' > "$TESTS_DIR_COMMENT_PROBE"
+set +e
+OUT=$("$GUARD_SCRIPT" 2>&1)
+rc=$?
+set -e
+rm -f "$TESTS_DIR_COMMENT_PROBE"
+if [[ $rc -eq 1 ]] && grep -q "tests/leak_probe_kindred2515.py:1:" <<<"$OUT"; then
+  echo "PASS: a needle in a tests/ comment is caught with no env override"
+else
+  echo "FAIL: expected exit 1 naming the tests/ comment probe, got $rc" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+
+echo
+echo "=== TEST 24: a needle in FIXTURE CODE under tests/ must still exit 0 ==="
+# The mirror of TEST 23, and why kindred#2515 chose Option A over exempting
+# tests/ wholesale: the existing test-file rule (TEST 11, TEST 19 for other
+# roots) applies here unchanged -- a real unit name as fixture DATA is
+# legitimate under tests/ exactly as it is under frontend/src/** or
+# pocketbase/, so widening SCAN_ROOTS must not also start failing fixtures.
+TESTS_DIR_CODE_PROBE="$REPO_ROOT/tests/leak_probe_kindred2515_code.py"
+cleanup21() { rm -f "$TESTS_DIR_CODE_PROBE"; }
+trap 'cleanup21; cleanup20; cleanup19; cleanup18; cleanup17; cleanup16; cleanup15; cleanup14; cleanup13; cleanup12; cleanup11; cleanup10; cleanup9; cleanup8; cleanup7; cleanup6; cleanup5; cleanup4; cleanup3; cleanup' EXIT INT TERM
+echo 'UNIT = "Manzanita 3"' > "$TESTS_DIR_CODE_PROBE"
+set +e
+OUT=$("$GUARD_SCRIPT" 2>&1)
+rc=$?
+set -e
+rm -f "$TESTS_DIR_CODE_PROBE"
+if [[ $rc -eq 0 ]]; then
+  echo "PASS: a needle as fixture code under tests/ is still exempt"
+else
+  echo "FAIL: expected exit 0 for a needle as fixture code under tests/, got $rc" >&2
+  echo "$OUT" >&2
+  exit 1
+fi
+
+echo
 echo "All tests passed."

--- a/scripts/dev/verify-no-hardcoded-lodging.sh
+++ b/scripts/dev/verify-no-hardcoded-lodging.sh
@@ -61,18 +61,20 @@ NEEDLES="Ridge Yurt|Tawonga Village|Manzanita|Tuolumne|Cloud'?s Rest|Wawona|Half
 # Scan roots, overridable ONLY so the test suite can point the guard at a
 # missing directory and assert it fails rather than reporting a clean scan.
 #
-# THESE FIVE ARE THE WHOLE SCOPE. Every rule stated below -- including the
-# code/comment table -- describes what happens INSIDE these roots and nowhere
-# else. The pytest tree at tests/ is NOT among them and never has been: it
-# carries 71 needle hits (80 case-insensitively) across three files under
-# tests/unit/api/services/, of which 4 sit in comments, and none of them has
-# ever been checked. One of those comments restates in prose the exact fact
-# kindred#2512 scrubbed out of api/services/lodging_rules.py, so the scrub
-# moved the sentence into an unscanned file rather than out of the repository.
-# Widening the roots changes what every future PR is measured against, so it
-# gets its own change: kindred#2515 carries the measurement and the
-# scrub-or-exempt decision.
-read -r -a SCAN_ROOTS <<<"${LODGING_SCAN_ROOTS:-pocketbase/ api/ bunking/ frontend/src/ scripts/}"
+# SIX ROOTS, AND THE RULE TABLE BELOW APPLIES TO ALL OF THEM EQUALLY. tests/
+# joined in kindred#2515 -- DECISION: OPTION A, not B. It was missing from the
+# very first version of this guard and stayed missing through every widening
+# since, so nothing under the pytest tree was ever checked, in either column:
+# a full-registry re-measurement (not just the NEEDLES sample) found 17
+# comment-line hits across two files under tests/unit/api/services/, all
+# rewritten in the same change that added this root. Option B -- exempt
+# tests/ deliberately -- was rejected because it is not a coherent rule: this
+# guard already scans other test files (frontend/src/**/*.test.ts,
+# pocketbase/**/*_test.go) under the code/comment table below, so the same
+# comment would fail in a Go test file and pass in a pytest file purely by
+# directory. Fixture CODE in a test file stays exempt here exactly as it does
+# under every other root -- only the comment split changed.
+read -r -a SCAN_ROOTS <<<"${LODGING_SCAN_ROOTS:-pocketbase/ api/ bunking/ frontend/src/ scripts/ tests/}"
 
 # Capture grep's OWN status before the filter pipeline swallows it. grep exits
 # 0 for matches, 1 for none, and >=2 when the scan itself failed — an
@@ -138,8 +140,8 @@ done
 #   not a test file -> code hits fail, comment hits fail
 #   a test file     -> code hits are exempt, comment hits fail
 #
-# ...for files under SCAN_ROOTS. See the note there: tests/ is outside them
-# (kindred#2515).
+# ...for files under SCAN_ROOTS, which since kindred#2515 is all six roots,
+# tests/ included -- see the note there for why it joined and what it cost.
 #
 # The 18 comment hits this widening newly caught were scrubbed in the same
 # change (7 outside test files, including `effective_bathroom`'s own docstring

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -1542,8 +1542,8 @@ class TestCountsFollowTheDrawLevel:
     async def test_a_combined_container_with_no_own_figure_still_totals_its_measured_rooms(self) -> None:
         """The inverse of the case where a container's own figure already
         includes measured common-space furniture: none was ever recorded for
-        this house, and that is a real zero, not a
-        missing measurement (kindred#2041) -- 14 of 15 production containers
+        this house, and that is a real zero, not a missing measurement
+        (kindred#2041) -- 14 of 15 production containers
         are in exactly this state. The card drawn still totals what its
         rooms report: 0 + 2 + 2 = 4, and the total is KNOWN.
         """
@@ -2105,7 +2105,7 @@ class TestPartyEffectiveBathroom:
     @pytest.mark.asyncio
     async def test_whole_container_let_covering_its_bathroom_group_is_private(self) -> None:
         """A party placed on the CONTAINER id alone -- staff booked the whole
-        the whole container rather than naming its two bedrooms. The container's
+        container rather than naming its two bedrooms. The container's
         own row is bathroom="none" (a building is not a room), so without
         inheritance from its leaves this reads as no bathroom at all -- the
         "container whole-let" gap #2022's re-measurement widened the issue
@@ -2763,8 +2763,8 @@ class TestScenarioResolution:
         assert by_code["ridge-a"].family_available_override is False
         assert by_code["ridge-a"].reason == "Burst pipe"
         # No row for the second unit: absence means "ask the unit's role", which
-        # is not
-        # the same answer as a stored False and must not be flattened into one.
+        # is not the same answer as a stored False and must not be flattened
+        # into one.
         assert by_code["ridge-b"].family_available_override is None
 
 
@@ -5979,7 +5979,7 @@ class TestFamilyAvailabilityIsResolvedOverTheTree:
     """
 
     def test_a_fully_covered_combined_house_is_not_a_family_space(self) -> None:
-        """The house built above: a combined container whose four rooms each carry a
+        """The house built below: a combined container whose four rooms each carry a
         write-in and which carries none itself.
 
         The card has always drawn the write-in badge and all four occupants --

--- a/tests/unit/api/services/test_lodging_roster_service.py
+++ b/tests/unit/api/services/test_lodging_roster_service.py
@@ -82,8 +82,9 @@ def _unit(
     # exists to undo -- so the fixture default is the blank string, exactly as
     # 104 of the 118 production rows are.
     has_ramp: str = "",
-    # False builds the default RIDGE area (honouring `area_sort_order`); True
-    # resolves the expanded `area` relation to None -- the missing-area case.
+    # False builds the fixture's default area (honouring `area_sort_order`);
+    # True resolves the expanded `area` relation to None -- the missing-area
+    # case.
     area_missing: bool = False,
     area_sort_order: int = 1,
 ) -> SimpleNamespace:
@@ -1539,8 +1540,9 @@ class TestCountsFollowTheDrawLevel:
 
     @pytest.mark.asyncio
     async def test_a_combined_container_with_no_own_figure_still_totals_its_measured_rooms(self) -> None:
-        """The inverse of the Doctor's House case: no common-space furniture
-        was ever recorded for this house, and that is a real zero, not a
+        """The inverse of the case where a container's own figure already
+        includes measured common-space furniture: none was ever recorded for
+        this house, and that is a real zero, not a
         missing measurement (kindred#2041) -- 14 of 15 production containers
         are in exactly this state. The card drawn still totals what its
         rooms report: 0 + 2 + 2 = 4, and the total is KNOWN.
@@ -1922,7 +1924,7 @@ class TestSlotMergeTiers:
     async def test_full_bathroom_group_merge_is_not_assumed_for_a_lone_unit(self) -> None:
         """A unit is evaluated as its own one-element slot in slice 1.
 
-        Tioga 1 alone does not get the whole group's bathroom, so it stays
+        One room alone does not get the whole group's bathroom, so it stays
         shared. Only merging every member of the group upgrades it.
         """
         repo = _repo(
@@ -2103,7 +2105,7 @@ class TestPartyEffectiveBathroom:
     @pytest.mark.asyncio
     async def test_whole_container_let_covering_its_bathroom_group_is_private(self) -> None:
         """A party placed on the CONTAINER id alone -- staff booked the whole
-        Doctor's House rather than naming its two bedrooms. The container's
+        the whole container rather than naming its two bedrooms. The container's
         own row is bathroom="none" (a building is not a room), so without
         inheritance from its leaves this reads as no bathroom at all -- the
         "container whole-let" gap #2022's re-measurement widened the issue
@@ -2760,7 +2762,8 @@ class TestScenarioResolution:
         by_code = {u.code: u for u in scoped.units}
         assert by_code["ridge-a"].family_available_override is False
         assert by_code["ridge-a"].reason == "Burst pipe"
-        # No row for ridge-b: absence means "ask the unit's role", which is not
+        # No row for the second unit: absence means "ask the unit's role", which
+        # is not
         # the same answer as a stored False and must not be flattened into one.
         assert by_code["ridge-b"].family_available_override is None
 
@@ -4492,7 +4495,8 @@ class TestUnitPowerCoverage:
 
     @pytest.mark.asyncio
     async def test_it_resolves_to_leaves_at_any_depth_never_direct_children(self) -> None:
-        """The `hc-health-center` shape, which is why one level is not enough.
+        """The three-level container shape below, which is why one level is not
+        enough.
 
         The building's two direct children are themselves containers recording
         no power, and every leaf beneath THEM has power. A one-level walk
@@ -5927,7 +5931,7 @@ class TestWriteInCovers:
 def _clouds_rest_units() -> list[SimpleNamespace]:
     """A combined container whose four rooms are the only measured space.
 
-    The production shape kindred#2503 was found on: `gt-clouds-rest` carries no
+    The production shape kindred#2503 was found on: the container carries no
     `sleeps` of its own (a container's own figure is a DELTA over its rooms),
     its four rooms sleep 3 + 1 + 2 + 2, and it draws as ONE card because it is
     combined. Fictional occupant names throughout; the registry codes are not
@@ -5975,7 +5979,7 @@ class TestFamilyAvailabilityIsResolvedOverTheTree:
     """
 
     def test_a_fully_covered_combined_house_is_not_a_family_space(self) -> None:
-        """gt-clouds-rest: a combined container whose four rooms each carry a
+        """The house built above: a combined container whose four rooms each carry a
         write-in and which carries none itself.
 
         The card has always drawn the write-in badge and all four occupants --
@@ -6082,7 +6086,7 @@ class TestFamilyAvailabilityIsResolvedOverTheTree:
 
     def test_a_sized_write_in_never_reopens_a_role_closed_unit(self) -> None:
         """A size answers "how many beds are left", never "is this family
-        inventory". Ridge A is closed by its ROLE row and holds a two-person
+        inventory". The cabin is closed by its ROLE row and holds a two-person
         write-in in five beds: three beds are free and the cabin is still shut.
         """
         unit = _summary("ridge-a", sleeps=5, family_available_override=False, party_size=2)
@@ -6490,7 +6494,7 @@ class TestWriteInsResolveFromTheirOwnTable:
 
         counts = summary.weekends[0].counts
         assert counts.units_family_available == 1
-        # The written-into cabin's five beds are NOT on offer; only Ridge B's.
+        # The written-into cabin's five beds are NOT on offer; only the other unit's.
         assert counts.beds_family_available == 4
         assert counts == roster.counts
 
@@ -6951,7 +6955,7 @@ class TestAScenariosWriteInsReplaceTheLiveOnes:
 
         counts = summary.weekends[0].counts
         assert counts.units_family_available == 1
-        # The written-into cabin's five beds are NOT on offer; only Ridge B's.
+        # The written-into cabin's five beds are NOT on offer; only the other unit's.
         assert counts.beds_family_available == 4
         assert counts == roster.counts
 

--- a/tests/unit/api/services/test_lodging_rules.py
+++ b/tests/unit/api/services/test_lodging_rules.py
@@ -119,8 +119,8 @@ class TestIsFamilyAvailable:
         came out of `dragPlacement.ts` with it. The stats bar has disagreed
         with the board it sits above ever since.
 
-        Ridge A sleeps 15. Two people written in leaves thirteen, and the board
-        will accept a family in them.
+        A fifteen-bed cabin. Two people written in leaves thirteen, and the
+        board will accept a family in them.
         """
         assert is_family_available("family_pool", None, free=13) is True
 
@@ -143,7 +143,8 @@ class TestEffectiveBathroom:
         assert effective_bathroom("private", "", frozenset(), frozenset({"hc-upstairs-5"})) == "private"
 
     def test_full_group_merge_upgrades_shared_to_private(self) -> None:
-        """merge{Tioga 1, Tioga 2} covers the whole gt-tioga-12 group."""
+        """Merging both members of a two-room bathroom group upgrades the
+        group's shared bathroom to private."""
         assert (
             effective_bathroom(
                 "shared",
@@ -155,7 +156,8 @@ class TestEffectiveBathroom:
         )
 
     def test_partial_group_merge_stays_shared(self) -> None:
-        """merge{Upstairs 1, Upstairs 2} leaves 3 members of hc-upstairs-hall out."""
+        """Merging two of a five-room bathroom group's members leaves the
+        other three out, so the group stays shared."""
         assert (
             effective_bathroom(
                 "shared",
@@ -657,8 +659,8 @@ class TestWriteInDemand:
         assert write_in_demand(15, loads) == WriteInDemand(consumed=15, sized=0, known=False)
 
     def test_descendants_consume_their_own_capacity_not_the_card_s(self) -> None:
-        """gt-clouds-rest: a combined house whose four rooms are each written
-        into. Each room contributes ITS beds, not the house's."""
+        """A combined house whose four rooms are each written into. Each room
+        contributes ITS beds, not the house's."""
         loads = [
             WriteInLoad("descendant", None, 3),
             WriteInLoad("descendant", None, 1),
@@ -681,7 +683,7 @@ class TestWriteInDemand:
         assert write_in_demand(8, loads) == WriteInDemand(consumed=7, sized=2, known=False)
 
     def test_an_ancestor_takes_the_whole_card_and_contributes_no_sized_people(self) -> None:
-        """Wawona written into whole, then split. Each room is inside a house
+        """A house written into whole, then split. Each room is inside a house
         somebody has taken, so neither is separately lettable -- but the
         house's size is a fact about the HOUSE, and printing it on both rooms
         would spend one two-person party twice on one screen.
@@ -773,7 +775,7 @@ class TestFreeFamilyBeds:
         assert free_family_beds(None, [WriteInLoad("own", 2, None)]) == 0
 
     def test_a_sized_write_in_leaves_the_remainder(self) -> None:
-        """Ridge A sleeps 15; two people written in leaves thirteen. Since
+        """A fifteen-bed cabin; two people written in leaves thirteen. Since
         kindred#2432 the board will accept a family there, so the bar must
         agree with it."""
         assert free_family_beds(15, [WriteInLoad("own", 2, 15)]) == 13


### PR DESCRIPTION
## Summary

`scripts/dev/verify-no-hardcoded-lodging.sh` never included `tests/` in
`SCAN_ROOTS` — not in its original version, and not through any of the
widenings since. Every rule the guard states, including the code/comment
table #2512 added, has only ever applied inside five directories; the
pytest tree was outside all of them, so nothing under `tests/` was ever
checked, in either column.

A full-registry re-measurement (every area name, unit name, unit code, and
alias string in the private registry — not just the guard's own
representative `NEEDLES` sample) found **17 comment lines across two
files** under `tests/unit/api/services/` naming real lodging units, areas,
or codes: `test_lodging_roster_service.py` (11) and `test_lodging_rules.py`
(6). One of them restated in prose the exact fact kindred#2512 had just
scrubbed out of `api/services/lodging_rules.py`'s `effective_bathroom`
docstring — the scrub had moved the sentence into an unscanned file rather
than out of the repository.

## Decision: Option A, not B

kindred#2515 laid out two coherent answers and asked for one to be chosen
and recorded:

- **A.** Add `tests/` to `SCAN_ROOTS` and scrub the comments.
- **B.** Exempt `tests/` deliberately, and say so in the guard.

**B is not tenable**: this guard already scans other test files
(`frontend/src/**/*.test.ts`, `pocketbase/**/*_test.go`) under the same
code/comment split, so exempting `tests/` by directory would mean the same
comment fails in a Go test file and passes in a pytest file for no reason
but its folder.

Went with **A**. The guard's own comment block now records the decision
and the reasoning, so it can't silently regrow.

## What changed

1. `tests/` added to `SCAN_ROOTS` (six roots now, all under the same rule
   table).
2. All 17 comment lines rewritten to drop the real names while keeping
   their explanatory force — no fixture code touched, since real unit
   names as fixture *data* stay exempt under the existing test-file rule.
3. Two new self-tests (`TEST 23`, `TEST 24` in
   `scripts/dev/test-verify-no-hardcoded-lodging.sh`) plant a probe under
   `tests/`: a comment naming a unit must fail the guard, fixture code
   naming one must still pass. Verified red against the unmodified guard
   before the `SCAN_ROOTS` change landed, green after.

## Test plan

- [x] `bash scripts/dev/verify-no-hardcoded-lodging.sh` — exit 0
- [x] `bash scripts/dev/test-verify-no-hardcoded-lodging.sh` — exit 0 (24
      tests, including the two new ones)
- [x] `uv run pytest tests/unit/api/services/test_lodging_roster_service.py
      tests/unit/api/services/test_lodging_rules.py` — 406 passed
- [x] `bash scripts/pre-push-verify.sh` — ALL CHECKS PASSED
- [x] Full pre-push hook on `git push` (ruff, mypy, shellcheck, full pytest
      suite) — all green

Closes #2515.