### PR TITLE
refactor(sync): extract setMedicalFields so upsertMedical's two branches share one column list

### DIFF
--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -2819,22 +2819,60 @@ func formatRequestStamp(t time.Time) string {
 	return t.UTC().Format("2006-01-02 15:04:05.000Z")
 }
 
+// medicalColumnValue pairs one family_camp_medical column with the value
+// medicalData currently holds for it.
+type medicalColumnValue struct {
+	column string
+	value  string
+}
+
+// medicalColumnValues lists every family_camp_medical column setMedicalFields
+// writes, next to med's current value for it. Both setMedicalFields and
+// medicalNeedsUpdate walk this ONE list rather than each naming the same 13
+// columns by hand -- so, unlike setRegistrationRequestFields' comparison
+// sibling registrationNeedsUpdate (which stays a hand-written list because it
+// mixes bools with a normalisation step, NormalizeShareEligibility, that has
+// no single scalar to compare), a column added here reaches the write path
+// and the change-detection path in one edit. What makes a shared list
+// workable here and not there: every field on medicalData is a plain string,
+// with no normalisation applied between the struct and the column.
+func medicalColumnValues(med *medicalData) []medicalColumnValue {
+	return []medicalColumnValue{
+		{"cpap_info", med.cpapInfo},
+		{"physician_info", med.physicianInfo},
+		{"special_needs_info", med.specialNeedsInfo},
+		{"allergy_info", med.allergyInfo},
+		{"dietary_info", med.dietaryInfo},
+		{"additional_info", med.additionalInfo},
+		{"bathroom_explain", med.bathroomExplain},
+		{"accommodation_explain", med.accommodationExplain},
+		{"allergy_gate", med.allergyGate},
+		{"dietary_gate", med.dietaryGate},
+		{"special_needs_gate", med.specialNeedsGate},
+		{"physician_gate", med.physicianGate},
+		{"cpap_gate", med.cpapGate},
+		{enrollmentStatusColumn, med.enrollmentStatus},
+	}
+}
+
 // medicalNeedsUpdate checks if a medical record needs updating
 func (s *FamilyCampDerivedSync) medicalNeedsUpdate(existing *core.Record, med *medicalData) bool {
-	return existing.GetString("cpap_info") != med.cpapInfo ||
-		existing.GetString("physician_info") != med.physicianInfo ||
-		existing.GetString("special_needs_info") != med.specialNeedsInfo ||
-		existing.GetString("allergy_info") != med.allergyInfo ||
-		existing.GetString("dietary_info") != med.dietaryInfo ||
-		existing.GetString("additional_info") != med.additionalInfo ||
-		existing.GetString("bathroom_explain") != med.bathroomExplain ||
-		existing.GetString("accommodation_explain") != med.accommodationExplain ||
-		existing.GetString("allergy_gate") != med.allergyGate ||
-		existing.GetString("dietary_gate") != med.dietaryGate ||
-		existing.GetString("special_needs_gate") != med.specialNeedsGate ||
-		existing.GetString("physician_gate") != med.physicianGate ||
-		existing.GetString("cpap_gate") != med.cpapGate ||
-		existing.GetString(enrollmentStatusColumn) != med.enrollmentStatus
+	for _, c := range medicalColumnValues(med) {
+		if existing.GetString(c.column) != c.value {
+			return true
+		}
+	}
+	return false
+}
+
+// setMedicalFields writes the household's medical disclosures and derived
+// gate answers. Shared by the create and update branches so the two cannot
+// drift -- PocketBase Set on a column the schema lacks is a silent no-op, so
+// a field written in only one branch fails invisibly on the other path.
+func setMedicalFields(record *core.Record, med *medicalData) {
+	for _, c := range medicalColumnValues(med) {
+		record.Set(c.column, c.value)
+	}
 }
 
 // ============================================================================
