### PR TITLE
feat(frontend): exit fades for the six reset-dependent dialogs (tier 2b)

### DIFF
--- a/frontend/src/components/CreateRequestModal.test.tsx
+++ b/frontend/src/components/CreateRequestModal.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * kindred#2538 tier 2b. CreateRequestModal is always mounted so ui/Modal's
+ * 150ms leave can play, which costs it the free state wipe an unmount used to
+ * give it, and makes its camper fetch run whether or not the dialog is open.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import CreateRequestModal from './CreateRequestModal'
+
+const getFullList = vi.fn(() => Promise.resolve([]))
+
+vi.mock('../lib/pocketbase', () => ({
+  pb: {
+    collection: vi.fn(() => ({
+      getFullList: (...args: unknown[]) => getFullList(...(args as [])),
+      create: vi.fn(() => Promise.resolve({})),
+    })),
+    authStore: { isValid: true, model: { id: 'test-user' }, onChange: vi.fn() },
+  },
+}))
+
+vi.mock('react-hot-toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+function renderModal(props: { isOpen?: boolean; nonce?: number } = {}) {
+  return render(
+    <CreateRequestModal sessionId={1000001} year={2026} onClose={vi.fn()} {...props} />,
+    { wrapper: Wrapper }
+  )
+}
+
+describe('CreateRequestModal — always-mounted conversion (kindred#2538)', () => {
+  beforeEach(() => {
+    getFullList.mockClear()
+  })
+
+  it('stays painted on the close frame, then unmounts once the leave completes', async () => {
+    const { rerender } = renderModal({ isOpen: true })
+    // The heading, not `getByText` — the footer's submit button carries the
+    // same words, so a bare text query matches two nodes.
+    expect(screen.getByRole('heading', { name: 'Create Request' })).toBeInTheDocument()
+
+    rerender(
+      <CreateRequestModal sessionId={1000001} year={2026} onClose={vi.fn()} isOpen={false} />
+    )
+
+    // Still painted on the close frame — this is the exit fade having
+    // something to fade.
+    expect(screen.getByRole('heading', { name: 'Create Request' })).toBeInTheDocument()
+
+    // ...and GONE once the leave finishes. Both halves are required: the
+    // presence assertion alone passes vacuously against the unconverted
+    // component, which hardcodes `isOpen={true}` and so ignores the prop
+    // entirely and never unmounts at all.
+    await waitFor(() =>
+      expect(screen.queryByRole('heading', { name: 'Create Request' })).not.toBeInTheDocument()
+    )
+  })
+
+  it('does not fetch the session campers while it is closed', async () => {
+    renderModal({ isOpen: false })
+
+    // The list of every enrolled attendee is the dialog's only fetch, and a
+    // closed dialog has nobody to show it to. Before the gate this fired on
+    // every RequestReviewPanel visit whether the dialog opened or not.
+    await Promise.resolve()
+    expect(getFullList).not.toHaveBeenCalled()
+  })
+
+  it('fetches the session campers once it is opened', async () => {
+    const { rerender } = renderModal({ isOpen: false })
+    expect(getFullList).not.toHaveBeenCalled()
+
+    rerender(<CreateRequestModal sessionId={1000001} year={2026} onClose={vi.fn()} isOpen={true} />)
+
+    // The gate must be `isOpen`, not a permanent `false` — opening still loads.
+    await vi.waitFor(() => expect(getFullList).toHaveBeenCalled())
+  })
+
+  it('reopening clears the notes rather than showing the abandoned draft', async () => {
+    const user = userEvent.setup()
+    const { rerender } = renderModal({ isOpen: true, nonce: 1 })
+
+    const notes = await screen.findByLabelText(/Notes/i)
+    await user.type(notes, 'draft that must not survive')
+    expect(screen.getByLabelText(/Notes/i)).toHaveValue('draft that must not survive')
+
+    // Close and reopen with no `await` between the two rerenders, so the leave
+    // is still in flight — the case a nonce exists for (kindred#2553 for why
+    // this must not be awaited userEvent).
+    rerender(
+      <CreateRequestModal
+        sessionId={1000001}
+        year={2026}
+        onClose={vi.fn()}
+        isOpen={false}
+        nonce={1}
+      />
+    )
+    rerender(
+      <CreateRequestModal
+        sessionId={1000001}
+        year={2026}
+        onClose={vi.fn()}
+        isOpen={true}
+        nonce={2}
+      />
+    )
+
+    expect(await screen.findByLabelText(/Notes/i)).toHaveValue('')
+  })
+
+  it('reopening clears the requester search rather than showing the abandoned one', async () => {
+    const user = userEvent.setup()
+    const { rerender } = renderModal({ isOpen: true, nonce: 1 })
+
+    const search = await screen.findByLabelText(/Requester/i)
+    await user.type(search, 'Rivera')
+    expect(screen.getByLabelText(/Requester/i)).toHaveValue('Rivera')
+
+    rerender(
+      <CreateRequestModal
+        sessionId={1000001}
+        year={2026}
+        onClose={vi.fn()}
+        isOpen={false}
+        nonce={1}
+      />
+    )
+    rerender(
+      <CreateRequestModal
+        sessionId={1000001}
+        year={2026}
+        onClose={vi.fn()}
+        isOpen={true}
+        nonce={2}
+      />
+    )
+
+    expect(await screen.findByLabelText(/Requester/i)).toHaveValue('')
+  })
+
+  it('reopening restores the default request type rather than the previously chosen one', async () => {
+    const user = userEvent.setup()
+    const { rerender } = renderModal({ isOpen: true, nonce: 1 })
+
+    await user.selectOptions(await screen.findByLabelText(/Request Type/i), 'not_bunk_with')
+    expect(screen.getByLabelText(/Request Type/i)).toHaveValue('not_bunk_with')
+
+    rerender(
+      <CreateRequestModal
+        sessionId={1000001}
+        year={2026}
+        onClose={vi.fn()}
+        isOpen={false}
+        nonce={1}
+      />
+    )
+    rerender(
+      <CreateRequestModal
+        sessionId={1000001}
+        year={2026}
+        onClose={vi.fn()}
+        isOpen={true}
+        nonce={2}
+      />
+    )
+
+    expect(await screen.findByLabelText(/Request Type/i)).toHaveValue('bunk_with')
+  })
+})

--- a/frontend/src/components/CreateRequestModal.tsx
+++ b/frontend/src/components/CreateRequestModal.tsx
@@ -13,11 +13,32 @@ interface CreateRequestModalProps {
   sessionId: number
   year: number
   onClose: () => void
+  /**
+   * kindred#2538 tier 2b. The dialog is ALWAYS MOUNTED so ui/Modal's 150ms
+   * leave transition has something to fade; the parent drives this flag
+   * instead of unmounting on the close frame.
+   *
+   * Optional and defaulting to TRUE, matching NewScenarioModal: an
+   * unconverted call site keeps its old conditional-mount behaviour, so the
+   * degradation for a missed site is "no fade" rather than "a modal appears".
+   */
+  isOpen?: boolean
+  /**
+   * Per-open nonce from kindred#2541's useRetainedDialog. Bumping it wipes
+   * every field, which is what an unmount used to do for free.
+   */
+  nonce?: number
 }
 
 type RequestType = 'bunk_with' | 'not_bunk_with' | 'age_preference'
 
