### PR TITLE
test(frontend): two load-sensitive flakes, not cross-file pollution

### DIFF
--- a/frontend/src/components/admin/lodging/LodgingUnitsPanel.test.tsx
+++ b/frontend/src/components/admin/lodging/LodgingUnitsPanel.test.tsx
@@ -1,6 +1,6 @@
 /** Units list: sortable, grouped by area, confirm in one click, never delete. */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -584,9 +584,23 @@ describe('LodgingUnitsPanel — the editor opens in a modal', () => {
     await user.type(name, 'STALE DRAFT')
 
     const dialogBefore = screen.getByRole('dialog')
-    await user.click(screen.getByRole('button', { name: 'Cancel' }))
-    // Reopen before the leave completes — no waitFor between close and open.
-    await user.click(screen.getByRole('button', { name: 'Edit Cabin A' }))
+    // Synchronous `fireEvent`, NOT `await user.click()` — and the two calls
+    // must stay adjacent with no `await` between them (kindred#2553).
+    //
+    // Modal's leave does not last 150ms under jsdom. Headless UI ends a leave
+    // when `getAnimations()` reports no running CSSTransition, and in a test
+    // env it polyfills that method to return `[]` (the warning it logs is
+    // swallowed by setup.ts's console mock). So `duration-150` is never
+    // honoured here: the leave completes after three queued animation frames
+    // — `nextFrame` is a double rAF, plus one more before the check.
+    // `await user.click()` yields to the macrotask queue, which lets those
+    // frames run, so whether the leave was still in flight at reopen was
+    // decided by event-loop scheduling — i.e. by machine load. It held on an
+    // idle box and lost roughly 1 run in 5 under CPU saturation.
+    // Both `fireEvent` calls run in one synchronous stack, so the rAF
+    // callbacks provably cannot interleave and the leave is always in flight.
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Cabin A' }))
     // Same element = the leave really was interrupted, which is the case
     // this test exists for. Without this, a timing change that let the
     // leave complete would unmount + freshly remount the subtree and the

--- a/frontend/src/pages/WeekendRosterPage.codeSplitting.test.tsx
+++ b/frontend/src/pages/WeekendRosterPage.codeSplitting.test.tsx
@@ -194,14 +194,26 @@ describe('code splitting (#1964)', () => {
     // second, independent signal for the same gate.
     expect(screen.queryByTestId('map-canvas')).not.toBeInTheDocument()
 
-    expect(await screen.findByText('Ridge A')).toBeInTheDocument()
-  })
+    // Explicit timeout, well above `findBy`'s 1000ms default (kindred#2553).
+    // This line waits on a REAL dynamic `import()` — the whole point of the
+    // test — so vitest must transform and evaluate the board's module graph
+    // before 'Ridge A' can paint. Measured: 369ms on an idle box, but 2536ms
+    // and 3059ms with all 12 cores saturated, which is what a full-suite run
+    // looks like. The default budget made this a load-sensitive flake. The
+    // assertion is unchanged: the fallback checks above are what pin the
+    // lazy + gated behaviour, and this one only pins that the chunk DOES
+    // arrive — so waiting longer for it weakens nothing.
+    expect(await screen.findByText('Ridge A', undefined, { timeout: 10000 })).toBeInTheDocument()
+  }, 15000)
 
   it('paints a fallback for the map first, then the map once its chunk resolves', async () => {
     renderPage('map')
     expect(screen.queryByTestId('map-canvas')).not.toBeInTheDocument()
     expect(screen.getByTestId('lodging-view-loading')).toBeInTheDocument()
 
-    expect(await screen.findByTestId('map-canvas')).toBeInTheDocument()
-  })
+    // Same real-`import()` wait as the housing test above (kindred#2553).
+    expect(
+      await screen.findByTestId('map-canvas', undefined, { timeout: 10000 })
+    ).toBeInTheDocument()
+  }, 15000)
 })


### PR DESCRIPTION
## What this fixes

The full unsharded frontend suite failed on `main`. #2553 framed it as cross-file state pollution and asked for the polluting file to be named.

**There isn't one.** Both failures reproduce with the single file alone in its own process, with no other test file present. What decides them is machine load.

| | idle | 12 cores saturated |
|---|---|---|
| `LodgingUnitsPanel` "reopening WITHIN the exit fade" | 0/5 fail | **1/5 fail** |
| `WeekendRosterPage.codeSplitting` | 0/5 fail | **5/5 fail** |

That also corrects #2553's "not flake" row: two consecutive full-run failures are exactly what a load-sensitive race looks like when load is consistently high. A later instrumented full run passed.

## Why each one raced

**`LodgingUnitsPanel` — Modal's leave does not last 150ms under jsdom.**

Headless UI ends a leave when `getAnimations()` reports no running `CSSTransition`. In a test env it *polyfills that method to return `[]`* — and the warning it logs about doing so is swallowed by `setup.ts`'s `console.warn` mock, so nobody ever saw it. `duration-150` is therefore never honoured here. The leave instead completes after **three queued animation frames** (`nextFrame` is a double rAF, plus one more before the check).

Each `await user.click()` yields to the macrotask queue, which lets those frames run. So whether the leave was still in flight at reopen was decided by event-loop scheduling. On an idle box the two clicks won by ~16ms of margin; under load they lost, the dialog unmounted and remounted, and the identity guard at `:594` caught it — working exactly as its comment says it should.

Fixed by closing and reopening with synchronous `fireEvent` in one stack, so the rAF callbacks provably cannot interleave. This is the same idiom `Modal.test.tsx`'s own interrupted-leave test already uses (three back-to-back `rerender()` calls, no `await` between them).

**`WeekendRosterPage.codeSplitting` — `findBy*`'s 1000ms default vs a real `import()`.**

Both final assertions wait on a genuine dynamic import — the whole point of the test — so vitest must transform and evaluate the module graph before anything paints. Measured 369ms idle, but 2536ms and 3059ms saturated. Given an explicit 10s budget.

## Nothing is weakened

- **Mutation-checked.** Replacing `key={editor.nonce}` with a static key still reds the reopen test — and it reds on `toHaveValue('Cabin A')`, the stale-draft assertion itself, not vacuously on the identity guard. The #2529 behaviour pin is intact and still doing its job.
- The code-splitting test's synchronous assertions (`:178`, `:192`, `:195`) are what pin the lazy + `Activity`-gated behaviour. The lines changed only pin that the chunk *does* arrive, so waiting longer for it removes no coverage.

## Verification

- `0/10` failures under full CPU saturation for `LodgingUnitsPanel` (was 1/5).
- `0/6` under the same saturation for `codeSplitting` (was 5/5).
- **Two consecutive clean full-suite runs: `461 passed (461)`, `7522 passed (7522)`, exit 0.**
- `tsc --noEmit` clean; eslint clean on both files (2 pre-existing warnings at `:56`/`:89` untouched).

## Open decision for the owner — #2553's fourth acceptance box

#2553 asks for a recorded decision on whether CI gains an unsharded run. **My finding argues against it.** Sharding was never providing isolation — these are probabilistic races, so an unsharded job would catch this class only by luck, while costing full CI time on every PR. What actually surfaces it is *repetition under load*, which is a different tool (a periodic repeat-until-fail job, or `vitest --repeat` on `main` only). I have not built either; flagging it rather than deciding it, since it is a standing CI-cost tradeoff.

Closes #2553.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved form interaction tests for more reliable validation during interrupted modal transitions.
  * Extended loading wait times in housing and map tests to accommodate slower dynamic loading.
  * Added comments clarifying timing considerations for full-suite test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->