@@ -3005,20 +3043,7 @@ func (s *FamilyCampDerivedSync) upsertMedical(
 		if existingRecord, ok := existing[key]; ok {
 			// Record exists - check if update needed
 			if s.medicalNeedsUpdate(existingRecord, med) {
-				existingRecord.Set("cpap_info", med.cpapInfo)
-				existingRecord.Set("physician_info", med.physicianInfo)
-				existingRecord.Set("special_needs_info", med.specialNeedsInfo)
-				existingRecord.Set("allergy_info", med.allergyInfo)
-				existingRecord.Set("dietary_info", med.dietaryInfo)
-				existingRecord.Set("additional_info", med.additionalInfo)
-				existingRecord.Set("bathroom_explain", med.bathroomExplain)
-				existingRecord.Set("accommodation_explain", med.accommodationExplain)
-				existingRecord.Set("allergy_gate", med.allergyGate)
-				existingRecord.Set("dietary_gate", med.dietaryGate)
-				existingRecord.Set("special_needs_gate", med.specialNeedsGate)
-				existingRecord.Set("physician_gate", med.physicianGate)
-				existingRecord.Set("cpap_gate", med.cpapGate)
-				existingRecord.Set(enrollmentStatusColumn, med.enrollmentStatus)
+				setMedicalFields(existingRecord, med)
 
 				if err := s.App.Save(existingRecord); err != nil {
 					slog.Error("Error updating medical record", "household", med.householdPBID, "error", err)
@@ -3034,20 +3059,7 @@ func (s *FamilyCampDerivedSync) upsertMedical(
 			record := core.NewRecord(col)
 			record.Set("household", med.householdPBID)
 			record.Set("year", year)
-			record.Set("cpap_info", med.cpapInfo)
-			record.Set("physician_info", med.physicianInfo)
-			record.Set("special_needs_info", med.specialNeedsInfo)
-			record.Set("allergy_info", med.allergyInfo)
-			record.Set("dietary_info", med.dietaryInfo)
-			record.Set("additional_info", med.additionalInfo)
-			record.Set("bathroom_explain", med.bathroomExplain)
-			record.Set("accommodation_explain", med.accommodationExplain)
-			record.Set("allergy_gate", med.allergyGate)
-			record.Set("dietary_gate", med.dietaryGate)
-			record.Set("special_needs_gate", med.specialNeedsGate)
-			record.Set("physician_gate", med.physicianGate)
-			record.Set("cpap_gate", med.cpapGate)
-			record.Set(enrollmentStatusColumn, med.enrollmentStatus)
+			setMedicalFields(record, med)
 
 			if err := s.App.Save(record); err != nil {
 				slog.Error("Error creating medical record", "household", med.householdPBID, "error", err)

--- a/pocketbase/sync/family_camp_derived.go
+++ b/pocketbase/sync/family_camp_derived.go
@@ -2828,7 +2828,7 @@ type medicalColumnValue struct {
 
 // medicalColumnValues lists every family_camp_medical column setMedicalFields
 // writes, next to med's current value for it. Both setMedicalFields and
-// medicalNeedsUpdate walk this ONE list rather than each naming the same 13
+// medicalNeedsUpdate walk this ONE list rather than each naming the same 14
 // columns by hand -- so, unlike setRegistrationRequestFields' comparison
 // sibling registrationNeedsUpdate (which stays a hand-written list because it
 // mixes bools with a normalisation step, NormalizeShareEligibility, that has
@@ -2836,6 +2836,20 @@ type medicalColumnValue struct {
 // and the change-detection path in one edit. What makes a shared list
 // workable here and not there: every field on medicalData is a plain string,
 // with no normalisation applied between the struct and the column.
+//
+// The registration comparison is also only PARTLY solved, which the sentence
+// above should not be read as denying: setRegistrationRequestFields covers
+// about 17 of the 25 columns registrationNeedsUpdate compares, and the other
+// eight are still hand-copied into both branches of upsertRegistrations.
+// Seven of those eight are plain strings and would meet the criterion stated
+// here. Tracked separately; it is a registration change, not a medical one.
+//
+// ONE LIST FUSES TWO QUESTIONS -- "is this column written?" and "does a
+// change to it make the row dirty?" -- and today those sets are identical for
+// every medical column. A future column where they should DIVERGE (a
+// write-only stamp, or a value deliberately outside change detection) must
+// not simply be appended: it would make every row compare dirty on every run,
+// which is the kindred#2384 shape. Split the list before adding one.
 func medicalColumnValues(med *medicalData) []medicalColumnValue {
 	return []medicalColumnValue{
 		{"cpap_info", med.cpapInfo},

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -943,6 +943,15 @@ func TestMedicalNeedsUpdateSeesAGateOnlyChange(t *testing.T) {
 // core.NewBaseCollection with just the columns this test touches, and
 // core.NewRecord + Set -- no app, no Save, since setMedicalFields only ever
 // calls record.Set.
+// ⚠️ The collection built below is a REALISTIC fixture, not a schema
+// assertion. PocketBase's Record.Set falls through to SetRaw for an unknown
+// key and GetString reads it straight back, so this test passes identically
+// with every Fields.Add removed -- it cannot detect a column the schema
+// lacks. That property is a house pattern here (see
+// TestMedicalNeedsUpdateSeesAGateOnlyChange), and the silent-no-op hazard is
+// covered instead by TestMedicalColumnValuesAreSchemaBacked, which reads the
+// migrations. What THIS test pins is kindred#2546's actual acceptance: both
+// branches write every column, and an update overwrites stale values.
 func TestSetMedicalFieldsReachesBothCreateAndUpdate(t *testing.T) {
 	t.Parallel()
 	col := core.NewBaseCollection("family_camp_medical")
@@ -4508,5 +4517,107 @@ func TestProcessMedicalKeepsAGateOnlyHousehold(t *testing.T) {
 	}
 	if got, want := meds[0].allergyGate, gateNo; got != want {
 		t.Errorf("allergyGate = %q, want %q", got, want)
+	}
+}
+
+// TestMedicalColumnValuesAreSchemaBacked closes the gap kindred#2546's own
+// premise is about. medicalColumnValues is now the single write list for
+// family_camp_medical, so it is the one place a new column enters the write
+// path -- and record.Set() on a column no migration declares is a SILENT
+// no-op: no error, no log, the value simply never persists.
+//
+// Thirteen of today's fourteen columns are guarded only INCIDENTALLY: eight
+// by TestMedicalColumnLimitsMatchTheSchema (they are capped text) and five by
+// TestMedicalGateColumnsExistInASchemaMigration. A fifteenth column that is
+// neither capped text nor a gate would join the write list with no schema
+// guard at all, which is exactly the failure those two tests exist to stop.
+// This asserts the property directly over the write list itself, so coverage
+// no longer depends on which OTHER list a column happens to also be on.
+func TestMedicalColumnValuesAreSchemaBacked(t *testing.T) {
+	t.Parallel()
+
+	paths, err := filepath.Glob("../pb_migrations/*.js")
+	if err != nil {
+		t.Fatalf("globbing migrations: %v", err)
+	}
+	if len(paths) == 0 {
+		t.Fatal("no migrations found -- this test would pass vacuously")
+	}
+
+	written := make([]string, 0, 16)
+	for _, cv := range medicalColumnValues(&medicalData{}) {
+		written = append(written, cv.column)
+	}
+	if len(written) == 0 {
+		t.Fatal("medicalColumnValues returned nothing -- this test would pass vacuously")
+	}
+
+	declared := make(map[string]string, len(written))
+	for _, path := range paths {
+		source, err := os.ReadFile(path) //nolint:gosec // fixed repo-relative glob
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+		text := string(source)
+		if !strings.Contains(text, "family_camp_medical") {
+			continue
+		}
+		for _, column := range written {
+			if strings.Contains(text, `name: "`+column+`"`) {
+				declared[column] = filepath.Base(path)
+			}
+		}
+	}
+
+	for _, column := range written {
+		if _, ok := declared[column]; !ok {
+			t.Errorf("family_camp_medical.%s is written by setMedicalFields but no "+
+				"migration creates it -- record.Set() would silently no-op, so the "+
+				"value never persists and nothing reports it", column)
+		}
+	}
+}
+
+// TestMedicalColumnValuesMatchesTheGuardedVocabulary pins the write list
+// against the export-guard lists, so the two cannot drift apart.
+//
+// The precedent and the reason are both already in this package:
+// TestMedicalGateColumnsExistInASchemaMigration's comment says "two identical
+// lists in this package is exactly the drift shape
+// TestMedicalColumnLimitsMatchTheSchema above already guards against", and
+// kindred#2542 was ruled on the same ground. A column written to
+// family_camp_medical but absent from guardedColumns() is a column that
+// reaches an export unguarded; one on guardedColumns() but never written is a
+// dead entry that makes the export ban look wider than it is.
+//
+// enrollment_status is the deliberate exception and the only one: it is
+// written here (stamped in Step 7b) but is NOT medical content, so it is
+// correctly outside the export ban.
+func TestMedicalColumnValuesMatchesTheGuardedVocabulary(t *testing.T) {
+	t.Parallel()
+
+	written := make(map[string]bool)
+	for _, cv := range medicalColumnValues(&medicalData{}) {
+		written[cv.column] = true
+	}
+
+	expected := append(guardedColumns(), enrollmentStatusColumn)
+	for _, column := range expected {
+		if !written[column] {
+			t.Errorf("%s is in the guarded vocabulary but setMedicalFields never "+
+				"writes it -- either add it to medicalColumnValues or drop it", column)
+		}
+	}
+
+	allowed := make(map[string]bool, len(expected))
+	for _, column := range expected {
+		allowed[column] = true
+	}
+	for column := range written {
+		if !allowed[column] {
+			t.Errorf("setMedicalFields writes family_camp_medical.%s but it is on "+
+				"neither guardedColumns() nor the enrollment_status exception -- a "+
+				"medical column outside the export ban reaches Google Sheets", column)
+		}
 	}
 }

--- a/pocketbase/sync/family_camp_derived_test.go
+++ b/pocketbase/sync/family_camp_derived_test.go
@@ -923,6 +923,114 @@ func TestMedicalNeedsUpdateSeesAGateOnlyChange(t *testing.T) {
 	}
 }
 
+// TestSetMedicalFieldsReachesBothCreateAndUpdate is the acceptance test for
+// kindred#2546. upsertMedical used to hand-copy family_camp_medical's 13
+// columns into both its create branch and its update branch -- a field
+// written into only ONE of them still compiles and fails SILENTLY, because
+// PocketBase's record.Set on a column the schema doesn't carry is a no-op
+// with no error (setRegistrationRequestFields' doc comment states the same
+// invariant for the registration sibling this mirrors).
+//
+// This drives the shared setMedicalFields helper against two separate
+// records: "created" stands in for the create branch's brand-new record,
+// "updated" stands in for the update branch's pre-existing record, seeded
+// here with different STALE values first. Every column on medicalData must
+// land its real value on BOTH -- which is only guaranteed while both
+// upsertMedical branches call this one function instead of naming the
+// columns twice more by hand.
+//
+// Same harness as TestMedicalNeedsUpdateSeesAGateOnlyChange: a bare
+// core.NewBaseCollection with just the columns this test touches, and
+// core.NewRecord + Set -- no app, no Save, since setMedicalFields only ever
+// calls record.Set.
+func TestSetMedicalFieldsReachesBothCreateAndUpdate(t *testing.T) {
+	t.Parallel()
+	col := core.NewBaseCollection("family_camp_medical")
+	col.Fields.Add(&core.TextField{Name: "cpap_info"})
+	col.Fields.Add(&core.TextField{Name: "physician_info"})
+	col.Fields.Add(&core.TextField{Name: "special_needs_info"})
+	col.Fields.Add(&core.TextField{Name: "allergy_info"})
+	col.Fields.Add(&core.TextField{Name: "dietary_info"})
+	col.Fields.Add(&core.TextField{Name: "additional_info"})
+	col.Fields.Add(&core.TextField{Name: "bathroom_explain"})
+	col.Fields.Add(&core.TextField{Name: "accommodation_explain"})
+	col.Fields.Add(&core.TextField{Name: enrollmentStatusColumn})
+	col.Fields.Add(&core.TextField{Name: "allergy_gate"})
+	col.Fields.Add(&core.TextField{Name: "dietary_gate"})
+	col.Fields.Add(&core.TextField{Name: "special_needs_gate"})
+	col.Fields.Add(&core.TextField{Name: "physician_gate"})
+	col.Fields.Add(&core.TextField{Name: "cpap_gate"})
+
+	med := &medicalData{
+		householdPBID:        "hh_1",
+		cpapInfo:             "Household reports a CPAP machine is needed overnight.",
+		physicianInfo:        "A family physician is listed on file with the camp health center.",
+		specialNeedsInfo:     "Camper uses a wheelchair to get around camp.",
+		allergyInfo:          "Camper carries an EpiPen for a tree-nut allergy.",
+		dietaryInfo:          "Camper follows a gluten-free diet.",
+		additionalInfo:       "Family requested a ground-floor cabin if one is available.",
+		bathroomExplain:      "Camper needs a private bathroom for a mobility aid.",
+		accommodationExplain: "Camper needs a step-free path to the cabin door.",
+		enrollmentStatus:     enrollmentStatusEnrolled,
+		allergyGate:          gateYes,
+		dietaryGate:          gateYes,
+		specialNeedsGate:     gateYes,
+		physicianGate:        gateNo,
+		cpapGate:             gateYes,
+	}
+
+	// Stands in for the create branch: a brand-new record with nothing set.
+	created := core.NewRecord(col)
+	setMedicalFields(created, med)
+
+	// Stands in for the update branch: a record pre-loaded with different,
+	// stale values before setMedicalFields overwrites them.
+	updated := core.NewRecord(col)
+	updated.Set("cpap_info", "stale")
+	updated.Set("physician_info", "stale")
+	updated.Set("special_needs_info", "stale")
+	updated.Set("allergy_info", "stale")
+	updated.Set("dietary_info", "stale")
+	updated.Set("additional_info", "stale")
+	updated.Set("bathroom_explain", "stale")
+	updated.Set("accommodation_explain", "stale")
+	updated.Set(enrollmentStatusColumn, "waitlisted")
+	updated.Set("allergy_gate", gateNo)
+	updated.Set("dietary_gate", gateNo)
+	updated.Set("special_needs_gate", gateNo)
+	updated.Set("physician_gate", gateYes)
+	updated.Set("cpap_gate", gateNo)
+	setMedicalFields(updated, med)
+
+	checks := []struct {
+		column string
+		want   string
+	}{
+		{"cpap_info", med.cpapInfo},
+		{"physician_info", med.physicianInfo},
+		{"special_needs_info", med.specialNeedsInfo},
+		{"allergy_info", med.allergyInfo},
+		{"dietary_info", med.dietaryInfo},
+		{"additional_info", med.additionalInfo},
+		{"bathroom_explain", med.bathroomExplain},
+		{"accommodation_explain", med.accommodationExplain},
+		{enrollmentStatusColumn, med.enrollmentStatus},
+		{"allergy_gate", med.allergyGate},
+		{"dietary_gate", med.dietaryGate},
+		{"special_needs_gate", med.specialNeedsGate},
+		{"physician_gate", med.physicianGate},
+		{"cpap_gate", med.cpapGate},
+	}
+	for _, c := range checks {
+		if got := created.GetString(c.column); got != c.want {
+			t.Errorf("create: %s = %q, want %q", c.column, got, c.want)
+		}
+		if got := updated.GetString(c.column); got != c.want {
+			t.Errorf("update: %s = %q, want %q", c.column, got, c.want)
+		}
+	}
+}
+
 // TestCompositeKeyFormats verifies the composite key format for each table
 func TestCompositeKeyFormats(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

`upsertMedical` hand-copied `family_camp_medical`'s 13 columns into both its
create branch and its update branch, with a third copy of the same column
names in `medicalNeedsUpdate`. PocketBase's `record.Set` on a column the
schema lacks is a **silent no-op** -- no error, no log -- so a field written
into only one branch fails invisibly on the other path. The medical path had
already been widened twice by hand under exactly that hazard (kindred#2305's
`enrollment_status`, kindred#2542's five gate columns) and got it right both
times, which is luck holding rather than a structure preventing the mistake.

This is a pure refactor: the same values reach the same columns as before.

## What changed

- Extracted `setMedicalFields(record *core.Record, med *medicalData)`,
  modelled on `setRegistrationRequestFields` (the sibling that already solved
  this for the registration path), carrying the same doc comment stating the
  silent-no-op invariant. Both the create and update branches of
  `upsertMedical` now call it instead of naming the 13 columns by hand.
- `medicalNeedsUpdate` no longer keeps a fourth hand-written column list
  either. Both it and `setMedicalFields` now walk a single
  `medicalColumnValues(med)` slice of column/value pairs. This is possible
  here in a way it wasn't for `registrationNeedsUpdate` (which stays a
  hand-written comparison) because every field on `medicalData` is a plain
  string with no normalisation step between the struct and the column --
  registration's comparison mixes bools with `NormalizeShareEligibility`,
  which has no single scalar to compare generically.
- No schema change, no migration, no new columns -- all 13 columns
  (including the five gate columns kindred#2542 added) are unchanged in
  value and destination.

## Tests

Wrote `TestSetMedicalFieldsReachesBothCreateAndUpdate` first and verified it
failed (`undefined: setMedicalFields`, a compile error) before implementing
the helper -- there was no pre-existing runtime bug to catch, since both
hand-copied branches already wrote every column correctly, so the RED state
here is "the extracted function doesn't exist yet," matching a pure
extraction refactor.

The test drives `setMedicalFields` directly against two separate
`*core.Record`s: one standing in for the create branch (freshly created,
nothing set), one standing in for the update branch (pre-loaded with
different stale values first). It asserts every column on `medicalData`
lands its real value on **both** -- the acceptance criterion from the issue.
I additionally mutation-tested it locally (temporarily dropped one column
from the shared list) and confirmed the test fails on both the "create" and
"update" record with a clear mismatch message, then restored the
implementation.

Existing tests (`TestUpsertMedicalIdempotency`,
`TestMedicalNeedsUpdateSeesAGateOnlyChange`,
`TestFamilyCampEnrollmentStatusReachesAllThreeTables`) were left untouched
and still pass, confirming no behaviour change.

## Test plan

- [x] `cd pocketbase && go build ./...` -- exit 0
- [x] `cd pocketbase && go test ./sync/...` -- exit 0
- [x] `cd pocketbase && go test ./...` -- exit 0 (full package suite)
- [x] `bash scripts/pre-push-verify.sh` -- ALL CHECKS PASSED (go build,
      golangci-lint with 0 issues, go test), exit 0

Closes #2546.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when comparing and saving medical and enrollment information.
  * Ensured medical narratives, enrollment statuses, and gate values are correctly retained for both new and existing records.

* **Tests**
  * Added coverage verifying that all medical fields are written correctly during record creation and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->