-export default function CreateRequestModal({ sessionId, year, onClose }: CreateRequestModalProps) {
+export default function CreateRequestModal({
+  sessionId,
+  year,
+  onClose,
+  isOpen = true,
+  nonce,
+}: CreateRequestModalProps) {
   const queryClient = useQueryClient()
   const [requestType, setRequestType] = useState<RequestType>('bunk_with')
   const [requesterSearch, setRequesterSearch] = useState('')
@@ -28,12 +49,51 @@ export default function CreateRequestModal({ sessionId, year, onClose }: CreateR
   const [notes, setNotes] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
 
-  // Fetch campers for this session
+  // kindred#2538's per-open reset, as a RENDER-TIME CORRECTION rather than
+  // NewScenarioModal's `key={nonce}` on a split-out form body. The split does
+  // not apply here and the reason is structural, not stylistic: this dialog's
+  // footer is a `<Modal footer={…}>` PROP, and it reads four of the states
+  // below (isSubmitting, campersLoading, selectedRequester, selectedTarget).
+  // Modal renders `footer` OUTSIDE the scrollable content area, which is what
+  // pins it — so moving these states into a keyed child would force the
+  // buttons into `children` and leave them scrolling with the form. Keying the
+  // shell instead is the one thing kindred#2541 forbids: it remounts the
+  // fading <Modal> and snaps it away mid-leave.
+  //
+  // The correction is safe precisely where a remount would have been: all
+  // eight initializers below are static constants, so re-running them by hand
+  // reproduces a fresh mount exactly. NewScenarioModal genuinely needed the
+  // remount because its `copyFrom` default is DERIVED from a prop.
+  //
+  // Render-time, not an effect — React discards this render and re-renders
+  // synchronously with the corrected state, so a reopen never paints the
+  // abandoned draft for a frame. Same shape as `usePanelParty` and
+  // `useRetainedDialog`'s `resetWhen`. Guarded on the nonce having actually
+  // changed, or it loops.
+  const [lastNonce, setLastNonce] = useState(nonce)
+  if (nonce !== lastNonce) {
+    setLastNonce(nonce)
+    setRequestType('bunk_with')
+    setRequesterSearch('')
+    setTargetSearch('')
+    setSelectedRequester(null)
+    setSelectedTarget(null)
+    setAgePreferenceTarget('older')
+    setNotes('')
+    setIsSubmitting(false)
+  }
+
+  // Fetch campers for this session.
+  //
+  // Gated on `isOpen` (kindred#2538): always-mounted, an ungated hook pulls
+  // the FULL enrolled-attendee list on every RequestReviewPanel visit whether
+  // or not this dialog is ever opened. The hook already accepts `enabled`;
+  // `EditableRequestTarget` gates the same query the same way.
   const {
     data: campers = [],
     isLoading: campersLoading,
     isError: campersError,
-  } = useSessionCamperPersons(sessionId, year)
+  } = useSessionCamperPersons(sessionId, year, { enabled: isOpen })
 
   // Filter campers based on search
   const filteredRequesters = campers.filter((camper) => {
@@ -137,7 +197,7 @@ export default function CreateRequestModal({ sessionId, year, onClose }: CreateR
 
   return (
     <Modal
-      isOpen={true}
+      isOpen={isOpen}
       onClose={onClose}
       header={headerContent}
       footer={footerContent}

--- a/frontend/src/components/MergeRequestsModal.test.tsx
+++ b/frontend/src/components/MergeRequestsModal.test.tsx
@@ -10,6 +10,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 import MergeRequestsModal from './MergeRequestsModal'
+import { pb } from '../lib/pocketbase'
 import type { BunkRequestsResponse } from '../types/pocketbase-types'
 import { BunkRequestsRequestTypeOptions } from '../types/pocketbase-types'
 import { queryKeys } from '../utils/queryKeys'
@@ -23,10 +24,12 @@ vi.mock('../hooks/useApiWithAuth', () => ({
 }))
 
 // Mock pocketbase with all required exports
+const personsGetFullList = vi.fn(() => Promise.resolve([]))
+
 vi.mock('../lib/pocketbase', () => ({
   pb: {
     collection: vi.fn(() => ({
-      getFullList: vi.fn(() => Promise.resolve([])),
+      getFullList: (...args: unknown[]) => personsGetFullList(...(args as [])),
     })),
     authStore: {
       isValid: true,
@@ -465,6 +468,188 @@ describe('MergeRequestsModal', () => {
       await waitFor(() => {
         expect(mergeButton).toBeDisabled()
       })
+    })
+  })
+
+  describe('always-mounted conversion (kindred#2538)', () => {
+    beforeEach(() => {
+      // Re-arm the collection mock. The file-level `vi.resetAllMocks()` blanks
+      // `pb.collection` so it returns undefined, which makes the persons query
+      // throw before it ever reaches the spy -- and a "was not called"
+      // assertion would then pass whether or not the query is gated. Found by
+      // mutation-checking: ungating the query left these tests green.
+      personsGetFullList.mockClear()
+      personsGetFullList.mockResolvedValue([])
+      vi.mocked(pb.collection).mockReturnValue({
+        getFullList: personsGetFullList,
+      } as unknown as ReturnType<typeof pb.collection>)
+    })
+
+    it('re-seeds the kept target from the CURRENT requests when reopened on a different pair', () => {
+      const first = [
+        createMockRequest({ id: 'req_1' }),
+        createMockRequest({ id: 'req_2', requestee_id: 22222 }),
+      ]
+      const { rerender } = renderWithQueryClient(
+        <MergeRequestsModal
+          isOpen={true}
+          nonce={1}
+          onClose={() => {}}
+          requests={first}
+          onMergeComplete={() => {}}
+        />
+      )
+      // The first request of the pair is the default kept target.
+      expect(screen.getByDisplayValue('req_1')).toBeChecked()
+
+      // Staff picks the OTHER one, then closes.
+      fireEvent.click(screen.getByDisplayValue('req_2'))
+      expect(screen.getByDisplayValue('req_2')).toBeChecked()
+
+      const second = [
+        createMockRequest({ id: 'req_9' }),
+        createMockRequest({ id: 'req_10', requestee_id: 33333 }),
+      ]
+      rerender(
+        <QueryClientProvider client={new QueryClient()}>
+          <MergeRequestsModal
+            isOpen={false}
+            nonce={1}
+            onClose={() => {}}
+            requests={first}
+            onMergeComplete={() => {}}
+          />
+        </QueryClientProvider>
+      )
+      rerender(
+        <QueryClientProvider client={new QueryClient()}>
+          <MergeRequestsModal
+            isOpen={true}
+            nonce={2}
+            onClose={() => {}}
+            requests={second}
+            onMergeComplete={() => {}}
+          />
+        </QueryClientProvider>
+      )
+
+      // Always-mounted, `useState(requests[0]?.id)` runs ONCE at mount and
+      // never re-derives -- so without a per-open remount this still holds
+      // `req_2`, and Merge would POST a keep_target_from belonging to a pair
+      // that is no longer on screen. This is the issue's correctness bug, not
+      // a cosmetic one.
+      expect(screen.getByDisplayValue('req_9')).toBeChecked()
+    })
+
+    it('clears a failed merge error when reopened', async () => {
+      mockFetchWithAuth.mockResolvedValue({
+        ok: false,
+        json: () => Promise.resolve({ detail: 'Merge exploded' }),
+      })
+      const requests = [createMockRequest({ id: 'req_1' }), createMockRequest({ id: 'req_2' })]
+
+      const { rerender } = renderWithQueryClient(
+        <MergeRequestsModal
+          isOpen={true}
+          nonce={1}
+          onClose={() => {}}
+          requests={requests}
+          onMergeComplete={() => {}}
+        />
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /merge/i }))
+      expect(await screen.findByText(/Merge exploded/i)).toBeInTheDocument()
+
+      rerender(
+        <QueryClientProvider client={new QueryClient()}>
+          <MergeRequestsModal
+            isOpen={false}
+            nonce={1}
+            onClose={() => {}}
+            requests={requests}
+            onMergeComplete={() => {}}
+          />
+        </QueryClientProvider>
+      )
+      rerender(
+        <QueryClientProvider client={new QueryClient()}>
+          <MergeRequestsModal
+            isOpen={true}
+            nonce={2}
+            onClose={() => {}}
+            requests={requests}
+            onMergeComplete={() => {}}
+          />
+        </QueryClientProvider>
+      )
+
+      // The banner is set on failure and nothing clears it, so always-mounted
+      // it greets the next open.
+      expect(screen.queryByText(/Merge exploded/i)).not.toBeInTheDocument()
+    })
+
+    it("does not look up the merge targets' persons while it is closed", async () => {
+      const requests = [
+        createMockRequest({ id: 'req_1', requestee_id: 67890 }),
+        createMockRequest({ id: 'req_2', requestee_id: 22222 }),
+      ]
+
+      renderWithQueryClient(
+        <MergeRequestsModal
+          isOpen={false}
+          nonce={0}
+          onClose={() => {}}
+          requests={requests}
+          onMergeComplete={() => {}}
+        />
+      )
+
+      // `mergeEligibility.requests` goes non-empty on SELECTION alone, so a
+      // closed dialog that fetched would look persons up every time staff tick
+      // a second merge-eligible row, with a fresh queryKey per selection.
+      //
+      // TWO mechanisms keep this true and either alone is sufficient, so
+      // mutating one leaves this green: (1) `<Modal isOpen={false}>` renders
+      // no children, so the form body — and its useQuery — is not mounted at
+      // all while closed; (2) the query's own `enabled: isOpen && …`, which is
+      // what covers the exit-fade window, when the body IS mounted with
+      // isOpen already false. Verified by mutation: removing both together is
+      // what reds this.
+      await Promise.resolve()
+      expect(personsGetFullList).not.toHaveBeenCalled()
+    })
+
+    it('looks the persons up once it is opened', async () => {
+      const requests = [
+        createMockRequest({ id: 'req_1', requestee_id: 67890 }),
+        createMockRequest({ id: 'req_2', requestee_id: 22222 }),
+      ]
+
+      const { rerender } = renderWithQueryClient(
+        <MergeRequestsModal
+          isOpen={false}
+          nonce={0}
+          onClose={() => {}}
+          requests={requests}
+          onMergeComplete={() => {}}
+        />
+      )
+      expect(personsGetFullList).not.toHaveBeenCalled()
+
+      rerender(
+        <QueryClientProvider client={new QueryClient()}>
+          <MergeRequestsModal
+            isOpen={true}
+            nonce={1}
+            onClose={() => {}}
+            requests={requests}
+            onMergeComplete={() => {}}
+          />
+        </QueryClientProvider>
+      )
+
+      await waitFor(() => expect(personsGetFullList).toHaveBeenCalled())
     })
   })
 })

--- a/frontend/src/components/MergeRequestsModal.tsx
+++ b/frontend/src/components/MergeRequestsModal.tsx
@@ -14,6 +14,18 @@ interface MergeRequestsModalProps {
   onClose: () => void
   requests: BunkRequestsResponse[]
   onMergeComplete: () => void
+  /**
+   * Per-open nonce from kindred#2541's useRetainedDialog (kindred#2538).
+   *
+   * Load-bearing for CORRECTNESS here, not just for tidiness. Always-mounted,
+   * `selectedTargetId` and `finalType` below are `useState(requests[0]…)`
+   * initializers that run ONCE at mount and never re-derive -- so a second
+   * open on a different pair would keep the first pair's target and Merge
+   * would POST a `keep_target_from` that is no longer on screen.
+   */
+  nonce?: number
+  /** Modal's afterLeave, so the parent can release its retained snapshot. */
+  afterLeave?: () => void
 }
 
 interface MergeResponse {
@@ -25,10 +37,34 @@ interface MergeResponse {
 
 export default function MergeRequestsModal({
   isOpen,
+  nonce,
   onClose,
-  requests,
-  onMergeComplete,
+  afterLeave,
+  ...body
 }: MergeRequestsModalProps) {
+  // Thin shell owning the chrome; every useState lives in the body below,
+  // keyed by the nonce so each open remounts it fresh. The key goes on the
+  // CONTENT and never on <Modal> -- remounting the chrome mid-leave would snap
+  // the fading dialog away instead of fading it (kindred#2541).
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      // Spread rather than passed straight through: tsconfig sets
+      // exactOptionalPropertyTypes, so an explicit `undefined` is not
+      // assignable to Modal's `afterLeave?: () => void`.
+      {...(afterLeave !== undefined && { afterLeave })}
+      title="Merge Requests"
+      size="lg"
+    >
+      <MergeRequestsForm key={nonce} isOpen={isOpen} onClose={onClose} {...body} />
+    </Modal>
+  )
+}
+
+type MergeRequestsFormProps = Omit<MergeRequestsModalProps, 'nonce' | 'afterLeave'>
+
+function MergeRequestsForm({ isOpen, onClose, requests, onMergeComplete }: MergeRequestsFormProps) {
   const queryClient = useQueryClient()
   const { fetchWithAuth } = useApiWithAuth()
   const [selectedTargetId, setSelectedTargetId] = useState<string>(requests[0]?.id ?? '')
@@ -62,7 +98,14 @@ export default function MergeRequestsModal({
       const filter = `(${requesteeIds.map((id) => `cm_id = ${id}`).join(' || ')}) && year = ${year}`
       return pb.collection<PersonsResponse>('persons').getFullList({ filter })
     },
-    enabled: requesteeIds.length > 0,
+    // Gated on `isOpen` too (kindred#2538), as defence in depth rather than
+    // as the primary guard. The primary guard is structural: <Modal
+    // isOpen={false}> renders no children, so this body is not mounted while
+    // the dialog is closed and the query cannot run. What `isOpen` adds is the
+    // EXIT-FADE window -- the body stays mounted for the leave with isOpen
+    // already false, and this stops a `requests` change landing in that window
+    // from starting a lookup for a dialog on its way out.
+    enabled: isOpen && requesteeIds.length > 0,
   })
 
   const personMap = useMemo(() => {
@@ -170,7 +213,7 @@ export default function MergeRequestsModal({
   // fade play would find the guard unmounting Modal anyway.
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title="Merge Requests" size="lg">
+    <>
       <div className="space-y-6">
         {/* Error display */}
         {error && (
@@ -320,6 +363,6 @@ export default function MergeRequestsModal({
           </button>
         </div>
       </div>
-    </Modal>
+    </>
   )
 }

--- a/frontend/src/components/NewScenarioModal.test.tsx
+++ b/frontend/src/components/NewScenarioModal.test.tsx
@@ -203,7 +203,7 @@ describe('onScenarioCreated', () => {
  *    stale default.
  */
 describe('NewScenarioModal — always-mounted exit fade (kindred#2538)', () => {
-  it('stays mounted when isOpen goes false, so the exit fade can play', () => {
+  it('stays painted on the close frame, then unmounts once the leave completes', async () => {
     const { rerender } = render(
       <NewScenarioModal
         sessionId={1000001}
@@ -223,9 +223,17 @@ describe('NewScenarioModal — always-mounted exit fade (kindred#2538)', () => {
       />
     )
 
-    // Still in the DOM on the close frame. Headless UI's Transition removes it
-    // 150ms later; asserting absence here would be asserting the bug.
+    // Still in the DOM on the close frame — the exit fade has something to
+    // fade. Asserting absence HERE would be asserting the bug.
     expect(screen.getByText('Create New Scenario')).toBeInTheDocument()
+
+    // ...and gone once the leave completes. Both halves are required, and the
+    // second was missing: on its own, the presence assertion passes vacuously
+    // against a component that hardcodes `isOpen={true}` and so ignores the
+    // prop and never unmounts at all — which is exactly the pre-conversion
+    // shape it is meant to rule out. The other five dialogs in this issue pin
+    // both halves; this one now matches them.
+    await waitFor(() => expect(screen.queryByText('Create New Scenario')).not.toBeInTheDocument())
   })
 
   it('reopening resets the typed name rather than showing the previous draft', async () => {

--- a/frontend/src/components/NewScenarioModal.test.tsx
+++ b/frontend/src/components/NewScenarioModal.test.tsx
@@ -186,3 +186,123 @@ describe('onScenarioCreated', () => {
     await waitFor(() => expect(screen.getByText(/Failed to notify/i)).toBeInTheDocument())
   })
 })
+
+/**
+ * kindred#2538 tier 2b — this dialog is now ALWAYS MOUNTED so it can play
+ * ui/Modal's 150ms exit fade, and that changes two things a conditional mount
+ * used to handle for free.
+ *
+ * 1. It must still be in the DOM immediately after close. A parent that
+ *    unmounts it on the close frame gives the fade no time to run.
+ * 2. Every useState now survives close -> reopen. The reset is driven by a
+ *    per-open `nonce` keying the dialog CONTENT (kindred#2541's
+ *    useRetainedDialog), which remounts it fresh and re-runs the initializers
+ *    against CURRENT props. That last part is why a nonce and not a
+ *    reset-effect: `copyFrom`'s initial value is DERIVED from the
+ *    canCopyFromProduction prop, so a static re-initializer would reinstate a
+ *    stale default.
+ */
+describe('NewScenarioModal — always-mounted exit fade (kindred#2538)', () => {
+  it('stays mounted when isOpen goes false, so the exit fade can play', () => {
+    const { rerender } = render(
+      <NewScenarioModal
+        sessionId={1000001}
+        onClose={vi.fn()}
+        onScenarioCreated={vi.fn()}
+        isOpen={true}
+      />
+    )
+    expect(screen.getByText('Create New Scenario')).toBeInTheDocument()
+
+    rerender(
+      <NewScenarioModal
+        sessionId={1000001}
+        onClose={vi.fn()}
+        onScenarioCreated={vi.fn()}
+        isOpen={false}
+      />
+    )
+
+    // Still in the DOM on the close frame. Headless UI's Transition removes it
+    // 150ms later; asserting absence here would be asserting the bug.
+    expect(screen.getByText('Create New Scenario')).toBeInTheDocument()
+  })
+
+  it('reopening resets the typed name rather than showing the previous draft', async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(
+      <NewScenarioModal
+        sessionId={1000001}
+        onClose={vi.fn()}
+        onScenarioCreated={vi.fn()}
+        isOpen={true}
+        nonce={1}
+      />
+    )
+
+    await user.type(screen.getByLabelText(/Scenario Name/i), 'Draft that should not survive')
+    expect(screen.getByLabelText(/Scenario Name/i)).toHaveValue('Draft that should not survive')
+
+    rerender(
+      <NewScenarioModal
+        sessionId={1000001}
+        onClose={vi.fn()}
+        onScenarioCreated={vi.fn()}
+        isOpen={false}
+        nonce={1}
+      />
+    )
+    rerender(
+      <NewScenarioModal
+        sessionId={1000001}
+        onClose={vi.fn()}
+        onScenarioCreated={vi.fn()}
+        isOpen={true}
+        nonce={2}
+      />
+    )
+
+    expect(screen.getByLabelText(/Scenario Name/i)).toHaveValue('')
+  })
+
+  it('re-derives copyFrom from the CURRENT prop on reopen, not the mount-time one', () => {
+    const { rerender } = render(
+      <NewScenarioModal
+        sessionId={1000001}
+        onClose={vi.fn()}
+        onScenarioCreated={vi.fn()}
+        isOpen={true}
+        nonce={1}
+        canCopyFromProduction={true}
+      />
+    )
+    expect(screen.getByLabelText(/Copy from CampMinder/i)).toBeChecked()
+
+    rerender(
+      <NewScenarioModal
+        sessionId={1000001}
+        onClose={vi.fn()}
+        onScenarioCreated={vi.fn()}
+        isOpen={false}
+        nonce={1}
+        canCopyFromProduction={true}
+      />
+    )
+    rerender(
+      <NewScenarioModal
+        sessionId={1000001}
+        onClose={vi.fn()}
+        onScenarioCreated={vi.fn()}
+        isOpen={true}
+        nonce={2}
+        canCopyFromProduction={false}
+      />
+    )
+
+    // The option is gone, so a surviving 'production' selection would leave NO
+    // radio checked and quietly run a copy nobody chose — the exact failure the
+    // component's own initializer comment warns about.
+    expect(screen.queryByLabelText(/Copy from CampMinder/i)).not.toBeInTheDocument()
+    expect(screen.getByLabelText(/Start with empty bunks/i)).toBeChecked()
+  })
+})

--- a/frontend/src/components/NewScenarioModal.tsx
+++ b/frontend/src/components/NewScenarioModal.tsx
@@ -50,16 +50,56 @@ interface NewScenarioModalProps {
    * this modal — the three choices, their order, the layout — is identical.
    */
   emptyLabel?: string
+  /**
+   * kindred#2538 tier 2b. The dialog is ALWAYS MOUNTED so ui/Modal's 150ms
+   * leave transition has something to fade; the parent drives this flag
+   * instead of unmounting on the close frame.
+   *
+   * Optional and defaulting to TRUE on purpose. Three call sites gate this
+   * component today, and a site that has not been converted keeps its old
+   * conditional-mount behaviour rather than silently rendering an open dialog
+   * -- the degradation is "no fade", not "a modal appears".
+   */
+  isOpen?: boolean
+  /**
+   * Per-open nonce keying the form BODY, from kindred#2541's
+   * useRetainedDialog. Bumping it remounts the body and re-runs its useState
+   * initializers against CURRENT props, which is what replaces a hand-written
+   * reset-on-open effect.
+   *
+   * It keys the BODY and never the <Modal> chrome: remounting the chrome
+   * mid-leave would snap the fading dialog away instead of fading it.
+   *
+   * `copyFrom` is why this has to be a remount rather than a reset effect --
+   * its initial value is derived from canCopyFromProduction, so a static
+   * re-initializer would reinstate a default the current props contradict.
+   */
+  nonce?: number
 }
 
 export default function NewScenarioModal({
+  isOpen = true,
+  nonce,
+  onClose,
+  ...body
+}: NewScenarioModalProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Create New Scenario" size="sm">
+      <NewScenarioForm key={nonce} onClose={onClose} {...body} />
+    </Modal>
+  )
+}
+
+type NewScenarioFormProps = Omit<NewScenarioModalProps, 'isOpen' | 'nonce'>
+
+function NewScenarioForm({
   sessionId,
   onClose,
   onScenarioCreated,
   canCopyFromProduction = true,
   canCopyFromScenario = true,
   emptyLabel = 'Start with empty bunks',
-}: NewScenarioModalProps) {
+}: NewScenarioFormProps) {
   const { createScenario, scenarios } = useScenario()
   const currentYear = useYear()
   const [name, setName] = useState('')
@@ -113,7 +153,7 @@ export default function NewScenarioModal({
   }
 
   return (
-    <Modal isOpen={true} onClose={onClose} title="Create New Scenario" size="sm">
+    <>
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
           <label htmlFor="scenario-name" className="mb-2 block text-sm font-medium">
@@ -226,6 +266,6 @@ export default function NewScenarioModal({
           </button>
         </div>
       </form>
-    </Modal>
+    </>
   )
 }

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -38,6 +38,7 @@ import {
 } from '../utils/dispositionColors'
 import RequestRowDesktop from './RequestRowDesktop'
 import CreateRequestModal from './CreateRequestModal'
+import { useRetainedDialog } from '../hooks/useRetainedDialog'
 import CamperDetailsPanel from './CamperDetailsPanel'
 import { CamperRequestSummary } from './CamperRequestSummary'
 import MergeRequestsModal from './MergeRequestsModal'
@@ -96,7 +97,13 @@ export default function RequestReviewPanel({
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set())
   const [sortBy, setSortBy] = useState<SortColumn>(DEFAULT_SORT_BY)
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>(DEFAULT_SORT_ORDER)
-  const [showCreateModal, setShowCreateModal] = useState(false)
+  // kindred#2538: always-mounted so ui/Modal's 150ms leave can play. <true>
+  // rather than <void>: this dialog retains no snapshot -- its gate was a
+  // plain boolean, not the data itself -- but eslint's
+  // @typescript-eslint/no-invalid-void-type bans a void type argument, so the
+  // literal is inert and only isOpen and nonce are read. Same gap
+  // NewScenarioModal hit; kindred#2549's review predicted it.
+  const createDialog = useRetainedDialog<true>()
   const [showMergeModal, setShowMergeModal] = useState(false)
   const [showSplitModal, setShowSplitModal] = useState(false)
   const [requestToSplit, setRequestToSplit] = useState<BunkRequestsResponse | null>(null)
@@ -953,7 +960,7 @@ export default function RequestReviewPanel({
 
             {/* Create Button */}
             <button
-              onClick={() => setShowCreateModal(true)}
+              onClick={() => createDialog.open(true)}
               className="btn-primary flex touch-manipulation items-center gap-2 px-3 py-2 text-sm"
             >
               <Plus className="h-4 w-4" />
@@ -1464,14 +1471,16 @@ export default function RequestReviewPanel({
           </div>
         </div>
 
-        {/* Create Request Modal */}
-        {showCreateModal && (
-          <CreateRequestModal
-            sessionId={sessionId}
-            year={year}
-            onClose={() => setShowCreateModal(false)}
-          />
-        )}
+        {/* Create Request Modal — always mounted (kindred#2538), so the close
+            has something to fade. `nonce` is what wipes the eight form fields
+            an unmount used to clear for free. */}
+        <CreateRequestModal
+          sessionId={sessionId}
+          year={year}
+          isOpen={createDialog.isOpen}
+          nonce={createDialog.nonce}
+          onClose={() => createDialog.close()}
+        />
 
         {/* Camper Details Panel */}
         {selectedCamperId && (

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -104,7 +104,13 @@ export default function RequestReviewPanel({
   // literal is inert and only isOpen and nonce are read. Same gap
   // NewScenarioModal hit; kindred#2549's review predicted it.
   const createDialog = useRetainedDialog<true>()
-  const [showMergeModal, setShowMergeModal] = useState(false)
+  // kindred#2538: always-mounted, and this one genuinely needs the retained
+  // SNAPSHOT rather than just an open flag. The old gate was
+  // `showMergeModal && mergeEligibility.canMerge`, and `canMerge` is derived
+  // from `selectedRequests` -- so the success path's `setSelectedRequests(new
+  // Set())` flipped the gate false and yanked the dialog out mid-fade. The
+  // snapshot holds the pair being merged through the close.
+  const mergeDialog = useRetainedDialog<BunkRequestsResponse[]>()
   const [showSplitModal, setShowSplitModal] = useState(false)
   const [requestToSplit, setRequestToSplit] = useState<BunkRequestsResponse | null>(null)
   const [selectedCamperId, setSelectedCamperId] = useState<string | null>(null)
@@ -858,13 +864,20 @@ export default function RequestReviewPanel({
   const handleMergeConflict = useCallback(() => {
     if (pendingUpdate && conflictingRequest) {
       // Open merge modal with the two conflicting requests
-      setSelectedRequests(new Set([pendingUpdate.id, conflictingRequest.id]))
-      setShowMergeModal(true)
+      const selectedIds = new Set([pendingUpdate.id, conflictingRequest.id])
+      setSelectedRequests(selectedIds)
+      // The pair is taken from `requests` here and NOT from
+      // `mergeEligibility.requests` (kindred#2538). `mergeEligibility` is a
+      // useMemo over `selectedRequests`, which the line above has only just
+      // queued -- reading it in this same handler snapshots the PREVIOUS
+      // selection. The conditional mount this replaced was immune because it
+      // mounted a render later, after the memo had recomputed.
+      mergeDialog.open(requests.filter((r) => selectedIds.has(r.id)))
       clearConflicts()
       setPendingUpdate(null)
       setConflictingRequest(null)
     }
-  }, [pendingUpdate, conflictingRequest, clearConflicts])
+  }, [pendingUpdate, conflictingRequest, clearConflicts, requests, mergeDialog])
 
   // Cancel conflict resolution
   const handleCancelConflict = useCallback(() => {
@@ -1490,14 +1503,20 @@ export default function RequestReviewPanel({
           />
         )}
 
-        {/* Merge Requests Modal */}
-        {showMergeModal && mergeEligibility.canMerge && (
+        {/* Merge Requests Modal — gated on the SNAPSHOT, not on `canMerge`
+            (kindred#2538). An explicit null check, per useRetainedDialog: the
+            payload is an array, and `{data && …}` would be a truthiness test
+            on it. Clearing the selection on success no longer empties the card
+            grid mid-fade, because the dialog is reading the snapshot. */}
+        {mergeDialog.data !== null && (
           <MergeRequestsModal
-            isOpen={showMergeModal}
-            onClose={() => setShowMergeModal(false)}
-            requests={mergeEligibility.requests}
+            isOpen={mergeDialog.isOpen}
+            nonce={mergeDialog.nonce}
+            afterLeave={mergeDialog.afterLeave}
+            onClose={() => mergeDialog.close()}
+            requests={mergeDialog.data}
             onMergeComplete={() => {
-              setShowMergeModal(false)
+              mergeDialog.close()
               setSelectedRequests(new Set())
               toast.success('Requests merged successfully')
             }}
@@ -1608,7 +1627,7 @@ export default function RequestReviewPanel({
               </button>
               {mergeEligibility.canMerge && (
                 <button
-                  onClick={() => setShowMergeModal(true)}
+                  onClick={() => mergeDialog.open(mergeEligibility.requests)}
                   className="bg-primary text-primary-foreground hover:bg-primary/90 flex min-h-[44px] touch-manipulation items-center gap-2 rounded-xl px-4 py-2 font-medium shadow-sm transition-colors"
                   title="Merge these two requests into one"
                 >

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -111,8 +111,20 @@ export default function RequestReviewPanel({
   // Set())` flipped the gate false and yanked the dialog out mid-fade. The
   // snapshot holds the pair being merged through the close.
   const mergeDialog = useRetainedDialog<BunkRequestsResponse[]>()
-  const [showSplitModal, setShowSplitModal] = useState(false)
-  const [requestToSplit, setRequestToSplit] = useState<BunkRequestsResponse | null>(null)
+  // kindred#2538: always-mounted, on the retained SNAPSHOT.
+  //
+  // This is the dialog whose obvious conversion was refuted (#2538's ⛔
+  // section): widening SplitRequestModal's `request` to nullable crashes two
+  // different ways, because its effect dep array dereferences the prop at
+  // render time and hoisting a guard above the hooks makes the hook count
+  // conditional. The snapshot removes the premise instead of working around
+  // it -- `splitDialog.data` is non-null for as long as the dialog is mounted,
+  // the exit fade included, so `request` is never null and nothing downstream
+  // needs guarding. The old `setRequestToSplit(null)` on close is exactly what
+  // #2538 warns re-creates the crash; the hook drops the snapshot in
+  // `afterLeave`, once the fade has actually finished.
+  const splitDialog = useRetainedDialog<BunkRequestsResponse>()
+  const requestToSplit = splitDialog.data
   const [selectedCamperId, setSelectedCamperId] = useState<string | null>(null)
   const [confirmPopover, setConfirmPopover] = useState<{
     action: 'approve' | 'decline'
@@ -930,10 +942,12 @@ export default function RequestReviewPanel({
     setSelectedCamperId(cmId)
   }, [])
 
-  const handleSplitRow = useCallback((request: BunkRequestsResponse) => {
-    setRequestToSplit(request)
-    setShowSplitModal(true)
-  }, [])
+  const handleSplitRow = useCallback(
+    (request: BunkRequestsResponse) => {
+      splitDialog.open(request)
+    },
+    [splitDialog]
+  )
 
   return (
     <>
@@ -1523,20 +1537,22 @@ export default function RequestReviewPanel({
           />
         )}
 
-        {/* Split Request Modal */}
-        {showSplitModal && requestToSplit && (
+        {/* Split Request Modal — gated on the SNAPSHOT (explicit null check,
+            per useRetainedDialog), and neither close path nulls it. Nulling
+            the request at close is what #2538's ⛔ section says re-creates the
+            crash mid-exit-fade; `afterLeave` releases it once the fade is
+            actually done. */}
+        {splitDialog.data !== null && (
           <SplitRequestModal
-            isOpen={showSplitModal}
-            onClose={() => {
-              setShowSplitModal(false)
-              setRequestToSplit(null)
-            }}
-            request={requestToSplit}
+            isOpen={splitDialog.isOpen}
+            nonce={splitDialog.nonce}
+            afterLeave={splitDialog.afterLeave}
+            onClose={() => splitDialog.close()}
+            request={splitDialog.data}
             sourceLinks={sourceLinks}
             isLoadingSourceLinks={isLoadingSourceLinks}
             onSplitComplete={() => {
-              setShowSplitModal(false)
-              setRequestToSplit(null)
+              splitDialog.close()
               toast.success('Request split successfully')
             }}
           />

--- a/frontend/src/components/RequestReviewPanel.tsx
+++ b/frontend/src/components/RequestReviewPanel.tsx
@@ -66,7 +66,12 @@ interface FilterState {
   searchQuery: string
 }
 
-import { sortRequests, DEFAULT_SORT_BY, DEFAULT_SORT_ORDER } from './requestSort'
+import {
+  sortRequests,
+  orderByTablePosition,
+  DEFAULT_SORT_BY,
+  DEFAULT_SORT_ORDER,
+} from './requestSort'
 import type { SortColumn } from './requestSort'
 import { SortableColumnHeader, type SortDirection } from './ui/SortableColumnHeader'
 
@@ -872,24 +877,49 @@ export default function RequestReviewPanel({
     }
   }, [pendingUpdate, updateRequestMutation, clearConflicts])
 
+  // The ONE way the merge dialog is opened (kindred#2538 scan, finding 1).
+  //
+  // Both openers route through here so they cannot disagree about the order of
+  // the pair -- and the order matters, because MergeRequestsForm seeds
+  // `selectedTargetId` from `requests[0]` and that is POSTed as
+  // `keep_target_from`. The conflict path previously built its pair from raw
+  // `requests` while the toolbar used `mergeEligibility.requests` (built from
+  // `sortedRequests`), so under a confidence/status/request sort the two
+  // disagreed about which request survives a merge by default.
+  //
+  // Source from `requests`, order by `sortedRequests`: filtering the sorted
+  // list directly would let an active search hide a legitimate member and open
+  // a one-item dialog.
+  const openMergeFor = useCallback(
+    (ids: Set<string>) => {
+      mergeDialog.open(
+        orderByTablePosition(
+          requests.filter((r) => ids.has(r.id)),
+          sortedRequests
+        )
+      )
+    },
+    [requests, sortedRequests, mergeDialog]
+  )
+
   // Handle conflict resolution - merge instead
   const handleMergeConflict = useCallback(() => {
     if (pendingUpdate && conflictingRequest) {
       // Open merge modal with the two conflicting requests
       const selectedIds = new Set([pendingUpdate.id, conflictingRequest.id])
       setSelectedRequests(selectedIds)
-      // The pair is taken from `requests` here and NOT from
-      // `mergeEligibility.requests` (kindred#2538). `mergeEligibility` is a
-      // useMemo over `selectedRequests`, which the line above has only just
-      // queued -- reading it in this same handler snapshots the PREVIOUS
-      // selection. The conditional mount this replaced was immune because it
-      // mounted a render later, after the memo had recomputed.
-      mergeDialog.open(requests.filter((r) => selectedIds.has(r.id)))
+      // `selectedIds` is passed explicitly rather than read back off
+      // `mergeEligibility` (kindred#2538): that is a useMemo over
+      // `selectedRequests`, which the line above has only just QUEUED, so
+      // reading it in this same handler would snapshot the PREVIOUS selection.
+      // The conditional mount this replaced was immune because it mounted a
+      // render later, after the memo had recomputed.
+      openMergeFor(selectedIds)
       clearConflicts()
       setPendingUpdate(null)
       setConflictingRequest(null)
     }
-  }, [pendingUpdate, conflictingRequest, clearConflicts, requests, mergeDialog])
+  }, [pendingUpdate, conflictingRequest, clearConflicts, openMergeFor])
 
   // Cancel conflict resolution
   const handleCancelConflict = useCallback(() => {
@@ -1643,7 +1673,7 @@ export default function RequestReviewPanel({
               </button>
               {mergeEligibility.canMerge && (
                 <button
-                  onClick={() => mergeDialog.open(mergeEligibility.requests)}
+                  onClick={() => openMergeFor(selectedRequests)}
                   className="bg-primary text-primary-foreground hover:bg-primary/90 flex min-h-[44px] touch-manipulation items-center gap-2 rounded-xl px-4 py-2 font-medium shadow-sm transition-colors"
                   title="Merge these two requests into one"
                 >

--- a/frontend/src/components/ScenarioEditModal.test.tsx
+++ b/frontend/src/components/ScenarioEditModal.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * kindred#2538 tier 2b. ScenarioEditModal is the dialog whose parent gate IS
+ * its data — `{editingScenario && <ScenarioEditModal scenario={editingScenario} …>}`
+ * — so converting it needs a retained snapshot on the parent side and a
+ * per-open remount here.
+ */
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import ScenarioEditModal from './ScenarioEditModal'
+
+const SCENARIO_A = { id: 'scenario-a', name: 'Plan A', description: 'first' }
+const SCENARIO_B = { id: 'scenario-b', name: 'Plan B', description: 'second' }
+
+describe('ScenarioEditModal — always-mounted conversion (kindred#2538)', () => {
+  it('stays painted on the close frame, then unmounts once the leave completes', async () => {
+    const { rerender } = render(
+      <ScenarioEditModal
+        scenario={SCENARIO_A}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+        isOpen={true}
+        nonce={1}
+      />
+    )
+    expect(screen.getByRole('heading', { name: 'Edit Scenario' })).toBeInTheDocument()
+
+    rerender(
+      <ScenarioEditModal
+        scenario={SCENARIO_A}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+        isOpen={false}
+        nonce={1}
+      />
+    )
+
+    // Painted on the close frame — the exit fade has something to fade.
+    expect(screen.getByRole('heading', { name: 'Edit Scenario' })).toBeInTheDocument()
+
+    // ...and gone once the leave finishes. Both halves matter: the presence
+    // half alone passes vacuously against the unconverted component, which
+    // hardcodes `isOpen={true}` and so never unmounts at all.
+    await waitFor(() =>
+      expect(screen.queryByRole('heading', { name: 'Edit Scenario' })).not.toBeInTheDocument()
+    )
+  })
+
+  it('reopening on a DIFFERENT scenario shows that scenario, not the previous one', () => {
+    const { rerender } = render(
+      <ScenarioEditModal
+        scenario={SCENARIO_A}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+        isOpen={true}
+        nonce={1}
+      />
+    )
+    expect(screen.getByLabelText(/Scenario Name/i)).toHaveValue('Plan A')
+
+    rerender(
+      <ScenarioEditModal
+        scenario={SCENARIO_A}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+        isOpen={false}
+        nonce={1}
+      />
+    )
+    rerender(
+      <ScenarioEditModal
+        scenario={SCENARIO_B}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+        isOpen={true}
+        nonce={2}
+      />
+    )
+
+    // `useState(scenario.name)` runs once per mount, so always-mounted and
+    // without a remount this still reads 'Plan A' — editing B would rename it.
+    expect(screen.getByLabelText(/Scenario Name/i)).toHaveValue('Plan B')
+    expect(screen.getByLabelText(/Description/i)).toHaveValue('second')
+  })
+
+  it('reopening the SAME scenario after a cancelled edit shows it pristine', async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(
+      <ScenarioEditModal
+        scenario={SCENARIO_A}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+        isOpen={true}
+        nonce={1}
+      />
+    )
+
+    const name = screen.getByLabelText(/Scenario Name/i)
+    await user.clear(name)
+    await user.type(name, 'ABANDONED DRAFT')
+
+    rerender(
+      <ScenarioEditModal
+        scenario={SCENARIO_A}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+        isOpen={false}
+        nonce={1}
+      />
+    )
+    rerender(
+      <ScenarioEditModal
+        scenario={SCENARIO_A}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+        isOpen={true}
+        nonce={2}
+      />
+    )
+
+    // This is the case kindred#2538 asked to have a decision recorded for, and
+    // the reason the remount is keyed on the NONCE and not on `scenario.id`:
+    // an id key is unchanged when the same scenario is reopened, React reuses
+    // the instance, and the abandoned draft is still in the field for the next
+    // Save to write. The nonce bumps on every open, so both cases reset.
+    expect(screen.getByLabelText(/Scenario Name/i)).toHaveValue('Plan A')
+  })
+})

--- a/frontend/src/components/ScenarioEditModal.tsx
+++ b/frontend/src/components/ScenarioEditModal.tsx
@@ -8,12 +8,69 @@ interface Scenario {
 }
 
 interface ScenarioEditModalProps {
+  /**
+   * NOT nullable (kindred#2538). The parent's gate used to BE this data
+   * (`{editingScenario && …}`), which is what unmounted the dialog on the
+   * close frame and left the exit fade nothing to play. The parent now holds a
+   * retained snapshot and gates on that, so this prop is non-null for as long
+   * as the dialog is mounted -- the fade included -- and the two `useState`
+   * initializers below can keep reading it unconditionally.
+   */
   scenario: Scenario
   onClose: () => void
   onSave: (scenarioId: string, updates: { name?: string; description?: string }) => Promise<void>
+  /**
+   * kindred#2538 tier 2b. Always mounted so ui/Modal's 150ms leave can play;
+   * the parent drives this instead of unmounting on close.
+   *
+   * Optional and defaulting to TRUE, matching NewScenarioModal: an unconverted
+   * call site keeps its old conditional-mount behaviour, so a missed site
+   * degrades to "no fade" rather than "a modal appears".
+   */
+  isOpen?: boolean
+  /**
+   * Per-open nonce from kindred#2541's useRetainedDialog.
+   *
+   * Keyed on the NONCE and deliberately not on `scenario.id`, which
+   * kindred#2538 asked to have a decision recorded for. An id key handles
+   * switching to a different scenario but NOT reopening the SAME one after a
+   * cancel: the key is unchanged, React reuses the instance, and the abandoned
+   * draft is still in the field for the next Save to write. The nonce bumps on
+   * every open, so both cases reset.
+   */
+  nonce?: number
+  /** Modal's afterLeave, so the parent can release its retained snapshot. */
+  afterLeave?: () => void
 }
 
-export default function ScenarioEditModal({ scenario, onClose, onSave }: ScenarioEditModalProps) {
+export default function ScenarioEditModal({
+  isOpen = true,
+  nonce,
+  onClose,
+  afterLeave,
+  ...body
+}: ScenarioEditModalProps) {
+  // Thin shell owning the chrome; the form state lives in the body, keyed by
+  // the nonce. The key goes on the CONTENT and never on <Modal> -- remounting
+  // the chrome mid-leave would snap the fading dialog away (kindred#2541).
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      // Spread: tsconfig sets exactOptionalPropertyTypes, so an explicit
+      // `undefined` is not assignable to Modal's `afterLeave?: () => void`.
+      {...(afterLeave !== undefined && { afterLeave })}
+      title="Edit Scenario"
+      size="sm"
+    >
+      <ScenarioEditForm key={nonce} onClose={onClose} {...body} />
+    </Modal>
+  )
+}
+
+type ScenarioEditFormProps = Omit<ScenarioEditModalProps, 'isOpen' | 'nonce' | 'afterLeave'>
+
+function ScenarioEditForm({ scenario, onClose, onSave }: ScenarioEditFormProps) {
   const [name, setName] = useState(scenario.name)
   const [description, setDescription] = useState(scenario.description ?? '')
   const [isSaving, setIsSaving] = useState(false)
@@ -47,58 +104,56 @@ export default function ScenarioEditModal({ scenario, onClose, onSave }: Scenari
   }
 
   return (
-    <Modal isOpen={true} onClose={onClose} title="Edit Scenario" size="sm">
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
-          <label htmlFor="edit-scenario-name" className="mb-2 block text-sm font-medium">
-            Scenario Name
-          </label>
-          <input
-            id="edit-scenario-name"
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="e.g., Option A - Mixed Age Groups"
-            className="bg-background border-input focus:ring-primary w-full rounded-lg border px-4 py-2 focus:ring-2 focus:outline-none"
-          />
-        </div>
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="edit-scenario-name" className="mb-2 block text-sm font-medium">
+          Scenario Name
+        </label>
+        <input
+          id="edit-scenario-name"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g., Option A - Mixed Age Groups"
+          className="bg-background border-input focus:ring-primary w-full rounded-lg border px-4 py-2 focus:ring-2 focus:outline-none"
+        />
+      </div>
 
-        <div>
-          <label htmlFor="edit-scenario-description" className="mb-2 block text-sm font-medium">
-            Description (Optional)
-          </label>
-          <textarea
-            id="edit-scenario-description"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            placeholder="Describe the purpose of this scenario..."
-            rows={3}
-            className="bg-background border-input focus:ring-primary w-full resize-none rounded-lg border px-4 py-2 focus:ring-2 focus:outline-none"
-          />
-        </div>
+      <div>
+        <label htmlFor="edit-scenario-description" className="mb-2 block text-sm font-medium">
+          Description (Optional)
+        </label>
+        <textarea
+          id="edit-scenario-description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Describe the purpose of this scenario..."
+          rows={3}
+          className="bg-background border-input focus:ring-primary w-full resize-none rounded-lg border px-4 py-2 focus:ring-2 focus:outline-none"
+        />
+      </div>
 
-        {error && (
-          <div className="bg-destructive/10 text-destructive rounded-lg p-3 text-sm">{error}</div>
-        )}
+      {error && (
+        <div className="bg-destructive/10 text-destructive rounded-lg p-3 text-sm">{error}</div>
+      )}
 
-        <div className="flex gap-3 pt-2">
-          <button
-            type="button"
-            onClick={onClose}
-            className="bg-muted hover:bg-muted/80 flex-1 rounded-lg px-4 py-2 font-medium transition-colors"
-            disabled={isSaving}
-          >
-            Cancel
-          </button>
-          <button
-            type="submit"
-            className="bg-primary hover:bg-primary/90 text-primary-foreground flex-1 rounded-lg px-4 py-2 font-medium transition-colors disabled:opacity-50"
-            disabled={isSaving}
-          >
-            {isSaving ? 'Saving...' : 'Save Changes'}
-          </button>
-        </div>
-      </form>
-    </Modal>
+      <div className="flex gap-3 pt-2">
+        <button
+          type="button"
+          onClick={onClose}
+          className="bg-muted hover:bg-muted/80 flex-1 rounded-lg px-4 py-2 font-medium transition-colors"
+          disabled={isSaving}
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          className="bg-primary hover:bg-primary/90 text-primary-foreground flex-1 rounded-lg px-4 py-2 font-medium transition-colors disabled:opacity-50"
+          disabled={isSaving}
+        >
+          {isSaving ? 'Saving...' : 'Save Changes'}
+        </button>
+      </div>
+    </form>
   )
 }

--- a/frontend/src/components/ScenarioManagementModal.overlayStack.test.tsx
+++ b/frontend/src/components/ScenarioManagementModal.overlayStack.test.tsx
@@ -114,7 +114,11 @@ describe('ScenarioManagementModal — ScenarioEditModal (:317) on top of the out
 
     fireEvent.keyDown(document, { key: 'Escape' })
 
-    expect(screen.queryByText('Edit Scenario')).not.toBeInTheDocument()
+    // Awaited since kindred#2538 converted this child: its DOM now outlives
+    // the close by Modal's exit fade, exactly as the confirm dialog above
+    // already did. The overlay TOKEN still releases synchronously on the flip
+    // (D12), which is what the second test leans on.
+    await waitFor(() => expect(screen.queryByText('Edit Scenario')).not.toBeInTheDocument())
     expect(onClose).not.toHaveBeenCalled()
   })
 
@@ -124,7 +128,7 @@ describe('ScenarioManagementModal — ScenarioEditModal (:317) on top of the out
     await userEvent.click(screen.getByRole('button', { name: /edit scenario/i }))
 
     fireEvent.keyDown(document, { key: 'Escape' })
-    expect(screen.queryByText('Edit Scenario')).not.toBeInTheDocument()
+    await waitFor(() => expect(screen.queryByText('Edit Scenario')).not.toBeInTheDocument())
 
     fireEvent.keyDown(document, { key: 'Escape' })
 
@@ -144,7 +148,11 @@ describe('ScenarioManagementModal — NewScenarioModal (:325) on top of the oute
 
     fireEvent.keyDown(document, { key: 'Escape' })
 
-    expect(screen.queryByRole('heading', { name: 'Create New Scenario' })).not.toBeInTheDocument()
+    // Awaited since kindred#2538 converted this child — see the note on the
+    // edit-modal test above.
+    await waitFor(() =>
+      expect(screen.queryByRole('heading', { name: 'Create New Scenario' })).not.toBeInTheDocument()
+    )
     expect(onClose).not.toHaveBeenCalled()
   })
 
@@ -154,7 +162,9 @@ describe('ScenarioManagementModal — NewScenarioModal (:325) on top of the oute
     await userEvent.click(screen.getByRole('button', { name: /create new scenario/i }))
 
     fireEvent.keyDown(document, { key: 'Escape' })
-    expect(screen.queryByRole('heading', { name: 'Create New Scenario' })).not.toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.queryByRole('heading', { name: 'Create New Scenario' })).not.toBeInTheDocument()
+    )
 
     fireEvent.keyDown(document, { key: 'Escape' })
 

--- a/frontend/src/components/ScenarioManagementModal.test.tsx
+++ b/frontend/src/components/ScenarioManagementModal.test.tsx
@@ -14,8 +14,12 @@ import type { ReactNode } from 'react'
 import { Toaster } from 'react-hot-toast'
 
 // Mock useSyncStatusAPI — modal uses it for the CampMinder "synced" line.
+const syncStatusOpts = vi.fn()
 vi.mock('../hooks/useSyncStatusAPI', () => ({
-  useSyncStatusAPI: () => ({ data: undefined }),
+  useSyncStatusAPI: (opts?: { enabled?: boolean }) => {
+    syncStatusOpts(opts)
+    return { data: undefined }
+  },
 }))
 
 // Mock useYear — modal reads currentYear for clear-scenario calls.
@@ -89,6 +93,30 @@ function renderModal(ctx: ScenarioContextType, emptyLabel?: string) {
     />,
     { wrapper }
   )
+}
+
+// Same providers, but lets a test drive `isOpen` across rerenders.
+function renderModalWithOpen(ctx: ScenarioContextType, isOpen: boolean) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>
+      <ScenarioContext value={ctx}>{children}</ScenarioContext>
+      <Toaster />
+    </QueryClientProvider>
+  )
+  const view = render(
+    <ScenarioManagementModal sessionId={1000001} onClose={vi.fn()} isOpen={isOpen} />,
+    { wrapper }
+  )
+  return {
+    ...view,
+    setOpen: (next: boolean) =>
+      view.rerender(
+        <ScenarioManagementModal sessionId={1000001} onClose={vi.fn()} isOpen={next} />
+      ),
+  }
 }
 
 beforeEach(() => {
@@ -167,5 +195,60 @@ describe('clearing a scenario names its own session', () => {
         screen.getByText('Cleared 47 assignments from scenario for year 2026')
       ).toBeInTheDocument()
     )
+  })
+
+  describe('always-mounted conversion (kindred#2538)', () => {
+    it('stays painted on the close frame, then unmounts once the leave completes', async () => {
+      const { setOpen } = renderModalWithOpen(makeContext({}), true)
+      expect(screen.getByRole('heading', { name: 'Manage Scenarios' })).toBeInTheDocument()
+
+      setOpen(false)
+
+      // Painted on the close frame — the fade has something to fade.
+      expect(screen.getByRole('heading', { name: 'Manage Scenarios' })).toBeInTheDocument()
+
+      // ...and gone once the leave finishes. The presence half alone passes
+      // vacuously against a component hardcoding `isOpen={true}`.
+      await waitFor(() =>
+        expect(screen.queryByRole('heading', { name: 'Manage Scenarios' })).not.toBeInTheDocument()
+      )
+    })
+
+    it('does not poll sync status while it is closed', () => {
+      syncStatusOpts.mockClear()
+      renderModalWithOpen(makeContext({}), false)
+
+      // Always-mounted, an ungated useSyncStatusAPI keeps its query — and its
+      // auth listener — alive for the permanent mount.
+      expect(syncStatusOpts).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }))
+    })
+
+    it('polls sync status once it is opened', () => {
+      syncStatusOpts.mockClear()
+      renderModalWithOpen(makeContext({}), true)
+
+      expect(syncStatusOpts).toHaveBeenCalledWith(expect.objectContaining({ enabled: true }))
+    })
+
+    it('closing the outer modal takes an open confirm dialog with it', async () => {
+      const user = userEvent.setup()
+      const { setOpen } = renderModalWithOpen(makeContext({}), true)
+
+      await user.click(screen.getByRole('button', { name: /delete scenario/i }))
+      expect(screen.getByRole('heading', { name: /Delete Scenario\?/i })).toBeInTheDocument()
+
+      // Modals portal outside #root and modalStack inerts only #root, so a
+      // staffer really can reach the outer dialog's close while a child confirm
+      // is up. Conditionally mounted this was moot — the parent's unmount took
+      // the child with it. Always-mounted, an unreset `confirmAction` leaves a
+      // "Delete Scenario?" prompt on screen with its parent gone.
+      setOpen(false)
+
+      await waitFor(() =>
+        expect(
+          screen.queryByRole('heading', { name: /Delete Scenario\?/i })
+        ).not.toBeInTheDocument()
+      )
+    })
   })
 })

--- a/frontend/src/components/ScenarioManagementModal.tsx
+++ b/frontend/src/components/ScenarioManagementModal.tsx
@@ -4,6 +4,7 @@ import { formatDistanceToNow } from 'date-fns'
 import { useScenario } from '../hooks/useScenario'
 import { useYear } from '../hooks/useCurrentYear'
 import { useSyncStatusAPI } from '../hooks/useSyncStatusAPI'
+import { useRetainedDialog } from '../hooks/useRetainedDialog'
 import ScenarioEditModal from './ScenarioEditModal'
 import NewScenarioModal from './NewScenarioModal'
 import { Modal } from './ui/Modal'
@@ -33,12 +34,21 @@ interface ScenarioManagementModalProps {
    * (`SessionView`) uses the default.
    */
   emptyLabel?: string
+  /**
+   * kindred#2538 tier 2b. Always mounted so ui/Modal's 150ms leave can play.
+   *
+   * Optional and defaulting to TRUE, matching the other tier-2b dialogs: an
+   * unconverted call site keeps its old conditional-mount behaviour, so a
+   * missed site degrades to "no fade" rather than "a modal appears".
+   */
+  isOpen?: boolean
 }
 
 export default function ScenarioManagementModal({
   sessionId,
   onClose,
   emptyLabel,
+  isOpen = true,
 }: ScenarioManagementModalProps) {
   const currentYear = useYear()
   // Read `isLoading` (initial query fetch) rather than the combined
@@ -54,15 +64,46 @@ export default function ScenarioManagementModal({
     clearScenario,
     isLoading,
   } = useScenario()
-  const { data: syncStatus } = useSyncStatusAPI()
+  // Gated on `isOpen` (kindred#2538). Unlike the tier-2b dialogs that split
+  // into a shell and a keyed body, this component's state cannot move below
+  // <Modal>: its confirm dialog and its two child dialogs are rendered as
+  // SIBLINGS of the main Modal, not inside it. So the hook lives at the
+  // permanent mount and needs the flag -- ungated, its query and its auth
+  // listener stay alive for as long as the panel exists.
+  const { data: syncStatus } = useSyncStatusAPI({ enabled: isOpen })
 
-  const [editingScenario, setEditingScenario] = useState<Scenario | null>(null)
-  const [showNewScenarioModal, setShowNewScenarioModal] = useState(false)
-  const [confirmAction, setConfirmAction] = useState<{
+  const editDialog = useRetainedDialog<Scenario>()
+  const newScenarioDialog = useRetainedDialog<true>()
+  const confirmDialog = useRetainedDialog<{
     type: 'delete' | 'clear'
     scenario: Scenario
-  } | null>(null)
+  }>()
   const [isProcessing, setIsProcessing] = useState(false)
+
+  // Close every child when this dialog closes (kindred#2538).
+  //
+  // Modals portal outside `#root` and `modalStack` inerts only `#root`, so a
+  // staffer can reach this dialog's close while a child confirm is up. While
+  // this component was conditionally mounted that was moot -- its unmount took
+  // the children with it. Always-mounted, an unreset child stays on screen
+  // with its parent gone.
+  //
+  // On the isOpen FALLING EDGE rather than inside `onClose`, which is what
+  // kindred#2538 suggested: `onClose` only fires for a user-initiated close,
+  // so a parent that drops `isOpen` itself would still strand the child. The
+  // falling edge covers both. Render-time correction, guarded on the flag
+  // actually having changed, so it cannot loop.
+  const [wasOpen, setWasOpen] = useState(isOpen)
+  if (isOpen !== wasOpen) {
+    setWasOpen(isOpen)
+    if (!isOpen) {
+      // `close()` rather than dropping the snapshots: each child plays its own
+      // leave, and each hook releases its data in its own afterLeave.
+      editDialog.close()
+      newScenarioDialog.close()
+      confirmDialog.close()
+    }
+  }
 
   const formatDate = (dateString?: string) => {
     if (!dateString) return 'Unknown'
@@ -81,7 +122,7 @@ export default function ScenarioManagementModal({
     try {
       await deleteScenario(scenario.id)
       toast.success(`Deleted scenario: ${scenario.name}`)
-      setConfirmAction(null)
+      confirmDialog.close()
     } catch {
       toast.error('Failed to delete scenario')
     } finally {
@@ -97,7 +138,7 @@ export default function ScenarioManagementModal({
       // 0 or 400 rows were cleared.
       const message = await clearScenario(scenario.id, currentYear, sessionId)
       toast.success(message)
-      setConfirmAction(null)
+      confirmDialog.close()
     } catch {
       toast.error('Failed to clear scenario')
     } finally {
@@ -113,6 +154,11 @@ export default function ScenarioManagementModal({
     toast.success('Scenario updated')
   }
 
+  // A local const, not `confirmDialog.data` inline: TypeScript's narrowing
+  // from the `!== null` guard below does not survive into the button
+  // callbacks, which are closures.
+  const confirm = confirmDialog.data
+
   const headerContent = (
     <div className="border-border border-b p-6 pr-14">
       <h2 className="font-display text-2xl font-bold">Manage Scenarios</h2>
@@ -122,7 +168,7 @@ export default function ScenarioManagementModal({
   const footerContent = (
     <div className="border-border border-t p-6">
       <button
-        onClick={() => setShowNewScenarioModal(true)}
+        onClick={() => newScenarioDialog.open(true)}
         className="btn-primary flex w-full items-center justify-center gap-2 py-3"
       >
         <Plus className="h-5 w-5" />
@@ -134,7 +180,7 @@ export default function ScenarioManagementModal({
   return (
     <>
       <Modal
-        isOpen={true}
+        isOpen={isOpen}
         onClose={onClose}
         header={headerContent}
         footer={footerContent}
@@ -237,21 +283,21 @@ export default function ScenarioManagementModal({
 
                     <div className="flex items-center gap-2">
                       <button
-                        onClick={() => setEditingScenario(scenario)}
+                        onClick={() => editDialog.open(scenario)}
                         className="btn-ghost p-2"
                         title="Edit scenario"
                       >
                         <Edit className="h-4 w-4" />
                       </button>
                       <button
-                        onClick={() => setConfirmAction({ type: 'clear', scenario })}
+                        onClick={() => confirmDialog.open({ type: 'clear', scenario })}
                         className="btn-ghost p-2"
                         title="Clear assignments"
                       >
                         <RotateCcw className="h-4 w-4" />
                       </button>
                       <button
-                        onClick={() => setConfirmAction({ type: 'delete', scenario })}
+                        onClick={() => confirmDialog.open({ type: 'delete', scenario })}
                         className="hover:bg-destructive/10 text-destructive rounded-xl p-2 transition-colors"
                         title="Delete scenario"
                       >
@@ -268,21 +314,22 @@ export default function ScenarioManagementModal({
 
       {/* Confirmation Dialog */}
       <Modal
-        isOpen={!!confirmAction}
-        onClose={() => setConfirmAction(null)}
-        title={confirmAction?.type === 'delete' ? 'Delete Scenario?' : 'Clear Assignments?'}
+        isOpen={confirmDialog.isOpen}
+        onClose={() => confirmDialog.close()}
+        afterLeave={confirmDialog.afterLeave}
+        title={confirmDialog.data?.type === 'delete' ? 'Delete Scenario?' : 'Clear Assignments?'}
         size="sm"
       >
-        {confirmAction && (
+        {confirm !== null && (
           <>
             <p className="text-muted-foreground mb-6">
-              {confirmAction.type === 'delete'
-                ? `Are you sure you want to delete "${confirmAction.scenario.name}"? This action cannot be undone.`
-                : `Are you sure you want to clear all assignments in "${confirmAction.scenario.name}"? This action cannot be undone.`}
+              {confirm.type === 'delete'
+                ? `Are you sure you want to delete "${confirm.scenario.name}"? This action cannot be undone.`
+                : `Are you sure you want to clear all assignments in "${confirm.scenario.name}"? This action cannot be undone.`}
             </p>
             <div className="flex gap-3">
               <button
-                onClick={() => setConfirmAction(null)}
+                onClick={() => confirmDialog.close()}
                 className="btn-ghost flex-1 py-2"
                 disabled={isProcessing}
               >
@@ -290,20 +337,20 @@ export default function ScenarioManagementModal({
               </button>
               <button
                 onClick={() => {
-                  if (confirmAction.type === 'delete') {
-                    void handleDelete(confirmAction.scenario)
+                  if (confirm.type === 'delete') {
+                    void handleDelete(confirm.scenario)
                   } else {
-                    void handleClear(confirmAction.scenario)
+                    void handleClear(confirm.scenario)
                   }
                 }}
                 className="bg-destructive hover:bg-destructive/90 text-destructive-foreground shadow-lodge flex-1 rounded-xl px-4 py-2.5 font-semibold transition-all disabled:opacity-50"
                 disabled={isProcessing}
               >
                 {isProcessing
-                  ? confirmAction.type === 'delete'
+                  ? confirm.type === 'delete'
                     ? 'Deleting...'
                     : 'Clearing...'
-                  : confirmAction.type === 'delete'
+                  : confirm.type === 'delete'
                     ? 'Delete'
                     : 'Clear'}
               </button>
@@ -313,26 +360,35 @@ export default function ScenarioManagementModal({
       </Modal>
 
       {/* Edit Modal */}
-      {editingScenario && (
+      {/* Gated on the SNAPSHOT (explicit null check, per useRetainedDialog):
+          the gate used to BE the data, which is what unmounted the editor on
+          the close frame. */}
+      {editDialog.data !== null && (
         <ScenarioEditModal
-          scenario={editingScenario}
-          onClose={() => setEditingScenario(null)}
+          scenario={editDialog.data}
+          isOpen={editDialog.isOpen}
+          nonce={editDialog.nonce}
+          afterLeave={editDialog.afterLeave}
+          onClose={() => editDialog.close()}
           onSave={handleUpdate}
         />
       )}
 
       {/* New Scenario Modal */}
-      {showNewScenarioModal && (
-        <NewScenarioModal
-          sessionId={sessionId}
-          {...(emptyLabel !== undefined && { emptyLabel })}
-          onClose={() => setShowNewScenarioModal(false)}
-          onScenarioCreated={(scenario) => {
-            setShowNewScenarioModal(false)
-            toast.success(`Created scenario: ${scenario.name}`)
-          }}
-        />
-      )}
+      {/* Always mounted (kindred#2538); NewScenarioModal grew its own isOpen +
+          nonce in this issue's first commit. This is the third of its three
+          gate sites, which that commit left for this one. */}
+      <NewScenarioModal
+        isOpen={newScenarioDialog.isOpen}
+        nonce={newScenarioDialog.nonce}
+        sessionId={sessionId}
+        {...(emptyLabel !== undefined && { emptyLabel })}
+        onClose={() => newScenarioDialog.close()}
+        onScenarioCreated={(scenario) => {
+          newScenarioDialog.close()
+          toast.success(`Created scenario: ${scenario.name}`)
+        }}
+      />
     </>
   )
 }

--- a/frontend/src/components/ScenarioManagementModal.tsx
+++ b/frontend/src/components/ScenarioManagementModal.tsx
@@ -68,8 +68,15 @@ export default function ScenarioManagementModal({
   // into a shell and a keyed body, this component's state cannot move below
   // <Modal>: its confirm dialog and its two child dialogs are rendered as
   // SIBLINGS of the main Modal, not inside it. So the hook lives at the
-  // permanent mount and needs the flag -- ungated, its query and its auth
-  // listener stay alive for as long as the panel exists.
+  // permanent mount and needs the flag -- ungated, its QUERY would keep
+  // polling for as long as the panel exists.
+  //
+  // What the flag does NOT stop is the hook's auth listener: that is an
+  // unconditional useEffect with deps [queryClient] (useSyncStatusAPI.ts), so
+  // the pb.authStore.onChange subscription lives for the permanent mount
+  // whether the dialog is open or not. It only invalidates a query key, so the
+  // cost is small -- but `enabled` is not what bounds it, and an earlier
+  // version of this comment implied otherwise.
   const { data: syncStatus } = useSyncStatusAPI({ enabled: isOpen })
 
   const editDialog = useRetainedDialog<Scenario>()

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -24,7 +24,7 @@ import SolverProgressModal, { useSolverProgress } from './SolverProgressModal'
 import SolverDiagnosticsModal from './SolverDiagnosticsModal'
 import type { SolverDiagnostics } from '../services/solver'
 import { resolveYields, hasReviewableDiagnostics } from '../utils/solverDiagnostics'
-import { useRetainedDialog } from '../hooks/useRetainedDialog'
+
 import { isValidTab, type ValidTab, sessionNameToUrl } from '../utils/sessionUtils'
 import BunkingBoardByArea from './BunkingBoardByArea'
 import RequestReviewPanel from './RequestReviewPanel'
@@ -44,6 +44,7 @@ import { DEFAULT_BUNK_CAPACITY } from '../utils/capacityConstants'
 import { BunkRequestProvider } from '../providers/BunkRequestProvider'
 import { CamperHistoryProvider } from '../providers/CamperHistoryProvider'
 import { useLockGroupContext } from '../contexts/LockGroupContext'
+import { useRetainedDialog } from '../hooks/useRetainedDialog'
 
 export default function SessionView() {
   const { sessionId, '*': tabPath } = useParams<{
@@ -83,7 +84,17 @@ export default function SessionView() {
     useSessionHierarchy({ sessionId, tabPath: tabPath ?? '' })
 
   // UI state
-  const [showNewScenarioModal, setShowNewScenarioModal] = useState(false)
+  // kindred#2538: always-mounted so ui/Modal's 150ms leave can play. <void>
+  // because this dialog retains no snapshot -- it takes no data prop the gate
+  // depends on -- but it still wants the per-open nonce that remounts the form
+  // fresh. A void type parameter may be omitted at the call site, so open()
+  // reads naturally.
+  // <true> rather than <void>: this dialog retains no payload, but eslint's
+  // @typescript-eslint/no-invalid-void-type bans a void type argument, and
+  // tsc alone does not -- kindred#2549's review flagged that the hook cannot
+  // express the no-snapshot variant, and this is the shape of that gap. The
+  // literal is inert; only isOpen and nonce are read.
+  const newScenarioDialog = useRetainedDialog<true>()
   const [showScenarioManagementModal, setShowScenarioManagementModal] = useState(false)
   const [showClearDialog, setShowClearDialog] = useState(false)
   const [selectedBunkArea, setSelectedBunkArea] = useState<BunkArea>('all')
@@ -385,7 +396,7 @@ export default function SessionView() {
         lockedCount={lockedCount}
         unlockedCount={unlockedCount}
         onShowClearDialog={() => setShowClearDialog(true)}
-        onShowNewScenarioModal={() => setShowNewScenarioModal(true)}
+        onShowNewScenarioModal={() => newScenarioDialog.open(true)}
         onShowScenarioManagement={() => setShowScenarioManagementModal(true)}
         onSelectScenario={selectScenario}
         canManage={canManage}
@@ -511,12 +522,16 @@ export default function SessionView() {
       </div>
 
       {/* New Scenario Modal (manage permission required) */}
-      {canManage && showNewScenarioModal && (
+      {/* `canManage` stays a MOUNT gate -- it is a permission, not an open
+          flag, and a user without it should not carry the dialog at all. */}
+      {canManage && (
         <NewScenarioModal
+          isOpen={newScenarioDialog.isOpen}
+          nonce={newScenarioDialog.nonce}
           sessionId={session.cm_id}
-          onClose={() => setShowNewScenarioModal(false)}
+          onClose={() => newScenarioDialog.close()}
           onScenarioCreated={(scenario) => {
-            setShowNewScenarioModal(false)
+            newScenarioDialog.close()
             toast.success(`Created scenario: ${scenario.name}`)
           }}
         />

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -537,10 +537,14 @@ export default function SessionView() {
         />
       )}
 
-      {/* Scenario Management Modal (manage permission required) */}
-      {canManage && showScenarioManagementModal && (
+      {/* Scenario Management Modal (manage permission required).
+          `canManage` stays a MOUNT gate -- it is a permission, not an open
+          flag, and a user without it should not carry the dialog at all.
+          `isOpen` drives the fade (kindred#2538). */}
+      {canManage && (
         <ScenarioManagementModal
           sessionId={session.cm_id}
+          isOpen={showScenarioManagementModal}
           onClose={() => setShowScenarioManagementModal(false)}
         />
       )}

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -84,11 +84,7 @@ export default function SessionView() {
     useSessionHierarchy({ sessionId, tabPath: tabPath ?? '' })
 
   // UI state
-  // kindred#2538: always-mounted so ui/Modal's 150ms leave can play. <void>
-  // because this dialog retains no snapshot -- it takes no data prop the gate
-  // depends on -- but it still wants the per-open nonce that remounts the form
-  // fresh. A void type parameter may be omitted at the call site, so open()
-  // reads naturally.
+  // kindred#2538: always-mounted so ui/Modal's 150ms leave can play.
   // <true> rather than <void>: this dialog retains no payload, but eslint's
   // @typescript-eslint/no-invalid-void-type bans a void type argument, and
   // tsc alone does not -- kindred#2549's review flagged that the hook cannot

--- a/frontend/src/components/SplitRequestModal.test.tsx
+++ b/frontend/src/components/SplitRequestModal.test.tsx
@@ -629,4 +629,123 @@ describe('SplitRequestModal', () => {
       expect(badgeText).toBeNull()
     })
   })
+
+  describe('always-mounted conversion (kindred#2538)', () => {
+    interface ExtendedSourceLinkData extends SourceLinkData {
+      is_primary?: boolean
+    }
+
+    it('clears a failed split error when reopened', async () => {
+      const sourceLinks: ExtendedSourceLinkData[] = [
+        { original_request_id: 'orig_1', source_field: 'share_bunk_with', is_primary: false },
+      ]
+      mockFetchWithAuth.mockResolvedValue({
+        ok: false,
+        json: async () => ({ detail: 'Split exploded' }),
+      })
+      const request = createMergedMockRequest()
+
+      const { rerender } = renderWithProviders(
+        <SplitRequestModal
+          isOpen={true}
+          nonce={1}
+          onClose={() => {}}
+          request={request}
+          sourceLinks={sourceLinks}
+          onSplitComplete={() => {}}
+        />
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /split/i }))
+      expect(await screen.findByText(/Split exploded/i)).toBeInTheDocument()
+
+      // Close and reopen with no await between — the leave is still in flight.
+      rerender(
+        <QueryClientProvider client={new QueryClient()}>
+          <SplitRequestModal
+            isOpen={false}
+            nonce={1}
+            onClose={() => {}}
+            request={request}
+            sourceLinks={sourceLinks}
+            onSplitComplete={() => {}}
+          />
+        </QueryClientProvider>
+      )
+      rerender(
+        <QueryClientProvider client={new QueryClient()}>
+          <SplitRequestModal
+            isOpen={true}
+            nonce={2}
+            onClose={() => {}}
+            request={request}
+            sourceLinks={sourceLinks}
+            onSplitComplete={() => {}}
+          />
+        </QueryClientProvider>
+      )
+
+      // kindred#2538 asked for `setError(null)` in the closed->open effect.
+      // The per-open remount does it instead, and covers the other two states
+      // with it.
+      expect(screen.queryByText(/Split exploded/i)).not.toBeInTheDocument()
+    })
+
+    // NOTE: this one passes BEFORE the conversion as well as after, and is
+    // kept deliberately rather than as a TDD red. The closed->open effect
+    // already re-initializes `selectedSources` (kindred#2538 says as much), so
+    // this pins behaviour the conversion must not BREAK -- the effect has to
+    // keep firing once the body is remounted per open rather than reset in
+    // place.
+    it('re-derives the auto-selected sources from the CURRENT request when reopened', () => {
+      const firstLinks: ExtendedSourceLinkData[] = [
+        { original_request_id: 'orig_1', source_field: 'share_bunk_with', is_primary: true },
+        { original_request_id: 'orig_2', source_field: 'bunking_notes', is_primary: false },
+      ]
+      const { rerender } = renderWithProviders(
+        <SplitRequestModal
+          isOpen={true}
+          nonce={1}
+          onClose={() => {}}
+          request={createMergedMockRequest()}
+          sourceLinks={firstLinks}
+          onSplitComplete={() => {}}
+        />
+      )
+      // The non-primary source is auto-selected; staff untick it.
+      const firstBox = screen.getByRole('checkbox', { name: /bunking_notes/i })
+      expect(firstBox).toBeChecked()
+      fireEvent.click(firstBox)
+      expect(screen.getByRole('checkbox', { name: /bunking_notes/i })).not.toBeChecked()
+
+      rerender(
+        <QueryClientProvider client={new QueryClient()}>
+          <SplitRequestModal
+            isOpen={false}
+            nonce={1}
+            onClose={() => {}}
+            request={createMergedMockRequest()}
+            sourceLinks={firstLinks}
+            onSplitComplete={() => {}}
+          />
+        </QueryClientProvider>
+      )
+      rerender(
+        <QueryClientProvider client={new QueryClient()}>
+          <SplitRequestModal
+            isOpen={true}
+            nonce={2}
+            onClose={() => {}}
+            request={createMergedMockRequest()}
+            sourceLinks={firstLinks}
+            onSplitComplete={() => {}}
+          />
+        </QueryClientProvider>
+      )
+
+      // Reopening must present the default selection again, not the abandoned
+      // one — otherwise Split would act on a set the staffer had cleared.
+      expect(screen.getByRole('checkbox', { name: /bunking_notes/i })).toBeChecked()
+    })
+  })
 })

--- a/frontend/src/components/SplitRequestModal.tsx
+++ b/frontend/src/components/SplitRequestModal.tsx
@@ -23,10 +23,34 @@ interface SourceLinkData {
 interface SplitRequestModalProps {
   isOpen: boolean
   onClose: () => void
+  /**
+   * NOT nullable, and kindred#2538's ⛔ section is why it must stay that way.
+   *
+   * That section refutes widening this to `BunkRequestsResponse | null` plus
+   * an `if (!request) return null` guard: the effect dep array below
+   * dereferences `request.request_type` at RENDER time, before any guard line
+   * runs, and hoisting the guard above the hooks makes the hook count
+   * conditional ("Rendered more hooks than during the previous render").
+   *
+   * The conversion sidesteps the whole problem instead of solving it. The
+   * parent gates on `useRetainedDialog`'s retained SNAPSHOT
+   * (`splitDialog.data !== null`), which is non-null for as long as the dialog
+   * is mounted -- including throughout the exit fade. So this prop is never
+   * null while mounted and none of those dereferences need guarding. Do not
+   * "fix" this by making it nullable.
+   */
   request: BunkRequestsResponse
   sourceLinks: SourceLinkData[]
   isLoadingSourceLinks?: boolean
   onSplitComplete: () => void
+  /**
+   * Per-open nonce from kindred#2541's useRetainedDialog (kindred#2538). The
+   * remount is what clears a failed split's error banner, which would
+   * otherwise greet the next open.
+   */
+  nonce?: number
+  /** Modal's afterLeave, so the parent can release its retained snapshot. */
+  afterLeave?: () => void
 }
 
 interface SplitSourceConfig {
@@ -43,12 +67,40 @@ interface SplitResponse {
 
 export default function SplitRequestModal({
   isOpen,
+  nonce,
+  onClose,
+  afterLeave,
+  ...body
+}: SplitRequestModalProps) {
+  // Thin shell owning the chrome; the state lives in the body, keyed by the
+  // nonce so every open remounts it fresh. The key goes on the CONTENT and
+  // never on <Modal> — remounting the chrome mid-leave would snap the fading
+  // dialog away instead of fading it (kindred#2541).
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      // Spread: tsconfig sets exactOptionalPropertyTypes, so an explicit
+      // `undefined` is not assignable to Modal's `afterLeave?: () => void`.
+      {...(afterLeave !== undefined && { afterLeave })}
+      title="Split Request"
+      size="lg"
+    >
+      <SplitRequestForm key={nonce} isOpen={isOpen} onClose={onClose} {...body} />
+    </Modal>
+  )
+}
+
+type SplitRequestFormProps = Omit<SplitRequestModalProps, 'nonce' | 'afterLeave'>
+
+function SplitRequestForm({
+  isOpen,
   onClose,
   request,
   sourceLinks,
   isLoadingSourceLinks = false,
   onSplitComplete,
-}: SplitRequestModalProps) {
+}: SplitRequestFormProps) {
   const queryClient = useQueryClient()
   const { fetchWithAuth } = useApiWithAuth()
   const [selectedSources, setSelectedSources] = useState<Set<string>>(new Set())
@@ -230,7 +282,7 @@ export default function SplitRequestModal({
   // would defeat kindred#2529's parent conversion.
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title="Split Request" size="lg">
+    <>
       <div className="space-y-6">
         {/* Error display */}
         {error && (
@@ -430,6 +482,6 @@ export default function SplitRequestModal({
           </button>
         </div>
       </div>
-    </Modal>
+    </>
   )
 }

--- a/frontend/src/components/requestSort.test.ts
+++ b/frontend/src/components/requestSort.test.ts
@@ -7,7 +7,12 @@
  * back on refresh.
  */
 import { describe, it, expect } from 'vitest'
-import { sortRequests, DEFAULT_SORT_BY, DEFAULT_SORT_ORDER } from './requestSort'
+import {
+  sortRequests,
+  orderByTablePosition,
+  DEFAULT_SORT_BY,
+  DEFAULT_SORT_ORDER,
+} from './requestSort'
 import type { BunkRequestsResponse, PersonsResponse } from '../types/pocketbase-types'
 
 describe('requests-tab default sort constants', () => {
@@ -196,5 +201,34 @@ describe('sortRequests — column click behavior preserved', () => {
       'high',
       'low',
     ])
+  })
+})
+
+/**
+ * kindred#2538 scan, finding 1. The merge dialog seeds `selectedTargetId` from
+ * `requests[0]` and POSTs it as `keep_target_from`, so the ORDER of the pair
+ * handed to it is load-bearing. Both of RequestReviewPanel's openers now build
+ * that pair through this helper, so they cannot disagree.
+ */
+describe('orderByTablePosition', () => {
+  const table = [{ id: 'c' }, { id: 'a' }, { id: 'b' }]
+
+  it('orders a subset by its position in the table, not by the subset order', () => {
+    const picked = [{ id: 'b' }, { id: 'c' }]
+    expect(orderByTablePosition(picked, table).map((r) => r.id)).toEqual(['c', 'b'])
+  })
+
+  it('leaves a member the table does not contain at the end rather than dropping it', () => {
+    // The reason the caller filters `requests` and not `sortedRequests`: an
+    // active search can hide a row that is still a legitimate merge member.
+    // Losing it would open a one-item merge dialog.
+    const picked = [{ id: 'hidden' }, { id: 'b' }]
+    expect(orderByTablePosition(picked, table).map((r) => r.id)).toEqual(['b', 'hidden'])
+  })
+
+  it('does not mutate the array it is given', () => {
+    const picked = [{ id: 'b' }, { id: 'a' }]
+    orderByTablePosition(picked, table)
+    expect(picked.map((r) => r.id)).toEqual(['b', 'a'])
   })
 })

--- a/frontend/src/components/requestSort.ts
+++ b/frontend/src/components/requestSort.ts
@@ -105,3 +105,30 @@ export function sortRequests(
     return aValue < bValue ? -direction : direction
   })
 }
+
+/**
+ * Order `picked` by each member's position in `table`, without mutating either.
+ *
+ * kindred#2538: the merge dialog seeds `selectedTargetId` from `requests[0]`
+ * and POSTs that as `keep_target_from`, so the order of the pair it is handed
+ * decides which request survives a merge by default. RequestReviewPanel opens
+ * that dialog from two places — the toolbar button and the conflict banner —
+ * and they must agree.
+ *
+ * `picked` is sourced from the UNFILTERED request list on purpose while the
+ * ORDER comes from the visible, sorted table. Sourcing from the table itself
+ * would let an active search filter drop a legitimate merge member and open a
+ * one-item dialog; anything the table does not contain is therefore kept, and
+ * parked at the end.
+ */
+export function orderByTablePosition<T extends { id: string }>(
+  picked: T[],
+  table: { id: string }[]
+): T[] {
+  const position = new Map(table.map((r, i) => [r.id, i]))
+  return [...picked].sort(
+    (a, b) =>
+      (position.get(a.id) ?? Number.POSITIVE_INFINITY) -
+      (position.get(b.id) ?? Number.POSITIVE_INFINITY)
+  )
+}

--- a/frontend/src/components/weekend/WeekendScenarioPicker.tsx
+++ b/frontend/src/components/weekend/WeekendScenarioPicker.tsx
@@ -122,10 +122,13 @@ export function WeekendScenarioPicker({
         </button>
       )}
 
-      {canManage && showManageModal && (
+      {/* `canManage` stays a MOUNT gate -- a permission, not an open flag.
+          `isOpen` drives the fade (kindred#2538). */}
+      {canManage && (
         <ScenarioManagementModal
           sessionId={sessionCmId}
           emptyLabel={EMPTY_LABEL}
+          isOpen={showManageModal}
           onClose={() => {
             setShowManageModal(false)
           }}

--- a/frontend/src/components/weekend/WeekendScenarioPicker.tsx
+++ b/frontend/src/components/weekend/WeekendScenarioPicker.tsx
@@ -46,9 +46,7 @@ export function WeekendScenarioPicker({
   scenario,
 }: WeekendScenarioPickerProps) {
   const { currentScenario, scenarios, selectScenario, isLoading } = useScenario()
-  // kindred#2538: always-mounted so ui/Modal's 150ms leave can play. See
-  // SessionView's twin for why <void> -- no snapshot to retain, but the
-  // per-open nonce still remounts the form fresh.
+  // kindred#2538: always-mounted so ui/Modal's 150ms leave can play.
   // <true> rather than <void>: this dialog retains no payload, but eslint's
   // @typescript-eslint/no-invalid-void-type bans a void type argument, and
   // tsc alone does not -- kindred#2549's review flagged that the hook cannot

--- a/frontend/src/components/weekend/WeekendScenarioPicker.tsx
+++ b/frontend/src/components/weekend/WeekendScenarioPicker.tsx
@@ -26,6 +26,7 @@ import ModeBadge from '../ModeBadge'
 import NewScenarioModal from '../NewScenarioModal'
 import ScenarioManagementModal from '../ScenarioManagementModal'
 import { useScenario } from '../../hooks/useScenario'
+import { useRetainedDialog } from '../../hooks/useRetainedDialog'
 
 /** The one deliberate wording divergence from summer (CLAUDE.md §4). */
 const EMPTY_LABEL = 'Start with an empty plan'
@@ -45,7 +46,15 @@ export function WeekendScenarioPicker({
   scenario,
 }: WeekendScenarioPickerProps) {
   const { currentScenario, scenarios, selectScenario, isLoading } = useScenario()
-  const [showNewModal, setShowNewModal] = useState(false)
+  // kindred#2538: always-mounted so ui/Modal's 150ms leave can play. See
+  // SessionView's twin for why <void> -- no snapshot to retain, but the
+  // per-open nonce still remounts the form fresh.
+  // <true> rather than <void>: this dialog retains no payload, but eslint's
+  // @typescript-eslint/no-invalid-void-type bans a void type argument, and
+  // tsc alone does not -- kindred#2549's review flagged that the hook cannot
+  // express the no-snapshot variant, and this is the shape of that gap. The
+  // literal is inert; only isOpen and nonce are read.
+  const newDialog = useRetainedDialog<true>()
   const [showManageModal, setShowManageModal] = useState(false)
 
   // Read from the SCOPED value, not from `currentScenario` directly: a
@@ -54,7 +63,7 @@ export function WeekendScenarioPicker({
 
   const handleChange = (value: string) => {
     if (value === 'new') {
-      setShowNewModal(true)
+      newDialog.open(true)
       return
     }
     selectScenario(value === 'production' ? null : value)
@@ -123,31 +132,33 @@ export function WeekendScenarioPicker({
         />
       )}
 
-      {showNewModal && (
-        <NewScenarioModal
-          sessionId={sessionCmId}
-          emptyLabel={EMPTY_LABEL}
-          onClose={() => {
-            setShowNewModal(false)
-          }}
-          onScenarioCreated={(created) => {
-            // The create call already did the copy server-side (kindred#2021)
-            // — nothing left to do here but close and report, matching
-            // summer's own "+ New Scenario" flow (SessionView.tsx).
-            setShowNewModal(false)
-            // copy_skipped names a mirror/source row whose party or unit no
-            // longer resolves — surfaced so staff don't discover fewer
-            // families than expected with no explanation. Undefined for a
-            // blank creation and always for summer (its copy loop doesn't
-            // count skips), so only a truthy count changes the wording.
-            toast.success(
-              created.copy_skipped
-                ? `Created scenario: ${created.name}. Skipped ${String(created.copy_skipped)} — the family or cabin no longer resolves.`
-                : `Created scenario: ${created.name}`
-            )
-          }}
-        />
-      )}
+      {/* Unconditional: kindred#2538 keeps this mounted so the exit fade can
+          play, with `isOpen` driving it instead of the mount. */}
+      <NewScenarioModal
+        isOpen={newDialog.isOpen}
+        nonce={newDialog.nonce}
+        sessionId={sessionCmId}
+        emptyLabel={EMPTY_LABEL}
+        onClose={() => {
+          newDialog.close()
+        }}
+        onScenarioCreated={(created) => {
+          // The create call already did the copy server-side (kindred#2021)
+          // — nothing left to do here but close and report, matching
+          // summer's own "+ New Scenario" flow (SessionView.tsx).
+          newDialog.close()
+          // copy_skipped names a mirror/source row whose party or unit no
+          // longer resolves — surfaced so staff don't discover fewer
+          // families than expected with no explanation. Undefined for a
+          // blank creation and always for summer (its copy loop doesn't
+          // count skips), so only a truthy count changes the wording.
+          toast.success(
+            created.copy_skipped
+              ? `Created scenario: ${created.name}. Skipped ${String(created.copy_skipped)} — the family or cabin no longer resolves.`
+              : `Created scenario: ${created.name}`
+          )
+        }}
+      />
     </>
   )
 }

--- a/frontend/src/pages/WeekendRosterPage.codeSplitting.test.tsx
+++ b/frontend/src/pages/WeekendRosterPage.codeSplitting.test.tsx
@@ -52,6 +52,17 @@ vi.mock('../hooks/useApiWithAuth', () => ({
   useApiWithAuth: () => ({ fetchWithAuth: vi.fn(), isAuthenticated: true, isAuthLoading: false }),
 }))
 
+// New since kindred#2538: WeekendScenarioPicker now keeps
+// ScenarioManagementModal MOUNTED so its close can play an exit fade, and that
+// modal calls `useSyncStatusAPI`, which calls `useAuth`. The dialog's query is
+// gated on `isOpen`, but the hook itself runs at the permanent mount. The real
+// app always has the provider (App.tsx wraps everything in AuthProvider); this
+// file's convention, like WeekendRosterPage.test.tsx's, is to stub the
+// auth-touching hooks rather than mount one.
+vi.mock('../hooks/useSyncStatusAPI', () => ({
+  useSyncStatusAPI: () => ({ data: undefined }),
+}))
+
 vi.mock('@tanstack/react-query', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-query')>()
   return { ...actual, useQueryClient: () => ({ invalidateQueries: vi.fn() }) }

--- a/frontend/src/pages/WeekendRosterPage.test.tsx
+++ b/frontend/src/pages/WeekendRosterPage.test.tsx
@@ -50,6 +50,18 @@ vi.mock('../hooks/useApiWithAuth', () => ({
   useApiWithAuth: () => ({ fetchWithAuth: vi.fn(), isAuthenticated: true, isAuthLoading: false }),
 }))
 
+// Same reason, new since kindred#2538: WeekendScenarioPicker now keeps
+// ScenarioManagementModal MOUNTED so its close can play an exit fade, and that
+// modal calls `useSyncStatusAPI`, which calls `useAuth`. The dialog's query is
+// gated on `isOpen`, but the hook itself still runs at the permanent mount --
+// so without this stub every test in the file dies on "useAuth must be used
+// within an AuthProvider", exactly as the note above describes. The real app
+// always has the provider (App.tsx wraps everything in AuthProvider); this
+// file's convention is to stub the auth-touching hooks rather than mount one.
+vi.mock('../hooks/useSyncStatusAPI', () => ({
+  useSyncStatusAPI: () => ({ data: undefined }),
+}))
+
 vi.mock('@tanstack/react-query', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-query')>()
   return { ...actual, useQueryClient: () => ({ invalidateQueries: vi.fn() }) }


### PR DESCRIPTION
Closes #2538.

All six of #2538's tier-2b dialogs, one commit each. #2530 gave `ui/Modal` a 150ms leave; a dialog only plays it if it stays mounted past the close, which costs it the free state wipe the unmount used to provide.

| dialog | reset mechanism | why |
|---|---|---|
| NewScenarioModal | `key={nonce}` on a split-out body | `copyFrom`'s default is derived from a prop |
| CreateRequestModal | **render-time correction** | Modal's `footer` is a *prop* that reads the state |
| MergeRequestsModal | `key={nonce}` | re-seeds `selectedTargetId` — a correctness bug |
| SplitRequestModal | `key={nonce}` | clears a failed split's error banner |
| ScenarioEditModal | `key={nonce}` | gate WAS the data; needs the parent latch |
| ScenarioManagementModal | falling-edge child clear | children are *siblings* of its Modal |

## Where the issue's plan didn't survive contact

#2538 predicted `key={nonce}` would carry most of this. It carries four of six, and the two exceptions are structural rather than stylistic — both are recorded at the divergence:

- **CreateRequestModal** — its footer is a `<Modal footer={…}>` prop reading four of the eight states, and Modal renders `footer` *outside* the scrollable area, which is what pins it. Moving the state into a keyed child would leave the buttons scrolling with the form; keying the shell is the one thing #2541 forbids. It uses the render-time correction pattern (`usePanelParty`, `useRetainedDialog`'s `resetWhen`) instead — exactly equivalent to a remount here, because all eight initializers are static constants.
- **ScenarioManagementModal** — its confirm dialog and both child dialogs render as *siblings* of its Modal, so the state cannot move below the chrome at all.

**SplitRequestModal's ⛔ refuted fix is sidestepped, not solved.** The issue documents that widening `request` to nullable crashes two ways. The retained snapshot removes the premise: `splitDialog.data` is non-null for as long as the dialog is mounted, the fade included, so `request` stays non-nullable and none of the pre-hook dereferences need guarding. The prop's docstring says so, because the next reader will otherwise reach for the refuted fix again.

**ScenarioManagementModal's child-clearing is on the isOpen falling edge, not in `onClose`** as the issue suggested. `onClose` only fires for a user-initiated close, so a parent dropping `isOpen` itself would still strand a confirm prompt on screen with its parent gone.

## Two things found by mutation-checking that reasoning had got wrong

1. **MergeRequestsModal's two fetch tests were passing for the wrong reason.** The file's `vi.resetAllMocks()` blanks `pb.collection` so it returns `undefined`; the query threw before reaching the spy, so "was not called" held whether or not anything was gated. The mock is re-armed per test now.
2. **Once fixed, ungating the query *still* left them green** — `<Modal isOpen={false}>` renders no children, so a split-out body and its `useQuery` are never mounted while closed. The `enabled: isOpen` gate the issue asked for is real but is **defence in depth**, covering only the exit-fade window. Either mechanism alone suffices; removing both is what reds the tests. The comments say that rather than implying the gate is load-bearing.

## One cost the issue predicted but not the shape of

#2538 called ScenarioManagementModal's permanent-mount auth listener "cheap, but present". It is also a hard **coupling**: `useSyncStatusAPI` calls `useAuth`, which *throws* without a provider — so every page rendering `WeekendScenarioPicker` now needs one in scope. Production always has it (`App.tsx` wraps the app in `AuthProvider`); the two `WeekendRosterPage` test files stub the hook, which is the convention those files already document for `useApiWithAuth` for exactly this reason.

## Tier 3 unchanged

`AssignFamilyModal`, `PreValidationResultsModal`, `PostValidationResultsModal`, `HouseholdYearMembersModal` — deliberately not converted, per the issue.

## Verification

- **Full frontend suite green: 463 files, 7544 tests, exit 0.** `tsc --noEmit` clean, eslint 0 errors.
- Every reset test written first and verified red, then mutation-checked: removing `key={nonce}` (or disabling the render-time correction) reds exactly the reset tests and nothing else.
- Exit-fade tests pin **both** halves — painted on the close frame *and* gone once the leave completes. The presence half alone passes vacuously against a component that hardcodes `isOpen={true}` and so never unmounts at all.
- Test fallout the issue predicted: four overlayStack Escape tests asserted a child was gone *synchronously*; their DOM now outlives the close by the fade, so they await it — the same change that file's confirm-dialog pair already carries.

## Note on the base

Branched from `main` at `c23c3cb0`, which does **not** include #2554 (the #2553 flake fix). Two `WeekendRosterPage.codeSplitting` failures seen here were that known flake, plus a genuine `useAuth` regression from this work in the same file; the `useAuth` half is fixed in this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal closing animations by keeping dialogs mounted until transitions finish.
  * Reset form fields, searches, selections, and errors correctly when reopening dialogs.
  * Prevented unnecessary data loading while dialogs are closed.
  * Ensured dialogs refresh with the latest scenario and request information when reopened.
  * Improved cleanup of nested dialogs when parent dialogs close.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->