### PR TITLE
feat(frontend): the assign modal pins the four staff groups instead of hiding

### DIFF
--- a/frontend/src/components/ui/FloatingQueueBadge.test.tsx
+++ b/frontend/src/components/ui/FloatingQueueBadge.test.tsx
@@ -339,3 +339,80 @@ describe('FloatingQueueBadge — the drop target', () => {
     expect(attached.length).toBeGreaterThan(0)
   })
 })
+
+/**
+ * The caller-owned filter seam (kindred#2480). Summer passes none of these and
+ * must be unaffected — need-based filtering is a weekend concept, and baking
+ * it into the shell would put dead controls on the camper queue.
+ */
+describe('the optional filter seam', () => {
+  const rows = ['Alvarez', 'Bennett', 'Castillo']
+  function shell(extra: Record<string, unknown> = {}) {
+    return (
+      <FloatingQueueBadge<string>
+        items={rows}
+        sortKey={(i) => [i]}
+        getSearchText={(i) => i}
+        renderList={(visible) => (
+          <ul>
+            {visible.map((i) => (
+              <li key={i}>{i}</li>
+            ))}
+          </ul>
+        )}
+        label="Unplaced"
+        noun="parties"
+        cardSelector="[data-row]"
+        emptyState={<p>nothing queued</p>}
+        isExpanded={true}
+        onToggle={() => {}}
+        onClose={() => {}}
+        {...extra}
+      />
+    )
+  }
+
+  it('renders no filter row and filters nothing when the props are omitted', () => {
+    render(shell())
+    expect(screen.getByText('Alvarez')).toBeInTheDocument()
+    expect(screen.getByText('Castillo')).toBeInTheDocument()
+    expect(screen.queryByTestId('row')).not.toBeInTheDocument()
+  })
+
+  it('applies itemFilter and the name search together', async () => {
+    render(
+      shell({
+        itemFilter: (i: string) => i !== 'Castillo',
+        filterRow: <div data-testid="row">chips</div>,
+      })
+    )
+    expect(screen.getByTestId('row')).toBeInTheDocument()
+    expect(screen.queryByText('Castillo')).not.toBeInTheDocument()
+
+    await userEvent.type(screen.getByPlaceholderText(/filter by name/i), 'Alv')
+    expect(screen.getByText('Alvarez')).toBeInTheDocument()
+    expect(screen.queryByText('Bennett')).not.toBeInTheDocument()
+  })
+
+  it('shows filterEmptyState when the predicate empties the list, but the SEARCH miss still wins', async () => {
+    // Two different dead ends. A name-search miss names the term; a filter
+    // miss names the group. Whichever the staff member just did is the one
+    // that should explain itself.
+    render(
+      shell({
+        itemFilter: () => false,
+        filterEmptyState: <p>no parties in that group</p>,
+      })
+    )
+    expect(screen.getByText('no parties in that group')).toBeInTheDocument()
+
+    await userEvent.type(screen.getByPlaceholderText(/filter by name/i), 'zzz')
+    expect(screen.getByText(/No parties match "zzz"/)).toBeInTheDocument()
+    expect(screen.queryByText('no parties in that group')).not.toBeInTheDocument()
+  })
+
+  it('counts N/M in the header while a group filter is active, with no search term', () => {
+    render(shell({ itemFilter: (i: string) => i === 'Alvarez' }))
+    expect(screen.getByText('1/3')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/ui/FloatingQueueBadge.tsx
+++ b/frontend/src/components/ui/FloatingQueueBadge.tsx
@@ -43,6 +43,26 @@ export interface FloatingQueueBadgeProps<T> {
   cardSelector: string
   /** Shown when there is nothing queued at all, as opposed to nothing matching the filter. */
   emptyState: ReactNode
+  /**
+   * A row of caller-owned controls, rendered under the name search.
+   *
+   * Chrome only: the shell renders the node and never reads it. What the
+   * controls MEAN is the adapter's business, which is why the predicate
+   * arrives separately as `itemFilter` — need-based filtering is a weekend
+   * concept and a summer camper queue has no `needs_private_bathroom` to
+   * offer. Both are optional, so summer passes neither and is unchanged.
+   */
+  filterRow?: ReactNode
+  /**
+   * Applied BEFORE the name search; both compose.
+   *
+   * `| undefined` is explicit because the project builds with
+   * `exactOptionalPropertyTypes`: without it a caller cannot pass the
+   * "no filter" case through as a variable, only by omitting the prop.
+   */
+  itemFilter?: ((item: T) => boolean) | undefined
+  /** Shown when `itemFilter` hides everything — a different dead end from a name-search miss. */
+  filterEmptyState?: ReactNode
   footer?: ReactNode
   isExpanded: boolean
   onToggle: () => void
@@ -70,6 +90,9 @@ export function FloatingQueueBadge<T>({
   noun,
   cardSelector,
   emptyState,
+  filterRow,
+  itemFilter,
+  filterEmptyState,
   footer,
   isExpanded,
   onToggle,
@@ -100,10 +123,12 @@ export function FloatingQueueBadge<T>({
       return 0
     })
 
-    if (!trimmedSearchTerm) return sorted
+    const grouped = itemFilter ? sorted.filter((item) => itemFilter(item)) : sorted
+
+    if (!trimmedSearchTerm) return grouped
     const term = trimmedSearchTerm.toLowerCase()
-    return sorted.filter((item) => getSearchText(item).toLowerCase().includes(term))
-  }, [items, trimmedSearchTerm, sortKey, getSearchText])
+    return grouped.filter((item) => getSearchText(item).toLowerCase().includes(term))
+  }, [items, trimmedSearchTerm, sortKey, getSearchText, itemFilter])
 
   const handleClickOutside = useCallback(
     (event: MouseEvent) => {
@@ -209,7 +234,7 @@ export function FloatingQueueBadge<T>({
                 <span className="text-muted-foreground ml-1.5 text-sm font-normal">
                   (
                   <span>
-                    {trimmedSearchTerm
+                    {trimmedSearchTerm || itemFilter
                       ? `${String(visible.length)}/${String(items.length)}`
                       : items.length}
                   </span>
@@ -256,6 +281,10 @@ export function FloatingQueueBadge<T>({
             </div>
           )}
 
+          {items.length > 0 && filterRow !== undefined && (
+            <div className="border-border flex-shrink-0 border-b px-3 py-2">{filterRow}</div>
+          )}
+
           <div
             className={clsx(
               'min-h-[200px] flex-1 overflow-y-auto p-3',
@@ -264,12 +293,14 @@ export function FloatingQueueBadge<T>({
           >
             {items.length === 0 ? (
               emptyState
-            ) : visible.length === 0 ? (
+            ) : visible.length === 0 && trimmedSearchTerm ? (
               <div className="flex h-full flex-col items-center justify-center py-8 text-center">
                 <p className="text-muted-foreground text-sm">
                   No {noun} match "{trimmedSearchTerm}"
                 </p>
               </div>
+            ) : visible.length === 0 ? (
+              filterEmptyState
             ) : (
               renderList(visible)
             )}

--- a/frontend/src/components/weekend/AssignFamilyModal.test.tsx
+++ b/frontend/src/components/weekend/AssignFamilyModal.test.tsx
@@ -1477,3 +1477,91 @@ describe('AssignFamilyModal — it is the shared dialog, not a second pattern', 
     expect(props.onClose).toHaveBeenCalled()
   })
 })
+
+/**
+ * The staff-group chips — kindred#2480's Assign-modal half, owner pick "B"
+ * (2026-08-24): the same row the Unplaced popout carries, but a pick PINS its
+ * matches to the top instead of hiding everyone else.
+ *
+ * The load-bearing property is that nothing is hidden. `placementCandidates`'
+ * "annotate and order, never hide" ruling is what makes the picker usable at
+ * all — 4 of 62 parties ask for a bathroom, so a hiding filter would leave 4
+ * rows where pinning surfaces 4 and keeps 58.
+ */
+describe('the staff-group chips (kindred#2480)', () => {
+  const BATHROOMER = party({
+    household_cm_id: 201,
+    display_name: 'Alvarez',
+    sort_name: 'Alvarez',
+    children: [{ person_cm_id: 9101, display_name: 'Mia Alvarez', age: 5, grade: 0 }],
+    flags: { needs_private_bathroom: true },
+  })
+
+  function chips() {
+    return within(screen.getByTestId('assign-group-chips'))
+  }
+
+  it('renders one chip per group, each carrying its count', () => {
+    renderModal({ parties: [BATHROOMER, party(), NGUYEN] })
+    expect(chips().getByRole('button', { name: /bathroom in unit/i })).toHaveTextContent('1')
+    expect(chips().getByRole('button', { name: /power/i })).toHaveTextContent('0')
+  })
+
+  it('PINS the matches and keeps everyone else listed below', async () => {
+    renderModal({ parties: [BATHROOMER, party(), NGUYEN] })
+    await userEvent.click(chips().getByRole('button', { name: /bathroom in unit/i }))
+
+    // The match is first. Queried by ROLE, not by a `candidate-` testid
+    // prefix — the row carries nested `candidate-detail-line` and
+    // `candidate-…-fit` testids that a prefix match would also collect.
+    const rows = screen.getAllByRole('option')
+    expect(rows[0]).toHaveTextContent(/Alvarez/)
+    // ...and NOBODY is gone. This is the assertion the ruling exists for.
+    expect(rows).toHaveLength(3)
+    expect(screen.getByText(/Nguyen/)).toBeInTheDocument()
+  })
+
+  it('labels the pinned band with the group and its count', async () => {
+    renderModal({ parties: [BATHROOMER, party(), NGUYEN] })
+    await userEvent.click(chips().getByRole('button', { name: /bathroom in unit/i }))
+    expect(screen.getByText(/1 asked for bathroom in unit/i)).toBeInTheDocument()
+    expect(screen.getByText(/everyone else/i)).toBeInTheDocument()
+  })
+
+  it('is single-select, and clicking the active chip clears the pin', async () => {
+    renderModal({ parties: [BATHROOMER, party(), NGUYEN] })
+    const chip = () => chips().getByRole('button', { name: /bathroom in unit/i })
+    await userEvent.click(chip())
+    expect(chip()).toHaveAttribute('aria-pressed', 'true')
+    await userEvent.click(chip())
+    expect(chip()).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.queryByText(/everyone else/i)).not.toBeInTheDocument()
+  })
+
+  it('disables a zero-count chip rather than hiding it', () => {
+    renderModal({ parties: [party(), NGUYEN] })
+    expect(chips().getByRole('button', { name: /child under 2/i })).toBeDisabled()
+  })
+
+  it('leaves the footer count untouched — pinning is not filtering', async () => {
+    renderModal({ parties: [BATHROOMER, party(), NGUYEN] })
+    const before = screen.getByText(/3 of 3/).textContent
+    await userEvent.click(chips().getByRole('button', { name: /bathroom in unit/i }))
+    expect(screen.getByText(/3 of 3/).textContent).toBe(before)
+  })
+
+  it('renders no chip row when there are no candidates to pin', () => {
+    // Write-in-only mode: the card offered no placements, so there is no list
+    // to reorder and a chip row would be four dead controls.
+    renderModal({ parties: [] })
+    expect(screen.queryByTestId('assign-group-chips')).not.toBeInTheDocument()
+  })
+
+  it('keeps the typed search working alongside a pin', async () => {
+    renderModal({ parties: [BATHROOMER, party(), NGUYEN] })
+    await userEvent.click(chips().getByRole('button', { name: /bathroom in unit/i }))
+    await userEvent.type(searchBox(), 'Nguyen')
+    expect(screen.getByText(/Nguyen/)).toBeInTheDocument()
+    expect(screen.queryByText(/Alvarez/)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/weekend/AssignFamilyModal.tsx
+++ b/frontend/src/components/weekend/AssignFamilyModal.tsx
@@ -83,7 +83,16 @@ import { childrenRunLabel, partyIdentityLabel, partySearchText } from './househo
 import { NeedGlyphMark } from './NeedGlyph'
 import { resolveNeedGlyphs } from './needGlyphs'
 import { partyKey } from './partyKey'
-import { placementCandidates, type PlacementCandidate } from './placementCandidates'
+import {
+  UNPLACED_FILTER_GROUPS,
+  unplacedFilterGroup,
+  type UnplacedFilterKey,
+} from './unplacedFilters'
+import {
+  partitionByGroup,
+  placementCandidates,
+  type PlacementCandidate,
+} from './placementCandidates'
 import { effectiveSleeps, partyBeds } from './rosterAttention'
 import { PARTY_SIZE_CHOICES, coveringWriteIns, writeInDemand } from './writeIn'
 
@@ -544,6 +553,48 @@ export function AssignFamilyModal({
   )
 
   /**
+   * The staff-group pin (kindred#2480, owner pick "B" 2026-08-24). Single-select
+   * like the Unplaced popout's row, because the ruling behind that — a party in
+   * two groups never needs a tie-break — is the same one here.
+   */
+  const [group, setGroup] = useState<UnplacedFilterKey | null>(null)
+
+  // Over every party the card offered, never the typed subset: the number
+  // answers "is this group worth pinning" before the click, and one that moved
+  // while you typed would stop answering it. Same rule as the popout's chips.
+  const groupCounts = useMemo(() => {
+    const tally = {} as Record<UnplacedFilterKey, number>
+    for (const spec of UNPLACED_FILTER_GROUPS) {
+      tally[spec.key] = parties.filter((party) => spec.matches(party)).length
+    }
+    return tally
+  }, [parties])
+
+  /**
+   * PINNED, NOT FILTERED. Both halves render, one after the other — see
+   * `partitionByGroup`, and the "never hide" ruling it protects. `candidates`
+   * itself is untouched, which is what keeps the footer count and the write-in
+   * offer honest.
+   */
+  const { pinned, rest } = useMemo(() => partitionByGroup(candidates, group), [candidates, group])
+
+  const listEntries = useMemo(() => {
+    type ListEntry =
+      { kind: 'band'; label: string } | { kind: 'row'; candidate: PlacementCandidate }
+    const entries: ListEntry[] = []
+    if (pinned.length > 0 && group) {
+      entries.push({
+        kind: 'band',
+        label: `${String(pinned.length)} asked for ${unplacedFilterGroup(group).label.toLowerCase()}`,
+      })
+      for (const candidate of pinned) entries.push({ kind: 'row', candidate })
+      entries.push({ kind: 'band', label: 'Everyone else' })
+    }
+    for (const candidate of rest) entries.push({ kind: 'row', candidate })
+    return entries
+  }, [pinned, rest, group])
+
+  /**
    * THE WRITE-IN OFFER, and the three conditions are each load-bearing.
    *
    * `onWriteIn` — the caller can actually write one.
@@ -782,6 +833,51 @@ export function AssignFamilyModal({
             The artifact's separator (`.mswap`'s `border-top: 1px dashed`) is
             what makes the boundary between "what you typed" and "what that
             found" legible once the region no longer shrinks to fit. */}
+        {/* THE GROUP CHIPS — above the swap region on purpose. That region's
+            `h-80` is a fixed height fixing a measured jump; putting a row of
+            controls INSIDE it would spend list rows on chrome, and putting one
+            that can change height inside it would reopen the jump. Here the row
+            is constant and the region below is untouched. */}
+        {parties.length > 0 && (
+          <div
+            data-testid="assign-group-chips"
+            className="flex flex-wrap items-center gap-1 px-3.5 pb-1.5"
+          >
+            {UNPLACED_FILTER_GROUPS.map((spec) => {
+              const Icon = spec.Icon
+              const isActive = group === spec.key
+              const count = groupCounts[spec.key]
+              return (
+                <button
+                  key={spec.key}
+                  type="button"
+                  // Icon + count, no text label — the popout's locked style.
+                  // The label is the button's only name, a test handle per
+                  // frontend/CLAUDE.md rather than an accessibility posture.
+                  aria-label={spec.label}
+                  aria-pressed={isActive}
+                  title={spec.label}
+                  // Dimmed at zero, never hidden — a chip that vanished could
+                  // not say the group is empty. The active chip stays live at
+                  // zero so a pin can always be undone.
+                  disabled={(count === 0 && !isActive) || isSaving}
+                  onClick={() => {
+                    setGroup((current) => (current === spec.key ? null : spec.key))
+                  }}
+                  className={`inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium tabular-nums transition-colors ${
+                    isActive
+                      ? 'bg-primary text-primary-foreground'
+                      : 'text-muted-foreground hover:bg-muted disabled:opacity-40 disabled:hover:bg-transparent'
+                  }`}
+                >
+                  <Icon className={`h-3 w-3 flex-shrink-0 ${isActive ? '' : spec.hueClassName}`} />
+                  {count}
+                </button>
+              )
+            })}
+          </div>
+        )}
+
         <div
           data-testid="assign-swap-region"
           className="border-border h-80 overflow-y-auto border-t border-dashed pt-[9px]"
@@ -925,7 +1021,19 @@ export function AssignFamilyModal({
               aria-label={`Families to place in ${unit.name}`}
               className="flex flex-col gap-[6px]"
             >
-              {candidates.map((candidate) => {
+              {listEntries.map((entry) => {
+                if (entry.kind === 'band') {
+                  return (
+                    <div
+                      key={`band-${entry.label}`}
+                      className="text-muted-foreground flex items-center gap-1.5 pt-0.5 text-[10px] font-bold tracking-wider uppercase"
+                    >
+                      <span>{entry.label}</span>
+                      <span className="bg-border h-px flex-1" />
+                    </div>
+                  )
+                }
+                const candidate = entry.candidate
                 const party = candidate.party
                 const lastYearCabin = (party.last_year_cabin ?? '').trim()
                 // The PROSPECTIVE reading — graded against the cabin being

--- a/frontend/src/components/weekend/FloatingUnplacedBadge.test.tsx
+++ b/frontend/src/components/weekend/FloatingUnplacedBadge.test.tsx
@@ -2,7 +2,7 @@
  * The weekend's unplaced queue. Fictional data throughout.
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -190,5 +190,170 @@ describe('FloatingUnplacedBadge', () => {
     // household salutation ('The Johnson Family') no longer renders.
     await userEvent.click(screen.getByRole('button', { name: /Noah Johnson/ }))
     expect(onOpenParty).toHaveBeenCalledWith(expect.objectContaining({ household_cm_id: 101 }))
+  })
+})
+
+/**
+ * The four-group filter row — kindred#2480, picks locked 2026-08-24.
+ *
+ * Chips are ICON + COUNT with no text label, so every query below addresses
+ * them by accessible name (test infrastructure per frontend/CLAUDE.md, not an
+ * accessibility posture).
+ */
+describe('the filter chips (kindred#2480)', () => {
+  function open() {
+    return userEvent.click(screen.getByRole('button', { name: /unplaced parties/i }))
+  }
+
+  /**
+   * Chips are addressed through the filter row, never through `screen`: each
+   * card draws its OWN marks as tooltip buttons carrying the same names, so a
+   * bare `getByRole` matches the chip and every card that has that mark.
+   */
+  function chip(name: RegExp) {
+    return within(screen.getByTestId('unplaced-filters')).getByRole('button', { name })
+  }
+
+  // Distinct CHILD names, not just distinct sort_names: the card draws its
+  // identity from the children run, so same-named children make every row
+  // read identically and the list assertions cannot tell them apart.
+  const under2 = party({
+    household_cm_id: 201,
+    sort_name: 'Alvarez',
+    children: [{ person_cm_id: 9101, display_name: 'Mia Alvarez', age: 1, grade: 0 }],
+    flags: { has_child_under_two: true },
+  })
+  const bathroom = party({
+    household_cm_id: 202,
+    sort_name: 'Bennett',
+    children: [{ person_cm_id: 9102, display_name: 'Liam Bennett', age: 7, grade: 2 }],
+    flags: { needs_private_bathroom: true },
+  })
+  const sharer = party({
+    household_cm_id: 203,
+    sort_name: 'Castillo',
+    children: [{ person_cm_id: 9103, display_name: 'Ivy Castillo', age: 9, grade: 4 }],
+    share: { preference: 'yes_share' },
+  })
+  const plain = party({
+    household_cm_id: 204,
+    sort_name: 'Delgado',
+    children: [{ person_cm_id: 9104, display_name: 'Theo Delgado', age: 6, grade: 1 }],
+  })
+
+  it('renders one chip per group, each carrying its count', async () => {
+    render(
+      <FloatingUnplacedBadge parties={[under2, bathroom, sharer, plain]} onOpenParty={vi.fn()} />,
+      { wrapper }
+    )
+    await open()
+    expect(chip(/child under 2/i)).toHaveTextContent('1')
+    expect(chip(/bathroom in unit/i)).toHaveTextContent('1')
+    expect(chip(/open to sharing/i)).toHaveTextContent('1')
+    // Power: nobody asked. The chip still renders — a hidden chip cannot say
+    // "this group is empty", which is the whole reason the pick was "dim".
+    expect(chip(/power/i)).toHaveTextContent('0')
+  })
+
+  it('narrows the list to the picked group', async () => {
+    render(
+      <FloatingUnplacedBadge parties={[under2, bathroom, sharer, plain]} onOpenParty={vi.fn()} />,
+      { wrapper }
+    )
+    await open()
+    await userEvent.click(chip(/child under 2/i))
+    expect(screen.getByText(/Alvarez/)).toBeInTheDocument()
+    expect(screen.queryByText(/Bennett/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Delgado/)).not.toBeInTheDocument()
+  })
+
+  it('is SINGLE-select: a second chip replaces the first, never adds to it', async () => {
+    // The ruling's whole purpose — a party in 2+ groups never needs a
+    // tie-break rule because two groups are never active at once.
+    render(<FloatingUnplacedBadge parties={[under2, bathroom, plain]} onOpenParty={vi.fn()} />, {
+      wrapper,
+    })
+    await open()
+    await userEvent.click(chip(/child under 2/i))
+    await userEvent.click(chip(/bathroom in unit/i))
+
+    expect(chip(/bathroom in unit/i)).toHaveAttribute('aria-pressed', 'true')
+    expect(chip(/child under 2/i)).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByText(/Bennett/)).toBeInTheDocument()
+    expect(screen.queryByText(/Alvarez/)).not.toBeInTheDocument()
+  })
+
+  it('clears the filter when the active chip is clicked again', async () => {
+    render(<FloatingUnplacedBadge parties={[under2, plain]} onOpenParty={vi.fn()} />, { wrapper })
+    await open()
+    await userEvent.click(chip(/child under 2/i))
+    expect(screen.queryByText(/Delgado/)).not.toBeInTheDocument()
+    await userEvent.click(chip(/child under 2/i))
+    expect(screen.getByText(/Delgado/)).toBeInTheDocument()
+    expect(chip(/child under 2/i)).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('disables a zero-count chip rather than hiding it', async () => {
+    render(<FloatingUnplacedBadge parties={[plain]} onOpenParty={vi.fn()} />, { wrapper })
+    await open()
+    expect(chip(/power/i)).toBeInTheDocument()
+    expect(chip(/power/i)).toBeDisabled()
+  })
+
+  it('counts over ALL unplaced parties, not the name-search subset', async () => {
+    // A chip's number must not move while you type, or it stops answering
+    // "is this group worth clicking".
+    render(<FloatingUnplacedBadge parties={[under2, bathroom, plain]} onOpenParty={vi.fn()} />, {
+      wrapper,
+    })
+    await open()
+    await userEvent.type(screen.getByPlaceholderText(/filter by name/i), 'Bennett')
+    expect(chip(/child under 2/i)).toHaveTextContent('1')
+  })
+
+  it('names the group in its own empty state, and offers a way out', async () => {
+    // Distinct from "Everyone has a cabin." (nothing queued) and from the
+    // name-search miss — three different dead ends, three different messages.
+    //
+    // Reached by PLACING the last match while the filter is live, not by
+    // clicking: an empty group's chip is disabled, so a dead end can never be
+    // chosen, only worked into. That is the working-session case — filter to
+    // sharing, place the last sharer, and the list empties under you.
+    const { rerender } = render(
+      <FloatingUnplacedBadge parties={[sharer, plain]} onOpenParty={vi.fn()} />,
+      { wrapper }
+    )
+    await open()
+    await userEvent.click(chip(/open to sharing/i))
+    expect(screen.getByText(/Castillo/)).toBeInTheDocument()
+
+    rerender(<FloatingUnplacedBadge parties={[plain]} onOpenParty={vi.fn()} />)
+    expect(screen.getByText(/no unplaced parties are open to sharing/i)).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /clear filter/i }))
+    expect(screen.getByText(/Theo Delgado/)).toBeInTheDocument()
+  })
+
+  it('keeps the ACTIVE chip clickable at zero so the dead end can be left', async () => {
+    // The disabled rule is `count === 0 && !isActive`. Without the second
+    // half, working the last match out of a filtered group would trap the
+    // queue: an empty list and a chip that cannot be switched off.
+    const { rerender } = render(
+      <FloatingUnplacedBadge parties={[sharer, plain]} onOpenParty={vi.fn()} />,
+      { wrapper }
+    )
+    await open()
+    await userEvent.click(chip(/open to sharing/i))
+    rerender(<FloatingUnplacedBadge parties={[plain]} onOpenParty={vi.fn()} />)
+    expect(chip(/open to sharing/i)).toBeEnabled()
+    await userEvent.click(chip(/open to sharing/i))
+    expect(screen.getByText(/Theo Delgado/)).toBeInTheDocument()
+  })
+
+  it('shows no filter row at all when the queue is empty', async () => {
+    render(<FloatingUnplacedBadge parties={[]} onOpenParty={vi.fn()} />, { wrapper })
+    await open()
+    expect(screen.queryByTestId('unplaced-filters')).not.toBeInTheDocument()
+    expect(screen.getByText(/everyone has a cabin/i)).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/weekend/FloatingUnplacedBadge.tsx
+++ b/frontend/src/components/weekend/FloatingUnplacedBadge.tsx
@@ -9,7 +9,7 @@
  * other board affordances read it; nothing on the weekend surfaces does.
  */
 import { useDroppable } from '@dnd-kit/core'
-import { useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 import type { RosterPartyRow } from '../../types/lodging'
 import { FloatingQueueBadge } from '../ui'
@@ -17,6 +17,11 @@ import { UNPLACED_DROPPABLE_ID } from './dragPlacement'
 import { FamilyCard } from './FamilyCard'
 import { partyIdentityLabel, partySearchText } from './householdIdentity'
 import { partyKey } from './partyKey'
+import {
+  UNPLACED_FILTER_GROUPS,
+  unplacedFilterGroup,
+  type UnplacedFilterKey,
+} from './unplacedFilters'
 
 export interface FloatingUnplacedBadgeProps {
   parties: RosterPartyRow[]
@@ -52,6 +57,40 @@ export function FloatingUnplacedBadge({
   canPlace = false,
 }: FloatingUnplacedBadgeProps) {
   const [isExpanded, setIsExpanded] = useState(false)
+  // Single-select by ruling (kindred#2480): `null` or exactly one group, so a
+  // party in two groups never needs a tie-break. Local, like `isExpanded` --
+  // nothing outside this popout reads it, and the board's URL state is for
+  // things worth linking to, not a scratch filter.
+  const [group, setGroup] = useState<UnplacedFilterKey | null>(null)
+
+  // Over ALL unplaced parties, never the name-searched subset: the number is
+  // there to answer "is this group worth clicking", and one that moved while
+  // you typed would stop answering it.
+  const counts = useMemo(() => {
+    const tally = {} as Record<UnplacedFilterKey, number>
+    for (const spec of UNPLACED_FILTER_GROUPS) {
+      tally[spec.key] = parties.filter((party) => spec.matches(party)).length
+    }
+    return tally
+  }, [parties])
+
+  const itemFilter = useMemo(() => {
+    if (!group) return undefined
+    const { matches } = unplacedFilterGroup(group)
+    return (party: RosterPartyRow) => matches(party)
+  }, [group])
+
+  const clearFilter = useCallback(() => {
+    setGroup(null)
+  }, [])
+
+  // "…are open to sharing" reads; "…need open to sharing" does not. The two
+  // need-shaped groups and the one state-shaped group take different verbs.
+  const emptyFilterSentence = group
+    ? `No unplaced parties ${group === 'sharing' ? 'are' : 'need'} ${unplacedFilterGroup(
+        group
+      ).label.toLowerCase()}.`
+    : ''
   // The shell has carried `listRef`/`isDropTarget` since it was extracted,
   // annotated "the weekend's at C2". This is C2.
   const { setNodeRef, isOver } = useDroppable({
@@ -77,6 +116,60 @@ export function FloatingUnplacedBadge({
           ))}
         </div>
       )}
+      filterRow={
+        <div data-testid="unplaced-filters" className="flex flex-wrap items-center gap-1">
+          {UNPLACED_FILTER_GROUPS.map((spec) => {
+            const Icon = spec.Icon
+            const isActive = group === spec.key
+            const count = counts[spec.key]
+            return (
+              <button
+                key={spec.key}
+                type="button"
+                // Icon + count, no text label (owner pick 2026-08-24), so the
+                // label is the button's only name -- a test handle per
+                // frontend/CLAUDE.md, not an accessibility posture.
+                aria-label={spec.label}
+                aria-pressed={isActive}
+                title={spec.label}
+                // A zero-count chip is DIMMED, never hidden: a chip that
+                // vanished could not tell staff the group is empty, and empty
+                // groups are ordinary (2026's FC3 has no power parties). The
+                // active chip stays live at zero so it can be switched off.
+                disabled={count === 0 && !isActive}
+                onClick={() => {
+                  setGroup((current) => (current === spec.key ? null : spec.key))
+                }}
+                className={`inline-flex items-center gap-1 rounded-lg px-2 py-1 text-xs font-medium tabular-nums transition-colors ${
+                  isActive
+                    ? 'bg-primary text-primary-foreground shadow-lodge-sm'
+                    : 'text-muted-foreground hover:bg-muted disabled:opacity-40 disabled:hover:bg-transparent'
+                }`}
+              >
+                <Icon
+                  className={`h-3.5 w-3.5 flex-shrink-0 ${isActive ? '' : spec.hueClassName}`}
+                />
+                {count}
+              </button>
+            )
+          })}
+        </div>
+      }
+      itemFilter={itemFilter}
+      filterEmptyState={
+        <div className="flex h-full flex-col items-center justify-center gap-2 py-8 text-center">
+          {/* Built as ONE string, not an interleaved JSX sentence: the latter
+              splits into several text nodes and stops matching as a sentence. */}
+          <p className="text-muted-foreground text-sm">{emptyFilterSentence}</p>
+          <button
+            type="button"
+            onClick={clearFilter}
+            className="border-border hover:bg-muted rounded-lg border px-2.5 py-1 text-xs transition-colors"
+          >
+            Clear filter
+          </button>
+        </div>
+      }
       label="Unplaced"
       // "parties", not "families": an adult weekend enrols individuals, so the
       // person-grain rows in this queue are not families and the accessible

--- a/frontend/src/components/weekend/placementCandidates.test.ts
+++ b/frontend/src/components/weekend/placementCandidates.test.ts
@@ -12,7 +12,12 @@
 import { describe, expect, it } from 'vitest'
 
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
-import { candidateFit, placementCandidates } from './placementCandidates'
+import {
+  candidateFit,
+  partitionByGroup,
+  placementCandidates,
+  type PlacementCandidate,
+} from './placementCandidates'
 
 function unit(overrides: Partial<LodgingUnitRow> = {}): LodgingUnitRow {
   return {
@@ -587,5 +592,68 @@ describe('candidateFit — one grading, and the notes the glyphs now carry (kind
     const result = candidateFit(party({ party_size: 6 }), unit({ sleeps: 4 }), [])
     expect(result.fit).toBe('unmet')
     expect(result.notes).toEqual(['Over capacity · needs 6, 4 free'])
+  })
+})
+
+/**
+ * Pinning by staff group — the Assign modal's half of kindred#2480.
+ *
+ * The module's "it annotates and orders, it never hides" ruling is the whole
+ * constraint here: a group PIN reorders and nothing else. Every test below
+ * exists to prove the list that comes out is the list that went in.
+ */
+describe('partitionByGroup — pins without hiding', () => {
+  const bathroomer = party({
+    household_cm_id: 301,
+    sort_name: 'Alvarez',
+    flags: { needs_private_bathroom: true },
+  })
+  const plainA = party({ household_cm_id: 302, sort_name: 'Bennett' })
+  const plainB = party({ household_cm_id: 303, sort_name: 'Castillo' })
+
+  function candidates(): PlacementCandidate[] {
+    return [plainA, bathroomer, plainB].map((party) => ({
+      party,
+      fit: 'fits' as const,
+      notes: [],
+    }))
+  }
+
+  it('returns every candidate it was given, split in two', () => {
+    const { pinned, rest } = partitionByGroup(candidates(), 'bathroom')
+    expect(pinned).toHaveLength(1)
+    expect(rest).toHaveLength(2)
+    // The invariant the module doc protects: nothing is lost in the split.
+    expect([...pinned, ...rest]).toHaveLength(candidates().length)
+  })
+
+  it('puts the matches first and leaves everyone else in their existing order', () => {
+    const { pinned, rest } = partitionByGroup(candidates(), 'bathroom')
+    expect(pinned[0]?.party.sort_name).toBe('Alvarez')
+    // Bennett/Castillo keep the fit-then-name order they arrived in — the
+    // pin is a second axis over the fit sort, never a replacement for it.
+    expect(rest.map((c) => c.party.sort_name)).toEqual(['Bennett', 'Castillo'])
+  })
+
+  it('pins nobody when no group is picked', () => {
+    const { pinned, rest } = partitionByGroup(candidates(), null)
+    expect(pinned).toHaveLength(0)
+    expect(rest).toHaveLength(3)
+  })
+
+  it('keeps the fit order WITHIN the pinned band', () => {
+    // An over-capacity family must not float above one that fits merely
+    // because it asked for a bathroom. The band is a grouping, not a promotion.
+    const other = party({
+      household_cm_id: 304,
+      sort_name: 'Abbott',
+      flags: { needs_private_bathroom: true },
+    })
+    const list: PlacementCandidate[] = [
+      { party: bathroomer, fit: 'fits', notes: [] },
+      { party: other, fit: 'unmet', notes: ['Over capacity'] },
+    ]
+    const { pinned } = partitionByGroup(list, 'bathroom')
+    expect(pinned.map((c) => c.fit)).toEqual(['fits', 'unmet'])
   })
 })

--- a/frontend/src/components/weekend/placementCandidates.ts
+++ b/frontend/src/components/weekend/placementCandidates.ts
@@ -75,6 +75,7 @@
  * what no glyph can say, which today is capacity alone.
  */
 import type { LodgingUnitRow, RosterPartyRow } from '../../types/lodging'
+import { unplacedFilterGroup, type UnplacedFilterKey } from './unplacedFilters'
 import { partyIdentityLabel } from './householdIdentity'
 import { resolveNeedGlyphs } from './needGlyphs'
 import { worseOf, type NeedsFit } from './needsFit'
@@ -275,4 +276,42 @@ export function placementCandidates(
       if (bySort !== 0) return bySort
       return partyIdentityLabel(a.party).localeCompare(partyIdentityLabel(b.party))
     })
+}
+
+/**
+ * Split an already-ordered candidate list into a pinned band and the rest —
+ * the Assign modal's half of kindred#2480 (owner pick "B", 2026-08-24).
+ *
+ * ## This is the "never hide" ruling holding, not bending
+ *
+ * The module doc above rules that a fit-filtered list would be empty most of
+ * the time, so this list never removes anyone. A GROUP pin is a different
+ * axis and removes nobody either: both halves come back, and the caller
+ * renders them one after the other. The arithmetic that makes hiding wrong
+ * here makes pinning right — on a 62-party weekend, 4 ask for a bathroom, so
+ * hiding would leave 4 rows while pinning surfaces those 4 and keeps 58.
+ *
+ * ## Why the fit order survives inside each band
+ *
+ * The input is already sorted by fit then name, and a stable partition keeps
+ * that order in both halves. So an over-capacity family never floats above one
+ * that fits merely because it asked for a bathroom — the band groups, it does
+ * not promote. Fit remains the primary signal; the group is a lens over it.
+ *
+ * A `null` group is the no-pick case and puts everyone in `rest`, which is
+ * exactly today's list.
+ */
+export function partitionByGroup(
+  candidates: PlacementCandidate[],
+  group: UnplacedFilterKey | null
+): { pinned: PlacementCandidate[]; rest: PlacementCandidate[] } {
+  if (!group) return { pinned: [], rest: candidates }
+  const { matches } = unplacedFilterGroup(group)
+  const pinned: PlacementCandidate[] = []
+  const rest: PlacementCandidate[] = []
+  for (const candidate of candidates) {
+    if (matches(candidate.party)) pinned.push(candidate)
+    else rest.push(candidate)
+  }
+  return { pinned, rest }
 }

--- a/frontend/src/components/weekend/unplacedFilters.test.ts
+++ b/frontend/src/components/weekend/unplacedFilters.test.ts
@@ -1,0 +1,137 @@
+/**
+ * The four groups the unplaced popout filters by — kindred#2480, staff ruling
+ * 2026-08-21, visual picks locked 2026-08-24.
+ *
+ * This file is the specification for `unplacedFilters.ts`. The load-bearing
+ * assertion is §"one calculation": the sharing predicate must BE the emphasis
+ * predicate, not a copy of it, so the filter and the marks that glow on the
+ * board can never disagree about who is open to sharing.
+ *
+ * Fictional data throughout.
+ */
+import { describe, expect, it } from 'vitest'
+
+import type { RosterPartyRow } from '../../types/lodging'
+import { anchorIsEmphasized, clusterIsEmphasized } from './shareEmphasis'
+import { resolveShareAnchor, resolveShareCluster } from './shareMarks'
+import { UNPLACED_FILTER_GROUPS, unplacedFilterGroup } from './unplacedFilters'
+
+function party(overrides: Partial<RosterPartyRow> = {}): RosterPartyRow {
+  return {
+    grain: 'household',
+    household_cm_id: 1000001,
+    display_name: 'Johnson',
+    ...overrides,
+  }
+}
+
+describe('UNPLACED_FILTER_GROUPS — the closed set', () => {
+  it('is exactly four groups, in the ruled order', () => {
+    // Single-select, one group at a time (owner 2026-08-21) — the ruling
+    // exists so a party in 2+ groups never needs a tie-break. Four parties in
+    // a median 2026 weekend are in 2+, so this is not hypothetical.
+    expect(UNPLACED_FILTER_GROUPS.map((group) => group.key)).toEqual([
+      'under_two',
+      'bathroom',
+      'power',
+      'sharing',
+    ])
+  })
+
+  it('takes the bathroom and power marks from needGlyphs, never a second copy', async () => {
+    // The chip must be the same mark the card draws. Importing the spec is
+    // what guarantees that; a hand-written icon/hue pair would drift the first
+    // time either changes.
+    const { needGlyph } = await import('./needGlyphs')
+    expect(unplacedFilterGroup('bathroom').Icon).toBe(needGlyph('bathroom').Icon)
+    expect(unplacedFilterGroup('bathroom').hueClassName).toBe(needGlyph('bathroom').hueClassName)
+    expect(unplacedFilterGroup('power').Icon).toBe(needGlyph('power').Icon)
+    expect(unplacedFilterGroup('power').hueClassName).toBe(needGlyph('power').hueClassName)
+  })
+
+  it('gives every group an accessible name — the chips are icon-only', () => {
+    // Icon + count is the locked style (no text label), so the label is the
+    // button's only name. Test-infrastructure per frontend/CLAUDE.md, not a11y.
+    for (const group of UNPLACED_FILTER_GROUPS) {
+      expect(group.label.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('under_two — the computed flag, never has_infant', () => {
+  it('matches on has_child_under_two', () => {
+    expect(
+      unplacedFilterGroup('under_two').matches(party({ flags: { has_child_under_two: true } }))
+    ).toBe(true)
+    expect(
+      unplacedFilterGroup('under_two').matches(party({ flags: { has_child_under_two: false } }))
+    ).toBe(false)
+    expect(unplacedFilterGroup('under_two').matches(party())).toBe(false)
+  })
+
+  it('never keys on has_infant, which is dead on family weekends', () => {
+    // 0 of 3,923 production family_camp_registrations rows — its source field
+    // is answered only on adult sessions. A filter keyed there matches nobody.
+    expect(unplacedFilterGroup('under_two').matches(party({ flags: { has_infant: true } }))).toBe(
+      false
+    )
+  })
+})
+
+describe('bathroom and power — the party-side flags', () => {
+  it('match their own flag and nothing else', () => {
+    expect(
+      unplacedFilterGroup('bathroom').matches(party({ flags: { needs_private_bathroom: true } }))
+    ).toBe(true)
+    expect(unplacedFilterGroup('bathroom').matches(party({ flags: { needs_power: true } }))).toBe(
+      false
+    )
+    expect(unplacedFilterGroup('power').matches(party({ flags: { needs_power: true } }))).toBe(true)
+    expect(
+      unplacedFilterGroup('power').matches(party({ flags: { needs_private_bathroom: true } }))
+    ).toBe(false)
+  })
+})
+
+describe('sharing — ONE calculation, shared with the emphasis treatment', () => {
+  /*
+   * `shareEmphasis.ts`'s own docstring says this issue "should import them
+   * rather than restate them". These tests pin that it did: for every shape
+   * that matters, the filter's answer and the emphasis answer agree.
+   */
+  const emphasized = (p: RosterPartyRow) =>
+    anchorIsEmphasized(resolveShareAnchor(p)) || clusterIsEmphasized(resolveShareCluster(p))
+
+  const cases: ReadonlyArray<readonly [string, RosterPartyRow, boolean]> = [
+    ['a yes anchor', party({ share: { preference: 'yes_share' } }), true],
+    ['WITH-named ticked', party({ share: { wants_with_named: true, proximity: ['with'] } }), true],
+    ['similar-age ticked', party({ share: { proximity: ['similar_ages', 'with'] } }), true],
+    ['a maybe anchor', party({ share: { preference: 'maybe_mutual' } }), false],
+    ['a no anchor', party({ share: { preference: 'no_share' } }), false],
+    ['unanswered', party({ share: { preference: 'unknown' } }), false],
+    ['NEAR only', party({ share: { preference: 'no_share', proximity: ['near'] } }), false],
+    ['no share block at all', party(), false],
+  ]
+
+  it.each(cases)('%s — the filter and the emphasis agree', (_name, p, expected) => {
+    expect(unplacedFilterGroup('sharing').matches(p)).toBe(expected)
+    expect(emphasized(p)).toBe(expected)
+  })
+
+  it('excludes maybe_mutual and unknown by ruling, not by accident', () => {
+    // "Maybe" means "only with a family I already know" — narrower than open.
+    // 97 households in 2026 answer maybe; folding them in would nearly double
+    // the group and make it mean something else.
+    expect(
+      unplacedFilterGroup('sharing').matches(party({ share: { preference: 'maybe_mutual' } }))
+    ).toBe(false)
+  })
+
+  it('never matches a person-grain party, which has no share block', () => {
+    // Adult weekends enrol individuals; absence is not a refusal, but it is
+    // also not an opt-in.
+    expect(
+      unplacedFilterGroup('sharing').matches(party({ grain: 'person', person_cm_id: 1000002 }))
+    ).toBe(false)
+  })
+})

--- a/frontend/src/components/weekend/unplacedFilters.ts
+++ b/frontend/src/components/weekend/unplacedFilters.ts
@@ -1,0 +1,117 @@
+/**
+ * The four groups the board's Unplaced popout filters by — kindred#2480.
+ *
+ * Staff ruling 2026-08-21: **single-select, one group at a time.** The ruling
+ * is not a simplification, it is the whole design — it means a party in two
+ * groups never needs a tie-break rule, and four parties in a median 2026
+ * weekend are in two (56 unplaced: 4 under-2, 6 bathroom, 5 power, 13 sharing).
+ *
+ * Visual picks locked 2026-08-24 (Unplaced Filter Lab): icon + count, no text
+ * label, solid-fill active state, zero-count chips DIMMED rather than hidden.
+ * The count is the load-bearing part — it answers "is this group worth
+ * clicking" before the click, and a hidden chip cannot say "this group is
+ * empty". Empty groups are ordinary: 2026's FC3 has zero power parties and
+ * FC7 has one bathroom party.
+ *
+ * ## Why this is not `NEED_FILTER_OPTIONS`
+ *
+ * The roster tab's filter (`AccessibilityFlagList.ts`) is a SIX-key
+ * multi-select over the graded needs plus `accommodation` and the dead
+ * `infant`. kindred#2480's body asked this surface to reuse it; the owner's
+ * later single-select ruling supersedes that. These four groups are a
+ * different question — "which unplaced party do I work next" rather than
+ * "who asked for what" — so `accommodation`, `fridge` and `step_free` are out,
+ * `sharing` is new, and `under_two` replaces `infant`.
+ *
+ * What IS shared is the part that can drift into a contradiction: the mark
+ * vocabulary (`needGlyphs.ts`) and the share predicate (`shareEmphasis.ts`).
+ * Both are imported below, never restated.
+ */
+import { Baby, HeartHandshake, type LucideIcon } from 'lucide-react'
+
+import type { RosterPartyRow } from '../../types/lodging'
+import { needGlyph } from './needGlyphs'
+import { anchorIsEmphasized, clusterIsEmphasized } from './shareEmphasis'
+import { resolveShareAnchor, resolveShareCluster } from './shareMarks'
+
+export type UnplacedFilterKey = 'under_two' | 'bathroom' | 'power' | 'sharing'
+
+export interface UnplacedFilterGroup {
+  readonly key: UnplacedFilterKey
+  /** The chip's accessible name and tooltip — the chips are icon-only. */
+  readonly label: string
+  readonly Icon: LucideIcon
+  readonly hueClassName: string
+  readonly matches: (party: RosterPartyRow) => boolean
+}
+
+/**
+ * Open to sharing — the owner's set, resolved through the SAME two predicates
+ * the glow treatment uses.
+ *
+ * `shareEmphasis.ts`'s docstring instructs this issue to import them rather
+ * than restate them, and that is not tidiness: a second copy would let the
+ * filter and the marks that glow disagree about who is open to sharing, on the
+ * same card, in the same popout.
+ *
+ * The set is the yes anchor, WITH-named, and similar-age. `maybe_mutual` is
+ * OUT by ruling — it means "only with a family I already know", which is
+ * narrower than open, and folding its 97 households in would nearly double the
+ * group into meaning something else. NEAR is proximity, not sharing.
+ */
+function isOpenToSharing(party: RosterPartyRow): boolean {
+  return (
+    anchorIsEmphasized(resolveShareAnchor(party)) || clusterIsEmphasized(resolveShareCluster(party))
+  )
+}
+
+const bathroomGlyph = needGlyph('bathroom')
+const powerGlyph = needGlyph('power')
+
+export const UNPLACED_FILTER_GROUPS: readonly UnplacedFilterGroup[] = [
+  {
+    key: 'under_two',
+    label: 'Child under 2',
+    Icon: Baby,
+    // The Baby mark's own pink (`FamilyCard`), which sits deliberately outside
+    // the closed four-hue need set: under-2 is an ungraded fact about the
+    // party, not a need matched against a cabin.
+    hueClassName: 'text-pink-500 dark:text-pink-400',
+    // `has_child_under_two`, computed server-side from birthdates against the
+    // session start (24 months). NEVER `has_infant` — that is form-declared
+    // from a question only adult sessions answer, and is false on all 3,923
+    // production family_camp_registrations rows.
+    matches: (party) => party.flags?.has_child_under_two === true,
+  },
+  {
+    key: 'bathroom',
+    label: bathroomGlyph.label,
+    Icon: bathroomGlyph.Icon,
+    hueClassName: bathroomGlyph.hueClassName,
+    matches: (party) => party.flags?.[bathroomGlyph.flag] === true,
+  },
+  {
+    key: 'power',
+    label: powerGlyph.label,
+    Icon: powerGlyph.Icon,
+    hueClassName: powerGlyph.hueClassName,
+    matches: (party) => party.flags?.[powerGlyph.flag] === true,
+  },
+  {
+    key: 'sharing',
+    label: 'Open to sharing',
+    // HeartHandshake — the WITH-named mark, owner pick 2026-08-24. The group is
+    // three marks wide (yes anchor, WITH-named, similar-age) and no single
+    // icon means all three; this one names the commonest member.
+    Icon: HeartHandshake,
+    hueClassName: 'text-forest-800 dark:text-forest-300',
+    matches: isOpenToSharing,
+  },
+]
+
+/** Lookup by key. Throws on an unknown key rather than returning undefined. */
+export function unplacedFilterGroup(key: UnplacedFilterKey): UnplacedFilterGroup {
+  const group = UNPLACED_FILTER_GROUPS.find((candidate) => candidate.key === key)
+  if (!group) throw new Error(`Unknown unplaced filter group: ${key}`)
+  return group
+}


### PR DESCRIPTION
Follow-up to #2559 — the Assign modal's half of item 9. **Stacked on
`feature/unplaced-filter`; review that one first.** Base is set to it, so this
diff is only the modal change.

Owner pick **"B"** (2026-08-24) from the options mock: the same chip row the
Unplaced popout carries, but a pick **pins** its matches to the top instead of
hiding everyone else.

## Why pinning rather than filtering

`placementCandidates.ts` carries an owner ruling — *"it annotates and orders, it
never hides"* — because a fit-filtered list would be empty most of the time. A
group filter would have the same problem from the other direction: on a 62-party
weekend only 4 ask for a bathroom, so hiding would leave 4 rows. Pinning surfaces
those 4 **and keeps the other 58**.

`partitionByGroup` returns both halves and the caller renders them in order, so:

- **Nothing is hidden** — a test asserts the option count is unchanged after a pin.
- **The fit order survives inside each band**, so an over-capacity family never
  floats above one that fits merely because it asked for a bathroom. The band
  groups; it does not promote.
- **The footer count is untouched** — pinned or not, it still reads `N of M`.
- **The write-in offer is untouched** — it keys on `candidates.length`, which the
  partition does not change.

## What the fit sort was missing

The sort answers "is this placement permitted", not "is this a good use of a
scarce cabin". Because `resolveNeedGlyphs` omits a need a family never asked for,
a family with no needs and one that *needs a bathroom* both grade `fits`. On
Family Camp 1 2026, **all 62 parties grade `fits`** for a private-bathroom
cabin — and there are only **6 private bathrooms in the registry** (90 none, 22
shared). The 4 who asked sat alphabetically among 62.

## Placement of the row

Above the swap region, not inside it. That region's `h-80` is a fixed height
fixing a measured jump (the search box moving 133px mid-typeahead); putting
controls inside would spend list rows on chrome, and putting a variable-height
row inside would reopen the jump. The chip row is constant, so the region below
is untouched.

## Verification

- `placementCandidates.test.ts` — 4 new tests (nothing lost in the split, order preserved in both bands, fit order inside the pinned band, null group is today's list)
- `AssignFamilyModal.test.tsx` — 8 new tests (counts, pin, band labels, single-select, dimming, footer unchanged, no row without candidates, search composes)
- Full frontend suite: **470 files / 7668 tests passed**
- `scripts/pre-push-verify.sh`: prettier · eslint · tsc · vitest all PASS
- Mutation-checked: disabling the pin predicate turns 5 tests red

Not merged, auto-merge not enabled. Visual surface — held for the owner's eyes
(worktree Vite port 3146).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
