### PR TITLE
feat(frontend): the share marks glow and breathe on arrival

### DIFF
--- a/frontend/src/components/weekend/LodgingBoard.emphasis.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.emphasis.test.tsx
@@ -1,21 +1,30 @@
 /**
- * The board arms the share-emphasis burst exactly once, and a drag kills it.
+ * The board arms the share-emphasis burst exactly once, and either drag kills
+ * it.
  *
  * The hook's own rules are pinned in `hooks/useShareEmphasisBurst.test.tsx`
  * and the timeline's in `shareEmphasis.test.ts`; this file exists for the one
  * thing neither can see — that the board is actually WIRED to them, and that
  * a halo reaches the DOM through `FamilyCard` -> `ShareMarks`.
  *
+ * "Either drag" is load-bearing and is why the drag cases below are two, not
+ * one. The board holds `dragging` AND `draggingMergeUnit`, and
+ * `handleDragStart` sets exactly one of them per gesture — so a suppression
+ * that reads only the first is dead through every merge. A hook test cannot
+ * catch that; it only ever sees the boolean the board already computed.
+ *
  * Fictional data throughout.
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render } from '@testing-library/react'
+import { act, render } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { MemoryRouter } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+import { mergeDragId } from './dragPlacement'
 import { LodgingBoard } from './LodgingBoard'
+import { partyKey } from './partyKey'
 import {
   SHARE_MOTION_SELECTOR,
   defaultShareEmphasisRunner,
@@ -47,6 +56,34 @@ vi.mock('../../hooks/useUnitAvailability', () => ({
   useUnitAvailability: () => ({ setAvailability: vi.fn(), pendingUnitId: '' }),
 }))
 
+/**
+ * The last `onDragStart` the board handed to DndContext.
+ *
+ * jsdom cannot perform a pointer drag — every element measures 0x0, so dnd-kit
+ * has nothing to collide. The settled idiom in this repo (see
+ * `LodgingBoard.drag.test.tsx`) is to mock at the boundary and deliver the
+ * exact event dnd-kit would have, which exercises the board's real
+ * `handleDragStart` and the real state it sets.
+ */
+let onDragStart: ((event: unknown) => void) | undefined
+
+vi.mock('@dnd-kit/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@dnd-kit/core')>()
+  return {
+    ...actual,
+    DndContext: ({
+      children,
+      onDragStart: startHandler,
+    }: {
+      children: ReactNode
+      onDragStart: (e: unknown) => void
+    }) => {
+      onDragStart = startHandler
+      return <div data-testid="dnd-context">{children}</div>
+    },
+  }
+})
+
 /** Stands in for the GSAP timeline — this file asserts on the WIRING, not the motion. */
 function fakeBurst(): ShareEmphasisBurst {
   const burst = { targets: [] as HTMLElement[], active: true, kill: (): void => {} }
@@ -58,11 +95,19 @@ function fakeBurst(): ShareEmphasisBurst {
 
 let client: QueryClient
 let run: ReturnType<typeof vi.spyOn>
+/** Every burst the board armed this test, so a kill can be observed. */
+let bursts: ShareEmphasisBurst[]
 
 beforeEach(() => {
   vi.restoreAllMocks()
+  onDragStart = undefined
+  bursts = []
   client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  run = vi.spyOn(defaultShareEmphasisRunner, 'run').mockImplementation(() => fakeBurst())
+  run = vi.spyOn(defaultShareEmphasisRunner, 'run').mockImplementation(() => {
+    const burst = fakeBurst()
+    bursts.push(burst)
+    return burst
+  })
 })
 
 function wrapper({ children }: { children: ReactNode }) {
@@ -149,5 +194,37 @@ describe('LodgingBoard — the share-emphasis burst', () => {
     expect(run).not.toHaveBeenCalled()
     rerender(<LodgingBoard parties={[party()]} units={[unit()]} year={2026} />)
     expect(run).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('LodgingBoard — a drag kills the burst, and there are TWO kinds of drag', () => {
+  function armBoard(): ShareEmphasisBurst {
+    render(<LodgingBoard parties={[party()]} units={[unit()]} year={2026} />, { wrapper })
+    if (!onDragStart) throw new Error('the board never registered a drag-start handler')
+    const burst = bursts[0]
+    if (!burst) throw new Error('the board never armed a burst')
+    expect(burst.active).toBe(true)
+    return burst
+  }
+
+  it('suppresses on a party drag — the card gesture staff use most', () => {
+    const burst = armBoard()
+    act(() => {
+      onDragStart?.({ active: { id: partyKey(party()) } })
+    })
+    expect(burst.active).toBe(false)
+  })
+
+  it('suppresses on a merge-handle drag, which never sets `dragging` at all', () => {
+    // `handleDragStart` takes the merge branch with `setDraggingMergeUnit(...)`
+    // and `setDragging(null)`, so `dragging` stays null for the WHOLE merge
+    // gesture. Suppression keyed on `dragging` alone therefore reads "no drag
+    // in flight" while the marks pulse over #2528's hatch/wash highlight —
+    // exactly the precision task the suppression rule exists to protect.
+    const burst = armBoard()
+    act(() => {
+      onDragStart?.({ active: { id: mergeDragId('cedar-1') } })
+    })
+    expect(burst.active).toBe(false)
   })
 })

--- a/frontend/src/components/weekend/LodgingBoard.emphasis.test.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.emphasis.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * The board arms the share-emphasis burst exactly once, and a drag kills it.
+ *
+ * The hook's own rules are pinned in `hooks/useShareEmphasisBurst.test.tsx`
+ * and the timeline's in `shareEmphasis.test.ts`; this file exists for the one
+ * thing neither can see — that the board is actually WIRED to them, and that
+ * a halo reaches the DOM through `FamilyCard` -> `ShareMarks`.
+ *
+ * Fictional data throughout.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { MemoryRouter } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+import { LodgingBoard } from './LodgingBoard'
+import {
+  SHARE_MOTION_SELECTOR,
+  defaultShareEmphasisRunner,
+  type ShareEmphasisBurst,
+} from './shareEmphasis'
+
+vi.mock('../../hooks/usePermissions', () => ({
+  usePermissions: () => ({
+    isAdmin: true,
+    permissions: [],
+    hasPermission: () => true,
+    hasAnyPermission: () => true,
+  }),
+}))
+
+vi.mock('../../hooks/useWeekendRoster', () => ({
+  useHouseholdMedical: () => ({ data: undefined, isLoading: false, error: null }),
+}))
+
+vi.mock('../../hooks/useLodgingPlacement', () => ({
+  useLodgingPlacement: () => ({ move: vi.fn(), isMoving: false }),
+}))
+
+vi.mock('../../hooks/useUnitMerge', () => ({
+  useUnitMerge: () => ({ setCombined: vi.fn(), pendingUnitId: null }),
+}))
+
+vi.mock('../../hooks/useUnitAvailability', () => ({
+  useUnitAvailability: () => ({ setAvailability: vi.fn(), pendingUnitId: '' }),
+}))
+
+/** Stands in for the GSAP timeline — this file asserts on the WIRING, not the motion. */
+function fakeBurst(): ShareEmphasisBurst {
+  const burst = { targets: [] as HTMLElement[], active: true, kill: (): void => {} }
+  burst.kill = (): void => {
+    burst.active = false
+  }
+  return burst
+}
+
+let client: QueryClient
+let run: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  run = vi.spyOn(defaultShareEmphasisRunner, 'run').mockImplementation(() => fakeBurst())
+})
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={['/weekend/fc1/housing']}>{children}</MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
+  return {
+    unit_id: 'u1',
+    code: 'cedar-1',
+    name: 'Cedar 1',
+    area_code: 'CG',
+    area_name: 'Cedar Grove',
+    sleeps: 5,
+    bathroom: 'shared',
+    bathroom_group: '',
+    near_bathhouse: false,
+    has_power: false,
+    has_ac: false,
+    has_fridge: false,
+    is_accessible: false,
+    is_confirmed: false,
+    is_active: true,
+    is_container: false,
+    inventory_class: 'family_pool',
+    family_available_override: null,
+    reason: '',
+    is_family_available: true,
+    map_x: 0.5,
+    map_y: 0.5,
+    ...overrides,
+  }
+}
+
+function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
+  return {
+    grain: 'household',
+    household_cm_id: 1000001,
+    display_name: 'Johnson',
+    sort_name: 'Johnson',
+    adults: [{ adult_number: 1, display_name: 'Emma Johnson', relationship: 'Mother' }],
+    children: [{ person_cm_id: 9001, display_name: 'Samuel Johnson', age: 8, grade: 3 }],
+    party_size: 3,
+    unit_code: 'cedar-1',
+    unit_name: 'Cedar 1',
+    is_merged_slot: false,
+    arrival_eta: '',
+    is_returning: false,
+    share: { preference: 'yes_share' },
+    ...overrides,
+  }
+}
+
+describe('LodgingBoard — the share-emphasis burst', () => {
+  it('draws the halo on an open-to-sharing household', () => {
+    const { container } = render(
+      <LodgingBoard parties={[party()]} units={[unit()]} year={2026} />,
+      {
+        wrapper,
+      }
+    )
+    expect(container.querySelectorAll(SHARE_MOTION_SELECTOR).length).toBeGreaterThan(0)
+  })
+
+  it('arms the burst once on arrival and never again on a refetch', () => {
+    const { rerender } = render(<LodgingBoard parties={[party()]} units={[unit()]} year={2026} />, {
+      wrapper,
+    })
+    expect(run).toHaveBeenCalledTimes(1)
+    // A refetch hands the board a fresh array with the same content — the
+    // failure this test exists for is a board that re-breathes on it.
+    rerender(<LodgingBoard parties={[party()]} units={[unit()]} year={2026} />)
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not arm on an empty roster, so the first real payload still gets its burst', () => {
+    const { rerender } = render(<LodgingBoard parties={[]} units={[unit()]} year={2026} />, {
+      wrapper,
+    })
+    expect(run).not.toHaveBeenCalled()
+    rerender(<LodgingBoard parties={[party()]} units={[unit()]} year={2026} />)
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -289,11 +289,19 @@ export function LodgingBoard({
    * `parties.length > 0` is that moment — the board renders empty while the
    * page's query is still in flight, and the first payload is the arrival.
    *
-   * It reads the SAME `dragging` state the unit cards receive as
-   * `draggingParty`, deliberately, rather than threading a new prop down
-   * through `FamilyCard`: one drag signal, one meaning.
+   * Suppression reads BOTH drag states, and it has to. `handleDragStart`
+   * splits the two gestures: a merge-handle drag takes the early-return branch
+   * that sets `draggingMergeUnit` and `setDragging(null)`, so `dragging` stays
+   * null for the entire merge. Keying this on `dragging` alone therefore reads
+   * "no drag in flight" through the one gesture that puts #2528's three-state
+   * hatch/wash highlight on every unit card — the precision task the marks are
+   * not allowed to compete with. Whatever else is added here, a new drag state
+   * has to be added to this expression too.
    */
-  useShareEmphasisBurst({ ready: parties.length > 0, suppressed: dragging !== null })
+  useShareEmphasisBurst({
+    ready: parties.length > 0,
+    suppressed: dragging !== null || draggingMergeUnit !== null,
+  })
 
   // THREE conditions, not two. `sessionCmId` is in there because every write
   // names a weekend, and the prop defaults to 0 for the thirty tests that do

--- a/frontend/src/components/weekend/LodgingBoard.tsx
+++ b/frontend/src/components/weekend/LodgingBoard.tsx
@@ -45,6 +45,7 @@ import { useSearchParams } from 'react-router'
 import { useDismissOnDeadSpace } from '../../hooks/useDismissOnDeadSpace'
 import { useLodgingPlacement } from '../../hooks/useLodgingPlacement'
 import { usePanelParty } from '../../hooks/usePanelParty'
+import { useShareEmphasisBurst } from '../../hooks/useShareEmphasisBurst'
 import { useUnitAvailability } from '../../hooks/useUnitAvailability'
 import { useUnitMerge } from '../../hooks/useUnitMerge'
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
@@ -280,6 +281,19 @@ export function LodgingBoard({
   const [dragging, setDragging] = useState<RosterPartyRow | null>(null)
   /** The card currently being dragged BY ITS MERGE HANDLE, for grey-out. */
   const [draggingMergeUnit, setDraggingMergeUnit] = useState<LodgingUnitRow | null>(null)
+
+  /*
+   * The share marks' arrival burst (spec 2026-08-24 §5), armed HERE rather
+   * than in `ShareMarks` because it is a board-level event: the marks
+   * cascade once when the roster becomes visible, not once per card mount.
+   * `parties.length > 0` is that moment — the board renders empty while the
+   * page's query is still in flight, and the first payload is the arrival.
+   *
+   * It reads the SAME `dragging` state the unit cards receive as
+   * `draggingParty`, deliberately, rather than threading a new prop down
+   * through `FamilyCard`: one drag signal, one meaning.
+   */
+  useShareEmphasisBurst({ ready: parties.length > 0, suppressed: dragging !== null })
 
   // THREE conditions, not two. `sessionCmId` is in there because every write
   // names a weekend, and the prop defaults to 0 for the thirty tests that do

--- a/frontend/src/components/weekend/ShareMarks.test.tsx
+++ b/frontend/src/components/weekend/ShareMarks.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
 import type { RosterPartyRow } from '../../types/lodging'
+import { SHARE_GLOW_CLASS, SHARE_MOTION_SELECTOR } from './shareEmphasis'
 import { ShareMarks } from './ShareMarks'
 
 function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
@@ -64,5 +65,149 @@ describe('ShareMarks — anchor and cluster are independent', () => {
     render(<ShareMarks party={party({ share: { preference: 'yes_share' } })} />)
     expect(screen.getByRole('button', { name: 'Share: Open to sharing' })).toBeInTheDocument()
     expect(screen.queryByTestId('share-cluster')).not.toBeInTheDocument()
+  })
+})
+
+/**
+ * The emphasis treatment — spec 2026-08-24 §3 ("The halo") and §4 ("why the
+ * halo and the motion ride different elements"). Four card shapes, one row of
+ * §3's table each, plus the two rules the geometry finding produced.
+ */
+describe('ShareMarks — the emphasis halo, per card shape (§3)', () => {
+  /** The halo/transform vehicles inside one rendered card, in document order. */
+  const vehicles = (container: HTMLElement): HTMLElement[] =>
+    Array.from(container.querySelectorAll<HTMLElement>(SHARE_MOTION_SELECTOR))
+
+  it('anchor yes, no cluster ticks: one halo, on the anchor circle', () => {
+    const { container } = render(
+      <ShareMarks party={party({ share: { preference: 'yes_share' } })} />
+    )
+    const found = vehicles(container)
+    expect(found).toHaveLength(1)
+    expect(found[0]?.className).toContain(SHARE_GLOW_CLASS)
+    expect(found[0]?.contains(screen.getByRole('button', { name: 'Share: Open to sharing' }))).toBe(
+      true
+    )
+  })
+
+  it('a hot cluster: one halo on the CAPSULE, hugging NEAR along with it', () => {
+    // WITH + NEAR flush-joined — the mixed capsule §3's capsule halo exists
+    // for, ~11 of 88 emphasized households in 2026.
+    const { container } = render(
+      <ShareMarks
+        party={party({
+          share: { preference: 'no_share', proximity: ['near'], wants_with_named: true },
+        })}
+      />
+    )
+    const found = vehicles(container)
+    expect(found).toHaveLength(1)
+    expect(found[0]).toBe(screen.getByTestId('share-cluster'))
+    expect(found[0]?.className).toContain(SHARE_GLOW_CLASS)
+  })
+
+  it('a similar-age-only cluster is hot too (the 8-household case)', () => {
+    const { container } = render(
+      <ShareMarks
+        party={party({ share: { preference: 'no_share', proximity: ['similar_ages'] } })}
+      />
+    )
+    expect(vehicles(container)).toHaveLength(1)
+  })
+
+  it('anchor yes AND a hot cluster: TWO separate halos, never one merged', () => {
+    const { container } = render(
+      <ShareMarks
+        party={party({
+          share: { preference: 'yes_share', proximity: ['near'], wants_with_named: true },
+        })}
+      />
+    )
+    const found = vehicles(container)
+    expect(found).toHaveLength(2)
+    const [anchorVehicle, clusterVehicle] = found as [HTMLElement, HTMLElement]
+    expect(clusterVehicle).toBe(screen.getByTestId('share-cluster'))
+    // Separate questions: neither halo may swallow the other, which is what a
+    // single vehicle wrapping both would draw.
+    expect(anchorVehicle.contains(clusterVehicle)).toBe(false)
+    expect(clusterVehicle.contains(anchorVehicle)).toBe(false)
+    expect(anchorVehicle.className).toContain(SHARE_GLOW_CLASS)
+    expect(clusterVehicle.className).toContain(SHARE_GLOW_CLASS)
+  })
+
+  it('a NEAR-only cluster gets nothing — proximity is not sharing (147 households)', () => {
+    const { container } = render(
+      <ShareMarks party={party({ share: { preference: 'no_share', proximity: ['near'] } })} />
+    )
+    expect(vehicles(container)).toHaveLength(0)
+    expect(container.querySelector(`.${SHARE_GLOW_CLASS}`)).toBeNull()
+  })
+
+  it.each(['maybe_mutual', 'no_share', 'unknown'] as const)(
+    'a %s anchor never glows',
+    (preference) => {
+      const { container } = render(<ShareMarks party={party({ share: { preference } })} />)
+      expect(vehicles(container)).toHaveLength(0)
+    }
+  )
+
+  it('renders no vehicle for a person-grain party, which has no share question', () => {
+    const { container } = render(<ShareMarks party={party({ grain: 'person' })} />)
+    expect(vehicles(container)).toHaveLength(0)
+  })
+})
+
+describe('ShareMarks — the transform vehicle is the capsule, never a glyph (§4)', () => {
+  it('stamps the wrapper, and no button inside it', () => {
+    // Measured 2026-08-24: scaling one glyph inside a flush capsule takes it
+    // to 21.45px beside its 20px neighbour and the pill goes lopsided. The
+    // wrapper scales both halves proportionally.
+    const { container } = render(
+      <ShareMarks
+        party={party({
+          share: {
+            preference: 'no_share',
+            proximity: ['near', 'similar_ages'],
+            wants_with_named: true,
+          },
+        })}
+      />
+    )
+    const found = Array.from(container.querySelectorAll<HTMLElement>(SHARE_MOTION_SELECTOR))
+    expect(found).toHaveLength(1)
+    expect(found[0]?.tagName).toBe('SPAN')
+    for (const button of container.querySelectorAll('button')) {
+      expect(button.matches(SHARE_MOTION_SELECTOR)).toBe(false)
+      expect(button.className).not.toContain(SHARE_GLOW_CLASS)
+    }
+  })
+
+  it('leaves every fill exactly as the parent spec locked it', () => {
+    // Emphasis is a halo plus motion layer and nothing else — a treatment
+    // that recoloured NEAR would contradict green-means-share.
+    render(
+      <ShareMarks
+        party={party({
+          share: { preference: 'yes_share', proximity: ['near'], wants_with_named: true },
+        })}
+      />
+    )
+    expect(screen.getByRole('button', { name: 'Near family' }).className).toContain('bg-indigo-100')
+    expect(screen.getByRole('button', { name: 'Share with family' }).className).toContain(
+      'bg-forest-100'
+    )
+    expect(screen.getByRole('button', { name: 'Share: Open to sharing' }).className).toContain(
+      'bg-forest-100'
+    )
+  })
+
+  it('keeps the halo in the markup, so a reduced-motion viewer still sees it', () => {
+    // The glow is the STATE; the breathe is only the entrance. Nothing in
+    // this component consults motion preference — `shareEmphasis` gates the
+    // burst — so the halo renders whether or not the burst ever runs.
+    const { container } = render(
+      <ShareMarks party={party({ share: { preference: 'yes_share' } })} />
+    )
+    expect(container.querySelector(`.${SHARE_GLOW_CLASS}`)).not.toBeNull()
   })
 })

--- a/frontend/src/components/weekend/ShareMarks.tsx
+++ b/frontend/src/components/weekend/ShareMarks.tsx
@@ -14,15 +14,46 @@
  * vocabulary module — every anchor state draws the same icon, so
  * `ShareAnchorSpec` carries no `Icon` field at all (see `shareMarks.ts`'s
  * header comment).
+ *
+ * ## The emphasis wrappers (spec 2026-08-24)
+ *
+ * Each mark family is wrapped in a span that carries the halo and the
+ * breathe for the "open to sharing" set — see `shareEmphasis.ts` for which
+ * marks qualify and why the transform must never land on a glyph inside a
+ * capsule. The wrappers render UNCONDITIONALLY so there is one DOM shape to
+ * reason about; only the glow class and the motion handle are conditional.
+ * The anchor and the cluster get SEPARATE wrappers even when both are hot,
+ * because they answer separate questions and the parent spec forbids the
+ * anchor looking merged into the cluster.
  */
 import { Handshake } from 'lucide-react'
 
 import type { RosterPartyRow } from '../../types/lodging'
 import { Tooltip } from '../ui/Tooltip'
+import { SHARE_GLOW_CLASS, anchorIsEmphasized, clusterIsEmphasized } from './shareEmphasis'
 import { CAP_CLASSES, clusterCap, resolveShareAnchor, resolveShareCluster } from './shareMarks'
 
 /** 20px frame, matching the glyph grid `NeedGlyphMark`'s `GLYPH_BASE` established. */
 const FRAME = 'flex h-5 w-5 items-center justify-center'
+
+/**
+ * The halo/transform vehicle.
+ *
+ * `rounded-full` is load-bearing, not decoration: the halo is a `box-shadow`
+ * on this wrapper, and a box-shadow follows the BORDER RADIUS. Without it the
+ * capsule's pill silhouette would wear a rectangular glow. The wrapper
+ * shrink-wraps its 20px content, so `rounded-full` resolves to the same 10px
+ * caps the marks inside already draw.
+ */
+const VEHICLE = 'inline-flex rounded-full'
+
+/*
+ * `data-share-emphasis-motion` below is spelled out rather than spread from
+ * `SHARE_MOTION_ATTR` — JSX cannot take a computed attribute name without a
+ * spread object, which reads worse than the literal. The coupling is pinned
+ * instead: `ShareMarks.test.tsx` queries with `SHARE_MOTION_SELECTOR`, so
+ * renaming the constant alone turns that suite red.
+ */
 
 export function ShareMarks({ party }: { party: RosterPartyRow }) {
   const anchor = resolveShareAnchor(party)
@@ -30,24 +61,36 @@ export function ShareMarks({ party }: { party: RosterPartyRow }) {
 
   if (!anchor && cluster.length === 0) return null
 
+  const anchorHot = anchorIsEmphasized(anchor)
+  const clusterHot = clusterIsEmphasized(cluster)
+
   return (
     <>
       {anchor && (
-        // Always its own circle — `CAP_CLASSES.solo`, never a capsule cap —
-        // because the anchor is a separate question from the cluster and
-        // must never look like it merged into it.
-        <Tooltip
-          content={anchor.tooltip}
-          aria-label={anchor.ariaLabel}
-          className={`${FRAME} ${anchor.className} ${CAP_CLASSES.solo}`}
+        <span
+          className={`${VEHICLE}${anchorHot ? ` ${SHARE_GLOW_CLASS}` : ''}`}
+          data-share-emphasis-motion={anchorHot ? '' : undefined}
         >
-          <Handshake className="h-3 w-3" />
-        </Tooltip>
+          {/* Always its own circle — `CAP_CLASSES.solo`, never a capsule cap —
+              because the anchor is a separate question from the cluster and
+              must never look like it merged into it. */}
+          <Tooltip
+            content={anchor.tooltip}
+            aria-label={anchor.ariaLabel}
+            className={`${FRAME} ${anchor.className} ${CAP_CLASSES.solo}`}
+          >
+            <Handshake className="h-3 w-3" />
+          </Tooltip>
+        </span>
       )}
       {cluster.length > 0 && (
         // No gap classes here — the cap classes' own `-ml-px` (right/middle)
         // IS the flush join; an added gap would reopen the seam.
-        <span className="inline-flex" data-testid="share-cluster">
+        <span
+          className={`${VEHICLE}${clusterHot ? ` ${SHARE_GLOW_CLASS}` : ''}`}
+          data-testid="share-cluster"
+          data-share-emphasis-motion={clusterHot ? '' : undefined}
+        >
           {cluster.map((mark, index) => {
             // Caps come from the mark's POSITION IN THE ARRAY, never CSS tree
             // position — `ui/Tooltip` nests each glyph in its own trigger

--- a/frontend/src/components/weekend/shareEmphasis.test.ts
+++ b/frontend/src/components/weekend/shareEmphasis.test.ts
@@ -164,13 +164,29 @@ describe('shareEmphasis — the burst', () => {
     expect(burst).not.toBeNull()
     expect(burst?.targets).toEqual([el])
     expect(burst?.active).toBe(true)
+    // A real ~6s timeline, and `afterEach` only restores mocks and clears the
+    // DOM — nothing there stops a GSAP ticker. Every sibling that starts an
+    // unmocked burst kills it, and so does this one.
+    burst?.kill()
   })
 
   it('kill() leaves the mark at its resting glow — no inline transform, nothing running', () => {
     mockReducedMotion(false)
     const el = mountVehicle()
     el.classList.add(SHARE_GLOW_CLASS)
+    const spy = vi.spyOn(gsap, 'timeline')
     const burst = defaultShareEmphasisRunner.run()
+    const timeline = spy.mock.results[0]?.value as gsap.core.Timeline
+    expect(timeline).toBeDefined()
+
+    // ADVANCE FIRST, or the assertion below is vacuous. A burst that has never
+    // been ticked has had no frame written, so `style.transform` is '' before
+    // the kill as well as after — a `settle()` that cleared nothing would sail
+    // through. Half a cycle in, the mark is at its peak and there is a real
+    // inline transform for the kill to have to remove.
+    timeline.time(SHARE_EMPHASIS_CYCLE_SECONDS / 2)
+    expect(el.style.transform).not.toBe('')
+
     burst?.kill()
     expect(burst?.active).toBe(false)
     expect(el.style.transform).toBe('')

--- a/frontend/src/components/weekend/shareEmphasis.test.ts
+++ b/frontend/src/components/weekend/shareEmphasis.test.ts
@@ -1,0 +1,194 @@
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  SHARE_EMPHASIS_AMP,
+  SHARE_EMPHASIS_CYCLES,
+  SHARE_EMPHASIS_CYCLE_SECONDS,
+  SHARE_EMPHASIS_PEAK_SCALE,
+  SHARE_EMPHASIS_STAGGER_SECONDS,
+  SHARE_GLOW_CLASS,
+  SHARE_MOTION_ATTR,
+  SHARE_MOTION_SELECTOR,
+  anchorIsEmphasized,
+  clusterIsEmphasized,
+  defaultShareEmphasisRunner,
+  prefersReducedMotion,
+  shareEmphasisTargets,
+} from './shareEmphasis'
+import type { ShareAnchorSpec, ShareClusterMark } from './shareMarks'
+
+const css = readFileSync(resolve(__dirname, '../../index.css'), 'utf-8')
+
+/** jsdom honours no media query at all — every reduced-motion read is mocked. */
+function mockReducedMotion(reduce: boolean): void {
+  vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => ({
+    matches: query.includes('prefers-reduced-motion') ? reduce : false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+}
+
+function mountVehicle(): HTMLElement {
+  const el = document.createElement('span')
+  el.setAttribute(SHARE_MOTION_ATTR, '')
+  document.body.appendChild(el)
+  return el
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  document.body.innerHTML = ''
+})
+
+describe('shareEmphasis — the locked knobs (spec §2)', () => {
+  it('carries the ruled intensity, cycle count, duration and stagger', () => {
+    expect(SHARE_EMPHASIS_AMP).toBe(0.4)
+    expect(SHARE_EMPHASIS_CYCLES).toBe(4)
+    expect(SHARE_EMPHASIS_CYCLE_SECONDS).toBe(1.4)
+    expect(SHARE_EMPHASIS_STAGGER_SECONDS).toBe(0.035)
+  })
+
+  it('resolves the peak scale from the amp rather than hard-coding 1.064', () => {
+    expect(SHARE_EMPHASIS_PEAK_SCALE).toBeCloseTo(1.064, 5)
+    expect(SHARE_EMPHASIS_PEAK_SCALE).toBe(1 + SHARE_EMPHASIS_AMP * 0.16)
+  })
+
+  it('runs four cycles at 1400ms — a 5600ms burst before the stagger tail', () => {
+    expect(SHARE_EMPHASIS_CYCLES * SHARE_EMPHASIS_CYCLE_SECONDS).toBeCloseTo(5.6, 5)
+  })
+})
+
+describe('shareEmphasis — the halo is CSS, and one number tunes it', () => {
+  it('index.css declares --share-emphasis-amp at the value the module animates to', () => {
+    const declared = css.match(/--share-emphasis-amp:\s*([\d.]+)\s*;/)?.[1]
+    expect(declared).toBeDefined()
+    expect(Number(declared)).toBe(SHARE_EMPHASIS_AMP)
+  })
+
+  it(`declares .${SHARE_GLOW_CLASS} as a plain class rule so it is emitted without a scan`, () => {
+    // #1894/#2027: a Tailwind @utility that never appears as a scanned
+    // candidate generates NOTHING and the element silently keeps its old
+    // styling. This class is only ever applied through a constant, so it is
+    // written as a plain rule that is always emitted.
+    expect(css).toMatch(new RegExp(`\\.${SHARE_GLOW_CLASS}\\s*{`))
+  })
+
+  it('expresses blur, spread and alpha against the amp, never as resolved pixels', () => {
+    const rule = css.match(new RegExp(`\\.${SHARE_GLOW_CLASS}\\s*{([\\s\\S]*?)\\n {2}}`))?.[1] ?? ''
+    expect(rule).toContain('box-shadow')
+    expect(rule).toContain('var(--share-emphasis-amp)')
+    expect(rule).toContain('var(--share-yes)')
+    // The resolved 7.2px/0.8px/48% must not be pasted in — the whole point of
+    // the calc form is that the intensity stays ONE tunable number.
+    expect(rule).not.toContain('7.2px')
+  })
+
+  it('defines --share-yes in both themes, because the halo is always the share green', () => {
+    expect(css).toMatch(/--share-yes:\s*hsl\(160 100% 24%\)/)
+    expect(css).toMatch(/--share-yes:\s*hsl\(160 55% 62%\)/)
+  })
+
+  it('adds no prefers-reduced-motion block — the burst is gated in JS instead', () => {
+    // `index.css.guard.test.ts` pins the same fact from the other side. The
+    // app's zero-reduced-motion CSS policy is unchanged: GSAP owns the
+    // breathe, so `matchMedia` is where the gate belongs.
+    expect(css).not.toMatch(/prefers-reduced-motion/)
+  })
+})
+
+describe('shareEmphasis — which marks are hot (spec §1)', () => {
+  const anchor = (state: ShareAnchorSpec['state']): ShareAnchorSpec => ({
+    state,
+    className: '',
+    tooltip: '',
+    ariaLabel: '',
+  })
+  const mark = (key: ShareClusterMark['key']): ShareClusterMark =>
+    ({ key }) as unknown as ShareClusterMark
+
+  it('emphasizes the yes anchor and nothing else', () => {
+    expect(anchorIsEmphasized(anchor('yes'))).toBe(true)
+    expect(anchorIsEmphasized(anchor('maybe'))).toBe(false)
+    expect(anchorIsEmphasized(anchor('no'))).toBe(false)
+    expect(anchorIsEmphasized(anchor('unanswered'))).toBe(false)
+    expect(anchorIsEmphasized(null)).toBe(false)
+  })
+
+  it('emphasizes a cluster holding WITH-named or similar-age, never NEAR alone', () => {
+    expect(clusterIsEmphasized([mark('with')])).toBe(true)
+    expect(clusterIsEmphasized([mark('similar_ages')])).toBe(true)
+    expect(clusterIsEmphasized([mark('with'), mark('near')])).toBe(true)
+    expect(clusterIsEmphasized([mark('near')])).toBe(false)
+    expect(clusterIsEmphasized([])).toBe(false)
+  })
+})
+
+describe('shareEmphasis — the burst', () => {
+  it('collects its targets in document order, which is what the stagger indexes', () => {
+    const first = mountVehicle()
+    const second = mountVehicle()
+    expect(shareEmphasisTargets()).toEqual([first, second])
+  })
+
+  it('reads prefers-reduced-motion through matchMedia', () => {
+    mockReducedMotion(true)
+    expect(prefersReducedMotion()).toBe(true)
+    mockReducedMotion(false)
+    expect(prefersReducedMotion()).toBe(false)
+  })
+
+  it('does not animate under prefers-reduced-motion — the glow stands alone', () => {
+    mockReducedMotion(true)
+    mountVehicle()
+    expect(defaultShareEmphasisRunner.run()).toBeNull()
+  })
+
+  it('declines when the board carries no emphasized mark at all', () => {
+    mockReducedMotion(false)
+    expect(defaultShareEmphasisRunner.run()).toBeNull()
+  })
+
+  it('animates every emphasized vehicle and reports itself alive', () => {
+    mockReducedMotion(false)
+    const el = mountVehicle()
+    const burst = defaultShareEmphasisRunner.run()
+    expect(burst).not.toBeNull()
+    expect(burst?.targets).toEqual([el])
+    expect(burst?.active).toBe(true)
+  })
+
+  it('kill() leaves the mark at its resting glow — no inline transform, nothing running', () => {
+    mockReducedMotion(false)
+    const el = mountVehicle()
+    el.classList.add(SHARE_GLOW_CLASS)
+    const burst = defaultShareEmphasisRunner.run()
+    burst?.kill()
+    expect(burst?.active).toBe(false)
+    expect(el.style.transform).toBe('')
+    // The glow is markup, not motion — killing the burst must not remove it.
+    expect(el.classList.contains(SHARE_GLOW_CLASS)).toBe(true)
+  })
+
+  it('kill() is idempotent, so an unmount after a drag cannot double-kill', () => {
+    mockReducedMotion(false)
+    mountVehicle()
+    const burst = defaultShareEmphasisRunner.run()
+    burst?.kill()
+    expect(() => {
+      burst?.kill()
+    }).not.toThrow()
+    expect(burst?.active).toBe(false)
+  })
+
+  it('selects vehicles by the attribute the markup stamps', () => {
+    expect(SHARE_MOTION_SELECTOR).toBe(`[${SHARE_MOTION_ATTR}]`)
+  })
+})

--- a/frontend/src/components/weekend/shareEmphasis.test.ts
+++ b/frontend/src/components/weekend/shareEmphasis.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'fs'
 import { resolve } from 'path'
 
+import gsap from 'gsap'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -190,5 +191,75 @@ describe('shareEmphasis — the burst', () => {
 
   it('selects vehicles by the attribute the markup stamps', () => {
     expect(SHARE_MOTION_SELECTOR).toBe(`[${SHARE_MOTION_ATTR}]`)
+  })
+})
+
+describe('shareEmphasis — the burst is FOUR CONTINUOUS CYCLES, not four staggered sets', () => {
+  /** The median weekend's emphasized-mark count (spec §6). */
+  const MEDIAN_MARKS = 13
+
+  function runOnMedianBoard(): {
+    /** Head and tail of the cascade — the only two the assertions need. */
+    first: HTMLElement
+    last: HTMLElement
+    timeline: gsap.core.Timeline
+    kill: () => void
+  } {
+    mockReducedMotion(false)
+    const first = mountVehicle()
+    for (let i = 0; i < MEDIAN_MARKS - 2; i += 1) mountVehicle()
+    const last = mountVehicle()
+    const spy = vi.spyOn(gsap, 'timeline')
+    const burst = defaultShareEmphasisRunner.run()
+    expect(burst?.targets).toHaveLength(MEDIAN_MARKS)
+    const timeline = spy.mock.results[0]?.value as gsap.core.Timeline
+    expect(timeline).toBeDefined()
+    return {
+      first,
+      last,
+      timeline,
+      kill: () => {
+        burst?.kill()
+      },
+    }
+  }
+
+  it('lasts one breathe-run plus the cascade tail — never one tail PER cycle', () => {
+    // `repeat` beside `stagger` at the TWEEN level makes GSAP repeat the whole
+    // staggered SET as one unit: the set is 1.4s + a 0.42s tail = 1.82s, and
+    // four of those is 7.28s — 21% over the locked ~6.0s, and it gets worse as
+    // the board gets busier (0.63s of tail on a 19-mark weekend).
+    const { timeline, kill } = runOnMedianBoard()
+    const expectedSeconds =
+      SHARE_EMPHASIS_CYCLES * SHARE_EMPHASIS_CYCLE_SECONDS +
+      (MEDIAN_MARKS - 1) * SHARE_EMPHASIS_STAGGER_SECONDS
+    expect(expectedSeconds).toBeCloseTo(6.02, 5)
+    expect(timeline.totalDuration()).toBeCloseTo(expectedSeconds, 5)
+    kill()
+  })
+
+  it('breathes without a stall — the first mark is at peak halfway through cycle two', () => {
+    // The stall is what the totals above are made of, and it is the part a
+    // viewer actually sees: with the repeat at tween level the mark sits dead
+    // at scale 1 for 420ms between every cycle, so "breathe" reads as four
+    // separate blips rather than one continuous pulse.
+    const { first, timeline, kill } = runOnMedianBoard()
+    timeline.time(SHARE_EMPHASIS_CYCLE_SECONDS * 1.5)
+    expect(Number(gsap.getProperty(first, 'scaleX'))).toBeCloseTo(SHARE_EMPHASIS_PEAK_SCALE, 3)
+    kill()
+  })
+
+  it('staggers the LAST mark by exactly the cascade, so the tail stays a cascade', () => {
+    const { last, timeline, kill } = runOnMedianBoard()
+    // The last mark starts its first breathe one full cascade in, so at that
+    // moment it is still at rest while the first mark has already moved.
+    timeline.time((MEDIAN_MARKS - 1) * SHARE_EMPHASIS_STAGGER_SECONDS)
+    expect(Number(gsap.getProperty(last, 'scaleX'))).toBeCloseTo(1, 4)
+    // ...and one half-cycle later it is at its own peak.
+    timeline.time(
+      (MEDIAN_MARKS - 1) * SHARE_EMPHASIS_STAGGER_SECONDS + SHARE_EMPHASIS_CYCLE_SECONDS / 2
+    )
+    expect(Number(gsap.getProperty(last, 'scaleX'))).toBeCloseTo(SHARE_EMPHASIS_PEAK_SCALE, 3)
+    kill()
   })
 })

--- a/frontend/src/components/weekend/shareEmphasis.ts
+++ b/frontend/src/components/weekend/shareEmphasis.ts
@@ -1,0 +1,204 @@
+/**
+ * The share-mark EMPHASIS treatment — spec 2026-08-24 (`docs/plans/`, LOCAL
+ * ONLY; the picks were made in the Share Emphasis Lab artifact). Parent
+ * contract: the 2026-08-22 share-icons spec, which locks the vocabulary this
+ * module must not touch.
+ *
+ * ## What it emphasizes, and what it never does
+ *
+ * Exactly the owner's "open to sharing" set — the same three marks the
+ * unplaced-popout filter predicate keys on:
+ *
+ *   - the anchor when the radio says **yes** (61 households in 2026)
+ *   - a cluster carrying **WITH-named** (55) or **similar-age** (8)
+ *
+ * NEAR is proximity, not sharing, and is never the REASON a card is
+ * emphasized (158 households; 147 of them NEAR-only, which draw nothing at
+ * all). `maybe`/`no`/`unanswered` anchors, the need glyphs and the Baby mark
+ * are untouched.
+ *
+ * **Fills never change in any mode.** Emphasis is a halo plus motion layer
+ * and nothing else — a treatment that recoloured NEAR would contradict the
+ * parent spec's green-means-share ruling. That is why this module owns no
+ * class names beyond the one glow utility, and why `shareMarks.ts` is
+ * imported for its TYPES only.
+ *
+ * ## Two vehicles, deliberately not collapsed into one
+ *
+ * The halo rides `share-emphasis-glow` (plain CSS, `index.css`); the breathe
+ * rides `data-share-emphasis-motion` (queried here, animated by GSAP). They
+ * land on the same element today, and are kept apart in code because a future
+ * per-glyph halo — the "two-tone" mode that was built, measured and rejected
+ * — would move the halo without moving the transform.
+ *
+ * **The transform target is always a WRAPPER, never a glyph inside a
+ * capsule.** Measured in a real browser 2026-08-24: scaling one glyph of a
+ * flush capsule takes it to 21.45px beside its 20px neighbour, so the pill
+ * goes lopsided and the seam overlap grows from -1px to -1.72px. Scaling the
+ * wrapper takes both halves to 21.45px and scales the seam proportionally.
+ *
+ * ## Why GSAP rather than a CSS animation
+ *
+ * Two reasons, both structural. `stagger` over the emphasized marks in
+ * document order is exactly this problem; and a timeline can be KILLED
+ * cleanly when a drag starts, which a CSS animation cannot be without
+ * fighting the class that draws the resting glow.
+ *
+ * ## Why `prefers-reduced-motion` is gated HERE and not in the stylesheet
+ *
+ * `index.css.guard.test.ts` pins that the stylesheet carries no
+ * `prefers-reduced-motion` block, and that policy is unchanged: the breathe
+ * lives in JS, so the gate lives in JS with it. A reduced-motion viewer gets
+ * the static glow and nothing else — which is the argument that settled the
+ * "4 cycles then settle" ruling in the first place. Some viewers only ever
+ * see the resting state, so the glow has to carry the signal alone.
+ */
+import gsap from 'gsap'
+
+import type { ShareAnchorSpec, ShareClusterMark } from './shareMarks'
+
+/**
+ * The one tunable number (locked at 0.4). Everything else about the treatment
+ * — blur, spread, alpha, peak scale — is resolved from it, here and in
+ * `index.css`'s `--share-emphasis-amp`. `shareEmphasis.test.ts` pins the two
+ * declarations to the same value.
+ */
+export const SHARE_EMPHASIS_AMP = 0.4
+
+/** Four breathes, then a permanent static glow. */
+export const SHARE_EMPHASIS_CYCLES = 4
+
+/** Seconds per breathe. 4 x 1.4 = a 5.6s burst before the stagger tail. */
+export const SHARE_EMPHASIS_CYCLE_SECONDS = 1.4
+
+/**
+ * Seconds between successive marks, indexed over the EMPHASIZED MARKS in
+ * document order — a deliberate deviation from the lab, which indexed over
+ * all cards and left a 56-card board still animating at ~7.5s. ~13 marks on a
+ * median weekend gives a 420ms cascade tail, so the whole burst is ~6.0s.
+ *
+ * If the cascade ever reads as too tight, RAISE THIS — do not re-index over
+ * all cards. A two-second lead-in on a signal that lasts four cycles is
+ * mostly dead air.
+ */
+export const SHARE_EMPHASIS_STAGGER_SECONDS = 0.035
+
+/** Peak of the breathe, resolved from the amp: 1.064 at 0.4. */
+export const SHARE_EMPHASIS_PEAK_SCALE = 1 + SHARE_EMPHASIS_AMP * 0.16
+
+/**
+ * The HALO vehicle — a plain class rule in `index.css`, never a Tailwind
+ * `@utility`. #1894/#2027 both bit this codebase the same way: a utility that
+ * never appears as a scanned candidate generates no rule at all and the
+ * element silently keeps its old styling. This class only ever reaches the
+ * markup through this constant, so it is written as a rule that is always
+ * emitted.
+ */
+export const SHARE_GLOW_CLASS = 'share-emphasis-glow'
+
+/** The TRANSFORM vehicle's query handle. */
+export const SHARE_MOTION_ATTR = 'data-share-emphasis-motion'
+
+/** `SHARE_MOTION_ATTR` as a selector, so callers never rebuild the brackets. */
+export const SHARE_MOTION_SELECTOR = `[${SHARE_MOTION_ATTR}]`
+
+/** A running burst. Killed, never paused — see `kill`. */
+export interface ShareEmphasisBurst {
+  /** The vehicles this burst animates, in document order. */
+  readonly targets: readonly HTMLElement[]
+  /** False once the burst has finished or been killed. */
+  readonly active: boolean
+  /**
+   * Stop immediately and leave every mark at its RESTING GLOW.
+   *
+   * Not a pause: a burst that resumes halfway through a placement is the
+   * thing the drag rule exists to prevent. Idempotent.
+   */
+  kill: () => void
+}
+
+/** Injectable for tests, exactly as `BoardMorphRunner` is. */
+export interface ShareEmphasisRunner {
+  /** `null` when there is nothing to animate, or nothing that should be. */
+  run: () => ShareEmphasisBurst | null
+}
+
+/** Emphasized iff the radio says yes (spec §1). */
+export function anchorIsEmphasized(anchor: ShareAnchorSpec | null): boolean {
+  return anchor?.state === 'yes'
+}
+
+/**
+ * Emphasized iff the capsule carries a HOT mark. NEAR rides along inside an
+ * emphasized capsule but is never the reason for one — the whole capsule gets
+ * one halo, so the same NEAR answer never renders two ways depending on its
+ * neighbour (the rejected two-tone mode's defect).
+ */
+export function clusterIsEmphasized(cluster: readonly ShareClusterMark[]): boolean {
+  return cluster.some((mark) => mark.key === 'with' || mark.key === 'similar_ages')
+}
+
+/** True when the viewer asked for no motion. jsdom honours no media query; tests mock this. */
+export function prefersReducedMotion(): boolean {
+  if (typeof window.matchMedia !== 'function') return false
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+/**
+ * Every emphasized vehicle currently on the page, in DOCUMENT ORDER — which
+ * is what `SHARE_EMPHASIS_STAGGER_SECONDS` indexes over.
+ *
+ * Document-scoped rather than scoped to the board's own subtree, on purpose.
+ * The board's marks are spread across the area grids, `LodgingUnitCard`, the
+ * off-board grid and `FloatingUnplacedBadge`, and a subtree root tight enough
+ * to exclude the map tab would drop some of those. The only leakage is the
+ * map tab when it has been opened before the board (`Activity` keeps an
+ * opened tab mounted-but-hidden): its marks sit AFTER the housing panel in
+ * document order, so they take the tail of the cascade and animate nothing
+ * anybody can see.
+ */
+export function shareEmphasisTargets(root: ParentNode = document): HTMLElement[] {
+  return Array.from(root.querySelectorAll<HTMLElement>(SHARE_MOTION_SELECTOR))
+}
+
+function run(): ShareEmphasisBurst | null {
+  if (prefersReducedMotion()) return null
+  const targets = shareEmphasisTargets()
+  if (targets.length === 0) return null
+
+  let alive = true
+  /**
+   * Drop the inline transform GSAP wrote, so the mark sits at its resting
+   * glow with nothing left over. No `animation-fill-mode` question arises —
+   * the keyframe already ends at rest; this only removes the residue.
+   */
+  const settle = (): void => {
+    alive = false
+    gsap.set(targets, { clearProps: 'transform,transformOrigin' })
+  }
+
+  const half = SHARE_EMPHASIS_CYCLE_SECONDS / 2
+  const timeline = gsap.timeline({ onComplete: settle })
+  timeline.to(targets, {
+    keyframes: [
+      { scale: SHARE_EMPHASIS_PEAK_SCALE, duration: half, ease: 'power1.inOut' },
+      { scale: 1, duration: half, ease: 'power1.inOut' },
+    ],
+    repeat: SHARE_EMPHASIS_CYCLES - 1,
+    stagger: SHARE_EMPHASIS_STAGGER_SECONDS,
+  })
+
+  return {
+    targets,
+    get active(): boolean {
+      return alive
+    },
+    kill: (): void => {
+      if (!alive) return
+      timeline.kill()
+      settle()
+    },
+  }
+}
+
+export const defaultShareEmphasisRunner: ShareEmphasisRunner = { run }

--- a/frontend/src/components/weekend/shareEmphasis.ts
+++ b/frontend/src/components/weekend/shareEmphasis.ts
@@ -6,11 +6,19 @@
  *
  * ## What it emphasizes, and what it never does
  *
- * Exactly the owner's "open to sharing" set — the same three marks the
- * unplaced-popout filter predicate keys on:
+ * Exactly the owner's "open to sharing" set, which is the spec's §1 shared
+ * definition of an emphasized mark:
  *
  *   - the anchor when the radio says **yes** (61 households in 2026)
  *   - a cluster carrying **WITH-named** (55) or **similar-age** (8)
+ *
+ * That definition is shared with kindred#2480 (the unplaced-families picker's
+ * share filter), whose body records the same three marks as a ruling. #2480 is
+ * deliberately sequenced AFTER this item and is NOT BUILT — there is no filter
+ * predicate to point at, and `FloatingUnplacedBadge.tsx` carries no share
+ * logic at all. `anchorIsEmphasized` and `clusterIsEmphasized` below are
+ * therefore the only implementation of the definition that exists; when #2480
+ * lands it should import them rather than restate them.
  *
  * NEAR is proximity, not sharing, and is never the REASON a card is
  * emphasized (158 households; 147 of them NEAR-only, which draw nothing at

--- a/frontend/src/components/weekend/shareEmphasis.ts
+++ b/frontend/src/components/weekend/shareEmphasis.ts
@@ -184,8 +184,23 @@ function run(): ShareEmphasisBurst | null {
       { scale: SHARE_EMPHASIS_PEAK_SCALE, duration: half, ease: 'power1.inOut' },
       { scale: 1, duration: half, ease: 'power1.inOut' },
     ],
-    repeat: SHARE_EMPHASIS_CYCLES - 1,
-    stagger: SHARE_EMPHASIS_STAGGER_SECONDS,
+    /**
+     * `repeat` belongs INSIDE the stagger object, and this is the one detail
+     * of the whole module that is easy to get wrong silently.
+     *
+     * At the TWEEN level — `repeat` beside `stagger` rather than within it —
+     * GSAP repeats the whole staggered SET as one unit. Measured on
+     * gsap@3.15.0 with the median weekend's 13 marks: the set is 1.82s (a 1.4s
+     * breathe plus the 0.42s cascade tail) and four of those is 7.28s, 21%
+     * over the locked ~6.0s. Worse than the total, each mark then sits DEAD at
+     * scale 1 for 420ms between cycles, so the breathe reads as four separate
+     * blips; the stall is the cascade tail, so it grows with the board (0.63s
+     * on a 19-mark weekend).
+     *
+     * The advanced stagger object repeats each MARK instead — measured 6.02s,
+     * breathing continuously, cascade intact.
+     */
+    stagger: { each: SHARE_EMPHASIS_STAGGER_SECONDS, repeat: SHARE_EMPHASIS_CYCLES - 1 },
   })
 
   return {

--- a/frontend/src/hooks/useShareEmphasisBurst.test.tsx
+++ b/frontend/src/hooks/useShareEmphasisBurst.test.tsx
@@ -1,0 +1,113 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ShareEmphasisBurst, ShareEmphasisRunner } from '../components/weekend/shareEmphasis'
+import { useShareEmphasisBurst } from './useShareEmphasisBurst'
+
+/** A burst that records its own death, standing in for the GSAP timeline. */
+function fakeBurst(): ShareEmphasisBurst & { killed: number } {
+  const burst = {
+    targets: [] as HTMLElement[],
+    active: true,
+    killed: 0,
+    kill(): void {
+      burst.killed += 1
+      burst.active = false
+    },
+  }
+  return burst
+}
+
+function fakeRunner(): ShareEmphasisRunner & { bursts: Array<ReturnType<typeof fakeBurst>> } {
+  const bursts: Array<ReturnType<typeof fakeBurst>> = []
+  return {
+    bursts,
+    run: vi.fn(() => {
+      const burst = fakeBurst()
+      bursts.push(burst)
+      return burst
+    }),
+  }
+}
+
+describe('useShareEmphasisBurst — the trigger fires once per board arrival', () => {
+  it('fires when the roster first becomes visible', () => {
+    const runner = fakeRunner()
+    renderHook(() => {
+      useShareEmphasisBurst({ ready: true, suppressed: false, runner })
+    })
+    expect(runner.run).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fire before the roster has anything to draw', () => {
+    const runner = fakeRunner()
+    const { rerender } = renderHook(
+      ({ ready }: { ready: boolean }) => {
+        useShareEmphasisBurst({ ready, suppressed: false, runner })
+      },
+      { initialProps: { ready: false } }
+    )
+    expect(runner.run).not.toHaveBeenCalled()
+    rerender({ ready: true })
+    expect(runner.run).toHaveBeenCalledTimes(1)
+  })
+
+  it('never re-arms — a refetch, a scenario switch, a tab return all re-render, and none re-burst', () => {
+    // A CSS animation keyed to mount re-fires on every remount. A board that
+    // re-breathes every time staff confirm a cabin is worse than one that
+    // never breathes at all, so the ref is the whole point of this hook.
+    const runner = fakeRunner()
+    const { rerender } = renderHook(
+      ({ ready }: { ready: boolean }) => {
+        useShareEmphasisBurst({ ready, suppressed: false, runner })
+      },
+      { initialProps: { ready: true } }
+    )
+    expect(runner.run).toHaveBeenCalledTimes(1)
+    rerender({ ready: true })
+    rerender({ ready: false })
+    rerender({ ready: true })
+    expect(runner.run).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useShareEmphasisBurst — a drag kills it outright', () => {
+  it('kills the timeline the moment a drag begins, and does not resume after', () => {
+    // Kill, never pause-and-resume: a burst that restarts halfway through a
+    // placement is the thing this rule exists to prevent.
+    const runner = fakeRunner()
+    const { rerender } = renderHook(
+      ({ suppressed }: { suppressed: boolean }) => {
+        useShareEmphasisBurst({ ready: true, suppressed, runner })
+      },
+      { initialProps: { suppressed: false } }
+    )
+    const burst = runner.bursts[0]
+    expect(burst?.active).toBe(true)
+
+    rerender({ suppressed: true })
+    expect(burst?.killed).toBe(1)
+    expect(burst?.active).toBe(false)
+
+    rerender({ suppressed: false })
+    expect(runner.run).toHaveBeenCalledTimes(1)
+    expect(burst?.active).toBe(false)
+  })
+
+  it('does not start a burst that arrives mid-drag', () => {
+    const runner = fakeRunner()
+    renderHook(() => {
+      useShareEmphasisBurst({ ready: true, suppressed: true, runner })
+    })
+    expect(runner.run).not.toHaveBeenCalled()
+  })
+
+  it('kills the timeline on unmount so a navigation cannot leave it running', () => {
+    const runner = fakeRunner()
+    const { unmount } = renderHook(() => {
+      useShareEmphasisBurst({ ready: true, suppressed: false, runner })
+    })
+    unmount()
+    expect(runner.bursts[0]?.killed).toBe(1)
+  })
+})

--- a/frontend/src/hooks/useShareEmphasisBurst.test.tsx
+++ b/frontend/src/hooks/useShareEmphasisBurst.test.tsx
@@ -1,13 +1,14 @@
 import { renderHook } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { StrictMode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { ShareEmphasisBurst, ShareEmphasisRunner } from '../components/weekend/shareEmphasis'
 import { useShareEmphasisBurst } from './useShareEmphasisBurst'
 
 /** A burst that records its own death, standing in for the GSAP timeline. */
-function fakeBurst(): ShareEmphasisBurst & { killed: number } {
+function fakeBurst(targets: HTMLElement[] = []): ShareEmphasisBurst & { killed: number } {
   const burst = {
-    targets: [] as HTMLElement[],
+    targets,
     active: true,
     killed: 0,
     kill(): void {
@@ -18,17 +19,36 @@ function fakeBurst(): ShareEmphasisBurst & { killed: number } {
   return burst
 }
 
-function fakeRunner(): ShareEmphasisRunner & { bursts: Array<ReturnType<typeof fakeBurst>> } {
+function fakeRunner(
+  targets: HTMLElement[] = []
+): ShareEmphasisRunner & { bursts: Array<ReturnType<typeof fakeBurst>> } {
   const bursts: Array<ReturnType<typeof fakeBurst>> = []
   return {
     bursts,
     run: vi.fn(() => {
-      const burst = fakeBurst()
+      const burst = fakeBurst(targets)
       bursts.push(burst)
       return burst
     }),
   }
 }
+
+/**
+ * A stand-in for a share mark sitting on the board. Tracked so it is removed
+ * between tests without clearing `document.body`, which would fight RTL's own
+ * cleanup for the render containers.
+ */
+const vehicles: HTMLElement[] = []
+function mountVehicle(): HTMLElement {
+  const el = document.createElement('span')
+  document.body.appendChild(el)
+  vehicles.push(el)
+  return el
+}
+
+afterEach(() => {
+  while (vehicles.length > 0) vehicles.pop()?.remove()
+})
 
 describe('useShareEmphasisBurst — the trigger fires once per board arrival', () => {
   it('fires when the roster first becomes visible', () => {
@@ -109,5 +129,62 @@ describe('useShareEmphasisBurst — a drag kills it outright', () => {
     })
     unmount()
     expect(runner.bursts[0]?.killed).toBe(1)
+  })
+
+  it('kills it when the marks themselves have left the document', () => {
+    // React tears the board's host nodes out during the mutation phase, which
+    // runs BEFORE passive cleanups — so a real navigation reaches this cleanup
+    // with every target already disconnected. Verified against React 19 in
+    // this worktree: `isConnected` is false by the time the cleanup fires.
+    const el = mountVehicle()
+    const runner = fakeRunner([el])
+    const { unmount } = renderHook(() => {
+      useShareEmphasisBurst({ ready: true, suppressed: false, runner })
+    })
+    el.remove()
+    unmount()
+    expect(runner.bursts[0]?.killed).toBe(1)
+    expect(runner.bursts[0]?.active).toBe(false)
+  })
+})
+
+describe('useShareEmphasisBurst — StrictMode must not eat the burst', () => {
+  it('survives the double-invoked mount effect, so the breathe plays in dev', () => {
+    // `main.tsx` wraps the app in <StrictMode> and React 19 double-invokes
+    // mount effects in development: setup -> cleanup -> setup. `armed` is
+    // spent by pass 1, so a cleanup that kills unconditionally kills the only
+    // burst there will ever be and pass 2 returns early — the dev server (the
+    // environment the design review happens in) shows the static glow and no
+    // motion at all. Production builds do not double-invoke, which is exactly
+    // why this is invisible until someone looks at the running app.
+    //
+    // The cleanup tells the two cases apart by the DOM: StrictMode's simulated
+    // unmount removes nothing, so the marks are still connected.
+    const el = mountVehicle()
+    const runner = fakeRunner([el])
+    renderHook(
+      () => {
+        useShareEmphasisBurst({ ready: true, suppressed: false, runner })
+      },
+      { wrapper: StrictMode }
+    )
+    expect(runner.run).toHaveBeenCalledTimes(1)
+    expect(runner.bursts[0]?.killed).toBe(0)
+    expect(runner.bursts[0]?.active).toBe(true)
+  })
+
+  it('still kills on drag under StrictMode — suppression is the unconditional kill', () => {
+    const el = mountVehicle()
+    const runner = fakeRunner([el])
+    const { rerender } = renderHook(
+      ({ suppressed }: { suppressed: boolean }) => {
+        useShareEmphasisBurst({ ready: true, suppressed, runner })
+      },
+      { initialProps: { suppressed: false }, wrapper: StrictMode }
+    )
+    expect(runner.bursts[0]?.active).toBe(true)
+    rerender({ suppressed: true })
+    expect(runner.bursts[0]?.killed).toBeGreaterThanOrEqual(1)
+    expect(runner.bursts[0]?.active).toBe(false)
   })
 })

--- a/frontend/src/hooks/useShareEmphasisBurst.test.tsx
+++ b/frontend/src/hooks/useShareEmphasisBurst.test.tsx
@@ -146,6 +146,26 @@ describe('useShareEmphasisBurst — a drag kills it outright', () => {
     expect(runner.bursts[0]?.killed).toBe(1)
     expect(runner.bursts[0]?.active).toBe(false)
   })
+
+  it('kills it when the board is gone but a hidden tab still holds marks of its own', () => {
+    // THE MIXED CASE, and the one a "some target is still connected" test can
+    // never see. `shareEmphasisTargets()` queries the whole DOCUMENT on
+    // purpose, and `Activity` keeps an already-opened map tab mounted-but-
+    // hidden — so a burst armed by the board legitimately owns marks from two
+    // surfaces. When the board navigates away, ITS marks disconnect and the
+    // map's stay put. Reading that as StrictMode leaves the timeline ticking
+    // against detached nodes with `burst.current` still dangling.
+    const boardMark = mountVehicle()
+    const hiddenTabMark = mountVehicle()
+    const runner = fakeRunner([boardMark, hiddenTabMark])
+    const { unmount } = renderHook(() => {
+      useShareEmphasisBurst({ ready: true, suppressed: false, runner })
+    })
+    boardMark.remove()
+    unmount()
+    expect(runner.bursts[0]?.killed).toBe(1)
+    expect(runner.bursts[0]?.active).toBe(false)
+  })
 })
 
 describe('useShareEmphasisBurst — StrictMode must not eat the burst', () => {

--- a/frontend/src/hooks/useShareEmphasisBurst.ts
+++ b/frontend/src/hooks/useShareEmphasisBurst.ts
@@ -61,10 +61,27 @@ export function useShareEmphasisBurst({
   }, [ready, suppressed, runner])
 
   // A navigation away mid-burst must not leave a timeline ticking against
-  // elements React has unmounted.
+  // elements React has unmounted — but this cleanup ALSO runs on React 19's
+  // StrictMode double-invoke (setup -> cleanup -> setup), and `main.tsx` wraps
+  // the whole app in <StrictMode>. Killing unconditionally there kills the
+  // only burst there will ever be: `armed` was spent by pass 1, so pass 2
+  // returns early and the dev server shows the static glow with no motion.
+  // Production builds do not double-invoke, which is exactly why this is
+  // invisible in CI and in the bundle, and visible only to whoever opens the
+  // running dev app to look at the animation.
+  //
+  // The DOM tells the two cases apart. React tears out the board's host nodes
+  // during the mutation phase, which runs BEFORE passive cleanups, so a real
+  // unmount reaches this line with every target already disconnected;
+  // StrictMode's simulated unmount removes nothing and they all read
+  // connected. `suppressed` in the effect above stays the one unconditional
+  // kill, because a drag has to stop the burst whatever the DOM says.
   useEffect(
     () => () => {
-      burst.current?.kill()
+      const running = burst.current
+      if (!running) return
+      if (running.targets.some((target) => target.isConnected)) return
+      running.kill()
       burst.current = null
     },
     []

--- a/frontend/src/hooks/useShareEmphasisBurst.ts
+++ b/frontend/src/hooks/useShareEmphasisBurst.ts
@@ -1,0 +1,72 @@
+import { useEffect, useRef } from 'react'
+
+import {
+  defaultShareEmphasisRunner,
+  type ShareEmphasisBurst,
+  type ShareEmphasisRunner,
+} from '../components/weekend/shareEmphasis'
+
+export interface UseShareEmphasisBurstOptions {
+  /**
+   * "This roster just became visible" — the board has a payload with cards in
+   * it. NOT component mount: the board stays mounted behind `Activity` across
+   * tab switches, and a mount-keyed trigger would also fire on every scenario
+   * switch and every refetch.
+   */
+  ready: boolean
+  /**
+   * A drag is in flight. #2528 put a three-state hatch/wash highlight on unit
+   * cards during a drag, and reading a hatch pattern is a precision task —
+   * thirteen marks pulsing in the periphery compete with it.
+   */
+  suppressed: boolean
+  /** Injectable for tests; the GSAP runner otherwise. */
+  runner?: ShareEmphasisRunner
+}
+
+/**
+ * Fires the share-emphasis burst ONCE per board arrival, and kills it the
+ * moment a drag starts.
+ *
+ * The ref is the whole point. A CSS animation keyed to mount re-fires on
+ * every remount — a scenario switch, a refetch after
+ * `invalidateLodgingRegistryQueries`, a tab return — and a board that
+ * re-breathes every time staff confirm a cabin is worse than one that never
+ * breathes at all. The weekend roster inherits the app-default 30-minute
+ * `staleTime`, so ordinary refetches are rare, but rare is not never and the
+ * failure is invisible until staff complain.
+ *
+ * Arming happens on the first render where `ready` is true and no drag is in
+ * flight; nothing re-arms it afterwards, for the life of the mount.
+ */
+export function useShareEmphasisBurst({
+  ready,
+  suppressed,
+  runner = defaultShareEmphasisRunner,
+}: UseShareEmphasisBurstOptions): void {
+  const armed = useRef(true)
+  const burst = useRef<ShareEmphasisBurst | null>(null)
+
+  useEffect(() => {
+    if (suppressed) {
+      // KILL, never pause-and-resume. `armed` stays false afterwards, so the
+      // burst does not pick up again when the family lands.
+      burst.current?.kill()
+      burst.current = null
+      return
+    }
+    if (!armed.current || !ready) return
+    armed.current = false
+    burst.current = runner.run()
+  }, [ready, suppressed, runner])
+
+  // A navigation away mid-burst must not leave a timeline ticking against
+  // elements React has unmounted.
+  useEffect(
+    () => () => {
+      burst.current?.kill()
+      burst.current = null
+    },
+    []
+  )
+}

--- a/frontend/src/hooks/useShareEmphasisBurst.ts
+++ b/frontend/src/hooks/useShareEmphasisBurst.ts
@@ -49,8 +49,20 @@ export function useShareEmphasisBurst({
 
   useEffect(() => {
     if (suppressed) {
-      // KILL, never pause-and-resume. `armed` stays false afterwards, so the
-      // burst does not pick up again when the family lands.
+      // KILL, never pause-and-resume: a burst that resumes halfway through a
+      // placement is the thing this rule exists to prevent.
+      //
+      // This branch writes NOTHING to `armed` — only the arming line below
+      // ever does. It does not need to, and the two cases are worth spelling
+      // out because they look like one:
+      //
+      //   - The drag interrupted a burst already playing. `armed` was spent
+      //     when that burst started, so the effect that runs when the family
+      //     lands returns early and the killed burst never picks up again.
+      //   - The drag beat the first payload, so no burst has ever run and
+      //     `armed` is still true. When the drag ends the burst fires — which
+      //     is right: the arrival cascade is still owed, and nothing has been
+      //     interrupted to resume.
       burst.current?.kill()
       burst.current = null
       return
@@ -70,17 +82,37 @@ export function useShareEmphasisBurst({
   // invisible in CI and in the bundle, and visible only to whoever opens the
   // running dev app to look at the animation.
   //
-  // The DOM tells the two cases apart. React tears out the board's host nodes
-  // during the mutation phase, which runs BEFORE passive cleanups, so a real
-  // unmount reaches this line with every target already disconnected;
-  // StrictMode's simulated unmount removes nothing and they all read
-  // connected. `suppressed` in the effect above stays the one unconditional
-  // kill, because a drag has to stop the burst whatever the DOM says.
+  // The DOM tells the two cases apart, and the test is EVERY target, not any.
+  // React tears out the board's host nodes during the mutation phase, which
+  // runs BEFORE passive cleanups, so a real unmount reaches this line with its
+  // targets already disconnected; StrictMode's simulated unmount removes
+  // nothing and they all read connected. Only the second case may skip the
+  // kill, so only "all still connected" may return early.
+  //
+  // `some` is the tempting spelling and it is wrong, because the target set is
+  // not all one surface. `shareEmphasisTargets()` queries the whole document
+  // on purpose, and `Activity` keeps an already-opened map tab mounted-but-
+  // hidden — so a board navigation disconnects the board's marks and leaves
+  // the map's connected. Under `some` that MIXED case reads as StrictMode: the
+  // cleanup returns early, the timeline goes on ticking against detached nodes
+  // and `burst.current` is left dangling with nothing that will ever kill it.
+  //
+  // The length guard is the degenerate third case. An empty target set is no
+  // evidence either way rather than evidence of StrictMode (`[].every` is
+  // vacuously true), and the safe reading of no evidence is to kill. The real
+  // runner never returns such a burst — it declines with `null` when there is
+  // nothing to animate — but an injected one can, and a cleanup that leaks on
+  // it would leak silently.
+  //
+  // `suppressed` in the effect above stays the one unconditional kill, because
+  // a drag has to stop the burst whatever the DOM says.
   useEffect(
     () => () => {
       const running = burst.current
       if (!running) return
-      if (running.targets.some((target) => target.isConnected)) return
+      if (running.targets.length > 0 && running.targets.every((target) => target.isConnected)) {
+        return
+      }
       running.kill()
       burst.current = null
     },

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -138,6 +138,17 @@
     /* Custom Lodge Tokens */
     --shadow-color: 160 40% 10%;
     --glow-color: 42 92% 62%;
+
+    /* Share-emphasis (spec 2026-08-24). A COMPLETE color, not this block's
+       bare HSL triplet convention, because `color-mix()` needs a real color
+       — see `.share-emphasis-glow`. Green because the REASON a capsule is
+       emphasized is always the share mark inside it. */
+    --share-yes: hsl(160 100% 24%);
+    /* The one number that tunes the whole treatment: blur, spread and alpha
+       all resolve from it, as does `SHARE_EMPHASIS_PEAK_SCALE` in
+       `components/weekend/shareEmphasis.ts`. `shareEmphasis.test.ts` pins
+       this declaration and that constant to the same value. */
+    --share-emphasis-amp: 0.4;
   }
 
   .dark {
@@ -164,6 +175,10 @@
 
     --shadow-color: 160 80% 3%;
     --glow-color: 42 85% 55%;
+
+    /* The dark-theme share green — lighter and less saturated so the halo
+       reads as a bloom against the forest-night card, not a smear. */
+    --share-yes: hsl(160 55% 62%);
   }
 }
 
@@ -868,6 +883,32 @@
   .pending-lock-glow {
     animation: pulse-glow 2s ease-in-out infinite;
     /* All elements using this class share the same animation timeline */
+  }
+
+  /*
+   * The share-emphasis halo (spec 2026-08-24 §3) — the RESTING state of the
+   * treatment, and on its own the whole treatment for a viewer who asked for
+   * reduced motion. The breathe that plays over it on board arrival is GSAP's
+   * (`components/weekend/shareEmphasis.ts`); this rule never animates.
+   *
+   * A plain class rule, deliberately, NOT a Tailwind `@utility`: the class
+   * reaches the markup only through the `SHARE_GLOW_CLASS` constant, and a
+   * utility Tailwind never sees as a scanned candidate generates nothing at
+   * all — the silent-dead-class shape of #1894 and #2027. Nothing here needs
+   * a `hover:`/`dark:` variant, which is the only thing `@utility` would buy.
+   *
+   * Every value resolves from `--share-emphasis-amp` rather than being pasted
+   * in at its 0.4 reading (blur 7.2px, spread 0.8px, alpha 48%), so the
+   * intensity stays one tunable number.
+   *
+   * It rides a WRAPPER span, so `border-radius` — which a box-shadow follows
+   * — describes the capsule silhouette rather than a rectangle. `ShareMarks`
+   * puts `rounded-full` there for exactly that reason.
+   */
+  .share-emphasis-glow {
+    box-shadow:
+      0 0 calc(4px + var(--share-emphasis-amp) * 8px) calc(var(--share-emphasis-amp) * 2px)
+      color-mix(in srgb, var(--share-yes) calc(30% + var(--share-emphasis-amp) * 45%), transparent);
   }
 
   /* Stagger delays for lists */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -906,8 +906,8 @@
    * puts `rounded-full` there for exactly that reason.
    */
   .share-emphasis-glow {
-    box-shadow:
-      0 0 calc(4px + var(--share-emphasis-amp) * 8px) calc(var(--share-emphasis-amp) * 2px)
+    box-shadow: 0 0 calc(4px + var(--share-emphasis-amp) * 8px)
+      calc(var(--share-emphasis-amp) * 2px)
       color-mix(in srgb, var(--share-yes) calc(30% + var(--share-emphasis-amp) * 45%), transparent);
   }
 


### PR DESCRIPTION
The three marks that mean "this family is open to sharing" now carry a green
halo, and breathe four times when the board arrives. Everything else on the
card is untouched.

Implements the emphasis half of the 2026-08-24 share-emphasis spec
(`docs/plans/`, LOCAL ONLY — the picks were made in an interactive lab against
real board density). Parent contract is the 2026-08-22 share-icons spec,
shipped as #2544; nothing it locks is touched here.

## What gets emphasized

| Mark | Condition | 2026 households |
|---|---|---|
| Anchor = yes | `share.preference === 'yes_share'` | 61 |
| Cluster WITH-named | `share.wants_with_named` | 55 |
| Cluster similar-age | `share.proximity` includes `similar_ages` | 8 |

**Never emphasized, and this is the load-bearing half.** NEAR is proximity, not
sharing — a NEAR-only capsule draws nothing at all (147 households). `maybe`,
`no` and the dotted `unanswered` anchor stay as they are, as do the need
glyphs, the Baby mark and the returning mark.

**No fill changes anywhere.** Emphasis is a halo plus motion layer and nothing
else; a treatment that recoloured NEAR would contradict the parent spec's
green-means-share ruling. `shareMarks.ts` — the vocabulary, icons, hues, cap
classes, tooltips and order — is not edited by this PR.

## Where the halo attaches

Per the spec's four card shapes:

| Card shape | Halo |
|---|---|
| Anchor yes, no cluster ticks | the anchor circle |
| Cluster holds a hot mark | the whole capsule, one halo, NEAR included |
| Anchor yes **and** a hot cluster | two separate halos — they are separate questions, and the parent spec forbids the anchor looking merged into the cluster |
| Cluster is NEAR-only | nothing |

## Two vehicles, deliberately not collapsed

The halo rides a CSS class (`share-emphasis-glow`); the breathe rides a
`data-share-emphasis-motion` handle that GSAP queries. Same element today,
kept apart in code because the rejected per-glyph "two-tone" halo would have
moved one without the other.

Both land on a **wrapper span, never a glyph inside a capsule.** Measured in a
real browser: scaling one glyph of a flush capsule takes it to 21.45px beside
its 20px neighbour, so the pill goes lopsided and the seam overlap grows from
−1px to −1.72px. Scaling the wrapper takes both halves to 21.45px and scales
the seam proportionally. The wrapper carries `rounded-full` so the box-shadow
follows the capsule silhouette rather than a rectangle.

## The motion

GSAP rather than a CSS animation, for two structural reasons: `stagger` over
the emphasized marks is exactly this problem, and a timeline can be killed
cleanly on drag.

- **4 cycles × 1400ms**, `power1.inOut`, peak `scale(1.064)`, ending at rest —
  then a permanent static glow.
- **35ms stagger indexed over the emphasized marks in document order**, a
  deliberate deviation from the lab, which indexed over all cards and left a
  56-card board still animating at ~7.5s. ~13 marks on a median weekend gives a
  420ms tail, so the burst is 6.02s, measured. If the cascade ever reads as too
  tight, raise the stagger — do not re-index over all cards.
- **The repeat lives INSIDE the stagger object**, and this is the one detail of
  the module that fails silently. A `repeat` at the tween level makes GSAP
  repeat the whole staggered *set* as one unit: 13 marks give a 1.82s set (1.4s
  breathe + the 0.42s tail) repeated four times, so 7.28s total with each mark
  sitting dead at scale 1 for the length of the tail between every cycle — and
  the stall grows with the board, 630ms on a 19-mark weekend. The advanced
  stagger object repeats each *mark* instead. Nothing throws either way; the
  only symptom is the feel, so a test pins the total against the constants and
  another scrubs to the peak of cycle two.
- **Once per board arrival, never per mount.** The trigger is a board-level
  hook holding a ref, armed on the first render with a non-empty roster. A
  mount-keyed animation would re-fire on every scenario switch, every refetch
  after `invalidateLodgingRegistryQueries` and every tab return; a board that
  re-breathes each time staff confirm a cabin is worse than one that never
  breathes at all.
- **Either drag kills the timeline outright** and leaves every mark at its
  resting glow — never pause-and-resume, because a burst that restarts halfway
  through a placement is what the rule exists to prevent. It reads the board's
  existing drag state rather than threading a new prop through `FamilyCard`,
  but it reads **both** of them: the board holds `dragging` *and*
  `draggingMergeUnit`, and `handleDragStart` sets exactly one per gesture, so
  `dragging` alone is null through every merge-handle drag. #2528 put a
  three-state hatch/wash highlight on unit cards during a drag, and reading a
  hatch is a precision task that thirteen pulsing marks would compete with.
- **The unmount cleanup kills only when the marks have actually left the DOM.**
  `main.tsx` wraps the app in `<StrictMode>` and React 19 double-invokes mount
  effects in development as setup → cleanup → setup. An unconditional kill in
  that cleanup destroys the only burst there will ever be — the arming ref is
  already spent, so the second pass returns early and the dev server shows the
  static glow with no motion at all, while production builds are fine. React
  detaches host nodes during the mutation phase, before passive cleanups run,
  so a real unmount reaches the cleanup with its targets disconnected while
  StrictMode's simulated one leaves them connected; that is what tells the two
  apart. The test is **every** target, not any: `shareEmphasisTargets()` queries
  the whole document on purpose, so a mounted-hidden map tab contributes marks
  the board's navigation does not detach, and only "all still connected" may
  skip the kill. Drag suppression stays the single unconditional kill, because a
  drag has to stop the burst whatever the DOM says.

## Two implementation notes worth a reviewer's eye

**`prefers-reduced-motion` is gated in JS, not in the stylesheet.**
`index.css.guard.test.ts` pins that the stylesheet carries no
`prefers-reduced-motion` block, and that policy is unchanged: the breathe lives
in GSAP, so the gate lives with it. A reduced-motion viewer gets the static
glow and nothing else — which is the argument that settled "4 cycles then
settle" in the first place. Some viewers only ever see the resting state, so
the glow has to carry the signal alone.

**The glow is a plain class rule, not a Tailwind `@utility`.** The class
reaches the markup only through a TS constant, and a utility Tailwind never
sees as a scanned candidate generates no rule at all — the silent-dead-class
shape of #1894 and #2027. A plain rule is always emitted; verified in the built
bundle, along with `--share-yes` resolving in both themes.

## Tuning

`--share-emphasis-amp` (0.4) is the one number. Blur (7.2px), spread (0.8px),
alpha (48%) and the peak scale (1.064) all resolve from it — the CSS in calc
form, the scale in `SHARE_EMPHASIS_PEAK_SCALE`. A test pins the stylesheet
declaration and the TS constant to the same value so they cannot drift.

## Tests

55 assertions across four suites, written before the implementation:

- `ShareMarks.test.tsx` — the halo target for each of the four card shapes,
  including the NEAR-only card getting none and the anchor-yes + hot-cluster
  card getting two separate halos rather than one merged one; that the motion
  handle sits on the wrapper and on no button inside it; that every fill is
  unchanged; that the halo is markup, so a reduced-motion viewer still sees it.
- `shareEmphasis.test.ts` — the locked knobs, the amp/CSS parity guard, the
  hot-mark predicates, document-order targets, and the burst itself: declines
  under reduced motion, declines with no targets, and `kill()` leaves no inline
  transform and does not remove the glow. Its timing suite mounts a median
  board's 13 marks and asserts against the real GSAP timeline — total duration
  equal to `CYCLES × CYCLE_SECONDS + (marks − 1) × STAGGER` computed from the
  exported constants, the first mark at peak halfway through cycle two, and the
  last mark still at rest one full cascade in, so a future fix cannot buy
  continuity by deleting the cascade.
- `useShareEmphasisBurst.test.tsx` — fires once, never re-arms across
  rerenders, is killed by a drag and does not resume, does not start mid-drag,
  is killed on a real unmount once its marks have left the document, is killed
  in the mixed case where the board's marks detach and a hidden tab's do not,
  and survives StrictMode's double-invoked mount effect while still dying on
  drag under it.
- `LodgingBoard.emphasis.test.tsx` — the wiring neither of the others can see:
  a halo reaches the DOM through `FamilyCard` → `ShareMarks`, the board arms
  the burst once, an empty first payload does not consume the arrival, and a
  drag of **each** kind suppresses it — the party gesture and the merge-handle
  gesture, delivered through the `vi.mock('@dnd-kit/core')` boundary idiom
  `LodgingBoard.drag.test.tsx` established.

Full frontend suite green; `pre-push-verify.sh` clean (read from its summary block, not
its exit code — the script returns 0 even on failure when piped).

## Scan round

Seven findings, all fixed in-branch (commit `1602cc50`). Two were real defects;
the rest were tests that could not fail and comments describing code that was
not there.

| # | Sev | Where | What was wrong |
|---|---|---|---|
| 1 | Med | `LodgingBoard.tsx` | Suppression read `dragging` only, so a **merge-handle drag never suppressed the burst**. `handleDragStart`'s merge branch sets `draggingMergeUnit` and `setDragging(null)`, leaving `dragging` null for the whole gesture. Now `dragging !== null \|\| draggingMergeUnit !== null`; the "one drag signal, one meaning" comment that caused it is replaced. |
| 2 | Med | `useShareEmphasisBurst.ts` | The unmount kill had **the wrong polarity**: `.some(isConnected)` skipped the kill whenever *any* target was still connected. Since targets are collected document-wide, a mounted-hidden map tab's marks kept the timeline ticking against the board's detached nodes with `burst.current` dangling. Now `.every`. |
| 3 | Med | `shareEmphasis.test.ts` | The `kill()` resting-glow assertion was **vacuous** — no frame had ever been written, so `style.transform` was `''` before the kill as well as after. It now advances into the breathe first. |
| 4 | Med | `LodgingBoard.emphasis.test.tsx` | The header claimed the drag wiring was covered; **no test simulated a drag**. Both gestures are now covered. |
| 5 | Low | `useShareEmphasisBurst.ts` | The `suppressed` branch's comment claimed "`armed` stays false afterwards"; that branch never writes `armed` at all. |
| 6 | Low | `shareEmphasis.ts` | The header cited "the same three marks the unplaced-popout filter predicate keys on" — a **symbol that does not exist**. #2480 is sequenced after this item and unbuilt. Now cites the spec's §1 shared definition and #2480's recorded ruling. |
| 7 | Low | `shareEmphasis.test.ts` | A real ~6s GSAP timeline was started and never killed, outliving its test. |

**Polarity truth table for #2**, since `.every` is not obviously the safe swap:

| Case | Targets | `.some` (was) | `.every` (now) |
|---|---|---|---|
| StrictMode simulated unmount | all connected | skip kill ✅ | skip kill ✅ |
| Real full unmount | all disconnected | kill ✅ | kill ✅ |
| Board unmounts, hidden tab retains marks | mixed | skip kill ❌ | kill ✅ |
| Injected burst with no targets | empty | kill ✅ | *vacuously true → would skip* |

The empty row is why the guard reads `targets.length > 0 && targets.every(...)`
rather than a bare `.every`. An empty target set is *no evidence* rather than
evidence of StrictMode, and the safe reading of no evidence is to kill. The real
runner never produces one (it declines with `null` when there is nothing to
animate), but an injected runner can, and a bare `.every` would have silently
weakened the existing unmount test rather than fixing anything.

**Both behaviour fixes were mutation-checked.** Deleting `settle()`'s
`clearProps` makes the #3 assertion fail with `'scale(1.064, 1.064)'` instead of
`''`; forcing `suppressed: false` makes both #4 drag tests fail. Both restored,
both exit 1 under mutation.

The local spec's drag-suppression section carried the implementation hint that
produced #1 ("use that same state at board level"). It now carries a correction
noting the second drag state, so the next reader does not re-derive the bug.


Not in scope, per the spec: the "Answers disagree" removal (a sibling PR), the
roster tab, the unplaced-popout filters, the Assign modal's picker glyphs, and
anything in the share-eligibility layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual share-emphasis halo to lodging marks.
  * Added a one-time arrival animation when lodging data first becomes available.
  * Animation pauses during drag interactions and respects reduced-motion preferences.
  * Added light- and dark-theme styling for share emphasis.

* **Bug Fixes**
  * Prevented emphasis animations from retriggering during refetches or repeated renders.
  * Ensured emphasis effects are cleaned up when relevant content is removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
